### PR TITLE
fix: fixed ping translations in German [WPB-4728]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
@@ -81,7 +81,7 @@ class RegularMessageMapper @Inject constructor(
                 UIText.StringResource(messageResourceProvider.memberNameYouTitlecase)
             } else {
                 sender?.name.orUnknownName()
-            }
+            }, message.isSelfMessage
         )
 
         is MessageContent.RestrictedAsset -> toRestrictedAsset(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -359,7 +359,7 @@ fun PreviewSystemMessageKnock() {
     WireTheme {
         SystemMessageItem(
             message = mockMessageWithKnock.copy(
-                messageContent = SystemMessage.Knock(UIText.DynamicString("Barbara Cotolina"))
+                messageContent = SystemMessage.Knock(UIText.DynamicString("Barbara Cotolina"), true)
             )
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
@@ -238,7 +238,7 @@ Enable typographer option to see result.
 
 val mockMessageWithKnock = UIMessage.System(
     header = mockHeader,
-    messageContent = UIMessageContent.SystemMessage.Knock(UIText.DynamicString("John Doe pinged")),
+    messageContent = UIMessageContent.SystemMessage.Knock(UIText.DynamicString("John Doe pinged"), true),
     source = MessageSource.Self,
 )
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -273,9 +273,9 @@ sealed class UIMessageContent {
         @StringRes val learnMoreResId: Int? = null
     ) : UIMessageContent() {
 
-        data class Knock(val author: UIText) : SystemMessage(
+        data class Knock(val author: UIText, val isSelfTriggered: Boolean) : SystemMessage(
             R.drawable.ic_ping,
-            R.string.label_message_knock
+            if (isSelfTriggered) R.string.label_system_message_self_user_knock else R.string.label_system_message_other_user_knock
         )
 
         data class MemberAdded(

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -49,7 +49,8 @@
     <string name="label_message_receive_failure">Fehler beim Herunterladen</string>
     <string name="label_message_decryption_failure_message">Nachricht konnte nicht entschlüsselt werden.</string>
     <string name="label_message_decryption_failure_informative_message">Versuchen Sie, die Session zurückzusetzen, um neue Verschlüsselungsschlüssel zu erzeugen.</string>
-    <string name="label_message_knock">%s hat gepingt</string>
+    <string name="label_system_message_self_user_knock">%s haben gepingt</string>
+    <string name="label_system_message_other_user_knock">%s hat gepingt</string>
     <string name="label_message_partial_delivery_participants_count">%1$d Teilnehmer haben Ihre Nachricht nicht erhalten.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s werden Ihre Nachricht nicht erhalten.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s wird Ihre Nachricht später erhalten.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -49,7 +49,8 @@
     <string name="label_message_receive_failure">Errores en la descarga</string>
     <string name="label_message_decryption_failure_message">El mensaje no se pudo descifrar.</string>
     <string name="label_message_decryption_failure_informative_message">Intenta restablecer la sesión para generar nuevas claves de cifrado.</string>
-    <string name="label_message_knock">%s hizo ping</string>
+    <string name="label_system_message_self_user_knock">%s hizo ping</string>
+    <string name="label_system_message_other_user_knock">%s has hecho ping</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participantes no recibieron tu mensaje.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s no recibirá tu mensaje.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s recibirá tu mensaje más tarde.</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Allalaadimise viga</string>
     <string name="label_message_decryption_failure_message">Sõnumi dekrüpteerimine ebaõnnestus.</string>
     <string name="label_message_decryption_failure_informative_message">Proovi seanss lähtestada, et luua uued krüptimisvõtmed.</string>
-    <string name="label_message_knock">%s pingiti</string>
+    <string name="label_system_message_self_user_knock">%s pingiti</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Erreur lors du téléchargement</string>
     <string name="label_message_decryption_failure_message">Le message n\'a pas pu être déchiffré.</string>
     <string name="label_message_decryption_failure_informative_message">Essayez de réinitialiser la session pour générer de nouvelles clés de chiffrement.</string>
-    <string name="label_message_knock">%s a fait un signe</string>
+    <string name="label_system_message_self_user_knock">%s a fait un signe</string>
     <string name="label_message_partial_delivery_participants_count">%1$d Les participants n\'ont pas reçu votre message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s n\'a pas reçu votre message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s recevra votre message plus tard.</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Greška pri preuzimanju</string>
     <string name="label_message_decryption_failure_message">Poruka se ne može dešifrirati.</string>
     <string name="label_message_decryption_failure_informative_message">Pokušajte resetirati sesiju zbog generiranja novih ključeva za enkripciju.</string>
-    <string name="label_message_knock">%s pingao/la</string>
+    <string name="label_system_message_self_user_knock">%s pingao/la</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Letöltési hiba</string>
     <string name="label_message_decryption_failure_message">Az üzenetet nem sikerült dekódolni.</string>
     <string name="label_message_decryption_failure_informative_message">Próbálja meg újraindítani a munkamenetet, hogy új titkosítási kulcsot generáljon.</string>
-    <string name="label_message_knock">%s kopogott</string>
+    <string name="label_system_message_self_user_knock">%s kopogott</string>
     <string name="label_message_partial_delivery_participants_count">%1$d résztvevők nem kapták meg az Ön üzenetét.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s nem fogja megkapni az Ön üzenetét.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Errore di download</string>
     <string name="label_message_decryption_failure_message">Il messaggio non pu&#242; essere decifrato.</string>
     <string name="label_message_decryption_failure_informative_message">Prova a re-impostare la sessione per generare nuove chiavi di cifratura.</string>
-    <string name="label_message_knock">%s ha effettuato un ping.</string>
+    <string name="label_system_message_self_user_knock">%s ha effettuato un ping.</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">B&#322;&#261;d Pobierania</string>
     <string name="label_message_decryption_failure_message">Wiadomo&#347;&#263; nie mog&#322;a zosta&#263; odszyfrowana.</string>
     <string name="label_message_decryption_failure_informative_message">Spr&#243;buj zresetowa&#263; sesj&#281;, aby wygenerowa&#263; nowe klucze szyfrowania.</string>
-    <string name="label_message_knock">%s zaczepi&#322;(a)</string>
+    <string name="label_system_message_self_user_knock">%s zaczepi&#322;(a)</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Erro ao baixar</string>
     <string name="label_message_decryption_failure_message">A mensagem não pôde ser descriptografada.</string>
     <string name="label_message_decryption_failure_informative_message">Tente redefinir a sessão para gerar novas chaves de criptografia.</string>
-    <string name="label_message_knock">%s chamou</string>
+    <string name="label_system_message_self_user_knock">%s chamou</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Ошибка загрузки</string>
     <string name="label_message_decryption_failure_message">Не удалось расшифровать сообщение.</string>
     <string name="label_message_decryption_failure_informative_message">Попробуйте сбросить сессию для генерации новых ключей шифрования.</string>
-    <string name="label_message_knock">%s отправил(-а) пинг</string>
+    <string name="label_system_message_self_user_knock">%s отправил(-а) пинг</string>
     <string name="label_message_partial_delivery_participants_count">%1$d участников не получили ваше сообщение.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s не получит ваше сообщение.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s получит ваше сообщение позднее.</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">බාගැනීමේ දෝෂයකි</string>
     <string name="label_message_decryption_failure_message">පණිවිඩය විසංකේතනයට නොහැකි විය.</string>
     <string name="label_message_decryption_failure_informative_message">නව සංකේතන යතුරු උත්පාදනයට වාරය යළි සකසන්න.</string>
-    <string name="label_message_knock">%s හැඬවීය</string>
+    <string name="label_system_message_self_user_knock">%s හැඬවීය</string>
     <string name="label_message_partial_delivery_participants_count">සහභාගීන් %1$d දෙනෙකුට පණිවිඩය නොලැබිණි.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">ඔබගේ පණිවිඩය %s වෙත නොලැබෙනු ඇත.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">ඔබගේ පණිවිඩය %s වෙත පසුව ලැබෙනු ඇත.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Hämtningsfel</string>
     <string name="label_message_decryption_failure_message">Meddelandet kunde inte avkrypteras.</string>
     <string name="label_message_decryption_failure_informative_message">Försök att återställa sessionen för att generera nya krypteringsnycklar.</string>
-    <string name="label_message_knock">%s pingade</string>
+    <string name="label_system_message_self_user_knock">%s pingade</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">İndirme Hatası</string>
     <string name="label_message_decryption_failure_message">Mesajın şifresi çözülemedi.</string>
     <string name="label_message_decryption_failure_informative_message">Yeni şifreleme anahtarları oluşturmak için oturumu sıfırlamayı deneyin.</string>
-    <string name="label_message_knock">%s ping attı</string>
+    <string name="label_system_message_self_user_knock">%s ping attı</string>
     <string name="label_message_partial_delivery_participants_count">%1$d katılımcı mesajınızı alamadı.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s mesajınızı alamayacak.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s mesajınızı daha sonra alacak.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Помилка завантаження</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,7 +50,8 @@
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
-    <string name="label_message_knock">%s pinged</string>
+    <string name="label_system_message_self_user_knock">%s pinged</string>
+    <string name="label_system_message_other_user_knock">%s pinged</string>
     <string name="label_message_partial_delivery_participants_count">%1$d participants didn\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_wont_deliver">%s won\'t get your message.</string>
     <string name="label_message_partial_delivery_participants_one_deliver_later">%s will get your message later.</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelperTest.kt
@@ -202,7 +202,7 @@ class AuthorHeaderHelperTest {
                 userId = userId
             ),
             source = MessageSource.OtherUser,
-            messageContent = UIMessageContent.SystemMessage.Knock(UIText.DynamicString("pinged")),
+            messageContent = UIMessageContent.SystemMessage.Knock(UIText.DynamicString("pinged"), false),
         )
 
         private fun testRegularMessage(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4728" title="WPB-4728" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4728</a>  Applause -[Android] Chat - Poor translated ping message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Knock system messages translations were still not discriminating between self and other users triggering the action, hence the German translation was broken (`Sie hat gepingt` vs `Sie haben gepingt`)

### Solutions

Added a flag to discern whether self user triggered the action or not.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- Change locale to German.
- Go into a conversation.
- Send a ping.
- Receive a ping.
- Check translations are correct

### Attachments (Optional)


| Before | After |
| ----------- | ------------ |
| ![Captura de pantalla 2023-09-27 a las 11 48 37](https://github.com/wireapp/wire-android-reloaded/assets/2468164/3ff1a384-82d5-48fc-9a21-e38a09b023b4)|   ![Captura de pantalla 2023-09-27 a las 11 46 33](https://github.com/wireapp/wire-android-reloaded/assets/2468164/1b726893-d701-41e3-9577-e4c7ecc97f63) |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
