### PR TITLE
fix: audio messages partial delivery missing (WPB-4886)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
@@ -65,7 +65,9 @@ class RegularMessageMapper @Inject constructor(
                 is AssetContent.AssetMetadata.Audio -> {
                     mapAudio(
                         assetContent = content.value,
-                        metadata = metadata
+                        metadata = metadata,
+                        userList = userList,
+                        deliveryStatus = message.deliveryStatus
                     )
                 }
 
@@ -125,6 +127,8 @@ class RegularMessageMapper @Inject constructor(
     private fun mapAudio(
         assetContent: AssetContent,
         metadata: AssetContent.AssetMetadata.Audio,
+        userList: List<User>,
+        deliveryStatus: DeliveryStatus,
     ): UIMessageContent {
         with(assetContent) {
             return UIMessageContent.AudioAssetMessage(
@@ -133,7 +137,8 @@ class RegularMessageMapper @Inject constructor(
                 assetId = AssetId(remoteData.assetId, remoteData.assetDomain.orEmpty()),
                 audioMessageDurationInMs = metadata.durationMs ?: 0,
                 uploadStatus = uploadStatus,
-                downloadStatus = downloadStatus
+                downloadStatus = downloadStatus,
+                deliveryStatus = mapRecipientsFailure(userList, deliveryStatus)
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -556,23 +556,26 @@ private fun MessageContent(
         }
 
         is UIMessageContent.AudioAssetMessage -> {
-            val audioMessageState: AudioState = audioMessagesState[message.header.messageId]
-                ?: AudioState.DEFAULT
+            Column {
+                val audioMessageState: AudioState = audioMessagesState[message.header.messageId]
+                    ?: AudioState.DEFAULT
 
-            val totalTimeInMs = remember(audioMessageState.totalTimeInMs) {
-                audioMessageState.sanitizeTotalTime(messageContent.audioMessageDurationInMs.toInt())
+                val totalTimeInMs = remember(audioMessageState.totalTimeInMs) {
+                    audioMessageState.sanitizeTotalTime(messageContent.audioMessageDurationInMs.toInt())
+                }
+
+                AudioMessage(
+                    audioMediaPlayingState = audioMessageState.audioMediaPlayingState,
+                    totalTimeInMs = totalTimeInMs,
+                    currentPositionInMs = audioMessageState.currentPositionInMs,
+                    onPlayButtonClick = { onAudioClick(message.header.messageId) },
+                    onSliderPositionChange = { position ->
+                        onChangeAudioPosition(message.header.messageId, position.toInt())
+                    },
+                    onAudioMessageLongClick = onLongClick
+                )
+                PartialDeliveryInformation(messageContent.deliveryStatus)
             }
-
-            AudioMessage(
-                audioMediaPlayingState = audioMessageState.audioMediaPlayingState,
-                totalTimeInMs = totalTimeInMs,
-                currentPositionInMs = audioMessageState.currentPositionInMs,
-                onPlayButtonClick = { onAudioClick(message.header.messageId) },
-                onSliderPositionChange = { position ->
-                    onChangeAudioPosition(message.header.messageId, position.toInt())
-                },
-                onAudioMessageLongClick = onLongClick
-            )
         }
 
         UIMessageContent.Deleted -> {}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Failures for audio messages are not displaying the partial delivery information.

### Solutions

Add the component that displays this info message to audio messages.


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
