### PR TITLE
feat: add logger with userid and clientid

### DIFF
--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: gradle
 
       - name: Validate Gradle wrapper

--- a/app/src/beta/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/beta/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -23,18 +23,25 @@ package com.wire.android.util
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Severity
 import com.datadog.android.log.Logger
+import com.wire.kalium.logger.KaliumLogger
 
 object DataDogLogger : LogWriter() {
 
     private val logger = Logger.Builder()
         .setNetworkInfoEnabled(true)
-        .setLogcatLogsEnabled(true)
+        .setLogcatLogsEnabled(false) // we already use platformLogWriter() along with DataDogLogger, don't need duplicates in LogCat
         .setDatadogLogsEnabled(true)
         .setBundleWithTraceEnabled(true)
         .setLoggerName("DATADOG")
         .build()
 
     override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
-        logger.log(severity.ordinal, message, throwable)
+        val attributes = KaliumLogger.UserClientData.getFromTag(tag)?.let { userClientData ->
+            mapOf(
+                "userId" to userClientData.userId,
+                "clientId" to userClientData.clientId,
+            )
+        } ?: emptyMap<String, Any?>()
+        logger.log(severity.ordinal, message, throwable, attributes)
     }
 }

--- a/app/src/dev/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/dev/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -23,6 +23,7 @@ package com.wire.android.util
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Severity
 import com.datadog.android.log.Logger
+import com.wire.kalium.logger.KaliumLogger
 
 object DataDogLogger : LogWriter() {
 

--- a/app/src/dev/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/dev/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -28,13 +28,19 @@ object DataDogLogger : LogWriter() {
 
     private val logger = Logger.Builder()
         .setNetworkInfoEnabled(true)
-        .setLogcatLogsEnabled(true)
+        .setLogcatLogsEnabled(false) // we already use platformLogWriter() along with DataDogLogger, don't need duplicates in LogCat
         .setDatadogLogsEnabled(true)
         .setBundleWithTraceEnabled(true)
         .setLoggerName("DATADOG")
         .build()
 
     override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
-        logger.log(severity.ordinal, message, throwable)
+        val attributes = KaliumLogger.UserClientData.getFromTag(tag)?.let { userClientData ->
+            mapOf(
+                "userId" to userClientData.userId,
+                "clientId" to userClientData.clientId,
+            )
+        } ?: emptyMap<String, Any?>()
+        logger.log(severity.ordinal, message, throwable, attributes)
     }
 }

--- a/app/src/internal/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/internal/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -23,6 +23,7 @@ package com.wire.android.util
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Severity
 import com.datadog.android.log.Logger
+import com.wire.kalium.logger.KaliumLogger
 
 object DataDogLogger : LogWriter() {
 

--- a/app/src/internal/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/internal/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -28,13 +28,19 @@ object DataDogLogger : LogWriter() {
 
     private val logger = Logger.Builder()
         .setNetworkInfoEnabled(true)
-        .setLogcatLogsEnabled(true)
+        .setLogcatLogsEnabled(false) // we already use platformLogWriter() along with DataDogLogger, don't need duplicates in LogCat
         .setDatadogLogsEnabled(true)
         .setBundleWithTraceEnabled(true)
         .setLoggerName("DATADOG")
         .build()
 
     override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
-        logger.log(severity.ordinal, message, throwable)
+        val attributes = KaliumLogger.UserClientData.getFromTag(tag)?.let { userClientData ->
+            mapOf(
+                "userId" to userClientData.userId,
+                "clientId" to userClientData.clientId,
+            )
+        } ?: emptyMap<String, Any?>()
+        logger.log(severity.ordinal, message, throwable, attributes)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/AppLogger.kt
+++ b/app/src/main/kotlin/com/wire/android/AppLogger.kt
@@ -1,0 +1,34 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android
+
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+
+private var appLoggerConfig = KaliumLogger.Config.disabled()
+// App wide global logger, carefully initialized when our application is "onCreate"
+internal var appLogger = KaliumLogger.disabled()
+object AppLogger {
+    fun init(config: KaliumLogger.Config) {
+        appLoggerConfig = config
+        appLogger = KaliumLogger(config = config, tag = "WireAppLogger")
+    }
+    fun setLogLevel(level: KaliumLogLevel) {
+        appLoggerConfig.setLogLevel(level)
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/debug/UserDebugViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/UserDebugViewModel.kt
@@ -25,10 +25,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import co.touchlab.kermit.platformLogWriter
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.CurrentAccount
-import com.wire.android.util.DataDogLogger
 import com.wire.android.util.EMPTY
 import com.wire.android.util.LogFileWriter
 import com.wire.kalium.logger.KaliumLogLevel
@@ -77,10 +75,10 @@ class UserDebugViewModel
         }
         if (isEnabled) {
             logFileWriter.start()
-            CoreLogger.setLoggingLevel(level = KaliumLogLevel.VERBOSE, logWriters = arrayOf(DataDogLogger, platformLogWriter()))
+            CoreLogger.setLoggingLevel(level = KaliumLogLevel.VERBOSE)
         } else {
             logFileWriter.stop()
-            CoreLogger.setLoggingLevel(level = KaliumLogLevel.DISABLED, logWriters = arrayOf(DataDogLogger, platformLogWriter()))
+            CoreLogger.setLoggingLevel(level = KaliumLogLevel.DISABLED)
         }
     }
 

--- a/app/src/staging/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/staging/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -23,6 +23,7 @@ package com.wire.android.util
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Severity
 import com.datadog.android.log.Logger
+import com.wire.kalium.logger.KaliumLogger
 
 object DataDogLogger : LogWriter() {
 

--- a/app/src/staging/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/staging/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -28,13 +28,19 @@ object DataDogLogger : LogWriter() {
 
     private val logger = Logger.Builder()
         .setNetworkInfoEnabled(true)
-        .setLogcatLogsEnabled(true)
+        .setLogcatLogsEnabled(false) // we already use platformLogWriter() along with DataDogLogger, don't need duplicates in LogCat
         .setDatadogLogsEnabled(true)
         .setBundleWithTraceEnabled(true)
         .setLoggerName("DATADOG")
         .build()
 
     override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
-        logger.log(severity.ordinal, message, throwable)
+        val attributes = KaliumLogger.UserClientData.getFromTag(tag)?.let { userClientData ->
+            mapOf(
+                "userId" to userClientData.userId,
+                "clientId" to userClientData.clientId,
+            )
+        } ?: emptyMap<String, Any?>()
+        logger.log(severity.ordinal, message, throwable, attributes)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently logs are not associated with specific user and client which makes debugging harder.

### Solutions

Create a logger in user scope that can pass userId and clientId with each log.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- https://github.com/wireapp/kalium/pull/2100

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
