### PR TITLE
fix: do not show confirmation dialogs when unarchiving conversations [WPB-4435]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
@@ -92,7 +92,7 @@ internal fun ConversationMainSheetContent(
             customVerticalPadding = dimensions().spacing8x
         ),
         menuItems = buildList<@Composable () -> Unit> {
-            if (conversationSheetContent.canEditNotifications()) {
+            if (conversationSheetContent.canEditNotifications() && !conversationSheetContent.isArchived) {
                 add {
                     MenuBottomSheetItem(
                         title = stringResource(R.string.label_notifications),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
@@ -69,6 +69,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 // Since the HomeScreen is responsible for displaying the bottom sheet content,
 // we create a bridge that passes the content of the BottomSheet
 // also we expose the lambda which expands the BottomSheet from the HomeScreen
+@Suppress("ComplexMethod")
 @Composable
 fun ConversationRouterHomeBridge(
     navigator: Navigator,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
@@ -59,6 +59,7 @@ import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.ui.home.conversationslist.model.ConversationsSource
 import com.wire.android.ui.home.conversationslist.model.DialogState
 import com.wire.android.ui.home.conversationslist.model.GroupDialogState
+import com.wire.android.ui.home.conversationslist.model.isArchive
 import com.wire.android.ui.home.conversationslist.search.SearchConversationScreen
 import com.wire.android.util.extension.openAppInfoScreen
 import com.wire.kalium.logic.data.id.ConversationId
@@ -119,6 +120,16 @@ fun ConversationRouterHomeBridge(
         }
     }
 
+    fun showConfirmationDialogOrUnarchive(): (DialogState) -> Unit {
+        return { dialogState ->
+            if (dialogState.isArchived) {
+                viewModel.moveConversationToArchive(dialogState)
+            } else {
+                conversationRouterHomeState.archiveConversationDialogState.show(dialogState)
+            }
+        }
+    }
+
     with(conversationRouterHomeState) {
         fun openConversationBottomSheet(
             conversationItem: ConversationItem,
@@ -156,7 +167,7 @@ fun ConversationRouterHomeBridge(
                     },
                     addConversationToFavourites = viewModel::addConversationToFavourites,
                     moveConversationToFolder = viewModel::moveConversationToFolder,
-                    updateConversationArchiveStatus = archiveConversationDialogState::show,
+                    updateConversationArchiveStatus = showConfirmationDialogOrUnarchive(),
                     clearConversationContent = clearContentDialogState::show,
                     blockUser = blockUserDialogState::show,
                     unblockUser = unblockUserDialogState::show,
@@ -201,6 +212,7 @@ fun ConversationRouterHomeBridge(
                 ConversationItemType.ALL_CONVERSATIONS ->
                     AllConversationScreenContent(
                         conversations = foldersWithConversations,
+                        isFromArchive = conversationsSource.isArchive(),
                         hasNoConversations = hasNoConversations,
                         onEditConversation = onEditConversationItem,
                         onOpenConversationNotificationsSettings = onEditNotifications,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/SearchQuery.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/SearchQuery.kt
@@ -29,3 +29,5 @@ enum class ConversationsSource {
     MAIN,
     ARCHIVE
 }
+
+fun ConversationsSource.isArchive(): Boolean = this == ConversationsSource.ARCHIVE


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4435" title="WPB-4435" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-4435</a>  add un-archive option in the context menu of the archived list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
When trying to unarchive a conversation item from the Archive screen, app was displaying the archiving confirmation dialog which is wrong. Also, when the Archive screen was empty, we were showing the wrong message. This PR fixes both issues.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
