### PR TITLE
fix: not showing dialog when archiving users from user profile screen [WPB-4993]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileEventsHandlers.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileEventsHandlers.kt
@@ -71,7 +71,7 @@ interface OtherUserProfileBottomSheetEventsHandler {
     fun onMutingConversationStatusChange(conversationId: ConversationId?, status: MutedConversationStatus)
     fun onAddConversationToFavourites(conversationId: ConversationId? = null)
     fun onMoveConversationToFolder(conversationId: ConversationId? = null)
-    fun onMoveConversationToArchive(conversationId: ConversationId, isArchivingConversation: Boolean)
+    fun onMoveConversationToArchive(dialogState: DialogState)
     fun onClearConversationContent(dialogState: DialogState)
 
     companion object {
@@ -81,7 +81,7 @@ interface OtherUserProfileBottomSheetEventsHandler {
             override fun onMutingConversationStatusChange(conversationId: ConversationId?, status: MutedConversationStatus) {}
             override fun onAddConversationToFavourites(conversationId: ConversationId?) {}
             override fun onMoveConversationToFolder(conversationId: ConversationId?) {}
-            override fun onMoveConversationToArchive(conversationId: ConversationId, isArchivingConversation: Boolean) {}
+            override fun onMoveConversationToArchive(dialogState: DialogState) {}
             override fun onClearConversationContent(dialogState: DialogState) {}
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -75,11 +75,13 @@ import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.calculateCurrentTab
+import com.wire.android.ui.common.dialogs.ArchiveConversationDialog
 import com.wire.android.ui.common.dialogs.BlockUserDialogContent
 import com.wire.android.ui.common.dialogs.BlockUserDialogState
 import com.wire.android.ui.common.dialogs.UnblockUserDialogContent
 import com.wire.android.ui.common.dialogs.UnblockUserDialogState
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.topBarElevation
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
@@ -90,7 +92,6 @@ import com.wire.android.ui.destinations.DeviceDetailsScreenDestination
 import com.wire.android.ui.home.conversations.details.dialog.ClearConversationContentDialog
 import com.wire.android.ui.home.conversationslist.model.DialogState
 import com.wire.android.ui.home.conversationslist.model.Membership
-import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -312,6 +313,10 @@ fun OtherProfileScreenContent(
         onClearConversationContent = {
             bottomSheetEventsHandler.onClearConversationContent(it)
         }
+    )
+    ArchiveConversationDialog(
+        dialogState = archivingConversationDialogState,
+        onArchiveButtonClicked = bottomSheetEventsHandler::onMoveConversationToArchive
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -295,18 +295,23 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     override fun onMoveConversationToFolder(conversationId: ConversationId?) {
     }
 
-    override fun onMoveConversationToArchive(conversationId: ConversationId, isArchivingConversation: Boolean) {
+    override fun onMoveConversationToArchive(dialogState: DialogState) {
         viewModelScope.launch {
+            val shouldArchive = !dialogState.isArchived
             requestInProgress = true
-            val result = withContext(dispatchers.io()) { updateConversationArchivedStatus(conversationId, isArchivingConversation) }
+            val result = withContext(dispatchers.io()) { updateConversationArchivedStatus(dialogState.conversationId, shouldArchive) }
             requestInProgress = false
             when (result) {
                 ArchiveStatusUpdateResult.Failure -> {
-                    closeBottomSheetAndShowInfoMessage(OtherUserProfileInfoMessageType.ArchiveConversationError(isArchivingConversation))
+                    closeBottomSheetAndShowInfoMessage(OtherUserProfileInfoMessageType.ArchiveConversationError(shouldArchive))
                 }
 
                 ArchiveStatusUpdateResult.Success -> {
-                    closeBottomSheetAndShowInfoMessage(OtherUserProfileInfoMessageType.ArchiveConversationSuccess(isArchivingConversation))
+                    closeBottomSheetAndShowInfoMessage(
+                        OtherUserProfileInfoMessageType.ArchiveConversationSuccess(
+                            shouldArchive
+                        )
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/bottomsheet/OtherUserProfileBottomSheet.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/bottomsheet/OtherUserProfileBottomSheet.kt
@@ -58,7 +58,7 @@ fun OtherUserProfileBottomSheetContent(
                     if (!it.isArchived) {
                         archivingStatusState(it)
                     } else {
-                        eventsHandler.onMoveConversationToArchive(it.conversationId, isArchivingConversation = false)
+                        eventsHandler.onMoveConversationToArchive(it)
                     }
                 },
                 clearConversationContent = clearContent,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4993" title="WPB-4993" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4993</a>  [Android] Issue when archiving private user from profile screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We were not showing any dialog nor performing any action when trying to archive a conversation of another user from the user profile details screen. The reason was because I had forgotten to add the archive confirmation dialog component on the `OtherUserProfileScreen` 

### Solutions

Add the dialog and handle the logic.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
