### PR TITLE
feat(mls): navigate to migrated conversation [WPB-4705]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -112,7 +112,7 @@ class WireApplication : Application(), Configuration.Provider {
                     .detectDiskReads()
                     .detectDiskWrites()
                     .penaltyLog()
-                    .penaltyDeath()
+//                    .penaltyDeath()
                     .build()
             )
             StrictMode.setVmPolicy(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -62,6 +62,7 @@ import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.model.SnackBarMessage
+import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.calling.common.MicrophoneBTPermissionsDeniedDialog
@@ -75,6 +76,7 @@ import com.wire.android.ui.common.dialogs.calling.JoinAnywayDialog
 import com.wire.android.ui.common.dialogs.calling.OngoingActiveCallDialog
 import com.wire.android.ui.common.error.CoreFailureErrorDialog
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
+import com.wire.android.ui.destinations.ConversationScreenDestination
 import com.wire.android.ui.destinations.GroupConversationDetailsScreenDestination
 import com.wire.android.ui.destinations.InitiatingCallScreenDestination
 import com.wire.android.ui.destinations.MediaGalleryScreenDestination
@@ -95,6 +97,7 @@ import com.wire.android.ui.home.conversations.info.ConversationInfoViewModel
 import com.wire.android.ui.home.conversations.info.ConversationInfoViewState
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewState
+import com.wire.android.ui.home.conversations.migration.ConversationMigrationViewModel
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
@@ -151,6 +154,7 @@ fun ConversationScreen(
     conversationCallViewModel: ConversationCallViewModel = hiltViewModel(),
     conversationMessagesViewModel: ConversationMessagesViewModel = hiltViewModel(),
     messageComposerViewModel: MessageComposerViewModel = hiltViewModel(),
+    conversationMigrationViewModel: ConversationMigrationViewModel = hiltViewModel(),
     groupDetailsScreenResultRecipient: ResultRecipient<GroupConversationDetailsScreenDestination, GroupConversationDetailsNavBackArgs>,
     mediaGalleryScreenResultRecipient: ResultRecipient<MediaGalleryScreenDestination, MediaGalleryNavBackArgs>,
     resultNavigator: ResultBackNavigator<GroupConversationDetailsNavBackArgs>,
@@ -176,6 +180,15 @@ fun ConversationScreen(
         }
     }
     val context = LocalContext.current
+
+    conversationMigrationViewModel.migratedConversationId?.let { migratedConversationId ->
+        navigator.navigate(
+            NavigationCommand(
+                ConversationScreenDestination(migratedConversationId),
+                BackStackMode.REMOVE_CURRENT
+            )
+        )
+    }
 
     with(conversationCallViewModel) {
         if (conversationCallViewState.shouldShowJoinAnywayDialog) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/banner/ConversationBannerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/banner/ConversationBannerViewModel.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@Suppress("LongParameterList")
 @HiltViewModel
 class ConversationBannerViewModel @Inject constructor(
     override val savedStateHandle: SavedStateHandle,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/migration/ConversationMigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/migration/ConversationMigrationViewModel.kt
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.migration
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.wire.android.navigation.SavedStateViewModel
+import com.wire.android.ui.home.conversations.ConversationNavArgs
+import com.wire.android.ui.navArgs
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ConversationMigrationViewModel(
+    override val savedStateHandle: SavedStateHandle,
+    private val observeConversationDetails: ObserveConversationDetailsUseCase
+) : SavedStateViewModel(savedStateHandle) {
+
+    /**
+     * Represents the target conversation for a conversation migration.
+     * The target conversation is the active one-on-one conversation ID if the current conversation
+     * is migrated to a different conversation.
+     * If the conversation is not migrated, the target conversation is null.
+     */
+    var targetConversation by mutableStateOf<ConversationId?>(null)
+        private set
+
+    private val conversationNavArgs: ConversationNavArgs = savedStateHandle.navArgs()
+    private val conversationId: QualifiedID = conversationNavArgs.conversationId
+
+    init {
+        viewModelScope.launch {
+            observeConversationDetails(conversationId)
+                .filterIsInstance<ObserveConversationDetailsUseCase.Result.Success>()
+                .map { it.conversationDetails }
+                .filterIsInstance<ConversationDetails.OneOne>()
+                .collectLatest {
+                    val activeOneOnOneConversationId = it.otherUser.activeOneOnOneConversationId
+                    val wasThisConversationMigrated = activeOneOnOneConversationId != conversationId
+                    if (wasThisConversationMigrated) {
+                        targetConversation = activeOneOnOneConversationId
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/migration/ConversationMigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/migration/ConversationMigrationViewModel.kt
@@ -34,23 +34,24 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
-class ConversationMigrationViewModel(
+class ConversationMigrationViewModel @Inject constructor(
     override val savedStateHandle: SavedStateHandle,
     private val observeConversationDetails: ObserveConversationDetailsUseCase
 ) : SavedStateViewModel(savedStateHandle) {
 
     /**
-     * Represents the target conversation for a conversation migration.
+     * Represents the target conversation, after a conversation migration.
      * The target conversation is the active one-on-one conversation ID if the current conversation
      * is migrated to a different conversation.
-     * If the conversation is not migrated, the target conversation is null.
+     * If this conversation was not migrated to another one, the target conversation is null.
      */
-    var targetConversation by mutableStateOf<ConversationId?>(null)
+    var migratedConversationId by mutableStateOf<ConversationId?>(null)
         private set
 
-    private val conversationNavArgs: ConversationNavArgs = savedStateHandle.navArgs()
+    private val conversationNavArgs = savedStateHandle.navArgs<ConversationNavArgs>()
     private val conversationId: QualifiedID = conversationNavArgs.conversationId
 
     init {
@@ -63,7 +64,7 @@ class ConversationMigrationViewModel(
                     val activeOneOnOneConversationId = it.otherUser.activeOneOnOneConversationId
                     val wasThisConversationMigrated = activeOneOnOneConversationId != conversationId
                     if (wasThisConversationMigrated) {
-                        targetConversation = activeOneOnOneConversationId
+                        migratedConversationId = activeOneOnOneConversationId
                     }
                 }
         }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/migration/ConversationMigrationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/migration/ConversationMigrationViewModelTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.migration
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.NavigationTestExtension
+import com.wire.android.framework.TestConversation
+import com.wire.android.framework.TestUser
+import com.wire.android.ui.home.conversations.ConversationNavArgs
+import com.wire.android.ui.navArgs
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.LegalHoldStatus
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(CoroutineTestExtension::class)
+@ExtendWith(NavigationTestExtension::class)
+class ConversationMigrationViewModelTest {
+
+    @Test
+    fun givenActiveOneOnOneMatchesCurrentConversation_thenMigratedConversationShouldBeNull() = runTest {
+        val (_, conversationMigrationViewModel) = arrange {
+            withConversationDetailsReturning(
+                ConversationDetails.OneOne(
+                    conversation = TestConversation.ONE_ON_ONE,
+                    otherUser = TestUser.OTHER_USER.copy(activeOneOnOneConversationId = conversationId),
+                    legalHoldStatus = LegalHoldStatus.ENABLED,
+                    userType = UserType.NONE,
+                    unreadEventCount = mapOf(),
+                    lastMessage = null
+                )
+            )
+        }
+
+        conversationMigrationViewModel.migratedConversationId shouldBe null
+    }
+
+    @Test
+    fun givenActiveOneOnOneDiffersFromCurrentConversation_thenMigratedConversationShouldBeTheOneInDetails() = runTest {
+        val expectedActiveOneOnOneId = ConversationId("expectedActiveOneOnOneId", "testDomain")
+        val (_, conversationMigrationViewModel) = arrange {
+            withConversationDetailsReturning(
+                ConversationDetails.OneOne(
+                    conversation = TestConversation.ONE_ON_ONE,
+                    otherUser = TestUser.OTHER_USER.copy(activeOneOnOneConversationId = expectedActiveOneOnOneId),
+                    legalHoldStatus = LegalHoldStatus.ENABLED,
+                    userType = UserType.NONE,
+                    unreadEventCount = mapOf(),
+                    lastMessage = null
+                )
+            )
+        }
+
+        conversationMigrationViewModel.migratedConversationId shouldBeEqualTo expectedActiveOneOnOneId
+    }
+
+    private class Arrangement(private val configure: Arrangement.() -> Unit) {
+
+        @MockK
+        lateinit var observeConversationDetailsUseCase: ObserveConversationDetailsUseCase
+
+        @MockK
+        lateinit var savedStateHandle: SavedStateHandle
+
+        init {
+            MockKAnnotations.init(this)
+            every { savedStateHandle.navArgs<ConversationNavArgs>() } returns ConversationNavArgs(conversationId)
+        }
+
+        fun withConversationDetailsReturning(conversationDetails: ConversationDetails) = apply {
+            coEvery { observeConversationDetailsUseCase(conversationId) } returns
+                    flowOf(ObserveConversationDetailsUseCase.Result.Success(conversationDetails))
+        }
+
+        fun arrange(): Pair<Arrangement, ConversationMigrationViewModel> = run {
+            configure()
+            this@Arrangement to ConversationMigrationViewModel(savedStateHandle, observeConversationDetailsUseCase)
+        }
+    }
+
+    private companion object {
+        val conversationId = TestConversation.ID
+
+        fun arrange(configure: Arrangement.() -> Unit) = Arrangement(configure).arrange()
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4705" title="WPB-4705" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-4705</a>  [Android] Observe & navigate to active 1-1 conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a 1:1 Proteus conversation is migrated to MLS, it actually creates a _new_ conversation, and moves all the content to the new conversation.

If that happens _while_ the user has the conversation open on the screen, a blank conversation would appear, and the user would interact with a now "defunct" conversation that should no longer be visible.

### Solutions

Observe the details of the conversation, and if it is a 1:1 conversation, check the `activeOneOnOneConversationId` with the other user and navigate to it, if it differs from the conversation being observed.

Added a new `ConversationMigrationViewModel` so it can be specialised into observing this kind of things.

It doesn't work using the current version of Kalium, as Kalium always returns `null` for `activeOneOnOneConversationId` when observing the conversation details, but I'm creating a PR in Kalium to fix it.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

You can use the DB inspector to change the `activeOneOnOneConversationId` of some user to some other conversation while you have it open.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
