### PR TITLE
fix: sanitize urls before displaying warning dialog [WPB-4782]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
@@ -41,7 +41,7 @@ fun normalizeLink(url: String): String {
 @Suppress("TooGenericExceptionCaught")
 fun sanitizeUrl(url: String): String {
     try {
-        val urlComponents = url.split("://")
+        val urlComponents = url.split("://", limit = 2)
         val scheme = urlComponents[0] // Extract the URL scheme (e.g., "http")
         val restOfUrl = urlComponents[1] // Extract the rest of the URL
 
@@ -53,7 +53,9 @@ fun sanitizeUrl(url: String): String {
         val asciiDomain = IDN.toASCII(domain)
 
         // Reconstruct the sanitized URL
-        return "$scheme://$asciiDomain/${domainAndPath.subList(1, domainAndPath.size).joinToString("/")}"
+        return "$scheme://$asciiDomain" +
+                if (domainAndPath.size > 1) "/" + domainAndPath.subList(1, domainAndPath.size).joinToString("/") else ""
+
     } catch (e: Exception) {
         // Handle any exceptions that might occur during the processing
         appLogger.w("Error sanitizing URL: $url", e)

--- a/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
@@ -55,7 +55,6 @@ fun sanitizeUrl(url: String): String {
         // Reconstruct the sanitized URL
         return "$scheme://$asciiDomain" +
                 if (domainAndPath.size > 1) "/" + domainAndPath.subList(1, domainAndPath.size).joinToString("/") else ""
-
     } catch (e: Exception) {
         // Handle any exceptions that might occur during the processing
         appLogger.w("Error sanitizing URL: $url", e)

--- a/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
@@ -17,6 +17,8 @@
  */
 package com.wire.android.util
 
+import com.wire.android.appLogger
+import java.net.IDN
 import java.net.URI
 
 fun containsSchema(url: String): Boolean {
@@ -28,9 +30,33 @@ fun containsSchema(url: String): Boolean {
 }
 
 fun normalizeLink(url: String): String {
-    return if (containsSchema(url)) {
-        url
+    val sanitizedUrl = sanitizeUrl(url)
+    return if (containsSchema(sanitizedUrl)) {
+        sanitizedUrl
     } else {
-        "https://$url"
+        "https://$sanitizedUrl"
+    }
+}
+
+@Suppress("TooGenericExceptionCaught")
+fun sanitizeUrl(url: String): String {
+    try {
+        val urlComponents = url.split("://")
+        val scheme = urlComponents[0] // Extract the URL scheme (e.g., "http")
+        val restOfUrl = urlComponents[1] // Extract the rest of the URL
+
+        // Split the rest of the URL by '/' to isolate the domain
+        val domainAndPath = restOfUrl.split("/")
+        val domain = domainAndPath[0] // Extract the domain
+
+        // Use IDN.toASCII to convert the domain to ASCII representation
+        val asciiDomain = IDN.toASCII(domain)
+
+        // Reconstruct the sanitized URL
+        return "$scheme://$asciiDomain/${domainAndPath.subList(1, domainAndPath.size).joinToString("/")}"
+    } catch (e: Exception) {
+        // Handle any exceptions that might occur during the processing
+        appLogger.e("Error sanitizing URL: $url", e)
+        return url // Return the original URL if any errors occur
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/UriUtil.kt
@@ -56,7 +56,7 @@ fun sanitizeUrl(url: String): String {
         return "$scheme://$asciiDomain/${domainAndPath.subList(1, domainAndPath.size).joinToString("/")}"
     } catch (e: Exception) {
         // Handle any exceptions that might occur during the processing
-        appLogger.e("Error sanitizing URL: $url", e)
+        appLogger.w("Error sanitizing URL: $url", e)
         return url // Return the original URL if any errors occur
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4782" title="WPB-4782" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4782</a>  [Android] Punycode Links popup show the wrong URL
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some users might try to send links on chats with hidden punycodes camouflaged as normal links. Therefore, we need to sanitize all urls before displaying the warning dialog to users to make sure they are aware where they will be navigating to.

### Solutions

Use the `IDN.toASCII()` method to transform to ASCII any malicious characters.


### Attachments (Optional)

<img width="444" alt="Captura de pantalla 2023-10-12 a las 14 05 05" src="https://github.com/wireapp/wire-android-reloaded/assets/2468164/88e9b4b0-63ab-4ebb-af23-3dc0dd2f9dee">

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
