### PR TITLE
fix: modify download placeholders to clarify saved and downloaded cases [WPB-4732]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
@@ -39,7 +39,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -299,21 +298,6 @@ private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus, asse
                 assetDownloadStatus == Message.DownloadStatus.DOWNLOAD_IN_PROGRESS -> WireCircularProgressIndicator(
             progressColor = MaterialTheme.wireColorScheme.secondaryText,
             size = dimensions().spacing16x
-        )
-
-        assetUploadStatus == Message.UploadStatus.FAILED_UPLOAD -> {}
-        assetDownloadStatus == Message.DownloadStatus.SAVED_INTERNALLY -> Icon(
-            painter = painterResource(id = R.drawable.ic_download),
-            contentDescription = stringResource(R.string.content_description_download_icon),
-            modifier = Modifier.size(dimensions().wireIconButtonSize),
-            tint = MaterialTheme.wireColorScheme.secondaryText
-        )
-
-        assetDownloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY -> Icon(
-            painter = painterResource(id = R.drawable.ic_check_tick),
-            contentDescription = stringResource(R.string.content_description_check),
-            modifier = Modifier.size(dimensions().wireIconButtonSize),
-            tint = MaterialTheme.wireColorScheme.secondaryText
         )
 
         else -> {}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -405,7 +405,7 @@
     <string name="asset_message_tap_to_download_text">Tap to download</string>
     <string name="asset_message_upload_in_progress_text">Uploading…</string>
     <string name="asset_message_download_in_progress_text">Downloading…</string>
-    <string name="asset_message_downloaded_internally_text">Downloaded</string>
+    <string name="asset_message_downloaded_internally_text">Tap to view</string>
     <string name="asset_message_saved_externally_text">Saved</string>
     <string name="asset_message_failed_download_text">File not available</string>
     <string name="asset_message_failed_upload_text">File upload failed</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4732" title="WPB-4732" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4732</a>  Applause -[Android] Chat - Poor translated "download" button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was still some confussion among users with Assets being downloaded externally and saved internally when sending and receiving these over conversations. Also icons were not helping as they were being displayed in multiple ways, adding to the problematic, so they have been removed following the [design specs in Figma.](https://www.figma.com/file/UgKehvwIbiIiQ2CCEdsVuf/Android?type=design&node-id=39687-52981&mode=design&t=FRuNhK0wroF2iZJ2-0)

### Solutions
Substituted "Downloaded copy" on the asset placeholder for "Tap to view" in order to help user understand that the asset is ready to use. 

### Attachments (Optional)
<img width="439" alt="Captura de pantalla 2023-10-12 a las 15 57 23" src="https://github.com/wireapp/wire-android-reloaded/assets/2468164/40b4e9b0-9bee-42b6-880b-47dc6d291e41">


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
