### PR TITLE
fix(typing): back handler and jumping screen typing indicator

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -22,6 +22,7 @@ package com.wire.android.ui.home.conversations
 
 import SwipeableSnackbar
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -42,6 +43,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
@@ -318,11 +320,7 @@ fun ConversationScreen(
                 }
             }
         },
-        onBackButtonClick = {
-            messageComposerViewModel.sendTypingEvent(TypingIndicatorMode.STOPPED)
-            focusManager.clearFocus(true)
-            navigator.navigateBack()
-        },
+        onBackButtonClick = { conversationScreenOnBackButtonClick(messageComposerViewModel, focusManager, navigator) },
         composerMessages = messageComposerViewModel.infoMessage,
         conversationMessages = conversationMessagesViewModel.infoMessage,
         conversationMessagesViewModel = conversationMessagesViewModel,
@@ -351,6 +349,7 @@ fun ConversationScreen(
         },
         onTypingEvent = messageComposerViewModel::sendTypingEvent
     )
+    BackHandler { conversationScreenOnBackButtonClick(messageComposerViewModel, focusManager, navigator) }
     DeleteMessageDialog(
         state = messageComposerViewModel.deleteMessageDialogsState,
         actions = messageComposerViewModel.deleteMessageHelper
@@ -428,6 +427,16 @@ fun ConversationScreen(
             }
         }
     }
+}
+
+private fun conversationScreenOnBackButtonClick(
+    messageComposerViewModel: MessageComposerViewModel,
+    focusManager: FocusManager,
+    navigator: Navigator
+) {
+    messageComposerViewModel.sendTypingEvent(TypingIndicatorMode.STOPPED)
+    focusManager.clearFocus(true)
+    navigator.navigateBack()
 }
 
 @Suppress("LongParameterList")

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/UsersTypingIndicator.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/UsersTypingIndicator.kt
@@ -78,18 +78,18 @@ fun UsersTypingIndicatorForConversation(
 
 @Composable
 fun UsersTypingIndicator(usersTyping: List<UIParticipant>) {
-    if (usersTyping.isNotEmpty()) {
-        val rememberTransition =
-            rememberInfiniteTransition(label = stringResource(R.string.animation_label_typing_indicator_horizontal_transition))
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .height(dimensions().spacing24x)
-                .background(
-                    color = colorsScheme().surface,
-                    shape = RoundedCornerShape(dimensions().corner14x),
-                )
-        ) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .height(dimensions().spacing24x)
+            .background(
+                color = colorsScheme().surface,
+                shape = RoundedCornerShape(dimensions().corner14x),
+            )
+    ) {
+        if (usersTyping.isNotEmpty()) {
+            val rememberTransition =
+                rememberInfiniteTransition(label = stringResource(R.string.animation_label_typing_indicator_horizontal_transition))
             UsersTypingAvatarPreviews(usersTyping)
             Text(
                 text = pluralStringResource(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In the playtest session we discover
- A padding issue, that made the messages jump.
- System back handler didn't send a stop event.

### Solutions

Add fixed element for ui adjustment, and make inside content displayable according to list empty or not.
Implements `BackHandler` in conversation screen to send the stop event.

### Testing

#### How to Test

Receive some typing events should not make jump messages and going back to conversation list should send a stop event to other clients.

### Attachments (Optional)

https://github.com/wireapp/wire-android-reloaded/assets/5806454/ac88f667-80a1-4d63-a497-09c1b2f31fb9

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
