### PR TITLE
fix: keyboard size after gifs expand [WPB-4985]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -82,12 +82,21 @@ fun EnabledMessageComposer(
     val isImeVisible = WindowInsets.isImeVisible
     val offsetY = WindowInsets.ime.getBottom(density)
     val isKeyboardMoving = isKeyboardMoving()
+    val imeAnimationSource = WindowInsets.imeAnimationSource.getBottom(density)
+    val imeAnimationTarget = WindowInsets.imeAnimationTarget.getBottom(density)
 
     with(messageComposerStateHolder) {
         val inputStateHolder = messageCompositionInputStateHolder
 
         LaunchedEffect(offsetY) {
-            inputStateHolder.handleOffsetChange(with(density) { offsetY.toDp() }, navBarHeight)
+            with(density) {
+                inputStateHolder.handleOffsetChange(
+                    offsetY.toDp(),
+                    navBarHeight,
+                    imeAnimationSource.toDp(),
+                    imeAnimationTarget.toDp()
+                )
+            }
         }
 
         LaunchedEffect(isImeVisible) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
@@ -64,6 +64,9 @@ class MessageCompositionInputStateHolder(
     var isTextExpanded by mutableStateOf(false)
         private set
 
+    var initialKeyboardHeight by mutableStateOf(0.dp)
+        private set
+
     var previousOffset by mutableStateOf(0.dp)
         private set
 
@@ -90,8 +93,14 @@ class MessageCompositionInputStateHolder(
         }
     }
 
-    fun handleOffsetChange(offset: Dp, navBarHeight: Dp) {
+    fun handleOffsetChange(offset: Dp, navBarHeight: Dp, source: Dp, target: Dp) {
         val actualOffset = max(offset - navBarHeight, 0.dp)
+
+        // this check secures that if some additional space will be added to keyboard
+        // like gifs search it will save initial keyboard height
+        if (source == target && source > 0.dp && initialKeyboardHeight == 0.dp) {
+            initialKeyboardHeight = source - navBarHeight
+        }
 
         if (previousOffset < actualOffset) {
             optionsVisible = true
@@ -151,7 +160,11 @@ class MessageCompositionInputStateHolder(
     fun showOptions() {
         optionsVisible = true
         subOptionsVisible = true
-        optionsHeight = keyboardHeight
+        if (initialKeyboardHeight > 0.dp) {
+            optionsHeight = initialKeyboardHeight
+        } else {
+            optionsHeight = keyboardHeight
+        }
         clearFocus()
     }
 
@@ -176,12 +189,14 @@ class MessageCompositionInputStateHolder(
         showSubOptions: Boolean = false,
         optionsHeight: Dp = 0.dp,
         showOptions: Boolean = false,
+        initialKeyboardHeight: Dp = 0.dp
     ) {
         this.keyboardHeight = keyboardHeight
         this.previousOffset = previousOffset
         this.subOptionsVisible = showSubOptions
         this.optionsHeight = optionsHeight
         this.optionsVisible = showOptions
+        this.initialKeyboardHeight = initialKeyboardHeight
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
@@ -182,6 +182,7 @@ class MessageCompositionInputStateHolder(
         return optionsHeight + if (additionalOptionsSubMenuState != AdditionalOptionSubMenuState.RecordAudio) 0.dp else composeTextHeight
     }
 
+    @Suppress("LongParameterList")
     @VisibleForTesting
     fun updateValuesForTesting(
         keyboardHeight: Dp = KeyboardHeight.default,

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
@@ -69,7 +69,12 @@ class MessageCompositionInputStateHolderTest {
     @Test
     fun `when offset increases and is bigger than previous and options height, options height is updated`() {
         // When
-        state.handleOffsetChange(50.dp, NAVIGATION_BAR_HEIGHT)
+        state.handleOffsetChange(
+            50.dp,
+            NAVIGATION_BAR_HEIGHT,
+            SOURCE,
+            TARGET
+        )
 
         // Then
         state.optionsHeight shouldBeEqualTo 50.dp
@@ -82,7 +87,12 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(previousOffset = 50.dp)
 
         // When
-        state.handleOffsetChange(20.dp, NAVIGATION_BAR_HEIGHT)
+        state.handleOffsetChange(
+            20.dp,
+            NAVIGATION_BAR_HEIGHT,
+            SOURCE,
+            TARGET
+        )
 
         // Then
         state.optionsHeight shouldBeEqualTo 20.dp
@@ -94,7 +104,12 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(previousOffset = 50.dp)
 
         // When
-        state.handleOffsetChange(0.dp, NAVIGATION_BAR_HEIGHT)
+        state.handleOffsetChange(
+            0.dp,
+            NAVIGATION_BAR_HEIGHT,
+            SOURCE,
+            TARGET
+        )
 
         // Then
         state.optionsVisible shouldBeEqualTo false
@@ -107,7 +122,12 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(keyboardHeight = 30.dp)
 
         // When
-        state.handleOffsetChange(30.dp, NAVIGATION_BAR_HEIGHT)
+        state.handleOffsetChange(
+            30.dp,
+            NAVIGATION_BAR_HEIGHT,
+            SOURCE,
+            TARGET
+        )
 
         // Then
         state.subOptionsVisible shouldBeEqualTo false
@@ -119,7 +139,12 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(keyboardHeight = 20.dp)
 
         // When
-        state.handleOffsetChange(30.dp, NAVIGATION_BAR_HEIGHT)
+        state.handleOffsetChange(
+            30.dp,
+            NAVIGATION_BAR_HEIGHT,
+            SOURCE,
+            TARGET
+        )
 
         // Then
         state.keyboardHeight shouldBeEqualTo 30.dp
@@ -131,7 +156,12 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(previousOffset = 50.dp, keyboardHeight = 20.dp)
 
         // When
-        state.handleOffsetChange(30.dp, NAVIGATION_BAR_HEIGHT)
+        state.handleOffsetChange(
+            30.dp,
+            NAVIGATION_BAR_HEIGHT,
+            SOURCE,
+            TARGET
+        )
 
         // Then
         state.keyboardHeight shouldBeEqualTo 30.dp
@@ -149,7 +179,12 @@ class MessageCompositionInputStateHolderTest {
         )
 
         // When
-        state.handleOffsetChange(30.dp, NAVIGATION_BAR_HEIGHT)
+        state.handleOffsetChange(
+            30.dp,
+            NAVIGATION_BAR_HEIGHT,
+            SOURCE,
+            TARGET
+        )
 
         // Then
         state.optionsHeight shouldBeEqualTo 10.dp
@@ -166,7 +201,12 @@ class MessageCompositionInputStateHolderTest {
         )
 
         // When
-        state.handleOffsetChange(30.dp, NAVIGATION_BAR_HEIGHT)
+        state.handleOffsetChange(
+            30.dp,
+            NAVIGATION_BAR_HEIGHT,
+            SOURCE,
+            TARGET
+        )
 
         // Then
         state.optionsHeight shouldBeEqualTo 30.dp
@@ -178,11 +218,44 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(previousOffset = 40.dp, keyboardHeight = 20.dp)
 
         // When
-        state.handleOffsetChange(40.dp, NAVIGATION_BAR_HEIGHT)
+        state.handleOffsetChange(
+            40.dp,
+            NAVIGATION_BAR_HEIGHT,
+            SOURCE,
+            TARGET
+        )
 
         // Then
         state.keyboardHeight shouldBeEqualTo 40.dp
         state.optionsHeight shouldBeEqualTo 0.dp
+    }
+
+    @Test
+    fun `given first keyboard appear when source equals target, then initialKeyboardHeight is set`() {
+        // Given
+        val imeValue = 50.dp
+        state.updateValuesForTesting(initialKeyboardHeight = 0.dp)
+
+        // When
+        state.handleOffsetChange(20.dp, NAVIGATION_BAR_HEIGHT, source = imeValue, target = imeValue)
+
+        // Then
+        state.initialKeyboardHeight shouldBeEqualTo imeValue
+    }
+
+    @Test
+    fun `given extended keyboard height when attachment button is clicked, then keyboardHeight is set to initialKeyboardHeight`() {
+        // Given
+        val initialKeyboardHeight = 10.dp
+        state.updateValuesForTesting(previousOffset = 40.dp, keyboardHeight = 20.dp, initialKeyboardHeight = initialKeyboardHeight)
+
+        // When
+        state.showOptions()
+        state.handleOffsetChange(0.dp, NAVIGATION_BAR_HEIGHT, source = TARGET, target = SOURCE)
+
+        // Then
+        state.keyboardHeight shouldBeEqualTo 20.dp
+        state.optionsHeight shouldBeEqualTo initialKeyboardHeight
     }
 
     @Test
@@ -191,7 +264,12 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(previousOffset = 50.dp)
 
         // When
-        state.handleOffsetChange(10.dp, NAVIGATION_BAR_HEIGHT)
+        state.handleOffsetChange(
+            10.dp,
+            NAVIGATION_BAR_HEIGHT,
+            SOURCE,
+            TARGET
+        )
 
         // Then
         state.optionsHeight shouldBeEqualTo 10.dp
@@ -202,5 +280,7 @@ class MessageCompositionInputStateHolderTest {
     companion object {
         // I set it 0 to make tests more straight forward
         val NAVIGATION_BAR_HEIGHT = 0.dp
+        val SOURCE = 0.dp
+        val TARGET = 50.dp
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4985" title="WPB-4985" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4985</a>  [Android]- Keyboard behaviour when trying to attach GIFs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some keyboards are adding additional space for GIFs for example

### Causes (Optional)

After opening attachments view height is too big

### Solutions

Save initial keyboard size to get back to proper height after additional gifs space is hidden



### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
| Before | After |
| ----------- | ------------ |
| https://github.com/wireapp/wire-android-reloaded/assets/13151239/04bc3443-66b0-4a15-9064-b36a7743aa22 |  https://github.com/wireapp/wire-android-reloaded/assets/13151239/9732798e-1316-4438-8a57-ac6be84363f9  |




----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
