### PR TITLE
fix: disable conversation mute icon + UI fixes [WPB-3897][WPB-3658]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/StatusBox.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/StatusBox.kt
@@ -48,8 +48,8 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 fun StatusBox(
     statusText: String,
     modifier: Modifier = Modifier,
-    textColor: Color = MaterialTheme.wireColorScheme.labelText,
-    badgeColor: Color = MaterialTheme.wireColorScheme.surface,
+    textColor: Color = MaterialTheme.wireColorScheme.secondaryText,
+    badgeColor: Color = MaterialTheme.wireColorScheme.surfaceVariant,
     withBorder: Boolean = true,
 ) {
     Box(
@@ -61,7 +61,7 @@ fun StatusBox(
                 BorderStroke(
                     width = 1.dp,
                     color = if (withBorder) {
-                        MaterialTheme.wireColorScheme.divider
+                        MaterialTheme.wireColorScheme.outline
                     } else {
                         badgeColor
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -192,7 +192,7 @@ private fun QuotedMessageContent(
             )
             .border(
                 width = 1.dp,
-                color = MaterialTheme.wireColorScheme.divider,
+                color = MaterialTheme.wireColorScheme.outline,
                 shape = quoteOutlineShape
             )
             .padding(dimensions().spacing4x)
@@ -254,7 +254,7 @@ private fun QuotedMessageTopRow(
             )
         }
         senderName?.let {
-            Text(text = senderName, style = typography().label02, color = colorsScheme().secondaryText)
+            Text(text = senderName, style = typography().label02, color = colorsScheme().onSurfaceVariant)
         }
     }
 }
@@ -381,7 +381,7 @@ private fun QuotedImage(
                 )
                 .border(
                     width = 1.dp,
-                    color = MaterialTheme.wireColorScheme.divider,
+                    color = MaterialTheme.wireColorScheme.outline,
                     shape = quoteOutlineShape
                 )
                 .padding(dimensions().spacing4x)
@@ -434,7 +434,7 @@ private fun AutosizeContainer(
                 }.clip(RoundedCornerShape(dimensions().spacing8x))
                 .border(
                     width = 1.dp,
-                    color = MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline,
+                    color = MaterialTheme.wireColorScheme.outline,
                     shape = RoundedCornerShape(dimensions().spacing8x)
                 ),
             alignment = Alignment.Center,
@@ -482,7 +482,7 @@ private fun MainContentText(text: String, fontStyle: FontStyle = FontStyle.Norma
         style = typography().subline01,
         maxLines = TEXT_QUOTE_MAX_LINES,
         overflow = TextOverflow.Ellipsis,
-        color = colorsScheme().secondaryText,
+        color = colorsScheme().onSurfaceVariant,
         fontStyle = fontStyle
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
@@ -80,7 +80,7 @@ internal fun MessageAsset(
         modifier = Modifier
             .padding(top = dimensions().spacing4x)
             .background(
-                color = MaterialTheme.wireColorScheme.onPrimary,
+                color = MaterialTheme.wireColorScheme.surfaceVariant,
                 shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
             )
             .border(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
@@ -216,7 +216,6 @@ fun ConversationRouterHomeBridge(
                         isFromArchive = conversationsSource.isArchive(),
                         hasNoConversations = hasNoConversations,
                         onEditConversation = onEditConversationItem,
-                        onOpenConversationNotificationsSettings = onEditNotifications,
                         onOpenConversation = onOpenConversation,
                         onOpenUserProfile = onOpenUserProfile,
                         onJoinedCall = onJoinedCall,
@@ -251,7 +250,6 @@ fun ConversationRouterHomeBridge(
                         onOpenConversation = onOpenConversation,
                         onEditConversation = onEditConversationItem,
                         onOpenUserProfile = onOpenUserProfile,
-                        onOpenConversationNotificationsSettings = onEditNotifications,
                         onJoinCall = { viewModel.joinOngoingCall(it, onJoinedCall) },
                         onPermanentPermissionDecline = viewModel::showCallingPermissionDialog
                     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/AllConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/AllConversationScreen.kt
@@ -84,7 +84,6 @@ fun AllConversationScreenContent(
     isFromArchive: Boolean = false,
     viewModel: ConversationListViewModel = hiltViewModel(),
     onEditConversation: (ConversationItem) -> Unit,
-    onOpenConversationNotificationsSettings: (ConversationItem) -> Unit,
     onOpenConversation: (ConversationId) -> Unit,
     onOpenUserProfile: (UserId) -> Unit,
     onJoinedCall: (ConversationId) -> Unit,
@@ -114,7 +113,6 @@ fun AllConversationScreenContent(
             onOpenConversation = onOpenConversation,
             onEditConversation = onEditConversation,
             onOpenUserProfile = onOpenUserProfile,
-            onOpenConversationNotificationsSettings = onOpenConversationNotificationsSettings,
             onJoinCall = {
                 callConversationIdToJoin.value = it
                 viewModel.joinOngoingCall(it, onJoinedCall)
@@ -168,7 +166,6 @@ fun PreviewAllConversationScreen() {
         conversations = persistentMapOf(),
         hasNoConversations = false,
         onEditConversation = {},
-        onOpenConversationNotificationsSettings = {},
         onOpenConversation = {},
         onOpenUserProfile = {},
         onJoinedCall = {},
@@ -183,7 +180,6 @@ fun ConversationListEmptyStateScreenPreview() {
         conversations = persistentMapOf(),
         hasNoConversations = true,
         onEditConversation = {},
-        onOpenConversationNotificationsSettings = {},
         onOpenConversation = {},
         onOpenUserProfile = {},
         onJoinedCall = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/call/CallsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/call/CallsScreen.kt
@@ -103,7 +103,6 @@ fun CallContent(
                 openConversation = onCallItemClick,
                 openMenu = onEditConversationItem,
                 openUserProfile = onOpenUserProfile,
-                openNotificationsOptions = openConversationNotificationsSettings,
                 joinCall = { },
                 onPermanentPermissionDecline = {},
                 searchQuery = ""
@@ -119,7 +118,6 @@ fun CallContent(
                 openConversation = onCallItemClick,
                 openMenu = onEditConversationItem,
                 openUserProfile = onOpenUserProfile,
-                openNotificationsOptions = openConversationNotificationsSettings,
                 joinCall = { },
                 onPermanentPermissionDecline = {},
                 searchQuery = " "

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -60,7 +60,6 @@ fun ConversationItemFactory(
     openConversation: (ConversationId) -> Unit,
     openMenu: (ConversationItem) -> Unit,
     openUserProfile: (UserId) -> Unit,
-    openNotificationsOptions: (ConversationItem) -> Unit,
     joinCall: (ConversationId) -> Unit,
     onPermanentPermissionDecline: () -> Unit
 ) {
@@ -104,9 +103,6 @@ fun ConversationItemFactory(
             }
         },
         onConversationItemClick = onConversationItemClick,
-        onMutedIconClick = {
-            openNotificationsOptions(conversation)
-        },
         onJoinCallClick = {
             joinCall(conversation.conversationId)
         },
@@ -123,7 +119,6 @@ private fun GeneralConversationItem(
     isSelectable: Boolean,
     subTitle: @Composable () -> Unit = {},
     onConversationItemClick: Clickable,
-    onMutedIconClick: () -> Unit,
     onJoinCallClick: () -> Unit,
     onPermanentPermissionDecline: () -> Unit
 ) {
@@ -163,7 +158,7 @@ private fun GeneralConversationItem(
                                     horizontalArrangement = Arrangement.spacedBy(dimensions().spacing8x)
                                 ) {
                                     if (mutedStatus != MutedConversationStatus.AllAllowed) {
-                                        MutedConversationBadge(onMutedIconClick)
+                                        MutedConversationBadge()
                                     }
                                     EventBadgeFactory(eventType = conversation.badgeEventType)
                                 }
@@ -202,7 +197,7 @@ private fun GeneralConversationItem(
                                 horizontalArrangement = Arrangement.spacedBy(dimensions().spacing8x)
                             ) {
                                 if (mutedStatus != MutedConversationStatus.AllAllowed) {
-                                    MutedConversationBadge(onMutedIconClick)
+                                    MutedConversationBadge()
                                 }
                                 EventBadgeFactory(eventType = conversation.badgeEventType)
                             }
@@ -255,7 +250,7 @@ fun PreviewGroupConversationItemWithUnreadCount() {
         searchQuery = "",
         isSelectableItem = false,
         isChecked = false,
-        {}, {}, {}, {}, {}, {}, {}
+        {}, {}, {}, {}, {}, {},
     )
 }
 
@@ -278,7 +273,7 @@ fun PreviewGroupConversationItemWithNoBadges() {
         searchQuery = "",
         isSelectableItem = false,
         isChecked = false,
-        {}, {}, {}, {}, {}, {}, {}
+        {}, {}, {}, {}, {}, {},
     )
 }
 
@@ -301,7 +296,7 @@ fun PreviewGroupConversationItemWithMutedBadgeAndUnreadMentionBadge() {
         searchQuery = "",
         isSelectableItem = false,
         isChecked = false,
-        {}, {}, {}, {}, {}, {}, {}
+        {}, {}, {}, {}, {}, {},
     )
 }
 
@@ -325,7 +320,7 @@ fun PreviewGroupConversationItemWithOngoingCall() {
         searchQuery = "",
         isSelectableItem = false,
         isChecked = false,
-        {}, {}, {}, {}, {}, {}, {}
+        {}, {}, {}, {}, {}, {},
     )
 }
 
@@ -344,7 +339,7 @@ fun PreviewConnectionConversationItemWithReceivedConnectionRequestBadge() {
         searchQuery = "",
         isSelectableItem = false,
         isChecked = false,
-        {}, {}, {}, {}, {}, {}, {}
+        {}, {}, {}, {}, {}, {}
     )
 }
 
@@ -363,7 +358,7 @@ fun PreviewConnectionConversationItemWithSentConnectRequestBadge() {
         searchQuery = "",
         isSelectableItem = false,
         isChecked = false,
-        {}, {}, {}, {}, {}, {}, {}
+        {}, {}, {}, {}, {}, {}
     )
 }
 
@@ -386,6 +381,6 @@ fun PreviewPrivateConversationItemWithBlockedBadge() {
         searchQuery = "",
         isSelectableItem = false,
         isChecked = false,
-        {}, {}, {}, {}, {}, {}, {}
+        {}, {}, {}, {}, {}, {}
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -50,7 +50,6 @@ fun ConversationList(
     onOpenConversation: (ConversationId) -> Unit,
     onEditConversation: (ConversationItem) -> Unit,
     onOpenUserProfile: (UserId) -> Unit,
-    onOpenConversationNotificationsSettings: (ConversationItem) -> Unit,
     onJoinCall: (ConversationId) -> Unit,
     onPermanentPermissionDecline: () -> Unit
 ) {
@@ -93,7 +92,6 @@ fun ConversationList(
                     openConversation = onOpenConversation,
                     openMenu = onEditConversation,
                     openUserProfile = onOpenUserProfile,
-                    openNotificationsOptions = onOpenConversationNotificationsSettings,
                     joinCall = onJoinCall,
                     onPermanentPermissionDecline = onPermanentPermissionDecline
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
@@ -39,12 +39,12 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 
 @Composable
-fun MutedConversationBadge(onClick: () -> Unit) {
+fun MutedConversationBadge() {
     Box(modifier = Modifier
         .width(dimensions().spacing24x)
         .height(dimensions().spacing20x)) {
         WireSecondaryButton(
-            onClick = onClick,
+            onClick = {},
             leadingIcon = {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_mute),
@@ -65,5 +65,5 @@ fun MutedConversationBadge(onClick: () -> Unit) {
 @Preview
 @Composable
 fun PreviewMutedConversationBadge() {
-    MutedConversationBadge {}
+    MutedConversationBadge()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
@@ -43,6 +43,7 @@ import com.wire.android.R
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
 fun MutedConversationBadge() {
@@ -69,7 +70,7 @@ fun MutedConversationBadge() {
     }
 }
 
-@Preview(showBackground = true)
+@PreviewMultipleThemes
 @Composable
 fun PreviewMutedConversationBadge() {
     MutedConversationBadge()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.ui.common.colorsScheme

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
@@ -20,49 +20,56 @@
 
 package com.wire.android.ui.home.conversationslist.common
 
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import com.wire.android.R
-import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireColorScheme
 
 @Composable
 fun MutedConversationBadge() {
-    Box(modifier = Modifier
-        .width(dimensions().spacing24x)
-        .height(dimensions().spacing20x)) {
-        WireSecondaryButton(
-            onClick = {},
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_mute),
-                    contentDescription = stringResource(R.string.content_description_muted_conversation),
-                    modifier = Modifier.size(dimensions().spacing12x),
-                    tint = colorsScheme().onSecondaryButtonEnabled
-                )
-            },
-            fillMaxWidth = false,
-            minSize = DpSize(width = dimensions().spacing24x, height = dimensions().spacing20x),
-            minClickableSize = DpSize(width = dimensions().spacing24x, height = dimensions().spacing20x),
-            shape = RoundedCornerShape(size = dimensions().spacing6x),
-            contentPadding = PaddingValues(dimensions().spacing0x),
+    Box(
+        modifier = Modifier
+            .width(dimensions().spacing24x)
+            .height(dimensions().spacing20x)
+            .padding(PaddingValues(dimensions().spacing0x))
+            .clip(shape = RoundedCornerShape(size = dimensions().spacing6x))
+            .clickable(enabled = false, onClick = {})
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline,
+                shape = RoundedCornerShape(dimensions().spacing6x)
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_mute),
+            contentDescription = stringResource(R.string.content_description_muted_conversation),
+            modifier = Modifier.size(dimensions().spacing12x),
+            tint = colorsScheme().onSecondaryButtonEnabled
         )
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun PreviewMutedConversationBadge() {
     MutedConversationBadge()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/mention/MentionScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/mention/MentionScreen.kt
@@ -103,7 +103,6 @@ private fun MentionContent(
                 openConversation = onMentionItemClick,
                 openMenu = onEditConversationItem,
                 openUserProfile = onOpenUserProfile,
-                openNotificationsOptions = openConversationNotificationsSettings,
                 joinCall = {},
                 onPermanentPermissionDecline = {},
                 searchQuery = ""
@@ -119,7 +118,6 @@ private fun MentionContent(
                 openConversation = onMentionItemClick,
                 openMenu = onEditConversationItem,
                 openUserProfile = onOpenUserProfile,
-                openNotificationsOptions = openConversationNotificationsSettings,
                 joinCall = {},
                 onPermanentPermissionDecline = {},
                 searchQuery = ""

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/search/SearchConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/search/SearchConversationScreen.kt
@@ -56,7 +56,6 @@ fun SearchConversationScreen(
     onOpenConversation: (ConversationId) -> Unit,
     onEditConversation: (ConversationItem) -> Unit,
     onOpenUserProfile: (UserId) -> Unit,
-    onOpenConversationNotificationsSettings: (ConversationItem) -> Unit,
     onJoinCall: (ConversationId) -> Unit,
     onPermanentPermissionDecline: () -> Unit
 ) {
@@ -70,7 +69,6 @@ fun SearchConversationScreen(
                 onOpenConversation = onOpenConversation,
                 onEditConversation = onEditConversation,
                 onOpenUserProfile = onOpenUserProfile,
-                onOpenConversationNotificationsSettings = onOpenConversationNotificationsSettings,
                 onJoinCall = onJoinCall,
                 onPermanentPermissionDecline = onPermanentPermissionDecline
             )

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -420,7 +420,6 @@ private fun ImportMediaContent(
             onOpenConversation = onConversationClicked,
             onEditConversation = {},
             onOpenUserProfile = {},
-            onOpenConversationNotificationsSettings = {},
             onJoinCall = {},
             onPermanentPermissionDecline = {}
         )

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -142,7 +142,7 @@ private val LightWireColorScheme = WireColorScheme(
     background = WireColorPalette.Gray20, onBackground = Color.Black,
     backgroundVariant = WireColorPalette.Gray10, onBackgroundVariant = Color.Black,
     surface = Color.White, onSurface = Color.Black,
-    surfaceVariant = Color.White, onSurfaceVariant = Color.Black,
+    surfaceVariant = Color.White , onSurfaceVariant = Color.Black,
     inverted = Color.Black, onInverted = Color.White,
     primaryButtonEnabled = WireColorPalette.LightBlue500, onPrimaryButtonEnabled = Color.White,
     primaryButtonDisabled = WireColorPalette.Gray50, onPrimaryButtonDisabled = WireColorPalette.Gray80,

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -142,7 +142,7 @@ private val LightWireColorScheme = WireColorScheme(
     background = WireColorPalette.Gray20, onBackground = Color.Black,
     backgroundVariant = WireColorPalette.Gray10, onBackgroundVariant = Color.Black,
     surface = Color.White, onSurface = Color.Black,
-    surfaceVariant = Color.White , onSurfaceVariant = Color.Black,
+    surfaceVariant = Color.White, onSurfaceVariant = Color.Black,
     inverted = Color.Black, onInverted = Color.White,
     primaryButtonEnabled = WireColorPalette.LightBlue500, onPrimaryButtonEnabled = Color.White,
     primaryButtonDisabled = WireColorPalette.Gray50, onPrimaryButtonDisabled = WireColorPalette.Gray80,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3897" title="WPB-3897" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-3897</a>  [Android] Remove button functionality from "muted" indication in the conversation list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. Muting icon at the top right side of conversation items was clickable and displaying the muting options on click. This was causing that archived conversations could still be unmuted from archive screen.
2. Attribute `surfaceVariant` and `onSurfaceVariant` were not being applied correctly on some UI items. This was causing some visual incoherences with assets and quoted messages on Dark mode. 

### Solutions

1. Redesign the `MutedConversationBadge` item to just render an icon instead of a button.
2. Updated correct values and referenced them correctly from affected message items.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
