### PR TITLE
feat: app lock UI and UX adjustments [WPB-4695]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCase.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 @Singleton
 class ObserveAppLockConfigUseCase @Inject constructor(
@@ -37,12 +39,12 @@ class ObserveAppLockConfigUseCase @Inject constructor(
         }
 }
 
-sealed class AppLockConfig(open val timeoutInSeconds: Int = DEFAULT_TIMEOUT) {
+sealed class AppLockConfig(open val timeout: Duration = DEFAULT_TIMEOUT) {
     data object Disabled : AppLockConfig()
     data object Enabled : AppLockConfig()
-    data class EnforcedByTeam(override val timeoutInSeconds: Int) : AppLockConfig(timeoutInSeconds)
+    data class EnforcedByTeam(override val timeout: Duration) : AppLockConfig(timeout)
 
     companion object {
-        const val DEFAULT_TIMEOUT = 60
+        val DEFAULT_TIMEOUT = 60.seconds
     }
 }

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -94,6 +94,7 @@ private fun NavOptionsBuilder.popUpTo(
     getNavBackStackEntry: () -> NavBackStackEntry?,
 ) {
     getNavBackStackEntry()?.let { entry ->
+        appLogger.d("[$TAG] -> popUpTo:${entry.destination.route?.obfuscateId()} inclusive:${getInclusive(entry)}")
         popUpTo(entry.destination.id) {
             this.inclusive = getInclusive(entry)
         }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -187,7 +187,7 @@ class WireActivity : AppCompatActivity() {
                         setUpNavigation(navigator.navController, onComplete, scope)
                         isLoaded = true
                         handleScreenshotCensoring()
-                        handleAppLock()
+                        handleAppLock(navigator::navigate)
                         handleDialogs(navigator::navigate)
                     }
                 }
@@ -239,7 +239,7 @@ class WireActivity : AppCompatActivity() {
     }
 
     @Composable
-    private fun handleAppLock() {
+    private fun handleAppLock(navigate: (NavigationCommand) -> Unit) {
         LaunchedEffect(Unit) {
             lockCodeTimeManager.isLocked()
                 .filter { it }
@@ -249,13 +249,9 @@ class WireActivity : AppCompatActivity() {
                         .canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG)
 
                     if (canAuthenticateWithBiometrics == BiometricManager.BIOMETRIC_SUCCESS) {
-                        navigationCommands.emit(
-                            NavigationCommand(AppUnlockWithBiometricsScreenDestination)
-                        )
+                        navigate(NavigationCommand(AppUnlockWithBiometricsScreenDestination, BackStackMode.UPDATE_EXISTED))
                     } else {
-                        navigationCommands.emit(
-                            NavigationCommand(EnterLockCodeScreenDestination)
-                        )
+                        navigate(NavigationCommand(EnterLockCodeScreenDestination, BackStackMode.UPDATE_EXISTED))
                     }
                 }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsViewModel.kt
@@ -66,7 +66,7 @@ class CreateAccountDetailsViewModel @Inject constructor(
         detailsState = detailsState.copy(loading = true, continueEnabled = false)
         viewModelScope.launch {
             val detailsError = when {
-                !validatePasswordUseCase(detailsState.password.text) ->
+                !validatePasswordUseCase(detailsState.password.text).isValid ->
                     CreateAccountDetailsViewState.DetailsError.TextFieldError.InvalidPasswordError
 
                 detailsState.password.text != detailsState.confirmPassword.text ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/AppUnlockWithBiometricsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/AppUnlockWithBiometricsScreen.kt
@@ -80,7 +80,7 @@ fun AppUnlockWithBiometricsScreen(
                     navigator.navigate(
                         NavigationCommand(
                             EnterLockCodeScreenDestination(),
-                            BackStackMode.CLEAR_WHOLE
+                            BackStackMode.REMOVE_CURRENT
                         )
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/EnterLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/EnterLockCodeScreen.kt
@@ -28,15 +28,20 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.input.ImeAction
@@ -46,16 +51,18 @@ import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
+import com.wire.android.navigation.rememberNavigator
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
-import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.rememberBottomBarElevationState
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
-import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
 import java.util.Locale
 
 @RootNavGraph
@@ -94,19 +101,14 @@ fun EnterLockCodeScreenContent(
         onBackPress()
     }
 
-    WireScaffold(topBar = {
-        WireCenterAlignedTopAppBar(
-            onNavigationPressed = onBackPress,
-            elevation = dimensions().spacing0x,
-            title = stringResource(id = R.string.settings_enter_lock_screen_title)
-        )
-    }) { internalPadding ->
+    WireScaffold { internalPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(internalPadding)
         ) {
             Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
                     .weight(weight = 1f, fill = true)
                     .verticalScroll(scrollState)
@@ -115,11 +117,27 @@ fun EnterLockCodeScreenContent(
                         testTagsAsResourceId = true
                     }
             ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_wire_logo),
+                    tint = MaterialTheme.colorScheme.onBackground,
+                    contentDescription = stringResource(id = R.string.content_description_welcome_wire_logo),
+                    modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing56x)
+                )
+
+                Text(
+                    text = stringResource(id = R.string.settings_enter_lock_screen_title),
+                    style = MaterialTheme.wireTypography.title02,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.padding(
+                        top = MaterialTheme.wireDimensions.spacing32x,
+                        bottom = MaterialTheme.wireDimensions.spacing56x
+                    )
+                )
+
                 WirePasswordTextField(
                     value = state.password,
                     onValueChange = onPasswordChanged,
                     labelMandatoryIcon = true,
-                    descriptionText = stringResource(R.string.create_account_details_password_description),
                     imeAction = ImeAction.Done,
                     modifier = Modifier
                         .testTag("password"),
@@ -171,6 +189,21 @@ private fun ContinueButton(
             modifier = Modifier
                 .fillMaxWidth()
                 .testTag("continue_button")
+        )
+    }
+}
+
+@Composable
+@PreviewMultipleThemes
+fun PreviewEnterLockCodeScreen() {
+    WireTheme(isPreview = true) {
+        EnterLockCodeScreenContent(
+            navigator = rememberNavigator {},
+            state = EnterLockCodeViewState(),
+            scrollState = rememberScrollState(),
+            onPasswordChanged = {},
+            onBackPress = {},
+            onContinue = {}
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/EnterLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/EnterLockScreenViewModel.kt
@@ -48,7 +48,7 @@ class EnterLockScreenViewModel @Inject constructor(
             error = EnterLockCodeError.None,
             password = password
         )
-        state = if (validatePassword(password.text)) {
+        state = if (validatePassword(password.text).isValid) {
             state.copy(
                 continueEnabled = true,
                 isUnlockEnabled = true
@@ -64,7 +64,7 @@ class EnterLockScreenViewModel @Inject constructor(
         state = state.copy(continueEnabled = false)
         // the continue button is enabled iff the password is valid
         // this check is for safety only
-        if (!validatePassword(state.password.text)) {
+        if (!validatePassword(state.password.text).isValid) {
             state = state.copy(isUnlockEnabled = false)
         } else {
             viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/LockCodeTimeManager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/LockCodeTimeManager.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.android.ui.home.appLock
 
+import com.wire.android.appLogger
 import com.wire.android.di.ApplicationScope
 import com.wire.android.feature.AppLockConfig
 import com.wire.android.feature.ObserveAppLockConfigUseCase
@@ -27,6 +28,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -51,6 +53,7 @@ class LockCodeTimeManager @Inject constructor(
         runBlocking {
             observeAppLockConfigUseCase().firstOrNull()?.let { appLockConfig ->
                 if (appLockConfig !is AppLockConfig.Disabled) {
+                    appLogger.i("$TAG app initially locked")
                     isLockedFlow.value = true
                 }
             }
@@ -62,16 +65,23 @@ class LockCodeTimeManager @Inject constructor(
                 observeAppLockConfigUseCase(),
                 currentScreenManager.isAppVisibleFlow(),
                 ::Pair
-            ).flatMapLatest { (appLockConfig, isInForeground) ->
+            )
+                .distinctUntilChanged()
+                .flatMapLatest { (appLockConfig, isInForeground) ->
                 when {
                     appLockConfig is AppLockConfig.Disabled -> flowOf(false)
 
                     !isInForeground && !isLockedFlow.value -> flow {
+                        appLogger.i("$TAG lock is enabled and app in the background, lock count started")
                         delay(appLockConfig.timeout.inWholeMilliseconds)
+                        appLogger.i("$TAG lock count ended, app state is locked")
                         emit(true)
                     }
 
-                    else -> emptyFlow()
+                    else -> {
+                        appLogger.i("$TAG no change to lock state, isInForeground: $isInForeground, isLocked: ${isLockedFlow.value}")
+                        emptyFlow()
+                    }
                 }
             }.collectLatest {
                 isLockedFlow.value = it
@@ -80,8 +90,13 @@ class LockCodeTimeManager @Inject constructor(
     }
 
     fun appUnlocked() {
+        appLogger.i("$TAG app unlocked")
         isLockedFlow.value = false
     }
 
     fun isLocked(): Flow<Boolean> = isLockedFlow
+
+    companion object {
+        private const val TAG = "LockCodeTimeManager"
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/LockCodeTimeManager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/LockCodeTimeManager.kt
@@ -66,7 +66,7 @@ class LockCodeTimeManager @Inject constructor(
                 appVisibilityTimestampData.isAppVisible
                         && appLockConfig !is AppLockConfig.Disabled
                         && appVisibilityTimestampData.timestamp >= 0
-                        && (currentTimestamp() - appVisibilityTimestampData.timestamp) > (appLockConfig.timeoutInSeconds * 1000)
+                        && (currentTimestamp() - appVisibilityTimestampData.timestamp) > (appLockConfig.timeout.inWholeMilliseconds)
             }
                 .distinctUntilChanged()
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/SetLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/SetLockCodeScreen.kt
@@ -126,7 +126,10 @@ fun SetLockCodeScreenContent(
                     }
             ) {
                 Text(
-                    text = stringResource(id = R.string.settings_set_lock_screen_description, state.timeout.toTimeLongLabelUiText()),
+                    text = stringResource(
+                        id = R.string.settings_set_lock_screen_description,
+                        state.timeout.toTimeLongLabelUiText().asString()
+                    ),
                     style = MaterialTheme.wireTypography.body01,
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/SetLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/SetLockCodeScreen.kt
@@ -19,23 +19,28 @@ package com.wire.android.ui.home.appLock
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
@@ -46,17 +51,24 @@ import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
+import com.wire.android.navigation.rememberNavigator
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.rememberBottomBarElevationState
 import com.wire.android.ui.common.scaffold.WireScaffold
+import com.wire.android.ui.common.spacers.HorizontalSpace
+import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.toTimeLongLabelUiText
+import com.wire.android.util.ui.PreviewMultipleThemes
+import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
 import java.util.Locale
 
 @RootNavGraph
@@ -114,12 +126,11 @@ fun SetLockCodeScreenContent(
                     }
             ) {
                 Text(
-                    text = stringResource(id = R.string.settings_set_lock_screen_description),
+                    text = stringResource(id = R.string.settings_set_lock_screen_description, state.timeout.toTimeLongLabelUiText()),
                     style = MaterialTheme.wireTypography.body01,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(
-                            horizontal = MaterialTheme.wireDimensions.spacing16x,
                             vertical = MaterialTheme.wireDimensions.spacing24x
                         )
                         .testTag("registerText")
@@ -128,7 +139,6 @@ fun SetLockCodeScreenContent(
                     value = state.password,
                     onValueChange = onPasswordChanged,
                     labelMandatoryIcon = true,
-                    descriptionText = stringResource(R.string.create_account_details_password_description),
                     imeAction = ImeAction.Done,
                     modifier = Modifier
                         .testTag("password"),
@@ -137,6 +147,8 @@ fun SetLockCodeScreenContent(
                     placeholderText = stringResource(R.string.settings_set_lock_screen_passcode_label),
                     labelText = stringResource(R.string.settings_set_lock_screen_passcode_label).uppercase(Locale.getDefault())
                 )
+                VerticalSpace.x24()
+                PasswordVerificationGroup(state.passwordValidation)
                 Spacer(modifier = Modifier.weight(1f))
             }
 
@@ -148,7 +160,7 @@ fun SetLockCodeScreenContent(
                 }
             ) {
                 Box(modifier = Modifier.padding(MaterialTheme.wireDimensions.spacing16x)) {
-                    val enabled = state.password.text.isNotBlank() && state.isPasswordValid
+                    val enabled = state.password.text.isNotBlank() && state.passwordValidation.isValid
                     ContinueButton(
                         enabled = enabled,
                         onContinue = onContinue
@@ -156,6 +168,51 @@ fun SetLockCodeScreenContent(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun PasswordVerificationGroup(validatePasswordResult: ValidatePasswordResult) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.wireDimensions.spacing2x),
+    ) {
+        PasswordVerificationItem(
+            isInvalid = (validatePasswordResult as? ValidatePasswordResult.Invalid)?.tooShort ?: false,
+            text = stringResource(id = R.string.password_validation_length)
+        )
+        PasswordVerificationItem(
+            isInvalid = (validatePasswordResult as? ValidatePasswordResult.Invalid)?.missingLowercaseCharacter ?: false,
+            text = stringResource(id = R.string.password_validation_lowercase)
+        )
+        PasswordVerificationItem(
+            isInvalid = (validatePasswordResult as? ValidatePasswordResult.Invalid)?.missingUppercaseCharacter ?: false,
+            text = stringResource(id = R.string.password_validation_uppercase)
+        )
+        PasswordVerificationItem(
+            isInvalid = (validatePasswordResult as? ValidatePasswordResult.Invalid)?.missingDigit ?: false,
+            text = stringResource(id = R.string.password_validation_digit)
+        )
+        PasswordVerificationItem(
+            isInvalid = (validatePasswordResult as? ValidatePasswordResult.Invalid)?.missingSpecialCharacter ?: false,
+            text = stringResource(id = R.string.password_validation_special_character)
+        )
+    }
+}
+
+@Composable
+private fun PasswordVerificationItem(isInvalid: Boolean, text: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            painter = painterResource(id = if (isInvalid) R.drawable.ic_validation_block else R.drawable.ic_validation_check),
+            tint = if (isInvalid) MaterialTheme.wireColorScheme.secondaryText else MaterialTheme.wireColorScheme.positive,
+            contentDescription = null,
+        )
+        HorizontalSpace.x8()
+        Text(
+            text = text,
+            style = MaterialTheme.wireTypography.label04,
+            color = MaterialTheme.wireColorScheme.secondaryText,
+        )
     }
 }
 
@@ -175,6 +232,37 @@ private fun ContinueButton(
             modifier = Modifier
                 .fillMaxWidth()
                 .testTag("continue_button")
+        )
+    }
+}
+
+@Composable
+@PreviewMultipleThemes
+fun PreviewPasswordVerificationGroup() {
+    WireTheme {
+        PasswordVerificationGroup(
+            ValidatePasswordResult.Invalid(
+                tooShort = true,
+                missingLowercaseCharacter = false,
+                missingUppercaseCharacter = false,
+                missingDigit = true,
+                missingSpecialCharacter = false,
+            )
+        )
+    }
+}
+
+@Composable
+@PreviewMultipleThemes
+fun PreviewSetLockCodeScreen() {
+    WireTheme(isPreview = true) {
+        SetLockCodeScreenContent(
+            navigator = rememberNavigator {},
+            state = SetLockCodeViewState(),
+            scrollState = rememberScrollState(),
+            onPasswordChanged = {},
+            onBackPress = {},
+            onContinue = {}
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/SetLockCodeViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/SetLockCodeViewState.kt
@@ -18,10 +18,14 @@
 package com.wire.android.ui.home.appLock
 
 import androidx.compose.ui.text.input.TextFieldValue
+import com.wire.android.feature.AppLockConfig
+import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
+import kotlin.time.Duration
 
 data class SetLockCodeViewState(
     val continueEnabled: Boolean = false,
     val password: TextFieldValue = TextFieldValue(),
-    val isPasswordValid: Boolean = false,
+    val passwordValidation: ValidatePasswordResult = ValidatePasswordResult.Invalid(),
+    val timeout: Duration = AppLockConfig.DEFAULT_TIMEOUT,
     val done: Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordGuestLinkViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordGuestLinkViewModel.kt
@@ -84,7 +84,7 @@ class CreatePasswordGuestLinkViewModel @Inject constructor(
     }
 
     private fun checkIfPasswordIsValidAndConfirmed() {
-        state = if (validatePassword(state.password.text) && state.password.text == state.passwordConfirm.text) {
+        state = if (validatePassword(state.password.text).isValid && state.password.text == state.passwordConfirm.text) {
             state.copy(isPasswordValid = true)
         } else {
             state.copy(isPasswordValid = false)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -47,6 +47,7 @@ import com.wire.android.ui.common.collectAsStateLifecycleAware
 import com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel
 import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
 import com.wire.android.ui.home.conversationslist.common.FolderHeader
+import com.wire.android.ui.home.settings.SwitchState
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.Conversation

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
@@ -36,17 +36,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.ArrowRightIcon
-import com.wire.android.ui.common.WireSwitch
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.clickable
-import com.wire.android.ui.common.spacers.HorizontalSpace
+import com.wire.android.ui.home.settings.SettingsOptionSwitch
+import com.wire.android.ui.home.settings.SwitchState
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
@@ -101,7 +99,7 @@ fun GroupConversationOptionsItem(
                 if (titleTrailingItem != null) {
                     Box(modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing8x)) { titleTrailingItem() }
                 }
-                ConversationOptionSwitch(switchState, trailingOnText)
+                SettingsOptionSwitch(switchState, trailingOnText)
 
                 if (arrowType == ArrowType.TITLE_ALIGNED) {
                     ArrowRight()
@@ -124,39 +122,6 @@ fun GroupConversationOptionsItem(
 }
 
 @Composable
-fun ConversationOptionSwitch(
-    switchState: SwitchState,
-    trailingOnText: String?
-) {
-    if (switchState is SwitchState.Visible) {
-        if (switchState.isOnOffVisible) {
-            HorizontalSpace.x8()
-            Text(
-                text = stringResource(if (switchState.value) R.string.label_on else R.string.label_off),
-                style = MaterialTheme.wireTypography.body01,
-                color = MaterialTheme.wireColorScheme.onBackground
-            )
-        }
-        if (trailingOnText != null) {
-            HorizontalSpace.x2()
-            Text(
-                text = trailingOnText,
-                style = MaterialTheme.wireTypography.body01,
-                color = MaterialTheme.wireColorScheme.secondaryText,
-            )
-        }
-        HorizontalSpace.x8()
-        if (switchState.isSwitchVisible) {
-            WireSwitch(
-                checked = switchState.value,
-                enabled = switchState is SwitchState.Enabled,
-                onCheckedChange = (switchState as? SwitchState.Enabled)?.onCheckedChange
-            )
-        }
-    }
-}
-
-@Composable
 private fun ArrowRight() {
     Box(
         modifier = Modifier.padding(
@@ -168,30 +133,6 @@ private fun ArrowRight() {
 
 enum class ArrowType {
     CENTER_ALIGNED, TITLE_ALIGNED, NONE
-}
-
-sealed class SwitchState {
-    object None : SwitchState()
-    sealed class Visible(
-        open val value: Boolean = false,
-        open val isOnOffVisible: Boolean = true,
-        open val isSwitchVisible: Boolean = true
-    ) : SwitchState()
-
-    data class Enabled(
-        override val value: Boolean = false,
-        override val isOnOffVisible: Boolean = true,
-        val onCheckedChange: ((Boolean) -> Unit)?
-    ) : Visible(value = value, isOnOffVisible = isOnOffVisible, isSwitchVisible = true)
-
-    data class Disabled(
-        override val value: Boolean = false,
-        override val isOnOffVisible: Boolean = true
-    ) : Visible(value = value, isOnOffVisible = isOnOffVisible, isSwitchVisible = true)
-
-    data class TextOnly(
-        override val value: Boolean = false,
-    ) : Visible(value = value, isOnOffVisible = true, isSwitchVisible = false)
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
@@ -58,11 +58,11 @@ import com.wire.android.ui.destinations.HomeScreenDestination
 import com.wire.android.ui.destinations.NewConversationSearchPeopleScreenDestination
 import com.wire.android.ui.home.conversations.details.options.ArrowType
 import com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsItem
-import com.wire.android.ui.home.conversations.details.options.SwitchState
 import com.wire.android.ui.home.newconversation.common.CreateGroupErrorDialog
 import com.wire.android.ui.home.newconversation.common.CreateGroupState
 import com.wire.android.ui.home.newconversation.NewConversationViewModel
 import com.wire.android.ui.home.newconversation.common.NewConversationNavGraph
+import com.wire.android.ui.home.settings.SwitchState
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.kalium.logic.data.id.ConversationId

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
@@ -59,6 +59,7 @@ fun SettingsItem(
     title: String? = null,
     text: String,
     @DrawableRes trailingIcon: Int? = null,
+    switchState: SwitchState = SwitchState.None,
     onRowPressed: Clickable = Clickable(false),
     onIconPressed: Clickable = Clickable(false)
 ) {
@@ -80,6 +81,7 @@ fun SettingsItem(
             )
         },
         actions = {
+            SettingsOptionSwitch(switchState = switchState)
             trailingIcon?.let {
                 Icon(
                     painter = painterResource(id = trailingIcon),
@@ -96,71 +98,90 @@ fun SettingsItem(
     )
 }
 
-sealed class SettingsItem(val direction: Direction, val id: String, val title: UIText) {
-    data object AppSettings : SettingsItem(
+sealed class SettingsItem(open val id: String, open val title: UIText) {
+
+    sealed class DirectionItem(
+        val direction: Direction,
+        override val id: String,
+        override val title: UIText
+    ) : SettingsItem(id, title)
+
+    sealed class SwitchItem(
+        open val switchState: SwitchState,
+        override val id: String,
+        override val title: UIText
+    ) : SettingsItem(id, title)
+
+    data object AppSettings : DirectionItem(
         id = "general_app_settings",
         title = UIText.StringResource(R.string.app_settings_screen_title),
         direction = AppSettingsScreenDestination
     )
 
-    data object YourAccount : SettingsItem(
+    data object YourAccount : DirectionItem(
         id = "your_account_settings",
         title = UIText.StringResource(R.string.settings_your_account_label),
         direction = MyAccountScreenDestination
     )
 
-    data object NetworkSettings : SettingsItem(
+    data object NetworkSettings : DirectionItem(
         id = "network_settings",
         title = UIText.StringResource(R.string.settings_network_settings_label),
         direction = NetworkSettingsScreenDestination
     )
 
-    data object ManageDevices : SettingsItem(
+    data object ManageDevices : DirectionItem(
         id = "manage_devices",
         title = UIText.StringResource(R.string.settings_manage_devices_label),
         direction = SelfDevicesScreenDestination
     )
 
-    data object PrivacySettings : SettingsItem(
+    data object PrivacySettings : DirectionItem(
         id = "privacy_settings",
         title = UIText.StringResource(R.string.settings_privacy_settings_label),
         direction = PrivacySettingsConfigScreenDestination
     )
 
-    data object Licenses : SettingsItem(
+    data object Licenses : DirectionItem(
         id = "other_licenses",
         title = UIText.StringResource(R.string.settings_licenses_settings_label),
         direction = LicensesScreenDestination
     )
 
-    data object BackupAndRestore : SettingsItem(
+    data object BackupAndRestore : DirectionItem(
         id = "backups_backup_and_restore",
         title = UIText.StringResource(R.string.backup_and_restore_screen_title),
         direction = BackupAndRestoreScreenDestination
     )
 
-    data object Support : SettingsItem(
+    data object Support : DirectionItem(
         id = "other_support",
         title = UIText.StringResource(R.string.support_screen_title),
         direction = SupportScreenDestination
     )
 
-    data object DebugSettings : SettingsItem(
+    data object DebugSettings : DirectionItem(
         id = "other_debug_settings",
         title = UIText.StringResource(R.string.debug_settings_screen_title),
         direction = DebugScreenDestination
     )
 
-    data object GiveFeedback : SettingsItem(
+    data object GiveFeedback : DirectionItem(
         id = "give_feedback",
         title = UIText.StringResource(R.string.give_feedback_screen_title),
         direction = GiveFeedbackDestination
     )
 
-    data object ReportBug : SettingsItem(
+    data object ReportBug : DirectionItem(
         id = "report_bug",
         title = UIText.StringResource(R.string.report_bug_screen_title),
         direction = ReportBugDestination
+    )
+
+    data class AppLock(override val switchState: SwitchState) : SwitchItem(
+        switchState = switchState,
+        id = "app_lock",
+        title = UIText.StringResource(R.string.settings_app_lock_title),
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsOptionSwitch.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsOptionSwitch.kt
@@ -1,0 +1,89 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.settings
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
+import com.wire.android.ui.common.WireSwitch
+import com.wire.android.ui.common.spacers.HorizontalSpace
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireTypography
+
+@Composable
+fun SettingsOptionSwitch(
+    switchState: SwitchState,
+    trailingOnText: String? = null
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        if (switchState is SwitchState.Visible) {
+            if (switchState.isOnOffVisible) {
+                HorizontalSpace.x8()
+                Text(
+                    text = stringResource(if (switchState.value) R.string.label_on else R.string.label_off),
+                    style = MaterialTheme.wireTypography.body01,
+                    color = MaterialTheme.wireColorScheme.onBackground
+                )
+            }
+            if (trailingOnText != null) {
+                HorizontalSpace.x2()
+                Text(
+                    text = trailingOnText,
+                    style = MaterialTheme.wireTypography.body01,
+                    color = MaterialTheme.wireColorScheme.secondaryText,
+                )
+            }
+            HorizontalSpace.x8()
+            if (switchState.isSwitchVisible) {
+                WireSwitch(
+                    checked = switchState.value,
+                    enabled = switchState is SwitchState.Enabled,
+                    onCheckedChange = (switchState as? SwitchState.Enabled)?.onCheckedChange
+                )
+            }
+        }
+    }
+}
+
+sealed class SwitchState {
+    data object None : SwitchState()
+    sealed class Visible(
+        open val value: Boolean = false,
+        open val isOnOffVisible: Boolean = true,
+        open val isSwitchVisible: Boolean = true
+    ) : SwitchState()
+
+    data class Enabled(
+        override val value: Boolean = false,
+        override val isOnOffVisible: Boolean = true,
+        val onCheckedChange: ((Boolean) -> Unit)?
+    ) : Visible(value = value, isOnOffVisible = isOnOffVisible, isSwitchVisible = true)
+
+    data class Disabled(
+        override val value: Boolean = false,
+        override val isOnOffVisible: Boolean = true
+    ) : Visible(value = value, isOnOffVisible = isOnOffVisible, isSwitchVisible = true)
+
+    data class TextOnly(
+        override val value: Boolean = false,
+    ) : Visible(value = value, isOnOffVisible = true, isSwitchVisible = false)
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
@@ -30,13 +30,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
 import com.wire.android.BuildConfig
 import com.wire.android.R
+import com.wire.android.feature.AppLockConfig
 import com.wire.android.model.Clickable
+import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.HomeNavGraph
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.handleNavigation
+import com.wire.android.ui.common.visbility.rememberVisibilityState
+import com.wire.android.ui.destinations.SetLockCodeScreenDestination
 import com.wire.android.ui.home.HomeStateHolder
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.extension.folderWithElements
@@ -44,17 +49,27 @@ import com.wire.android.util.extension.folderWithElements
 @HomeNavGraph
 @Destination
 @Composable
-fun SettingsScreen(homeStateHolder: HomeStateHolder) {
+fun SettingsScreen(
+    homeStateHolder: HomeStateHolder,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
     val lazyListState: LazyListState = rememberLazyListState()
     val context = LocalContext.current
     SettingsScreenContent(
         lazyListState = lazyListState,
+        settingsState = viewModel.state,
         onItemClicked = remember {
             {
                 it.direction.handleNavigation(
                     context = context,
                     handleOtherDirection = { homeStateHolder.navigator.navigate(NavigationCommand(it)) }
                 )
+            }
+        },
+        onAppLockSwitchChanged = remember {
+            { isChecked ->
+                if (isChecked) homeStateHolder.navigator.navigate(NavigationCommand(SetLockCodeScreenDestination, BackStackMode.NONE))
+                else viewModel.disableAppLock()
             }
         }
     )
@@ -63,10 +78,13 @@ fun SettingsScreen(homeStateHolder: HomeStateHolder) {
 @Composable
 fun SettingsScreenContent(
     lazyListState: LazyListState = rememberLazyListState(),
-    onItemClicked: (SettingsItem) -> Unit
+    settingsState: SettingsState,
+    onItemClicked: (SettingsItem.DirectionItem) -> Unit,
+    onAppLockSwitchChanged: (Boolean) -> Unit
 ) {
     val context = LocalContext.current
     val featureVisibilityFlags = LocalFeatureVisibilityFlags.current
+    val turnAppLockOffDialogState = rememberVisibilityState<Unit>()
 
     with(featureVisibilityFlags) {
         LazyColumn(
@@ -93,6 +111,13 @@ fun SettingsScreenContent(
                         add(SettingsItem.AppSettings)
                     }
                     add(SettingsItem.NetworkSettings)
+                    add(SettingsItem.AppLock(
+                        when (settingsState.appLockConfig) {
+                            AppLockConfig.Disabled -> SwitchState.Enabled(false, true, onAppLockSwitchChanged)
+                            AppLockConfig.Enabled -> SwitchState.Enabled(true, true) { turnAppLockOffDialogState.show(Unit) }
+                            is AppLockConfig.EnforcedByTeam -> SwitchState.TextOnly(true)
+                        }
+                    ))
                 },
                 onItemClicked = onItemClicked
             )
@@ -113,12 +138,14 @@ fun SettingsScreenContent(
             )
         }
     }
+
+    TurnAppLockOffDialog(dialogState = turnAppLockOffDialogState) { onAppLockSwitchChanged(false) }
 }
 
 private fun LazyListScope.folderWithElements(
     header: String,
     items: List<SettingsItem>,
-    onItemClicked: (SettingsItem) -> Unit
+    onItemClicked: (SettingsItem.DirectionItem) -> Unit
 ) {
     folderWithElements(
         header = header.uppercase(),
@@ -126,9 +153,13 @@ private fun LazyListScope.folderWithElements(
     ) { settingsItem ->
         SettingsItem(
             text = settingsItem.title.asString(),
-            onRowPressed = remember { Clickable(enabled = true) { onItemClicked(settingsItem) } },
-            onIconPressed = remember { Clickable(enabled = true) { onItemClicked(settingsItem) } },
-            trailingIcon = R.drawable.ic_arrow_right,
+            switchState = (settingsItem as? SettingsItem.SwitchItem)?.switchState ?: SwitchState.None,
+            onRowPressed = remember {
+                Clickable(enabled = settingsItem is SettingsItem.DirectionItem) {
+                    (settingsItem as? SettingsItem.DirectionItem)?.let(onItemClicked)
+                }
+            },
+            trailingIcon = if (settingsItem is SettingsItem.DirectionItem) R.drawable.ic_arrow_right else null,
         )
     }
 }
@@ -136,5 +167,5 @@ private fun LazyListScope.folderWithElements(
 @Preview(showBackground = false)
 @Composable
 fun PreviewSettingsScreen() {
-    SettingsScreenContent {}
+    SettingsScreenContent(rememberLazyListState(), SettingsState(), {}, {})
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsState.kt
@@ -14,20 +14,11 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
- *
- *
  */
-
-package com.wire.android.ui.home.settings.privacy
+package com.wire.android.ui.home.settings
 
 import com.wire.android.feature.AppLockConfig
 
-data class PrivacySettingsState(
-    val areReadReceiptsEnabled: Boolean = true,
-    val isTypingIndicatorEnabled: Boolean = true,
-    val screenshotCensoringConfig: ScreenshotCensoringConfig = ScreenshotCensoringConfig.ENABLED_BY_USER,
+data class SettingsState(
+    val appLockConfig: AppLockConfig = AppLockConfig.Disabled,
 )
-
-enum class ScreenshotCensoringConfig {
-    DISABLED, ENABLED_BY_USER, ENFORCED_BY_TEAM
-}

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModel.kt
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ */
+
+package com.wire.android.ui.home.settings
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.feature.ObserveAppLockConfigUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val observeAppLockConfigUseCase: ObserveAppLockConfigUseCase,
+    private val globalDataStore: GlobalDataStore,
+) : ViewModel() {
+    var state by mutableStateOf(SettingsState())
+        private set
+
+    init {
+        viewModelScope.launch {
+            observeAppLockConfigUseCase().collect { appLockConfig -> state = state.copy(appLockConfig = appLockConfig) }
+        }
+    }
+
+    fun disableAppLock() {
+        viewModelScope.launch {
+            globalDataStore.clearAppLockPasscode()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/TurnAppLockOffDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/TurnAppLockOffDialog.kt
@@ -1,0 +1,68 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ */
+
+package com.wire.android.ui.home.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
+import com.wire.android.ui.common.VisibilityState
+import com.wire.android.ui.common.WireDialog
+import com.wire.android.ui.common.WireDialogButtonProperties
+import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.common.button.WireButtonState
+import com.wire.android.ui.common.visbility.VisibilityState
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.ui.PreviewMultipleThemes
+
+@Composable
+fun TurnAppLockOffDialog(
+    dialogState: VisibilityState<Unit>,
+    turnOff: () -> Unit
+) {
+    VisibilityState(dialogState) { state ->
+        WireDialog(
+            title = stringResource(R.string.turn_app_lock_off_dialog_title),
+            text = stringResource(id = R.string.turn_app_lock_off_dialog_description),
+            buttonsHorizontalAlignment = true,
+            onDismiss = dialogState::dismiss,
+            dismissButtonProperties = WireDialogButtonProperties(
+                onClick = dialogState::dismiss,
+                text = stringResource(id = R.string.label_cancel),
+                state = WireButtonState.Default
+            ),
+            optionButton1Properties = WireDialogButtonProperties(
+                onClick = remember(state) { { turnOff().also { dialogState.dismiss() } } },
+                text = stringResource(id = R.string.label_turn_off),
+                type = WireDialogButtonType.Primary,
+                state = WireButtonState.Default
+            )
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewTurnAppLockOffDialog() {
+    WireTheme(isPreview = true) {
+        TurnAppLockOffDialog(VisibilityState(isVisible = true)) {}
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -38,7 +38,7 @@ import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.home.conversations.details.options.ArrowType
 import com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsItem
-import com.wire.android.ui.home.conversations.details.options.SwitchState
+import com.wire.android.ui.home.settings.SwitchState
 import com.wire.android.util.isWebsocketEnabledByDefault
 
 @RootNavGraph

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
@@ -44,6 +44,7 @@ import com.wire.android.ui.destinations.SetLockCodeScreenDestination
 import com.wire.android.ui.home.conversations.details.options.ArrowType
 import com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsItem
 import com.wire.android.ui.home.conversations.details.options.SwitchState
+import com.wire.android.util.toTimeLongLabelUiText
 
 @RootNavGraph
 @Destination
@@ -177,7 +178,7 @@ fun AppLockItem(
             )
         },
         arrowType = ArrowType.NONE,
-        subtitle = stringResource(id = R.string.settings_app_lock_description, state.timeoutInSeconds),
+        subtitle = stringResource(id = R.string.settings_app_lock_description, state.timeout.toTimeLongLabelUiText()),
         clickable = Clickable(
             enabled = state !is AppLockConfig.EnforcedByTeam,
             onClick = onCLick

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -33,18 +32,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.R
-import com.wire.android.feature.AppLockConfig
-import com.wire.android.model.Clickable
-import com.wire.android.navigation.BackStackMode
-import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
-import com.wire.android.ui.destinations.SetLockCodeScreenDestination
 import com.wire.android.ui.home.conversations.details.options.ArrowType
 import com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsItem
-import com.wire.android.ui.home.conversations.details.options.SwitchState
-import com.wire.android.util.toTimeLongLabelUiText
+import com.wire.android.ui.home.settings.SwitchState
 
 @RootNavGraph
 @Destination
@@ -61,18 +54,7 @@ fun PrivacySettingsConfigScreen(
             setTypingIndicatorState = ::setTypingIndicatorState,
             screenshotCensoringConfig = state.screenshotCensoringConfig,
             setScreenshotCensoringConfig = ::setScreenshotCensoringConfig,
-            appLockConfig = state.appLockConfig,
             onBackPressed = navigator::navigateBack,
-            disableAppLock = viewModel::disableAppLock,
-            enableAppLock = {
-                // navigate to set app lock screen
-                navigator.navigate(
-                    NavigationCommand(
-                        SetLockCodeScreenDestination,
-                        backStackMode = BackStackMode.NONE
-                    )
-                )
-            }
         )
     }
 }
@@ -85,10 +67,7 @@ fun PrivacySettingsScreenContent(
     setTypingIndicatorState: (Boolean) -> Unit,
     screenshotCensoringConfig: ScreenshotCensoringConfig,
     setScreenshotCensoringConfig: (Boolean) -> Unit,
-    appLockConfig: AppLockConfig,
     onBackPressed: () -> Unit,
-    disableAppLock: () -> Unit,
-    enableAppLock: () -> Unit
 ) {
     WireScaffold(topBar = {
         WireCenterAlignedTopAppBar(
@@ -134,56 +113,8 @@ fun PrivacySettingsScreenContent(
                 arrowType = ArrowType.NONE,
                 subtitle = stringResource(id = R.string.settings_show_typing_indicator_description)
             )
-
-            AppLockItem(
-                state = appLockConfig,
-                disableAppLock = disableAppLock,
-                enableAppLock = enableAppLock
-            )
         }
     }
-}
-
-@Composable
-fun AppLockItem(
-    state: AppLockConfig,
-    disableAppLock: () -> Unit,
-    enableAppLock: () -> Unit,
-) {
-    val onCLick = remember(state) {
-        when (state) {
-            is AppLockConfig.EnforcedByTeam -> {
-                // do nothing, onClick is disabled anyway
-                {}
-            }
-
-            is AppLockConfig.Enabled -> {
-                // app-lock is not enforced by any of logged accounts, call function to disable the app-lock
-                disableAppLock
-            }
-
-            is AppLockConfig.Disabled -> {
-                // navigate to set app lock screen
-                enableAppLock
-            }
-        }
-    }
-    GroupConversationOptionsItem(
-        title = stringResource(id = R.string.settings_app_lock_title),
-        switchState = when (state) {
-            is AppLockConfig.EnforcedByTeam -> SwitchState.Disabled(value = true)
-            else -> SwitchState.Enabled(
-                value = state is AppLockConfig.Enabled,
-                onCheckedChange = null
-            )
-        },
-        arrowType = ArrowType.NONE,
-        subtitle = stringResource(id = R.string.settings_app_lock_description, state.timeout.toTimeLongLabelUiText()),
-        clickable = Clickable(
-            enabled = state !is AppLockConfig.EnforcedByTeam,
-            onClick = onCLick
-        )
-    )
 }
 
 @Composable
@@ -196,9 +127,6 @@ fun PreviewSendReadReceipts() {
         setTypingIndicatorState = {},
         screenshotCensoringConfig = ScreenshotCensoringConfig.DISABLED,
         setScreenshotCensoringConfig = {},
-        appLockConfig = AppLockConfig.Disabled,
         onBackPressed = {},
-        disableAppLock = {},
-        enableAppLock = {}
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsState.kt
@@ -20,8 +20,6 @@
 
 package com.wire.android.ui.home.settings.privacy
 
-import com.wire.android.feature.AppLockConfig
-
 data class PrivacySettingsState(
     val areReadReceiptsEnabled: Boolean = true,
     val isTypingIndicatorEnabled: Boolean = true,

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModel.kt
@@ -26,8 +26,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
-import com.wire.android.datastore.GlobalDataStore
-import com.wire.android.feature.ObserveAppLockConfigUseCase
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.feature.user.readReceipts.ObserveReadReceiptsEnabledUseCase
 import com.wire.kalium.logic.feature.user.readReceipts.PersistReadReceiptsStatusConfigUseCase
@@ -54,8 +52,6 @@ class PrivacySettingsViewModel @Inject constructor(
     private val observeScreenshotCensoringConfig: ObserveScreenshotCensoringConfigUseCase,
     private val persistTypingIndicatorStatusConfig: PersistTypingIndicatorStatusConfigUseCase,
     private val observeTypingIndicatorEnabled: ObserveTypingIndicatorEnabledUseCase,
-    private val observeAppLockConfigUseCase: ObserveAppLockConfigUseCase,
-    private val globalDataStore: GlobalDataStore,
 ) : ViewModel() {
 
     var state by mutableStateOf(PrivacySettingsState())
@@ -67,8 +63,7 @@ class PrivacySettingsViewModel @Inject constructor(
                 observeReadReceiptsEnabled(),
                 observeTypingIndicatorEnabled(),
                 observeScreenshotCensoringConfig(),
-                observeAppLockConfigUseCase(),
-            ) { readReceiptsEnabled, typingIndicatorEnabled, screenshotCensoringConfig, appLockConfig ->
+            ) { readReceiptsEnabled, typingIndicatorEnabled, screenshotCensoringConfig ->
                 PrivacySettingsState(
                     areReadReceiptsEnabled = readReceiptsEnabled,
                     isTypingIndicatorEnabled = typingIndicatorEnabled,
@@ -82,7 +77,6 @@ class PrivacySettingsViewModel @Inject constructor(
                         ObserveScreenshotCensoringConfigResult.Enabled.EnforcedByTeamSelfDeletingSettings ->
                             ScreenshotCensoringConfig.ENFORCED_BY_TEAM
                     },
-                    appLockConfig = appLockConfig
                 )
             }.collect { state = it }
         }
@@ -133,12 +127,6 @@ class PrivacySettingsViewModel @Inject constructor(
                     appLogger.d("Screenshot censoring config changed")
                 }
             }
-        }
-    }
-
-    fun disableAppLock() {
-        viewModelScope.launch {
-            globalDataStore.clearAppLockPasscode()
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/Theme.kt
@@ -22,11 +22,14 @@ package com.wire.android.ui.theme
 
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 
 @Composable
 fun WireTheme(
@@ -42,7 +45,8 @@ fun WireTheme(
         LocalWireTypography provides wireTypography,
         LocalWireDimensions provides wireDimensions,
         // we need to provide our default content color dependent on the current colorScheme, otherwise it's Color.Black
-        LocalContentColor provides wireColorScheme.onBackground
+        LocalContentColor provides wireColorScheme.onBackground,
+        *if (isPreview) arrayOf(LocalSnackbarHostState provides remember { SnackbarHostState() }) else emptyArray(),
     ) {
         MaterialTheme(
             colorScheme = wireColorScheme.toColorScheme(),

--- a/app/src/main/kotlin/com/wire/android/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/Theme.kt
@@ -40,6 +40,7 @@ fun WireTheme(
     content: @Composable () -> Unit
 ) {
     val systemUiController = rememberSystemUiController()
+    @Suppress("SpreadOperator")
     CompositionLocalProvider(
         LocalWireColors provides wireColorScheme,
         LocalWireTypography provides wireTypography,

--- a/app/src/main/res/drawable/ic_validation_block.xml
+++ b/app/src/main/res/drawable/ic_validation_block.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="10dp"
+    android:height="10dp"
+    android:viewportWidth="10"
+    android:viewportHeight="10">
+  <path
+      android:pathData="M5,10C2.239,10 0,7.761 0,5C0,2.239 2.239,0 5,0C7.761,0 10,2.239 10,5C10,7.761 7.761,10 5,10ZM8.057,2.827C8.493,3.44 8.75,4.19 8.75,5C8.75,7.071 7.071,8.75 5,8.75C4.19,8.75 3.44,8.493 2.827,8.057L7.942,2.942L8.057,2.827ZM5,1.25C5.81,1.25 6.56,1.507 7.173,1.943L7.058,2.058L1.943,7.173C1.507,6.56 1.25,5.81 1.25,5C1.25,2.929 2.929,1.25 5,1.25Z"
+      android:fillColor="#676B71"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/drawable/ic_validation_check.xml
+++ b/app/src/main/res/drawable/ic_validation_check.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="10dp"
+    android:height="10dp"
+    android:viewportWidth="10"
+    android:viewportHeight="10">
+  <path
+      android:pathData="M3.536,8.794L9.99,2.267L9.106,1.383L3.536,7.026L0.884,4.375L0,5.258L3.536,8.794Z"
+      android:fillColor="#1D7833"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -906,7 +906,6 @@
     <string name="settings_show_typing_indicator_title">Typing indicator</string>
     <string name="settings_show_typing_indicator_description">When this is off, you won\'t be able to see when other people are typing, and others won\'t see when you are typing. This setting applies to all conversations on this device.</string>
     <string name="settings_app_lock_title">Lock with passcode</string>
-    <string name="settings_app_lock_description">Lock Wire after %1$s in the background. Unlock with passcode or biometrics.</string>
     <!--Privacy Settings, App lock -->
     <string name="settings_set_lock_screen_title">Set app lock passcode</string>
     <string name="settings_set_lock_screen_description">The app will lock itself after %1$s of inactivity. To unlock the app you need to enter this passcode.\n\nMake sure to remember this passcode as there is no way to recover it.</string>
@@ -920,6 +919,9 @@
     <string name="password_validation_uppercase">An uppercase character</string>
     <string name="password_validation_digit">A digit</string>
     <string name="password_validation_special_character">A special character</string>
+    <string name="turn_app_lock_off_dialog_title">Turn app lock off?</string>
+    <string name="turn_app_lock_off_dialog_description">You will no longer need to unlock Wire with your passcode or biometric authentication.</string>
+    <string name="label_turn_off">Turn Off</string>
     <!--Devices -->
     <string name="devices_title">Your Devices</string>
     <string name="current_device_label">Current Device</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -906,15 +906,20 @@
     <string name="settings_show_typing_indicator_title">Typing indicator</string>
     <string name="settings_show_typing_indicator_description">When this is off, you won\'t be able to see when other people are typing, and others won\'t see when you are typing. This setting applies to all conversations on this device.</string>
     <string name="settings_app_lock_title">Lock with passcode</string>
-    <string name="settings_app_lock_description">Lock Wire after %1$s seconds in the background. Unlock with passcode or biometrics.</string>
+    <string name="settings_app_lock_description">Lock Wire after %1$s in the background. Unlock with passcode or biometrics.</string>
     <!--Privacy Settings, App lock -->
-    <string name="settings_set_lock_screen_title">Set a passcode</string>
-    <string name="settings_set_lock_screen_description">The app will lock itself after a certain time of inactivity. To unlock the app you need to enter this passcode. Make sure to remember this passcode as there is no way to recover it.</string>
+    <string name="settings_set_lock_screen_title">Set app lock passcode</string>
+    <string name="settings_set_lock_screen_description">The app will lock itself after %1$s of inactivity. To unlock the app you need to enter this passcode.\n\nMake sure to remember this passcode as there is no way to recover it.</string>
     <string name="settings_set_lock_screen_passcode_label">Passcode</string>
     <string name="settings_set_lock_screen_continue_button_label">Set a passcode</string>
     <string name="settings_enter_lock_screen_title">Enter passcode to unlock Wire</string>
     <string name="settings_enter_lock_screen_unlock_button_label">Unlock</string>
     <string name="settings_enter_lock_screen_wrong_passcode_label">Wrong passcode</string>
+    <string name="password_validation_length">At least 8 characters</string>
+    <string name="password_validation_lowercase">A lowercase character</string>
+    <string name="password_validation_uppercase">An uppercase character</string>
+    <string name="password_validation_digit">A digit</string>
+    <string name="password_validation_special_character">A special character</string>
     <!--Devices -->
     <string name="devices_title">Your Devices</string>
     <string name="current_device_label">Current Device</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/appLock/LockCodeTimeManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/appLock/LockCodeTimeManagerTest.kt
@@ -56,7 +56,7 @@ class LockCodeTimeManagerTest {
             assertEquals(expected, result)
         }
 
-    private fun AppLockConfig.timeoutInMillis(): Long = this.timeoutInSeconds * 1000L
+    private fun AppLockConfig.timeoutInMillis(): Long = this.timeout.inWholeMilliseconds
 
     @Test
     fun givenLockEnabledAndAppOpen_whenAppClosedAndOpenedAgainBeforeLockTimeout_thenDoNotRequirePasscode() =

--- a/app/src/test/kotlin/com/wire/android/ui/home/appLock/SetLockScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/appLock/SetLockScreenViewModelTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.feature.AppLockConfig
 import com.wire.android.feature.ObserveAppLockConfigUseCase
 import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
@@ -29,6 +30,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -74,6 +76,7 @@ class SetLockScreenViewModelTest {
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
             coEvery { globalDataStore.setAppLockPasscode(any()) } returns Unit
+            coEvery { observeAppLockConfigUseCase() } returns flowOf(AppLockConfig.Disabled)
         }
 
         fun withValidPassword() = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/CreatePasswordGuestLinkViewModelText.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/CreatePasswordGuestLinkViewModelText.kt
@@ -28,6 +28,7 @@ import com.wire.android.ui.home.conversations.details.editguestaccess.createPass
 import com.wire.android.ui.navArgs
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
 import com.wire.kalium.logic.feature.conversation.guestroomlink.GenerateGuestRoomLinkResult
 import com.wire.kalium.logic.feature.conversation.guestroomlink.GenerateGuestRoomLinkUseCase
@@ -240,7 +241,7 @@ class CreatePasswordGuestLinkViewModelText {
         fun withPasswordValidation(result: Boolean) = apply {
             every {
                 validatePassword(any())
-            } returns result
+            } returns if (result) ValidatePasswordResult.Valid else ValidatePasswordResult.Invalid()
         }
 
         fun withGenerateGuestLink(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4695" title="WPB-4695" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-4695</a>  [Android] Toggle app lock from the app settings (Password only)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- `ConversationOptionSwitch` extracted and renamed to `SettingsOptionSwitch` for easier reusability
- added new type of `SettingsItem` to allow adding also rows that contain switch
- moved app lock options from PrivacySettings to global Settings under “App Settings” group
- added `TurnAppLockOffDialog` for the user  to confirm that he/she wants to turn off the app lock
- implemented logic to show which particular passlock requirements are missing
- adjusted UI according to current designs of “set app lock” and “enter app lock”

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/2134

### Testing

#### How to Test

Open settings and set the app lock, kill the app and open again to see enter the app lock screen.

### Attachments (Optional)

| Before | After&nbsp;&nbsp;&nbsp; |
| ----------- | ------------ |
| ![settings_before](https://github.com/wireapp/wire-android-reloaded/assets/30429749/c329340d-478a-442e-a4ed-b4b6915de44a) | ![settings_after](https://github.com/wireapp/wire-android-reloaded/assets/30429749/1c7330dd-7625-4126-93c2-9cf28832342d) |
| ![set_passcode_before](https://github.com/wireapp/wire-android-reloaded/assets/30429749/9c661254-b1c0-4fbb-b33d-38e9f905d34b) | ![set_passcode_after](https://github.com/wireapp/wire-android-reloaded/assets/30429749/06e4593e-556b-41e0-8e8a-bce65f01107a) |
| ![enter_passcode_before](https://github.com/wireapp/wire-android-reloaded/assets/30429749/fbe47d38-0806-44f4-adeb-0c202e666f15) | ![enter_passcode_after](https://github.com/wireapp/wire-android-reloaded/assets/30429749/1959d79f-096c-4dbc-b3e0-eff8cbcb2160) |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
