### PR TITLE
feat: scroll bottom - jump to last message (WPB-4987) (WPB-3973)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -833,7 +833,7 @@ fun MessageList(
     }
 
     Scaffold(
-        floatingActionButton = { JumpToLastMessageButton(lazyListState) },
+        floatingActionButton = { JumpToLastMessageButton(lazyListState = lazyListState) },
         content = {
             LazyColumn(
                 state = lazyListState,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -23,14 +23,25 @@ package com.wire.android.ui.home.conversations
 import SwipeableSnackbar
 import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
@@ -49,6 +60,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
@@ -76,6 +88,7 @@ import com.wire.android.ui.common.dialogs.calling.CallingFeatureUnavailableDialo
 import com.wire.android.ui.common.dialogs.calling.ConfirmStartCallDialog
 import com.wire.android.ui.common.dialogs.calling.JoinAnywayDialog
 import com.wire.android.ui.common.dialogs.calling.OngoingActiveCallDialog
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.error.CoreFailureErrorDialog
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.destinations.ConversationScreenDestination
@@ -110,6 +123,7 @@ import com.wire.android.ui.home.messagecomposer.MessageComposer
 import com.wire.android.ui.home.messagecomposer.state.MessageBundle
 import com.wire.android.ui.home.messagecomposer.state.MessageComposerStateHolder
 import com.wire.android.ui.home.messagecomposer.state.rememberMessageComposerStateHolder
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.extension.openAppInfoScreen
 import com.wire.android.util.normalizeLink
 import com.wire.android.util.ui.UIText
@@ -868,6 +882,31 @@ fun MessageList(
                     onSelfDeletingMessageRead = onSelfDeletingMessageRead
                 )
             }
+        }
+    }
+}
+
+@Composable
+fun JumpToLastMessageButton() {
+    AnimatedVisibility(
+        visible = true, // todo change to dynamic when we have a proper implementation to hide it
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        SmallFloatingActionButton(
+            modifier = Modifier
+                .offset(y = -dimensions().spacing48x)
+                .zIndex(Float.MAX_VALUE),
+            onClick = { },
+            containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
+            contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,
+            shape = CircleShape,
+        ) {
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowDown,
+                contentDescription = "Small floating action button.", // todo change later
+                Modifier.size(dimensions().spacing32x)
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -913,7 +913,7 @@ fun JumpToLastMessageButton(
         ) {
             Icon(
                 imageVector = Icons.Default.KeyboardArrowDown,
-                contentDescription = "Small floating action button.", // todo change later
+                contentDescription = stringResource(id = R.string.content_description_jump_to_last_message),
                 Modifier.size(dimensions().spacing32x)
             )
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -833,7 +833,7 @@ fun MessageList(
     }
 
     Scaffold(
-        floatingActionButton = { JumpToLastMessageButton() },
+        floatingActionButton = { JumpToLastMessageButton(lazyListState) },
         content = {
             LazyColumn(
                 state = lazyListState,
@@ -895,7 +895,10 @@ fun MessageList(
 }
 
 @Composable
-fun JumpToLastMessageButton() {
+fun JumpToLastMessageButton(
+    coroutineScope: CoroutineScope = rememberCoroutineScope(),
+    lazyListState: LazyListState
+) {
     AnimatedVisibility(
         visible = true, // todo change to dynamic when we have a proper implementation to hide it
         enter = fadeIn(),
@@ -903,7 +906,9 @@ fun JumpToLastMessageButton() {
     ) {
         SmallFloatingActionButton(
             modifier = Modifier.offset(y = dimensions().spacing18x),
-            onClick = { },
+            onClick = {
+                coroutineScope.launch { lazyListState.animateScrollToItem(0) }
+            },
             containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
             contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,
             shape = CircleShape,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -25,8 +25,8 @@ import android.annotation.SuppressLint
 import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
+import androidx.compose.animation.expandIn
+import androidx.compose.animation.shrinkOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -900,15 +900,13 @@ fun JumpToLastMessageButton(
     lazyListState: LazyListState
 ) {
     AnimatedVisibility(
-        visible = true, // todo change to dynamic when we have a proper implementation to hide it
-        enter = fadeIn(),
-        exit = fadeOut(),
+        visible = lazyListState.firstVisibleItemIndex > 0,
+        enter = expandIn { it },
+        exit = shrinkOut { it }
     ) {
         SmallFloatingActionButton(
             modifier = Modifier.offset(y = dimensions().spacing18x),
-            onClick = {
-                coroutineScope.launch { lazyListState.animateScrollToItem(0) }
-            },
+            onClick = { coroutineScope.launch { lazyListState.animateScrollToItem(0) } },
             containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
             contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,
             shape = CircleShape,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -21,11 +21,13 @@
 package com.wire.android.ui.home.conversations
 
 import SwipeableSnackbar
+import android.annotation.SuppressLint
 import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -60,7 +62,6 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
@@ -82,6 +83,7 @@ import com.wire.android.navigation.Navigator
 import com.wire.android.ui.calling.common.MicrophoneBTPermissionsDeniedDialog
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
+import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dialogs.InvalidLinkDialog
 import com.wire.android.ui.common.dialogs.VisitLinkDialog
 import com.wire.android.ui.common.dialogs.calling.CallingFeatureUnavailableDialog
@@ -785,6 +787,7 @@ private fun SnackBarMessage(
     }
 }
 
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun MessageList(
     lazyPagingMessages: LazyPagingItems<UIMessage>,
@@ -829,61 +832,66 @@ fun MessageList(
         }
     }
 
-    LazyColumn(
-        state = lazyListState,
-        reverseLayout = true,
-        modifier = Modifier
-            .fillMaxHeight()
-            .fillMaxWidth()
-    ) {
-        itemsIndexed(lazyPagingMessages, key = { _, uiMessage ->
-            uiMessage.header.messageId
-        }) { index, message ->
-            if (message == null) {
-                // We can draw a placeholder here, as we fetch the next page of messages
-                return@itemsIndexed
-            }
-            val showAuthor by remember {
-                mutableStateOf(
-                    AuthorHeaderHelper.shouldShowHeader(
-                        index,
-                        lazyPagingMessages.itemSnapshotList.items,
-                        message
-                    )
-                )
-            }
+    Scaffold(
+        floatingActionButton = { JumpToLastMessageButton() },
+        content = {
+            LazyColumn(
+                state = lazyListState,
+                reverseLayout = true,
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth()
+                    .background(color = colorsScheme().backgroundVariant)
+            ) {
+                itemsIndexed(lazyPagingMessages, key = { _, uiMessage ->
+                    uiMessage.header.messageId
+                }) { index, message ->
+                    if (message == null) {
+                        // We can draw a placeholder here, as we fetch the next page of messages
+                        return@itemsIndexed
+                    }
+                    val showAuthor by remember {
+                        mutableStateOf(
+                            AuthorHeaderHelper.shouldShowHeader(
+                                index,
+                                lazyPagingMessages.itemSnapshotList.items,
+                                message
+                            )
+                        )
+                    }
 
-            when (message) {
-                is UIMessage.Regular -> {
-                    MessageItem(
-                        message = message,
-                        conversationDetailsData = conversationDetailsData,
-                        showAuthor = showAuthor,
-                        audioMessagesState = audioMessagesState,
-                        onAudioClick = onAudioItemClicked,
-                        onChangeAudioPosition = onChangeAudioPosition,
-                        onLongClicked = onShowEditingOption,
-                        onAssetMessageClicked = onAssetItemClicked,
-                        onImageMessageClicked = onImageFullScreenMode,
-                        onOpenProfile = onOpenProfile,
-                        onReactionClicked = onReactionClicked,
-                        onResetSessionClicked = onResetSessionClicked,
-                        onSelfDeletingMessageRead = onSelfDeletingMessageRead,
-                        onFailedMessageCancelClicked = onFailedMessageCancelClicked,
-                        onFailedMessageRetryClicked = onFailedMessageRetryClicked,
-                        onLinkClick = onLinkClick
-                    )
+                    when (message) {
+                        is UIMessage.Regular -> {
+                            MessageItem(
+                                message = message,
+                                conversationDetailsData = conversationDetailsData,
+                                showAuthor = showAuthor,
+                                audioMessagesState = audioMessagesState,
+                                onAudioClick = onAudioItemClicked,
+                                onChangeAudioPosition = onChangeAudioPosition,
+                                onLongClicked = onShowEditingOption,
+                                onAssetMessageClicked = onAssetItemClicked,
+                                onImageMessageClicked = onImageFullScreenMode,
+                                onOpenProfile = onOpenProfile,
+                                onReactionClicked = onReactionClicked,
+                                onResetSessionClicked = onResetSessionClicked,
+                                onSelfDeletingMessageRead = onSelfDeletingMessageRead,
+                                onFailedMessageCancelClicked = onFailedMessageCancelClicked,
+                                onFailedMessageRetryClicked = onFailedMessageRetryClicked,
+                                onLinkClick = onLinkClick
+                            )
+                        }
+
+                        is UIMessage.System -> SystemMessageItem(
+                            message = message,
+                            onFailedMessageCancelClicked = onFailedMessageCancelClicked,
+                            onFailedMessageRetryClicked = onFailedMessageRetryClicked,
+                            onSelfDeletingMessageRead = onSelfDeletingMessageRead
+                        )
+                    }
                 }
-
-                is UIMessage.System -> SystemMessageItem(
-                    message = message,
-                    onFailedMessageCancelClicked = onFailedMessageCancelClicked,
-                    onFailedMessageRetryClicked = onFailedMessageRetryClicked,
-                    onSelfDeletingMessageRead = onSelfDeletingMessageRead
-                )
             }
-        }
-    }
+        })
 }
 
 @Composable
@@ -894,9 +902,7 @@ fun JumpToLastMessageButton() {
         exit = fadeOut(),
     ) {
         SmallFloatingActionButton(
-            modifier = Modifier
-                .offset(y = -dimensions().spacing48x)
-                .zIndex(Float.MAX_VALUE),
+            modifier = Modifier.offset(y = dimensions().spacing18x),
             onClick = { },
             containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
             contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -17,13 +17,9 @@
  */
 package com.wire.android.ui.home.messagecomposer
 
-import android.annotation.SuppressLint
 import android.net.Uri
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,17 +32,8 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imeAnimationSource
 import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.foundation.layout.isImeVisible
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -62,19 +49,16 @@ import androidx.compose.ui.unit.dp
 import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
 import com.wire.android.ui.common.bottombar.BottomNavigationBarHeight
 import com.wire.android.ui.common.colorsScheme
-import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.UsersTypingIndicatorForConversation
 import com.wire.android.ui.home.conversations.model.UriAsset
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSelectItem
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSubMenuState
 import com.wire.android.ui.home.messagecomposer.state.MessageComposerStateHolder
 import com.wire.android.ui.home.messagecomposer.state.MessageCompositionType
-import com.wire.android.ui.theme.wireColorScheme
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.util.isPositiveNotNull
 
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalLayoutApi::class, ExperimentalComposeUiApi::class)
 @Suppress("ComplexMethod")
 @Composable
@@ -129,45 +113,21 @@ fun EnabledMessageComposer(
                     } else {
                         Modifier.weight(1f)
                     }
-                Scaffold(
-                    modifier = expandOrHideMessagesModifier,
-                    floatingActionButton = {
-                        AnimatedVisibility(
-                            visible = messageComposerViewState.value.mentionSearchResult.isEmpty(), // todo change to dynamic when we have a proper implementation to hide it
-                            enter = fadeIn(),
-                            exit = fadeOut(),
-                        ) {
-                            SmallFloatingActionButton(
-                                onClick = { },
-                                containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
-                                contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,
-                                shape = CircleShape,
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.KeyboardArrowDown,
-                                    contentDescription = "Small floating action button.", // todo change later
-                                    Modifier.size(dimensions().spacing32x)
-                                )
+                Box(
+                    modifier = expandOrHideMessagesModifier.background(color = colorsScheme().backgroundVariant)
+                ) {
+                    messageListContent()
+                    if (messageComposerViewState.value.mentionSearchResult.isNotEmpty()) {
+                        MembersMentionList(
+                            membersToMention = messageComposerViewState.value.mentionSearchResult,
+                            searchQuery = messageComposition.value.messageText,
+                            onMentionPicked = { pickedMention ->
+                                messageCompositionHolder.addMention(pickedMention)
+                                onClearMentionSearchResult()
                             }
-                        }
-                    },
-                    content = {
-                        Box(
-                            modifier = Modifier.background(color = colorsScheme().backgroundVariant)
-                        ) {
-                            messageListContent()
-                            if (messageComposerViewState.value.mentionSearchResult.isNotEmpty()) {
-                                MembersMentionList(
-                                    membersToMention = messageComposerViewState.value.mentionSearchResult,
-                                    searchQuery = messageComposition.value.messageText,
-                                    onMentionPicked = { pickedMention ->
-                                        messageCompositionHolder.addMention(pickedMention)
-                                        onClearMentionSearchResult()
-                                    }
-                                )
-                            }
-                        }
-                    })
+                        )
+                    }
+                }
                 val fillRemainingSpaceOrWrapContent =
                     if (!inputStateHolder.isTextExpanded) {
                         Modifier.wrapContentHeight()
@@ -175,8 +135,7 @@ fun EnabledMessageComposer(
                         Modifier.weight(1f)
                     }
                 Column(
-                    modifier = fillRemainingSpaceOrWrapContent
-                        .fillMaxWidth()
+                    modifier = fillRemainingSpaceOrWrapContent.fillMaxWidth()
                 ) {
                     Column(
                         modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -123,7 +123,8 @@ fun EnabledMessageComposer(
                         Modifier.weight(1f)
                     }
                 Box(
-                    modifier = expandOrHideMessagesModifier.background(color = colorsScheme().backgroundVariant)
+                    modifier = expandOrHideMessagesModifier
+                        .background(color = colorsScheme().backgroundVariant)
                 ) {
                     messageListContent()
                     if (messageComposerViewState.value.mentionSearchResult.isNotEmpty()) {
@@ -144,7 +145,8 @@ fun EnabledMessageComposer(
                         Modifier.weight(1f)
                     }
                 Column(
-                    modifier = fillRemainingSpaceOrWrapContent.fillMaxWidth()
+                    modifier = fillRemainingSpaceOrWrapContent
+                        .fillMaxWidth()
                 ) {
                     Column(
                         modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -17,9 +17,13 @@
  */
 package com.wire.android.ui.home.messagecomposer
 
+import android.annotation.SuppressLint
 import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -32,8 +36,17 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imeAnimationSource
 import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.foundation.layout.isImeVisible
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -49,16 +62,19 @@ import androidx.compose.ui.unit.dp
 import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
 import com.wire.android.ui.common.bottombar.BottomNavigationBarHeight
 import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.UsersTypingIndicatorForConversation
 import com.wire.android.ui.home.conversations.model.UriAsset
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSelectItem
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSubMenuState
 import com.wire.android.ui.home.messagecomposer.state.MessageComposerStateHolder
 import com.wire.android.ui.home.messagecomposer.state.MessageCompositionType
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.util.isPositiveNotNull
 
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalLayoutApi::class, ExperimentalComposeUiApi::class)
 @Suppress("ComplexMethod")
 @Composable
@@ -113,22 +129,45 @@ fun EnabledMessageComposer(
                     } else {
                         Modifier.weight(1f)
                     }
-                Box(
-                    modifier = expandOrHideMessagesModifier
-                        .background(color = colorsScheme().backgroundVariant)
-                ) {
-                    messageListContent()
-                    if (messageComposerViewState.value.mentionSearchResult.isNotEmpty()) {
-                        MembersMentionList(
-                            membersToMention = messageComposerViewState.value.mentionSearchResult,
-                            searchQuery = messageComposition.value.messageText,
-                            onMentionPicked = { pickedMention ->
-                                messageCompositionHolder.addMention(pickedMention)
-                                onClearMentionSearchResult()
+                Scaffold(
+                    modifier = expandOrHideMessagesModifier,
+                    floatingActionButton = {
+                        AnimatedVisibility(
+                            visible = messageComposerViewState.value.mentionSearchResult.isEmpty(), // todo change to dynamic when we have a proper implementation to hide it
+                            enter = fadeIn(),
+                            exit = fadeOut(),
+                        ) {
+                            SmallFloatingActionButton(
+                                onClick = { },
+                                containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
+                                contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,
+                                shape = CircleShape,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.KeyboardArrowDown,
+                                    contentDescription = "Small floating action button.", // todo change later
+                                    Modifier.size(dimensions().spacing32x)
+                                )
                             }
-                        )
-                    }
-                }
+                        }
+                    },
+                    content = {
+                        Box(
+                            modifier = Modifier.background(color = colorsScheme().backgroundVariant)
+                        ) {
+                            messageListContent()
+                            if (messageComposerViewState.value.mentionSearchResult.isNotEmpty()) {
+                                MembersMentionList(
+                                    membersToMention = messageComposerViewState.value.mentionSearchResult,
+                                    searchQuery = messageComposition.value.messageText,
+                                    onMentionPicked = { pickedMention ->
+                                        messageCompositionHolder.addMention(pickedMention)
+                                        onClearMentionSearchResult()
+                                    }
+                                )
+                            }
+                        }
+                    })
                 val fillRemainingSpaceOrWrapContent =
                     if (!inputStateHolder.isTextExpanded) {
                         Modifier.wrapContentHeight()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,7 @@
     <string name="content_description_record_audio_button_send">Send Audio Message</string>
     <string name="content_description_mls_certificate_valid">All devices of all participants have a valid MLS certificate</string>
     <string name="content_description_proteus_certificate_valid">All of all participants are verified (Proteus)</string>
+    <string name="content_description_jump_to_last_message">Scroll down to last message, button</string>
     <!-- Non translatable strings-->
     <string name="url_support" translatable="false">https://support.wire.com</string>
     <string name="url_decryption_failure_learn_more" translatable="false">https://support.wire.com/hc/articles/207948115-Why-was-I-notified-that-a-message-from-a-contact-was-not-received-</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4987" title="WPB-4987" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-4987</a>  [Android] Add a button to jump to the latest message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We don't have a way in the app to quickly navigate to the bottom of the messages list, aka. jump to last message.

### Solutions

Implement it by using Scaffold FAB embedded into messages list component, taking at the same time advantage that MessagesList component, passed down is a composable, so I was able to have it for free for Disabled message composer as well.

Using the outer scaffold was not an option after many tries, because it also considers the attachment options menu, making it almost impossible to customize the position dynamically.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Scroll so the last message is hidden, then the button should appear.

### Attachments (Optional)

###Conversations with several messages and without scrollable content

https://github.com/wireapp/wire-android-reloaded/assets/5806454/a0b86227-d826-4b15-aaba-57b10e988b00

###Read only Conversations

https://github.com/wireapp/wire-android-reloaded/assets/5806454/56ee8196-8d44-4238-be5c-9cb5f35b7740

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
