### PR TITLE
fix: App crash on app unlock with fingerprint (WPB-5110) (WPB-5108)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/biomitric/BiometricPromptUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/biomitric/BiometricPromptUtils.kt
@@ -43,7 +43,7 @@ object BiometricPromptUtils {
             override fun onAuthenticationError(errorCode: Int, errorString: CharSequence) {
                 super.onAuthenticationError(errorCode, errorString)
                 appLogger.i("$TAG errorCode is $errorCode and errorString is: $errorString")
-                if (errorCode == ERROR_NEGATIVE_BUTTON) {
+                if (errorCode == ERROR_NEGATIVE_BUTTON || errorCode == BiometricPrompt.ERROR_LOCKOUT) {
                     onRequestPasscode()
                 } else {
                     onCancel()
@@ -78,16 +78,15 @@ fun AppCompatActivity.showBiometricPrompt(
     onCancel: () -> Unit,
     onRequestPasscode: () -> Unit
 ) {
-    appLogger.i("$TAG showing biometrics dialog...")
-
     val canAuthenticate = BiometricManager.from(this)
         .canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG)
     if (canAuthenticate == BiometricManager.BIOMETRIC_SUCCESS) {
+        appLogger.i("$TAG showing biometrics dialog...")
         val biometricPrompt = BiometricPromptUtils.createBiometricPrompt(
-            this,
-            onSuccess,
-            onCancel,
-            onRequestPasscode,
+            activity = this,
+            onSuccess = onSuccess,
+            onCancel = onCancel,
+            onRequestPasscode = onRequestPasscode
         )
         val promptInfo = BiometricPromptUtils.createPromptInfo(this)
         biometricPrompt.authenticate(promptInfo)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -30,6 +30,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.SnackbarHostState
@@ -40,7 +41,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
@@ -48,7 +48,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import com.ramcosta.composedestinations.spec.Route
@@ -92,12 +95,9 @@ import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.ui.updateScreenSettings
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -168,7 +168,6 @@ class WireActivity : AppCompatActivity() {
                     Column(modifier = Modifier.statusBarsPadding()) {
                         ReportDrawnWhen { isLoaded }
                         val navigator = rememberNavigator(this@WireActivity::finish)
-                        val scope = rememberCoroutineScope()
                         CommonTopAppBar(
                             connectivityUIState = commonTopAppBarViewModel.connectivityState,
                             onReturnToCallClick = { establishedCall ->
@@ -182,7 +181,7 @@ class WireActivity : AppCompatActivity() {
 
                         // This setup needs to be done after the navigation graph is created, because building the graph takes some time,
                         // and if any NavigationCommand is executed before the graph is fully built, it will cause a NullPointerException.
-                        setUpNavigation(navigator.navController, onComplete, scope)
+                        setUpNavigation(navigator.navController, onComplete)
                         isLoaded = true
                         handleScreenshotCensoring()
                         handleAppLock()
@@ -197,17 +196,20 @@ class WireActivity : AppCompatActivity() {
     private fun setUpNavigation(
         navController: NavHostController,
         onComplete: () -> Unit,
-        scope: CoroutineScope
     ) {
         val currentKeyboardController by rememberUpdatedState(LocalSoftwareKeyboardController.current)
         val currentNavController by rememberUpdatedState(navController)
-        LaunchedEffect(scope) {
-            navigationCommands
-                .onSubscription { onComplete() }
-                .onEach { command ->
-                    currentKeyboardController?.hide()
-                    currentNavController.navigateToItem(command)
-                }.launchIn(scope)
+        LaunchedEffect(Unit) {
+            lifecycleScope.launch {
+                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    navigationCommands
+                        .onSubscription { onComplete() }
+                        .collectLatest {
+                            currentKeyboardController?.hide()
+                            currentNavController.navigateToItem(it)
+                        }
+                }
+            }
         }
 
         DisposableEffect(navController) {
@@ -239,23 +241,26 @@ class WireActivity : AppCompatActivity() {
     @Composable
     private fun handleAppLock() {
         LaunchedEffect(Unit) {
-            lockCodeTimeManager.isLocked()
-                .filter { it }
-                .collectLatest {
-                    val canAuthenticateWithBiometrics = BiometricManager
-                        .from(this@WireActivity)
-                        .canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG)
-
-                    if (canAuthenticateWithBiometrics == BiometricManager.BIOMETRIC_SUCCESS) {
-                        navigationCommands.emit(
-                            NavigationCommand(AppUnlockWithBiometricsScreenDestination)
-                        )
-                    } else {
-                        navigationCommands.emit(
-                            NavigationCommand(EnterLockCodeScreenDestination)
-                        )
+            lifecycleScope.launch {
+                // Listen to one flow in a lifecycle-aware manner using flowWithLifecycle
+                lockCodeTimeManager.isLocked()
+                    .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+                    .filter { it }
+                    .collectLatest {
+                        val canAuthenticateWithBiometrics = BiometricManager
+                            .from(this@WireActivity)
+                            .canAuthenticate(BIOMETRIC_STRONG)
+                        if (canAuthenticateWithBiometrics == BiometricManager.BIOMETRIC_SUCCESS) {
+                            navigationCommands.emit(
+                                NavigationCommand(AppUnlockWithBiometricsScreenDestination)
+                            )
+                        } else {
+                            navigationCommands.emit(
+                                NavigationCommand(EnterLockCodeScreenDestination)
+                            )
+                        }
                     }
-                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/AppUnlockWithBiometricsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/AppUnlockWithBiometricsScreen.kt
@@ -80,7 +80,7 @@ fun AppUnlockWithBiometricsScreen(
                     navigator.navigate(
                         NavigationCommand(
                             EnterLockCodeScreenDestination(),
-                            BackStackMode.CLEAR_WHOLE
+                            BackStackMode.REMOVE_CURRENT
                         )
                     )
                 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5110" title="WPB-5110" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5110</a>  [Android] Applock - Fail applock biometrics more than 3 times , Crash
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. App crash when unlock with biometrics fails due to too many failed attempts
2. Black screen shown without showing biometrics prompt dialog

### Causes (Optional)

1. After 5 failed attempts of auth with biometrics, the system will lock out the biometrics API and will return an error which we were not handling it.

2. The app was emitting the screen to go when it's in the background causing a failure when showing biometrics prompt.
`Unable to start authentication. Called after onSaveInstanceState()`


### Solutions

1. handle that error by navigating the user to passcode screen

2. Make flow observation lifecycle aware so the app will stop emitting/observing when it's in background. Also this way the app will prevent resource wasting.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

1. 
- Try to authenticate with wrong biometrics multiple time so the API get locked out.
- Open the app again
- The app should not crash

2.
- Authenticate with biometrics
- Close the app and let it in background for 1min
- Open the app again, you should see biometrics dialog

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
