### PR TITLE
feat: Show conversation Proteus verification status

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -310,6 +310,14 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
         }
 
         MessagePreviewContent.CryptoSessionReset -> UILastMessageContent.None
+        MessagePreviewContent.VerificationChanged.VerifiedMls ->
+            UILastMessageContent.VerificationChanged(R.string.last_message_verified_conversation_mls)
+        MessagePreviewContent.VerificationChanged.VerifiedProteus ->
+            UILastMessageContent.VerificationChanged(R.string.last_message_verified_conversation_proteus)
+        MessagePreviewContent.VerificationChanged.DegradedMls ->
+            UILastMessageContent.VerificationChanged(R.string.last_message_conversations_verification_degraded_mls)
+        MessagePreviewContent.VerificationChanged.DegradedProteus ->
+            UILastMessageContent.VerificationChanged(R.string.last_message_conversations_verification_degraded_proteus)
         Unknown -> UILastMessageContent.None
     }
 }

--- a/app/src/main/kotlin/com/wire/android/migration/MigrationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationMapper.kt
@@ -105,7 +105,8 @@ class MigrationMapper @Inject constructor() {
                 userMessageTimer = null,
                 archived = false,
                 archivedDateTime = null,
-                verificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+                mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+                proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
@@ -183,7 +183,7 @@ private fun DeviceItemTexts(
         )
         if (shouldShowVerifyLabel) {
             Spacer(modifier = Modifier.width(MaterialTheme.wireDimensions.spacing8x))
-            if (device.isVerifiedProteus) ProteusVerifiedIcon(Modifier.wrapContentWidth())
+            if (device.isVerifiedProteus) ProteusVerifiedIcon(Modifier.wrapContentWidth().align(Alignment.CenterVertically))
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/VerifiedIcons.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/VerifiedIcons.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.android.ui.common
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -26,10 +27,25 @@ import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 
 @Composable
-fun ProteusVerifiedIcon(modifier: Modifier = Modifier) {
+fun ProteusVerifiedIcon(
+    modifier: Modifier = Modifier,
+    @StringRes contentDescriptionId: Int = R.string.label_client_verified
+) {
     Image(
         modifier = modifier.padding(start = dimensions().spacing4x),
         painter = painterResource(id = R.drawable.ic_certificate_valid_proteus),
-        contentDescription = stringResource(R.string.label_client_verified)
+        contentDescription = stringResource(contentDescriptionId)
+    )
+}
+
+@Composable
+fun MLSVerifiedIcon(
+    modifier: Modifier = Modifier,
+    @StringRes contentDescriptionId: Int = R.string.label_client_verified
+) {
+    Image(
+        modifier = modifier.padding(start = dimensions().spacing4x),
+        painter = painterResource(id = R.drawable.ic_certificate_valid_mls),
+        contentDescription = stringResource(contentDescriptionId)
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
@@ -125,7 +125,10 @@ data class ConversationSheetContent(
     val conversationTypeDetail: ConversationTypeDetail,
     val selfRole: Conversation.Member.Role?,
     val isTeamConversation: Boolean,
-    val isArchived: Boolean
+    val isArchived: Boolean,
+    val protocol: Conversation.ProtocolInfo,
+    val mlsVerificationStatus: Conversation.VerificationStatus,
+    val proteusVerificationStatus: Conversation.VerificationStatus
 ) {
 
     private val isSelfUserMember: Boolean get() = selfRole != null

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
@@ -76,10 +76,14 @@ fun rememberConversationSheetState(
                     ),
                     isTeamConversation = teamId != null,
                     selfRole = selfMemberRole,
-                    isArchived = conversationItem.isArchived
+                    isArchived = conversationItem.isArchived,
+                    protocol = Conversation.ProtocolInfo.Proteus,
+                    mlsVerificationStatus = Conversation.VerificationStatus.VERIFIED,
+                    proteusVerificationStatus = Conversation.VerificationStatus.VERIFIED
                 )
             }
         }
+
         is ConversationItem.PrivateConversation -> {
             with(conversationItem) {
                 ConversationSheetContent(
@@ -95,10 +99,14 @@ fun rememberConversationSheetState(
                     ),
                     isTeamConversation = isTeamConversation,
                     selfRole = Conversation.Member.Role.Member,
-                    isArchived = conversationItem.isArchived
+                    isArchived = conversationItem.isArchived,
+                    protocol = Conversation.ProtocolInfo.Proteus,
+                    mlsVerificationStatus = Conversation.VerificationStatus.VERIFIED,
+                    proteusVerificationStatus = Conversation.VerificationStatus.VERIFIED
                 )
             }
         }
+
         is ConversationItem.ConnectionConversation -> {
             with(conversationItem) {
                 ConversationSheetContent(
@@ -110,7 +118,10 @@ fun rememberConversationSheetState(
                     ),
                     isTeamConversation = isTeamConversation,
                     selfRole = Conversation.Member.Role.Member,
-                    isArchived = conversationItem.isArchived
+                    isArchived = conversationItem.isArchived,
+                    protocol = Conversation.ProtocolInfo.Proteus,
+                    mlsVerificationStatus = Conversation.VerificationStatus.VERIFIED,
+                    proteusVerificationStatus = Conversation.VerificationStatus.VERIFIED
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -20,7 +20,6 @@
 
 package com.wire.android.ui.home.conversations
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -193,16 +192,23 @@ private fun RowScope.VerificationIcons(
     mlsVerificationStatus: Conversation.VerificationStatus?,
     proteusVerificationStatus: Conversation.VerificationStatus?
 ) {
-    if (protocolInfo is Conversation.ProtocolInfo.MLS) {
-        if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+    val mlsIcon: @Composable () -> Unit = {
+        if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
             MLSVerifiedIcon(contentDescriptionId = R.string.content_description_mls_certificate_valid)
-        if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+        }
+    }
+    val proteusIcon: @Composable () -> Unit = {
+        if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
             ProteusVerifiedIcon(contentDescriptionId = R.string.content_description_proteus_certificate_valid)
+        }
+    }
+
+    if (protocolInfo is Conversation.ProtocolInfo.Proteus) {
+        proteusIcon()
+        mlsIcon()
     } else {
-        if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED)
-            ProteusVerifiedIcon(contentDescriptionId = R.string.content_description_proteus_certificate_valid)
-        if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED)
-            MLSVerifiedIcon(contentDescriptionId = R.string.content_description_mls_certificate_valid)
+        mlsIcon()
+        proteusIcon()
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -48,6 +49,8 @@ import com.wire.android.R
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.calling.controlbuttons.JoinButton
 import com.wire.android.ui.calling.controlbuttons.StartCallButton
+import com.wire.android.ui.common.MLSVerifiedIcon
+import com.wire.android.ui.common.ProteusVerifiedIcon
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.colorsScheme
@@ -133,7 +136,11 @@ private fun ConversationScreenTopAppBarContent(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(weight = 1f, fill = false)
                 )
-                VerificationIcon(conversationInfoViewState.protocolInfo, conversationInfoViewState.verificationStatus)
+                VerificationIcons(
+                    conversationInfoViewState.protocolInfo,
+                    conversationInfoViewState.mlsVerificationStatus,
+                    conversationInfoViewState.proteusVerificationStatus
+                )
                 if (isDropDownEnabled && isInteractionEnabled) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_dropdown_icon),
@@ -181,21 +188,22 @@ private fun ConversationScreenTopAppBarContent(
 }
 
 @Composable
-private fun VerificationIcon(protocolInfo: Conversation.ProtocolInfo?, verificationStatus: Conversation.VerificationStatus?) {
-    if (verificationStatus != Conversation.VerificationStatus.VERIFIED || protocolInfo == null) return
-
-    val (iconId, contentDescriptionId) = when (protocolInfo) {
-        is Conversation.ProtocolInfo.MLS ->
-            R.drawable.ic_certificate_valid_mls to R.string.content_description_mls_certificate_valid
-
-        Conversation.ProtocolInfo.Proteus ->
-            R.drawable.ic_certificate_valid_proteus to R.string.content_description_proteus_certificate_valid
+private fun RowScope.VerificationIcons(
+    protocolInfo: Conversation.ProtocolInfo?,
+    mlsVerificationStatus: Conversation.VerificationStatus?,
+    proteusVerificationStatus: Conversation.VerificationStatus?
+) {
+    if (protocolInfo is Conversation.ProtocolInfo.MLS) {
+        if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+            MLSVerifiedIcon(contentDescriptionId = R.string.content_description_mls_certificate_valid)
+        if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+            ProteusVerifiedIcon(contentDescriptionId = R.string.content_description_proteus_certificate_valid)
+    } else {
+        if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+            ProteusVerifiedIcon(contentDescriptionId = R.string.content_description_proteus_certificate_valid)
+        if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+            MLSVerifiedIcon(contentDescriptionId = R.string.content_description_mls_certificate_valid)
     }
-    Image(
-        modifier = Modifier.padding(start = dimensions().spacing4x),
-        painter = painterResource(id = iconId),
-        contentDescription = stringResource(contentDescriptionId)
-    )
 }
 
 @Composable
@@ -365,6 +373,33 @@ fun PreviewConversationScreenTopAppBarShortTitleWithOngoingCall() {
         onSearchButtonClick = {},
         onPhoneButtonClick = {},
         hasOngoingCall = true,
+        onJoinCallButtonClick = {},
+        onPermanentPermissionDecline = {},
+        isInteractionEnabled = true,
+        isSearchEnabled = false
+    )
+}
+
+@Preview("Topbar with a short conversation title and verified")
+@Composable
+fun PreviewConversationScreenTopAppBarShortTitleWithVerified() {
+    val conversationId = QualifiedID("", "")
+    ConversationScreenTopAppBarContent(
+        ConversationInfoViewState(
+            conversationId = ConversationId("value", "domain"),
+            conversationName = UIText.DynamicString("Short title"),
+            conversationDetailsData = ConversationDetailsData.Group(conversationId),
+            conversationAvatar = ConversationAvatar.Group(conversationId),
+            protocolInfo = Conversation.ProtocolInfo.Proteus,
+            proteusVerificationStatus = Conversation.VerificationStatus.VERIFIED,
+            mlsVerificationStatus = Conversation.VerificationStatus.VERIFIED
+        ),
+        onBackButtonClick = {},
+        onDropDownClick = {},
+        isDropDownEnabled = true,
+        onSearchButtonClick = {},
+        onPhoneButtonClick = {},
+        hasOngoingCall = false,
         onJoinCallButtonClick = {},
         onPermanentPermissionDecline = {},
         isInteractionEnabled = true,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
@@ -81,7 +80,6 @@ import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.calculateCurrentTab
 import com.wire.android.ui.common.dialogs.ArchiveConversationDialog
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.topBarElevation
 import com.wire.android.ui.common.topappbar.NavigationIconType
@@ -93,6 +91,7 @@ import com.wire.android.ui.destinations.EditGuestAccessScreenDestination
 import com.wire.android.ui.destinations.EditSelfDeletingMessagesScreenDestination
 import com.wire.android.ui.destinations.GroupConversationAllParticipantsScreenDestination
 import com.wire.android.ui.destinations.OtherUserProfileScreenDestination
+import com.wire.android.ui.destinations.SearchConversationMessagesScreenDestination
 import com.wire.android.ui.destinations.SelfUserProfileScreenDestination
 import com.wire.android.ui.destinations.ServiceDetailsScreenDestination
 import com.wire.android.ui.home.conversations.details.dialog.ClearConversationContentDialog
@@ -106,7 +105,6 @@ import com.wire.android.ui.home.conversations.details.participants.GroupConversa
 import com.wire.android.ui.home.conversations.details.participants.model.UIParticipant
 import com.wire.android.ui.home.conversationslist.model.DialogState
 import com.wire.android.ui.home.conversationslist.model.GroupDialogState
-import com.wire.android.ui.destinations.SearchConversationMessagesScreenDestination
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -301,16 +300,7 @@ private fun GroupConversationDetailsContent(
                 onNavigationPressed = onBackPressed,
                 actions = { MoreOptionIcon(onButtonClicked = openBottomSheet) },
             ) {
-                if (conversationSheetContent?.proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
-                    if (conversationSheetContent.protocol == Conversation.ProtocolInfo.Proteus ||
-                        conversationSheetContent.mlsVerificationStatus != Conversation.VerificationStatus.VERIFIED
-                    )
-                        ProteusVerifiedLabel()
-                } else if (conversationSheetContent?.mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
-                    if (conversationSheetContent.protocol is Conversation.ProtocolInfo.MLS) {
-                        MLSVerifiedLabel()
-                    }
-                }
+                VerificationInfo(conversationSheetContent)
                 WireTabRow(
                     tabs = GroupConversationDetailsTabItem.entries,
                     selectedTabIndex = currentTabState,
@@ -425,6 +415,21 @@ private fun GroupConversationDetailsContent(
             bottomSheetEventsHandler.updateConversationArchiveStatus(dialogState = it, onMessage = closeBottomSheetAndShowSnackbarMessage)
         }
     )
+}
+
+@Composable
+private fun VerificationInfo(conversationSheetContent: ConversationSheetContent?) {
+    if (conversationSheetContent == null) return
+
+    val isProteusVerified = conversationSheetContent.proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED
+    val isMlsVerified = conversationSheetContent.mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED
+    val isProteusProtocol = conversationSheetContent.protocol == Conversation.ProtocolInfo.Proteus
+
+    if (isProteusVerified && (isProteusProtocol || !isMlsVerified)) {
+        ProteusVerifiedLabel()
+    } else if (isMlsVerified) {
+        MLSVerifiedLabel()
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
@@ -50,6 +51,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -84,6 +86,7 @@ import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.topBarElevation
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.common.topappbar.WireTopAppBarTitle
 import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.destinations.AddMembersSearchScreenDestination
 import com.wire.android.ui.destinations.EditConversationNameScreenDestination
@@ -312,13 +315,18 @@ private fun GroupConversationDetailsContent(
         topBarHeader = {
             WireCenterAlignedTopAppBar(
                 elevation = elevationState,
-                title = stringResource(R.string.conversation_details_title),
+                titleContent = {
+                    WireTopAppBarTitle(
+                        title = stringResource(R.string.conversation_details_title),
+                        style = MaterialTheme.wireTypography.title01,
+                        maxLines = 2
+                    )
+                    VerificationInfo(conversationSheetContent)
+                },
                 navigationIconType = NavigationIconType.Close,
                 onNavigationPressed = onBackPressed,
                 actions = { MoreOptionIcon(onButtonClicked = openBottomSheet) }
-            ) {
-                VerificationInfo(conversationSheetContent)
-            }
+            )
         },
         topBarCollapsing = {
             conversationSheetState.conversationSheetContent?.let {
@@ -474,35 +482,39 @@ private fun VerificationInfo(conversationSheetContent: ConversationSheetContent?
 
 @Composable
 private fun MLSVerifiedLabel() {
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-        Text(
-            modifier = Modifier.padding(
-                start = dimensions().spacing6x,
-                end = dimensions().spacing6x
-            ),
-            text = stringResource(id = R.string.label_conversations_details_verified_mls).uppercase(),
-            style = MaterialTheme.wireTypography.label01,
-            color = MaterialTheme.wireColorScheme.mlsVerificationTextColor,
-            overflow = TextOverflow.Ellipsis
-        )
-        MLSVerifiedIcon()
-    }
+    VerifiedLabel(
+        stringResource(id = R.string.label_conversations_details_verified_mls).uppercase(),
+        MaterialTheme.wireColorScheme.mlsVerificationTextColor
+    ) { MLSVerifiedIcon() }
 }
 
 @Composable
 private fun ProteusVerifiedLabel() {
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+    VerifiedLabel(
+        stringResource(id = R.string.label_conversations_details_verified_proteus).uppercase(),
+        MaterialTheme.wireColorScheme.primary
+    ) { ProteusVerifiedIcon() }
+}
+
+@Composable
+private fun VerifiedLabel(text: String, color: Color, icon: @Composable RowScope.() -> Unit = {}) {
+    Row(
+        modifier = Modifier
+            .padding(top = dimensions().spacing4x)
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center
+    ) {
         Text(
             modifier = Modifier.padding(
                 start = dimensions().spacing6x,
                 end = dimensions().spacing6x
             ),
-            text = stringResource(id = R.string.label_conversations_details_verified_proteus).uppercase(),
+            text = text,
             style = MaterialTheme.wireTypography.label01,
-            color = MaterialTheme.wireColorScheme.primary,
+            color = color,
             overflow = TextOverflow.Ellipsis
         )
-        ProteusVerifiedIcon()
+        icon()
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -23,6 +23,8 @@ package com.wire.android.ui.home.conversations.details
 import androidx.annotation.StringRes
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalOverscrollConfiguration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -31,7 +33,9 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -47,6 +51,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
@@ -59,7 +64,9 @@ import com.wire.android.appLogger
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.style.PopUpNavigationAnimation
+import com.wire.android.ui.common.MLSVerifiedIcon
 import com.wire.android.ui.common.MoreOptionIcon
+import com.wire.android.ui.common.ProteusVerifiedIcon
 import com.wire.android.ui.common.TabItem
 import com.wire.android.ui.common.WireTabRow
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
@@ -68,6 +75,7 @@ import com.wire.android.ui.common.bottomsheet.conversation.rememberConversationS
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.calculateCurrentTab
 import com.wire.android.ui.common.dialogs.ArchiveConversationDialog
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topBarElevation
 import com.wire.android.ui.common.topappbar.NavigationIconType
@@ -94,8 +102,11 @@ import com.wire.android.ui.home.conversationslist.model.DialogState
 import com.wire.android.ui.home.conversationslist.model.GroupDialogState
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.theme.WireTheme
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.conversation.Conversation
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.launch
 
@@ -291,8 +302,18 @@ private fun GroupConversationDetailsContent(
                 title = stringResource(R.string.conversation_details_title),
                 navigationIconType = NavigationIconType.Close,
                 onNavigationPressed = onBackPressed,
-                actions = { MoreOptionIcon(onButtonClicked = openBottomSheet) }
+                actions = { MoreOptionIcon(onButtonClicked = openBottomSheet) },
             ) {
+                if (conversationSheetContent?.proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
+                    if (conversationSheetContent.protocol == Conversation.ProtocolInfo.Proteus ||
+                        conversationSheetContent.mlsVerificationStatus != Conversation.VerificationStatus.VERIFIED
+                    )
+                        ProteusVerifiedLabel()
+                } else if (conversationSheetContent?.mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
+                    if (conversationSheetContent.protocol is Conversation.ProtocolInfo.MLS) {
+                        MLSVerifiedLabel()
+                    }
+                }
                 WireTabRow(
                     tabs = GroupConversationDetailsTabItem.values().toList(),
                     selectedTabIndex = currentTabState,
@@ -407,6 +428,40 @@ private fun GroupConversationDetailsContent(
             bottomSheetEventsHandler.updateConversationArchiveStatus(dialogState = it, onMessage = closeBottomSheetAndShowSnackbarMessage)
         }
     )
+}
+
+@Composable
+private fun MLSVerifiedLabel() {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+        Text(
+            modifier = Modifier.padding(
+                start = dimensions().spacing6x,
+                end = dimensions().spacing6x
+            ),
+            text = stringResource(id = R.string.label_conversations_details_verified_mls).uppercase(),
+            style = MaterialTheme.wireTypography.label01,
+            color = MaterialTheme.wireColorScheme.mlsVerificationTextColor,
+            overflow = TextOverflow.Ellipsis
+        )
+        MLSVerifiedIcon()
+    }
+}
+
+@Composable
+private fun ProteusVerifiedLabel() {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+        Text(
+            modifier = Modifier.padding(
+                start = dimensions().spacing6x,
+                end = dimensions().spacing6x
+            ),
+            text = stringResource(id = R.string.label_conversations_details_verified_proteus).uppercase(),
+            style = MaterialTheme.wireTypography.label01,
+            color = MaterialTheme.wireColorScheme.primary,
+            overflow = TextOverflow.Ellipsis
+        )
+        ProteusVerifiedIcon()
+    }
 }
 
 enum class GroupConversationDetailsTabItem(@StringRes override val titleResId: Int) : TabItem {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -150,7 +150,10 @@ class GroupConversationDetailsViewModel @Inject constructor(
                     conversationTypeDetail = ConversationTypeDetail.Group(conversationId, groupDetails.isSelfUserCreator),
                     isTeamConversation = groupDetails.conversation.teamId?.value != null,
                     selfRole = groupDetails.selfRole,
-                    isArchived = groupDetails.conversation.archived
+                    isArchived = groupDetails.conversation.archived,
+                    protocol = groupDetails.conversation.protocol,
+                    mlsVerificationStatus = groupDetails.conversation.mlsVerificationStatus,
+                    proteusVerificationStatus = groupDetails.conversation.proteusVerificationStatus
                 )
                 val isGuestAllowed = groupDetails.conversation.isGuestAllowed() || groupDetails.conversation.isNonTeamMemberAllowed()
                 val isUpdatingReadReceiptAllowed = if (selfTeam == null) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -118,7 +118,8 @@ class ConversationInfoViewModel @Inject constructor(
             hasUserPermissionToEdit = detailsData !is ConversationDetailsData.None,
             conversationType = conversationDetails.conversation.type,
             protocolInfo = conversationDetails.conversation.protocol,
-            verificationStatus = conversationDetails.conversation.verificationStatus
+            mlsVerificationStatus = conversationDetails.conversation.mlsVerificationStatus,
+            proteusVerificationStatus = conversationDetails.conversation.proteusVerificationStatus
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
@@ -36,7 +36,8 @@ data class ConversationInfoViewState(
     val hasUserPermissionToEdit: Boolean = false,
     val conversationType: Conversation.Type = Conversation.Type.ONE_ON_ONE,
     val protocolInfo: Conversation.ProtocolInfo? = null,
-    val verificationStatus: Conversation.VerificationStatus? = null,
+    val mlsVerificationStatus: Conversation.VerificationStatus? = null,
+    val proteusVerificationStatus: Conversation.VerificationStatus? = null,
 )
 
 sealed class ConversationDetailsData {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -193,6 +193,8 @@ sealed class UILastMessageContent {
     data class MultipleMessage(val messages: List<UIText>, val separator: String = " ") : UILastMessageContent()
 
     data class Connection(val connectionState: ConnectionState, val userId: UserId) : UILastMessageContent()
+
+    data class VerificationChanged(@StringRes val textResId: Int) : UILastMessageContent()
 }
 
 sealed class UIMessageContent {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -469,7 +469,8 @@ sealed class UIMessageContent {
         data class ConversationDegraded(val protocol: Conversation.Protocol) : SystemMessage(
             if (protocol == Conversation.Protocol.MLS) R.drawable.ic_conversation_degraded_mls
             else R.drawable.ic_shield_holo,
-            R.string.label_system_message_conversation_degraded
+            if (protocol == Conversation.Protocol.MLS) R.string.label_system_message_conversation_degraded_mls
+            else R.string.label_system_message_conversation_degraded_proteus
         )
 
         data class ConversationVerified(val protocol: Conversation.Protocol) : SystemMessage(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -486,7 +486,9 @@ private fun ConversationDetails.toConversationItem(
             isSelfUserMember = isSelfUserMember,
             teamId = conversation.teamId,
             selfMemberRole = selfRole,
-            isArchived = conversation.archived
+            isArchived = conversation.archived,
+            mlsVerificationStatus = conversation.mlsVerificationStatus,
+            proteusVerificationStatus = conversation.proteusVerificationStatus
         )
     }
 
@@ -517,7 +519,9 @@ private fun ConversationDetails.toConversationItem(
             userId = otherUser.id,
             blockingState = otherUser.BlockState,
             teamId = otherUser.teamId,
-            isArchived = conversation.archived
+            isArchived = conversation.archived,
+            mlsVerificationStatus = conversation.mlsVerificationStatus,
+            proteusVerificationStatus = conversation.proteusVerificationStatus
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -115,6 +115,7 @@ fun ConversationItemFactory(
     )
 }
 
+@Suppress("ComplexMethod")
 @Composable
 private fun GeneralConversationItem(
     searchQuery: String,
@@ -147,10 +148,12 @@ private fun GeneralConversationItem(
                             isLegalHold = conversation.isLegalHold,
                             searchQuery = searchQuery,
                             badges = {
-                                if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+                                if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
                                     ProteusVerifiedIcon(contentDescriptionId = R.string.content_description_proteus_certificate_valid)
-                                if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+                                }
+                                if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
                                     MLSVerifiedIcon(contentDescriptionId = R.string.content_description_mls_certificate_valid)
+                                }
                             }
                         )
                     },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -32,6 +32,8 @@ import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.calling.controlbuttons.JoinButton
+import com.wire.android.ui.common.MLSVerifiedIcon
+import com.wire.android.ui.common.ProteusVerifiedIcon
 import com.wire.android.ui.common.RowItemTemplate
 import com.wire.android.ui.common.WireRadioButton
 import com.wire.android.ui.common.colorsScheme
@@ -45,6 +47,7 @@ import com.wire.android.ui.home.conversationslist.model.ConversationInfo
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.ui.home.conversationslist.model.toUserInfoLabel
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -99,6 +102,8 @@ fun ConversationItemFactory(
                     )
 
                     is UILastMessageContent.Connection -> ConnectionLabel(connectionInfo = messageContent)
+                    is UILastMessageContent.VerificationChanged -> LastMessageSubtitle(UIText.StringResource(messageContent.textResId))
+
                     else -> {}
                 }
             }
@@ -145,7 +150,13 @@ private fun GeneralConversationItem(
                         ConversationTitle(
                             name = groupName.ifEmpty { stringResource(id = R.string.member_name_deleted_label) },
                             isLegalHold = conversation.isLegalHold,
-                            searchQuery = searchQuery
+                            searchQuery = searchQuery,
+                            badges = {
+                                if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+                                    ProteusVerifiedIcon(contentDescriptionId = R.string.content_description_proteus_certificate_valid)
+                                if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+                                    MLSVerifiedIcon(contentDescriptionId = R.string.content_description_mls_certificate_valid)
+                            }
                         )
                     },
                     subTitle = subTitle,
@@ -250,7 +261,9 @@ fun PreviewGroupConversationItemWithUnreadCount() {
             badgeEventType = BadgeEventType.UnreadMessage(100),
             selfMemberRole = null,
             teamId = null,
-            isArchived = false
+            isArchived = false,
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         ),
         searchQuery = "",
         isSelectableItem = false,
@@ -273,7 +286,9 @@ fun PreviewGroupConversationItemWithNoBadges() {
             badgeEventType = BadgeEventType.None,
             selfMemberRole = null,
             teamId = null,
-            isArchived = false
+            isArchived = false,
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         ),
         searchQuery = "",
         isSelectableItem = false,
@@ -296,7 +311,9 @@ fun PreviewGroupConversationItemWithMutedBadgeAndUnreadMentionBadge() {
             badgeEventType = BadgeEventType.UnreadMention,
             selfMemberRole = null,
             teamId = null,
-            isArchived = false
+            isArchived = false,
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         ),
         searchQuery = "",
         isSelectableItem = false,
@@ -320,7 +337,9 @@ fun PreviewGroupConversationItemWithOngoingCall() {
             selfMemberRole = null,
             teamId = null,
             hasOnGoingCall = true,
-            isArchived = false
+            isArchived = false,
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         ),
         searchQuery = "",
         isSelectableItem = false,
@@ -381,7 +400,9 @@ fun PreviewPrivateConversationItemWithBlockedBadge() {
             blockingState = BlockingState.BLOCKED,
             teamId = null,
             userId = UserId("value", "domain"),
-            isArchived = false
+            isArchived = false,
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         ),
         searchQuery = "",
         isSelectableItem = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/UserLabel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/UserLabel.kt
@@ -50,10 +50,12 @@ fun UserLabel(
                     Spacer(modifier = Modifier.width(6.dp))
                     MembershipQualifierLabel(membership)
                 }
-                if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+                if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
                     ProteusVerifiedIcon(contentDescriptionId = R.string.content_description_proteus_certificate_valid)
-                if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+                }
+                if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
                     MLSVerifiedIcon(contentDescriptionId = R.string.content_description_mls_certificate_valid)
+                }
             },
             searchQuery = searchQuery
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/UserLabel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/UserLabel.kt
@@ -27,9 +27,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
+import com.wire.android.ui.common.MLSVerifiedIcon
 import com.wire.android.ui.common.MembershipQualifierLabel
+import com.wire.android.ui.common.ProteusVerifiedIcon
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.conversationslist.model.hasLabel
+import com.wire.kalium.logic.data.conversation.Conversation
 
 @Composable
 fun UserLabel(
@@ -47,6 +50,10 @@ fun UserLabel(
                     Spacer(modifier = Modifier.width(6.dp))
                     MembershipQualifierLabel(membership)
                 }
+                if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+                    ProteusVerifiedIcon(contentDescriptionId = R.string.content_description_proteus_certificate_valid)
+                if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED)
+                    MLSVerifiedIcon(contentDescriptionId = R.string.content_description_mls_certificate_valid)
             },
             searchQuery = searchQuery
         )
@@ -57,5 +64,7 @@ data class UserInfoLabel(
     val labelName: String,
     val isLegalHold: Boolean,
     val membership: Membership,
-    val unavailable: Boolean = false
+    val unavailable: Boolean = false,
+    val proteusVerificationStatus: Conversation.VerificationStatus? = null,
+    val mlsVerificationStatus: Conversation.VerificationStatus? = null,
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -40,6 +40,8 @@ sealed class ConversationItem {
     abstract val badgeEventType: BadgeEventType
     abstract val teamId: TeamId?
     abstract val isArchived: Boolean
+    abstract val mlsVerificationStatus: Conversation.VerificationStatus
+    abstract val proteusVerificationStatus: Conversation.VerificationStatus
 
     val isTeamConversation get() = teamId != null
 
@@ -56,6 +58,8 @@ sealed class ConversationItem {
         override val badgeEventType: BadgeEventType,
         override val teamId: TeamId?,
         override val isArchived: Boolean,
+        override val mlsVerificationStatus: Conversation.VerificationStatus,
+        override val proteusVerificationStatus: Conversation.VerificationStatus
     ) : ConversationItem()
 
     data class PrivateConversation(
@@ -69,7 +73,9 @@ sealed class ConversationItem {
         override val lastMessageContent: UILastMessageContent?,
         override val badgeEventType: BadgeEventType,
         override val teamId: TeamId?,
-        override val isArchived: Boolean
+        override val isArchived: Boolean,
+        override val mlsVerificationStatus: Conversation.VerificationStatus,
+        override val proteusVerificationStatus: Conversation.VerificationStatus
     ) : ConversationItem()
 
     data class ConnectionConversation(
@@ -83,6 +89,8 @@ sealed class ConversationItem {
         override val isArchived: Boolean = false,
     ) : ConversationItem() {
         override val teamId: TeamId? = null
+        override val mlsVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        override val proteusVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
     }
 }
 
@@ -111,7 +119,9 @@ fun ConversationItem.PrivateConversation.toUserInfoLabel() =
         labelName = conversationInfo.name,
         isLegalHold = isLegalHold,
         membership = conversationInfo.membership,
-        unavailable = conversationInfo.isSenderUnavailable
+        unavailable = conversationInfo.isSenderUnavailable,
+        mlsVerificationStatus = mlsVerificationStatus,
+        proteusVerificationStatus = proteusVerificationStatus
     )
 
 fun ConversationItem.ConnectionConversation.toUserInfoLabel() =

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -244,7 +244,7 @@ private fun DeviceDetailsTopBar(
                     maxLines = 2
                 )
                 if (!isCurrentDevice && device.isVerifiedProteus) {
-                    ProteusVerifiedIcon()
+                    ProteusVerifiedIcon(Modifier.align(Alignment.CenterVertically))
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -39,7 +39,6 @@ import com.wire.android.util.parcelableArrayList
 import com.wire.android.util.resampleImageAndCopyToTempPath
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -39,6 +39,7 @@ import com.wire.android.util.parcelableArrayList
 import com.wire.android.util.resampleImageAndCopyToTempPath
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
@@ -192,7 +193,9 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
                 isSelfUserMember = isSelfUserMember,
                 teamId = conversation.teamId,
                 selfMemberRole = selfRole,
-                isArchived = conversation.archived
+                isArchived = conversation.archived,
+                mlsVerificationStatus = conversation.mlsVerificationStatus,
+                proteusVerificationStatus = conversation.proteusVerificationStatus
             )
         }
 
@@ -228,7 +231,9 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
                 userId = otherUser.id,
                 blockingState = otherUser.BlockState,
                 teamId = otherUser.teamId,
-                isArchived = conversation.archived
+                isArchived = conversation.archived,
+                mlsVerificationStatus = conversation.mlsVerificationStatus,
+                proteusVerificationStatus = conversation.proteusVerificationStatus
             )
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -100,7 +100,8 @@ data class WireColorScheme(
     val unclassifiedBannerBackgroundColor: Color,
     val unclassifiedBannerForegroundColor: Color,
     val recordAudioStartColor: Color,
-    val recordAudioStopColor: Color
+    val recordAudioStopColor: Color,
+    val mlsVerificationTextColor: Color,
 ) {
     fun toColorScheme(): ColorScheme = ColorScheme(
         primary = primary,
@@ -231,7 +232,8 @@ private val LightWireColorScheme = WireColorScheme(
     unclassifiedBannerBackgroundColor = WireColorPalette.LightRed600,
     unclassifiedBannerForegroundColor = Color.White,
     recordAudioStartColor = WireColorPalette.LightBlue500,
-    recordAudioStopColor = WireColorPalette.LightRed500
+    recordAudioStopColor = WireColorPalette.LightRed500,
+    mlsVerificationTextColor = WireColorPalette.DarkGreen700
 )
 
 // Dark WireColorScheme
@@ -336,7 +338,8 @@ private val DarkWireColorScheme = WireColorScheme(
     unclassifiedBannerBackgroundColor = WireColorPalette.DarkRed500,
     unclassifiedBannerForegroundColor = Color.Black,
     recordAudioStartColor = WireColorPalette.LightBlue500,
-    recordAudioStopColor = WireColorPalette.LightRed500
+    recordAudioStopColor = WireColorPalette.LightRed500,
+    mlsVerificationTextColor = WireColorPalette.DarkGreen700
 )
 
 @PackagePrivate

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -379,7 +379,10 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                     ),
                     isTeamConversation = conversation.isTeamGroup(),
                     selfRole = Conversation.Member.Role.Member,
-                    isArchived = conversation.archived
+                    isArchived = conversation.archived,
+                    protocol = conversation.protocol,
+                    mlsVerificationStatus = conversation.mlsVerificationStatus,
+                    proteusVerificationStatus = conversation.proteusVerificationStatus
                 )
             }
         )

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -597,7 +597,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -593,7 +593,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -590,7 +590,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **Teilnehmer** konnten der Gruppe nicht hinzugefügt werden.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s konnten der Gruppe nicht hinzugefügt werden.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s konnte der Gruppe nicht hinzugefügt werden.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -587,7 +587,7 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s no pudieron ser añadidos a la conversación.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s no pudo ser añadido a la conversación.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -578,7 +578,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -593,7 +593,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -585,7 +585,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **résztvevőket** nem sikerült hozzáadni a csoporthoz.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -587,7 +587,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -587,7 +587,7 @@ Fino a 500 persone possono unirsi a una conversazione di gruppo.</string>
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -587,7 +587,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -587,7 +587,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -593,7 +593,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -593,7 +593,7 @@ Do grupy mo&#380;e do&#322;&#261;czy&#263; maksymalnie 500 os&#243;b.</string>
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -588,7 +588,7 @@ Até 500 pessoas podem participar de uma conversa em grupo.</string>
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -591,7 +591,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -593,7 +593,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">Не удалось добавить в группу %1$s **участников**.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">Не удалось добавить %1$s в группу.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">Не удалось добавить %1$s в группу.</string>
-    <string name="label_system_message_conversation_degraded">Эта беседа больше не верифицируется, так как кто-то из пользователей использует по крайней мере одно устройство без действительного сертификата сквозной идентификации.</string>
+    <string name="label_system_message_conversation_degraded_mls">Эта беседа больше не верифицируется, так как кто-то из пользователей использует по крайней мере одно устройство без действительного сертификата сквозной идентификации.</string>
     <string name="label_system_message_conversation_verified_mls">Все устройства верифицированы (сквозная идентификация)</string>
     <string name="label_system_message_conversation_verified_proteus">Все отпечатки верифицированы (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -579,7 +579,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">**සහභාගීන්** %1$s ක් සමූහයට එක් කිරීමට නොහැකි විය.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s දෙනෙක් සමූහයට එක් කිරීමට නොහැකි විය.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s දෙනෙක් සමූහයට එක් කිරීමට නොහැකි විය.</string>
-    <string name="label_system_message_conversation_degraded">ඇතැම් පරිශ්‍රීලකයින් වලංගු අන්ත අනන්‍යතා සහතිකයක් නැතිව අවම වශයෙන් එක් උපාංගයක් භාවිතා කරන බැවින් මෙම සංවාදය තවදුරටත් සත්‍යාපිත නොවේ.</string>
+    <string name="label_system_message_conversation_degraded_mls">ඇතැම් පරිශ්‍රීලකයින් වලංගු අන්ත අනන්‍යතා සහතිකයක් නැතිව අවම වශයෙන් එක් උපාංගයක් භාවිතා කරන බැවින් මෙම සංවාදය තවදුරටත් සත්‍යාපිත නොවේ.</string>
     <string name="label_system_message_conversation_verified_mls">සියලු උපාංග සත්‍යාපිතයි (අන්ත අනන්‍යතාව)</string>
     <string name="label_system_message_conversation_verified_proteus">සියලු ඇඟිලි සටහන් සත්‍යාපිතයි (ප්‍රෝතියස්)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -593,7 +593,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -593,7 +593,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -591,7 +591,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -589,7 +589,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -593,7 +593,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -587,7 +587,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -587,7 +587,7 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <!-- Last messages -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -605,6 +605,8 @@
     <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
+    <string name="label_conversations_details_verified_proteus">Verified (Proteus)</string>
+    <string name="label_conversations_details_verified_mls">Verified (End-to-end Identity)</string>
     <!-- Last messages -->
     <plurals name="last_message_self_added_users">
         <item quantity="one">You added 1 person to the conversation</item>
@@ -653,6 +655,10 @@
     <string name="last_message_self_user_left_conversation">left the conversation.</string>
     <string name="last_message_other_user_joined_conversation">joined the conversation.</string>
     <string name="last_message_other_user_left_conversation">left the conversation.</string>
+    <string name="last_message_verified_conversation_proteus">All device fingerprints are verified (Proteus)</string>
+    <string name="last_message_verified_conversation_mls">All devices are verified (End-to-end Identity)</string>
+    <string name="last_message_conversations_verification_degraded_mls">Conversation is no longer verified</string>
+    <string name="last_message_conversations_verification_degraded_proteus">Conversation is no longer verified</string>
     <!-- Unread Events -->
     <plurals name="unread_event_knock">
         <item quantity="one">%1$d ping</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -602,7 +602,8 @@
     <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
     <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_degraded">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
+    <string name="label_system_message_conversation_degraded_proteus">This conversation is no longer verified, as some user uses at least one device without a valid end-to-end identity certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
     <string name="label_conversations_details_verified_proteus">Verified (Proteus)</string>

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
@@ -52,7 +52,8 @@ object TestConversation {
         userMessageTimer = null,
         archived = false,
         archivedDateTime = null,
-        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+        proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
     )
     val SELF = Conversation(
         ID.copy(value = "SELF ID"),
@@ -73,7 +74,8 @@ object TestConversation {
         userMessageTimer = null,
         archived = false,
         archivedDateTime = null,
-        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+        proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
     )
 
     fun GROUP(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
@@ -95,7 +97,8 @@ object TestConversation {
         userMessageTimer = null,
         archived = false,
         archivedDateTime = null,
-        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+        proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
     )
 
     fun one_on_one(convId: ConversationId) = Conversation(
@@ -117,7 +120,8 @@ object TestConversation {
         userMessageTimer = null,
         archived = false,
         archivedDateTime = null,
-        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+        proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
     )
 
     val USER_1 = UserId("member1", "domainMember")
@@ -146,6 +150,7 @@ object TestConversation {
         userMessageTimer = null,
         archived = false,
         archivedDateTime = null,
-        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+        proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
     )
 }

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
@@ -52,7 +52,7 @@ object TestConversation {
         userMessageTimer = null,
         archived = false,
         archivedDateTime = null,
-        verificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
     )
     val SELF = Conversation(
         ID.copy(value = "SELF ID"),
@@ -73,7 +73,7 @@ object TestConversation {
         userMessageTimer = null,
         archived = false,
         archivedDateTime = null,
-        verificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
     )
 
     fun GROUP(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
@@ -95,7 +95,7 @@ object TestConversation {
         userMessageTimer = null,
         archived = false,
         archivedDateTime = null,
-        verificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
     )
 
     fun one_on_one(convId: ConversationId) = Conversation(
@@ -117,7 +117,7 @@ object TestConversation {
         userMessageTimer = null,
         archived = false,
         archivedDateTime = null,
-        verificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
     )
 
     val USER_1 = UserId("member1", "domainMember")
@@ -146,6 +146,6 @@ object TestConversation {
         userMessageTimer = null,
         archived = false,
         archivedDateTime = null,
-        verificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
     )
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -585,7 +585,7 @@ class GroupConversationDetailsViewModelTest {
                 userMessageTimer = null,
                 archived = false,
                 archivedDateTime = null,
-                verificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+                mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
             ),
             legalHoldStatus = LegalHoldStatus.DISABLED,
             hasOngoingCall = false,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -415,7 +415,10 @@ class GroupConversationDetailsViewModelTest {
             conversationTypeDetail = ConversationTypeDetail.Group(details.conversation.id, details.isSelfUserCreator),
             selfRole = Conversation.Member.Role.Member,
             isTeamConversation = details.conversation.isTeamGroup(),
-            isArchived = false
+            isArchived = false,
+            protocol = Conversation.ProtocolInfo.Proteus,
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         )
         // When - Then
         assertEquals(expected, viewModel.conversationSheetContent)
@@ -585,7 +588,8 @@ class GroupConversationDetailsViewModelTest {
                 userMessageTimer = null,
                 archived = false,
                 archivedDateTime = null,
-                mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+                mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+                proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
             ),
             legalHoldStatus = LegalHoldStatus.DISABLED,
             hasOngoingCall = false,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelTest.kt
@@ -233,8 +233,8 @@ class ConversationInfoViewModelTest {
                 viewModel.conversationInfoViewState.protocolInfo
             )
             assertEquals(
-                groupConversationDetails.conversation.verificationStatus,
-                viewModel.conversationInfoViewState.verificationStatus
+                groupConversationDetails.conversation.mlsVerificationStatus,
+                viewModel.conversationInfoViewState.mlsVerificationStatus
             )
             cancel()
         }
@@ -257,8 +257,8 @@ class ConversationInfoViewModelTest {
                 viewModel.conversationInfoViewState.protocolInfo
             )
             assertEquals(
-                groupConversationDetails.conversation.verificationStatus,
-                viewModel.conversationInfoViewState.verificationStatus
+                groupConversationDetails.conversation.mlsVerificationStatus,
+                viewModel.conversationInfoViewState.mlsVerificationStatus
             )
             cancel()
         }
@@ -281,8 +281,8 @@ class ConversationInfoViewModelTest {
                 viewModel.conversationInfoViewState.protocolInfo
             )
             assertEquals(
-                groupConversationDetails.conversation.verificationStatus,
-                viewModel.conversationInfoViewState.verificationStatus
+                groupConversationDetails.conversation.mlsVerificationStatus,
+                viewModel.conversationInfoViewState.mlsVerificationStatus
             )
             cancel()
         }
@@ -302,7 +302,7 @@ class ConversationInfoViewModelTest {
         )
         assertEquals(
             null,
-            viewModel.conversationInfoViewState.verificationStatus
+            viewModel.conversationInfoViewState.mlsVerificationStatus
         )
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -42,6 +42,7 @@ import com.wire.android.ui.home.conversationslist.model.DialogState
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.util.orDefault
 import com.wire.android.util.ui.WireSessionImageLoader
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
@@ -402,7 +403,9 @@ class ConversationListViewModelTest {
             userId = userId,
             blockingState = BlockingState.CAN_NOT_BE_BLOCKED,
             teamId = null,
-            isArchived = false
+            isArchived = false,
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         )
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -304,7 +304,7 @@ class MediaGalleryViewModelTest {
                 userMessageTimer = null,
                 archived = false,
                 archivedDateTime = null,
-                verificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+                mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
             ),
             otherUser = OtherUser(
                 QualifiedID("other-user-id", "domain-id"),

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -305,7 +305,8 @@ class MediaGalleryViewModelTest {
                 userMessageTimer = null,
                 archived = false,
                 archivedDateTime = null,
-                mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+                mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+                proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
             ),
             otherUser = OtherUser(
                 QualifiedID("other-user-id", "domain-id"),

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -159,7 +159,8 @@ internal class NewConversationViewModelArrangement {
             userMessageTimer = null,
             archived = false,
             archivedDateTime = null,
-            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         )
 
         val PUBLIC_USER = OtherUser(

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -158,7 +158,7 @@ internal class NewConversationViewModelArrangement {
             userMessageTimer = null,
             archived = false,
             archivedDateTime = null,
-            verificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         )
 
         val PUBLIC_USER = OtherUser(

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -247,7 +247,8 @@ class OtherUserProfileScreenViewModelTest {
             userMessageTimer = null,
             archived = false,
             archivedDateTime = null,
-            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         )
         val CONVERSATION_ROLE_DATA = ConversationRoleData(
             "some_name",

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -245,7 +245,7 @@ class OtherUserProfileScreenViewModelTest {
             userMessageTimer = null,
             archived = false,
             archivedDateTime = null,
-            verificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         )
         val CONVERSATION_ROLE_DATA = ConversationRoleData(
             "some_name",


### PR DESCRIPTION
# What's new in this PR?

### Issues

When the conversation is "Proteus verified" user should know about it: corresponding icon next to the conversation name and systemMessage in a conversation + systemMessage when the conversation becomes Degraded (was verified in past but not anymore).

Needs releases with:

- wireapp/kalium/pull/2157

#### How to Test

1. 
- open some users profile
- go to Devices tab
- verify all the devices of the user
- go to the conversation with that user
expected result: 
there should be a system message informing that conversation is Verified now + blue shield icon is next to the user name 
- go to the Conversations List screen 
expected: 
blue shield icon is next to the user name and second line in conversation item is SystemMessage

2. 
- open some group conversation
- verify all the devices of all the users in that group (see the prev. test)
- go to that conversation
expected result: 
there should be a system message informing that conversation is Verified now + blue is next to the conversation name
- go to the Conversations List screen 
expected: 
blue shield icon is next to the conversation name and second line in conversation item is SystemMessage

3. 
- do all from test-2
- un-verify at least 1 device of 1 user
- go to that conversation
expected result: 
there should be a system message informing that conversation is NOT Verified anymore + NO blue is next to the conversation name
- go to the Conversations List screen 
expected: 
NO blue shield is next to the conversation name and second line in conversation item is SystemMessage

### Attachments (Optional)

<img width="286" alt="Screenshot 2023-10-27 at 11 40 09" src="https://github.com/wireapp/wire-android-reloaded/assets/6539347/3d8d35cf-9532-450c-a580-fb4cc9beb132">

<img width="286" alt="Screenshot 2023-10-27 at 11 40 21" src="https://github.com/wireapp/wire-android-reloaded/assets/6539347/3c69c3c5-c5bb-438d-84c2-1d78054271a2">

<img width="285" alt="Screenshot 2023-10-19 at 17 59 17" src="https://github.com/wireapp/wire-android-reloaded/assets/6539347/f025d893-3741-41cd-a398-f06bfab7b318">

<img width="289" alt="Screenshot 2023-10-19 at 17 59 53" src="https://github.com/wireapp/wire-android-reloaded/assets/6539347/7f17e757-c4ee-45d1-a68f-9b6f7281a3dd">

<img width="281" alt="Screenshot 2023-10-19 at 17 59 35" src="https://github.com/wireapp/wire-android-reloaded/assets/6539347/8227f731-543e-4ac9-aa52-6b8724a3976e">
