### PR TITLE
fix: expanded message composer improvements [WPB-5131]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/AttachmentButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/AttachmentButton.kt
@@ -32,8 +32,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,7 +43,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.common.spacers.VerticalSpace
@@ -90,7 +89,6 @@ fun AttachmentButton(
             text = text,
             maxLines = 2,
             textAlign = TextAlign.Center,
-            overflow = TextOverflow.Ellipsis,
             style = labelStyle,
             color = MaterialTheme.wireColorScheme.onBackground,
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -833,7 +833,7 @@ fun MessageList(
     }
 
     Scaffold(
-        floatingActionButton = { JumpToLastMessageButton(lazyListState) },
+        floatingActionButton = { JumpToLastMessageButton(lazyListState = lazyListState) },
         content = {
             LazyColumn(
                 state = lazyListState,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -30,9 +30,8 @@ import androidx.compose.animation.shrinkOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -55,6 +54,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.platform.LocalContext
@@ -832,16 +832,21 @@ fun MessageList(
         }
     }
 
-    Scaffold(
-        floatingActionButton = { JumpToLastMessageButton(lazyListState = lazyListState) },
+    Box(
+        contentAlignment = Alignment.BottomEnd,
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = colorsScheme().backgroundVariant),
         content = {
             LazyColumn(
                 state = lazyListState,
                 reverseLayout = true,
+                // calculating bottom padding to have space for [UsersTypingIndicator]
+                contentPadding = PaddingValues(
+                    bottom = dimensions().typingIndicatorHeight - (dimensions().messageItemBottomPadding / 2)
+                ),
                 modifier = Modifier
-                    .fillMaxHeight()
-                    .fillMaxWidth()
-                    .background(color = colorsScheme().backgroundVariant)
+                    .fillMaxSize()
             ) {
                 itemsIndexed(lazyPagingMessages, key = { _, uiMessage ->
                     uiMessage.header.messageId
@@ -891,6 +896,7 @@ fun MessageList(
                     }
                 }
             }
+            JumpToLastMessageButton(lazyListState = lazyListState)
         })
 }
 
@@ -905,7 +911,6 @@ fun JumpToLastMessageButton(
         exit = shrinkOut { it }
     ) {
         SmallFloatingActionButton(
-            modifier = Modifier.offset(y = dimensions().spacing18x),
             onClick = { coroutineScope.launch { lazyListState.animateScrollToItem(0) } },
             containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
             contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -23,14 +23,25 @@ package com.wire.android.ui.home.conversations
 import SwipeableSnackbar
 import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
@@ -49,6 +60,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
@@ -76,6 +88,7 @@ import com.wire.android.ui.common.dialogs.calling.CallingFeatureUnavailableDialo
 import com.wire.android.ui.common.dialogs.calling.ConfirmStartCallDialog
 import com.wire.android.ui.common.dialogs.calling.JoinAnywayDialog
 import com.wire.android.ui.common.dialogs.calling.OngoingActiveCallDialog
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.error.CoreFailureErrorDialog
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.destinations.ConversationScreenDestination
@@ -110,6 +123,7 @@ import com.wire.android.ui.home.messagecomposer.MessageComposer
 import com.wire.android.ui.home.messagecomposer.state.MessageBundle
 import com.wire.android.ui.home.messagecomposer.state.MessageComposerStateHolder
 import com.wire.android.ui.home.messagecomposer.state.rememberMessageComposerStateHolder
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.extension.openAppInfoScreen
 import com.wire.android.util.normalizeLink
 import com.wire.android.util.ui.UIText
@@ -868,6 +882,31 @@ fun MessageList(
                     onSelfDeletingMessageRead = onSelfDeletingMessageRead
                 )
             }
+        }
+    }
+}
+
+@Composable
+fun JumpToLastMessageButton() {
+    AnimatedVisibility(
+        visible = true, // todo change to dynamic when we have a proper implementation to hide it
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        SmallFloatingActionButton(
+            modifier = Modifier
+                .offset(y = -dimensions().spacing48x)
+                .zIndex(Float.MAX_VALUE),
+            onClick = { },
+            containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
+            contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,
+            shape = CircleShape,
+        ) {
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowDown,
+                contentDescription = "Small floating action button.", // todo change later
+                Modifier.size(dimensions().spacing32x)
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -913,7 +913,7 @@ fun JumpToLastMessageButton(
         ) {
             Icon(
                 imageVector = Icons.Default.KeyboardArrowDown,
-                contentDescription = "Small floating action button.", // todo change later
+                contentDescription = stringResource(id = R.string.content_description_jump_to_last_message),
                 Modifier.size(dimensions().spacing32x)
             )
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -833,7 +833,7 @@ fun MessageList(
     }
 
     Scaffold(
-        floatingActionButton = { JumpToLastMessageButton() },
+        floatingActionButton = { JumpToLastMessageButton(lazyListState) },
         content = {
             LazyColumn(
                 state = lazyListState,
@@ -895,7 +895,10 @@ fun MessageList(
 }
 
 @Composable
-fun JumpToLastMessageButton() {
+fun JumpToLastMessageButton(
+    coroutineScope: CoroutineScope = rememberCoroutineScope(),
+    lazyListState: LazyListState
+) {
     AnimatedVisibility(
         visible = true, // todo change to dynamic when we have a proper implementation to hide it
         enter = fadeIn(),
@@ -903,7 +906,9 @@ fun JumpToLastMessageButton() {
     ) {
         SmallFloatingActionButton(
             modifier = Modifier.offset(y = dimensions().spacing18x),
-            onClick = { },
+            onClick = {
+                coroutineScope.launch { lazyListState.animateScrollToItem(0) }
+            },
             containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
             contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,
             shape = CircleShape,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -25,8 +25,8 @@ import android.annotation.SuppressLint
 import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
+import androidx.compose.animation.expandIn
+import androidx.compose.animation.shrinkOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -900,15 +900,13 @@ fun JumpToLastMessageButton(
     lazyListState: LazyListState
 ) {
     AnimatedVisibility(
-        visible = true, // todo change to dynamic when we have a proper implementation to hide it
-        enter = fadeIn(),
-        exit = fadeOut(),
+        visible = lazyListState.firstVisibleItemIndex > 0,
+        enter = expandIn { it },
+        exit = shrinkOut { it }
     ) {
         SmallFloatingActionButton(
             modifier = Modifier.offset(y = dimensions().spacing18x),
-            onClick = {
-                coroutineScope.launch { lazyListState.animateScrollToItem(0) }
-            },
+            onClick = { coroutineScope.launch { lazyListState.animateScrollToItem(0) } },
             containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
             contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,
             shape = CircleShape,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -21,11 +21,13 @@
 package com.wire.android.ui.home.conversations
 
 import SwipeableSnackbar
+import android.annotation.SuppressLint
 import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -60,7 +62,6 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
@@ -82,6 +83,7 @@ import com.wire.android.navigation.Navigator
 import com.wire.android.ui.calling.common.MicrophoneBTPermissionsDeniedDialog
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
+import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dialogs.InvalidLinkDialog
 import com.wire.android.ui.common.dialogs.VisitLinkDialog
 import com.wire.android.ui.common.dialogs.calling.CallingFeatureUnavailableDialog
@@ -785,6 +787,7 @@ private fun SnackBarMessage(
     }
 }
 
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun MessageList(
     lazyPagingMessages: LazyPagingItems<UIMessage>,
@@ -829,61 +832,66 @@ fun MessageList(
         }
     }
 
-    LazyColumn(
-        state = lazyListState,
-        reverseLayout = true,
-        modifier = Modifier
-            .fillMaxHeight()
-            .fillMaxWidth()
-    ) {
-        itemsIndexed(lazyPagingMessages, key = { _, uiMessage ->
-            uiMessage.header.messageId
-        }) { index, message ->
-            if (message == null) {
-                // We can draw a placeholder here, as we fetch the next page of messages
-                return@itemsIndexed
-            }
-            val showAuthor by remember {
-                mutableStateOf(
-                    AuthorHeaderHelper.shouldShowHeader(
-                        index,
-                        lazyPagingMessages.itemSnapshotList.items,
-                        message
-                    )
-                )
-            }
+    Scaffold(
+        floatingActionButton = { JumpToLastMessageButton() },
+        content = {
+            LazyColumn(
+                state = lazyListState,
+                reverseLayout = true,
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth()
+                    .background(color = colorsScheme().backgroundVariant)
+            ) {
+                itemsIndexed(lazyPagingMessages, key = { _, uiMessage ->
+                    uiMessage.header.messageId
+                }) { index, message ->
+                    if (message == null) {
+                        // We can draw a placeholder here, as we fetch the next page of messages
+                        return@itemsIndexed
+                    }
+                    val showAuthor by remember {
+                        mutableStateOf(
+                            AuthorHeaderHelper.shouldShowHeader(
+                                index,
+                                lazyPagingMessages.itemSnapshotList.items,
+                                message
+                            )
+                        )
+                    }
 
-            when (message) {
-                is UIMessage.Regular -> {
-                    MessageItem(
-                        message = message,
-                        conversationDetailsData = conversationDetailsData,
-                        showAuthor = showAuthor,
-                        audioMessagesState = audioMessagesState,
-                        onAudioClick = onAudioItemClicked,
-                        onChangeAudioPosition = onChangeAudioPosition,
-                        onLongClicked = onShowEditingOption,
-                        onAssetMessageClicked = onAssetItemClicked,
-                        onImageMessageClicked = onImageFullScreenMode,
-                        onOpenProfile = onOpenProfile,
-                        onReactionClicked = onReactionClicked,
-                        onResetSessionClicked = onResetSessionClicked,
-                        onSelfDeletingMessageRead = onSelfDeletingMessageRead,
-                        onFailedMessageCancelClicked = onFailedMessageCancelClicked,
-                        onFailedMessageRetryClicked = onFailedMessageRetryClicked,
-                        onLinkClick = onLinkClick
-                    )
+                    when (message) {
+                        is UIMessage.Regular -> {
+                            MessageItem(
+                                message = message,
+                                conversationDetailsData = conversationDetailsData,
+                                showAuthor = showAuthor,
+                                audioMessagesState = audioMessagesState,
+                                onAudioClick = onAudioItemClicked,
+                                onChangeAudioPosition = onChangeAudioPosition,
+                                onLongClicked = onShowEditingOption,
+                                onAssetMessageClicked = onAssetItemClicked,
+                                onImageMessageClicked = onImageFullScreenMode,
+                                onOpenProfile = onOpenProfile,
+                                onReactionClicked = onReactionClicked,
+                                onResetSessionClicked = onResetSessionClicked,
+                                onSelfDeletingMessageRead = onSelfDeletingMessageRead,
+                                onFailedMessageCancelClicked = onFailedMessageCancelClicked,
+                                onFailedMessageRetryClicked = onFailedMessageRetryClicked,
+                                onLinkClick = onLinkClick
+                            )
+                        }
+
+                        is UIMessage.System -> SystemMessageItem(
+                            message = message,
+                            onFailedMessageCancelClicked = onFailedMessageCancelClicked,
+                            onFailedMessageRetryClicked = onFailedMessageRetryClicked,
+                            onSelfDeletingMessageRead = onSelfDeletingMessageRead
+                        )
+                    }
                 }
-
-                is UIMessage.System -> SystemMessageItem(
-                    message = message,
-                    onFailedMessageCancelClicked = onFailedMessageCancelClicked,
-                    onFailedMessageRetryClicked = onFailedMessageRetryClicked,
-                    onSelfDeletingMessageRead = onSelfDeletingMessageRead
-                )
             }
-        }
-    }
+        })
 }
 
 @Composable
@@ -894,9 +902,7 @@ fun JumpToLastMessageButton() {
         exit = fadeOut(),
     ) {
         SmallFloatingActionButton(
-            modifier = Modifier
-                .offset(y = -dimensions().spacing48x)
-                .zIndex(Float.MAX_VALUE),
+            modifier = Modifier.offset(y = dimensions().spacing18x),
             onClick = { },
             containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
             contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/UsersTypingIndicator.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/UsersTypingIndicator.kt
@@ -78,16 +78,17 @@ fun UsersTypingIndicatorForConversation(
 
 @Composable
 fun UsersTypingIndicator(usersTyping: List<UIParticipant>) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .height(dimensions().spacing24x)
-            .background(
-                color = colorsScheme().surface,
-                shape = RoundedCornerShape(dimensions().corner14x),
-            )
-    ) {
-        if (usersTyping.isNotEmpty()) {
+    if (usersTyping.isNotEmpty()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .padding(bottom = dimensions().spacing4x)
+                .height(dimensions().typingIndicatorHeight)
+                .background(
+                    color = colorsScheme().surfaceVariant,
+                    shape = RoundedCornerShape(dimensions().corner14x),
+                )
+        ) {
             val rememberTransition =
                 rememberInfiniteTransition(label = stringResource(R.string.animation_label_typing_indicator_horizontal_transition))
             UsersTypingAvatarPreviews(usersTyping)

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AdditionalOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AdditionalOptions.kt
@@ -21,6 +21,7 @@
 package com.wire.android.ui.home.messagecomposer
 
 import android.net.Uri
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.wrapContentSize
@@ -28,6 +29,7 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.home.conversations.model.UriAsset
 import com.wire.android.ui.home.messagecomposer.recordaudio.RecordAudioComponent
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionMenuState
@@ -54,7 +56,7 @@ fun AdditionalOptionsMenu(
     onRichOptionButtonClicked: (RichTextMarkdown) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Box(modifier) {
+    Box(modifier.background(colorsScheme().messageComposerBackgroundColor)) {
         when (additionalOptionsState) {
             AdditionalOptionMenuState.AttachmentAndAdditionalOptionsMenu -> {
                 AttachmentAndAdditionalOptionsMenuItems(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -17,13 +17,9 @@
  */
 package com.wire.android.ui.home.messagecomposer
 
-import android.annotation.SuppressLint
 import android.net.Uri
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,17 +32,8 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imeAnimationSource
 import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.foundation.layout.isImeVisible
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -62,19 +49,16 @@ import androidx.compose.ui.unit.dp
 import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
 import com.wire.android.ui.common.bottombar.BottomNavigationBarHeight
 import com.wire.android.ui.common.colorsScheme
-import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.UsersTypingIndicatorForConversation
 import com.wire.android.ui.home.conversations.model.UriAsset
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSelectItem
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSubMenuState
 import com.wire.android.ui.home.messagecomposer.state.MessageComposerStateHolder
 import com.wire.android.ui.home.messagecomposer.state.MessageCompositionType
-import com.wire.android.ui.theme.wireColorScheme
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.util.isPositiveNotNull
 
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalLayoutApi::class, ExperimentalComposeUiApi::class)
 @Suppress("ComplexMethod")
 @Composable
@@ -129,45 +113,21 @@ fun EnabledMessageComposer(
                     } else {
                         Modifier.weight(1f)
                     }
-                Scaffold(
-                    modifier = expandOrHideMessagesModifier,
-                    floatingActionButton = {
-                        AnimatedVisibility(
-                            visible = messageComposerViewState.value.mentionSearchResult.isEmpty(), // todo change to dynamic when we have a proper implementation to hide it
-                            enter = fadeIn(),
-                            exit = fadeOut(),
-                        ) {
-                            SmallFloatingActionButton(
-                                onClick = { },
-                                containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
-                                contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,
-                                shape = CircleShape,
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.KeyboardArrowDown,
-                                    contentDescription = "Small floating action button.", // todo change later
-                                    Modifier.size(dimensions().spacing32x)
-                                )
+                Box(
+                    modifier = expandOrHideMessagesModifier.background(color = colorsScheme().backgroundVariant)
+                ) {
+                    messageListContent()
+                    if (messageComposerViewState.value.mentionSearchResult.isNotEmpty()) {
+                        MembersMentionList(
+                            membersToMention = messageComposerViewState.value.mentionSearchResult,
+                            searchQuery = messageComposition.value.messageText,
+                            onMentionPicked = { pickedMention ->
+                                messageCompositionHolder.addMention(pickedMention)
+                                onClearMentionSearchResult()
                             }
-                        }
-                    },
-                    content = {
-                        Box(
-                            modifier = Modifier.background(color = colorsScheme().backgroundVariant)
-                        ) {
-                            messageListContent()
-                            if (messageComposerViewState.value.mentionSearchResult.isNotEmpty()) {
-                                MembersMentionList(
-                                    membersToMention = messageComposerViewState.value.mentionSearchResult,
-                                    searchQuery = messageComposition.value.messageText,
-                                    onMentionPicked = { pickedMention ->
-                                        messageCompositionHolder.addMention(pickedMention)
-                                        onClearMentionSearchResult()
-                                    }
-                                )
-                            }
-                        }
-                    })
+                        )
+                    }
+                }
                 val fillRemainingSpaceOrWrapContent =
                     if (!inputStateHolder.isTextExpanded) {
                         Modifier.wrapContentHeight()
@@ -175,8 +135,7 @@ fun EnabledMessageComposer(
                         Modifier.weight(1f)
                     }
                 Column(
-                    modifier = fillRemainingSpaceOrWrapContent
-                        .fillMaxWidth()
+                    modifier = fillRemainingSpaceOrWrapContent.fillMaxWidth()
                 ) {
                     Column(
                         modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -123,7 +123,8 @@ fun EnabledMessageComposer(
                         Modifier.weight(1f)
                     }
                 Box(
-                    modifier = expandOrHideMessagesModifier.background(color = colorsScheme().backgroundVariant)
+                    modifier = expandOrHideMessagesModifier
+                        .background(color = colorsScheme().backgroundVariant)
                 ) {
                     messageListContent()
                     if (messageComposerViewState.value.mentionSearchResult.isNotEmpty()) {
@@ -144,7 +145,8 @@ fun EnabledMessageComposer(
                         Modifier.weight(1f)
                     }
                 Column(
-                    modifier = fillRemainingSpaceOrWrapContent.fillMaxWidth()
+                    modifier = fillRemainingSpaceOrWrapContent
+                        .fillMaxWidth()
                 ) {
                     Column(
                         modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -123,10 +123,14 @@ fun EnabledMessageComposer(
                         Modifier.weight(1f)
                     }
                 Box(
+                    contentAlignment = Alignment.BottomCenter,
                     modifier = expandOrHideMessagesModifier
                         .background(color = colorsScheme().backgroundVariant)
                 ) {
                     messageListContent()
+                    if (!inputStateHolder.isTextExpanded) {
+                        UsersTypingIndicatorForConversation(conversationId = conversationId)
+                    }
                     if (messageComposerViewState.value.mentionSearchResult.isNotEmpty()) {
                         MembersMentionList(
                             membersToMention = messageComposerViewState.value.mentionSearchResult,
@@ -134,7 +138,8 @@ fun EnabledMessageComposer(
                             onMentionPicked = { pickedMention ->
                                 messageCompositionHolder.addMention(pickedMention)
                                 onClearMentionSearchResult()
-                            }
+                            },
+                            modifier = Modifier.align(Alignment.BottomCenter)
                         )
                     }
                 }
@@ -145,18 +150,11 @@ fun EnabledMessageComposer(
                         Modifier.weight(1f)
                     }
                 Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = fillRemainingSpaceOrWrapContent
                         .fillMaxWidth()
+                        .background(color = colorsScheme().backgroundVariant)
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .background(color = colorsScheme().backgroundVariant)
-                            .fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        UsersTypingIndicatorForConversation(conversationId = conversationId)
-                    }
-
                     Box(Modifier.wrapContentSize()) {
                         SecurityClassificationBannerForConversation(
                             conversationId = conversationId
@@ -169,6 +167,7 @@ fun EnabledMessageComposer(
                             var cursorCoordinateY by remember { mutableStateOf(0F) }
 
                             ActiveMessageComposerInput(
+                                conversationId = conversationId,
                                 messageComposition = messageComposition.value,
                                 isTextExpanded = inputStateHolder.isTextExpanded,
                                 inputType = messageCompositionInputStateHolder.inputType,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -17,9 +17,13 @@
  */
 package com.wire.android.ui.home.messagecomposer
 
+import android.annotation.SuppressLint
 import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -32,8 +36,17 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imeAnimationSource
 import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.foundation.layout.isImeVisible
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -49,16 +62,19 @@ import androidx.compose.ui.unit.dp
 import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
 import com.wire.android.ui.common.bottombar.BottomNavigationBarHeight
 import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.UsersTypingIndicatorForConversation
 import com.wire.android.ui.home.conversations.model.UriAsset
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSelectItem
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSubMenuState
 import com.wire.android.ui.home.messagecomposer.state.MessageComposerStateHolder
 import com.wire.android.ui.home.messagecomposer.state.MessageCompositionType
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.util.isPositiveNotNull
 
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalLayoutApi::class, ExperimentalComposeUiApi::class)
 @Suppress("ComplexMethod")
 @Composable
@@ -113,22 +129,45 @@ fun EnabledMessageComposer(
                     } else {
                         Modifier.weight(1f)
                     }
-                Box(
-                    modifier = expandOrHideMessagesModifier
-                        .background(color = colorsScheme().backgroundVariant)
-                ) {
-                    messageListContent()
-                    if (messageComposerViewState.value.mentionSearchResult.isNotEmpty()) {
-                        MembersMentionList(
-                            membersToMention = messageComposerViewState.value.mentionSearchResult,
-                            searchQuery = messageComposition.value.messageText,
-                            onMentionPicked = { pickedMention ->
-                                messageCompositionHolder.addMention(pickedMention)
-                                onClearMentionSearchResult()
+                Scaffold(
+                    modifier = expandOrHideMessagesModifier,
+                    floatingActionButton = {
+                        AnimatedVisibility(
+                            visible = messageComposerViewState.value.mentionSearchResult.isEmpty(), // todo change to dynamic when we have a proper implementation to hide it
+                            enter = fadeIn(),
+                            exit = fadeOut(),
+                        ) {
+                            SmallFloatingActionButton(
+                                onClick = { },
+                                containerColor = MaterialTheme.wireColorScheme.onSecondaryButtonDisabled,
+                                contentColor = MaterialTheme.wireColorScheme.secondaryButtonDisabled,
+                                shape = CircleShape,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.KeyboardArrowDown,
+                                    contentDescription = "Small floating action button.", // todo change later
+                                    Modifier.size(dimensions().spacing32x)
+                                )
                             }
-                        )
-                    }
-                }
+                        }
+                    },
+                    content = {
+                        Box(
+                            modifier = Modifier.background(color = colorsScheme().backgroundVariant)
+                        ) {
+                            messageListContent()
+                            if (messageComposerViewState.value.mentionSearchResult.isNotEmpty()) {
+                                MembersMentionList(
+                                    membersToMention = messageComposerViewState.value.mentionSearchResult,
+                                    searchQuery = messageComposition.value.messageText,
+                                    onMentionPicked = { pickedMention ->
+                                        messageCompositionHolder.addMention(pickedMention)
+                                        onClearMentionSearchResult()
+                                    }
+                                )
+                            }
+                        }
+                    })
                 val fillRemainingSpaceOrWrapContent =
                     if (!inputStateHolder.isTextExpanded) {
                         Modifier.wrapContentHeight()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActions.kt
@@ -55,14 +55,11 @@ fun MessageSendActions(
     onSendButtonClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Box(modifier) {
-        Row(Modifier.padding(end = dimensions().spacing8x)) {
-            SendButton(
-                isEnabled = sendButtonEnabled,
-                onSendButtonClicked = onSendButtonClicked
-            )
-        }
-    }
+    SendButton(
+        isEnabled = sendButtonEnabled,
+        onSendButtonClicked = onSendButtonClicked,
+        modifier = modifier.padding(end = dimensions().spacing8x)
+    )
 }
 
 @Composable
@@ -147,9 +144,11 @@ fun MessageEditActions(
 @Composable
 private fun SendButton(
     isEnabled: Boolean,
+    modifier: Modifier = Modifier,
     onSendButtonClicked: () -> Unit
 ) {
     WirePrimaryIconButton(
+        modifier = modifier,
         onButtonClicked = onSendButtonClicked,
         iconResource = R.drawable.ic_send,
         contentDescription = R.string.content_description_send_button,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -254,7 +254,6 @@ private fun InputContent(
     }
 }
 
-
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun MessageComposerTextInput(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -61,6 +60,7 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.textfield.WireTextField
 import com.wire.android.ui.common.textfield.WireTextFieldColors
+import com.wire.android.ui.home.conversations.UsersTypingIndicatorForConversation
 import com.wire.android.ui.home.conversations.messages.QuotedMessagePreview
 import com.wire.android.ui.home.messagecomposer.attachments.AdditionalOptionButton
 import com.wire.android.ui.home.messagecomposer.state.MessageComposition
@@ -68,9 +68,11 @@ import com.wire.android.ui.home.messagecomposer.state.MessageCompositionType
 import com.wire.android.ui.home.messagecomposer.state.MessageType
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.kalium.logic.data.id.ConversationId
 
 @Composable
 fun ActiveMessageComposerInput(
+    conversationId: ConversationId,
     messageComposition: MessageComposition,
     isTextExpanded: Boolean,
     inputType: MessageCompositionType,
@@ -91,7 +93,8 @@ fun ActiveMessageComposerInput(
 ) {
     Column(
         modifier = modifier
-            .wrapContentSize()
+            .wrapContentHeight()
+            .fillMaxWidth()
             .background(inputType.backgroundColor())
     ) {
         Divider(color = MaterialTheme.wireColorScheme.outline)
@@ -110,65 +113,60 @@ fun ActiveMessageComposerInput(
                 )
             }
         }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .wrapContentHeight(),
-            verticalAlignment = Alignment.Bottom
-        ) {
-            val stretchToMaxParentConstraintHeightOrWithInBoundary = if (isTextExpanded) {
-                Modifier.fillMaxHeight()
-            } else {
-                Modifier.heightIn(max = dimensions().messageComposerActiveInputMaxHeight)
-            }.weight(1f)
 
-            if (!showOptions) {
-                AdditionalOptionButton(
-                    isSelected = false,
-                    onClick = {
-                        onPlusClick()
-                    },
-                    modifier = Modifier.padding(start = dimensions().spacing8x)
+        val stretchToMaxParentConstraintHeightOrWithInBoundary = if (isTextExpanded) {
+            Modifier.fillMaxHeight()
+        } else {
+            Modifier.heightIn(max = dimensions().messageComposerActiveInputMaxHeight)
+        }.weight(1F)
+
+        if (isTextExpanded) {
+            Column(
+                horizontalAlignment = Alignment.End,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
+            ) {
+                InputContent(
+                    conversationId = conversationId,
+                    messageComposition = messageComposition,
+                    isTextExpanded = true,
+                    inputType = inputType,
+                    inputFocused = inputFocused,
+                    onMessageTextChanged = onMessageTextChanged,
+                    onSendButtonClicked = onSendButtonClicked,
+                    onChangeSelfDeletionClicked = onChangeSelfDeletionClicked,
+                    onInputFocusedChanged = onInputFocusedChanged,
+                    onSelectedLineIndexChanged = onSelectedLineIndexChanged,
+                    onLineBottomYCoordinateChanged = onLineBottomYCoordinateChanged,
+                    showOptions = showOptions,
+                    onPlusClick = onPlusClick,
+                    modifier = stretchToMaxParentConstraintHeightOrWithInBoundary,
                 )
             }
-
-            MessageComposerTextInput(
-                inputFocused = inputFocused,
-                colors = inputType.inputTextColor(),
-                messageText = messageComposition.messageTextFieldValue,
-                placeHolderText = inputType.labelText(),
-                onMessageTextChanged = onMessageTextChanged,
-                singleLine = false,
-                onFocusChanged = onInputFocusedChanged,
-                onSelectedLineIndexChanged = onSelectedLineIndexChanged,
-                onLineBottomYCoordinateChanged = onLineBottomYCoordinateChanged,
-                modifier = stretchToMaxParentConstraintHeightOrWithInBoundary
-            )
-
-            if (showOptions) {
-                Row(Modifier.wrapContentSize()) {
-                    if (inputType is MessageCompositionType.Composing) {
-                        when (val messageType = inputType.messageType.value) {
-                            is MessageType.Normal -> {
-                                MessageSendActions(
-                                    onSendButtonClicked = onSendButtonClicked,
-                                    sendButtonEnabled = inputType.isSendButtonEnabled
-                                )
-                            }
-
-                            is MessageType.SelfDeleting -> {
-                                SelfDeletingActions(
-                                    onSendButtonClicked = onSendButtonClicked,
-                                    sendButtonEnabled = inputType.isSendButtonEnabled,
-                                    selfDeletionTimer = messageType.selfDeletionTimer,
-                                    onChangeSelfDeletionClicked = onChangeSelfDeletionClicked
-                                )
-                            }
-
-                            else -> {}
-                        }
-                    }
-                }
+        } else {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight(),
+                verticalAlignment = Alignment.Bottom
+            ) {
+                InputContent(
+                    conversationId = conversationId,
+                    messageComposition = messageComposition,
+                    isTextExpanded = false,
+                    inputType = inputType,
+                    inputFocused = inputFocused,
+                    onMessageTextChanged = onMessageTextChanged,
+                    onSendButtonClicked = onSendButtonClicked,
+                    onChangeSelfDeletionClicked,
+                    onInputFocusedChanged = onInputFocusedChanged,
+                    onSelectedLineIndexChanged = onSelectedLineIndexChanged,
+                    onLineBottomYCoordinateChanged = onLineBottomYCoordinateChanged,
+                    showOptions = showOptions,
+                    onPlusClick = onPlusClick,
+                    modifier = stretchToMaxParentConstraintHeightOrWithInBoundary
+                )
             }
         }
         when (inputType) {
@@ -184,6 +182,78 @@ fun ActiveMessageComposerInput(
         }
     }
 }
+
+// flexible composable to adapt when [MessageComposerTextInput] is expanded or collapsed
+@Composable
+private fun InputContent(
+    conversationId: ConversationId,
+    messageComposition: MessageComposition,
+    isTextExpanded: Boolean,
+    inputType: MessageCompositionType,
+    inputFocused: Boolean,
+    onMessageTextChanged: (TextFieldValue) -> Unit,
+    onSendButtonClicked: () -> Unit,
+    onChangeSelfDeletionClicked: () -> Unit,
+    onInputFocusedChanged: (Boolean) -> Unit,
+    onSelectedLineIndexChanged: (Int) -> Unit,
+    onLineBottomYCoordinateChanged: (Float) -> Unit,
+    showOptions: Boolean,
+    onPlusClick: () -> Unit,
+    modifier: Modifier,
+) {
+    if (!showOptions) {
+        AdditionalOptionButton(
+            isSelected = false,
+            onClick = {
+                onPlusClick()
+            },
+            modifier = Modifier.padding(start = dimensions().spacing8x)
+        )
+    }
+
+    MessageComposerTextInput(
+        inputFocused = inputFocused,
+        colors = inputType.inputTextColor(),
+        messageText = messageComposition.messageTextFieldValue,
+        placeHolderText = inputType.labelText(),
+        onMessageTextChanged = onMessageTextChanged,
+        singleLine = false,
+        onFocusChanged = onInputFocusedChanged,
+        onSelectedLineIndexChanged = onSelectedLineIndexChanged,
+        onLineBottomYCoordinateChanged = onLineBottomYCoordinateChanged,
+        modifier = modifier
+    )
+
+    Box(contentAlignment = Alignment.BottomEnd, modifier = if (isTextExpanded) Modifier.fillMaxWidth() else Modifier) {
+        if (isTextExpanded) {
+            Box(modifier = Modifier.align(Alignment.BottomCenter)) {
+                UsersTypingIndicatorForConversation(conversationId = conversationId)
+            }
+        }
+        if (showOptions) {
+            if (inputType is MessageCompositionType.Composing) {
+                when (val messageType = inputType.messageType.value) {
+                    is MessageType.Normal -> {
+                        MessageSendActions(
+                            onSendButtonClicked = onSendButtonClicked,
+                            sendButtonEnabled = inputType.isSendButtonEnabled
+                        )
+                    }
+
+                    is MessageType.SelfDeleting -> {
+                        SelfDeletingActions(
+                            onSendButtonClicked = onSendButtonClicked,
+                            sendButtonEnabled = inputType.isSendButtonEnabled,
+                            selfDeletionTimer = messageType.selfDeletionTimer,
+                            onChangeSelfDeletionClicked = onChangeSelfDeletionClicked
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/UiMention.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/UiMention.kt
@@ -18,9 +18,6 @@
 package com.wire.android.ui.home.messagecomposer
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
@@ -49,34 +46,30 @@ data class UiMention(
 fun MembersMentionList(
     membersToMention: List<Contact>,
     searchQuery: String,
-    onMentionPicked: (Contact) -> Unit
+    onMentionPicked: (Contact) -> Unit,
+    modifier: Modifier
 ) {
-    Column(
-        modifier = Modifier.fillMaxHeight(),
-        verticalArrangement = Arrangement.Bottom
+    if (membersToMention.isNotEmpty()) Divider()
+    LazyColumn(
+        modifier = modifier.background(colorsScheme().background),
+        reverseLayout = true
     ) {
-        if (membersToMention.isNotEmpty()) Divider()
-        LazyColumn(
-            modifier = Modifier.background(colorsScheme().background),
-            reverseLayout = true
-        ) {
-            membersToMention.forEach {
-                if (it.membership != Membership.Service) {
-                    item {
-                        MemberItemToMention(
-                            avatarData = it.avatarData,
-                            name = it.name,
-                            label = it.label,
-                            membership = it.membership,
-                            clickable = Clickable { onMentionPicked(it) },
-                            searchQuery = searchQuery,
-                            modifier = Modifier
-                        )
-                        Divider(
-                            color = MaterialTheme.wireColorScheme.divider,
-                            thickness = Dp.Hairline
-                        )
-                    }
+        membersToMention.forEach {
+            if (it.membership != Membership.Service) {
+                item {
+                    MemberItemToMention(
+                        avatarData = it.avatarData,
+                        name = it.name,
+                        label = it.label,
+                        membership = it.membership,
+                        clickable = Clickable { onMentionPicked(it) },
+                        searchQuery = searchQuery,
+                        modifier = Modifier
+                    )
+                    Divider(
+                        color = MaterialTheme.wireColorScheme.divider,
+                        thickness = Dp.Hairline
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
@@ -85,6 +85,7 @@ data class WireDimensions(
     val messageComposerPaddingEnd: Dp,
     val systemMessageIconSize: Dp,
     val systemMessageIconLargeSize: Dp,
+    val typingIndicatorHeight: Dp,
     // TextFields
     val textFieldMinHeight: Dp,
     val textFieldCornerSize: Dp,
@@ -328,7 +329,8 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     conversationOptionsItemMinHeight = 57.dp,
     ongoingCallLabelHeight = 28.dp,
     audioMessageHeight = 48.dp,
-    importedMediaAssetSize = 120.dp
+    importedMediaAssetSize = 120.dp,
+    typingIndicatorHeight = 24.dp
 )
 
 private val DefaultPhoneLandscapeWireDimensions: WireDimensions = DefaultPhonePortraitWireDimensions

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,7 @@
     <string name="content_description_record_audio_button_send">Send Audio Message</string>
     <string name="content_description_mls_certificate_valid">All devices of all participants have a valid MLS certificate</string>
     <string name="content_description_proteus_certificate_valid">All of all participants are verified (Proteus)</string>
+    <string name="content_description_jump_to_last_message">Scroll down to last message, button</string>
     <!-- Non translatable strings-->
     <string name="url_support" translatable="false">https://support.wire.com</string>
     <string name="url_decryption_failure_learn_more" translatable="false">https://support.wire.com/hc/articles/207948115-Why-was-I-notified-that-a-message-from-a-contact-was-not-received-</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5131" title="WPB-5131" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5131</a>  Typing indicator in expanded message composer is above not under text field
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Features
- user typing indicator on expanded message composer
- improved structure of message composer on expanded state to have more space for text

### Fixes
- text overflow in attachments 
- removed unnecessary composables
- padding overlapping messages on scroll

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->

| Before | After |
| ----------- | ------------ |
| ![attachments before](https://github.com/wireapp/wire-android-reloaded/assets/13151239/faf4d5da-fad5-4dbe-a194-8569f4433112)  |  ![attachments after](https://github.com/wireapp/wire-android-reloaded/assets/13151239/4d838cfa-59f4-4214-bacf-49a29e6c463a) |
| ![expanded before](https://github.com/wireapp/wire-android-reloaded/assets/13151239/236ae6de-f18b-4ac5-b8ae-79e711398ee6) | ![expanded after](https://github.com/wireapp/wire-android-reloaded/assets/13151239/ea516983-33fe-4f91-a1b7-f448582dfa12) |
| ![padding before](https://github.com/wireapp/wire-android-reloaded/assets/13151239/34548210-1cf5-439f-a252-68b5d8f06ed1) | ![padding after](https://github.com/wireapp/wire-android-reloaded/assets/13151239/d0ed3c4e-aa2d-4530-ac51-9b60c1c853b8) |
| ![typing before](https://github.com/wireapp/wire-android-reloaded/assets/13151239/397f67e2-12cd-460f-b55f-31230998dd9f) | ![typing after](https://github.com/wireapp/wire-android-reloaded/assets/13151239/f28902b7-5de6-4c82-99f4-09ec2f2003b2) |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
