### PR TITLE
fix: fixed issue not activating search on long click in search bar [WPB-2231]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchTopBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchTopBar.kt
@@ -24,13 +24,15 @@ package com.wire.android.ui.common.topappbar.search
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
@@ -39,6 +41,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -49,6 +54,7 @@ import com.wire.android.R
 import com.wire.android.ui.common.SearchBarInput
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireDimensions
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
@@ -72,51 +78,59 @@ fun SearchTopBar(
         }
 
         val focusManager = LocalFocusManager.current
+        val focusRequester = remember { FocusRequester() }
 
         LaunchedEffect(isSearchActive) {
             if (!isSearchActive) {
                 focusManager.clearFocus()
                 onSearchQueryChanged(TextFieldValue(""))
+            } else {
+                focusRequester.requestFocus()
             }
         }
 
-        SearchBarInput(
-            placeholderText = searchBarHint,
-            text = searchQuery,
-            onTextTyped = onSearchQueryChanged,
-            leadingIcon = {
-                AnimatedContent(!isSearchActive) { isVisible ->
-                    IconButton(onClick = {
-                        if (!isVisible) {
-                            onCloseSearchClicked()
+        Box {
+            SearchBarInput(
+                placeholderText = searchBarHint,
+                text = searchQuery,
+                onTextTyped = onSearchQueryChanged,
+                leadingIcon = {
+                    AnimatedContent(!isSearchActive, label = "") { isVisible ->
+                        IconButton(onClick = {
+                            if (!isVisible) {
+                                onCloseSearchClicked()
+                            }
+                        }) {
+                            Icon(
+                                painter = painterResource(
+                                    id = if (isVisible) R.drawable.ic_search
+                                    else R.drawable.ic_arrow_left
+                                ),
+                                contentDescription = stringResource(R.string.content_description_conversation_search_icon),
+                                tint = MaterialTheme.wireColorScheme.onBackground
+                            )
                         }
-                    }) {
-                        Icon(
-                            painter = painterResource(
-                                id = if (isVisible) R.drawable.ic_search
-                                else R.drawable.ic_arrow_left
-                            ),
-                            contentDescription = stringResource(R.string.content_description_conversation_search_icon),
-                            tint = MaterialTheme.wireColorScheme.onBackground
-                        )
                     }
-                }
-            },
-            placeholderTextStyle = textStyleAlignment(isTopBarVisible = !isSearchActive),
-            textStyle = textStyleAlignment(isTopBarVisible = !isSearchActive),
-            interactionSource = interactionSource,
-            modifier = Modifier.padding(dimensions().spacing8x)
-        )
-
-        if (interactionSource.collectIsPressedAsState().value) {
-            // we want to propagate the click on the input of the search
-            // only the first time the user clicks on the input
-            // that is when the search is not active
+                },
+                placeholderTextStyle = textStyleAlignment(isTopBarVisible = !isSearchActive),
+                textStyle = textStyleAlignment(isTopBarVisible = !isSearchActive),
+                interactionSource = interactionSource,
+                modifier = Modifier
+                    .padding(dimensions().spacing8x)
+                    .focusRequester(focusRequester)
+            )
+            // We added an invisible clickable box only present when the search is not active.
+            // That way we can still make the whole top bar clickable and intercept and discard the long press gestures.
             if (!isSearchActive) {
-                onInputClicked()
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .padding(dimensions().spacing8x)
+                        .clip(RoundedCornerShape(MaterialTheme.wireDimensions.textFieldCornerSize))
+                        .clickable(onClick = onInputClicked)
+                )
             }
         }
-
         bottomContent()
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2231" title="WPB-2231" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2231</a>  Longclick on magnifier Icon activates search, but search is not possible
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
There was an issue with `TopSearchBar` which basically was preventing the `isSearchActive` flag to be updated whenever a long tap event was happening on the leading magnifying icon, hence forwarding the long tap event to the inner text field.

### Solutions

@saleniuk had the great idea of adding an extra invisible box on top of the search bar, only present when search is not active, that will intercept and discard the long click events, and open the search for normal ones. 

### Attachments
https://github.com/wireapp/wire-android-reloaded/assets/2468164/638c1f43-47ac-488e-ac2b-2fbfade93114

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
