### PR TITLE
feat: archive locally for non members [WPB-5006]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
@@ -153,10 +153,11 @@ internal fun ConversationMainSheetContent(
                         with(conversationSheetContent) {
                             updateConversationArchiveStatus(
                                 DialogState(
-                                    conversationId,
-                                    title,
-                                    conversationTypeDetail,
-                                    isArchived
+                                    conversationId = conversationId,
+                                    conversationName = title,
+                                    conversationTypeDetail = conversationTypeDetail,
+                                    isArchived = isArchived,
+                                    isMember = conversationSheetContent.selfRole != null
                                 )
                             )
                         }
@@ -174,10 +175,11 @@ internal fun ConversationMainSheetContent(
                     onItemClick = {
                         clearConversationContent(
                             DialogState(
-                                conversationSheetContent.conversationId,
-                                conversationSheetContent.title,
-                                conversationSheetContent.conversationTypeDetail,
-                                conversationSheetContent.isArchived
+                                conversationId = conversationSheetContent.conversationId,
+                                conversationName = conversationSheetContent.title,
+                                conversationTypeDetail = conversationSheetContent.conversationTypeDetail,
+                                isArchived = conversationSheetContent.isArchived,
+                                isMember = conversationSheetContent.selfRole != null
                             )
                         )
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -387,7 +387,14 @@ class GroupConversationDetailsViewModel @Inject constructor(
         viewModelScope.launch {
             val shouldArchive = dialogState.isArchived.not()
             requestInProgress = true
-            val result = withContext(dispatcher.io()) { updateConversationArchivedStatus(conversationId, shouldArchive, timestamp) }
+            val result = withContext(dispatcher.io()) {
+                updateConversationArchivedStatus(
+                    conversationId = conversationId,
+                    shouldArchiveConversation = shouldArchive,
+                    onlyLocally = !dialogState.isMember,
+                    archivedStatusTimestamp = timestamp
+                )
+            }
             requestInProgress = false
             when (result) {
                 ArchiveStatusUpdateResult.Failure -> onMessage(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -414,8 +414,14 @@ class ConversationListViewModel @Inject constructor(
         with(dialogState) {
             viewModelScope.launch {
                 val isArchiving = !isArchived
+
                 requestInProgress = true
-                val result = updateConversationArchivedStatus(conversationId, isArchiving, timestamp)
+                val result = updateConversationArchivedStatus(
+                    conversationId = conversationId,
+                    shouldArchiveConversation = isArchiving,
+                    onlyLocally = !dialogState.isMember,
+                    archivedStatusTimestamp = timestamp
+                )
                 requestInProgress = false
                 when (result) {
                     is ArchiveStatusUpdateResult.Failure -> {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/GroupDialogState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/GroupDialogState.kt
@@ -32,5 +32,6 @@ data class DialogState(
     val conversationId: ConversationId,
     val conversationName: String,
     val conversationTypeDetail: ConversationTypeDetail,
-    val isArchived: Boolean
+    val isArchived: Boolean,
+    val isMember: Boolean
 )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -299,7 +299,13 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         viewModelScope.launch {
             val shouldArchive = !dialogState.isArchived
             requestInProgress = true
-            val result = withContext(dispatchers.io()) { updateConversationArchivedStatus(dialogState.conversationId, shouldArchive) }
+            val result = withContext(dispatchers.io()) {
+                updateConversationArchivedStatus(
+                    conversationId = dialogState.conversationId,
+                    shouldArchiveConversation = shouldArchive,
+                    onlyLocally = !dialogState.isMember
+                )
+            }
             requestInProgress = false
             when (result) {
                 ArchiveStatusUpdateResult.Failure -> {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -147,7 +147,8 @@ class GroupConversationDetailsViewModelTest {
                 conversationId = conversationDetails.conversation.id,
                 isCreator = conversationDetails.isSelfUserCreator
             ),
-            isArchived = conversationDetails.conversation.archived
+            isArchived = conversationDetails.conversation.archived,
+            isMember = true
         )
 
         val (arrangement, viewModel) = GroupConversationDetailsViewModelArrangement()
@@ -167,7 +168,8 @@ class GroupConversationDetailsViewModelTest {
             arrangement.updateConversationArchivedStatus(
                 conversationId = viewModel.conversationId,
                 shouldArchiveConversation = !conversationDetails.conversation.archived,
-                archivedStatusTimestamp = archivingEventTimestamp
+                archivedStatusTimestamp = archivingEventTimestamp,
+                onlyLocally = false
             )
         }
     }
@@ -194,7 +196,8 @@ class GroupConversationDetailsViewModelTest {
                 conversationId = conversationDetails.conversation.id,
                 isCreator = conversationDetails.isSelfUserCreator
             ),
-            isArchived = conversationDetails.conversation.archived
+            isArchived = conversationDetails.conversation.archived,
+            isMember = true
         )
 
         val (arrangement, viewModel) = GroupConversationDetailsViewModelArrangement()
@@ -214,7 +217,8 @@ class GroupConversationDetailsViewModelTest {
             arrangement.updateConversationArchivedStatus(
                 conversationId = viewModel.conversationId,
                 shouldArchiveConversation = false,
-                archivedStatusTimestamp = archivingEventTimestamp
+                archivedStatusTimestamp = archivingEventTimestamp,
+                onlyLocally = false
             )
         }
     }
@@ -692,7 +696,7 @@ internal class GroupConversationDetailsViewModelArrangement {
         coEvery { isMLSEnabledUseCase() } returns true
         coEvery { updateConversationMutedStatus(any(), any(), any()) } returns ConversationUpdateStatusResult.Success
         coEvery { observeSelfDeletionTimerSettingsForConversation(any(), any()) } returns flowOf(SelfDeletionTimer.Disabled)
-        coEvery { updateConversationArchivedStatus(any(), any()) } returns ArchiveStatusUpdateResult.Success
+        coEvery { updateConversationArchivedStatus(any(), any(), any()) } returns ArchiveStatusUpdateResult.Success
     }
 
     suspend fun withConversationDetailUpdate(conversationDetails: ConversationDetails) = apply {
@@ -719,8 +723,8 @@ internal class GroupConversationDetailsViewModelArrangement {
     }
 
     suspend fun withUpdateArchivedStatus(result: ArchiveStatusUpdateResult) = apply {
-        coEvery { updateConversationArchivedStatus(any(), any()) } returns result
         coEvery { updateConversationArchivedStatus(any(), any(), any()) } returns result
+        coEvery { updateConversationArchivedStatus(any(), any(), any(), any()) } returns result
     }
 
     fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -342,7 +342,7 @@ class ConversationListViewModelTest {
         )
         val archivingTimestamp = 123456789L
 
-        coEvery { updateConversationArchivedStatus(any(), any(), any()) } returns ArchiveStatusUpdateResult.Success
+        coEvery { updateConversationArchivedStatus(any(), any(), any(), any()) } returns ArchiveStatusUpdateResult.Success
 
         conversationListViewModel.homeSnackBarState.test {
             conversationListViewModel.moveConversationToArchive(dialogState, archivingTimestamp)
@@ -370,7 +370,7 @@ class ConversationListViewModelTest {
         )
         val archivingTimestamp = 123456789L
 
-        coEvery { updateConversationArchivedStatus(any(), any(), any()) } returns ArchiveStatusUpdateResult.Failure
+        coEvery { updateConversationArchivedStatus(any(), any(), any(), any()) } returns ArchiveStatusUpdateResult.Failure
 
         conversationListViewModel.homeSnackBarState.test {
             conversationListViewModel.moveConversationToArchive(dialogState, archivingTimestamp)

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -337,7 +337,8 @@ class ConversationListViewModelTest {
             conversationItem.conversationId,
             conversationItem.conversationInfo.name,
             ConversationTypeDetail.Private(null, conversationItem.userId, BlockingState.NOT_BLOCKED),
-            !isArchiving
+            !isArchiving,
+            true
         )
         val archivingTimestamp = 123456789L
 
@@ -351,6 +352,7 @@ class ConversationListViewModelTest {
             updateConversationArchivedStatus.invoke(
                 dialogState.conversationId,
                 !dialogState.isArchived,
+                onlyLocally = false,
                 archivingTimestamp
             )
         }
@@ -363,7 +365,8 @@ class ConversationListViewModelTest {
             conversationItem.conversationId,
             conversationItem.conversationInfo.name,
             ConversationTypeDetail.Private(null, conversationItem.userId, BlockingState.NOT_BLOCKED),
-            !isArchiving
+            !isArchiving,
+            isMember = true
         )
         val archivingTimestamp = 123456789L
 
@@ -377,7 +380,8 @@ class ConversationListViewModelTest {
             updateConversationArchivedStatus.invoke(
                 dialogState.conversationId,
                 !dialogState.isArchived,
-                archivingTimestamp
+                false,
+                archivingTimestamp,
             )
         }
     }

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -144,7 +144,7 @@ internal class OtherUserProfileViewModelArrangement {
             )
         )
         coEvery { observeSelfUser() } returns flowOf(TestUser.SELF_USER)
-        coEvery { updateConversationArchivedStatus(any(), any()) } returns ArchiveStatusUpdateResult.Success
+        coEvery { updateConversationArchivedStatus(any(), any(), any()) } returns ArchiveStatusUpdateResult.Success
         every { userTypeMapper.toMembership(any()) } returns Membership.None
         coEvery { getOneToOneConversation(USER_ID) } returns flowOf(
             GetOneToOneConversationUseCase.Result.Success(OtherUserProfileScreenViewModelTest.CONVERSATION)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5006" title="WPB-5006" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5006</a>  [Android] When user left or is removed a group conversation, he can not archive it anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user is no longer a member of conversation he cannot archive it because API returns not found error

### Solutions

Give user option to archive conversation locally when he is not a conversation member

Needs releases with:

https://github.com/wireapp/kalium/pull/2162
