### PR TITLE
feat: applock - handling deeplinks and intents

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/NotificationActions.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationActions.kt
@@ -30,15 +30,25 @@ import com.wire.android.R
 fun getActionFromOldOne(oldAction: Notification.Action) =
     NotificationCompat.Action.Builder(null, oldAction.title, oldAction.actionIntent).build()
 
-fun getActionReply(context: Context, conversationId: String, userId: String?): NotificationCompat.Action {
-    val resultPendingIntent = replyMessagePendingIntent(context, conversationId, userId)
+fun getActionReply(
+    context: Context,
+    conversationId: String,
+    userId: String?,
+    isAppLocked: Boolean
+): NotificationCompat.Action {
+    return if (isAppLocked) {
+        val resultPendingIntent = messagePendingIntent(context, conversationId, userId)
+        NotificationCompat.Action.Builder(null, context.getString(R.string.notification_action_reply), resultPendingIntent)
+            .build()
+    } else {
+        val resultPendingIntent = replyMessagePendingIntent(context, conversationId, userId)
+        val remoteInput = RemoteInput.Builder(NotificationConstants.KEY_TEXT_REPLY).build()
 
-    val remoteInput = RemoteInput.Builder(NotificationConstants.KEY_TEXT_REPLY).build()
-
-    return NotificationCompat.Action.Builder(null, context.getString(R.string.notification_action_reply), resultPendingIntent)
-        .addRemoteInput(remoteInput)
-        .setAllowGeneratedReplies(true)
-        .build()
+        NotificationCompat.Action.Builder(null, context.getString(R.string.notification_action_reply), resultPendingIntent)
+            .addRemoteInput(remoteInput)
+            .setAllowGeneratedReplies(true)
+            .build()
+    }
 }
 
 fun getOpenIncomingCallAction(context: Context, conversationId: String, userId: String) = getAction(

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NotificationReplyReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NotificationReplyReceiver.kt
@@ -28,6 +28,7 @@ import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.NoSession
 import com.wire.android.notification.MessageNotificationManager
 import com.wire.android.notification.NotificationConstants
+import com.wire.android.ui.home.appLock.LockCodeTimeManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -51,6 +52,9 @@ class NotificationReplyReceiver : BroadcastReceiver() { // requires zero argumen
     @Inject
     @NoSession
     lateinit var qualifiedIdMapper: QualifiedIdMapper
+
+    @Inject
+    lateinit var lockCodeTimeManager: LockCodeTimeManager
 
     override fun onReceive(context: Context, intent: Intent) {
         val remoteInput = RemoteInput.getResultsFromIntent(intent)
@@ -76,7 +80,13 @@ class NotificationReplyReceiver : BroadcastReceiver() { // requires zero argumen
     }
 
     private fun updateNotification(context: Context, conversationId: String, userId: QualifiedID, replyText: String?) =
-        MessageNotificationManager.updateNotificationAfterQuickReply(context, conversationId, userId, replyText)
+        MessageNotificationManager.updateNotificationAfterQuickReply(
+            context,
+            conversationId,
+            userId,
+            replyText,
+            lockCodeTimeManager.isLocked().value
+        )
 
     companion object {
         private const val EXTRA_CONVERSATION_ID = "conversation_id_extra"

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -195,7 +195,7 @@ class WireActivity : AppCompatActivity() {
                             )
                             // This setup needs to be done after the navigation graph is created, because building the graph takes some time,
                             // and if any NavigationCommand is executed before the graph is fully built, it will cause a NullPointerException.
-                            setUpNavigation(navigator.navController, onComplete, scope)
+                            setUpNavigation(navigator.navController, onComplete)
                         }
                         isLoaded = true
                         handleScreenshotCensoring()

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -193,8 +193,10 @@ class WireActivity : AppCompatActivity() {
                                 navigator = navigator,
                                 startDestination = startDestination
                             )
-                            // This setup needs to be done after the navigation graph is created, because building the graph takes some time,
-                            // and if any NavigationCommand is executed before the graph is fully built, it will cause a NullPointerException.
+                            /*
+                            This setup needs to be done after the navigation graph is created, because building the graph takes some time,
+                            and if any NavigationCommand is executed before the graph is fully built, it will cause a NullPointerException.
+                            */
                             setUpNavigation(navigator.navController, onComplete)
                         }
                         isLoaded = true

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/AppUnlockWithBiometricsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/AppUnlockWithBiometricsScreen.kt
@@ -34,23 +34,16 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.R
 import com.wire.android.biomitric.showBiometricPrompt
-import com.wire.android.navigation.BackStackMode
-import com.wire.android.navigation.NavigationCommand
-import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.destinations.EnterLockCodeScreenDestination
 
-@RootNavGraph
-@Destination
 @Composable
 fun AppUnlockWithBiometricsScreen(
+    onCanceled: () -> Unit,
+    onRequestPasscode: () -> Unit,
     appUnlockWithBiometricsViewModel: AppUnlockWithBiometricsViewModel = hiltViewModel(),
-    navigator: Navigator,
 ) {
     Box(
         modifier = Modifier
@@ -69,25 +62,13 @@ fun AppUnlockWithBiometricsScreen(
         val activity = LocalContext.current
         LaunchedEffect(Unit) {
             (activity as AppCompatActivity).showBiometricPrompt(
-                onSuccess = {
-                    appUnlockWithBiometricsViewModel.onAppUnlocked()
-                    navigator.navigateBack()
-                },
-                onCancel = {
-                    navigator.finish()
-                },
-                onRequestPasscode = {
-                    navigator.navigate(
-                        NavigationCommand(
-                            EnterLockCodeScreenDestination(),
-                            BackStackMode.REMOVE_CURRENT
-                        )
-                    )
-                }
+                onSuccess = { appUnlockWithBiometricsViewModel.onAppUnlocked() },
+                onCancel = onCanceled,
+                onRequestPasscode = onRequestPasscode
             )
         }
     }
     BackHandler {
-        navigator.finish()
+        onCanceled()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/EnterLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/EnterLockCodeScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -47,11 +46,7 @@ import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.R
-import com.wire.android.navigation.Navigator
-import com.wire.android.navigation.rememberNavigator
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.rememberBottomBarElevationState
@@ -65,40 +60,31 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
 import java.util.Locale
 
-@RootNavGraph
-@Destination
 @Composable
 fun EnterLockCodeScreen(
+    onCanceled: () -> Unit,
     viewModel: EnterLockScreenViewModel = hiltViewModel(),
-    navigator: Navigator
 ) {
     EnterLockCodeScreenContent(
-        navigator = navigator,
         state = viewModel.state,
         scrollState = rememberScrollState(),
         onPasswordChanged = viewModel::onPasswordChanged,
         onContinue = viewModel::onContinue,
-        onBackPress = { navigator.finish() }
+        onCanceled = onCanceled,
     )
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun EnterLockCodeScreenContent(
-    navigator: Navigator,
     state: EnterLockCodeViewState,
     scrollState: ScrollState,
     onPasswordChanged: (TextFieldValue) -> Unit,
-    onBackPress: () -> Unit,
-    onContinue: () -> Unit
+    onCanceled: () -> Unit,
+    onContinue: () -> Unit,
 ) {
-    LaunchedEffect(state.done) {
-        if (state.done) {
-            navigator.navigateBack()
-        }
-    }
     BackHandler {
-        onBackPress()
+        onCanceled()
     }
 
     WireScaffold { internalPadding ->
@@ -198,12 +184,11 @@ private fun ContinueButton(
 fun PreviewEnterLockCodeScreen() {
     WireTheme(isPreview = true) {
         EnterLockCodeScreenContent(
-            navigator = rememberNavigator {},
             state = EnterLockCodeViewState(),
             scrollState = rememberScrollState(),
             onPasswordChanged = {},
-            onBackPress = {},
-            onContinue = {}
+            onCanceled = {},
+            onContinue = {},
         )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When opening deeplinks, intents from notifications, it navigates to this screen even if the app is supposed to be locked so the enter lock screen should be visible on top. Also, some dialogs are also popping up so they appear on top of the enter lock screen.

### Solutions

Rearrange the WireActivity composable so that it shows enter lock screen on top of the main navigation and don't handle any dialogs when the app is locked so that there's always enter lock screen visible over the regular screens, and regular navigation works fine, so if the message notification is clicked for instance, it will navigate to the desired conversation and show enter lock screen on top of that so that when user unlocks the app, it will show the proper conversation screen.

### Attachments (Optional)

https://github.com/wireapp/wire-android-reloaded/assets/30429749/e0d5c650-05a7-4bdf-9709-cad1b33324cf

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
