### PR TITLE
feat: backup password validation [WPB-4374]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreState.kt
@@ -29,7 +29,7 @@ data class BackupAndRestoreState(
     val restorePasswordValidation: PasswordValidation,
     val backupCreationProgress: BackupCreationProgress,
     val passwordValidation: ValidatePasswordResult = ValidatePasswordResult.Valid
-    ) {
+) {
 
     data class CreatedBackup(val path: Path, val assetName: String, val assetSize: Long, val isEncrypted: Boolean)
     companion object {

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreState.kt
@@ -20,6 +20,7 @@
 
 package com.wire.android.ui.home.settings.backup
 
+import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
 import okio.Path
 
 data class BackupAndRestoreState(
@@ -27,8 +28,8 @@ data class BackupAndRestoreState(
     val restoreFileValidation: RestoreFileValidation,
     val restorePasswordValidation: PasswordValidation,
     val backupCreationProgress: BackupCreationProgress,
-    val backupCreationPasswordValidation: PasswordValidation
-) {
+    val passwordValidation: ValidatePasswordResult = ValidatePasswordResult.Valid
+    ) {
 
     data class CreatedBackup(val path: Path, val assetName: String, val assetSize: Long, val isEncrypted: Boolean)
     companion object {
@@ -37,7 +38,7 @@ data class BackupAndRestoreState(
             restoreFileValidation = RestoreFileValidation.Initial,
             backupCreationProgress = BackupCreationProgress.InProgress(),
             restorePasswordValidation = PasswordValidation.NotVerified,
-            backupCreationPasswordValidation = PasswordValidation.Valid,
+            passwordValidation = ValidatePasswordResult.Valid,
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
@@ -33,6 +33,8 @@ import com.wire.android.appLogger
 import com.wire.android.util.FileManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
+import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
 import com.wire.kalium.logic.feature.backup.CreateBackupResult
 import com.wire.kalium.logic.feature.backup.CreateBackupUseCase
 import com.wire.kalium.logic.feature.backup.RestoreBackupResult
@@ -58,6 +60,7 @@ class BackupAndRestoreViewModel
     private val importBackup: RestoreBackupUseCase,
     private val createBackupFile: CreateBackupUseCase,
     private val verifyBackup: VerifyBackupUseCase,
+    private val validatePassword: ValidatePasswordUseCase,
     private val kaliumFileSystem: KaliumFileSystem,
     private val fileManager: FileManager,
     private val dispatcher: DispatcherProvider,
@@ -228,7 +231,13 @@ class BackupAndRestoreViewModel
     }
 
     fun validateBackupCreationPassword(backupPassword: TextFieldValue) {
-        // TODO: modify in case the password requirements change
+        state = state.copy(
+            passwordValidation = if (backupPassword.text.isEmpty()) {
+                ValidatePasswordResult.Valid
+            } else {
+                validatePassword(backupPassword.text)
+            }
+        )
     }
 
     fun cancelBackupCreation() = viewModelScope.launch(dispatcher.main()) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogFlow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogFlow.kt
@@ -47,7 +47,7 @@ fun CreateBackupDialogFlow(
         when (currentBackupDialogStep) {
             BackUpDialogStep.SetPassword -> {
                 SetBackupPasswordDialog(
-                    isBackupPasswordValid = backUpAndRestoreState.backupCreationPasswordValidation is PasswordValidation.Valid,
+                    passwordValidation = backUpAndRestoreState.passwordValidation,
                     onBackupPasswordChanged = onValidateBackupPassword,
                     onCreateBackup = { password ->
                         toCreatingBackup()

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogFlow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogFlow.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.R
 import com.wire.android.ui.home.settings.backup.BackupAndRestoreState
 import com.wire.android.ui.home.settings.backup.BackupCreationProgress
-import com.wire.android.ui.home.settings.backup.PasswordValidation
 import com.wire.android.ui.home.settings.backup.dialog.common.FailureDialog
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
@@ -25,6 +25,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -42,18 +43,20 @@ import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.button.WireButtonState
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.wireDialogPropertiesBuilder
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.permission.rememberCreateFileFlow
+import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
 import java.util.Locale
 import kotlin.math.roundToInt
 
 @Composable
 fun SetBackupPasswordDialog(
-    isBackupPasswordValid: Boolean,
+    passwordValidation: ValidatePasswordResult,
     onBackupPasswordChanged: (TextFieldValue) -> Unit,
     onCreateBackup: (String) -> Unit,
     onDismissDialog: () -> Unit
@@ -73,12 +76,14 @@ fun SetBackupPasswordDialog(
             onClick = { onCreateBackup(backupPassword.text) },
             text = stringResource(id = R.string.backup_dialog_create_backup_now),
             type = WireDialogButtonType.Primary,
-            state = if (!isBackupPasswordValid) WireButtonState.Disabled else WireButtonState.Default
+            state = if (passwordValidation.isValid) WireButtonState.Default else WireButtonState.Disabled
         )
     ) {
         WirePasswordTextField(
+            modifier = Modifier.padding(bottom = dimensions().spacing16x),
             labelText = stringResource(R.string.label_textfield_optional_password).uppercase(Locale.getDefault()),
-            state = if (!isBackupPasswordValid) WireTextFieldState.Error("some error") else WireTextFieldState.Default,
+            descriptionText = stringResource(R.string.create_account_details_password_description),
+            state = if (passwordValidation.isValid) WireTextFieldState.Default else WireTextFieldState.Error(),
             value = backupPassword,
             onValueChange = {
                 backupPassword = it

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -981,7 +981,7 @@
     <string name="label_mls_thumbprint">MLS Thumbprint</string>
     <!--create and restore backup-->
     <string name="backup_dialog_create_backup_set_password_title">Set password</string>
-    <string name="backup_dialog_create_backup_set_password_message">The backup will be compressed, and you can encrypt it with a password.</string>
+    <string name="backup_dialog_create_backup_set_password_message">The backup will be compressed and encrypted with a password. Make sure to store it in a secure place.</string>
     <string name="backup_dialog_create_backup_now">Back Up Now</string>
     <string name="backup_dialog_create_backup_title">Creating Backup</string>
     <string name="backup_dialog_create_backup_subtitle">Saving conversations...</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/home/BackupAndRestoreViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/home/BackupAndRestoreViewModelTest.kt
@@ -121,7 +121,6 @@ class BackupAndRestoreViewModelTest {
         // Then
         assert(backupAndRestoreViewModel.state.passwordValidation.isValid)
         coVerify(exactly = 0) { arrangement.validatePassword(any()) }
-
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4374" title="WPB-4374" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4374</a>  [Android] Check complexity of passwords for backup files
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When creating a backup with password, the app does not check whether the complexity of the password complies with Wire’s own password guidelines. This allows for very weak passwords to be chosen for passwords.

### Solutions

Validate password with the same algorithm as for example app lock does


### Attachments (Optional)

https://github.com/wireapp/wire-android-reloaded/assets/13151239/08efdfd9-e4d6-444a-b728-516b050ff307
