### PR TITLE
fix: attachment width and android 14 crash on start [WPB-5101]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AttachmentOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AttachmentOptions.kt
@@ -101,7 +101,7 @@ fun AttachmentOptionsComponent(
     BoxWithConstraints(Modifier.fillMaxSize()) {
         val fullWidth: Dp = with(density) { constraints.maxWidth.toDp() }
         val minPadding: Dp = dimensions().spacing2x
-        val minColumnWidth: Dp = with(density) { maxTextWidth.toDp() + dimensions().spacing24x }
+        val minColumnWidth: Dp = with(density) { maxTextWidth.toDp() + dimensions().spacing28x }
         val visibleAttachmentOptions = attachmentOptions.filter { it.shouldShow }
         val params by remember(fullWidth, visibleAttachmentOptions.size) {
             derivedStateOf {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ androidx-biometric = "1.1.0"
 
 # Compose
 composeBom = "2023.10.00" # TODO check if in new version [anchoredDraggable] is available
+compose-activity = "1.8.0"
 compose-compiler = "1.5.2"
 compose-constraint = "1.0.1"
 compose-navigation = "2.7.3" # adjusted to work with compose-destinations "1.9.54"
@@ -159,7 +160,6 @@ hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "hilt-work" }
 
 # Compose BOM
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
-compose-activity = { module = "androidx.activity:activity-compose" }
 compose-foundation = { module = "androidx.compose.foundation:foundation" }
 compose-material-core = { module = "androidx.compose.material:material" }
 compose-material-icons = { module = "androidx.compose.material:material-icons-extended" }
@@ -173,6 +173,7 @@ compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 
 # Compose other
+compose-activity = { module = "androidx.activity:activity-compose", version.ref = "compose-activity" }
 compose-constraintLayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "compose-constraint" }
 compose-navigation = { module = "androidx.navigation:navigation-compose", version.ref = "compose-navigation" }
 compose-destinations-core = { module = "io.github.raamcosta.compose-destinations:animations-core", version.ref = "compose-destinations" }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5101" title="WPB-5101" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5101</a>  [Android] Attachments text are cut
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- fixed attachments text cut
- updated compose activity to solve crash on startup on android 14