### PR TITLE
ci: optimise build cache

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -17,7 +17,7 @@ jobs:
         submodules: recursive # Needed in order to fetch Kalium sources for building
         fetch-depth: 0
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: buildjet/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: buildjet/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: buildjet/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -33,13 +33,10 @@ jobs:
 
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4
-      
-      - name: Gradle cache
-        uses: gradle/gradle-build-action@v2
-        
+
       - name: AVD cache
-        uses: actions/cache@v3
-        id: avd-cache
+        uses: buildjet/cache@v3
+        id: avd-cache-${{ runner.os }}
         with:
           path: |
             ~/.android/avd/*

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: buildjet/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -33,9 +33,6 @@ jobs:
 
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4
-
-      - name: Gradle cache
-        uses: gradle/gradle-build-action@v2
 
       - name: Test Build Logic
         run: |


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We're not taking full advantage of Buildjet machines by using standard setup and cache actions.

### Solutions

As seen in this [guide by Buildjet](https://buildjet.com/for-github-actions/docs/guides/migrating-to-buildjet-cache), we can use their actions to optimise things.

Also, make sure we only use one gradle cache in each build, instead of two (setup-java + gradle-build-action).

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
