### PR TITLE
fix: navigating with UPDATE_EXISTED, extracting base route [WPB-5225]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/HomeDestination.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/HomeDestination.kt
@@ -112,7 +112,7 @@ sealed class HomeDestination(
 
         private const val ITEM_NAME_PREFIX = "HomeNavigationItem."
         fun fromRoute(fullRoute: String): HomeDestination? =
-            values().find { it.direction.route.getPrimaryRoute() == fullRoute.getPrimaryRoute() }
+            values().find { it.direction.route.getBaseRoute() == fullRoute.getBaseRoute() }
         fun values(): Array<HomeDestination> =
             arrayOf(Conversations, Calls, Mentions, Settings, Vault, Archive, Support, WhatsNew)
     }

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -45,7 +45,7 @@ internal fun NavController.navigateToItem(command: NavigationCommand) {
     fun lastDestination() = currentBackStack.value.lastOrNull { it.route() is DestinationSpec<*> }
     fun lastNestedGraph() = lastDestination()?.takeIf { it.navGraph() != navGraph }?.navGraph()
     fun firstDestinationWithRoute(route: String) =
-        currentBackStack.value.firstOrNull { it.destination.route?.getPrimaryRoute() == route.getPrimaryRoute() }
+        currentBackStack.value.firstOrNull { it.destination.route?.getBaseRoute() == route.getBaseRoute() }
     fun lastDestinationFromOtherGraph(graph: NavGraphSpec) = currentBackStack.value.lastOrNull { it.navGraph() != graph }
 
     appLogger.d("[$TAG] -> command: ${command.destination.route.obfuscateId()}")
@@ -104,17 +104,11 @@ private fun NavOptionsBuilder.popUpTo(
 internal fun NavDestination.toDestination(): Destination? =
     this.route?.let { currentRoute -> NavGraphs.root.destinationsByRoute[currentRoute] }
 
-fun String.getPrimaryRoute(): String {
-    val splitByQuestion = this.split("?")
-    val splitBySlash = this.split("/")
-
-    val primaryRoute = when {
-        splitByQuestion.size > 1 -> splitByQuestion[0]
-        splitBySlash.size > 1 -> splitBySlash[0]
-        else -> this
+fun String.getBaseRoute(): String =
+    this.indexOfAny(listOf("?", "/")).let {
+        if (it != -1) this.substring(0, it)
+        else this
     }
-    return primaryRoute
-}
 
 fun Direction.handleNavigation(context: Context, handleOtherDirection: (Direction) -> Unit) = when (this) {
     is ExternalUriDirection -> CustomTabsHelper.launchUri(context, this.uri)

--- a/app/src/test/kotlin/com/wire/android/navigation/NavigationUtilsTest.kt
+++ b/app/src/test/kotlin/com/wire/android/navigation/NavigationUtilsTest.kt
@@ -103,4 +103,47 @@ internal class NavigationUtilsTest {
         // Then
         assertEquals(mappedImagePrivateAsset, expectedPrivateAssetImage)
     }
+
+    @Test
+    fun `given route without segments and parameters, when getting primary route, then return only host part which is the same route`() {
+        // Given
+        val route = "route"
+        // When
+        val result = route.getBaseRoute()
+        // Then
+        assertEquals(route, result)
+    }
+
+    @Test
+    fun `given route with segments but without parameters, when getting primary route, then return only host part`() {
+        // Given
+        val host = "route"
+        val route = "$host/segment1/segment2"
+        // When
+        val result = route.getBaseRoute()
+        // Then
+        assertEquals(host, result)
+    }
+
+    @Test
+    fun `given route without segments but with parameters, when getting primary route, then return only host part`() {
+        // Given
+        val host = "route"
+        val route = "$host?param1=value1&param2=value2"
+        // When
+        val result = route.getBaseRoute()
+        // Then
+        assertEquals(host, result)
+    }
+
+    @Test
+    fun `given route with segments and parameters, when getting primary route, then return only host part`() {
+        // Given
+        val host = "route"
+        val route = "$host/segment1/segment2?param1=value1&param2=value2"
+        // When
+        val result = route.getBaseRoute()
+        // Then
+        assertEquals(host, result)
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5225" title="WPB-5225" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5225</a>  [Android] UPDATE_EXISTED flag not always working as expected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2374

---- 

 ⚠️ Conflicts during cherry-pick:
kalium

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The current code which has been used for months and has been moved around from place to place is faulty in cases when the path contains both path segments and parameters (path elements divided by slashes and arguments after the question mark) like `path/segment?argument=value`. Compose destinations generates non-nullable required navigation argument parameters as segments, and optional parameters as arguments. 
Function to retrieve the base part of route first checks for the question mark and if it's found, it returns substring up to the question mark, which means when there's a question mark, it ignores slashes and returns `path/segment` instead of `path`.

### Solutions

Change this function to find first occurrence of any of these characters (`/`, `?`) and substring up to this first found element.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
