### PR TITLE
fix: remove app lock after logout

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -218,7 +218,7 @@ class SelfUserProfileViewModel @Inject constructor(
             notificationManager.stopObservingOnLogout(selfUserId)
             notificationChannelsManager.deleteChannelGroup(selfUserId)
             accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount).also {
-                if(it == SwitchAccountResult.NoOtherAccountToSwitch) {
+                if (it == SwitchAccountResult.NoOtherAccountToSwitch) {
                     globalDataStore.clearAppLockPasscode()
                 }
             }.callAction(switchAccountActions)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After logout, the app is still requesting passcode

### Causes (Optional)

Not handled

### Solutions

On logout clear app lock if there is no other account to switch to

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
