### PR TITLE
fix: crash when saving file - duplicate names [WPB-5026]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -115,19 +115,18 @@ fun getTempWritableAttachmentUri(context: Context, attachmentPath: Path): Uri {
 private fun Context.saveFileDataToDownloadsFolder(assetName: String, downloadedDataPath: Path, fileSize: Long): Uri? {
     val resolver = contentResolver
     val mimeType = Uri.parse(downloadedDataPath.toString()).getMimeType(this@saveFileDataToDownloadsFolder)
+    val downloadsDir = Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS)
+    // we need to find the next available name with copy counter by ourselves before copying
+    val availableAssetName = findFirstUniqueName(downloadsDir, assetName.ifEmpty { ATTACHMENT_FILENAME })
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         val contentValues = ContentValues().apply {
-            // ContentResolver modifies the name if another file with the given name already exists, so we don't have to worry about it
-            put(DISPLAY_NAME, assetName.ifEmpty { ATTACHMENT_FILENAME })
+            put(DISPLAY_NAME, availableAssetName)
             put(MIME_TYPE, mimeType)
             put(SIZE, fileSize)
         }
         resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
     } else {
         val authority = getProviderAuthority()
-        val downloadsDir = Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS)
-        // we need to find the next available name with copy counter by ourselves before copying
-        val availableAssetName = findFirstUniqueName(downloadsDir, assetName.ifEmpty { ATTACHMENT_FILENAME })
         val destinationFile = File(downloadsDir, availableAssetName)
         val uri = FileProvider.getUriForFile(this, authority, destinationFile)
         if (mimeType?.isNotEmpty() == true) {
@@ -409,13 +408,17 @@ fun Context.getProviderAuthority() = "$packageName.provider"
 
 @VisibleForTesting
 fun findFirstUniqueName(dir: File, desiredName: String): String {
-    var currentName: String = desiredName
+    var currentName: String = desiredName.sanitizeFilename()
     while (File(dir, currentName).exists()) {
         val (nameWithoutCopyCounter, copyCounter, extension) = currentName.splitFileExtensionAndCopyCounter()
-        currentName = buildFileName(nameWithoutCopyCounter, extension, copyCounter + 1)
+        currentName = buildFileName(nameWithoutCopyCounter, extension, copyCounter + 1).sanitizeFilename()
     }
     return currentName
 }
+
+@VisibleForTesting
+fun String.sanitizeFilename(): String = replace(Regex("[\u0000-\u001f\u007f\"*/:<>?\\\\|]"), "_")
+
 
 fun getAudioLengthInMs(dataPath: Path, mimeType: String): Long =
     if (isAudioMimeType(mimeType)) {

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -424,7 +424,6 @@ fun findFirstUniqueName(dir: File, desiredName: String): String {
 @VisibleForTesting
 fun String.sanitizeFilename(): String = replace(Regex("[\u0000-\u001f\u007f\"*/:<>?\\\\|]"), "_")
 
-
 fun getAudioLengthInMs(dataPath: Path, mimeType: String): Long =
     if (isAudioMimeType(mimeType)) {
         val retriever = MediaMetadataRetriever()

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -416,6 +416,11 @@ fun findFirstUniqueName(dir: File, desiredName: String): String {
     return currentName
 }
 
+/**
+ * Removes disallowed characters and returns valid filename.
+ *
+ * Uses the same cases as in `isValidFatFilenameChar` and `isValidExtFilenameChar` from [android.os.FileUtils].
+ */
 @VisibleForTesting
 fun String.sanitizeFilename(): String = replace(Regex("[\u0000-\u001f\u007f\"*/:<>?\\\\|]"), "_")
 

--- a/app/src/test/kotlin/com/wire/android/util/FileUtilTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/FileUtilTest.kt
@@ -60,4 +60,13 @@ class FileUtilTest {
         val result = findFirstUniqueName(tempDir, desired)
         assertEquals(expected, result)
     }
+
+    @Test
+    fun `given file with invalid filename when finding unique name in directory then return name without disallowed characters`() {
+        val desired = "\u0020ab\u0008cd\u0000ef\u001fgh\u007Fij*kl/mn:op<qr>st?uv\\wx|yz.jpg"
+        val expected = "\u0020ab_cd_ef_gh_ij_kl_mn_op_qr_st_uv_wx_yz.jpg"
+
+        val result = desired.sanitizeFilename()
+        assertEquals(expected, result)
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On some devices, the app is randomly crashing when downloading a file.
`java.lang.IllegalStateException: Failed to build unique file: /storage/emulated/0/Download/image owner_package_name=com.waz.zclient.dev _display_name=image mime_type=application/octet-stream _data=/storage/emulated/0/Download/image _size=246181 is_download=1 relative_path=Download/`

### Causes (Optional)

In theory, `ContentResolver` handles duplicate names itself and we use it on Android 10 and up, but it uses `buildUniqueFileWithExtension` from `FileUtils` which looks like this:
```
while (file.exists()) {
            if (n++ >= 32) {
                throw new FileNotFoundException("Failed to create unique file");
            }
            file = buildFile(parent, name + " (" + n + ")", ext);
        }
```
so it works but up to 32 times, after that it returns this exact crash.

### Solutions

Use our function `findFirstUniqueName` also for Android versions that use `ContentResolver`, to also determine unique filename ourselves.

This `ContentResolver` also changes the file names to remove disallowed characters (like colon or quotation mark) so it's then not possible to compare these names, so it's required to do the same (also to not allow for creating files with invalid names), that's why `sanitizeFilename` is also added.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Try to save the same file more than 32 times.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
