### PR TITLE
fix: multiple merge conflicts

### DIFF
--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -30,7 +30,6 @@ on:
             - closed
 
 env:
-
     TARGET_BRANCH: develop
     SUBMODULE_NAME: kalium
 
@@ -119,7 +118,8 @@ jobs:
                   OUTPUT=$(git cherry-pick ${{ env.cherryPickCommit }} || true)
                   
                   # Handle conflicts
-                  CONFLICTED_FILES=$(git diff --name-only --diff-filter=U)
+                  CONFLICTED_FILES=$(git diff --name-only --diff-filter=U | awk 'ORS="\\\\n"' | sed 's/\\\\n$/\\n/')
+                  echo "Captured conflicted files: $CONFLICTED_FILES"
                   if [[ "$OUTPUT" == *"CONFLICT"* ]]; then
                       # Commit the remaining conflicts
                       git commit -am "Commit with unresolved merge conflicts outside of ${{ env.SUBMODULE_NAME }}"
@@ -139,5 +139,6 @@ jobs:
                   PR_TITLE: ${{ github.event.pull_request.title }}
                   PR_BRANCH: ${{ env.newBranchName }}
                   PR_ASSIGNEE: ${{ github.event.pull_request.user.login }}
-                  PR_BODY: "${{ format('Cherry pick from the original PR: \n- #{0}\n\n---- \n\n ⚠️ Conflicts during cherry-pick:\n{1}\n\n{2}', github.event.pull_request.number, env.conflictedFiles, github.event.pull_request.body) }}"
-              run: gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base ${{ env.TARGET_BRANCH }} --head "$PR_BRANCH" --label "cherry-pick" --assignee "$PR_ASSIGNEE"
+              run: |
+                  PR_BODY=$(echo -e "Cherry pick from the original PR: \n- #${{ github.event.pull_request.number }}\n\n---- \n\n ⚠️ Conflicts during cherry-pick:\n${{ env.conflictedFiles }}\n\n${{ github.event.pull_request.body }}")
+                  gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base ${{ env.TARGET_BRANCH }} --head "$PR_BRANCH" --label "cherry-pick" --assignee "$PR_ASSIGNEE"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When there was more than one merge conflict automatic cherry pick failed

### Solutions

- Use awk to set the Output Record Separator (ORS) to \\n, which echo -e in bash can interpret as a newline
- Pipe the output to sed to replace the last \\n with \n, to don't end up with an extra newline at the end.
- Move PR_BODY to script to handle properly variable formatting
