### PR TITLE
fix: Rejoining call can't be completed (WPB-5111)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListState.kt
@@ -39,11 +39,15 @@ data class ConversationListState(
     val allMentions: ImmutableList<ConversationItem> = persistentListOf(),
     val newActivityCount: Long = 0,
     val missedCallsCount: Long = 0,
-    val unreadMentionsCount: Long = 0,
+    val unreadMentionsCount: Long = 0
+) {
+    fun findConversationById(conversationId: ConversationId): ConversationItem? =
+        foldersWithConversations.values.flatten()
+            .firstOrNull { it.conversationId == conversationId }
+}
+
+data class ConversationListCallState(
     val hasEstablishedCall: Boolean = false,
     val shouldShowJoinAnywayDialog: Boolean = false,
     val shouldShowCallingPermissionDialog: Boolean = false
-) {
-    fun findConversationById(conversationId: ConversationId): ConversationItem? =
-        foldersWithConversations.values.flatten().firstOrNull { it.conversationId == conversationId }
-}
+)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -173,7 +173,9 @@ class ConversationListViewModel @Inject constructor(
         }
         viewModelScope.launch {
             searchQueryFlow.flatMapLatest { searchQuery ->
-                observeConversationListDetails(fromArchive = searchQuery.source == ConversationsSource.ARCHIVE)
+                observeConversationListDetails(
+                    fromArchive = searchQuery.source == ConversationsSource.ARCHIVE
+                )
                     .map {
                         it.map { conversationDetails ->
                             conversationDetails.toConversationItem(
@@ -223,12 +225,26 @@ class ConversationListViewModel @Inject constructor(
 
     // Mateusz : First iteration, just filter stuff
     // next iteration : SQL- query ?
-    private fun searchConversation(conversationDetails: List<ConversationItem>, searchQuery: String): List<ConversationItem> {
+    private fun searchConversation(
+        conversationDetails: List<ConversationItem>,
+        searchQuery: String
+    ): List<ConversationItem> {
         val matchingConversations = conversationDetails.filter { details ->
             when (details) {
-                is ConversationItem.ConnectionConversation -> details.conversationInfo.name.contains(searchQuery, true)
-                is ConversationItem.GroupConversation -> details.groupName.contains(searchQuery, true)
-                is ConversationItem.PrivateConversation -> details.conversationInfo.name.contains(searchQuery, true)
+                is ConversationItem.ConnectionConversation -> details.conversationInfo.name.contains(
+                    searchQuery,
+                    true
+                )
+
+                is ConversationItem.GroupConversation -> details.groupName.contains(
+                    searchQuery,
+                    true
+                )
+
+                is ConversationItem.PrivateConversation -> details.conversationInfo.name.contains(
+                    searchQuery,
+                    true
+                )
             }
         }
         return matchingConversations
@@ -246,7 +262,10 @@ class ConversationListViewModel @Inject constructor(
         return when (source) {
             ConversationsSource.ARCHIVE -> {
                 buildMap {
-                    if (this@withFolders.isNotEmpty()) put(ConversationFolder.WithoutHeader, this@withFolders)
+                    if (this@withFolders.isNotEmpty()) put(
+                        ConversationFolder.WithoutHeader,
+                        this@withFolders
+                    )
                 }
             }
 
@@ -266,12 +285,13 @@ class ConversationListViewModel @Inject constructor(
                             BadgeEventType.UnreadReply -> true
                         }
 
-                        MutedConversationStatus.OnlyMentionsAndRepliesAllowed -> when (it.badgeEventType) {
-                            BadgeEventType.UnreadReply -> true
-                            BadgeEventType.UnreadMention -> true
-                            BadgeEventType.ReceivedConnectionRequest -> true
-                            else -> false
-                        }
+                        MutedConversationStatus.OnlyMentionsAndRepliesAllowed ->
+                            when (it.badgeEventType) {
+                                BadgeEventType.UnreadReply -> true
+                                BadgeEventType.UnreadMention -> true
+                                BadgeEventType.ReceivedConnectionRequest -> true
+                                else -> false
+                            }
 
                         MutedConversationStatus.AllMuted -> false
                     } || (it is ConversationItem.GroupConversation && it.hasOnGoingCall)
@@ -280,20 +300,39 @@ class ConversationListViewModel @Inject constructor(
                 val remainingConversations = this - unreadConversations.toSet()
 
                 buildMap {
-                    if (unreadConversations.isNotEmpty()) put(ConversationFolder.Predefined.NewActivities, unreadConversations)
-                    if (remainingConversations.isNotEmpty()) put(ConversationFolder.Predefined.Conversations, remainingConversations)
+                    if (unreadConversations.isNotEmpty()) put(
+                        ConversationFolder.Predefined.NewActivities,
+                        unreadConversations
+                    )
+                    if (remainingConversations.isNotEmpty()) put(
+                        ConversationFolder.Predefined.Conversations,
+                        remainingConversations
+                    )
                 }
             }
         }
     }
 
-    fun muteConversation(conversationId: ConversationId?, mutedConversationStatus: MutedConversationStatus) {
+    fun muteConversation(
+        conversationId: ConversationId?,
+        mutedConversationStatus: MutedConversationStatus
+    ) {
         conversationId?.let {
             viewModelScope.launch {
-                when (updateConversationMutedStatus(conversationId, mutedConversationStatus, Date().time)) {
-                    ConversationUpdateStatusResult.Failure -> homeSnackBarState.emit(HomeSnackbarState.MutingOperationError)
+                when (updateConversationMutedStatus(
+                    conversationId,
+                    mutedConversationStatus,
+                    Date().time
+                )) {
+                    ConversationUpdateStatusResult.Failure -> homeSnackBarState.emit(
+                        HomeSnackbarState.MutingOperationError
+                    )
+
                     ConversationUpdateStatusResult.Success ->
-                        appLogger.d("MutedStatus changed for conversation: $conversationId to $mutedConversationStatus")
+                        appLogger.d(
+                            "MutedStatus changed for conversation: " +
+                                    "$conversationId to $mutedConversationStatus"
+                        )
                 }
             }
         }
@@ -311,23 +350,25 @@ class ConversationListViewModel @Inject constructor(
 
     fun joinOngoingCall(conversationId: ConversationId, onJoined: (ConversationId) -> Unit) {
         this.conversationId = conversationId
-            if (conversationListCallState.hasEstablishedCall) {
-                showJoinCallAnywayDialog()
-            } else {
-                dismissJoinCallAnywayDialog()
-                viewModelScope.launch {
-                    answerCall(conversationId = conversationId)
-                }
-                onJoined(conversationId)
+        if (conversationListCallState.hasEstablishedCall) {
+            showJoinCallAnywayDialog()
+        } else {
+            dismissJoinCallAnywayDialog()
+            viewModelScope.launch {
+                answerCall(conversationId = conversationId)
             }
+            onJoined(conversationId)
+        }
     }
 
     private fun showJoinCallAnywayDialog() {
-        conversationListCallState = conversationListCallState.copy(shouldShowJoinAnywayDialog = true)
+        conversationListCallState =
+            conversationListCallState.copy(shouldShowJoinAnywayDialog = true)
     }
 
     fun dismissJoinCallAnywayDialog() {
-        conversationListCallState = conversationListCallState.copy(shouldShowJoinAnywayDialog = false)
+        conversationListCallState =
+            conversationListCallState.copy(shouldShowJoinAnywayDialog = false)
     }
 
     fun blockUser(blockUserState: BlockUserDialogState) {
@@ -340,7 +381,10 @@ class ConversationListViewModel @Inject constructor(
                 }
 
                 is BlockUserResult.Failure -> {
-                    appLogger.d("Error while blocking user ${blockUserState.userId} ; Error ${result.coreFailure}")
+                    appLogger.d(
+                        "Error while blocking user ${blockUserState.userId} ;" +
+                                " Error ${result.coreFailure}"
+                    )
                     HomeSnackbarState.BlockingUserOperationError
                 }
             }
@@ -359,7 +403,10 @@ class ConversationListViewModel @Inject constructor(
                 }
 
                 is UnblockUserResult.Failure -> {
-                    appLogger.e("Error while unblocking user $userId ; Error ${result.coreFailure}")
+                    appLogger.e(
+                        "Error while unblocking user $userId ;" +
+                            " Error ${result.coreFailure}"
+                    )
                     homeSnackBarState.emit(HomeSnackbarState.UnblockingUserOperationError)
                 }
             }
@@ -419,7 +466,10 @@ class ConversationListViewModel @Inject constructor(
     fun moveConversationToFolder(id: String = "") {
     }
 
-    fun moveConversationToArchive(dialogState: DialogState, timestamp: Long = DateTimeUtil.currentInstant().toEpochMilliseconds()) =
+    fun moveConversationToArchive(
+        dialogState: DialogState,
+        timestamp: Long = DateTimeUtil.currentInstant().toEpochMilliseconds()
+    ) =
         with(dialogState) {
             viewModelScope.launch {
                 val isArchiving = !isArchived
@@ -434,11 +484,19 @@ class ConversationListViewModel @Inject constructor(
                 requestInProgress = false
                 when (result) {
                     is ArchiveStatusUpdateResult.Failure -> {
-                        homeSnackBarState.emit(HomeSnackbarState.UpdateArchivingStatusError(isArchiving))
+                        homeSnackBarState.emit(
+                            HomeSnackbarState.UpdateArchivingStatusError(
+                                isArchiving
+                            )
+                        )
                     }
 
                     is ArchiveStatusUpdateResult.Success -> {
-                        homeSnackBarState.emit(HomeSnackbarState.UpdateArchivingStatusSuccess(isArchiving))
+                        homeSnackBarState.emit(
+                            HomeSnackbarState.UpdateArchivingStatusSuccess(
+                                isArchiving
+                            )
+                        )
                     }
                 }
             }
@@ -570,9 +628,15 @@ private fun ConversationDetails.toConversationItem(
 }
 
 private fun parseConnectionEventType(connectionState: ConnectionState) =
-    if (connectionState == ConnectionState.SENT) BadgeEventType.SentConnectRequest else BadgeEventType.ReceivedConnectionRequest
+    if (connectionState == ConnectionState.SENT)
+        BadgeEventType.SentConnectRequest
+    else BadgeEventType.ReceivedConnectionRequest
 
-fun parsePrivateConversationEventType(connectionState: ConnectionState, isDeleted: Boolean, eventType: BadgeEventType) =
+fun parsePrivateConversationEventType(
+    connectionState: ConnectionState,
+    isDeleted: Boolean,
+    eventType: BadgeEventType
+) =
     if (connectionState == ConnectionState.BLOCKED) {
         BadgeEventType.Blocked
     } else if (isDeleted) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -89,7 +89,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMap
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -628,9 +627,11 @@ private fun ConversationDetails.toConversationItem(
 }
 
 private fun parseConnectionEventType(connectionState: ConnectionState) =
-    if (connectionState == ConnectionState.SENT)
+    if (connectionState == ConnectionState.SENT) {
         BadgeEventType.SentConnectRequest
-    else BadgeEventType.ReceivedConnectionRequest
+    } else {
+        BadgeEventType.ReceivedConnectionRequest
+    }
 
 fun parsePrivateConversationEventType(
     connectionState: ConnectionState,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
@@ -90,7 +90,7 @@ fun ConversationRouterHomeBridge(
     }
 
     MicrophoneBTPermissionsDeniedDialog(
-        shouldShow = viewModel.conversationListState.shouldShowCallingPermissionDialog,
+        shouldShow = viewModel.conversationListCallState.shouldShowCallingPermissionDialog,
         onDismiss = viewModel::dismissCallingPermissionDialog,
         onOpenSettings = {
             context.openAppInfoScreen()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/AllConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/AllConversationScreen.kt
@@ -92,7 +92,7 @@ fun AllConversationScreenContent(
     val lazyListState = rememberLazyListState()
     val callConversationIdToJoin = remember { mutableStateOf(ConversationId("", "")) }
 
-    if (viewModel.conversationListState.shouldShowJoinAnywayDialog) {
+    if (viewModel.conversationListCallState.shouldShowJoinAnywayDialog) {
         appLogger.i("$TAG showing showJoinAnywayDialog..")
         JoinAnywayDialog(
             onDismiss = viewModel::dismissJoinCallAnywayDialog,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -17,6 +17,7 @@
  *
  *
  */
+@file:Suppress("MaxLineLength", "MaximumLineLength")
 
 package com.wire.android.ui.home.conversationslist
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -268,18 +268,18 @@ class ConversationListViewModelTest {
 
     @Test
     fun `given join dialog displayed, when user dismiss it, then hide it`() {
-        conversationListViewModel.conversationListState = conversationListViewModel.conversationListState.copy(
+        conversationListViewModel.conversationListCallState = conversationListViewModel.conversationListCallState.copy(
             shouldShowJoinAnywayDialog = true
         )
 
         conversationListViewModel.dismissJoinCallAnywayDialog()
 
-        assertEquals(false, conversationListViewModel.conversationListState.shouldShowJoinAnywayDialog)
+        assertEquals(false, conversationListViewModel.conversationListCallState.shouldShowJoinAnywayDialog)
     }
 
     @Test
     fun `given no ongoing call, when user tries to join a call, then invoke answerCall call use case`() {
-        conversationListViewModel.conversationListState = conversationListViewModel.conversationListState.copy(hasEstablishedCall = false)
+        conversationListViewModel.conversationListCallState = conversationListViewModel.conversationListCallState.copy(hasEstablishedCall = false)
 
         coEvery { joinCall(conversationId = any()) } returns Unit
 
@@ -287,22 +287,22 @@ class ConversationListViewModelTest {
 
         coVerify(exactly = 1) { joinCall(conversationId = any()) }
         coVerify(exactly = 1) { onJoined(any()) }
-        assertEquals(false, conversationListViewModel.conversationListState.shouldShowJoinAnywayDialog)
+        assertEquals(false, conversationListViewModel.conversationListCallState.shouldShowJoinAnywayDialog)
     }
 
     @Test
     fun `given an ongoing call, when user tries to join a call, then show JoinCallAnywayDialog`() {
-        conversationListViewModel.conversationListState = conversationListViewModel.conversationListState.copy(hasEstablishedCall = true)
+        conversationListViewModel.conversationListCallState = conversationListViewModel.conversationListCallState.copy(hasEstablishedCall = true)
 
         conversationListViewModel.joinOngoingCall(conversationId, onJoined)
 
-        assertEquals(true, conversationListViewModel.conversationListState.shouldShowJoinAnywayDialog)
+        assertEquals(true, conversationListViewModel.conversationListCallState.shouldShowJoinAnywayDialog)
         coVerify(inverse = true) { joinCall(conversationId = any()) }
     }
 
     @Test
     fun `given an ongoing call, when user confirms dialog to join a call, then end current call and join the newer one`() {
-        conversationListViewModel.conversationListState = conversationListViewModel.conversationListState.copy(hasEstablishedCall = true)
+        conversationListViewModel.conversationListCallState = conversationListViewModel.conversationListCallState.copy(hasEstablishedCall = true)
         conversationListViewModel.establishedCallConversationId = ConversationId("value", "Domain")
         coEvery { endCall(any()) } returns Unit
 
@@ -313,22 +313,22 @@ class ConversationListViewModelTest {
 
     @Test
     fun `given permission dialog default state is false, when calling showPermissionDialog, then update the state to true`() = runTest {
-        conversationListViewModel.conversationListState =
-            conversationListViewModel.conversationListState.copy(shouldShowCallingPermissionDialog = false)
+        conversationListViewModel.conversationListCallState =
+            conversationListViewModel.conversationListCallState.copy(shouldShowCallingPermissionDialog = false)
 
         conversationListViewModel.showCallingPermissionDialog()
 
-        assertEquals(true, conversationListViewModel.conversationListState.shouldShowCallingPermissionDialog)
+        assertEquals(true, conversationListViewModel.conversationListCallState.shouldShowCallingPermissionDialog)
     }
 
     @Test
     fun `given default permission dialog state, when calling dismissPermissionDialog, then update the state to false`() = runTest {
-        conversationListViewModel.conversationListState =
-            conversationListViewModel.conversationListState.copy(shouldShowCallingPermissionDialog = true)
+        conversationListViewModel.conversationListCallState =
+            conversationListViewModel.conversationListCallState.copy(shouldShowCallingPermissionDialog = true)
 
         conversationListViewModel.dismissCallingPermissionDialog()
 
-        assertEquals(false, conversationListViewModel.conversationListState.shouldShowCallingPermissionDialog)
+        assertEquals(false, conversationListViewModel.conversationListCallState.shouldShowCallingPermissionDialog)
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5111" title="WPB-5111" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5111</a>  [Android] Join Call - Rejoining call can't be completed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After ending a group a call and immediately try to rejoin, a dialog appears saying you are already in a call

### Causes (Optional)

After implementing Archive feature, a race condition happened where we are updating the conversationListState from two different places: `observeEstablishedCall` and search in `init` block of `ConversationListViewModel`. 
This race condition can lead to wrong state of calling resulting a dialog to appear

### Solutions

Create a separate state for calling `ConversationListCallState` that will be updated on init from one place.


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

- Join a group call
- End the call
- Join it again
- You should not the any dialog saying that you are already in a call

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
