### PR TITLE
fix: white screen after splash screen (WPB-5439)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -145,6 +145,7 @@ class WireActivity : AppCompatActivity() {
             InitialAppState.LOGGED_IN -> HomeScreenDestination
         }
         setComposableContent(startDestination) {
+            shouldKeepSplashOpen = false
             handleDeepLink(intent, savedInstanceState)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -123,8 +123,16 @@ class WireActivity : AppCompatActivity() {
 
     val navigationCommands: MutableSharedFlow<NavigationCommand> = MutableSharedFlow()
 
+    // This flag is used to keep the splash screen open until the first screen is drawn.
+    private var shouldKeepSplashOpen = true
+
     override fun onCreate(savedInstanceState: Bundle?) {
-        installSplashScreen()
+        // We need to keep the splash screen open until the first screen is drawn.
+        // Otherwise a white screen is displayed.
+        // It's an API limitation, at some point we may need to remove it
+        installSplashScreen().setKeepOnScreenCondition {
+            shouldKeepSplashOpen
+        }
         super.onCreate(savedInstanceState)
         proximitySensorManager.initialize()
         lifecycle.addObserver(currentScreenManager)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5439" title="WPB-5439" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5439</a>  White screen after splash screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On cold startup, the app is showing a white screen for some seconds after splash screen.

### Causes (Optional)

Splash API limitation

### Solutions

Keep showing the splash screen until the app is drawn


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### How to Test

- Start the app on cold startup
- you should not see white screen after splash

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
