### PR TITLE
chore: Adjust minimum characters to search to 1 (WPB-4915)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationMessagesFromSearchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationMessagesFromSearchUseCase.kt
@@ -68,6 +68,6 @@ class GetConversationMessagesFromSearchUseCase @Inject constructor(
         }
 
     private companion object {
-        const val MINIMUM_CHARACTERS_TO_SEARCH = 2
+        const val MINIMUM_CHARACTERS_TO_SEARCH = 1
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationMessagesFromSearchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationMessagesFromSearchUseCaseTest.kt
@@ -60,7 +60,7 @@ class GetConversationMessagesFromSearchUseCaseTest {
                 .arrange()
 
             // when
-            val result = useCase("a", arrangement.conversationId)
+            val result = useCase("", arrangement.conversationId)
 
             // then
             assert(result is Either.Right<List<UIMessage>>)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4915" title="WPB-4915" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-4915</a>  [Android] search for text inside the conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

First ACs for search was that a minimum characters was set to 2. But after some internal discussions we decided on reducing it to 1 minimum character.

### Solutions

Change minimum character to 1 instead of 2.

### Testing

#### How to Test

- Open App
- Open Conversation
- Open Conversation Details
- Open Search Screen
- Type `1` character and it should start loading results.
