### PR TITLE
chore: hide search messages button (WPB-5419)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesButton.kt
@@ -33,9 +33,22 @@ import androidx.compose.ui.unit.DpSize
 import com.wire.android.R
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dimensions
+import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 
 @Composable
 fun SearchConversationMessagesButton(
+    onSearchConversationMessagesClick: () -> Unit
+) {
+    val localFeatureVisibilityFlags = LocalFeatureVisibilityFlags.current
+    if (localFeatureVisibilityFlags.SearchConversationMessages) {
+        SearchConversationMessagesButtonContent(
+            onSearchConversationMessagesClick = onSearchConversationMessagesClick
+        )
+    }
+}
+
+@Composable
+private fun SearchConversationMessagesButtonContent(
     onSearchConversationMessagesClick: () -> Unit
 ) {
     Column(

--- a/app/src/main/kotlin/com/wire/android/util/debug/FeatureVisibilityFlags.kt
+++ b/app/src/main/kotlin/com/wire/android/util/debug/FeatureVisibilityFlags.kt
@@ -56,6 +56,7 @@ object FeatureVisibilityFlags {
     const val ConversationSearchIcon = false
     const val UserProfileEditIcon = false
     const val MessageEditIcon = true
+    const val SearchConversationMessages = false
 }
 
 

--- a/app/src/main/kotlin/com/wire/android/util/debug/FeatureVisibilityFlags.kt
+++ b/app/src/main/kotlin/com/wire/android/util/debug/FeatureVisibilityFlags.kt
@@ -59,5 +59,4 @@ object FeatureVisibilityFlags {
     const val SearchConversationMessages = false
 }
 
-
 val LocalFeatureVisibilityFlags = staticCompositionLocalOf { FeatureVisibilityFlags }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5419" title="WPB-5419" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-5419</a>  Remove the search functionality before code freeze for 4.5.0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In order to not risk the performance of v4.5.0 release we are removing the possibility to the search inside a conversation for this version.

### Testing

#### How to Test
- Open Group Conversation Details / or User Profile Screen
- No search button is shown
