### PR TITLE
chore: rename project references as android, deprecating scala repo (rc)

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-app:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-app:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -17,7 +17,7 @@ jobs:
         submodules: recursive # Needed in order to fetch Kalium sources for building
         fetch-depth: 0
     - name: Set up JDK 17
-      uses: buildjet/setup-java@v3
+      uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v3
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   static-code-analysis:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   static-code-analysis:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   ui-tests:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: macos-latest
     strategy:
       matrix:
         api-level: [29]

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   ui-tests:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       matrix:
         api-level: [29]

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v3
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/codestyle.yml
   unit-tests:
     needs: [detekt]
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/codestyle.yml
   unit-tests:
     needs: [detekt]
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
 
     steps:
       - name: Checkout

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v3
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -61,7 +61,7 @@ jobs:
                   # The event file is a JSON containing the data of the event that triggered the tests.
                   # In this case, it will contain information about the PR.
               run: |
-                  CHECKS_LINK="https://github.com/wireapp/wire-android-reloaded/actions/runs/${{ github.event.workflow_run.id }}"
+                  CHECKS_LINK="https://github.com/wireapp/wire-android/actions/runs/${{ github.event.workflow_run.id }}"
                   PR_NUMBER=$(jq --raw-output .pull_request.number "$EVENT_FILE_PATH")
                   gh pr comment "$PR_NUMBER" --body "APKs built during tests are available [here]($CHECKS_LINK). Scroll down to **Artifacts**!"
 

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -23,7 +23,7 @@ String shellQuote(String s) {
 
 def postGithubComment(String changeId, String body) {
     def authHeader = shellQuote("Authorization: token ${env.GITHUB_API_TOKEN}")
-    def apiUrl = shellQuote("https://api.github.com/repos/wireapp/wire-android-reloaded/issues/${changeId}/comments")
+    def apiUrl = shellQuote("https://api.github.com/repos/wireapp/wire-android/issues/${changeId}/comments")
 
     // The comment body must be quoted for embedding into a JSON string,
     // and the JSON string must be quoted for embedding into the shell command

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ String shellQuote(String s) {
 
 def postGithubComment(String changeId, String body) {
     def authHeader = shellQuote("Authorization: token ${env.GITHUB_API_TOKEN}")
-    def apiUrl = shellQuote("https://api.github.com/repos/wireapp/wire-android-reloaded/issues/${changeId}/comments")
+    def apiUrl = shellQuote("https://api.github.com/repos/wireapp/wire-android/issues/${changeId}/comments")
 
     // The comment body must be quoted for embedding into a JSON string,
     // and the JSON string must be quoted for embedding into the shell command

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Wire™
-[![codecov](https://codecov.io/gh/wireapp/wire-android-reloaded/branch/develop/graph/badge.svg?token=9ELBEPM793)](https://codecov.io/gh/wireapp/wire-android-reloaded)
+[![codecov](https://codecov.io/gh/wireapp/wire-android/branch/develop/graph/badge.svg?token=9ELBEPM793)](https://codecov.io/gh/wireapp/wire-android)
 [![Crowdin](https://badges.crowdin.net/wire-android-reloaded/localized.svg)](https://crowdin.com/project/wire-android-reloaded)
 
 [![Wire logo](https://github.com/wireapp/wire/blob/master/assets/header-small.png?raw=true)](https://wire.com/jobs/)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
@@ -126,7 +126,7 @@ Sample text here...
 ```
 
 # Links
-[AR PR](https://github.com/wireapp/wire-android-reloaded/pulls)
+[AR PR](https://github.com/wireapp/wire-android/pulls)
 
 Autoconverted link https://github.com/wireapp/kalium/pulls
 """


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Renaming references, to explicitly use wire-android instead of the redirection (that works) wire-android-reloaded.
Allowing in the future to be consistent about naming.


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
