### PR TITLE
fix: app lock can be changes when enforced and it is cleared when not…

### DIFF
--- a/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
+++ b/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
@@ -55,9 +55,7 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
         private val IS_LOGGING_ENABLED = booleanPreferencesKey("is_logging_enabled")
         private val IS_ENCRYPTED_PROTEUS_STORAGE_ENABLED =
             booleanPreferencesKey("is_encrypted_proteus_storage_enabled")
-        private val IS_APP_LOCKED_BY_USER = booleanPreferencesKey("is_app_locked_by_user")
-        private val APP_LOCK_PASSCODE = stringPreferencesKey("app_lock_passcode")
-        private val TEAM_APP_LOCK_PASSCODE = stringPreferencesKey("team_app_lock_passcode")
+         private val APP_LOCK_PASSCODE = stringPreferencesKey("app_lock_passcode")
         val APP_THEME_OPTION = stringPreferencesKey("app_theme_option")
         private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = PREFERENCES_NAME)
         private fun userMigrationStatusKey(userId: String): Preferences.Key<Int> =
@@ -169,11 +167,10 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
      */
     @Suppress("TooGenericExceptionCaught")
     fun getAppLockPasscodeFlow(): Flow<String?> {
-        val preference = if (isAppLockPasscodeSet()) APP_LOCK_PASSCODE else TEAM_APP_LOCK_PASSCODE
         return context.dataStore.data.map {
-            it[preference]?.let { passcode ->
+            it[APP_LOCK_PASSCODE]?.let { passcode ->
                 try {
-                    EncryptionManager.decrypt(preference.name, passcode)
+                    EncryptionManager.decrypt(APP_LOCK_PASSCODE.name, passcode)
                 } catch (e: Exception) {
                     null
                 }
@@ -195,21 +192,9 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
         }.first()
     }
 
-    fun isAppTeamPasscodeSet(): Boolean = runBlocking {
-        context.dataStore.data.map {
-            it.contains(TEAM_APP_LOCK_PASSCODE)
-        }.first()
-    }
-
     suspend fun clearAppLockPasscode() {
         context.dataStore.edit {
             it.remove(APP_LOCK_PASSCODE)
-        }
-    }
-
-    suspend fun clearTeamAppLockPasscode() {
-        context.dataStore.edit {
-            it.remove(TEAM_APP_LOCK_PASSCODE)
         }
     }
 
@@ -227,13 +212,6 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
                 it.remove(key)
             }
         }
-    }
-
-    suspend fun setTeamAppLock(
-        passcode: String,
-        key: Preferences.Key<String> = TEAM_APP_LOCK_PASSCODE
-    ) {
-        setAppLockPasscode(passcode, key)
     }
 
     suspend fun setUserAppLock(

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.feature.connection.BlockUserUseCase
 import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveOtherUserSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
+import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveTeamSettingsSelfDeletingStatusUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
@@ -427,4 +428,10 @@ class UseCaseModule {
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
     ): ObserveScreenshotCensoringConfigUseCase = coreLogic.getSessionScope(currentAccount).observeScreenshotCensoringConfig
+
+    @ViewModelScoped
+    @Provides
+    fun provideIsAppLockEditableUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic
+    ): IsAppLockEditableUseCase = coreLogic.getGlobalScope().isAppLockEditableUseCase
 }

--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -65,8 +65,6 @@ class KaliumConfigsModule {
             wipeOnRootedDevice = BuildConfig.WIPE_ON_ROOTED_DEVICE,
             isWebSocketEnabledByDefault = isWebsocketEnabledByDefault(context),
             certPinningConfig = BuildConfig.CERTIFICATE_PINNING_CONFIG,
-            teamAppLock = BuildConfig.TEAM_APP_LOCK,
-            teamAppLockTimeout = BuildConfig.TEAM_APP_LOCK_TIMEOUT
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
@@ -67,6 +67,7 @@ class PersistentWebSocketService : Service() {
     @Inject
     lateinit var notificationManager: WireNotificationManager
 
+    // TODO: remove since it is not used
     @Inject
     @CurrentSessionFlowService
     lateinit var currentSessionFlow: CurrentSessionFlowUseCase

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -271,7 +271,6 @@ class WireActivity : AppCompatActivity() {
                         } else {
                             with(featureFlagNotificationViewModel) {
                                 markTeamAppLockStatusAsNot()
-                                clearTeamAppLockPasscode()
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeViewState.kt
@@ -18,7 +18,8 @@
 package com.wire.android.ui.home.appLock.set
 
 import androidx.compose.ui.text.input.TextFieldValue
-import com.wire.kalium.logic.feature.applock.AppLockTeamFeatureConfigObserverImpl.Companion.DEFAULT_TIMEOUT
+import com.wire.android.feature.ObserveAppLockConfigUseCase
+
 import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
 import kotlin.time.Duration
 
@@ -26,7 +27,6 @@ data class SetLockCodeViewState(
     val continueEnabled: Boolean = false,
     val password: TextFieldValue = TextFieldValue(),
     val passwordValidation: ValidatePasswordResult = ValidatePasswordResult.Invalid(),
-    val timeout: Duration = DEFAULT_TIMEOUT,
-    val isAppLockByUser: Boolean = true,
+    val timeout: Duration = ObserveAppLockConfigUseCase.DEFAULT_APP_LOCK_TIMEOUT,
     val done: Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.GlobalDataStore
-import com.wire.android.feature.AppLockConfig
 import com.wire.android.feature.ObserveAppLockConfigUseCase
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.sha256
@@ -53,8 +52,7 @@ class SetLockScreenViewModel @Inject constructor(
             observeAppLockConfigUseCase()
                 .collectLatest {
                     state = state.copy(
-                        timeout = it.timeout,
-                        isAppLockByUser = it !is AppLockConfig.EnforcedByTeam
+                        timeout = it.timeout
                     )
                 }
         }
@@ -82,11 +80,9 @@ class SetLockScreenViewModel @Inject constructor(
                 viewModelScope.launch {
                     withContext(dispatchers.io()) {
                         with(globalDataStore) {
-                            if (state.isAppLockByUser) {
-                                setUserAppLock(state.password.text.sha256())
-                            } else {
-                                setTeamAppLock(state.password.text.sha256())
-                            }
+                            setUserAppLock(state.password.text.sha256())
+
+                            // TODO: call only when needed
                             markTeamAppLockStatusAsNotified()
                         }
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
@@ -34,7 +34,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
 import com.wire.android.BuildConfig
 import com.wire.android.R
-import com.wire.android.feature.AppLockConfig
+import com.wire.android.appLogger
 import com.wire.android.model.Clickable
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.HomeNavGraph
@@ -112,21 +112,29 @@ fun SettingsScreenContent(
                         add(SettingsItem.AppSettings)
                     }
                     add(SettingsItem.NetworkSettings)
+
                     add(SettingsItem.AppLock(
-                        when (settingsState.appLockConfig) {
-                            is AppLockConfig.Disabled -> SwitchState.Enabled(
-                                value = false,
-                                isOnOffVisible = true,
-                                onCheckedChange = onAppLockSwitchChanged
-                            )
-                            is AppLockConfig.Enabled -> SwitchState.Enabled(
-                                value = true,
-                                isOnOffVisible = true
-                            ) {
-                                turnAppLockOffDialogState.show(Unit)
+                        when (settingsState.isAppLockEditable) {
+                            true -> {
+                                appLogger.d("AppLockConfig isAooLockEditable: ${settingsState.isAppLockEditable}")
+
+                                appLogger.d("AppLockConfig isAppLockEnabled: ${settingsState.isAppLockEnabled}")
+                                SwitchState.Enabled(
+                                    value = settingsState.isAppLockEnabled,
+                                    isOnOffVisible = true
+                                ) {
+                                    turnAppLockOffDialogState.show(Unit)
+                                }
                             }
-                            is AppLockConfig.EnforcedByTeam -> {
-                                SwitchState.TextOnly(true)
+
+                            false -> {
+                                appLogger.d("AppLockConfig isAooLockEditable: ${settingsState.isAppLockEditable}")
+
+                                appLogger.d("AppLockConfig isAppLockEnabled: ${settingsState.isAppLockEnabled}")
+                                SwitchState.Disabled(
+                                    value = settingsState.isAppLockEnabled,
+                                    isOnOffVisible = true,
+                                )
                             }
                         }
                     ))

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsState.kt
@@ -17,9 +17,7 @@
  */
 package com.wire.android.ui.home.settings
 
-import com.wire.android.feature.AppLockConfig
-import com.wire.kalium.logic.feature.applock.AppLockTeamFeatureConfigObserverImpl.Companion.DEFAULT_TIMEOUT
-
 data class SettingsState(
-    val appLockConfig: AppLockConfig = AppLockConfig.Disabled(DEFAULT_TIMEOUT),
+    val isAppLockEditable: Boolean = false,
+    val isAppLockEnabled: Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModel.kt
@@ -26,22 +26,27 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.GlobalDataStore
-import com.wire.android.feature.ObserveAppLockConfigUseCase
+import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    private val observeAppLockConfigUseCase: ObserveAppLockConfigUseCase,
     private val globalDataStore: GlobalDataStore,
+    private val isAppLockEditableUseCase: IsAppLockEditableUseCase
 ) : ViewModel() {
     var state by mutableStateOf(SettingsState())
         private set
 
     init {
         viewModelScope.launch {
-            observeAppLockConfigUseCase().collect { appLockConfig -> state = state.copy(appLockConfig = appLockConfig) }
+            isAppLockEditableUseCase().let {
+                state = state.copy(isAppLockEditable = it)
+            }
+            globalDataStore.isAppLockPasscodeSetFlow().collect {
+                state = state.copy(isAppLockEnabled = it)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -138,9 +138,9 @@ class FeatureFlagNotificationViewModel @Inject constructor(
             coreLogic.getSessionScope(userId).appLockTeamFeatureConfigObserver()
                 .distinctUntilChanged()
                 .collectLatest {
-                    it.isStatusChanged?.let { isStatusChanged ->
+                    it?.isStatusChanged?.let { isStatusChanged ->
                         featureFlagState = featureFlagState.copy(
-                            isTeamAppLockEnabled = it.isEnabled,
+                            isTeamAppLockEnabled = it.isEnforced,
                             shouldShowTeamAppLockDialog = isStatusChanged
                         )
                     }
@@ -236,12 +236,6 @@ class FeatureFlagNotificationViewModel @Inject constructor(
                     (currentSession as CurrentSessionResult.Success).accountInfo.userId
                 ).markTeamAppLockStatusAsNotified()
             }
-        }
-    }
-
-    fun clearTeamAppLockPasscode() {
-        viewModelScope.launch {
-            globalDataStore.clearTeamAppLockPasscode()
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCaseTest.kt
@@ -61,7 +61,7 @@ class ObserveAppLockConfigUseCaseTest {
             val (_, useCase) = Arrangement()
                 .withValidSession()
                 .withTeamAppLockEnabled()
-                .withAppLockedByCurrentUser()
+                .withAppLockedByCurrentUser(false)
                 .arrange()
 
             val result = useCase.invoke()
@@ -80,7 +80,7 @@ class ObserveAppLockConfigUseCaseTest {
             val (_, useCase) = Arrangement()
                 .withValidSession()
                 .withTeamAppLockDisabled()
-                .withAppLockedByCurrentUser()
+                .withAppLockedByCurrentUser(true)
                 .arrange()
 
             val result = useCase.invoke()
@@ -103,7 +103,6 @@ class ObserveAppLockConfigUseCaseTest {
                 .arrange()
 
             val result = useCase.invoke()
-
             result.test {
                 val appLockStatus = awaitItem()
 
@@ -141,10 +140,6 @@ class ObserveAppLockConfigUseCaseTest {
             MockKAnnotations.init(this, relaxUnitFun = true)
         }
 
-        fun withAppLockPasscodeSet(value: Boolean) = apply {
-            every { globalDataStore.isAppLockPasscodeSetFlow() } returns flowOf(value)
-        }
-
         fun arrange() = this to useCase
 
         fun withNonValidSession() = apply {
@@ -175,8 +170,8 @@ class ObserveAppLockConfigUseCaseTest {
             } returns flowOf(AppLockTeamConfig(false, timeout, false))
         }
 
-        fun withAppLockedByCurrentUser() = apply {
-            every { globalDataStore.isAppLockPasscodeSetFlow() } returns flowOf(true)
+        fun withAppLockedByCurrentUser(state: Boolean) = apply {
+            every { globalDataStore.isAppLockPasscodeSetFlow() } returns flowOf(state)
         }
 
         fun withAppNonLockedByCurrentUser() = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModelTest.kt
@@ -23,7 +23,6 @@ import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.feature.AppLockConfig
 import com.wire.android.feature.ObserveAppLockConfigUseCase
-import com.wire.kalium.logic.feature.applock.AppLockTeamFeatureConfigObserverImpl
 import com.wire.kalium.logic.feature.applock.MarkTeamAppLockStatusAsNotifiedUseCase
 import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
@@ -84,9 +83,8 @@ class SetLockScreenViewModelTest {
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
             coEvery { globalDataStore.setUserAppLock(any()) } returns Unit
-            coEvery { globalDataStore.setTeamAppLock(any()) } returns Unit
             coEvery { observeAppLockConfig() } returns flowOf(
-                AppLockConfig.Disabled(AppLockTeamFeatureConfigObserverImpl.DEFAULT_TIMEOUT)
+                AppLockConfig.Disabled(ObserveAppLockConfigUseCase.DEFAULT_APP_LOCK_TIMEOUT)
             )
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. App lock settings can be changed, even when enforced by team.
2. App lock is cleared when the team removes the enforce.
3. there are 2 different types of lock (user and team).

### Solutions

1. add use case to check if the app lock can be modified (if at least one user ha ve it enforced by team).
2. remove default timeout form klalium (this should be the app responsibility)
3. remove the team app lock and keep only one source for the lock
4. do not reset the app lock when team settings changes

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
