### PR TITLE
fix: reset passcode dialog state when empty input or sso user [WPB-5094]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeResetDeviceDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeResetDeviceDialog.kt
@@ -96,7 +96,7 @@ fun ForgotLockCodeResetDeviceDialog(
             state = if (!isResetDeviceEnabled) WireButtonState.Disabled else WireButtonState.Error
         )
     ) {
-        if(!isPasswordNotRequired) {
+        if (!isPasswordNotRequired) {
             // keyboard controller from outside the Dialog doesn't work inside its content so we have to pass the state
             // to the dialog's content and use keyboard controller from there
             keyboardController = LocalSoftwareKeyboardController.current

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeResetDeviceDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeResetDeviceDialog.kt
@@ -52,7 +52,7 @@ import com.wire.android.util.ui.stringWithStyledArgs
 @Composable
 fun ForgotLockCodeResetDeviceDialog(
     username: String,
-    isPasswordNotRequired: Boolean,
+    isPasswordRequired: Boolean,
     isPasswordValid: Boolean,
     isResetDeviceEnabled: Boolean,
     onPasswordChanged: (TextFieldValue) -> Unit,
@@ -67,9 +67,7 @@ fun ForgotLockCodeResetDeviceDialog(
     }
     WireDialog(
         title = stringResource(R.string.settings_forgot_lock_screen_reset_device),
-        text = if (isPasswordNotRequired) {
-            AnnotatedString(stringResource(id = R.string.settings_forgot_lock_screen_reset_device_without_password_description))
-        } else {
+        text = if (isPasswordRequired) {
             LocalContext.current.resources.stringWithStyledArgs(
                 R.string.settings_forgot_lock_screen_reset_device_description,
                 MaterialTheme.wireTypography.body01,
@@ -78,6 +76,8 @@ fun ForgotLockCodeResetDeviceDialog(
                 colorsScheme().onBackground,
                 username
             )
+        } else {
+            AnnotatedString(stringResource(id = R.string.settings_forgot_lock_screen_reset_device_without_password_description))
         },
         onDismiss = onDialogDismissHideKeyboard,
         buttonsHorizontalAlignment = false,
@@ -96,7 +96,7 @@ fun ForgotLockCodeResetDeviceDialog(
             state = if (!isResetDeviceEnabled) WireButtonState.Disabled else WireButtonState.Error
         )
     ) {
-        if (!isPasswordNotRequired) {
+        if (isPasswordRequired) {
             // keyboard controller from outside the Dialog doesn't work inside its content so we have to pass the state
             // to the dialog's content and use keyboard controller from there
             keyboardController = LocalSoftwareKeyboardController.current

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeResetDeviceDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeResetDeviceDialog.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.window.DialogProperties
 import com.wire.android.R
@@ -51,6 +52,7 @@ import com.wire.android.util.ui.stringWithStyledArgs
 @Composable
 fun ForgotLockCodeResetDeviceDialog(
     username: String,
+    isPasswordNotRequired: Boolean,
     isPasswordValid: Boolean,
     isResetDeviceEnabled: Boolean,
     onPasswordChanged: (TextFieldValue) -> Unit,
@@ -65,14 +67,18 @@ fun ForgotLockCodeResetDeviceDialog(
     }
     WireDialog(
         title = stringResource(R.string.settings_forgot_lock_screen_reset_device),
-        text = LocalContext.current.resources.stringWithStyledArgs(
-            R.string.settings_forgot_lock_screen_reset_device_description,
-            MaterialTheme.wireTypography.body01,
-            MaterialTheme.wireTypography.body02,
-            colorsScheme().onBackground,
-            colorsScheme().onBackground,
-            username
-        ),
+        text = if (isPasswordNotRequired) {
+            AnnotatedString(stringResource(id = R.string.settings_forgot_lock_screen_reset_device_without_password_description))
+        } else {
+            LocalContext.current.resources.stringWithStyledArgs(
+                R.string.settings_forgot_lock_screen_reset_device_description,
+                MaterialTheme.wireTypography.body01,
+                MaterialTheme.wireTypography.body02,
+                colorsScheme().onBackground,
+                colorsScheme().onBackground,
+                username
+            )
+        },
         onDismiss = onDialogDismissHideKeyboard,
         buttonsHorizontalAlignment = false,
         dismissButtonProperties = WireDialogButtonProperties(
@@ -90,23 +96,25 @@ fun ForgotLockCodeResetDeviceDialog(
             state = if (!isResetDeviceEnabled) WireButtonState.Disabled else WireButtonState.Error
         )
     ) {
-        // keyboard controller from outside the Dialog doesn't work inside its content so we have to pass the state
-        // to the dialog's content and use keyboard controller from there
-        keyboardController = LocalSoftwareKeyboardController.current
-        WirePasswordTextField(
-            state = when {
-                !isPasswordValid -> WireTextFieldState.Error(stringResource(id = R.string.remove_device_invalid_password))
-                else -> WireTextFieldState.Default
-            },
-            value = backupPassword,
-            onValueChange = {
-                backupPassword = it
-                onPasswordChanged(it)
-            },
-            autofill = false,
-            keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
-            modifier = Modifier.padding(bottom = dimensions().spacing16x)
-        )
+        if(!isPasswordNotRequired) {
+            // keyboard controller from outside the Dialog doesn't work inside its content so we have to pass the state
+            // to the dialog's content and use keyboard controller from there
+            keyboardController = LocalSoftwareKeyboardController.current
+            WirePasswordTextField(
+                state = when {
+                    !isPasswordValid -> WireTextFieldState.Error(stringResource(id = R.string.remove_device_invalid_password))
+                    else -> WireTextFieldState.Default
+                },
+                value = backupPassword,
+                onValueChange = {
+                    backupPassword = it
+                    onPasswordChanged(it)
+                },
+                autofill = false,
+                keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
+                modifier = Modifier.padding(bottom = dimensions().spacing16x)
+            )
+        }
     }
 }
 
@@ -124,7 +132,15 @@ fun ForgotLockCodeResettingDeviceDialog() {
 @Composable
 fun PreviewForgotLockCodeResetDeviceDialog() {
     WireTheme {
-        ForgotLockCodeResetDeviceDialog("Username", true, true, {}, {}, {})
+        ForgotLockCodeResetDeviceDialog("Username", false, true, true, {}, {}, {})
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewForgotLockCodeResetDeviceWithoutPasswordDialog() {
+    WireTheme {
+        ForgotLockCodeResetDeviceDialog("Username", true, true, true, {}, {}, {})
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
@@ -86,7 +86,7 @@ fun ForgotLockCodeScreen(
             if (dialogState.loading) ForgotLockCodeResettingDeviceDialog()
             else ForgotLockCodeResetDeviceDialog(
                 username = dialogState.username,
-                isPasswordNotRequired = dialogState.passwordNotRequired,
+                isPasswordRequired = dialogState.passwordRequired,
                 isPasswordValid = dialogState.passwordValid,
                 isResetDeviceEnabled = dialogState.resetDeviceEnabled,
                 onPasswordChanged = viewModel::onPasswordChanged,

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
@@ -86,6 +86,7 @@ fun ForgotLockCodeScreen(
             if (dialogState.loading) ForgotLockCodeResettingDeviceDialog()
             else ForgotLockCodeResetDeviceDialog(
                 username = dialogState.username,
+                isPasswordNotRequired = dialogState.passwordNotRequired,
                 isPasswordValid = dialogState.passwordValid,
                 isResetDeviceEnabled = dialogState.resetDeviceEnabled,
                 onPasswordChanged = viewModel::onPasswordChanged,

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeViewState.kt
@@ -31,8 +31,9 @@ sealed class ForgotLockCodeDialogState {
     data class Visible(
         val username: String,
         val password: TextFieldValue = TextFieldValue(""),
+        val passwordNotRequired: Boolean = false,
         val passwordValid: Boolean = true,
-        val resetDeviceEnabled: Boolean = true,
+        val resetDeviceEnabled: Boolean = false,
         val loading: Boolean = false,
     ) : ForgotLockCodeDialogState()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeViewState.kt
@@ -31,7 +31,7 @@ sealed class ForgotLockCodeDialogState {
     data class Visible(
         val username: String,
         val password: TextFieldValue = TextFieldValue(""),
-        val passwordNotRequired: Boolean = false,
+        val passwordRequired: Boolean = false,
         val passwordValid: Boolean = true,
         val resetDeviceEnabled: Boolean = false,
         val loading: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModel.kt
@@ -147,7 +147,7 @@ class ForgotLockScreenViewModel @Inject constructor(
             is IsPasswordRequiredUseCase.Result.Success -> when {
                 isPasswordRequiredResult.value && password.isBlank() -> Result.Failure.PasswordRequired to password
                 isPasswordRequiredResult.value && !validatePassword(password).isValid -> Result.Failure.InvalidPassword to password
-                else -> Result.Success to if(isPasswordRequiredResult.value) password else ""
+                else -> Result.Success to if (isPasswordRequiredResult.value) password else ""
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -963,6 +963,7 @@
     <string name="settings_forgot_lock_screen_warning">If you remove your device, you lose all local data and messages for all accounts on this device permanently.</string>
     <string name="settings_forgot_lock_screen_reset_device">Remove Device</string>
     <string name="settings_forgot_lock_screen_reset_device_description">Enter your password for the account %s to confirm the deletion of all data for all accounts on this device. After removing your device, you can log in with your account credentials.</string>
+    <string name="settings_forgot_lock_screen_reset_device_without_password_description">Confirm the deletion of all data for all accounts on this device. After removing your device, you can log in with your account credentials.</string>
     <string name="settings_forgot_lock_screen_please_wait_label">Please wait...</string>
     <!--Devices -->
     <string name="devices_title">Your Devices</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5094" title="WPB-5094" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-5094</a>  [Android] Reset passcode if user forgets
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If the password text box is empty, then remove your device button should be disable. It should be enable once’s the user enter’s the password.

### Solutions

Hide password input field for sso users who do not have a password, for others enable reset button only if password field is not empty.`

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Set the app lock, kill the app, open again, choose to use passcode, click on "forgot passcode".

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| ![image](https://github.com/wireapp/wire-android/assets/30429749/c878d13b-64a7-41b2-b06c-53a679735218) | ![Screenshot_20231121_152649](https://github.com/wireapp/wire-android/assets/30429749/b3e31c28-e326-4c81-806b-c5ef655be919) |

https://github.com/wireapp/wire-android/assets/30429749/20529917-a08e-447e-bb97-fc6385ae807a


<img width="862" alt="image" src="https://github.com/wireapp/wire-android/assets/30429749/e489c670-1d9f-4b7e-891d-e8d7cff64231">

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
