### PR TITLE
fix: enabling app lock manually displays the dialog turn off

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
@@ -160,7 +160,6 @@ fun SettingsScreenContent(
             )
         }
     }
-
 }
 
 private fun LazyListScope.folderWithElements(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
@@ -54,6 +54,8 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val lazyListState: LazyListState = rememberLazyListState()
+    val turnAppLockOffDialogState = rememberVisibilityState<Unit>()
+
     val context = LocalContext.current
     SettingsScreenContent(
         lazyListState = lazyListState,
@@ -69,10 +71,11 @@ fun SettingsScreen(
         onAppLockSwitchChanged = remember {
             { isChecked ->
                 if (isChecked) homeStateHolder.navigator.navigate(NavigationCommand(SetLockCodeScreenDestination, BackStackMode.NONE))
-                else viewModel.disableAppLock()
+                else turnAppLockOffDialogState.show(Unit)
             }
         }
     )
+    TurnAppLockOffDialog(dialogState = turnAppLockOffDialogState, turnOff = viewModel::disableAppLock)
 }
 
 @Composable
@@ -84,7 +87,6 @@ fun SettingsScreenContent(
 ) {
     val context = LocalContext.current
     val featureVisibilityFlags = LocalFeatureVisibilityFlags.current
-    val turnAppLockOffDialogState = rememberVisibilityState<Unit>()
 
     with(featureVisibilityFlags) {
         LazyColumn(
@@ -121,10 +123,9 @@ fun SettingsScreenContent(
                                 appLogger.d("AppLockConfig isAppLockEnabled: ${settingsState.isAppLockEnabled}")
                                 SwitchState.Enabled(
                                     value = settingsState.isAppLockEnabled,
-                                    isOnOffVisible = true
-                                ) {
-                                    turnAppLockOffDialogState.show(Unit)
-                                }
+                                    isOnOffVisible = true,
+                                    onCheckedChange = onAppLockSwitchChanged
+                                )
                             }
 
                             false -> {
@@ -159,7 +160,6 @@ fun SettingsScreenContent(
         }
     }
 
-    TurnAppLockOffDialog(dialogState = turnAppLockOffDialogState) { onAppLockSwitchChanged(false) }
 }
 
 private fun LazyListScope.folderWithElements(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
@@ -55,6 +55,12 @@ fun SettingsScreen(
 ) {
     val lazyListState: LazyListState = rememberLazyListState()
     val turnAppLockOffDialogState = rememberVisibilityState<Unit>()
+    val onAppLockSwitchClicked: (Boolean) -> Unit = remember {
+        { isChecked ->
+            if (isChecked) homeStateHolder.navigator.navigate(NavigationCommand(SetLockCodeScreenDestination, BackStackMode.NONE))
+            else turnAppLockOffDialogState.show(Unit)
+        }
+    }
 
     val context = LocalContext.current
     SettingsScreenContent(
@@ -68,12 +74,7 @@ fun SettingsScreen(
                 )
             }
         },
-        onAppLockSwitchChanged = remember {
-            { isChecked ->
-                if (isChecked) homeStateHolder.navigator.navigate(NavigationCommand(SetLockCodeScreenDestination, BackStackMode.NONE))
-                else turnAppLockOffDialogState.show(Unit)
-            }
-        }
+        onAppLockSwitchChanged = onAppLockSwitchClicked
     )
     TurnAppLockOffDialog(dialogState = turnAppLockOffDialogState, turnOff = viewModel::disableAppLock)
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

enabling app lock manually displays the dialog turn off

### Solutions

the wrong lambda was passed to the Composable

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
