### PR TITLE
fix: messages list IndexOutOfBoundsException [WPB-5612]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelper.kt
@@ -18,6 +18,11 @@
 package com.wire.android.ui.home.conversations
 
 import androidx.annotation.VisibleForTesting
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.paging.compose.LazyPagingItems
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.kalium.util.DateTimeUtil
 
@@ -26,41 +31,64 @@ object AuthorHeaderHelper {
     @VisibleForTesting
     internal const val AGGREGATION_TIME_WINDOW: Int = 30_000 // millis
 
-    internal fun shouldShowHeader(index: Int, messages: List<UIMessage>, currentMessage: UIMessage): Boolean {
-        var showHeader = currentMessage is UIMessage.Regular
-        val nextIndex = index + 1
-        if (nextIndex < messages.size) {
-            val nextUiMessage = messages[nextIndex]
-            if (currentMessage.header.userId == nextUiMessage.header.userId
-                && currentMessage is UIMessage.Regular
-                && nextUiMessage is UIMessage.Regular
-            ) {
-                val difference = DateTimeUtil.calculateMillisDifference(
-                    nextUiMessage.header.messageTime.utcISO,
-                    currentMessage.header.messageTime.utcISO,
-                )
-                showHeader = difference > AGGREGATION_TIME_WINDOW
+    private fun LazyPagingItems<UIMessage>.peekOrNull(index: Int) =
+        if (index in 0 until this.itemCount) this.peek(index) else null
+
+    @Suppress("ComplexCondition")
+    internal fun shouldShowHeader(currentMessage: UIMessage, messageAbove: UIMessage?): Boolean =
+        if (messageAbove != null
+            && currentMessage.header.userId == messageAbove.header.userId
+            && currentMessage is UIMessage.Regular
+            && messageAbove is UIMessage.Regular
+        ) {
+            val difference = DateTimeUtil.calculateMillisDifference(
+                messageAbove.header.messageTime.utcISO,
+                currentMessage.header.messageTime.utcISO,
+            )
+            difference > AGGREGATION_TIME_WINDOW
+        } else currentMessage is UIMessage.Regular
+
+    @Composable
+    internal fun rememberShouldShowHeader(
+        currentIndex: Int,
+        currentMessage: UIMessage,
+        messages: LazyPagingItems<UIMessage>
+    ): Boolean {
+        val messageAbove = messages.peekOrNull(currentIndex + 1) // order of messages is reversed (from bottom to top)
+        val state by remember(currentIndex, currentMessage, messageAbove) {
+            derivedStateOf {
+                shouldShowHeader(currentMessage, messageAbove)
             }
         }
-        return showHeader
+        return state
     }
 
-    internal fun shouldHaveSmallBottomPadding(index: Int, messages: List<UIMessage>, currentMessage: UIMessage): Boolean {
-        var shouldHaveSmallBottomPadding = false
-        if (index > 0) {
-            val previousIndex = index - 1
-            val previousUiMessage = messages[previousIndex]
-            if (currentMessage.header.userId == previousUiMessage.header.userId
-                && currentMessage is UIMessage.Regular
-                && previousUiMessage is UIMessage.Regular
-            ) {
-                val difference = DateTimeUtil.calculateMillisDifference(
-                    currentMessage.header.messageTime.utcISO,
-                    previousUiMessage.header.messageTime.utcISO
-                )
-                shouldHaveSmallBottomPadding = difference < AGGREGATION_TIME_WINDOW
+    @Suppress("ComplexCondition")
+    internal fun shouldHaveSmallBottomPadding(currentMessage: UIMessage, messageBelow: UIMessage?): Boolean =
+        if (messageBelow != null
+            && currentMessage.header.userId == messageBelow.header.userId
+            && currentMessage is UIMessage.Regular
+            && messageBelow is UIMessage.Regular
+        ) {
+            val difference = DateTimeUtil.calculateMillisDifference(
+                currentMessage.header.messageTime.utcISO,
+                messageBelow.header.messageTime.utcISO
+            )
+            difference < AGGREGATION_TIME_WINDOW
+        } else false
+
+    @Composable
+    internal fun rememberShouldHaveSmallBottomPadding(
+        currentIndex: Int,
+        currentMessage: UIMessage,
+        messages: LazyPagingItems<UIMessage>
+    ): Boolean {
+        val messageBelow = messages.peekOrNull(currentIndex - 1) // order of messages is reversed (from bottom to top)
+        val state by remember(currentIndex, currentMessage, messageBelow) {
+            derivedStateOf {
+                shouldHaveSmallBottomPadding(currentMessage, messageBelow)
             }
         }
-        return shouldHaveSmallBottomPadding
+        return state
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -49,12 +49,10 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -826,7 +824,7 @@ fun MessageList(
     onFailedMessageCancelClicked: (String) -> Unit,
     onLinkClick: (String) -> Unit
 ) {
-    val mostRecentMessage by remember { derivedStateOf { lazyPagingMessages.itemCount.takeIf { it > 0 }?.let { lazyPagingMessages[0] } } }
+    val mostRecentMessage = lazyPagingMessages.itemCount.takeIf { it > 0 }?.let { lazyPagingMessages[0] }
 
     LaunchedEffect(mostRecentMessage) {
         // Most recent message changed, if the user didn't scroll up, we automatically scroll down to reveal the new message
@@ -835,12 +833,9 @@ fun MessageList(
         }
     }
 
-    val isScrollInProgress by remember { derivedStateOf { lazyListState.isScrollInProgress } }
-    val currentLazyPagingItems by rememberUpdatedState(lazyPagingMessages)
-
-    LaunchedEffect(isScrollInProgress) {
-        if (!isScrollInProgress && currentLazyPagingItems.itemCount > 0) {
-            val lastVisibleMessage = currentLazyPagingItems[lazyListState.firstVisibleItemIndex] ?: return@LaunchedEffect
+    LaunchedEffect(lazyListState.isScrollInProgress) {
+        if (!lazyListState.isScrollInProgress && lazyPagingMessages.itemCount > 0) {
+            val lastVisibleMessage = lazyPagingMessages[lazyListState.firstVisibleItemIndex] ?: return@LaunchedEffect
 
             val lastVisibleMessageInstant = Instant.parse(lastVisibleMessage.header.messageTime.utcISO)
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelperTest.kt
@@ -19,6 +19,8 @@ package com.wire.android.ui.home.conversations
 
 import com.wire.android.framework.TestMessage
 import com.wire.android.model.UserAvatarData
+import com.wire.android.ui.home.conversations.AuthorHeaderHelper.shouldHaveSmallBottomPadding
+import com.wire.android.ui.home.conversations.AuthorHeaderHelper.shouldShowHeader
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.UIMessage
@@ -33,12 +35,17 @@ import java.util.UUID
 
 class AuthorHeaderHelperTest {
 
+    private data class Messages(val currentMessage: UIMessage, val messageAbove: UIMessage?, val messageBelow: UIMessage?)
+    private fun List<UIMessage>.forIndex(index: Int, action: (Messages) -> Boolean): Boolean =
+        action(Messages(this[index], this.getOrNull(index + 1), this.getOrNull(index - 1)))
+
+    // shouldShowHeader tests
     @Test
     fun givenOneRegularMessage_thenShouldShowHeaderForRecentMessage() {
         // given
         val messages = listOf(testRegularMessage())
         // when
-        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        val result = messages.forIndex(0) { shouldShowHeader(it.currentMessage, it.messageAbove) }
         // then
         assertEquals(true, result)
     }
@@ -48,7 +55,7 @@ class AuthorHeaderHelperTest {
         // given
         val messages = listOf(testSystemMessage())
         // when
-        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        val result = messages.forIndex(0) { shouldShowHeader(it.currentMessage, it.messageAbove) }
         // then
         assertEquals(false, result)
     }
@@ -58,7 +65,7 @@ class AuthorHeaderHelperTest {
         // given
         val messages = listOf(testPingMessage())
         // when
-        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        val result = messages.forIndex(0) { shouldShowHeader(it.currentMessage, it.messageAbove) }
         // then
         assertEquals(false, result)
     }
@@ -71,7 +78,7 @@ class AuthorHeaderHelperTest {
             testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
         )
         // when
-        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        val result = messages.forIndex(0) { shouldShowHeader(it.currentMessage, it.messageAbove) }
         // then
         assertEquals(false, result)
     }
@@ -84,7 +91,7 @@ class AuthorHeaderHelperTest {
             testRegularMessage(userId = OTHER_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
         )
         // when
-        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        val result = messages.forIndex(0) { shouldShowHeader(it.currentMessage, it.messageAbove) }
         // then
         assertEquals(true, result)
     }
@@ -97,7 +104,7 @@ class AuthorHeaderHelperTest {
             testSystemMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
         )
         // when
-        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        val result = messages.forIndex(0) { shouldShowHeader(it.currentMessage, it.messageAbove) }
         // then
         assertEquals(true, result)
     }
@@ -110,7 +117,7 @@ class AuthorHeaderHelperTest {
             testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
         )
         // when
-        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        val result = messages.forIndex(0) { shouldShowHeader(it.currentMessage, it.messageAbove) }
         // then
         assertEquals(false, result)
     }
@@ -123,7 +130,7 @@ class AuthorHeaderHelperTest {
             testPingMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
         )
         // when
-        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        val result = messages.forIndex(0) { shouldShowHeader(it.currentMessage, it.messageAbove) }
         // then
         assertEquals(true, result)
     }
@@ -136,7 +143,7 @@ class AuthorHeaderHelperTest {
             testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
         )
         // when
-        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        val result = messages.forIndex(0) { shouldShowHeader(it.currentMessage, it.messageAbove) }
         // then
         assertEquals(false, result)
     }
@@ -151,7 +158,7 @@ class AuthorHeaderHelperTest {
             testRegularMessage(userId = SELF_USER_ID, timestamp = timestampMinusLessThanThreshold)
         )
         // when
-        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        val result = messages.forIndex(0) { shouldShowHeader(it.currentMessage, it.messageAbove) }
         // then
         assertEquals(false, result)
     }
@@ -166,9 +173,164 @@ class AuthorHeaderHelperTest {
             testRegularMessage(userId = SELF_USER_ID, timestamp = timestampMinusMoreThanThreshold)
         )
         // when
-        val result = AuthorHeaderHelper.shouldShowHeader(0, messages, messages[0])
+        val result = messages.forIndex(0) { shouldShowHeader(it.currentMessage, it.messageAbove) }
         // then
         assertEquals(true, result)
+    }
+
+    // shouldHaveSmallBottomPadding tests
+    @Test
+    fun givenOneRegularMessage_thenShouldNotHaveSmallBottomPadding() {
+        // given
+        val messages = listOf(testRegularMessage())
+        // when
+        val result = messages.forIndex(0) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        // then
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenOneSystemMessage_thenShouldNotHaveSmallBottomPadding() {
+        // given
+        val messages = listOf(testSystemMessage())
+        // when
+        val result = messages.forIndex(0) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        // then
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenOnePingMessage_thenShouldNotHaveSmallBottomPadding() {
+        // given
+        val messages = listOf(testPingMessage())
+        // when
+        val result = messages.forIndex(0) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        // then
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenTwoRegularMessagesFromSameUser_thenPreviousShouldHaveSmallBottomPaddingAndRecentShouldNot() {
+        // given
+        val messages = listOf( // more recent message is first on list
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:01.000Z"),
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
+        )
+        // when
+        val resultPrevious = messages.forIndex(1) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        val resultRecent = messages.forIndex(0) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        // then
+        assertEquals(true, resultPrevious)
+        assertEquals(false, resultRecent)
+    }
+
+    @Test
+    fun givenTwoRegularMessagesFromDifferentUser_thenBothShouldNotHaveSmallBottomPadding() {
+        // given
+        val messages = listOf( // more recent message is first on list
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:01.000Z"),
+            testRegularMessage(userId = OTHER_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
+        )
+        // when
+        val resultPrevious = messages.forIndex(1) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        val resultRecent = messages.forIndex(0) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        // then
+        assertEquals(false, resultPrevious)
+        assertEquals(false, resultRecent)
+    }
+
+    @Test
+    fun givenSystemAndThenRegularMessageFromSameUser_thenBothShouldNotHaveSmallBottomPadding() {
+        // given
+        val messages = listOf( // more recent message is first on list
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:01.000Z"),
+            testSystemMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
+        )
+        // when
+        val resultPrevious = messages.forIndex(1) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        val resultRecent = messages.forIndex(0) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        // then
+        assertEquals(false, resultPrevious)
+        assertEquals(false, resultRecent)
+    }
+
+    @Test
+    fun givenRegularAndThenSystemMessagFromSameUsere_thenBothShouldNotHaveSmallBottomPadding() {
+        // given
+        val messages = listOf( // more recent message is first on list
+            testSystemMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:01.000Z"),
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
+        )
+        // when
+        val resultPrevious = messages.forIndex(1) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        val resultRecent = messages.forIndex(0) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        // then
+        assertEquals(false, resultPrevious)
+        assertEquals(false, resultRecent)
+    }
+
+    @Test
+    fun givenPingAndThenRegularMessageFromSameUser_thenBothShouldNotHaveSmallBottomPadding() {
+        // given
+        val messages = listOf( // more recent message is first on list
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:01.000Z"),
+            testPingMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
+        )
+        // when
+        val resultPrevious = messages.forIndex(1) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        val resultRecent = messages.forIndex(0) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        // then
+        assertEquals(false, resultPrevious)
+        assertEquals(false, resultRecent)
+    }
+
+    @Test
+    fun givenRegularAndThenPingMessageFromSameUser_thenBothShouldNotHaveSmallBottomPadding() {
+        // given
+        val messages = listOf( // more recent message is first on list
+            testPingMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:01.000Z"),
+            testRegularMessage(userId = SELF_USER_ID, timestamp = "2021-01-01T00:00:00.000Z")
+        )
+        // when
+        val resultPrevious = messages.forIndex(1) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        val resultRecent = messages.forIndex(0) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        // then
+        assertEquals(false, resultPrevious)
+        assertEquals(false, resultRecent)
+    }
+
+    @Test
+    fun givenTwoRegularMessagesFromSameUserAndTimestampsWithinThreshold_thenPreviousShouldHaveSmallBottomPaddingAndRecentShouldNot() {
+        // given
+        val timestamp = "2021-01-01T00:00:00.000Z"
+        val timestampMinusLessThanThreshold = DateTimeUtil.minusMilliseconds(timestamp, AuthorHeaderHelper.AGGREGATION_TIME_WINDOW - 1L)
+        val messages = listOf(
+            testRegularMessage(userId = SELF_USER_ID, timestamp = timestamp),
+            testRegularMessage(userId = SELF_USER_ID, timestamp = timestampMinusLessThanThreshold)
+        )
+        // when
+        val resultPrevious = messages.forIndex(1) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        val resultRecent = messages.forIndex(0) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        // then
+        assertEquals(true, resultPrevious)
+        assertEquals(false, resultRecent)
+    }
+
+    @Test
+    fun givenTwoRegularMessagesFromSameUserAndTimestampsBeyondThreshold_thenBothShouldNotHaveSmallBottomPadding() {
+        // given
+        val timestamp = "2021-01-01T00:00:00.000Z"
+        val timestampMinusMoreThanThreshold = DateTimeUtil.minusMilliseconds(timestamp, AuthorHeaderHelper.AGGREGATION_TIME_WINDOW + 1L)
+        val messages = listOf(
+            testRegularMessage(userId = SELF_USER_ID, timestamp = timestamp),
+            testRegularMessage(userId = SELF_USER_ID, timestamp = timestampMinusMoreThanThreshold)
+        )
+        // when
+        val resultPrevious = messages.forIndex(1) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        val resultRecent = messages.forIndex(0) { shouldHaveSmallBottomPadding(it.currentMessage, it.messageBelow) }
+        // then
+        assertEquals(false, resultPrevious)
+        assertEquals(false, resultRecent)
     }
 
     companion object {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5612" title="WPB-5612" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5612</a>  java.lang.IndexOutOfBoundsException:
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2457

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We were getting `IndexOutOfBoundsException` when opening conversation screen.

### Causes (Optional)

`shouldHaveSmallBottomPadding` didn't have any limit, only `index > 0`, but index could be higher than the items count  and that's what was happening, because `lazyPagingMessages.itemSnapshotList.items` is a list of only presented data, excluding placeholders. It was working fine when the app was always fetching messages starting from the most recent one, but in case the user has multiple unread messages or opens the conversation from the message search, the app may fetch not the last page but can start from the middle and then indexes don't match. 

For instance, if we have 100 total messages, page size is 20 and we have 30 unread messages, then the initially loaded batch should have first unread message, so it should contain for instance messages 20 to 39. `ItemSnapshotList` will have size of 100 (all available messages) and these fetched already elements will be at their proper indexes 20 to 39, all other elements are placeholders and they will be null, but `ItemSnapshotList.items` only contains these 20 non-null elements with indexes starting from 0 to 19, because it's just a sublist, and we can easily have `IndexOutOfBounds` when we want to get item with index 30 from that sublist, and items don't match - `itemSnapshotList.items[10]` is not the same item as `itemSnapshotList[10]` so the list could look wrong.

### Solutions

Get elements using their indexes from the `itemSnapshotList` instead of `itemSnapshotList.items`, use `derivedStateOf` to reduce number of recompositions and `remember` with keys to update value of `shouldHaveSmallBottomPadding` or `shouldShowHeader` when a neighbouring element is no longer a placeholder.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Have a lot of unread messages, like more than 50, and open conversation - it shouldn't crash and each message should look properly (without avatar, header and with small paddings in between if they are grouped messages from the same user).

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .
