### PR TITLE
fix: revert changes in message scroll state

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -49,12 +49,10 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -798,7 +796,7 @@ fun MessageList(
     onFailedMessageCancelClicked: (String) -> Unit,
     onLinkClick: (String) -> Unit
 ) {
-    val mostRecentMessage by remember { derivedStateOf { lazyPagingMessages.itemCount.takeIf { it > 0 }?.let { lazyPagingMessages[0] } } }
+    val mostRecentMessage = lazyPagingMessages.itemCount.takeIf { it > 0 }?.let { lazyPagingMessages[0] }
 
     LaunchedEffect(mostRecentMessage) {
         // Most recent message changed, if the user didn't scroll up, we automatically scroll down to reveal the new message
@@ -807,12 +805,9 @@ fun MessageList(
         }
     }
 
-    val isScrollInProgress by remember { derivedStateOf { lazyListState.isScrollInProgress } }
-    val currentLazyPagingItems by rememberUpdatedState(lazyPagingMessages)
-
-    LaunchedEffect(isScrollInProgress) {
-        if (!isScrollInProgress && currentLazyPagingItems.itemCount > 0) {
-            val lastVisibleMessage = currentLazyPagingItems[lazyListState.firstVisibleItemIndex] ?: return@LaunchedEffect
+    LaunchedEffect(lazyListState.isScrollInProgress) {
+        if (!lazyListState.isScrollInProgress && lazyPagingMessages.itemCount > 0) {
+            val lastVisibleMessage = lazyPagingMessages[lazyListState.firstVisibleItemIndex] ?: return@LaunchedEffect
 
             val lastVisibleMessageInstant = Instant.parse(lastVisibleMessage.header.messageTime.utcISO)
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Turns out that our implementation of LazyListState doesn't work well with derivedStateOf, even if implemented like in the documentation: https://developer.android.com/jetpack/compose/side-effects#correct-usage, probably because we're making new LazyListState when unreadEventCount changes so it can't rely on the same instance.

### Solutions

Revert recent changes related to `LazyListState` - it's better to make one more recomposition than to break our LaunchedEffects.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
