### PR TITLE
fix: closing keyboard or back pressing when editing a message

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -282,6 +282,9 @@ fun EnabledMessageComposer(
                 }
             }
 
+            BackHandler(inputStateHolder.inputType is MessageCompositionType.Editing) {
+                cancelEdit()
+            }
             BackHandler(isImeVisible || inputStateHolder.optionsVisible) {
                 inputStateHolder.handleBackPressed(
                     isImeVisible,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -200,7 +200,7 @@ private fun InputContent(
     onPlusClick: () -> Unit,
     modifier: Modifier,
 ) {
-    if (!showOptions) {
+    if (!showOptions && inputType is MessageCompositionType.Composing) {
         AdditionalOptionButton(
             isSelected = false,
             onClick = {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When during a message edit, if user hides a keyboard or pressed back button then composer ends up in a wrong state where "+" button is available but it's still in editing mode.

### Solutions

Do not show "+" button when editing, even if keyboard is closed and handle back press to close editing mode.

### Testing

#### How to Test

Open conversation, start editing a message and close keyboard or press back.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video src="https://github.com/wireapp/wire-android/assets/30429749/cbc9415d-377b-4be7-aecd-ac61eec3ba66"> | <video src="https://github.com/wireapp/wire-android/assets/30429749/8f84ac39-3848-420b-a760-88926b19bee0"> |







----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
