### PR TITLE
fix: app lock dialog blinking (WPB-5610)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -93,6 +93,7 @@ import com.wire.android.util.debug.FeatureVisibilityFlags
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.ui.updateScreenSettings
+import com.wire.kalium.logic.data.user.UserId
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -201,7 +202,10 @@ class WireActivity : AppCompatActivity() {
                         setUpNavigation(navigator.navController, onComplete)
                         isLoaded = true
                         handleScreenshotCensoring()
-                        handleDialogs(navigator::navigate)
+                        handleDialogs(
+                            navigator::navigate,
+                            viewModel.currentUserId.value
+                        )
                     }
                 }
             }
@@ -255,8 +259,10 @@ class WireActivity : AppCompatActivity() {
     }
 
     @Composable
-    private fun handleDialogs(navigate: (NavigationCommand) -> Unit) {
-        featureFlagNotificationViewModel.loadInitialSync()
+    private fun handleDialogs(navigate: (NavigationCommand) -> Unit, userId: UserId?) {
+        LaunchedEffect(userId) {
+            featureFlagNotificationViewModel.loadInitialSync()
+        }
         with(featureFlagNotificationViewModel.featureFlagState) {
             if (shouldShowTeamAppLockDialog) {
                 TeamAppLockFeatureFlagDialog(

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -21,6 +21,7 @@
 package com.wire.android.ui
 
 import android.content.Intent
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -120,6 +121,7 @@ class WireActivityViewModel @Inject constructor(
                 if (it.accountInfo.isValid().not()) {
                     handleInvalidSession((it.accountInfo as AccountInfo.Invalid).logoutReason)
                 }
+                currentUserId.value = it.accountInfo.userId
             }
         }
         .map { result ->
@@ -136,6 +138,8 @@ class WireActivityViewModel @Inject constructor(
 
     private val _observeSyncFlowState: MutableStateFlow<SyncState?> = MutableStateFlow(null)
     val observeSyncFlowState: StateFlow<SyncState?> = _observeSyncFlowState
+
+    val currentUserId: MutableState<UserId?> = mutableStateOf(null)
 
     init {
         observeSyncState()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5610" title="WPB-5610" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5610</a>  [Android] Applock dialog disappears immediately when on second accound
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

AppLock Dialog was blinking when being enabled/disabled when on a second account.

### Causes (Optional)

The observer for loading current user and its changes was not being propagated correctly due to it only being activated when we needed to do another sync (e.g.: app close then open)

### Solutions

As decided with @MohamadJaara we will only be showing the app lock dialog on the said account itself (not on other accounts that are logged in on the device).

We did two things:

Create a currentUserId variable in the view model to be updated whenever there is a change and listen to this change on a `LaunchedEffect` on the UI so it reloads the initial sync needed to show/hide the dialogs.

### Dependencies (Optional)

Needs releases with:

- [ ] [Kalium PR - fix: enable editable app lock toggle (WPB-5610) #2258](https://github.com/wireapp/kalium/pull/2258)

### Testing

#### How to Test

- Have 2 accounts (1 in a team, 1 non-team)
- Stay active on non-team account
- receive the event of enable app lock
- NON-TEAM account : nothing should be displayed
- when changing to TEAM account, app lock dialog should be displayed.
