### PR TITLE
fix: reset passcode dialog state when empty input or sso user [WPB-5094]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeResetDeviceDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeResetDeviceDialog.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.window.DialogProperties
 import com.wire.android.R
@@ -51,6 +52,7 @@ import com.wire.android.util.ui.stringWithStyledArgs
 @Composable
 fun ForgotLockCodeResetDeviceDialog(
     username: String,
+    isPasswordRequired: Boolean,
     isPasswordValid: Boolean,
     isResetDeviceEnabled: Boolean,
     onPasswordChanged: (TextFieldValue) -> Unit,
@@ -65,14 +67,18 @@ fun ForgotLockCodeResetDeviceDialog(
     }
     WireDialog(
         title = stringResource(R.string.settings_forgot_lock_screen_reset_device),
-        text = LocalContext.current.resources.stringWithStyledArgs(
-            R.string.settings_forgot_lock_screen_reset_device_description,
-            MaterialTheme.wireTypography.body01,
-            MaterialTheme.wireTypography.body02,
-            colorsScheme().onBackground,
-            colorsScheme().onBackground,
-            username
-        ),
+        text = if (isPasswordRequired) {
+            LocalContext.current.resources.stringWithStyledArgs(
+                R.string.settings_forgot_lock_screen_reset_device_description,
+                MaterialTheme.wireTypography.body01,
+                MaterialTheme.wireTypography.body02,
+                colorsScheme().onBackground,
+                colorsScheme().onBackground,
+                username
+            )
+        } else {
+            AnnotatedString(stringResource(id = R.string.settings_forgot_lock_screen_reset_device_without_password_description))
+        },
         onDismiss = onDialogDismissHideKeyboard,
         buttonsHorizontalAlignment = false,
         dismissButtonProperties = WireDialogButtonProperties(
@@ -90,23 +96,25 @@ fun ForgotLockCodeResetDeviceDialog(
             state = if (!isResetDeviceEnabled) WireButtonState.Disabled else WireButtonState.Error
         )
     ) {
-        // keyboard controller from outside the Dialog doesn't work inside its content so we have to pass the state
-        // to the dialog's content and use keyboard controller from there
-        keyboardController = LocalSoftwareKeyboardController.current
-        WirePasswordTextField(
-            state = when {
-                !isPasswordValid -> WireTextFieldState.Error(stringResource(id = R.string.remove_device_invalid_password))
-                else -> WireTextFieldState.Default
-            },
-            value = backupPassword,
-            onValueChange = {
-                backupPassword = it
-                onPasswordChanged(it)
-            },
-            autofill = false,
-            keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
-            modifier = Modifier.padding(bottom = dimensions().spacing16x)
-        )
+        if (isPasswordRequired) {
+            // keyboard controller from outside the Dialog doesn't work inside its content so we have to pass the state
+            // to the dialog's content and use keyboard controller from there
+            keyboardController = LocalSoftwareKeyboardController.current
+            WirePasswordTextField(
+                state = when {
+                    !isPasswordValid -> WireTextFieldState.Error(stringResource(id = R.string.remove_device_invalid_password))
+                    else -> WireTextFieldState.Default
+                },
+                value = backupPassword,
+                onValueChange = {
+                    backupPassword = it
+                    onPasswordChanged(it)
+                },
+                autofill = false,
+                keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
+                modifier = Modifier.padding(bottom = dimensions().spacing16x)
+            )
+        }
     }
 }
 
@@ -124,7 +132,15 @@ fun ForgotLockCodeResettingDeviceDialog() {
 @Composable
 fun PreviewForgotLockCodeResetDeviceDialog() {
     WireTheme {
-        ForgotLockCodeResetDeviceDialog("Username", true, true, {}, {}, {})
+        ForgotLockCodeResetDeviceDialog("Username", false, true, true, {}, {}, {})
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewForgotLockCodeResetDeviceWithoutPasswordDialog() {
+    WireTheme {
+        ForgotLockCodeResetDeviceDialog("Username", true, true, true, {}, {}, {})
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
@@ -86,6 +86,7 @@ fun ForgotLockCodeScreen(
             if (dialogState.loading) ForgotLockCodeResettingDeviceDialog()
             else ForgotLockCodeResetDeviceDialog(
                 username = dialogState.username,
+                isPasswordRequired = dialogState.passwordRequired,
                 isPasswordValid = dialogState.passwordValid,
                 isResetDeviceEnabled = dialogState.resetDeviceEnabled,
                 onPasswordChanged = viewModel::onPasswordChanged,

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeViewState.kt
@@ -31,8 +31,9 @@ sealed class ForgotLockCodeDialogState {
     data class Visible(
         val username: String,
         val password: TextFieldValue = TextFieldValue(""),
+        val passwordRequired: Boolean = false,
         val passwordValid: Boolean = true,
-        val resetDeviceEnabled: Boolean = true,
+        val resetDeviceEnabled: Boolean = false,
         val loading: Boolean = false,
     ) : ForgotLockCodeDialogState()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModel.kt
@@ -48,9 +48,6 @@ import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
-import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.functional.flatMap
-import com.wire.kalium.logic.functional.fold
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
@@ -88,12 +85,26 @@ class ForgotLockScreenViewModel @Inject constructor(
     }
 
     fun onPasswordChanged(password: TextFieldValue) {
-        updateIfDialogStateVisible { it.copy(password = password, resetDeviceEnabled = true) }
+        updateIfDialogStateVisible { it.copy(password = password, resetDeviceEnabled = password.text.isNotBlank()) }
     }
 
     fun onResetDevice() {
         viewModelScope.launch {
-            state = state.copy(dialogState = ForgotLockCodeDialogState.Visible(username = getSelf().firstOrNull()?.name ?: ""))
+            state = when (val isPasswordRequiredResult = isPasswordRequired()) {
+                is IsPasswordRequiredUseCase.Result.Success -> {
+                    state.copy(
+                        dialogState = ForgotLockCodeDialogState.Visible(
+                            username = getSelf().firstOrNull()?.name ?: "",
+                            passwordRequired = isPasswordRequiredResult.value,
+                            resetDeviceEnabled = !isPasswordRequiredResult.value,
+                        )
+                    )
+                }
+                is IsPasswordRequiredUseCase.Result.Failure -> {
+                    appLogger.e("$TAG Failed to check if password is required when opening reset passcode dialog")
+                    state.copy(error = isPasswordRequiredResult.cause)
+                }
+            }
         }
     }
 
@@ -110,40 +121,45 @@ class ForgotLockScreenViewModel @Inject constructor(
             updateIfDialogStateVisible { it.copy(resetDeviceEnabled = false) }
             viewModelScope.launch {
                 validatePasswordIfNeeded(dialogStateVisible.password.text)
-                    .flatMapIfSuccess {
+                    .flatMapIfSuccess { validatedPassword ->
                         updateIfDialogStateVisible { it.copy(loading = true) }
-                        deleteCurrentClient(dialogStateVisible.password.text)
-                            .flatMapIfSuccess { hardLogoutAllAccounts() }
+                        deleteCurrentClient(validatedPassword)
                     }
-                    .fold({ error ->
-                        state = state.copy(error = error)
-                        updateIfDialogStateVisible { it.copy(loading = false, resetDeviceEnabled = true) }
-                    }, { result ->
+                    .flatMapIfSuccess { hardLogoutAllAccounts() }
+                    .let { result ->
                         when (result) {
-                            Result.InvalidPassword -> updateIfDialogStateVisible { it.copy(passwordValid = false, loading = false) }
-                            Result.Success -> state = state.copy(completed = true, dialogState = ForgotLockCodeDialogState.Hidden)
+                            is Result.Failure.Generic -> {
+                                state = state.copy(error = result.cause)
+                                updateIfDialogStateVisible { it.copy(loading = false, resetDeviceEnabled = true) }
+                            }
+                            Result.Failure.PasswordRequired ->
+                                updateIfDialogStateVisible { it.copy(passwordRequired = true, passwordValid = false, loading = false) }
+                            Result.Failure.InvalidPassword ->
+                                updateIfDialogStateVisible { it.copy(passwordValid = false, loading = false) }
+                            Result.Success ->
+                                state = state.copy(completed = true, dialogState = ForgotLockCodeDialogState.Hidden)
                         }
                     }
-                    )
             }
         }
     }
 
     @VisibleForTesting
-    internal suspend fun validatePasswordIfNeeded(password: String): Either<CoreFailure, Result> =
+    internal suspend fun validatePasswordIfNeeded(password: String): Pair<Result, String> =
         when (val isPasswordRequiredResult = isPasswordRequired()) {
             is IsPasswordRequiredUseCase.Result.Failure -> {
                 appLogger.e("$TAG Failed to check if password is required when resetting passcode")
-                Either.Left(isPasswordRequiredResult.cause)
+                Result.Failure.Generic(isPasswordRequiredResult.cause) to password
             }
-            is IsPasswordRequiredUseCase.Result.Success -> {
-                if (!isPasswordRequiredResult.value || validatePassword(password).isValid) Either.Right(Result.Success)
-                else Either.Right(Result.InvalidPassword)
+            is IsPasswordRequiredUseCase.Result.Success -> when {
+                isPasswordRequiredResult.value && password.isBlank() -> Result.Failure.PasswordRequired to password
+                isPasswordRequiredResult.value && !validatePassword(password).isValid -> Result.Failure.InvalidPassword to password
+                else -> Result.Success to if (isPasswordRequiredResult.value) password else ""
             }
         }
 
     @VisibleForTesting
-    internal suspend fun deleteCurrentClient(password: String): Either<CoreFailure, Result> =
+    internal suspend fun deleteCurrentClient(password: String): Result =
         observeCurrentClientId()
             .filterNotNull()
             .first()
@@ -151,19 +167,19 @@ class ForgotLockScreenViewModel @Inject constructor(
                 when (val deleteClientResult = deleteClient(DeleteClientParam(password, clientId))) {
                     is DeleteClientResult.Failure.Generic -> {
                         appLogger.e("$TAG Failed to delete current client when resetting passcode")
-                        Either.Left(deleteClientResult.genericFailure)
+                        Result.Failure.Generic(deleteClientResult.genericFailure)
                     }
-                    DeleteClientResult.Success -> Either.Right(Result.Success)
-                    else -> Either.Right(Result.InvalidPassword)
+                    DeleteClientResult.Success -> Result.Success
+                    else -> Result.Failure.InvalidPassword
                 }
             }
 
     @VisibleForTesting
-    internal suspend fun hardLogoutAllAccounts(): Either<CoreFailure, Result> =
+    internal suspend fun hardLogoutAllAccounts(): Result =
         when (val getAllSessionsResult = getSessions()) {
             is GetAllSessionsResult.Failure.Generic -> {
                 appLogger.e("$TAG Failed to get all sessions when resetting passcode")
-                Either.Left(getAllSessionsResult.genericFailure)
+                Result.Failure.Generic(getAllSessionsResult.genericFailure)
             }
             is GetAllSessionsResult.Failure.NoSessionFound,
             is GetAllSessionsResult.Success -> {
@@ -178,7 +194,7 @@ class ForgotLockScreenViewModel @Inject constructor(
                 }.joinAll() // wait until all accounts are logged out
                 globalDataStore.clearAppLockPasscode()
                 accountSwitch(SwitchAccountParam.Clear)
-                Either.Right(Result.Success)
+                Result.Success
             }
         }
 
@@ -190,10 +206,20 @@ class ForgotLockScreenViewModel @Inject constructor(
         userDataStoreProvider.getOrCreate(userId).clear()
     }
 
-    internal enum class Result { InvalidPassword, Success; }
+    internal sealed class Result {
+        sealed class Failure : Result() {
+            data object InvalidPassword : Failure()
+            data object PasswordRequired : Failure()
+            data class Generic(val cause: CoreFailure) : Failure()
+        }
+        data object Success : Result()
+    }
 
-    private inline fun <T> Either<T, Result>.flatMapIfSuccess(block: () -> Either<T, Result>): Either<T, Result> =
-        this.flatMap { if (it == Result.Success) block() else Either.Right(it) }
+    private inline fun Result.flatMapIfSuccess(block: () -> Result): Result =
+        if (this is Result.Success) block() else this
+
+    private inline fun <T> Pair<Result, T>.flatMapIfSuccess(block: (T) -> Result): Result =
+        if (this.first is Result.Success) block(this.second) else this.first
 
     companion object {
         const val TAG = "ForgotLockResetPasscode"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -965,6 +965,7 @@
     <string name="settings_forgot_lock_screen_warning">If you remove your device, you lose all local data and messages for all accounts on this device permanently.</string>
     <string name="settings_forgot_lock_screen_reset_device">Remove Device</string>
     <string name="settings_forgot_lock_screen_reset_device_description">Enter your password for the account %s to confirm the deletion of all data for all accounts on this device. After removing your device, you can log in with your account credentials.</string>
+    <string name="settings_forgot_lock_screen_reset_device_without_password_description">Confirm the deletion of all data for all accounts on this device. After removing your device, you can log in with your account credentials.</string>
     <string name="settings_forgot_lock_screen_please_wait_label">Please wait...</string>
     <!--Devices -->
     <string name="devices_title">Your Devices</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5094" title="WPB-5094" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-5094</a>  [Android] Reset passcode if user forgets
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2447

---- 

⚠️ Conflicts during cherry-pick:
kalium

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If the password text box is empty, then remove your device button should be disable. It should be enable once’s the user enter’s the password.

### Solutions

Hide password input field for sso users who do not have a password, for others enable reset button only if password field is not empty.`

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Set the app lock, kill the app, open again, choose to use passcode, click on "forgot passcode".

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| ![image](https://github.com/wireapp/wire-android/assets/30429749/c878d13b-64a7-41b2-b06c-53a679735218) | ![Screenshot_20231121_152649](https://github.com/wireapp/wire-android/assets/30429749/b3e31c28-e326-4c81-806b-c5ef655be919) |

https://github.com/wireapp/wire-android/assets/30429749/20529917-a08e-447e-bb97-fc6385ae807a


<img width="862" alt="image" src="https://github.com/wireapp/wire-android/assets/30429749/e489c670-1d9f-4b7e-891d-e8d7cff64231">

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
