### PR TITLE
chore(ci): addresses issue about archiving in releases the APK (cycle 4.4)

### DIFF
--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -560,7 +560,6 @@ pipeline {
                         def fileApk = apks[0]
                         def filename = fileApk.getName()
 
-                        echo 'Uploading apk to github release: ' + filename
                         // headers request
                         def acceptHeader = shellQuote("Accept: application/vnd.github.v3+json")
                         def contentTypeHeader = shellQuote("Content-Type: application/octet-stream")
@@ -568,13 +567,11 @@ pipeline {
 
                         // api request
                         def apiUrl = shellQuote("https://api.github.com/repos/wireapp/wire-android/releases/latest")
-                        def releaseId = sh "curl -s ${apiUrl} | grep -m 1 \"id.:\" | grep -w id | tr : = | tr -cd '[[:alnum:]]=' | cut -d'=' -f2"
-                        def sanitizedUploadUrl = shellQuote("https://uploads.github.com/repos/wireapp/wire-android/releases/${releaseId}/assets?name=\$(basename ${filename})")
-
+                        def releaseId = sh(script: "curl -s ${apiUrl} | grep -m 1 \"id.:\" | grep -w id | tr : = | tr -cd '[[:alnum:]]=' | cut -d'=' -f2", returnStdout: true).trim()
+                        def sanitizedUploadUrl = shellQuote("https://uploads.github.com/repos/wireapp/wire-android/releases/${releaseId}/assets?name=\$(basename '${filename}')")
                         echo 'Uploading apk to github release: ' + sanitizedUploadUrl
 
-                        echo 'Preparing send'
-                        sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST --data-binary @${fileApk.getPath()} ${sanitizedUploadUrl}"
+                        sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST -T ${fileApk.getPath()} ${sanitizedUploadUrl}"
                     }
                 }
             }

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -215,9 +215,9 @@ pipeline {
                     last_started = env.STAGE_NAME
                 }
 
-                withGradle() {
-                    sh './gradlew compileApp'
-                }
+//                withGradle() {
+//                    sh './gradlew compileApp'
+//                }
 
             }
         }
@@ -548,12 +548,11 @@ pipeline {
                         def sanitizedUploadUrl = "https://uploads.github.com/repos/wireapp/wire-android/releases/${releaseId}/assets?name=\$(basename '${filename}')"
                         echo 'Uploading APK to Github Release destination: ' + sanitizedUploadUrl
 
-                        sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST -T ${fileApk.getPath()} '${sanitizedUploadUrl}'"
+                        sh "curl -v -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST -T '${fileApk.getPath()}' '${sanitizedUploadUrl}'"
                     }
                 }
             }
 
-            sh './gradlew jacocoReport'
             wireSend(secret: env.WIRE_BOT_SECRET, message: "**[#${BUILD_NUMBER} Link](${BUILD_URL})** [${SOURCE_BRANCH}] - ✅ SUCCESS 🎉" + "\nLast 5 commits:\n```text\n$lastCommits\n```")
         }
 

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -52,7 +52,9 @@ def postGithubApkToRelease(String flavor, String buildType) {
     if (apks.size() > 0) {
         echo 'Attaching APK to Github Release for tag: ' + env.SOURCE_BRANCH
         def fileApk = apks[0]
-        def filename = shellParentheses(fileApk.getName())
+        // note: apk name value rename to comply with github releases assets names requirements
+        // https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#upload-a-release-asset
+        def filename = fileApk.getName().replaceAll("\\(", "_").replaceAll("\\)", "_")
 
         // building headers request
         def acceptHeader = shellQuote("Accept: application/vnd.github.v3+json")

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -571,6 +571,9 @@ pipeline {
                         def releaseId = sh "curl -s ${apiUrl} | grep -m 1 \"id.:\" | grep -w id | tr : = | tr -cd '[[:alnum:]]=' | cut -d'=' -f2"
                         def sanitizedUploadUrl = shellQuote("https://uploads.github.com/repos/wireapp/wire-android/releases/${releaseId}/assets?name=\$(basename ${filename})")
 
+                        echo 'Uploading apk to github release: ' + sanitizedUploadUrl
+
+                        echo 'Preparing send'
                         sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST --data-binary @${fileApk.getPath()} ${sanitizedUploadUrl}"
                     }
                 }

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -567,7 +567,7 @@ pipeline {
 
                         // api request
                         def apiUrl = shellQuote("https://api.github.com/repos/wireapp/wire-android/releases/latest")
-                        def uploadUrl = sh("curl -s ${apiUrl} | jq -r '.upload_url' | cut -d'{' -f1", returnStdout: true).trim()
+                        def uploadUrl = sh "curl -s ${apiUrl} | jq -r '.upload_url' | cut -d'{' -f1"
                         def sanitizedUploadUrl = shellQuote(uploadUrl + "?name=\$(basename ${filename})")
 
                         sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST --data-binary @${fileApk.getPath()} ${sanitizedUploadUrl}"

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -560,7 +560,7 @@ pipeline {
                     postGithubComment(params.GITHUB_CHANGE_ID, payload)
                 }
 
-                if (env.SOURCE_BRANCH ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./) {
+                if (env.SOURCE_BRANCH ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+/) {
                     postGithubApkToRelease(params.FLAVOR, params.BUILD_TYPE)
                 }
             }

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -548,7 +548,7 @@ pipeline {
                         def sanitizedUploadUrl = "https://uploads.github.com/repos/wireapp/wire-android/releases/${releaseId}/assets?name=\$(basename '${filename}')"
                         echo 'Uploading APK to Github Release destination: ' + sanitizedUploadUrl
 
-                        sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST -T ${fileApk.getPath()} \"${sanitizedUploadUrl}\""
+                        sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST -T ${fileApk.getPath()} '${sanitizedUploadUrl}'"
                     }
                 }
             }

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -246,9 +246,9 @@ pipeline {
                     last_started = env.STAGE_NAME
                 }
 
-//                withGradle() {
-//                    sh './gradlew compileApp'
-//                }
+                withGradle() {
+                    sh './gradlew compileApp'
+                }
 
             }
         }

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -560,8 +560,7 @@ pipeline {
                     postGithubComment(params.GITHUB_CHANGE_ID, payload)
                 }
 
-                // if (env.SOURCE_BRANCH ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./) {
-                if (env.SOURCE_BRANCH ==~ /y\/.*/) {
+                if (env.SOURCE_BRANCH ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./) {
                     postGithubApkToRelease(params.FLAVOR, params.BUILD_TYPE)
                 }
             }

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -560,6 +560,7 @@ pipeline {
                         def fileApk = apks[0]
                         def filename = fileApk.getName()
 
+                        echo 'Uploading apk to github release: ' + filename
                         // headers request
                         def acceptHeader = shellQuote("Accept: application/vnd.github.v3+json")
                         def contentTypeHeader = shellQuote("Content-Type: application/octet-stream")
@@ -567,8 +568,8 @@ pipeline {
 
                         // api request
                         def apiUrl = shellQuote("https://api.github.com/repos/wireapp/wire-android/releases/latest")
-                        def uploadUrl = sh "curl -s ${apiUrl} | grep -m 1 \"id.:\" | grep -w id | tr : = | tr -cd '[[:alnum:]]=' | cut -d'=' -f2"
-                        def sanitizedUploadUrl = shellQuote(uploadUrl + "?name=\$(basename ${filename})")
+                        def releaseId = sh "curl -s ${apiUrl} | grep -m 1 \"id.:\" | grep -w id | tr : = | tr -cd '[[:alnum:]]=' | cut -d'=' -f2"
+                        def sanitizedUploadUrl = shellQuote("https://uploads.github.com/repos/wireapp/wire-android/releases/${releaseId}/assets?name=\$(basename ${filename})")
 
                         sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST --data-binary @${fileApk.getPath()} ${sanitizedUploadUrl}"
                     }

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -548,7 +548,7 @@ pipeline {
                         def sanitizedUploadUrl = "https://uploads.github.com/repos/wireapp/wire-android/releases/${releaseId}/assets?name=\$(basename '${filename}')"
                         echo 'Uploading APK to Github Release destination: ' + sanitizedUploadUrl
 
-                        sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST -T ${fileApk.getPath()} ${sanitizedUploadUrl}"
+                        sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST -T ${fileApk.getPath()} \"${sanitizedUploadUrl}\""
                     }
                 }
             }

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -567,7 +567,7 @@ pipeline {
 
                         // api request
                         def apiUrl = shellQuote("https://api.github.com/repos/wireapp/wire-android/releases/latest")
-                        def uploadUrl = sh "curl -s ${apiUrl} | jq -r '.upload_url' | cut -d'{' -f1"
+                        def uploadUrl = sh "curl -s ${apiUrl} | grep -m 1 \"id.:\" | grep -w id | tr : = | tr -cd '[[:alnum:]]=' | cut -d'=' -f2"
                         def sanitizedUploadUrl = shellQuote(uploadUrl + "?name=\$(basename ${filename})")
 
                         sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST --data-binary @${fileApk.getPath()} ${sanitizedUploadUrl}"

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -43,28 +43,6 @@ def postGithubComment(String changeId, String body) {
 
 }
 
-def postApkToGithubRelease(List<FileWrapper> apks) {
-    if (apks.isEmpty()) {
-        return
-    }
-
-    echo 'Attaching APK to Github Release for tag: ' + env.SOURCE_BRANCH
-    def fileApk = apks[0]
-    def filename = fileApk.getName()
-
-    // headers request
-    def acceptHeader = shellQuote("Accept: application/vnd.github.v3+json")
-    def contentTypeHeader = shellQuote("Content-Type: application/octet-stream")
-    def authHeader = shellQuote("Authorization: token ${env.GITHUB_API_TOKEN}")
-
-    // api request
-    def apiUrl = shellQuote("https://api.github.com/repos/wireapp/wire-android/releases/latest")
-    def uploadUrl = sh("curl -s ${apiUrl} | jq -r '.upload_url' | cut -d'{' -f1", returnStdout: true).trim()
-    def sanitizedUploadUrl = shellQuote(uploadUrl + "?name=\$(basename ${filename})")
-
-    sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST --data-binary @${fileApk.getPath()} ${sanitizedUploadUrl}"
-}
-
 def defineTrackName(String branchName) {
     def overwrite = env.CUSTOM_TRACK
 
@@ -555,7 +533,6 @@ pipeline {
                 if (env.SOURCE_BRANCH ==~ /y\/.*/) {
                     def apks = findFiles(glob: "app/build/outputs/apk/${params.FLAVOR.toLowerCase()}/${params.BUILD_TYPE.toLowerCase()}/com.wire.android-*.apk")
                     if (apks.size() > 0) {
-                        // postApkToGithubRelease(apks)
                         echo 'Attaching APK to Github Release for tag: ' + env.SOURCE_BRANCH
                         def fileApk = apks[0]
                         def filename = fileApk.getName()
@@ -568,8 +545,8 @@ pipeline {
                         // api request
                         def apiUrl = shellQuote("https://api.github.com/repos/wireapp/wire-android/releases/latest")
                         def releaseId = sh(script: "curl -s ${apiUrl} | grep -m 1 \"id.:\" | grep -w id | tr : = | tr -cd '[[:alnum:]]=' | cut -d'=' -f2", returnStdout: true).trim()
-                        def sanitizedUploadUrl = shellQuote("https://uploads.github.com/repos/wireapp/wire-android/releases/${releaseId}/assets?name=\$(basename '${filename}')")
-                        echo 'Uploading apk to github release: ' + sanitizedUploadUrl
+                        def sanitizedUploadUrl = "https://uploads.github.com/repos/wireapp/wire-android/releases/${releaseId}/assets?name=\$(basename '${filename}')"
+                        echo 'Uploading APK to Github Release destination: ' + sanitizedUploadUrl
 
                         sh "curl -s -H ${authHeader} -H ${acceptHeader} -H ${contentTypeHeader} -X POST -T ${fileApk.getPath()} ${sanitizedUploadUrl}"
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,7 @@ List<String> defineFlavor() {
     }
 
     def branchName = env.BRANCH_NAME
-    //     def isTagAndValid = env.TAG_NAME ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./ || branchName ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./
-    def isTagAndValid = env.BRANCH_NAME ==~ /y\/.*/
+    def isTagAndValid = env.TAG_NAME ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./ || branchName ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./
 
     if (branchName == "main") {
         return ['Beta']
@@ -79,8 +78,7 @@ String handleChangeBranch(String changeBranch) {
 * Force in case of a tag to not upload to PlayStore, otherwise it will delegate to the stage resolution.
 */
 String defineUploadToPlayStoreEnabled() {
-    return env.BRANCH_NAME !=~ /y\/.*/
-//     return env.BRANCH_NAME !=~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./
+    return env.BRANCH_NAME !=~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./
 }
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ List<String> defineFlavor() {
     }
 
     def branchName = env.BRANCH_NAME
-    def isTagAndValid = env.TAG_NAME ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./ || branchName ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./
+    def isTagAndValid = env.TAG_NAME ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+/ || branchName ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+/
 
     if (branchName == "main") {
         return ['Beta']
@@ -78,7 +78,7 @@ String handleChangeBranch(String changeBranch) {
 * Force in case of a tag to not upload to PlayStore, otherwise it will delegate to the stage resolution.
 */
 String defineUploadToPlayStoreEnabled() {
-    return env.BRANCH_NAME !=~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./
+    return env.BRANCH_NAME !=~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+/
 }
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,12 +6,14 @@ List<String> defineFlavor() {
     }
 
     def branchName = env.BRANCH_NAME
+    //     def isTagAndValid = env.TAG_NAME ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./ || branchName ==~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./
+    def isTagAndValid = env.BRANCH_NAME ==~ /y\/.*/
 
     if (branchName == "main") {
         return ['Beta']
     } else if (branchName == "develop") {
         return ['Staging', 'Dev']
-    } else if (branchName == "prod") {
+    } else if (branchName == "prod" || isTagAndValid) {
         return ['Prod']
     } else if (branchName == "internal") {
         return ['Internal']
@@ -73,6 +75,14 @@ String handleChangeBranch(String changeBranch) {
     return env.BRANCH_NAME
 }
 
+/**
+* Force in case of a tag to not upload to PlayStore, otherwise it will delegate to the stage resolution.
+*/
+String defineUploadToPlayStoreEnabled() {
+    return env.BRANCH_NAME !=~ /y\/.*/
+//     return env.BRANCH_NAME !=~ /v[0-9]+.[0-9]+.[0-9A-Za-z-+]+./
+}
+
 pipeline {
     agent {
         node {
@@ -99,6 +109,7 @@ pipeline {
                         String buildType = defineBuildType(flavor)
                         String stageName = "Build $flavor$buildType"
                         String definedChangeBranch = handleChangeBranch(env.CHANGE_BRANCH)
+                        Boolean uploadToPlayStoreEnabled = defineUploadToPlayStoreEnabled()
                         dynamicStages[stageName] = {
                             node {
                                 stage(stageName) {
@@ -110,7 +121,7 @@ pipeline {
                                                     string(name: 'BUILD_TYPE', value: buildType),
                                                     string(name: 'FLAVOR', value: flavor),
                                                     booleanParam(name: 'UPLOAD_TO_S3', value: true),
-                                                    booleanParam(name: 'UPLOAD_TO_PLAYSTORE_ENABLED', value: true),
+                                                    booleanParam(name: 'UPLOAD_TO_PLAYSTORE_ENABLED', value: uploadToPlayStoreEnabled),
                                                     booleanParam(name: 'RUN_UNIT_TEST', value: true),
                                                     booleanParam(name: 'RUN_ACCEPTANCE_TESTS', value: true),
                                                     booleanParam(name: 'RUN_STATIC_CODE_ANALYSIS', value: true),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Address issue to have APKs on GH releases.
https://github.com/wireapp/wire/issues/396

### Causes (Optional)

Whenever a new tag is created, it will run on Jenkins the tag workflow to upload the APK to the latest release.
This only considers semantic tags and named fixed versions, to be consistent with our GH Release action.

### Solutions

Use GH API to upload a release asset to a release.

### Testing

Manually tested

https://10.10.124.134/blue/organizations/jenkins/AR-build-pipeline/detail/AR-build-pipeline/2021/pipeline


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
