### PR TITLE
fix: hide search button in group conversation user profile [WPB-5656]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -131,7 +131,6 @@ fun OtherUserProfileScreen(
 
     val conversationId = viewModel.state.conversationId
         ?: viewModel.state.conversationSheetContent?.conversationId
-    val shouldShowSearchButton = viewModel.shouldShowSearchButton(conversationId = conversationId)
     val onSearchConversationMessagesClick: () -> Unit = {
         conversationId?.let {
             navigator.navigate(
@@ -160,7 +159,6 @@ fun OtherUserProfileScreen(
         onOpenConversation = { navigator.navigate(NavigationCommand(ConversationScreenDestination(it), BackStackMode.UPDATE_EXISTED)) },
         onOpenDeviceDetails = { navigator.navigate(NavigationCommand(DeviceDetailsScreenDestination(navArgs.userId, it.clientId))) },
         onSearchConversationMessagesClick = onSearchConversationMessagesClick,
-        shouldShowSearchButton = shouldShowSearchButton,
         navigateBack = navigator::navigateBack,
         navigationIconType = NavigationIconType.Close,
     )
@@ -194,7 +192,6 @@ fun OtherProfileScreenContent(
     onOpenConversation: (ConversationId) -> Unit = {},
     onOpenDeviceDetails: (Device) -> Unit = {},
     onSearchConversationMessagesClick: () -> Unit,
-    shouldShowSearchButton: Boolean,
     navigateBack: () -> Unit = {}
 ) {
     val otherUserProfileScreenState = rememberOtherUserProfileScreenState()
@@ -272,8 +269,7 @@ fun OtherProfileScreenContent(
         topBarCollapsing = {
             TopBarCollapsing(
                 state = state,
-                onSearchConversationMessagesClick = onSearchConversationMessagesClick,
-                shouldShowSearchButton = shouldShowSearchButton
+                onSearchConversationMessagesClick = onSearchConversationMessagesClick
             )
         },
         topBarFooter = { TopBarFooter(state, pagerState, tabBarElevationState, tabItems, currentTabState, scope) },
@@ -373,8 +369,7 @@ private fun TopBarHeader(
 @Composable
 private fun TopBarCollapsing(
     state: OtherUserProfileState,
-    onSearchConversationMessagesClick: () -> Unit,
-    shouldShowSearchButton: Boolean
+    onSearchConversationMessagesClick: () -> Unit
 ) {
     Crossfade(
         targetState = state,
@@ -393,7 +388,7 @@ private fun TopBarCollapsing(
             connection = targetState.connectionState,
             isProteusVerified = targetState.isProteusVerified,
             onSearchConversationMessagesClick = onSearchConversationMessagesClick,
-            shouldShowSearchButton = shouldShowSearchButton
+            shouldShowSearchButton = state.shouldShowSearchButton()
         )
     }
 }
@@ -550,8 +545,7 @@ fun PreviewOtherProfileScreenContent() {
             closeBottomSheet = {},
             eventsHandler = OtherUserProfileEventsHandler.PREVIEW,
             bottomSheetEventsHandler = OtherUserProfileBottomSheetEventsHandler.PREVIEW,
-            onSearchConversationMessagesClick = {},
-            shouldShowSearchButton = false
+            onSearchConversationMessagesClick = {}
         )
     }
 }
@@ -571,8 +565,7 @@ fun PreviewOtherProfileScreenContentNotConnected() {
             closeBottomSheet = {},
             eventsHandler = OtherUserProfileEventsHandler.PREVIEW,
             bottomSheetEventsHandler = OtherUserProfileBottomSheetEventsHandler.PREVIEW,
-            onSearchConversationMessagesClick = {},
-            shouldShowSearchButton = false
+            onSearchConversationMessagesClick = {}
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -54,7 +54,6 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
-import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
 import com.wire.kalium.logic.feature.client.PersistOtherUserClientsUseCase
@@ -395,10 +394,4 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         )
     }
 
-    fun shouldShowSearchButton(conversationId: ConversationId?): Boolean =
-        conversationId != null && state.connectionState in listOf(
-            ConnectionState.ACCEPTED,
-            ConnectionState.BLOCKED,
-            ConnectionState.MISSING_LEGALHOLD_CONSENT
-        )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -393,5 +393,4 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             }
         )
     }
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -75,6 +75,13 @@ data class OtherUserProfileState(
     fun isMetadataEmpty(): Boolean {
         return fullName.isEmpty() || userName.isEmpty()
     }
+
+    fun shouldShowSearchButton(): Boolean = (groupState == null
+            && connectionState in listOf(
+        ConnectionState.ACCEPTED,
+        ConnectionState.BLOCKED,
+        ConnectionState.MISSING_LEGALHOLD_CONSENT
+    ))
 }
 
 data class OtherUserProfileGroupState(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5656" title="WPB-5656" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5656</a>  [Android][Search] Hide search button when entering user profile from Group Participants
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- fixed showing search button when opening user profile from group details (it will check if state contains groupInfo)