### PR TITLE
fix: typo variable assign in cherry-pick

### DIFF
--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -92,7 +92,7 @@ jobs:
                   cd ..
                   git add ${{ env.SUBMODULE_NAME }}
                   git commit -m "Update submodule ${{ env.SUBMODULE_NAME }} to latest from ${{ env.TARGET_BRANCH }}"
-                  echo "lastCommitMessage=LAST_COMMIT_MESSAGE" >> $GITHUB_ENV
+                  echo "lastCommitMessage=$LAST_COMMIT_MESSAGE" >> $GITHUB_ENV
 
             - name: Get Cherry-pick commit
               id: get-cherry


### PR DESCRIPTION
Cherry pick from the original PR: 
- #2477

---- 

 ⚠️ Conflicts during cherry-pick:


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like 
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

I was not assigning properly last commit message in automatic cherry-pick