### PR TITLE
fix: disable back press when app lock team enforced (WPB-5644)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.android.ui.home.appLock.set
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -61,6 +62,7 @@ import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
+import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
@@ -109,6 +111,7 @@ fun SetLockCodeScreenContent(
         topBar = {
             WireCenterAlignedTopAppBar(
                 onNavigationPressed = onBackPress,
+                navigationIconType = if (state.isEditable) NavigationIconType.Back else null,
                 elevation = dimensions().spacing0x,
                 title = stringResource(id = R.string.settings_set_lock_screen_title)
             )
@@ -171,6 +174,12 @@ fun SetLockCodeScreenContent(
                         onContinue = onContinue
                     )
                 }
+            }
+        }
+
+        BackHandler {
+            if (state.isEditable) {
+                onBackPress()
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeViewState.kt
@@ -28,5 +28,6 @@ data class SetLockCodeViewState(
     val password: TextFieldValue = TextFieldValue(),
     val passwordValidation: ValidatePasswordResult = ValidatePasswordResult.Invalid(),
     val timeout: Duration = ObserveAppLockConfigUseCase.DEFAULT_APP_LOCK_TIMEOUT,
-    val done: Boolean = false
+    val done: Boolean = false,
+    val isEditable: Boolean = true
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
@@ -29,6 +29,7 @@ import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.sha256
 import com.wire.kalium.logic.feature.applock.MarkTeamAppLockStatusAsNotifiedUseCase
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
+import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -40,12 +41,8 @@ class SetLockScreenViewModel @Inject constructor(
     private val validatePassword: ValidatePasswordUseCase,
     private val globalDataStore: GlobalDataStore,
     private val dispatchers: DispatcherProvider,
-<<<<<<< HEAD
-    private val observeAppLockConfigUseCase: ObserveAppLockConfigUseCase,
-=======
     private val observeAppLockConfig: ObserveAppLockConfigUseCase,
     private val isAppLockEditable: IsAppLockEditableUseCase,
->>>>>>> e751f691a (fix: disable back press when app lock team enforced (WPB-5644) (#2474))
     private val markTeamAppLockStatusAsNotified: MarkTeamAppLockStatusAsNotifiedUseCase
 ) : ViewModel() {
 
@@ -87,15 +84,7 @@ class SetLockScreenViewModel @Inject constructor(
                 viewModelScope.launch {
                     withContext(dispatchers.io()) {
                         with(globalDataStore) {
-<<<<<<< HEAD
                             setUserAppLock(state.password.text.sha256())
-=======
-                            val source = if (isAppLockEditable()) {
-                                AppLockSource.Manual
-                            } else {
-                                AppLockSource.TeamEnforced
-                            }
->>>>>>> e751f691a (fix: disable back press when app lock team enforced (WPB-5644) (#2474))
 
                             // TODO: call only when needed
                             markTeamAppLockStatusAsNotified()

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
@@ -40,7 +40,12 @@ class SetLockScreenViewModel @Inject constructor(
     private val validatePassword: ValidatePasswordUseCase,
     private val globalDataStore: GlobalDataStore,
     private val dispatchers: DispatcherProvider,
+<<<<<<< HEAD
     private val observeAppLockConfigUseCase: ObserveAppLockConfigUseCase,
+=======
+    private val observeAppLockConfig: ObserveAppLockConfigUseCase,
+    private val isAppLockEditable: IsAppLockEditableUseCase,
+>>>>>>> e751f691a (fix: disable back press when app lock team enforced (WPB-5644) (#2474))
     private val markTeamAppLockStatusAsNotified: MarkTeamAppLockStatusAsNotifiedUseCase
 ) : ViewModel() {
 
@@ -49,10 +54,12 @@ class SetLockScreenViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            observeAppLockConfigUseCase()
+            val isEditable = isAppLockEditable()
+            observeAppLockConfig()
                 .collectLatest {
                     state = state.copy(
-                        timeout = it.timeout
+                        timeout = it.timeout,
+                        isEditable = isEditable
                     )
                 }
         }
@@ -80,7 +87,15 @@ class SetLockScreenViewModel @Inject constructor(
                 viewModelScope.launch {
                     withContext(dispatchers.io()) {
                         with(globalDataStore) {
+<<<<<<< HEAD
                             setUserAppLock(state.password.text.sha256())
+=======
+                            val source = if (isAppLockEditable()) {
+                                AppLockSource.Manual
+                            } else {
+                                AppLockSource.TeamEnforced
+                            }
+>>>>>>> e751f691a (fix: disable back press when app lock team enforced (WPB-5644) (#2474))
 
                             // TODO: call only when needed
                             markTeamAppLockStatusAsNotified()

--- a/app/src/test/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModelTest.kt
@@ -26,6 +26,7 @@ import com.wire.android.feature.ObserveAppLockConfigUseCase
 import com.wire.kalium.logic.feature.applock.MarkTeamAppLockStatusAsNotifiedUseCase
 import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
+import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -81,13 +82,16 @@ class SetLockScreenViewModelTest {
         @MockK
         private lateinit var markTeamAppLockStatusAsNotified: MarkTeamAppLockStatusAsNotifiedUseCase
 
+        @MockK
+        private lateinit var isAppLockEditable: IsAppLockEditableUseCase
+
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
             coEvery { globalDataStore.setUserAppLock(any()) } returns Unit
             coEvery { observeAppLockConfig() } returns flowOf(
                 AppLockConfig.Disabled(ObserveAppLockConfigUseCase.DEFAULT_APP_LOCK_TIMEOUT)
             )
-            coEvery { isAppLockEditableUseCase() } returns true
+            coEvery { isAppLockEditable() } returns true
         }
 
         fun withValidPassword() = apply {
@@ -103,6 +107,7 @@ class SetLockScreenViewModelTest {
             globalDataStore,
             TestDispatcherProvider(),
             observeAppLockConfig,
+            isAppLockEditable,
             markTeamAppLockStatusAsNotified
         )
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModelTest.kt
@@ -32,6 +32,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -39,7 +40,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 class SetLockScreenViewModelTest {
 
     @Test
-    fun `given new password input, when valid,then should update state`() {
+    fun `given new password input, when valid,then should update state`() = runTest {
         val (arrangement, viewModel) = Arrangement()
             .withValidPassword()
             .arrange()
@@ -53,7 +54,7 @@ class SetLockScreenViewModelTest {
     }
 
     @Test
-    fun `given new password input, when invalid,then should update state`() {
+    fun `given new password input, when invalid,then should update state`() = runTest {
         val (arrangement, viewModel) = Arrangement()
             .withInvalidPassword()
             .arrange()
@@ -86,6 +87,7 @@ class SetLockScreenViewModelTest {
             coEvery { observeAppLockConfig() } returns flowOf(
                 AppLockConfig.Disabled(ObserveAppLockConfigUseCase.DEFAULT_APP_LOCK_TIMEOUT)
             )
+            coEvery { isAppLockEditableUseCase() } returns true
         }
 
         fun withValidPassword() = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5644" title="WPB-5644" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5644</a>  [Android] Back button bypasses applock screen when it is forced
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2474

---- 

 ⚠️ Conflicts during cherry-pick:
app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like 
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When AppLock is enforced by team, it was able to press back button (either hardware or app button) and navigate back in the screen and use the app normally until next closing/opening app and being prompted with setting app lock password.

### Solutions

When AppLock is enforced by team, hide back button on app and disable back button on screen.
Functionalities remain the same when it is not enforced by team but user wants to set AppLock.

### Testing

#### How to Test

- Open App
- Receive AppLock enforced by team dialog
- on Set AppLock password screen
- make sure back button is hidden (top left) + hardware back button has no effect.