### PR TITLE
fix: app lock not disabled when team enforce is lifted (#2466)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
+++ b/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
@@ -29,8 +29,10 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.wire.android.BuildConfig
+import com.wire.android.feature.AppLockSource
 import com.wire.android.migration.failure.UserMigrationStatus
 import com.wire.android.ui.theme.ThemeOption
+import com.wire.android.util.sha256
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -55,9 +57,12 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
         private val IS_LOGGING_ENABLED = booleanPreferencesKey("is_logging_enabled")
         private val IS_ENCRYPTED_PROTEUS_STORAGE_ENABLED =
             booleanPreferencesKey("is_encrypted_proteus_storage_enabled")
-         private val APP_LOCK_PASSCODE = stringPreferencesKey("app_lock_passcode")
+        private val APP_LOCK_PASSCODE = stringPreferencesKey("app_lock_passcode")
+        private val APP_LOCK_SOURCE = intPreferencesKey("app_lock_source")
+
         val APP_THEME_OPTION = stringPreferencesKey("app_theme_option")
         private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = PREFERENCES_NAME)
+
         private fun userMigrationStatusKey(userId: String): Preferences.Key<Int> =
             intPreferencesKey("user_migration_status_$userId")
 
@@ -195,30 +200,34 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
     suspend fun clearAppLockPasscode() {
         context.dataStore.edit {
             it.remove(APP_LOCK_PASSCODE)
+            it.remove(APP_LOCK_SOURCE)
         }
+    }
+
+    suspend fun getAppLockSource(): AppLockSource {
+        return context.dataStore.data.map {
+            it[APP_LOCK_SOURCE]?.let { source ->
+                AppLockSource.fromInt(source)
+            }
+        }.firstOrNull() ?: AppLockSource.Manual
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun setAppLockPasscode(
+    suspend fun setUserAppLock(
         passcode: String,
-        key: Preferences.Key<String>
+        source: AppLockSource
     ) {
         context.dataStore.edit {
             try {
+                val hash = passcode.sha256()
                 val encrypted =
-                    EncryptionManager.encrypt(key.name, passcode)
-                it[key] = encrypted
+                    EncryptionManager.encrypt(APP_LOCK_PASSCODE.name, hash)
+                it[APP_LOCK_PASSCODE] = encrypted
+                it[APP_LOCK_SOURCE] = source.code
             } catch (e: Exception) {
-                it.remove(key)
+                it.remove(APP_LOCK_PASSCODE)
             }
         }
-    }
-
-    suspend fun setUserAppLock(
-        passcode: String,
-        key: Preferences.Key<String> = APP_LOCK_PASSCODE
-    ) {
-        setAppLockPasscode(passcode, key)
     }
 
     suspend fun setThemeOption(option: ThemeOption) {

--- a/app/src/main/kotlin/com/wire/android/feature/AppLockSource.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/AppLockSource.kt
@@ -1,0 +1,38 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature
+
+sealed interface AppLockSource {
+    val code: Int
+        get() = when (this) {
+            is Manual -> 0
+            is TeamEnforced -> 1
+        }
+    data object Manual : AppLockSource
+    data object TeamEnforced : AppLockSource
+
+    companion object {
+        fun fromInt(value: Int): AppLockSource {
+            return when (value) {
+                0 -> Manual
+                1 -> TeamEnforced
+                else -> throw IllegalArgumentException("Unknown AppLockSource value: $value")
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/feature/DisableAppLockUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/DisableAppLockUseCase.kt
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature
+
+import com.wire.android.datastore.GlobalDataStore
+import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
+import dagger.hilt.android.scopes.ViewModelScoped
+import javax.inject.Inject
+
+@ViewModelScoped
+class DisableAppLockUseCase @Inject constructor(
+    private val dataStore: GlobalDataStore,
+    private val isAppLockEditableUseCase: IsAppLockEditableUseCase
+) {
+    suspend operator fun invoke(): Boolean = if (isAppLockEditableUseCase()) {
+        dataStore.clearAppLockPasscode()
+        true
+    } else {
+        false
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -292,6 +292,7 @@ class WireActivity : AppCompatActivity() {
                         } else {
                             with(featureFlagNotificationViewModel) {
                                 markTeamAppLockStatusAsNot()
+                                confirmAppLockNotEnforced()
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
@@ -24,11 +24,12 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.feature.AppLockSource
 import com.wire.android.feature.ObserveAppLockConfigUseCase
 import com.wire.android.util.dispatchers.DispatcherProvider
-import com.wire.android.util.sha256
 import com.wire.kalium.logic.feature.applock.MarkTeamAppLockStatusAsNotifiedUseCase
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
+import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -41,6 +42,7 @@ class SetLockScreenViewModel @Inject constructor(
     private val globalDataStore: GlobalDataStore,
     private val dispatchers: DispatcherProvider,
     private val observeAppLockConfigUseCase: ObserveAppLockConfigUseCase,
+    private val isAppLockEditableUseCase: IsAppLockEditableUseCase,
     private val markTeamAppLockStatusAsNotified: MarkTeamAppLockStatusAsNotifiedUseCase
 ) : ViewModel() {
 
@@ -80,9 +82,15 @@ class SetLockScreenViewModel @Inject constructor(
                 viewModelScope.launch {
                     withContext(dispatchers.io()) {
                         with(globalDataStore) {
-                            setUserAppLock(state.password.text.sha256())
+                            val source = if (isAppLockEditableUseCase()) {
+                                AppLockSource.Manual
+                            } else {
+                                AppLockSource.TeamEnforced
+                            }
 
-                            // TODO: call only when needed
+                            setUserAppLock(state.password.text, source)
+
+                            // TODO(bug): this does not take into account which account enforced the app lock
                             markTeamAppLockStatusAsNotified()
                         }
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -28,6 +28,8 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.feature.AppLockSource
+import com.wire.android.feature.DisableAppLockUseCase
 import com.wire.android.ui.home.FeatureFlagState
 import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
 import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
@@ -51,7 +53,8 @@ import javax.inject.Inject
 class FeatureFlagNotificationViewModel @Inject constructor(
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val currentSessionUseCase: CurrentSessionUseCase,
-    private val globalDataStore: GlobalDataStore
+    private val globalDataStore: GlobalDataStore,
+    private val disableAppLockUseCase: DisableAppLockUseCase
 ) : ViewModel() {
 
     var featureFlagState by mutableStateOf(FeatureFlagState())
@@ -235,6 +238,16 @@ class FeatureFlagNotificationViewModel @Inject constructor(
                 coreLogic.getSessionScope(
                     (currentSession as CurrentSessionResult.Success).accountInfo.userId
                 ).markTeamAppLockStatusAsNotified()
+            }
+        }
+    }
+
+    fun confirmAppLockNotEnforced() {
+        viewModelScope.launch {
+            when (globalDataStore.getAppLockSource()) {
+                AppLockSource.Manual -> {}
+
+                AppLockSource.TeamEnforced -> disableAppLockUseCase()
             }
         }
     }

--- a/app/src/test/kotlin/com/wire/android/feature/DisableAppLockUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/DisableAppLockUseCaseTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature
+
+import com.wire.android.datastore.GlobalDataStore
+import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class DisableAppLockUseCaseTest {
+
+    @Test
+    fun `given app lock is editable when disable app lock is called then clear app lock passcode`() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withAppLockEditable(true)
+            .withClearAppLockPasscode()
+            .arrange()
+
+        useCase()
+
+        coVerify(exactly = 1) { arrangement.dataStore.clearAppLockPasscode() }
+    }
+
+    @Test
+    fun `given app lock is not editable when disable app lock is called then do not clear app lock passcode`() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withAppLockEditable(false)
+            .arrange()
+
+        useCase()
+
+        coVerify(exactly = 0) { arrangement.dataStore.clearAppLockPasscode() }
+    }
+    private class Arrangement {
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        @MockK
+        lateinit var dataStore: GlobalDataStore
+
+        @MockK
+        lateinit var isAppLockEditableUseCase: IsAppLockEditableUseCase
+
+        private val useCase = DisableAppLockUseCase(
+            dataStore,
+            isAppLockEditableUseCase
+        )
+
+        fun withAppLockEditable(result: Boolean) = apply {
+            coEvery { isAppLockEditableUseCase() } returns result
+        }
+
+        fun withClearAppLockPasscode() = apply {
+            coEvery { dataStore.clearAppLockPasscode() } returns Unit
+        }
+
+        fun arrange() = Pair(this, useCase)
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModelTest.kt
@@ -26,6 +26,7 @@ import com.wire.android.feature.ObserveAppLockConfigUseCase
 import com.wire.kalium.logic.feature.applock.MarkTeamAppLockStatusAsNotifiedUseCase
 import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
+import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -80,9 +81,12 @@ class SetLockScreenViewModelTest {
         @MockK
         private lateinit var markTeamAppLockStatusAsNotified: MarkTeamAppLockStatusAsNotifiedUseCase
 
+        @MockK
+        private lateinit var isAppLockEditableUseCase: IsAppLockEditableUseCase
+
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
-            coEvery { globalDataStore.setUserAppLock(any()) } returns Unit
+            coEvery { globalDataStore.setUserAppLock(any(), any()) } returns Unit
             coEvery { observeAppLockConfig() } returns flowOf(
                 AppLockConfig.Disabled(ObserveAppLockConfigUseCase.DEFAULT_APP_LOCK_TIMEOUT)
             )
@@ -96,11 +100,16 @@ class SetLockScreenViewModelTest {
             every { validatePassword(any()) } returns ValidatePasswordResult.Invalid()
         }
 
+        fun withIsAppLockEditable(result: Boolean) = apply {
+            coEvery { isAppLockEditableUseCase() } returns result
+        }
+
         private val viewModel = SetLockScreenViewModel(
             validatePassword,
             globalDataStore,
             TestDispatcherProvider(),
             observeAppLockConfig,
+            isAppLockEditableUseCase,
             markTeamAppLockStatusAsNotified
         )
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolderTest.kt
@@ -55,7 +55,7 @@ class MessageCompositionHolderTest {
     }
 
     @Test
-    fun `given empty text, when adding bold markdown, then 2x ** is added to the text`() = runTest {
+    fun `GivenEmptyText, WhenAddingBoldMarkdown, Then2X star char IsAddedToTheText`() = runTest {
         // given
         // when
         state.addOrRemoveMessageMarkdown(markdown = RichTextMarkdown.Bold)
@@ -106,7 +106,7 @@ class MessageCompositionHolderTest {
     }
 
     @Test
-    fun `given non empty text, when adding bold markdown on selection, then 2x ** is added to the text`() = runTest {
+    fun `given non empty text, when adding bold markdown on selection, then 2x star char is added to the text`() = runTest {
         // given
         state.messageComposition.update {
             it.copy(


### PR DESCRIPTION
(cherry picked from commit f593408bebc8864bff22ce07c924966c7e18f1f3)
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
if team enforce for app lock is removed then the app lock should be disabled

### Solutions

store the source of the app lock and disable automatically iff team enface is lifted and there is no other account with the app lock enforced

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
