### PR TITLE
feat: show pending legal hold request and approve it [WPB-4393]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -435,8 +435,7 @@ class WireActivityViewModel @Inject constructor(
         CurrentScreen.InBackground,
         is CurrentScreen.Conversation,
         CurrentScreen.Home,
-        is CurrentScreen.IncomingCallScreen,
-        is CurrentScreen.OngoingCallScreen,
+        is CurrentScreen.CallScreen,
         is CurrentScreen.OtherUserProfile,
         CurrentScreen.AuthRelated,
         CurrentScreen.SomeOther -> true

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.legalhold.LegalHoldRequestObserverResult
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -77,6 +78,16 @@ class CommonTopAppBarViewModel @Inject constructor(
         }
     }
 
+    private fun legalHoldStatusFlow(userId: UserId) = coreLogic.sessionScope(userId) {
+        legalHoldRequestUseCase() // TODO combine with legal host status
+            .map { legalHoldRequestResult ->
+                when {
+                    legalHoldRequestResult is LegalHoldRequestObserverResult.LegalHoldRequestAvailable -> LegalHoldStatus.PENDING
+                    else -> LegalHoldStatus.NO_CONSENT
+                }
+            }
+    }
+
     init {
         viewModelScope.launch {
             coreLogic.globalScope {
@@ -90,10 +101,11 @@ class CommonTopAppBarViewModel @Inject constructor(
                             combine(
                                 activeCallFlow(userId),
                                 currentScreenFlow(),
-                                connectivityFlow(userId)
-                            ) { activeCall, currentScreen, connectivity ->
+                                connectivityFlow(userId),
+                                legalHoldStatusFlow(userId),
+                            ) { activeCall, currentScreen, connectivity, legalHoldStatus ->
                                 mapToConnectivityUIState(currentScreen, connectivity, activeCall) to
-                                        mapToLegalHoldUIState(currentScreen, LegalHoldStatus.NO_CONSENT) // TODO: get legalHoldStatus
+                                        mapToLegalHoldUIState(currentScreen, legalHoldStatus)
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
@@ -79,11 +79,11 @@ class CommonTopAppBarViewModel @Inject constructor(
     }
 
     private fun legalHoldStatusFlow(userId: UserId) = coreLogic.sessionScope(userId) {
-        observeLegalHoldRequest() // TODO combine with legal host status
+        observeLegalHoldRequest() // TODO combine with legal hold status
             .map { legalHoldRequestResult ->
                 when (legalHoldRequestResult) {
                     is ObserveLegalHoldRequestUseCaseResult.ObserveLegalHoldRequestAvailable -> LegalHoldStatus.PENDING
-                    else -> LegalHoldStatus.NO_CONSENT
+                    else -> LegalHoldStatus.DISABLED
                 }
             }
     }
@@ -160,10 +160,7 @@ class CommonTopAppBarViewModel @Inject constructor(
         LegalHoldStatus.DISABLED,
         LegalHoldStatus.NO_CONSENT -> LegalHoldUIState.None
     }.let { legalHoldUIState ->
-        if (currentScreen is CurrentScreen.AuthRelated
-            || currentScreen is CurrentScreen.OngoingCallScreen
-            || currentScreen is CurrentScreen.IncomingCallScreen
-        ) LegalHoldUIState.None
+        if (currentScreen is CurrentScreen.AuthRelated || currentScreen is CurrentScreen.CallScreen) LegalHoldUIState.None
         else legalHoldUIState
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
@@ -34,7 +34,7 @@ import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.legalhold.LegalHoldRequestObserverResult
+import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldRequestObserverResult
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -82,7 +82,7 @@ class CommonTopAppBarViewModel @Inject constructor(
         legalHoldRequestUseCase() // TODO combine with legal host status
             .map { legalHoldRequestResult ->
                 when {
-                    legalHoldRequestResult is LegalHoldRequestObserverResult.LegalHoldRequestAvailable -> LegalHoldStatus.PENDING
+                    legalHoldRequestResult is ObserveLegalHoldRequestObserverResult.ObserveLegalHoldRequestAvailable -> LegalHoldStatus.PENDING
                     else -> LegalHoldStatus.NO_CONSENT
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
@@ -160,7 +160,10 @@ class CommonTopAppBarViewModel @Inject constructor(
         LegalHoldStatus.DISABLED,
         LegalHoldStatus.NO_CONSENT -> LegalHoldUIState.None
     }.let { legalHoldUIState ->
-        if (currentScreen is CurrentScreen.AuthRelated) LegalHoldUIState.None
+        if (currentScreen is CurrentScreen.AuthRelated
+            || currentScreen is CurrentScreen.OngoingCallScreen
+            || currentScreen is CurrentScreen.IncomingCallScreen
+        ) LegalHoldUIState.None
         else legalHoldUIState
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
@@ -34,7 +34,7 @@ import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldRequestObserverResult
+import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldRequestUseCaseResult
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -79,10 +79,10 @@ class CommonTopAppBarViewModel @Inject constructor(
     }
 
     private fun legalHoldStatusFlow(userId: UserId) = coreLogic.sessionScope(userId) {
-        legalHoldRequestUseCase() // TODO combine with legal host status
+        observeLegalHoldRequest() // TODO combine with legal host status
             .map { legalHoldRequestResult ->
-                when {
-                    legalHoldRequestResult is ObserveLegalHoldRequestObserverResult.ObserveLegalHoldRequestAvailable -> LegalHoldStatus.PENDING
+                when (legalHoldRequestResult) {
+                    is ObserveLegalHoldRequestUseCaseResult.ObserveLegalHoldRequestAvailable -> LegalHoldStatus.PENDING
                     else -> LegalHoldStatus.NO_CONSENT
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedDialog.kt
@@ -51,6 +51,7 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.extension.formatAsFingerPrint
 import com.wire.android.util.ui.PreviewMultipleThemes
+import com.wire.kalium.logic.data.user.UserId
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -141,7 +142,11 @@ fun LegalHoldRequestedDialog(
 fun PreviewLegalHoldRequestedDialogWithPassword() {
     WireTheme {
         LegalHoldRequestedDialog(
-            LegalHoldRequestedState.Visible(legalHoldDeviceFingerprint = "0123456789ABCDEF", requiresPassword = true), {}, {}, {}
+            LegalHoldRequestedState.Visible(
+                legalHoldDeviceFingerprint = "0123456789ABCDEF",
+                requiresPassword = true,
+                userId = UserId("", ""),
+            ), {}, {}, {}
         )
     }
 }
@@ -151,7 +156,11 @@ fun PreviewLegalHoldRequestedDialogWithPassword() {
 fun PreviewLegalHoldRequestedDialogWithoutPassword() {
     WireTheme {
         LegalHoldRequestedDialog(
-            LegalHoldRequestedState.Visible(legalHoldDeviceFingerprint = "0123456789ABCDEF", requiresPassword = false), {}, {}, {}
+            LegalHoldRequestedState.Visible(
+                legalHoldDeviceFingerprint = "0123456789ABCDEF",
+                requiresPassword = false,
+                userId = UserId("", ""),
+            ), {}, {}, {}
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedState.kt
@@ -19,6 +19,7 @@ package com.wire.android.ui.legalhold.dialog.requested
 
 import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.user.UserId
 
 sealed class LegalHoldRequestedState {
     data object Hidden : LegalHoldRequestedState()
@@ -29,6 +30,7 @@ sealed class LegalHoldRequestedState {
         val loading: Boolean = false,
         val acceptEnabled: Boolean = false,
         val error: LegalHoldRequestedError = LegalHoldRequestedError.None,
+        val userId: UserId,
     ) : LegalHoldRequestedState()
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModel.kt
@@ -26,10 +26,19 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
+import com.wire.kalium.logic.feature.legalhold.LegalHoldRequestObserverResult
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -41,7 +50,56 @@ class LegalHoldRequestedViewModel @Inject constructor(
 
     var state: LegalHoldRequestedState by mutableStateOf(LegalHoldRequestedState.Hidden)
         private set
-    // TODO: get legal hold status of current account
+
+    private val legalHoldRequestDataStateFlow = currentSessionFlow(noSession = LegalHoldRequestData.None) {
+            legalHoldRequestUseCase()
+                .mapLatest { legalHoldRequestResult ->
+                    when (legalHoldRequestResult) {
+                        is LegalHoldRequestObserverResult.Failure -> {
+                            appLogger.e("$TAG: Failed to get legal hold request data: ${legalHoldRequestResult.failure}")
+                            LegalHoldRequestData.None
+                        }
+                        LegalHoldRequestObserverResult.NoLegalHoldRequest -> LegalHoldRequestData.None
+                        is LegalHoldRequestObserverResult.LegalHoldRequestAvailable ->
+                            users.isPasswordRequired()
+                                .let {
+                                    LegalHoldRequestData.Pending(
+                                        legalHoldRequestResult.fingerprint.decodeToString(),
+                                        (it as? IsPasswordRequiredUseCase.Result.Success)?.value ?: true
+                                    )
+                                }
+                    }
+                }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, LegalHoldRequestData.None)
+
+    private fun <T> currentSessionFlow(noSession: T, session: UserSessionScope.() -> Flow<T>): Flow<T> =
+        coreLogic.getGlobalScope().session.currentSessionFlow()
+            .flatMapLatest { currentSessionResult ->
+                when (currentSessionResult) {
+                    is CurrentSessionResult.Failure.Generic -> {
+                        appLogger.e("$TAG: Failed to get current session")
+                        flowOf(noSession)
+                    }
+                    CurrentSessionResult.Failure.SessionNotFound -> flowOf(noSession)
+                    is CurrentSessionResult.Success -> coreLogic.getSessionScope(currentSessionResult.accountInfo.userId).session()
+                }
+            }
+
+    init {
+        viewModelScope.launch {
+            legalHoldRequestDataStateFlow.collectLatest { legalHoldRequestData ->
+                state = when (legalHoldRequestData) {
+                    is LegalHoldRequestData.Pending -> {
+                        LegalHoldRequestedState.Visible(
+                            requiresPassword = legalHoldRequestData.isPasswordRequired,
+                            legalHoldDeviceFingerprint = legalHoldRequestData.fingerprint
+                        )
+                    }
+                    LegalHoldRequestData.None -> LegalHoldRequestedState.Hidden
+                }
+            }
+        }
+    }
 
     private fun LegalHoldRequestedState.ifVisible(action: (LegalHoldRequestedState.Visible) -> Unit) {
         if (this is LegalHoldRequestedState.Visible) action(this)
@@ -57,25 +115,12 @@ class LegalHoldRequestedViewModel @Inject constructor(
         state = LegalHoldRequestedState.Hidden
     }
 
-    private suspend fun checkIfPasswordRequired(action: (Boolean) -> Unit) {
-        when (val currentSessionResult = coreLogic.getGlobalScope().session.currentSession()) {
-            CurrentSessionResult.Failure.SessionNotFound -> appLogger.e("$TAG: Session not found")
-            is CurrentSessionResult.Failure.Generic -> appLogger.e("$TAG: Failed to get current session")
-            is CurrentSessionResult.Success -> action(
-                coreLogic.getSessionScope(currentSessionResult.accountInfo.userId).users.isPasswordRequired()
-                    .let { (it as? IsPasswordRequiredUseCase.Result.Success)?.value ?: true }
-            )
-        }
-    }
-
     fun show() {
-        viewModelScope.launch {
-            checkIfPasswordRequired { isPasswordRequired ->
-                state = LegalHoldRequestedState.Visible(
-                    requiresPassword = isPasswordRequired,
-                    legalHoldDeviceFingerprint = "0123456789ABCDEF" // TODO: get legal hold client fingerprint
-                )
-            }
+        (legalHoldRequestDataStateFlow.value as? LegalHoldRequestData.Pending)?.let {
+            state = LegalHoldRequestedState.Visible(
+                requiresPassword = it.isPasswordRequired,
+                legalHoldDeviceFingerprint = it.fingerprint
+            )
         }
     }
 
@@ -90,6 +135,11 @@ class LegalHoldRequestedViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private sealed class LegalHoldRequestData {
+        data object None : LegalHoldRequestData()
+        data class Pending(val fingerprint: String, val isPasswordRequired: Boolean) : LegalHoldRequestData()
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -40,6 +40,7 @@ import com.wire.android.ui.destinations.HomeScreenDestination
 import com.wire.android.ui.destinations.ImportMediaScreenDestination
 import com.wire.android.ui.destinations.IncomingCallScreenDestination
 import com.wire.android.ui.destinations.InitialSyncScreenDestination
+import com.wire.android.ui.destinations.InitiatingCallScreenDestination
 import com.wire.android.ui.destinations.LoginScreenDestination
 import com.wire.android.ui.destinations.MigrationScreenDestination
 import com.wire.android.ui.destinations.OngoingCallScreenDestination
@@ -151,11 +152,16 @@ sealed class CurrentScreen {
     // Another User Profile Screen is opened
     data class OtherUserProfile(val id: ConversationId) : CurrentScreen()
 
+    sealed class CallScreen(open val id: QualifiedID) : CurrentScreen()
+
     // Ongoing call screen is opened
-    data class OngoingCallScreen(val id: QualifiedID) : CurrentScreen()
+    class OngoingCallScreen(override val id: QualifiedID) : CallScreen(id)
 
     // Incoming call screen is opened
-    data class IncomingCallScreen(val id: QualifiedID) : CurrentScreen()
+    class IncomingCallScreen(override val id: QualifiedID) : CallScreen(id)
+
+    // Initiating call screen is opened
+    class InitiatingCallScreen(override val id: QualifiedID) : CallScreen(id)
 
     // Import media screen is opened
     object ImportMedia : CurrentScreen()
@@ -192,6 +198,9 @@ sealed class CurrentScreen {
 
                 is IncomingCallScreenDestination ->
                     IncomingCallScreen(destination.argsFrom(arguments).conversationId)
+
+                is InitiatingCallScreenDestination ->
+                    InitiatingCallScreen(destination.argsFrom(arguments).conversationId)
 
                 is ImportMediaScreenDestination -> ImportMedia
 

--- a/app/src/test/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModelTest.kt
@@ -222,10 +222,10 @@ class CommonTopAppBarViewModelTest {
     )
 
     @Test
-    fun givenLegalHoldRequestAndCallScreen_whenGettingState_thenShouldHaveLegalHoldRequestInfo() = testLegalHoldRequestInfo(
+    fun givenLegalHoldRequestAndCallScreen_whenGettingState_thenShouldNotHaveLegalHoldRequestInfo() = testLegalHoldRequestInfo(
         currentScreen = CurrentScreen.OngoingCallScreen(mockk()),
         result = ObserveLegalHoldRequestUseCaseResult.ObserveLegalHoldRequestAvailable(byteArrayOf()),
-        expectedState = LegalHoldUIState.Pending
+        expectedState = LegalHoldUIState.None
     )
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModelTest.kt
@@ -21,6 +21,7 @@
 package com.wire.android.ui.common.topappbar
 
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.ui.legalhold.banner.LegalHoldUIState
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
 import com.wire.kalium.logic.CoreLogic
@@ -31,6 +32,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
+import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldRequestUseCaseResult
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import io.mockk.MockKAnnotations
@@ -159,10 +161,12 @@ class CommonTopAppBarViewModelTest {
     }
 
     @Test
-    fun givenActiveCallAndConnectivityIssueAndSomeOtherScreen_whenGettingState_thenShouldHaveNoInfo() = runTest {
+    fun givenActiveCallAndConnectivityIssueAndSomeOtherScreen_whenGettingState_thenShouldHaveActiveCallInfo() = runTest {
         val (_, commonTopAppBarViewModel) = Arrangement()
+            .withCurrentSessionExist()
             .withActiveCall()
             .withCurrentScreen(CurrentScreen.SomeOther)
+            .withCallMuted(false)
             .withSyncState(SyncState.Waiting)
             .arrange()
 
@@ -170,7 +174,7 @@ class CommonTopAppBarViewModelTest {
         val state = commonTopAppBarViewModel.state
 
         val info = state.connectivityState
-        info shouldBeInstanceOf ConnectivityUIState.None::class
+        info shouldBeInstanceOf ConnectivityUIState.EstablishedCall::class
     }
 
     @Test
@@ -182,9 +186,54 @@ class CommonTopAppBarViewModelTest {
         advanceUntilIdle()
         val state = commonTopAppBarViewModel.state
 
-        val info = state.connectivityState
-        info shouldBeInstanceOf ConnectivityUIState.None::class
+        state.connectivityState shouldBeInstanceOf ConnectivityUIState.None::class
+        state.legalHoldState shouldBeInstanceOf LegalHoldUIState.None::class
     }
+
+    private fun testLegalHoldRequestInfo(
+        currentScreen: CurrentScreen,
+        result: ObserveLegalHoldRequestUseCaseResult,
+        expectedState: LegalHoldUIState,
+    ) = runTest {
+        val (_, commonTopAppBarViewModel) = Arrangement()
+            .withCurrentSessionExist()
+            .withCurrentScreen(currentScreen)
+            .withLegalHoldRequestResult(result)
+            .arrange()
+
+        advanceUntilIdle()
+        val state = commonTopAppBarViewModel.state
+
+        state.legalHoldState shouldBeInstanceOf expectedState::class
+    }
+
+    @Test
+    fun givenNoLegalHoldRequest_whenGettingState_thenShouldNotHaveLegalHoldRequestInfo() = testLegalHoldRequestInfo(
+        currentScreen = CurrentScreen.Home,
+        result = ObserveLegalHoldRequestUseCaseResult.NoObserveLegalHoldRequest,
+        expectedState = LegalHoldUIState.None
+    )
+
+    @Test
+    fun givenLegalHoldRequestAndHomeScreen_whenGettingState_thenShouldHaveLegalHoldRequestInfo() = testLegalHoldRequestInfo(
+        currentScreen = CurrentScreen.Home,
+        result = ObserveLegalHoldRequestUseCaseResult.ObserveLegalHoldRequestAvailable(byteArrayOf()),
+        expectedState = LegalHoldUIState.Pending
+    )
+
+    @Test
+    fun givenLegalHoldRequestAndCallScreen_whenGettingState_thenShouldHaveLegalHoldRequestInfo() = testLegalHoldRequestInfo(
+        currentScreen = CurrentScreen.OngoingCallScreen(mockk()),
+        result = ObserveLegalHoldRequestUseCaseResult.ObserveLegalHoldRequestAvailable(byteArrayOf()),
+        expectedState = LegalHoldUIState.Pending
+    )
+
+    @Test
+    fun givenLegalHoldRequestAndAuthRelatedScreen_whenGettingState_thenShouldNotHaveLegalHoldRequestInfo() = testLegalHoldRequestInfo(
+        currentScreen = CurrentScreen.AuthRelated,
+        result = ObserveLegalHoldRequestUseCaseResult.ObserveLegalHoldRequestAvailable(byteArrayOf()),
+        expectedState = LegalHoldUIState.None
+    )
 
     private class Arrangement {
 
@@ -230,6 +279,10 @@ class CommonTopAppBarViewModelTest {
             every {
                 globalKaliumScope.session.currentSessionFlow()
             } returns emptyFlow()
+
+            withSyncState(SyncState.Live)
+            withoutActiveCall()
+            withLegalHoldRequestResult(ObserveLegalHoldRequestUseCaseResult.NoObserveLegalHoldRequest)
         }
 
         private val commonTopAppBarViewModel by lazy {
@@ -272,6 +325,10 @@ class CommonTopAppBarViewModelTest {
 
         fun withCurrentScreen(currentScreen: CurrentScreen) = apply {
             coEvery { currentScreenManager.observeCurrentScreen(any()) } returns MutableStateFlow(currentScreen)
+        }
+
+        fun withLegalHoldRequestResult(result: ObserveLegalHoldRequestUseCaseResult) = apply {
+            every { coreLogic.getSessionScope(any()).observeLegalHoldRequest() } returns flowOf(result)
         }
 
         fun arrange() = this to commonTopAppBarViewModel

--- a/app/src/test/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModelTest.kt
@@ -1,0 +1,281 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.legalhold.dialog.requested
+
+import androidx.compose.ui.text.input.TextFieldValue
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedViewModelTest.Arrangement.Companion.UNKNOWN_ERROR
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.auth.AccountInfo
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
+import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
+import com.wire.kalium.logic.feature.legalhold.ApproveLegalHoldRequestUseCase
+import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldRequestUseCaseResult
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(CoroutineTestExtension::class)
+class LegalHoldRequestedViewModelTest {
+
+    @Test
+    fun givenNoSession_whenGettingState_thenStateShouldBeHidden() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withNotCurrentSession()
+            .arrange()
+        advanceUntilIdle()
+        val state = viewModel.state
+        state shouldBeInstanceOf LegalHoldRequestedState.Hidden::class
+    }
+
+    @Test
+    fun givenSessionReturnsFailure_whenGettingState_thenStateShouldBeHidden() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withCurrentSessionFailure()
+            .arrange()
+        advanceUntilIdle()
+        viewModel.state shouldBeInstanceOf LegalHoldRequestedState.Hidden::class
+    }
+
+    @Test
+    fun givenLegalHoldRequestReturnsFailure_whenGettingState_thenStateShouldBeHidden() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withCurrentSessionExists()
+            .withLegalHoldRequestResult(ObserveLegalHoldRequestUseCaseResult.Failure(UNKNOWN_ERROR))
+            .arrange()
+        advanceUntilIdle()
+        viewModel.state shouldBeInstanceOf LegalHoldRequestedState.Hidden::class
+    }
+
+    @Test
+    fun givenNoPendingLegalHoldRequest_whenGettingState_thenStateShouldBeHidden() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withCurrentSessionExists()
+            .withLegalHoldRequestResult(ObserveLegalHoldRequestUseCaseResult.NoObserveLegalHoldRequest)
+            .arrange()
+        advanceUntilIdle()
+        viewModel.state shouldBeInstanceOf LegalHoldRequestedState.Hidden::class
+    }
+
+    @Test
+    fun givenPendingLegalHoldRequest_whenGettingState_thenStateShouldBeVisible() = runTest {
+        val fingerprint = "fingerprint".toByteArray()
+        val (_, viewModel) = Arrangement()
+            .withCurrentSessionExists()
+            .withLegalHoldRequestResult(ObserveLegalHoldRequestUseCaseResult.ObserveLegalHoldRequestAvailable(fingerprint))
+            .withIsPasswordRequiredResult(IsPasswordRequiredUseCase.Result.Success(true))
+            .arrange()
+        advanceUntilIdle()
+        val state = viewModel.state
+        state shouldBeInstanceOf LegalHoldRequestedState.Visible::class
+        state as LegalHoldRequestedState.Visible
+        state.legalHoldDeviceFingerprint shouldBeEqualTo fingerprint.decodeToString()
+    }
+
+    @Test
+    fun givenPendingLegalHoldRequestAndPasswordRequired_whenGettingState_thenShouldRequirePassword() = runTest {
+        val fingerprint = "fingerprint".toByteArray()
+        val (_, viewModel) = Arrangement()
+            .withCurrentSessionExists()
+            .withLegalHoldRequestResult(ObserveLegalHoldRequestUseCaseResult.ObserveLegalHoldRequestAvailable(fingerprint))
+            .withIsPasswordRequiredResult(IsPasswordRequiredUseCase.Result.Success(true))
+            .arrange()
+        advanceUntilIdle()
+        val state = viewModel.state
+        state shouldBeInstanceOf LegalHoldRequestedState.Visible::class
+        state as LegalHoldRequestedState.Visible
+        state.requiresPassword shouldBeEqualTo true
+    }
+
+    @Test
+    fun givenPendingLegalHoldRequestAndNoPasswordRequired_whenGettingState_thenShouldNotRequirePassword() = runTest {
+        val fingerprint = "fingerprint".toByteArray()
+        val (_, viewModel) = Arrangement()
+            .withCurrentSessionExists()
+            .withLegalHoldRequestResult(ObserveLegalHoldRequestUseCaseResult.ObserveLegalHoldRequestAvailable(fingerprint))
+            .withIsPasswordRequiredResult(IsPasswordRequiredUseCase.Result.Success(false))
+            .arrange()
+        advanceUntilIdle()
+        val state = viewModel.state
+        state shouldBeInstanceOf LegalHoldRequestedState.Visible::class
+        state as LegalHoldRequestedState.Visible
+        state.requiresPassword shouldBeEqualTo false
+    }
+
+    private fun arrangeWithLegalHoldRequest(isPasswordRequired: Boolean = true) = Arrangement()
+        .withCurrentSessionExists()
+        .withLegalHoldRequestResult(ObserveLegalHoldRequestUseCaseResult.ObserveLegalHoldRequestAvailable("fingerprint".toByteArray()))
+        .withIsPasswordRequiredResult(IsPasswordRequiredUseCase.Result.Success(isPasswordRequired))
+
+    private fun LegalHoldRequestedState.assertStateVisible(assert: (LegalHoldRequestedState.Visible) -> Unit) {
+        this shouldBeInstanceOf LegalHoldRequestedState.Visible::class
+        this as LegalHoldRequestedState.Visible
+        assert(this)
+    }
+
+    @Test
+    fun givenInvalidPassword_whenEnteringPassword_thenAcceptButtonShouldBeDisabled() = runTest {
+        val (_, viewModel) = arrangeWithLegalHoldRequest()
+            .withValidatePasswordResult(ValidatePasswordResult.Invalid())
+            .arrange()
+        advanceUntilIdle()
+        viewModel.passwordChanged(TextFieldValue("password"))
+        viewModel.state.assertStateVisible { it.acceptEnabled shouldBeEqualTo false }
+    }
+
+    @Test
+    fun givenPasswordNotEmptyAndValid_whenEnteringPassword_thenAcceptButtonShouldBeEnabled() = runTest {
+        val (_, viewModel) = arrangeWithLegalHoldRequest()
+            .withValidatePasswordResult(ValidatePasswordResult.Valid)
+            .arrange()
+        advanceUntilIdle()
+        viewModel.passwordChanged(TextFieldValue("password"))
+        viewModel.state.assertStateVisible { it.acceptEnabled shouldBeEqualTo true }
+    }
+
+    @Test
+    fun givenNotNowChosen_whenApproving_thenStateShouldBeHidden() = runTest {
+        val (_, viewModel) = arrangeWithLegalHoldRequest()
+            .withValidatePasswordResult(ValidatePasswordResult.Invalid())
+            .arrange()
+        advanceUntilIdle()
+        viewModel.notNowClicked()
+        viewModel.state shouldBeInstanceOf LegalHoldRequestedState.Hidden::class
+    }
+
+    @Test
+    fun givenInvalidPasswordResult_whenValidatingPassword_thenErrorStateShouldBeInvalidCredentials() = runTest {
+        val (_, viewModel) = arrangeWithLegalHoldRequest()
+            .withValidatePasswordResult(ValidatePasswordResult.Invalid())
+            .arrange()
+        advanceUntilIdle()
+        viewModel.acceptClicked()
+        viewModel.state.assertStateVisible { it.error shouldBeInstanceOf LegalHoldRequestedError.InvalidCredentialsError::class }
+    }
+
+    @Test
+    fun givenInvalidPasswordResult_whenApproving_thenErrorStateShouldBeInvalidCredentials() = runTest {
+        val (_, viewModel) = arrangeWithLegalHoldRequest()
+            .withValidatePasswordResult(ValidatePasswordResult.Valid)
+            .withApproveLegalHoldRequestResult(ApproveLegalHoldRequestUseCase.Result.Failure.InvalidPassword)
+            .arrange()
+        advanceUntilIdle()
+        viewModel.acceptClicked()
+        viewModel.state.assertStateVisible {
+            it.error shouldBeInstanceOf LegalHoldRequestedError.InvalidCredentialsError::class
+            it.requiresPassword shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun givenPasswordRequiredResult_whenApproving_thenErrorStateShouldBeInvalidCredentialsAndRequiresPasswordTrue() = runTest {
+        val (_, viewModel) = arrangeWithLegalHoldRequest(isPasswordRequired = false)
+            .withValidatePasswordResult(ValidatePasswordResult.Valid)
+            .withApproveLegalHoldRequestResult(ApproveLegalHoldRequestUseCase.Result.Failure.PasswordRequired)
+            .arrange()
+        advanceUntilIdle()
+        viewModel.acceptClicked()
+        viewModel.state.assertStateVisible {
+            it.error shouldBeInstanceOf LegalHoldRequestedError.InvalidCredentialsError::class
+            it.requiresPassword shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun givenGenericFailureResult_whenApproving_thenErrorStateShouldBeGenericError() = runTest {
+        val (_, viewModel) = arrangeWithLegalHoldRequest()
+            .withValidatePasswordResult(ValidatePasswordResult.Valid)
+            .withApproveLegalHoldRequestResult(ApproveLegalHoldRequestUseCase.Result.Failure.GenericFailure(UNKNOWN_ERROR))
+            .arrange()
+        advanceUntilIdle()
+        viewModel.acceptClicked()
+        viewModel.state.assertStateVisible {
+            it.error shouldBeInstanceOf LegalHoldRequestedError.GenericError::class
+        }
+    }
+
+    @Test
+    fun givenSuccess_whenApproving_thenStateShouldBeHidden() = runTest {
+        val (_, viewModel) = arrangeWithLegalHoldRequest()
+            .withValidatePasswordResult(ValidatePasswordResult.Valid)
+            .withApproveLegalHoldRequestResult(ApproveLegalHoldRequestUseCase.Result.Success)
+            .arrange()
+        advanceUntilIdle()
+        viewModel.acceptClicked()
+        viewModel.state shouldBeInstanceOf LegalHoldRequestedState.Hidden::class
+    }
+
+    private class Arrangement {
+
+        @MockK
+        private lateinit var validatePassword: ValidatePasswordUseCase
+
+        @MockK
+        private lateinit var coreLogic: CoreLogic
+
+        val viewModel by lazy { LegalHoldRequestedViewModel(validatePassword, coreLogic) }
+
+        init {
+            MockKAnnotations.init(this)
+        }
+        fun withNotCurrentSession() = apply {
+            every { coreLogic.globalScope { session.currentSessionFlow() } } returns
+                    flowOf(CurrentSessionResult.Failure.SessionNotFound)
+        }
+        fun withCurrentSessionFailure() = apply {
+            every { coreLogic.globalScope { session.currentSessionFlow() } } returns
+                    flowOf(CurrentSessionResult.Failure.Generic(UNKNOWN_ERROR))
+        }
+        fun withCurrentSessionExists() = apply {
+            every { coreLogic.globalScope { session.currentSessionFlow() } } returns
+                    flowOf(CurrentSessionResult.Success(AccountInfo.Valid(UserId("userId", "domain"))))
+        }
+        fun withLegalHoldRequestResult(result: ObserveLegalHoldRequestUseCaseResult) = apply {
+            every { coreLogic.getSessionScope(any()).observeLegalHoldRequest() } returns flowOf(result)
+        }
+        fun withIsPasswordRequiredResult(result: IsPasswordRequiredUseCase.Result) = apply {
+            coEvery { coreLogic.getSessionScope(any()).users.isPasswordRequired() } returns result
+        }
+        fun withValidatePasswordResult(result: ValidatePasswordResult) = apply {
+            coEvery { validatePassword(any()) } returns result
+        }
+        fun withApproveLegalHoldRequestResult(result: ApproveLegalHoldRequestUseCase.Result) = apply {
+            coEvery { coreLogic.getSessionScope(any()).approveLegalHoldRequest(any()) } returns result
+        }
+
+        fun arrange() = this to viewModel
+
+        companion object {
+            val UNKNOWN_ERROR = CoreFailure.Unknown(RuntimeException("error"))
+        }
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4393" title="WPB-4393" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-4393</a>  [Android] Receive a Legal hold request
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

The logic in view models to show the bar informing about pending legal hold request and a dialog with the option to approve this request.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

As a team admin request the legal hold for the user, then this user should see this bar and dialog when he/she opens the app.

### Attachments (Optional)

https://github.com/wireapp/wire-android/assets/30429749/eeae3710-c825-43b0-aebc-f0e562a9f711

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
