### PR TITLE
fix: display the app lock enforce dialogue when it is enforced but no…

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -140,11 +140,17 @@ class FeatureFlagNotificationViewModel @Inject constructor(
         viewModelScope.launch {
             coreLogic.getSessionScope(userId).appLockTeamFeatureConfigObserver()
                 .distinctUntilChanged()
-                .collectLatest {
-                    it?.isStatusChanged?.let { isStatusChanged ->
+                .collectLatest { appLockConfig ->
+                    appLockConfig?.isStatusChanged?.let { isStatusChanged ->
+                        val shouldBlockApp = if (isStatusChanged) {
+                            true
+                        } else {
+                            (!isUserAppLockSet() && appLockConfig.isEnforced)
+                        }
+
                         featureFlagState = featureFlagState.copy(
-                            isTeamAppLockEnabled = it.isEnforced,
-                            shouldShowTeamAppLockDialog = isStatusChanged
+                            isTeamAppLockEnabled = appLockConfig.isEnforced,
+                            shouldShowTeamAppLockDialog = shouldBlockApp
                         )
                     }
                 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
@@ -291,7 +291,6 @@ class FeatureFlagNotificationViewModelTest {
         @MockK
         lateinit var globalDataStore: GlobalDataStore
 
-
         val viewModel: FeatureFlagNotificationViewModel = FeatureFlagNotificationViewModel(
             coreLogic = coreLogic,
             currentSessionUseCase = currentSession,

--- a/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
@@ -7,11 +7,13 @@ import com.wire.android.feature.DisableAppLockUseCase
 import com.wire.android.framework.TestUser
 import com.wire.android.ui.home.FeatureFlagState
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.configuration.AppLockTeamConfig
 import com.wire.kalium.logic.configuration.FileSharingStatus
 import com.wire.kalium.logic.configuration.GuestRoomLinkStatus
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.applock.AppLockTeamFeatureConfigObserver
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.user.E2EIRequiredResult
@@ -30,8 +32,10 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -112,6 +116,20 @@ class FeatureFlagNotificationViewModelTest {
 
         coVerify(exactly = 1) { arrangement.markSelfDeletingStatusAsNotified() }
         assertEquals(false, viewModel.featureFlagState.shouldShowSelfDeletingMessagesDialog)
+    }
+
+    @Test
+    fun givenTeamAppLockIsEnforceButNotChanged_whenAppHaveNotAppLockSetup_thenDisplayTheAppLockDialog() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withCurrentSessions(CurrentSessionResult.Success(AccountInfo.Valid(UserId("value", "domain"))))
+            .withIsAppLockSetup(false)
+            .withTeamAppLockEnforce(AppLockTeamConfig(true, Duration.ZERO, false))
+            .arrange()
+
+        viewModel.initialSync()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.featureFlagState.shouldShowTeamAppLockDialog)
     }
 
     @Test
@@ -247,7 +265,6 @@ class FeatureFlagNotificationViewModelTest {
             coEvery { currentSession() } returns CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID))
             coEvery { coreLogic.getSessionScope(any()).observeSyncState() } returns flowOf(SyncState.Live)
             coEvery { coreLogic.getSessionScope(any()).observeTeamSettingsSelfDeletionStatus() } returns flowOf()
-            coEvery { coreLogic.getSessionScope(any()).appLockTeamFeatureConfigObserver() } returns flowOf()
         }
 
         @MockK
@@ -266,10 +283,14 @@ class FeatureFlagNotificationViewModelTest {
         lateinit var markE2EIRequiredAsNotified: MarkEnablingE2EIAsNotifiedUseCase
 
         @MockK
+        lateinit var ppLockTeamFeatureConfigObserver: AppLockTeamFeatureConfigObserver
+
+        @MockK
         lateinit var disableAppLockUseCase: DisableAppLockUseCase
 
         @MockK
         lateinit var globalDataStore: GlobalDataStore
+
 
         val viewModel: FeatureFlagNotificationViewModel = FeatureFlagNotificationViewModel(
             coreLogic = coreLogic,
@@ -282,14 +303,20 @@ class FeatureFlagNotificationViewModelTest {
             every { coreLogic.getSessionScope(any()).markGuestLinkFeatureFlagAsNotChanged } returns markGuestLinkFeatureFlagAsNotChanged
             every { coreLogic.getSessionScope(any()).markSelfDeletingMessagesAsNotified } returns markSelfDeletingStatusAsNotified
             every { coreLogic.getSessionScope(any()).markE2EIRequiredAsNotified } returns markE2EIRequiredAsNotified
+            coEvery { coreLogic.getSessionScope(any()).appLockTeamFeatureConfigObserver } returns ppLockTeamFeatureConfigObserver
             coEvery { coreLogic.getSessionScope(any()).observeFileSharingStatus.invoke() } returns flowOf()
             coEvery { coreLogic.getSessionScope(any()).observeGuestRoomLinkFeatureFlag.invoke() } returns flowOf()
             coEvery { coreLogic.getSessionScope(any()).observeE2EIRequired.invoke() } returns flowOf()
             coEvery { coreLogic.getSessionScope(any()).calls.observeEndCallDialog() } returns flowOf()
+            coEvery { ppLockTeamFeatureConfigObserver() } returns flowOf(null)
         }
 
         fun withCurrentSessions(result: CurrentSessionResult) = apply {
             coEvery { currentSession() } returns result
+        }
+
+        fun withIsAppLockSetup(result: Boolean) = apply {
+            coEvery { globalDataStore.isAppLockPasscodeSet() } returns result
         }
 
         fun withSyncState(stateFlow: Flow<SyncState>) = apply {
@@ -318,6 +345,10 @@ class FeatureFlagNotificationViewModelTest {
 
         fun withEndCallDialog() = apply {
             coEvery { coreLogic.getSessionScope(any()).calls.observeEndCallDialog() } returns flowOf(Unit)
+        }
+
+        fun withTeamAppLockEnforce(result: AppLockTeamConfig?) = apply {
+            coEvery { ppLockTeamFeatureConfigObserver() } returns flowOf(result)
         }
 
         fun arrange() = this to viewModel


### PR DESCRIPTION
…t enabled in the app

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

have team settings enforced but set to not changed
then the app will not be blocked 

### Solutions

block the app if the team setting is  enforced and the app is does not have a lock regardless of the is changed status

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
