### PR TITLE
fix: Mute Icon blocks click event

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/MutedConversationBadge.kt
@@ -21,7 +21,6 @@
 package com.wire.android.ui.home.conversationslist.common
 
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
@@ -52,7 +51,6 @@ fun MutedConversationBadge() {
             .height(dimensions().spacing20x)
             .padding(PaddingValues(dimensions().spacing0x))
             .clip(shape = RoundedCornerShape(size = dimensions().spacing6x))
-            .clickable(enabled = false, onClick = {})
             .border(
                 width = 1.dp,
                 color = MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a conversation has notifications muted, the muted icon will appear and block the click event (open conversation)

### Causes (Optional)

`clickable` parameter was being passed to `Box` that holds the muted icon UI, even when passed with `enabled=false` it still listens for a click and then does nothing, as its `false`.

### Solutions

Remove `clickable` parameter so it doesn't need to worry about any click specific on this icon/box.

### Testing

#### How to Test

- have a 1:1 or group conversation
- longtap on it on conversation list
- mute the conversation to any status
- mute icon next to the conversation is displayed
- now tap on the mute icon
- conversation should be opened
