### PR TITLE
fix: Second search query not updating and infinite loading icon (WPB-5744)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesViewModel.kt
@@ -33,7 +33,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -72,7 +72,7 @@ class SearchConversationMessagesViewModel @Inject constructor(
                 )
             }
             .debounce(SearchPeopleViewModel.DEFAULT_SEARCH_QUERY_DEBOUNCE)
-            .flatMapConcat { searchTerm ->
+            .flatMapLatest { searchTerm ->
                 getSearchMessagesForConversation(
                     searchTerm = searchTerm,
                     conversationId = conversationId,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5744" title="WPB-5744" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5744</a>  [Android] When searching for different terms without leaving search screen, first search is cached
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When trying a second search (when already a first search was done and there was no navigation from screen) it wouldn't bring any results and keep the previous results + an infinite loading icon on search input

### Causes (Optional)

We were using `flatMapConcat` instead of `flatMapLatest`

### Solutions

Use `flatMapLatest` so we always have the latest value available for search.

### Testing

#### How to Test

- Open App
- Open a Conversation (Group or 1:1)
- Open Search
- Type desired message to search
- Results will be displayed
- - Keep adding to search value and see results changing.
