### PR TITLE
fix: wrong system message icon paddings

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -165,7 +165,7 @@ fun SystemMessageItem(
                     isErrorString = message.addingFailed,
                 ),
                 onTextLayout = {
-                    centerOfFirstLine = if (it.lineCount == 0) 0f else (it.getLineTop(0) + it.getLineBottom(0) / 2)
+                    centerOfFirstLine = if (it.lineCount == 0) 0f else ((it.getLineTop(0) + it.getLineBottom(0)) / 2)
                 }
             )
             if ((message.addingFailed && expanded) || message.singleUserAddFailed) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -78,6 +78,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.annotatedText
 import com.wire.android.util.ui.toUIText
+import kotlin.math.roundToInt
 
 @Suppress("ComplexMethod")
 @Composable
@@ -117,48 +118,35 @@ fun SystemMessageItem(
                             + (dimensions().avatarStatusBorderSize * 2)
                             + (dimensions().avatarClickablePadding * 2)
                 )
-                .padding(
-                    end = fullAvatarOuterPadding,
-                    // because for now only end call icon is large and have vertical empty space
-                    // we need to disable padding for it
-                    top = if (message.messageContent.isSmallIcon) fullAvatarOuterPadding else dimensions().spacing0x
-                ),
+                .padding(end = fullAvatarOuterPadding)
+                .alignBy { it.measuredHeight / 2 },
             contentAlignment = Alignment.TopEnd
         ) {
             if (message.messageContent.iconResId != null) {
-                Box(
-                    modifier = Modifier.size(
-                        width = dimensions().systemMessageIconLargeSize,
-                        height = dimensions().systemMessageIconLargeSize
-                    ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    val size =
-                        if (message.messageContent.isSmallIcon) {
-                            dimensions().systemMessageIconSize
-                        } else {
-                            dimensions().systemMessageIconLargeSize
-                        }
                     Image(
                         painter = painterResource(id = message.messageContent.iconResId),
                         contentDescription = null,
                         colorFilter = getColorFilter(message.messageContent),
-                        modifier = Modifier.size(size),
+                        modifier = Modifier.size(
+                            if (message.messageContent.isSmallIcon) dimensions().systemMessageIconSize
+                            else dimensions().systemMessageIconLargeSize
+                        ),
                         contentScale = ContentScale.Crop
                     )
-                }
             }
         }
         Spacer(Modifier.width(dimensions().messageItemHorizontalPadding - fullAvatarOuterPadding))
+        val lineHeight = MaterialTheme.wireTypography.body02.lineHeight.value
+        var centerOfFirstLine by remember { mutableStateOf(lineHeight / 2f) }
         Column(
             Modifier
-                .defaultMinSize(minHeight = dimensions().spacing20x)
                 .animateContentSize(
                     animationSpec = spring(
                         dampingRatio = Spring.DampingRatioLowBouncy,
                         stiffness = Spring.StiffnessMediumLow
                     )
                 )
+                .alignBy { centerOfFirstLine.roundToInt() }
         ) {
             val context = LocalContext.current
             var expanded: Boolean by remember { mutableStateOf(false) }
@@ -174,22 +162,23 @@ fun SystemMessageItem(
                     normalColor = MaterialTheme.wireColorScheme.secondaryText,
                     boldColor = MaterialTheme.wireColorScheme.onBackground,
                     errorColor = MaterialTheme.wireColorScheme.error,
-                    isErrorString = message.addingFailed
-                )
+                    isErrorString = message.addingFailed,
+                ),
+                onTextLayout = {
+                    centerOfFirstLine = if (it.lineCount == 0) 0f else (it.getLineTop(0) + it.getLineBottom(0) / 2)
+                }
             )
             if ((message.addingFailed && expanded) || message.singleUserAddFailed) {
                 OfflineBackendsLearnMoreLink()
             }
-            if (message.messageContent is SystemMessage.Knock) {
-                VerticalSpace.x8()
-            }
             if (message.messageContent.expandable) {
+                VerticalSpace.x8()
                 WireSecondaryButton(
                     onClick = { expanded = !expanded },
                     text = stringResource(if (expanded) R.string.label_show_less else R.string.label_show_all),
                     fillMaxWidth = false,
                     minSize = dimensions().buttonSmallMinSize,
-                    minClickableSize = dimensions().buttonMinClickableSize,
+                    minClickableSize = dimensions().buttonSmallMinSize,
                     shape = RoundedCornerShape(size = dimensions().corner12x),
                     contentPadding = PaddingValues(horizontal = dimensions().spacing12x, vertical = dimensions().spacing8x),
                 )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The icons on system messages were wrongly placed lower than they should be, because of the overly complex paddings.

### Solutions

Remove some of the paddings and align icon to the first line of text, so that vertical center of icon is always at the vertical center of first line, no matter what font size and icon size there is.

### Testing

#### How to Test

Just look at the system messages.

### Attachments (Optional)

#### Before:
 ![system_message_icon_paddings_before](https://github.com/wireapp/wire-android/assets/30429749/8d886fe6-3fbb-41ab-a653-bb513627e8aa)

#### After:
![system_message_icon_paddings_after](https://github.com/wireapp/wire-android/assets/30429749/79bed7a6-1693-4647-8ee7-e1aab20df0c1)

https://github.com/wireapp/wire-android/assets/30429749/25e84931-7d01-402f-a9dc-7f04efdc122a

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
