### PR TITLE
fix: disable removing non-permanent clients [WPB-5700]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -121,7 +121,7 @@ fun DeviceDetailsContent(
                     .background(MaterialTheme.wireColorScheme.surface)
                     .wrapContentWidth(Alignment.CenterHorizontally)
             ) {
-                if (!state.isCurrentDevice && state.isSelfClient) {
+                if (state.canBeRemoved) {
                     Text(
                         text = stringResource(
                             id = if (BuildConfig.WIPE_ON_DEVICE_REMOVAL) {

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
@@ -15,6 +15,7 @@ import com.wire.android.ui.authentication.devices.remove.RemoveDeviceDialogState
 import com.wire.android.ui.authentication.devices.remove.RemoveDeviceError
 import com.wire.android.ui.navArgs
 import com.wire.android.ui.settings.devices.model.DeviceDetailsState
+import com.wire.kalium.logic.data.client.ClientType
 import com.wire.kalium.logic.data.client.DeleteClientParam
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.user.UserId
@@ -115,17 +116,18 @@ class DeviceDetailsViewModel @Inject constructor(
     private fun observeDeviceDetails() {
         viewModelScope.launch {
             observeClientDetails(userId, deviceId).collect { result ->
-                when (result) {
+                state = when (result) {
                     is GetClientDetailsResult.Failure.Generic -> {
                         appLogger.e("Error getting self clients $result")
-                        state = state.copy(error = RemoveDeviceError.InitError)
+                        state.copy(error = RemoveDeviceError.InitError)
                     }
 
                     is GetClientDetailsResult.Success -> {
-                        state = state.copy(
+                        state.copy(
                             device = Device(result.client),
                             isCurrentDevice = result.isCurrentClient,
-                            removeDeviceDialogState = RemoveDeviceDialogState.Hidden
+                            removeDeviceDialogState = RemoveDeviceDialogState.Hidden,
+                            canBeRemoved = !result.isCurrentClient && isSelfClient && result.client.type == ClientType.Permanent,
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/DeviceDetailsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/DeviceDetailsState.kt
@@ -14,5 +14,6 @@ data class DeviceDetailsState(
     val isSelfClient: Boolean = false,
     val userName: String? = null,
     val isE2eiCertificateActivated: Boolean = false,
-    val e2eiCertificate: E2eiCertificate = E2eiCertificate()
+    val e2eiCertificate: E2eiCertificate = E2eiCertificate(),
+    val canBeRemoved: Boolean = false,
 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5700" title="WPB-5700" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-5700</a>  [Android] Handle legal hold device
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry pick from the original PR: 
- #2485

---- 

 ⚠️ Conflicts during cherry-pick:


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, the user can remove clients of all types, even legal hold one.

### Solutions

Disable the option to delete non-permanent clients.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Have a user who has legal hold enabled, open my devices screen and click on legal hold device.

### Attachments (Optional)

| Before | After&nbsp;&nbsp;&nbsp; |
| ----------- | ------------ |
| ![remove_legalhold_client_before](https://github.com/wireapp/wire-android/assets/30429749/858e89e6-d477-4031-8c00-7b6dcbe46484) | ![remove_legalhold_client_after](https://github.com/wireapp/wire-android/assets/30429749/714ad1a1-cd17-4ec4-a0bc-4403c4fb4987) |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .