### PR TITLE
fix: App lock does not show up after fresh install (WPB-5609)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCase.kt
@@ -21,7 +21,6 @@ import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
-import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -34,39 +33,39 @@ import kotlin.time.Duration.Companion.seconds
 @Singleton
 class ObserveAppLockConfigUseCase @Inject constructor(
     private val globalDataStore: GlobalDataStore,
-    @KaliumCoreLogic private val coreLogic: CoreLogic,
-    private val currentSession: CurrentSessionUseCase
+    @KaliumCoreLogic private val coreLogic: CoreLogic
 ) {
-
     operator fun invoke(): Flow<AppLockConfig> = channelFlow {
-        when (val currentSession = currentSession()) {
-            is CurrentSessionResult.Failure -> {
-                send(AppLockConfig.Disabled(DEFAULT_APP_LOCK_TIMEOUT))
-            }
+        coreLogic.getGlobalScope().session.currentSessionFlow().collectLatest { sessionResult ->
+            when (sessionResult) {
+                is CurrentSessionResult.Failure -> {
+                    send(AppLockConfig.Disabled(DEFAULT_APP_LOCK_TIMEOUT))
+                }
 
-            is CurrentSessionResult.Success -> {
-                val userId = currentSession.accountInfo.userId
-                val appLockTeamFeatureConfigFlow =
-                    coreLogic.getSessionScope(userId).appLockTeamFeatureConfigObserver
+                is CurrentSessionResult.Success -> {
+                    val userId = sessionResult.accountInfo.userId
+                    val appLockTeamFeatureConfigFlow =
+                        coreLogic.getSessionScope(userId).appLockTeamFeatureConfigObserver
 
-                appLockTeamFeatureConfigFlow().combineTransform(
-                    globalDataStore.isAppLockPasscodeSetFlow()
-                ) { teamAppLockConfig, isAppLockConfigured ->
-                    when {
-                        isAppLockConfigured -> {
-                            emit(AppLockConfig.Enabled(teamAppLockConfig?.timeout ?: DEFAULT_APP_LOCK_TIMEOUT))
+                    appLockTeamFeatureConfigFlow().combineTransform(
+                        globalDataStore.isAppLockPasscodeSetFlow()
+                    ) { teamAppLockConfig, isAppLockConfigured ->
+                        when {
+                            isAppLockConfigured -> {
+                                emit(AppLockConfig.Enabled(teamAppLockConfig?.timeout ?: DEFAULT_APP_LOCK_TIMEOUT))
+                            }
+
+                            teamAppLockConfig != null && teamAppLockConfig.isEnforced -> {
+                                emit(AppLockConfig.EnforcedByTeam(teamAppLockConfig.timeout))
+                            }
+
+                            else -> {
+                                emit(AppLockConfig.Disabled(teamAppLockConfig?.timeout ?: DEFAULT_APP_LOCK_TIMEOUT))
+                            }
                         }
-
-                        teamAppLockConfig != null && teamAppLockConfig.isEnforced -> {
-                            emit(AppLockConfig.EnforcedByTeam(teamAppLockConfig.timeout))
-                        }
-
-                        else -> {
-                            emit(AppLockConfig.Disabled(teamAppLockConfig?.timeout ?: DEFAULT_APP_LOCK_TIMEOUT))
-                        }
+                    }.collectLatest {
+                        send(it)
                     }
-                }.collectLatest {
-                    send(it)
                 }
             }
         }

--- a/app/src/test/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCaseTest.kt
@@ -20,13 +20,12 @@ package com.wire.android.feature
 import app.cash.turbine.test
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.configuration.AppLockTeamConfig
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.UserSessionScope
-import com.wire.kalium.logic.configuration.AppLockTeamConfig
 import com.wire.kalium.logic.feature.applock.AppLockTeamFeatureConfigObserver
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
-import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -117,9 +116,6 @@ class ObserveAppLockConfigUseCaseTest {
         lateinit var globalDataStore: GlobalDataStore
 
         @MockK
-        lateinit var currentSession: CurrentSessionUseCase
-
-        @MockK
         lateinit var coreLogic: CoreLogic
 
         @MockK
@@ -131,8 +127,7 @@ class ObserveAppLockConfigUseCaseTest {
         val useCase by lazy {
             ObserveAppLockConfigUseCase(
                 globalDataStore = globalDataStore,
-                coreLogic = coreLogic,
-                currentSession = currentSession
+                coreLogic = coreLogic
             )
         }
 
@@ -143,11 +138,13 @@ class ObserveAppLockConfigUseCaseTest {
         fun arrange() = this to useCase
 
         fun withNonValidSession() = apply {
-            coEvery { currentSession() } returns CurrentSessionResult.Failure.SessionNotFound
+            coEvery { coreLogic.getGlobalScope().session.currentSessionFlow() } returns
+                    flowOf(CurrentSessionResult.Failure.SessionNotFound)
         }
 
         fun withValidSession() = apply {
-            coEvery { currentSession() } returns CurrentSessionResult.Success(accountInfo)
+            coEvery { coreLogic.getGlobalScope().session.currentSessionFlow() } returns
+                    flowOf(CurrentSessionResult.Success(accountInfo))
         }
 
         fun withTeamAppLockEnabled() = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5609" title="WPB-5609" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5609</a>  [Android] When screen locked applock doesn't start
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2499

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On fresh install, app lock is not showing up after enabling it, putting the in background and reopening the app again.

 
### Causes (Optional)

We were not observing current session. So every time we open the app, we use the old value returned  by , which is no session.
 As a result the app lock status is always **Disabled** and no app lock will shoup

### Solutions

Observe current session to get updated session value.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- Login on fresh install
- Enable app lock and put the app in background (don't kill it)
- Wait for the timeout(1min) and open the app again
- You should see the app lock

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .