### PR TITLE
feat(mls): reevaluate protocol on demand [WPB-5049]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/ConversationModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/ConversationModule.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.JoinConversationViaCodeUseCase
 import com.wire.kalium.logic.feature.conversation.LeaveConversationUseCase
+import com.wire.kalium.logic.feature.conversation.NotifyConversationIsOpenUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveArchivedUnreadConversationsCountUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationInteractionAvailabilityUseCase
@@ -90,6 +91,11 @@ class ConversationModule {
     @Provides
     fun provideObserveConversationDetailsUseCase(conversationScope: ConversationScope): ObserveConversationDetailsUseCase =
         conversationScope.observeConversationDetails
+
+    @ViewModelScoped
+    @Provides
+    fun provideNotifyConversationIsOpenUseCase(conversationScope: ConversationScope): NotifyConversationIsOpenUseCase =
+        conversationScope.notifyConversationIsOpen
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/banner/ConversationBannerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/banner/ConversationBannerViewModel.kt
@@ -34,6 +34,7 @@ import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.feature.conversation.NotifyConversationIsOpenUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -48,6 +49,7 @@ class ConversationBannerViewModel @Inject constructor(
     override val savedStateHandle: SavedStateHandle,
     private val observeConversationMembersByTypes: ObserveConversationMembersByTypesUseCase,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
+    private val notifyConversationIsOpen: NotifyConversationIsOpenUseCase,
 ) : SavedStateViewModel(savedStateHandle) {
 
     var bannerState by mutableStateOf<UIText?>(null)
@@ -66,6 +68,9 @@ class ConversationBannerViewModel @Inject constructor(
                 }
                 .flatMapLatest { observeConversationMembersByTypes(conversationId) }
                 .collect(::handleConversationMemberTypes)
+        }
+        viewModelScope.launch {
+            notifyConversationIsOpen(conversationId)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5049" title="WPB-5049" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-5049</a>  [Android] Re-evaluate 1-1 conversation upon navigating to it
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

As seen on:
- https://github.com/wireapp/kalium/pull/2278

> We should have a fallback / safety net for 1:1 migrations.

### Solutions


Kalium now exposes a `NotifyConversationIsOpenUseCase`. This way it can perform sanity checks when it knows that the conversation is visible to the user.

This PR adds a call to the new use case within `ConversationBannerViewModel`. Ensuring that every time a conversation is opened, Kalium will figure out its magic. Corresponding tests have also been added to validate this functionality.

### Dependencies

Needs releases with:

- https://github.com/wireapp/kalium/pull/2278

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

Navigate to any conversation. The UseCase should be called. Kalium will decide whether or not to upgrade protocol.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
