### PR TITLE
feat: display received location messages - default placeholder (WPB-5483)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -267,6 +267,13 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
 
                 is WithUser.MembersCreationAdded -> UILastMessageContent.None
                 is WithUser.MembersFailedToAdd -> UILastMessageContent.None
+                is WithUser.Location -> UILastMessageContent.SenderWithMessage(
+                    userUIText,
+                    UIText.StringResource(
+                        if (isSelfMessage) R.string.last_message_self_user_shared_location
+                        else R.string.last_message_other_user_shared_location
+                    )
+                )
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
@@ -23,6 +23,7 @@ package com.wire.android.mapper
 import com.wire.android.R
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.home.conversations.findUser
+import com.wire.android.ui.home.conversations.model.DEFAULT_LOCATION_ZOOM
 import com.wire.android.ui.home.conversations.model.DeliveryStatusContent
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.MessageButton
@@ -126,6 +127,7 @@ class RegularMessageMapper @Inject constructor(
                 latitude = content.latitude,
                 longitude = content.longitude,
                 name = content.name.orEmpty(),
+                zoom = content.zoom ?: DEFAULT_LOCATION_ZOOM,
                 deliveryStatus = mapRecipientsFailure(userList, message.deliveryStatus)
             )
         }

--- a/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
@@ -121,6 +121,15 @@ class RegularMessageMapper @Inject constructor(
             )
         }
 
+        is MessageContent.Location -> {
+            UIMessageContent.Location(
+                latitude = content.latitude,
+                longitude = content.longitude,
+                name = content.name.orEmpty(),
+                deliveryStatus = mapRecipientsFailure(userList, message.deliveryStatus)
+            )
+        }
+
         else -> toText(message.conversationId, content, userList, message.deliveryStatus)
     }
 

--- a/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
@@ -122,18 +122,22 @@ class RegularMessageMapper @Inject constructor(
             )
         }
 
-        is MessageContent.Location -> {
-            UIMessageContent.Location(
-                latitude = content.latitude,
-                longitude = content.longitude,
-                name = content.name.orEmpty(),
-                zoom = content.zoom ?: DEFAULT_LOCATION_ZOOM,
-                deliveryStatus = mapRecipientsFailure(userList, message.deliveryStatus)
-            )
-        }
+        is MessageContent.Location -> toLocation(content, userList, message)
 
         else -> toText(message.conversationId, content, userList, message.deliveryStatus)
     }
+
+    private fun toLocation(
+        content: MessageContent.Location,
+        userList: List<User>,
+        message: Message.Regular
+    ) = UIMessageContent.Location(
+        latitude = content.latitude,
+        longitude = content.longitude,
+        name = content.name.orEmpty(),
+        zoom = content.zoom ?: DEFAULT_LOCATION_ZOOM,
+        deliveryStatus = mapRecipientsFailure(userList, message.deliveryStatus)
+    )
 
     private fun mapAudio(
         assetContent: AssetContent,

--- a/app/src/main/kotlin/com/wire/android/notification/Models.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/Models.kt
@@ -141,6 +141,7 @@ enum class CommentResId(@StringRes val value: Int) {
     MISSED_CALL(R.string.notification_missed_call),
     NOT_SUPPORTED(R.string.notification_not_supported_issue),
     KNOCK(R.string.notification_knock),
+    LOCATION(R.string.notification_shared_location),
 }
 
 fun LocalNotification.Conversation.intoNotificationConversation(): NotificationConversation {
@@ -233,4 +234,5 @@ fun LocalNotificationCommentType.intoCommentResId(): CommentResId =
         LocalNotificationCommentType.REACTION -> CommentResId.REACTION
         LocalNotificationCommentType.MISSED_CALL -> CommentResId.MISSED_CALL
         LocalNotificationCommentType.NOT_SUPPORTED_YET -> CommentResId.NOT_SUPPORTED
+        LocalNotificationCommentType.LOCATION -> CommentResId.LOCATION
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -644,10 +644,11 @@ private fun MessageContent(
                     locationName = messageContent.name,
                     locationUrl = locationUrl,
                     onLocationClick = Clickable(
-                        enabled = !message.isPending && message.isAvailable,
+                        enabled = message.isAvailable,
                         onClick = { onLinkClick(locationUrl) },
                         onLongClick = onLongClick
-                    ))
+                    )
+                )
                 PartialDeliveryInformation(messageContent.deliveryStatus)
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -636,12 +636,11 @@ private fun MessageContent(
             }
         }
 
-        is UIMessageContent.Location -> {
-            val resources = LocalContext.current.resources
-            val locationUrl = messageContent.createLink(resources)
+        is UIMessageContent.Location -> with(messageContent) {
+            val locationUrl = stringResource(urlCoordinates, zoom, latitude, longitude)
             Column {
                 LocationMessageContent(
-                    locationName = messageContent.name,
+                    locationName = name,
                     locationUrl = locationUrl,
                     onLocationClick = Clickable(
                         enabled = message.isAvailable,
@@ -649,7 +648,7 @@ private fun MessageContent(
                         onLongClick = onLongClick
                     )
                 )
-                PartialDeliveryInformation(messageContent.deliveryStatus)
+                PartialDeliveryInformation(deliveryStatus)
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -87,6 +87,7 @@ import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMess
 import com.wire.android.ui.home.conversations.model.messagetypes.location.LocationMessageContent
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.launchGeoIntent
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.user.UserId
 
@@ -637,6 +638,7 @@ private fun MessageContent(
         }
 
         is UIMessageContent.Location -> with(messageContent) {
+            val context = LocalContext.current
             val locationUrl = stringResource(urlCoordinates, zoom, latitude, longitude)
             Column {
                 LocationMessageContent(
@@ -644,7 +646,7 @@ private fun MessageContent(
                     locationUrl = locationUrl,
                     onLocationClick = Clickable(
                         enabled = message.isAvailable,
-                        onClick = { onLinkClick(locationUrl) },
+                        onClick = { launchGeoIntent(latitude, longitude, name, locationUrl, context) },
                         onLongClick = onLongClick
                     )
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -84,6 +84,7 @@ import com.wire.android.ui.home.conversations.model.messagetypes.asset.Restricte
 import com.wire.android.ui.home.conversations.model.messagetypes.asset.RestrictedGenericFileMessage
 import com.wire.android.ui.home.conversations.model.messagetypes.audio.AudioMessage
 import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMessageParams
+import com.wire.android.ui.home.conversations.model.messagetypes.location.LocationMessageContent
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.kalium.logic.data.message.Message
@@ -631,6 +632,22 @@ private fun MessageContent(
                     },
                     onAudioMessageLongClick = onLongClick
                 )
+                PartialDeliveryInformation(messageContent.deliveryStatus)
+            }
+        }
+
+        is UIMessageContent.Location -> {
+            val resources = LocalContext.current.resources
+            val locationUrl = messageContent.createLink(resources)
+            Column {
+                LocationMessageContent(
+                    locationName = messageContent.name,
+                    locationUrl = locationUrl,
+                    onLocationClick = Clickable(
+                        enabled = !message.isPending && message.isAvailable,
+                        onClick = { onLinkClick(locationUrl) },
+                        onLongClick = onLongClick
+                    ))
                 PartialDeliveryInformation(messageContent.deliveryStatus)
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -212,13 +212,6 @@ sealed class UIMessageContent {
         val deliveryStatus: DeliveryStatusContent
     }
 
-    /**
-     * Interface for [UIMessage] classes that can generate a link.
-     */
-    interface Linkable {
-        fun createLink(resources: Resources): String
-    }
-
     data class TextMessage(
         val messageBody: MessageBody,
         override val deliveryStatus: DeliveryStatusContent = DeliveryStatusContent.CompleteDelivery
@@ -280,11 +273,9 @@ sealed class UIMessageContent {
         val longitude: Float,
         val name: String,
         val zoom: Int = DEFAULT_LOCATION_ZOOM,
+        @StringRes val urlCoordinates: Int = R.string.url_maps_location_coordinates,
         override val deliveryStatus: DeliveryStatusContent = DeliveryStatusContent.CompleteDelivery
-    ) : Regular(), PartialDeliverable, Linkable {
-        override fun createLink(resources: Resources): String =
-            resources.getString(R.string.url_maps_location_coordinates, zoom, latitude, longitude)
-    }
+    ) : Regular(), PartialDeliverable
 
     sealed class SystemMessage(
         @DrawableRes val iconResId: Int?,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -212,6 +212,13 @@ sealed class UIMessageContent {
         val deliveryStatus: DeliveryStatusContent
     }
 
+    /**
+     * Interface for [UIMessage] classes that can generate a link.
+     */
+    interface Linkable {
+        fun createLink(resources: Resources): String
+    }
+
     data class TextMessage(
         val messageBody: MessageBody,
         override val deliveryStatus: DeliveryStatusContent = DeliveryStatusContent.CompleteDelivery
@@ -266,6 +273,18 @@ sealed class UIMessageContent {
         val downloadStatus: Message.DownloadStatus,
         override val deliveryStatus: DeliveryStatusContent = DeliveryStatusContent.CompleteDelivery
     ) : Regular(), PartialDeliverable
+
+    @Stable
+    data class Location(
+        val latitude: Float,
+        val longitude: Float,
+        val name: String,
+        val zoom: Int = DEFAULT_LOCATION_ZOOM,
+        override val deliveryStatus: DeliveryStatusContent = DeliveryStatusContent.CompleteDelivery
+    ) : Regular(), PartialDeliverable, Linkable {
+        override fun createLink(resources: Resources): String =
+            resources.getString(R.string.url_maps_location_coordinates, zoom, latitude, longitude)
+    }
 
     sealed class SystemMessage(
         @DrawableRes val iconResId: Int?,
@@ -558,3 +577,5 @@ data class MessageButton(
     val text: String,
     val isSelected: Boolean,
 )
+
+const val DEFAULT_LOCATION_ZOOM = 20

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -273,7 +273,7 @@ sealed class UIMessageContent {
         val longitude: Float,
         val name: String,
         val zoom: Int = DEFAULT_LOCATION_ZOOM,
-        @StringRes val urlCoordinates: Int = R.string.url_maps_location_coordinates,
+        @StringRes val urlCoordinates: Int = R.string.url_maps_location_coordinates_fallback,
         override val deliveryStatus: DeliveryStatusContent = DeliveryStatusContent.CompleteDelivery
     ) : Regular(), PartialDeliverable
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -47,7 +46,6 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LocationMessageContent(
     locationName: String,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
@@ -55,7 +55,6 @@ fun LocationMessageContent(
     onLocationClick: Clickable
 ) {
     Card(
-        onClick = { },
         modifier = Modifier.clickable(onLocationClick),
         shape = RoundedCornerShape(dimensions().messageAssetBorderRadius),
         border = BorderStroke(dimensions().spacing1x, MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
@@ -17,8 +17,10 @@
  */
 package com.wire.android.ui.home.conversations.model.messagetypes.location
 
-import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -28,15 +30,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.sp
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.clickable
@@ -52,30 +56,41 @@ fun LocationMessageContent(
     locationUrl: String,
     onLocationClick: Clickable
 ) {
-    Card(
-        modifier = Modifier.clickable(onLocationClick),
-        shape = RoundedCornerShape(dimensions().messageAssetBorderRadius),
-        border = BorderStroke(dimensions().spacing1x, MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline)
+    Column(
+        modifier = Modifier
+            .clickable(onLocationClick)
+            .clip(shape = RoundedCornerShape(dimensions().messageAssetBorderRadius))
+            .border(
+                width = dimensions().spacing1x,
+                color = MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline,
+                shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
+            )
+            .background(
+                color = MaterialTheme.wireColorScheme.surfaceVariant,
+                shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
+            )
+            .height(dimensions().spacing64x),
+        verticalArrangement = Arrangement.SpaceEvenly,
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(PaddingValues(horizontal = dimensions().spacing8x))
-                .height(dimensions().audioMessageHeight),
+                .padding(PaddingValues(horizontal = dimensions().spacing8x)),
             horizontalArrangement = Arrangement.Start,
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
                 painter = painterResource(id = R.drawable.ic_location),
-                contentDescription = "location desc",
+                contentDescription = stringResource(id = R.string.content_description_location_icon),
                 modifier = Modifier.size(MaterialTheme.wireDimensions.wireIconButtonSize)
             )
             Spacer(modifier = Modifier.width(dimensions().spacing4x))
             Text(
                 text = locationName,
-                style = MaterialTheme.wireTypography.body02.copy(color = MaterialTheme.wireColorScheme.secondaryText),
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 1
+                style = MaterialTheme.wireTypography.body02,
+                fontSize = 15.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
         }
         Text(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
@@ -1,0 +1,108 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.model.messagetypes.location
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import com.wire.android.R
+import com.wire.android.model.Clickable
+import com.wire.android.ui.common.clickable
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LocationMessageContent(
+    locationName: String,
+    locationUrl: String,
+    onLocationClick: Clickable
+) {
+    Card(
+        onClick = { },
+        modifier = Modifier.clickable(onLocationClick),
+        shape = RoundedCornerShape(dimensions().messageAssetBorderRadius),
+        border = BorderStroke(dimensions().spacing1x, MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(PaddingValues(horizontal = dimensions().spacing8x))
+                .height(dimensions().audioMessageHeight),
+            horizontalArrangement = Arrangement.Start,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_location),
+                contentDescription = "location desc",
+                modifier = Modifier.size(MaterialTheme.wireDimensions.wireIconButtonSize)
+            )
+            Spacer(modifier = Modifier.width(dimensions().spacing4x))
+            Text(
+                text = locationName,
+                style = MaterialTheme.wireTypography.body02.copy(color = MaterialTheme.wireColorScheme.secondaryText),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1
+            )
+        }
+        Text(
+            text = locationUrl,
+            style = MaterialTheme.wireTypography.subline01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 1,
+            modifier = Modifier.padding(
+                PaddingValues(
+                    bottom = dimensions().spacing8x,
+                    start = dimensions().spacing8x,
+                    end = dimensions().spacing8x
+                )
+            )
+        )
+    }
+}
+
+@Composable
+@PreviewMultipleThemes
+fun PreviewLocationMessageContent() {
+    LocationMessageContent(
+        locationName = "Rapa Nui",
+        locationUrl = "https://www.google.com/maps/place/Rapa+Nui",
+        onLocationClick = Clickable()
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
@@ -59,6 +59,7 @@ fun LocationMessageContent(
     Column(
         modifier = Modifier
             .clickable(onLocationClick)
+            .padding(top = dimensions().spacing4x)
             .clip(shape = RoundedCornerShape(dimensions().messageAssetBorderRadius))
             .border(
                 width = dimensions().spacing1x,

--- a/app/src/main/kotlin/com/wire/android/util/CommonIntentUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CommonIntentUtil.kt
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.net.toUri
+import com.wire.android.appLogger
+
+/**
+ * Launches a geo intent with the given latitude and longitude.
+ * If no intent can be found to handle the geo intent, a fallback to url is used.
+ */
+fun launchGeoIntent(
+    latitude: Float,
+    longitude: Float,
+    placeName: String?,
+    fallbackUrl: String,
+    context: Context
+) {
+    val geoStringUrl = StringBuilder("geo:0,0?q=$latitude,$longitude")
+    if (!placeName.isNullOrEmpty()) geoStringUrl.append("(${Uri.encode(placeName)})")
+    try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(geoStringUrl.toString())))
+    } catch (e: ActivityNotFoundException) {
+        appLogger.e("No activity found to handle geo intent, fallback to url", e)
+        context.startActivity(Intent(Intent.ACTION_VIEW, fallbackUrl.toUri()))
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/util/CommonIntentUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CommonIntentUtil.kt
@@ -24,9 +24,12 @@ import android.net.Uri
 import androidx.core.net.toUri
 import com.wire.android.appLogger
 
+// geo intent url scheme
+internal const val GEO_INTENT_URL = "geo:0,0?q=%1f,%2f"
+
 /**
  * Launches a geo intent with the given latitude and longitude.
- * If no app/activity can be found to handle the geo intent, a fallback to url is used.
+ * If no app/activity can be found to handle the [GEO_INTENT_URL], a [fallbackUrl] is used.
  */
 fun launchGeoIntent(
     latitude: Float,
@@ -35,7 +38,7 @@ fun launchGeoIntent(
     fallbackUrl: String,
     context: Context
 ) {
-    val geoStringUrl = StringBuilder("geo:0,0?q=$latitude,$longitude")
+    val geoStringUrl = StringBuilder(String.format(GEO_INTENT_URL, latitude, longitude))
     if (!placeName.isNullOrEmpty()) geoStringUrl.append("(${Uri.encode(placeName)})")
     try {
         context.startActivity(Intent(Intent.ACTION_VIEW, geoStringUrl.toString().toUri()))

--- a/app/src/main/kotlin/com/wire/android/util/CommonIntentUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CommonIntentUtil.kt
@@ -25,7 +25,7 @@ import androidx.core.net.toUri
 import com.wire.android.appLogger
 
 // geo intent url scheme
-internal const val GEO_INTENT_URL = "geo:0,0?q=%1f,%2f"
+internal const val GEO_INTENT_URL = "geo:0,0?q=%f,%f"
 
 /**
  * Launches a geo intent with the given latitude and longitude.

--- a/app/src/main/kotlin/com/wire/android/util/CommonIntentUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CommonIntentUtil.kt
@@ -26,7 +26,7 @@ import com.wire.android.appLogger
 
 /**
  * Launches a geo intent with the given latitude and longitude.
- * If no intent can be found to handle the geo intent, a fallback to url is used.
+ * If no app/activity can be found to handle the geo intent, a fallback to url is used.
  */
 fun launchGeoIntent(
     latitude: Float,
@@ -38,7 +38,7 @@ fun launchGeoIntent(
     val geoStringUrl = StringBuilder("geo:0,0?q=$latitude,$longitude")
     if (!placeName.isNullOrEmpty()) geoStringUrl.append("(${Uri.encode(placeName)})")
     try {
-        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(geoStringUrl.toString())))
+        context.startActivity(Intent(Intent.ACTION_VIEW, geoStringUrl.toString().toUri()))
     } catch (e: ActivityNotFoundException) {
         appLogger.e("No activity found to handle geo intent, fallback to url", e)
         context.startActivity(Intent(Intent.ACTION_VIEW, fallbackUrl.toUri()))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,7 +187,7 @@
     <string name="url_federation_support" translatable="false">https://support.wire.com/hc/categories/4719917054365-Federation</string>
     <string name="url_create_account_learn_more" translatable="false">https://support.wire.com/hc/articles/115004082129</string>
     <string name="url_android_release_notes" translatable="false">https://medium.com/wire-news/android-updates/home</string>
-    <string name="url_maps_location_coordinates" translatable="false">http://maps.google.com/maps?z=%1d&amp;q=%2f,%2f</string>
+    <string name="url_maps_location_coordinates" translatable="false">http://maps.google.com/maps?z=%1d&amp;q=loc:%2f+%2f</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="archive_screen_title">Archive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,7 @@
     <string name="url_federation_support" translatable="false">https://support.wire.com/hc/categories/4719917054365-Federation</string>
     <string name="url_create_account_learn_more" translatable="false">https://support.wire.com/hc/articles/115004082129</string>
     <string name="url_android_release_notes" translatable="false">https://medium.com/wire-news/android-updates/home</string>
+    <string name="url_maps_location_coordinates" translatable="false">http://maps.google.com/maps?z=%1d&amp;q=%2f,%2f</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="archive_screen_title">Archive</string>
@@ -659,6 +660,8 @@
     <string name="last_message_other_user_shared_video">shared a video.</string>
     <string name="last_message_self_user_shared_audio">shared an audio message.</string>
     <string name="last_message_other_user_shared_audio">shared an audio message.</string>
+    <string name="last_message_self_user_shared_location">shared a location.</string>
+    <string name="last_message_other_user_shared_location">shared a location.</string>
     <string name="last_message_self_user_knock">pinged.</string>
     <string name="last_message_other_user_knock">pinged.</string>
     <string name="last_message_call">called.</string>
@@ -770,6 +773,7 @@
     <string name="phone_label">Phone</string>
     <!-- Notifications -->
     <string name="notification_shared_picture">Shared a picture</string>
+    <string name="notification_shared_location">Shared a location</string>
     <string name="notification_shared_file">Shared a file</string>
     <string name="notification_reacted">Added a reaction</string>
     <string name="notification_missed_call">Missed call</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Wire
   ~ Copyright (C) 2023 Wire Swiss GmbH
   ~
@@ -187,7 +186,7 @@
     <string name="url_federation_support" translatable="false">https://support.wire.com/hc/categories/4719917054365-Federation</string>
     <string name="url_create_account_learn_more" translatable="false">https://support.wire.com/hc/articles/115004082129</string>
     <string name="url_android_release_notes" translatable="false">https://medium.com/wire-news/android-updates/home</string>
-    <string name="url_maps_location_coordinates" translatable="false">http://maps.google.com/maps?z=%1d&amp;q=loc:%2f+%2f</string>
+    <string name="url_maps_location_coordinates_fallback" translatable="false">http://maps.google.com/maps?z=%1d&amp;q=loc:%2f+%2f</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="archive_screen_title">Archive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,6 +174,7 @@
     <string name="content_description_mls_certificate_valid">All devices of all participants have a valid MLS certificate</string>
     <string name="content_description_proteus_certificate_valid">All of all participants are verified (Proteus)</string>
     <string name="content_description_jump_to_last_message">Scroll down to last message, button</string>
+    <string name="content_description_location_icon">Location item</string>
     <!-- Non translatable strings-->
     <string name="url_support" translatable="false">https://support.wire.com</string>
     <string name="url_decryption_failure_learn_more" translatable="false">https://support.wire.com/hc/articles/207948115-Why-was-I-notified-that-a-message-from-a-contact-was-not-received-</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5483" title="WPB-5483" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-5483</a>  [Android] Receive Location - UI no image placeholder
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently we are displaying a placeholder that a location was shared "sent a message with Location content"

### Causes (Optional)

Not implemented.

### Solutions

Display a placeholder for the location message received with the possibility to open the link in google maps.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/2285

- [x] GitHub link to other pull request

### Testing

#### How to Test

Share a location from an iOS device and see it received in android.

### Attachments (Optional)

https://github.com/wireapp/wire-android/assets/5806454/b40377a7-a2ad-4bfc-89b8-b055f0a9760d

https://github.com/wireapp/wire-android/assets/5806454/dc39fffd-49e0-4d04-8d79-d49bde3f8430

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
