### PR TITLE
fix: Profile avatar not updating (WPB-5494)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
@@ -45,6 +45,7 @@ import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
+import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.ArrowRightIcon
@@ -74,7 +75,8 @@ import okio.Path
 @Composable
 fun AvatarPickerScreen(
     navigator: Navigator,
-    viewModel: AvatarPickerViewModel = hiltViewModel()
+    viewModel: AvatarPickerViewModel = hiltViewModel(),
+    resultNavigator: ResultBackNavigator<String?>
 ) {
     val context = LocalContext.current
 
@@ -96,7 +98,12 @@ fun AvatarPickerScreen(
         viewModel = viewModel,
         state = state,
         onCloseClick = navigator::navigateBack,
-        onSaveClick = { viewModel.uploadNewPickedAvatar(navigator::navigateBack) }
+        onSaveClick = {
+            viewModel.uploadNewPickedAvatar {
+                resultNavigator.setResult(it)
+                resultNavigator.navigateBack()
+            }
+        }
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
@@ -99,8 +99,8 @@ fun AvatarPickerScreen(
         state = state,
         onCloseClick = navigator::navigateBack,
         onSaveClick = {
-            viewModel.uploadNewPickedAvatar {
-                resultNavigator.setResult(it)
+            viewModel.uploadNewPickedAvatar { avatarAssetId ->
+                resultNavigator.setResult(avatarAssetId)
                 resultNavigator.navigateBack()
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
@@ -103,7 +103,7 @@ class AvatarPickerViewModel @Inject constructor(
         pictureState = PictureState.Picked(updatedUri)
     }
 
-    fun uploadNewPickedAvatar(onSuccess: () -> Unit) {
+    fun uploadNewPickedAvatar(onComplete: (avatarAssetId: String?) -> Unit) {
         val imgUri = pictureState.avatarUri
 
         viewModelScope.launch {
@@ -115,7 +115,7 @@ class AvatarPickerViewModel @Inject constructor(
             when (val result = uploadUserAvatar(avatarPath, imageDataSize)) {
                 is UploadAvatarResult.Success -> {
                     dataStore.updateUserAvatarAssetId(result.userAssetId.toString())
-                    onSuccess()
+                    onComplete(dataStore.avatarAssetId.first())
                 }
                 is UploadAvatarResult.Failure -> {
                     when (result.coreFailure) {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -53,7 +53,10 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
+import com.ramcosta.composedestinations.result.NavResult
+import com.ramcosta.composedestinations.result.ResultRecipient
 import com.wire.android.R
+import com.wire.android.appLogger
 import com.wire.android.feature.NavigationSwitchAccountActions
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.model.Clickable
@@ -102,7 +105,8 @@ import com.wire.kalium.logic.data.user.UserId
 @Composable
 fun SelfUserProfileScreen(
     navigator: Navigator,
-    viewModelSelf: SelfUserProfileViewModel = hiltViewModel()
+    viewModelSelf: SelfUserProfileViewModel = hiltViewModel(),
+    avatarPickerResultRecipient: ResultRecipient<AvatarPickerScreenDestination, String?>
 ) {
     SelfUserProfileContent(
         state = viewModelSelf.userProfileState,
@@ -120,6 +124,22 @@ fun SelfUserProfileScreen(
         onOtherAccountClick = { viewModelSelf.switchAccount(it, NavigationSwitchAccountActions(navigator::navigate)) },
         isUserInCall = viewModelSelf::isUserInCall
     )
+
+    avatarPickerResultRecipient.onNavResult { result ->
+        when (result) {
+            is NavResult.Canceled -> {
+                appLogger.i("Error with receiving navigation back args from avatar picker in SelfUserProfileScreen")
+            }
+
+            is NavResult.Value -> {
+                result.value?.let { avatarAssetId ->
+                    viewModelSelf.reloadNewPickedAvatar(
+                        avatarAssetId = avatarAssetId
+                    )
+                }
+            }
+        }
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -44,6 +44,8 @@ import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.user.SelfUser
@@ -95,7 +97,8 @@ class SelfUserProfileViewModel @Inject constructor(
     private val isReadOnlyAccount: IsReadOnlyAccountUseCase,
     private val notificationChannelsManager: NotificationChannelsManager,
     private val notificationManager: WireNotificationManager,
-    private val globalDataStore: GlobalDataStore
+    private val globalDataStore: GlobalDataStore,
+    private val qualifiedIdMapper: QualifiedIdMapper
 ) : ViewModel() {
 
     var userProfileState by mutableStateOf(SelfUserProfileState(userId = selfUserId, isAvatarLoading = true))
@@ -127,7 +130,11 @@ class SelfUserProfileViewModel @Inject constructor(
 
     fun isUserInCall(): Boolean = establishedCallsList.value.isNotEmpty()
 
-    private suspend fun fetchSelfUser() {
+    fun reloadNewPickedAvatar(avatarAssetId: String) {
+        updateUserAvatar(avatarAssetId = avatarAssetId.toQualifiedID(qualifiedIdMapper))
+    }
+
+    private fun fetchSelfUser() {
         viewModelScope.launch {
             val self = getSelf().flowOn(dispatchers.io()).shareIn(this, SharingStarted.WhileSubscribed(1))
             val selfTeam = getSelfTeam().flowOn(dispatchers.io()).shareIn(this, SharingStarted.WhileSubscribed(1))

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/image/AvatarPickerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/image/AvatarPickerViewModelTest.kt
@@ -82,7 +82,7 @@ class AvatarPickerViewModelTest {
                         uploadUserAvatarUseCase(any(), any())
                         userDataStore.updateUserAvatarAssetId(uploadedAssetId.toString())
                     }
-                    verify(exactly = 1) { onSuccess() }
+                    verify(exactly = 1) { onSuccess(any()) }
                 }
 
                 expectNoEvents()
@@ -107,7 +107,7 @@ class AvatarPickerViewModelTest {
                     uploadUserAvatarUseCase(any(), any())
                     avatarImageManager.getWritableAvatarUri(any()) wasNot Called
                 }
-                verify(exactly = 0) { onSuccess() }
+                verify(exactly = 0) { onSuccess(any()) }
             }
 
             assertEquals(AvatarPickerViewModel.InfoMessageType.UploadAvatarError.uiText, awaitItem())
@@ -126,7 +126,7 @@ class AvatarPickerViewModelTest {
 
         val context = mockk<Context>()
 
-        val onSuccess = mockk<() -> Unit>(relaxed = true)
+        val onSuccess = mockk<(String?) -> Unit>(relaxed = true)
 
         @MockK
         private lateinit var qualifiedIdMapper: QualifiedIdMapper


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5494" title="WPB-5494" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5494</a>  [Android] Changing profile picture doesn't reflect on user profile
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When updating user profile avatar, it doesn't reflect directly on the screen

### Causes (Optional)

When updating user profile avatar, it updates the database and dataStore but we are not properly listening to it.

### Solutions

On the already existing callback when a profile avatar is changed, we return the avatar asset id and force new change.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Go to self user profile
- Change picture
- On user profile screen new picture is visible
