### PR TITLE
feat: media files tab - Part 1 (WPB-5378)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
@@ -18,9 +18,26 @@
 
 package com.wire.android.ui.home.conversations.media
 
+import androidx.annotation.StringRes
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -30,13 +47,19 @@ import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.style.PopUpNavigationAnimation
+import com.wire.android.ui.common.TabItem
+import com.wire.android.ui.common.WireTabRow
+import com.wire.android.ui.common.calculateCurrentTab
 import com.wire.android.ui.common.colorsScheme
-import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.scaffold.WireScaffold
+import com.wire.android.ui.common.topBarElevation
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.destinations.MediaGalleryScreenDestination
+import com.wire.android.ui.home.conversations.model.messagetypes.asset.UIAssetMessage
+import com.wire.android.ui.theme.wireDimensions
 import com.wire.kalium.logic.data.id.ConversationId
+import kotlinx.coroutines.launch
 
 @RootNavGraph
 @Destination(
@@ -69,6 +92,7 @@ fun ConversationMediaScreen(navigator: Navigator) {
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun Content(
     state: ConversationAssetMessagesViewState,
@@ -76,24 +100,88 @@ private fun Content(
     onImageFullScreenMode: (conversationId: ConversationId, messageId: String, isSelfAsset: Boolean) -> Unit,
     continueAssetLoading: (shouldContinue: Boolean) -> Unit
 ) {
+    val scope = rememberCoroutineScope()
+    val lazyListStates: List<LazyListState> = ConversationMediaScreenTabItem.entries.map { rememberLazyListState() }
+    val initialPageIndex = ConversationMediaScreenTabItem.PICTURES.ordinal
+    val pagerState = rememberPagerState(initialPage = initialPageIndex, pageCount = { ConversationMediaScreenTabItem.entries.size })
+    val maxAppBarElevation = MaterialTheme.wireDimensions.topBarShadowElevation
+    val currentTabState by remember { derivedStateOf { pagerState.calculateCurrentTab() } }
+    val elevationState by remember { derivedStateOf { lazyListStates[currentTabState].topBarElevation(maxAppBarElevation) } }
+
     WireScaffold(
         modifier = Modifier
             .background(color = colorsScheme().backgroundVariant),
         topBar = {
             WireCenterAlignedTopAppBar(
-                elevation = dimensions().spacing0x,
+                elevation = elevationState,
                 title = stringResource(id = R.string.label_conversation_media),
                 navigationIconType = NavigationIconType.Back,
-                onNavigationPressed = onNavigationPressed
+                onNavigationPressed = onNavigationPressed,
+                bottomContent = {
+                    WireTabRow(
+                        tabs = ConversationMediaScreenTabItem.entries,
+                        selectedTabIndex = currentTabState,
+                        onTabChange = { scope.launch { pagerState.animateScrollToPage(it) } }
+                    )
+                }
             )
         },
     ) { padding ->
-        // TODO implement tab here for https://wearezeta.atlassian.net/browse/WPB-5378
+        var focusedTabIndex: Int by remember { mutableStateOf(initialPageIndex) }
+
+        CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(padding)
+            ) { pageIndex ->
+                when (ConversationMediaScreenTabItem.entries[pageIndex]) {
+                    ConversationMediaScreenTabItem.PICTURES -> PicturesContent(
+                        uiAssetMessageList = state.messages,
+                        onImageFullScreenMode = onImageFullScreenMode,
+                        continueAssetLoading = continueAssetLoading
+                    )
+                    ConversationMediaScreenTabItem.FILES -> FilesContent()
+                }
+            }
+
+            LaunchedEffect(pagerState.isScrollInProgress, focusedTabIndex, pagerState.currentPage) {
+                if (!pagerState.isScrollInProgress && focusedTabIndex != pagerState.currentPage) {
+                    focusedTabIndex = pagerState.currentPage
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PicturesContent(
+    uiAssetMessageList: List<UIAssetMessage>,
+    onImageFullScreenMode: (conversationId: ConversationId, messageId: String, isSelfAsset: Boolean) -> Unit,
+    continueAssetLoading: (shouldContinue: Boolean) -> Unit
+) {
+    if (uiAssetMessageList.isEmpty()) {
+        EmptyMediaContentScreen(
+            text = stringResource(R.string.label_conversation_pictures_empty)
+        )
+    } else {
         AssetGrid(
-            uiAssetMessageList = state.messages,
-            modifier = Modifier.padding(padding),
+            uiAssetMessageList = uiAssetMessageList,
             onImageFullScreenMode = onImageFullScreenMode,
             continueAssetLoading = continueAssetLoading
         )
     }
+}
+
+@Composable
+private fun FilesContent() {
+    EmptyMediaContentScreen(
+        text = stringResource(R.string.label_conversation_files_empty)
+    )
+}
+
+enum class ConversationMediaScreenTabItem(@StringRes override val titleResId: Int) : TabItem {
+    PICTURES(R.string.label_conversation_pictures),
+    FILES(R.string.label_conversation_files);
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
@@ -57,7 +57,9 @@ import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.destinations.MediaGalleryScreenDestination
 import com.wire.android.ui.home.conversations.model.messagetypes.asset.UIAssetMessage
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.id.ConversationId
 import kotlinx.coroutines.launch
 
@@ -184,4 +186,16 @@ private fun FilesContent() {
 enum class ConversationMediaScreenTabItem(@StringRes override val titleResId: Int) : TabItem {
     PICTURES(R.string.label_conversation_pictures),
     FILES(R.string.label_conversation_files);
+}
+
+@PreviewMultipleThemes
+@Composable
+fun previewConversationMediaScreenEmptyContent() {
+    WireTheme {
+        Content(
+            state = ConversationAssetMessagesViewState(),
+            onImageFullScreenMode = {_, _, _ -> },
+            continueAssetLoading = {}
+        )
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/EmptyMediaContentScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/EmptyMediaContentScreen.kt
@@ -1,0 +1,55 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.media
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireTypography
+
+@Composable
+fun EmptyMediaContentScreen(
+    text: String
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .padding(horizontal = dimensions().spacing48x),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = text,
+                style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/EmptyMediaContentScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/EmptyMediaContentScreen.kt
@@ -29,9 +29,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import com.wire.android.R
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
 fun EmptyMediaContentScreen(
@@ -52,5 +56,25 @@ fun EmptyMediaContentScreen(
                 textAlign = TextAlign.Center
             )
         }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun previewAssetEmptyMediaContentScreen() {
+    WireTheme {
+        EmptyMediaContentScreen(
+            text = stringResource(R.string.label_conversation_files_empty)
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun previewPictureEmptyMediaContentScreen() {
+    WireTheme {
+        EmptyMediaContentScreen(
+            text = stringResource(R.string.label_conversation_pictures_empty)
+        )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/EmptyMediaContentScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/EmptyMediaContentScreen.kt
@@ -17,12 +17,13 @@
  */
 package com.wire.android.ui.home.conversations.media
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,7 +31,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 
 @Composable
@@ -41,13 +41,14 @@ fun EmptyMediaContentScreen(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .wrapContentHeight()
+                .fillMaxHeight()
                 .padding(horizontal = dimensions().spacing48x),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
         ) {
             Text(
                 text = text,
-                style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
+                style = MaterialTheme.wireTypography.body01,
                 textAlign = TextAlign.Center
             )
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ImageAssetsContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ImageAssetsContent.kt
@@ -42,8 +42,13 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.model.MediaAssetImage
 import com.wire.android.ui.home.conversations.model.messagetypes.asset.UIAssetMessage
 import com.wire.android.ui.home.conversationslist.common.FolderHeader
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.util.ui.PreviewMultipleThemes
+import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.util.map.forEachIndexed
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
@@ -167,3 +172,39 @@ fun groupAssetsByMonthYear(uiAssetMessageList: List<UIAssetMessage>, timeZone: T
 }
 
 private const val COLUMN_COUNT = 4
+
+@PreviewMultipleThemes
+@Composable
+fun previewAssetGrid() {
+    val message1 = UIAssetMessage(
+        assetId = "1",
+        time = Instant.DISTANT_PAST,
+        username = UIText.DynamicString("Username 1"),
+        messageId = "msg1",
+        conversationId = QualifiedID("value", "domain"),
+        assetPath = null,
+        downloadStatus = Message.DownloadStatus.SAVED_EXTERNALLY,
+        isSelfAsset = false
+    )
+    val message2 = message1.copy(
+        messageId = "msg2",
+        username = UIText.DynamicString("Username 2"),
+        downloadStatus = Message.DownloadStatus.NOT_DOWNLOADED,
+        isSelfAsset = true
+    )
+    val message3 = message2.copy(
+        messageId = "msg3",
+        downloadStatus = Message.DownloadStatus.DOWNLOAD_IN_PROGRESS,
+    )
+    WireTheme {
+        AssetGrid(
+            uiAssetMessageList = listOf(
+                message1,
+                message2,
+                message3
+            ),
+            onImageFullScreenMode = {_, _, _ -> },
+            continueAssetLoading = {}
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -712,7 +712,8 @@
     <string name="label_conversation_media">Media</string>
     <string name="label_conversation_pictures">Pictures</string>
     <string name="label_conversation_files">Files</string>
-    <string name="label_conversation_links">Links</string>
+    <string name="label_conversation_pictures_empty">No pictures have been shared in this conversation yet 🥲</string>
+    <string name="label_conversation_files_empty">No files have been shared in this conversation yet 🙀</string>
     <!-- Search Contact-->
     <string name="label_contacts">CONTACTS</string>
     <string name="label_new_group">New Group</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5378" title="WPB-5378" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-5378</a>  Files tab in media gallery
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was no empty states and no tabs for (PICTURES, FILES)

### Causes (Optional)

Not implemented

### Solutions

Add tabs with (PICTURES, FILES) and empty state for both screens

### Dependencies (Optional)

### Testing

#### How to Test

- Open Conversation Details
- Open Media Screen
- Verify that there are tabs and there are empty states for both tabs

### Notes (Optional)

This is the first of many PRs to follow along for the implementation of displaying files.

### Attachments (Optional)

<img src="https://github.com/wireapp/wire-android/assets/5890660/fd984783-6290-4d9d-8326-fdaf512a2ae2" width="200" height="400" />

<img src="https://github.com/wireapp/wire-android/assets/5890660/8d788186-45b8-4698-89ae-5249f0d00bb9" width="200" height="400" />
