### PR TITLE
fix: set cert pinning for all app flavours 

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,15 +6,7 @@
             "logging_enabled": false,
             "application_is_private_build": false,
             "development_api_enabled": false,
-            "mls_support_enabled": false,
-            "cert_pinning_config": {
-                "sha256/fnBeCwh0imI9t46Onid49IwvsB5vcf7RCvafRRdCyRE=": [
-                    "**.prod-nginz-https.wire.com",
-                    "**.prod-nginz-ssl.wire.com",
-                    "**.prod-assets.wire.com",
-                    "clientblacklist.wire.com"
-                ]
-            }
+            "mls_support_enabled": false
         },
         "dev": {
             "application_id": "com.waz.zclient.dev",
@@ -105,7 +97,14 @@
     "default_backend_url_blacklist": "https://clientblacklist.wire.com/prod",
     "default_backend_url_website": "https://wire.com",
     "default_backend_title": "wire-production",
-    "cert_pinning_config": {},
+    "cert_pinning_config": {
+        "sha256/fnBeCwh0imI9t46Onid49IwvsB5vcf7RCvafRRdCyRE=": [
+            "**.prod-nginz-https.wire.com",
+            "**.prod-nginz-ssl.wire.com",
+            "**.prod-assets.wire.com",
+            "clientblacklist.wire.com"
+        ]
+    },
     "is_password_protected_guest_link_enabled": false,
     "url_rss_release_notes": "https://medium.com/feed/wire-news/tagged/android",
     "team_app_lock": false,


### PR DESCRIPTION
Cherry pick from the original PR: 
- #2512

---- 

 ⚠️ Conflicts during cherry-pick:


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like 
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the cert pinning issue for GET:/api-version went under the radar because cert pinning was not enabled for all app flavours 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .