### PR TITLE
fix: breaking lines title location (WPB-5483)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -651,6 +651,7 @@ private fun MessageContent(
                     )
                 )
                 PartialDeliveryInformation(deliveryStatus)
+                VerticalSpace.x4()
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -651,7 +651,6 @@ private fun MessageContent(
                     )
                 )
                 PartialDeliveryInformation(deliveryStatus)
-                VerticalSpace.x4()
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -70,9 +71,11 @@ fun LocationMessageContent(
                 color = MaterialTheme.wireColorScheme.surfaceVariant,
                 shape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
             )
-            .height(dimensions().spacing64x),
+            .defaultMinSize(minHeight = dimensions().spacing64x),
         verticalArrangement = Arrangement.SpaceEvenly,
     ) {
+        Spacer(modifier = Modifier.height(dimensions().spacing12x))
+
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -90,7 +93,6 @@ fun LocationMessageContent(
                 text = locationName,
                 style = MaterialTheme.wireTypography.body02,
                 fontSize = 15.sp,
-                maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
         }
@@ -99,14 +101,10 @@ fun LocationMessageContent(
             style = MaterialTheme.wireTypography.subline01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
             overflow = TextOverflow.Ellipsis,
             maxLines = 1,
-            modifier = Modifier.padding(
-                PaddingValues(
-                    bottom = dimensions().spacing8x,
-                    start = dimensions().spacing8x,
-                    end = dimensions().spacing8x
-                )
-            )
+            modifier = Modifier.padding(horizontal = dimensions().spacing8x)
         )
+
+        Spacer(modifier = Modifier.height(dimensions().spacing12x))
     }
 }
 
@@ -114,7 +112,7 @@ fun LocationMessageContent(
 @PreviewMultipleThemes
 fun PreviewLocationMessageContent() {
     LocationMessageContent(
-        locationName = "Rapa Nui",
+        locationName = "Rapa Nui, 2770000, CL",
         locationUrl = "https://www.google.com/maps/place/Rapa+Nui",
         onLocationClick = Clickable()
     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/location/LocationMessageType.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -81,12 +82,14 @@ fun LocationMessageContent(
                 .fillMaxWidth()
                 .padding(PaddingValues(horizontal = dimensions().spacing8x)),
             horizontalArrangement = Arrangement.Start,
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.Top
         ) {
             Icon(
                 painter = painterResource(id = R.drawable.ic_location),
                 contentDescription = stringResource(id = R.string.content_description_location_icon),
-                modifier = Modifier.size(MaterialTheme.wireDimensions.wireIconButtonSize)
+                modifier = Modifier
+                    .size(MaterialTheme.wireDimensions.wireIconButtonSize)
+                    .offset(y = dimensions().spacing4x)
             )
             Spacer(modifier = Modifier.width(dimensions().spacing4x))
             Text(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5483" title="WPB-5483" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-5483</a>  [Android] Receive Location - UI no image placeholder
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Design specs fixes and adjustment.

### Causes (Optional)

Missing/new specs for line breaking and alginment

### Solutions

Implement it

### Attachments (Optional)

<img src="https://github.com/wireapp/wire-android/assets/5806454/716ac1ab-24d9-48d2-92a4-6abd942957f5" width="300"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
