### PR TITLE
fix: app not locked after timeout when screen turned off [WPB-5682] [WPB-5832]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/AppModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/AppModule.kt
@@ -27,6 +27,7 @@ import android.media.MediaPlayer
 import androidx.core.app.NotificationManagerCompat
 import com.wire.android.BuildConfig
 import com.wire.android.mapper.MessageResourceProvider
+import com.wire.android.ui.home.appLock.CurrentTimestampProvider
 import com.wire.android.util.dispatchers.DefaultDispatcherProvider
 import com.wire.android.util.dispatchers.DispatcherProvider
 import dagger.Module
@@ -79,4 +80,8 @@ object AppModule {
             )
         }
     }
+
+    @Singleton
+    @Provides
+    fun provideCurrentTimestampProvider(): CurrentTimestampProvider = { System.currentTimeMillis() }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/appLock/LockCodeTimeManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/appLock/LockCodeTimeManagerTest.kt
@@ -175,6 +175,7 @@ class LockCodeTimeManagerTest {
         arrangement.withIsAppVisible(false)
         advanceTimeBy(startDelay)
         arrangement.withIsAppVisible(true)
+        advanceUntilIdle()
         // then
         assertEquals(expected, manager.observeAppLock().first())
     }
@@ -297,7 +298,8 @@ class LockCodeTimeManagerTest {
                 CoroutineScope(dispatcher),
                 currentScreenManager,
                 observeAppLockConfigUseCase,
-                globalDataStore
+                globalDataStore,
+                dispatcher.scheduler::currentTime
             )
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5682" title="WPB-5682" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5682</a>  doesn't lock the app when "keep connection to websocket" is on
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the device's screen is being turned off, the app is not locked when the app lock is on.

### Causes (Optional)

We use `delay` to emit locked state after given timeout, but when the device is turned off, it goes into "doze" mode and it disrupts the `delay` so that it can take way longer than it should:
![image](https://github.com/wireapp/wire-android/assets/30429749/61d97e7d-f66a-4a57-a635-be0197d91e82)

### Solutions

In addition also keep the timestamp and compare it when putting app back into foreground.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Turn app lock on, put the app into background and turn off the screen (phone should not be plugged in and charging), turn it on and open the app after the app lock timeout.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
