### PR TITLE
fix: wrong url for conversation creation in conflicting backends case (WPB-5014)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
@@ -74,7 +74,7 @@ fun CreateGroupErrorDialog(
                 }
                 addStringAnnotation(
                     tag = MarkdownConstants.TAG_URL,
-                    annotation = stringResource(id = R.string.url_support),
+                    annotation = stringResource(id = R.string.url_message_details_offline_backends_learn_more),
                     start = description.length + 1,
                     end = description.length + 1 + learnMore.length
                 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5014" title="WPB-5014" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5014</a>  [Android] Wrong "Learn more" link from message in can not create group alert
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Wrong link to support due to federated conflicting domains.

### Causes (Optional)

N/A.

### Solutions

Fix it according to mocks.


### Attachments (Optional)
<img width="970" alt="Screenshot 2023-12-13 at 18 00 46" src="https://github.com/wireapp/wire-android/assets/5806454/6d40d41f-1639-4ce8-b940-42302ffde074">


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
