### PR TITLE
fix: Remove reportDrawnWhen api due to crash on Android 9 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -25,7 +25,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.WindowManager
-import androidx.activity.compose.ReportDrawnWhen
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -38,10 +37,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -165,7 +162,6 @@ class WireActivity : AppCompatActivity() {
     ) {
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
-            var isLoaded by remember { mutableStateOf(false) }
 
             LaunchedEffect(viewModel.globalAppState.themeOption) {
                 when (viewModel.globalAppState.themeOption) {
@@ -184,7 +180,6 @@ class WireActivity : AppCompatActivity() {
             ) {
                 WireTheme {
                     Column(modifier = Modifier.statusBarsPadding()) {
-                        ReportDrawnWhen { isLoaded }
                         val navigator = rememberNavigator(this@WireActivity::finish)
                         CommonTopAppBar(
                             connectivityUIState = commonTopAppBarViewModel.connectivityState,
@@ -200,7 +195,6 @@ class WireActivity : AppCompatActivity() {
                         // This setup needs to be done after the navigation graph is created, because building the graph takes some time,
                         // and if any NavigationCommand is executed before the graph is fully built, it will cause a NullPointerException.
                         setUpNavigation(navigator.navController, onComplete)
-                        isLoaded = true
                         handleScreenshotCensoring()
                         handleDialogs(
                             navigator::navigate,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`ReportDrawnWhen` which used to improve app startup is causing some crashes on Samsung devices running on Android 9 

```
Exception java.lang.SecurityException: Permission Denial: broadcast from android asks to run as user -1 but is calling from user 0; this requires android.permission.INTERACT_ACROSS_USERS_FULL or android.permission.INTERACT_ACROSS_USERS
  at android.os.Parcel.createException (Parcel.java:1966)
  at android.os.Parcel.readException (Parcel.java:1934)
  at android.os.Parcel.readException (Parcel.java:1884)
  at android.app.IActivityManager$Stub$Proxy.reportActivityFullyDrawn (IActivityManager.java:7301)
  at android.app.Activity.reportFullyDrawn (Activity.java:2087)
  at androidx.activity.ComponentActivity.reportFullyDrawn (ComponentActivity.java)
  at androidx.activity.ComponentActivity.lambda$new$0 (ComponentActivity.java)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:988)
  at android.view.Choreographer.doCallbacks (Choreographer.java:765)
  at android.view.Choreographer.doFrame (Choreographer.java:697)
  at android.view.Choreographer$FrameDisplayEventReceiver.run (Choreographer.java:971)
  at android.os.Handler.handleCallback (Handler.java:873)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:216)
  at android.app.ActivityThread.main (ActivityThread.java:7266)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:494)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:975)
Caused by android.os.RemoteException: Remote stack trace:
  at com.android.server.am.UserController.handleIncomingUser (UserController.java:1832)
  at com.android.server.am.ActivityManagerService.broadcastIntentLocked (ActivityManagerService.java:26232)
  at com.android.server.am.ActivityManagerService.broadcastIntentLocked (ActivityManagerService.java:26163)
  at com.android.server.am.ActivityManagerService.broadcastIntent (ActivityManagerService.java:27033)
  at android.app.ContextImpl.sendBroadcastAsUser (ContextImpl.java:1264)
```

There is ticket created on issueTracker, it's still in progress : https://issuetracker.google.com/issues/316294709.

For now we are just going to remove it.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
