### PR TITLE
fix: Show verification icons in Calls flow (WPB-5792)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallState.kt
@@ -25,6 +25,7 @@ import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.call.ConversationType
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 
 data class CallState(
@@ -40,5 +41,8 @@ data class CallState(
     val isSpeakerOn: Boolean = false,
     val isCbrEnabled: Boolean = false,
     val conversationType: ConversationType = ConversationType.OneOnOne,
-    val membership: Membership = Membership.None
+    val membership: Membership = Membership.None,
+    val protocolInfo: Conversation.ProtocolInfo? = null,
+    val mlsVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+    val proteusVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
 )

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -146,7 +146,10 @@ class SharedCallingViewModel @Inject constructor(
                     is ConversationDetails.Group -> {
                         callState.copy(
                             conversationName = getConversationName(details.conversation.name),
-                            conversationType = ConversationType.Conference
+                            conversationType = ConversationType.Conference,
+                            protocolInfo = details.conversation.protocol,
+                            mlsVerificationStatus = details.conversation.mlsVerificationStatus,
+                            proteusVerificationStatus = details.conversation.proteusVerificationStatus
                         )
                     }
 
@@ -157,7 +160,10 @@ class SharedCallingViewModel @Inject constructor(
                                 ImageAsset.UserAvatarAsset(wireSessionImageLoader, assetId)
                             },
                             conversationType = ConversationType.OneOnOne,
-                            membership = userTypeMapper.toMembership(details.otherUser.userType)
+                            membership = userTypeMapper.toMembership(details.otherUser.userType),
+                            protocolInfo = details.conversation.protocol,
+                            mlsVerificationStatus = details.conversation.mlsVerificationStatus,
+                            proteusVerificationStatus = details.conversation.proteusVerificationStatus
                         )
                     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallerDetails.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallerDetails.kt
@@ -24,6 +24,7 @@ import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.IconButton
@@ -41,6 +42,7 @@ import com.wire.android.R
 import com.wire.android.model.ImageAsset
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.calling.ConversationName
+import com.wire.android.ui.common.ConversationVerificationIcons
 import com.wire.android.ui.common.MembershipQualifierLabel
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
@@ -52,6 +54,7 @@ import com.wire.android.ui.home.conversationslist.model.hasLabel
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.call.ConversationType
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import java.util.Locale
 
@@ -64,7 +67,10 @@ fun CallerDetails(
     avatarAssetId: ImageAsset.UserAvatarAsset?,
     conversationType: ConversationType,
     membership: Membership,
-    callingLabel: String
+    callingLabel: String,
+    protocolInfo: Conversation.ProtocolInfo?,
+    mlsVerificationStatus: Conversation.VerificationStatus?,
+    proteusVerificationStatus: Conversation.VerificationStatus?,
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -93,16 +99,23 @@ fun CallerDetails(
                 style = MaterialTheme.wireTypography.title03,
             )
         }
-        Text(
-            text = when (conversationName) {
-                is ConversationName.Known -> conversationName.name
-                is ConversationName.Unknown -> stringResource(id = conversationName.resourceId)
-                else -> ""
-            },
-            color = colorsScheme().onBackground,
-            style = MaterialTheme.wireTypography.title01,
-            modifier = Modifier.padding(top = dimensions().spacing24x)
-        )
+        Row(modifier = Modifier.padding(top = dimensions().spacing24x)) {
+            Text(
+                text = when (conversationName) {
+                    is ConversationName.Known -> conversationName.name
+                    is ConversationName.Unknown -> stringResource(id = conversationName.resourceId)
+                    else -> ""
+                },
+                color = colorsScheme().onBackground,
+                style = MaterialTheme.wireTypography.title01,
+            )
+
+            ConversationVerificationIcons(
+                protocolInfo,
+                mlsVerificationStatus,
+                proteusVerificationStatus
+            )
+        }
         Text(
             text = callingLabel,
             color = colorsScheme().onBackground,
@@ -116,8 +129,7 @@ fun CallerDetails(
 
         SecurityClassificationBannerForConversation(
             conversationId = conversationId,
-            modifier = Modifier.padding(top = dimensions().spacing8x),
-
+            modifier = Modifier.padding(top = dimensions().spacing8x)
         )
 
         if (!isCameraOn && conversationType == ConversationType.OneOnOne) {
@@ -142,5 +154,8 @@ fun PreviewCallerDetails() {
         conversationType = ConversationType.OneOnOne,
         membership = Membership.Guest,
         callingLabel = String.EMPTY,
+        protocolInfo = null,
+        mlsVerificationStatus = null,
+        proteusVerificationStatus = Conversation.VerificationStatus.VERIFIED
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
@@ -226,7 +226,10 @@ private fun IncomingCallContent(
                 avatarAssetId = callState.avatarAssetId,
                 conversationType = callState.conversationType,
                 membership = callState.membership,
-                callingLabel = isCallingString
+                callingLabel = isCallingString,
+                protocolInfo = callState.protocolInfo,
+                mlsVerificationStatus = callState.mlsVerificationStatus,
+                proteusVerificationStatus = callState.proteusVerificationStatus
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallScreen.kt
@@ -158,7 +158,10 @@ private fun InitiatingCallContent(
                 avatarAssetId = callState.avatarAssetId,
                 conversationType = callState.conversationType,
                 membership = callState.membership,
-                callingLabel = stringResource(id = R.string.calling_label_ringing_call)
+                callingLabel = stringResource(id = R.string.calling_label_ringing_call),
+                protocolInfo = callState.protocolInfo,
+                mlsVerificationStatus = callState.mlsVerificationStatus,
+                proteusVerificationStatus = callState.proteusVerificationStatus,
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -79,7 +79,6 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
-import com.wire.android.ui.common.topappbar.WireTopAppBarTitle
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
@@ -70,6 +71,7 @@ import com.wire.android.ui.calling.ongoing.fullscreen.DoubleTapToast
 import com.wire.android.ui.calling.ongoing.fullscreen.FullScreenTile
 import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
 import com.wire.android.ui.calling.ongoing.participantsview.VerticalCallingPager
+import com.wire.android.ui.common.ConversationVerificationIcons
 import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
 import com.wire.android.ui.common.bottomsheet.WireBottomSheetScaffold
 import com.wire.android.ui.common.colorsScheme
@@ -77,10 +79,12 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.common.topappbar.WireTopAppBarTitle
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import java.util.Locale
 
@@ -112,6 +116,9 @@ fun OngoingCallScreen(
             isSpeakerOn = isSpeakerOn,
             isCbrEnabled = isCbrEnabled,
             isOnFrontCamera = isOnFrontCamera,
+            protocolInfo = protocolInfo,
+            mlsVerificationStatus = mlsVerificationStatus,
+            proteusVerificationStatus = proteusVerificationStatus,
             shouldShowDoubleTapToast = ongoingCallViewModel.shouldShowDoubleTapToast,
             toggleSpeaker = sharedCallingViewModel::toggleSpeaker,
             toggleMute = sharedCallingViewModel::toggleMute,
@@ -140,6 +147,9 @@ private fun OngoingCallContent(
     isSpeakerOn: Boolean,
     isCbrEnabled: Boolean,
     shouldShowDoubleTapToast: Boolean,
+    protocolInfo: Conversation.ProtocolInfo?,
+    mlsVerificationStatus: Conversation.VerificationStatus?,
+    proteusVerificationStatus: Conversation.VerificationStatus?,
     toggleSpeaker: () -> Unit,
     toggleMute: () -> Unit,
     hangUpCall: () -> Unit,
@@ -174,7 +184,10 @@ private fun OngoingCallContent(
                     else -> ""
                 },
                 isCbrEnabled = isCbrEnabled,
-                onCollapse = navigateBack
+                onCollapse = navigateBack,
+                protocolInfo = protocolInfo,
+                mlsVerificationStatus = mlsVerificationStatus,
+                proteusVerificationStatus = proteusVerificationStatus
             )
         },
         sheetPeekHeight = dimensions().defaultSheetPeekHeight,
@@ -273,14 +286,34 @@ private fun OngoingCallContent(
 private fun OngoingCallTopBar(
     conversationName: String,
     isCbrEnabled: Boolean,
+    protocolInfo: Conversation.ProtocolInfo?,
+    mlsVerificationStatus: Conversation.VerificationStatus?,
+    proteusVerificationStatus: Conversation.VerificationStatus?,
     onCollapse: () -> Unit
 ) {
     Column {
         WireCenterAlignedTopAppBar(
             onNavigationPressed = onCollapse,
-            titleStyle = MaterialTheme.wireTypography.title02,
-            maxLines = 1,
-            title = conversationName,
+            titleContent = {
+                Row(
+                    modifier = Modifier.padding(
+                        start = dimensions().spacing6x,
+                        end = dimensions().spacing6x
+                    )
+                ) {
+                    Text(
+                        text = conversationName,
+                        style = MaterialTheme.wireTypography.title02,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    ConversationVerificationIcons(
+                        protocolInfo,
+                        mlsVerificationStatus,
+                        proteusVerificationStatus
+                    )
+                }
+            },
             navigationIconType = NavigationIconType.Collapse,
             elevation = 0.dp,
             actions = {}
@@ -354,5 +387,5 @@ private fun CallingControls(
 @PreviewMultipleThemes
 @Composable
 fun PreviewOngoingCallTopBar() {
-    OngoingCallTopBar("Default", true) { }
+    OngoingCallTopBar("Default", true, null, null, null) { }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/VerifiedIcons.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/VerifiedIcons.kt
@@ -19,12 +19,52 @@ package com.wire.android.ui.common
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
+import com.wire.kalium.logic.data.conversation.Conversation
+
+@Composable
+fun RowScope.ConversationVerificationIcons(
+    protocolInfo: Conversation.ProtocolInfo?,
+    mlsVerificationStatus: Conversation.VerificationStatus?,
+    proteusVerificationStatus: Conversation.VerificationStatus?
+) {
+    val mlsIcon: @Composable () -> Unit = {
+        if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
+            MLSVerifiedIcon(
+                contentDescriptionId = R.string.content_description_mls_certificate_valid,
+                modifier = Modifier
+                    .wrapContentWidth()
+                    .align(Alignment.CenterVertically)
+            )
+        }
+    }
+    val proteusIcon: @Composable () -> Unit = {
+        if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
+            ProteusVerifiedIcon(
+                contentDescriptionId = R.string.content_description_proteus_certificate_valid,
+                modifier = Modifier
+                    .wrapContentWidth()
+                    .align(Alignment.CenterVertically)
+            )
+        }
+    }
+
+    if (protocolInfo is Conversation.ProtocolInfo.Proteus) {
+        proteusIcon()
+        mlsIcon()
+    } else {
+        mlsIcon()
+        proteusIcon()
+    }
+}
 
 @Composable
 fun ProteusVerifiedIcon(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -48,9 +47,8 @@ import com.wire.android.R
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.calling.controlbuttons.JoinButton
 import com.wire.android.ui.calling.controlbuttons.StartCallButton
-import com.wire.android.ui.common.MLSVerifiedIcon
-import com.wire.android.ui.common.ProteusVerifiedIcon
 import com.wire.android.ui.common.UserProfileAvatar
+import com.wire.android.ui.common.ConversationVerificationIcons
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.conversationColor
@@ -135,7 +133,7 @@ private fun ConversationScreenTopAppBarContent(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(weight = 1f, fill = false)
                 )
-                VerificationIcons(
+                ConversationVerificationIcons(
                     conversationInfoViewState.protocolInfo,
                     conversationInfoViewState.mlsVerificationStatus,
                     conversationInfoViewState.proteusVerificationStatus
@@ -184,32 +182,6 @@ private fun ConversationScreenTopAppBarContent(
             navigationIconContentColor = MaterialTheme.colorScheme.onBackground
         )
     )
-}
-
-@Composable
-private fun RowScope.VerificationIcons(
-    protocolInfo: Conversation.ProtocolInfo?,
-    mlsVerificationStatus: Conversation.VerificationStatus?,
-    proteusVerificationStatus: Conversation.VerificationStatus?
-) {
-    val mlsIcon: @Composable () -> Unit = {
-        if (mlsVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
-            MLSVerifiedIcon(contentDescriptionId = R.string.content_description_mls_certificate_valid)
-        }
-    }
-    val proteusIcon: @Composable () -> Unit = {
-        if (proteusVerificationStatus == Conversation.VerificationStatus.VERIFIED) {
-            ProteusVerifiedIcon(contentDescriptionId = R.string.content_description_proteus_certificate_valid)
-        }
-    }
-
-    if (protocolInfo is Conversation.ProtocolInfo.Proteus) {
-        proteusIcon()
-        mlsIcon()
-    } else {
-        mlsIcon()
-        proteusIcon()
-    }
 }
 
 @Composable


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5792" title="WPB-5792" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5792</a>  [Android] Verified shield not shown during ongoing call in calling UI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

Icon about verification status of conversation should be shown in Ongoing call, Incoming call and Initializing call screens.
But it is not.

### Causes (Optional)

It wasn't described in the design.

### Solutions

Add it there :) 

### Attachments (Optional)

<img width="285" alt="Screenshot 2023-12-18 at 16 29 30" src="https://github.com/wireapp/wire-android/assets/6539347/da8a3c96-13cc-4146-a81e-3aeeb06408da">


<img width="286" alt="Screenshot 2023-12-18 at 16 29 09" src="https://github.com/wireapp/wire-android/assets/6539347/ffc6b074-2ee0-4e41-9271-b090c30be8a9">


<img width="286" alt="Screenshot 2023-12-18 at 16 29 20" src="https://github.com/wireapp/wire-android/assets/6539347/51cd1972-8ce2-48e2-a035-ff529f91e8e1">

