### PR TITLE
feat: show system message when migrating a mls conversation during a call (WPB-5349)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
@@ -70,6 +70,7 @@ class SystemMessageContentMapper @Inject constructor(
         is MessageContent.ConversationVerifiedProteus -> mapConversationVerified(Conversation.Protocol.PROTEUS)
         is MessageContent.FederationStopped -> mapFederationMessage(content)
         is MessageContent.ConversationProtocolChanged -> mapConversationProtocolChanged(content)
+        is MessageContent.ConversationProtocolChangedDuringACall -> mapConversationProtocolChangedDuringACall()
         is MessageContent.ConversationStartedUnverifiedWarning -> mapConversationCreatedUnverifiedWarning()
         is MessageContent.LegalHold -> mapLegalHoldMessage(content, message.senderUserId, members)
     }
@@ -118,9 +119,11 @@ class SystemMessageContentMapper @Inject constructor(
 
     private fun mapConversationProtocolChanged(
         content: MessageContent.ConversationProtocolChanged
-    ): UIMessageContent.SystemMessage {
-        return UIMessageContent.SystemMessage.ConversationProtocolChanged(content.protocol)
-    }
+    ): UIMessageContent.SystemMessage =
+        UIMessageContent.SystemMessage.ConversationProtocolChanged(content.protocol)
+
+    private fun mapConversationProtocolChangedDuringACall(): UIMessageContent.SystemMessage =
+        UIMessageContent.SystemMessage.ConversationProtocolChangedWithCallOngoing
 
     private fun mapResetSession(
         senderUserId: UserId,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -262,6 +262,7 @@ private fun getColorFilter(message: SystemMessage): ColorFilter? {
         is SystemMessage.HistoryLostProtocolChanged,
         is SystemMessage.NewConversationReceiptMode,
         is SystemMessage.ConversationProtocolChanged,
+        is SystemMessage.ConversationProtocolChangedWithCallOngoing,
         is SystemMessage.ConversationMessageTimerActivated,
         is SystemMessage.ConversationMessageCreated,
         is SystemMessage.ConversationStartedWithMembers,
@@ -556,6 +557,7 @@ private val SystemMessage.expandable
         is SystemMessage.HistoryLost -> false
         is SystemMessage.HistoryLostProtocolChanged -> false
         is SystemMessage.ConversationProtocolChanged -> false
+        is SystemMessage.ConversationProtocolChangedWithCallOngoing -> false
         is SystemMessage.ConversationMessageTimerActivated -> false
         is SystemMessage.ConversationMessageTimerDeactivated -> false
         is SystemMessage.ConversationMessageCreated -> false
@@ -642,6 +644,7 @@ fun SystemMessage.annotatedString(
         is SystemMessage.ConversationVerified -> arrayOf()
         is SystemMessage.HistoryLostProtocolChanged -> arrayOf()
         is SystemMessage.ConversationProtocolChanged -> arrayOf()
+        is SystemMessage.ConversationProtocolChangedWithCallOngoing -> arrayOf()
         is SystemMessage.ConversationMessageTimerActivated -> arrayOf(
             author.asString(res).markdownBold(),
             selfDeletionDuration.longLabel.asString(res).markdownBold()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -429,6 +429,10 @@ sealed class UIMessageContent {
                 Conversation.Protocol.MLS -> R.string.label_system_message_conversation_protocol_changed_mls
             }
         )
+        data object ConversationProtocolChangedWithCallOngoing : SystemMessage(
+            R.drawable.ic_info,
+            R.string.label_system_message_conversation_protocol_changed_during_a_call
+        )
 
         object HistoryLost : SystemMessage(
             R.drawable.ic_info,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -608,6 +608,7 @@
     <string name="label_system_message_conversation_mls_wrong_epoch_error_handled">The MLS group key was updated without our knowledge. This could happen due to lost messages between backends, or a bug. We have automatically rejoined the conversation, but you may have lost messages.</string>
     <string name="label_system_message_conversation_history_lost_protocol_changed">You didn\'t update your app in time. Some messages may not appear here.</string>
     <string name="label_system_message_conversation_protocol_changed_proteus">Migration of encryption protocol was canceled.</string>
+    <string name="label_system_message_conversation_protocol_changed_during_a_call">Due to migration to MLS, you might have issues with your current call. If that\'s the case, hang up and call again.</string>
     <string name="label_system_message_conversation_protocol_changed_mixed">Migration of encryption protocol has started. Make sure you all your Wire clients are updated.</string>
     <string name="label_system_message_conversation_protocol_changed_mls">Migration of encryption protocol is completed. Wire clients which haven\'t been updated will stop receiving messages.</string>
     <string name="label_system_message_receipt_mode_on">on</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5349" title="WPB-5349" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-5349</a>  [Android] If there is an ongoing call when migration finalization occurs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

We need to display a system message, informing the user that he might face some calling problems, when migrating a conversation to MLS during a call

![Wire 2023-12-19 at 4_53 PM](https://github.com/wireapp/wire-android/assets/18124919/9bc079cc-6182-4e20-a15c-5d7151dfbb53)


Needs releases with:

https://github.com/wireapp/kalium/pull/2321

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
