### PR TITLE
fix: Hiding E2EI dialogs on logout

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -99,7 +99,6 @@ import com.wire.android.util.debug.FeatureVisibilityFlags
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.ui.updateScreenSettings
-import com.wire.kalium.logic.data.user.UserId
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -214,10 +214,7 @@ class WireActivity : AppCompatActivity() {
                         setUpNavigation(navigator.navController, onComplete)
                         isLoaded = true
                         handleScreenshotCensoring()
-                        handleDialogs(
-                            navigator::navigate,
-                            viewModel.currentUserId.value
-                        )
+                        handleDialogs(navigator::navigate)
                     }
                 }
             }
@@ -272,8 +269,8 @@ class WireActivity : AppCompatActivity() {
 
     @Suppress("ComplexMethod")
     @Composable
-    private fun handleDialogs(navigate: (NavigationCommand) -> Unit, userId: UserId?) {
-        LaunchedEffect(userId) {
+    private fun handleDialogs(navigate: (NavigationCommand) -> Unit) {
+        LaunchedEffect(Unit) {
             featureFlagNotificationViewModel.loadInitialSync()
         }
         val context = LocalContext.current

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -121,7 +121,6 @@ class WireActivityViewModel @Inject constructor(
                 if (it.accountInfo.isValid().not()) {
                     handleInvalidSession((it.accountInfo as AccountInfo.Invalid).logoutReason)
                 }
-                currentUserId.value = it.accountInfo.userId
             }
         }
         .map { result ->
@@ -138,8 +137,6 @@ class WireActivityViewModel @Inject constructor(
 
     private val _observeSyncFlowState: MutableStateFlow<SyncState?> = MutableStateFlow(null)
     val observeSyncFlowState: StateFlow<SyncState?> = _observeSyncFlowState
-
-    val currentUserId: MutableState<UserId?> = mutableStateOf(null)
 
     init {
         observeSyncState()

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -21,7 +21,6 @@
 package com.wire.android.ui
 
 import android.content.Intent
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -60,7 +60,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.time.Duration
 
 @Suppress("TooManyFunctions")
 @HiltViewModel

--- a/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
@@ -280,7 +280,7 @@ class FeatureFlagNotificationViewModelTest {
         currentSessionsFlow.emit(CurrentSessionResult.Failure.SessionNotFound)
         advanceUntilIdle()
 
-        //then
+        // then
         assertEquals(null, viewModel.featureFlagState.e2EIRequired)
     }
 


### PR DESCRIPTION
# What's new in this PR?

There are 2 issue that were found during the E2EI Play-test session.

### Issues

1. when tapping on "get certificate" button on alert and certificate fails, user is stuck in dialog loop
2. when user gets logged out because his device was removed, he sees the E2EI dialogue on welcome screen

### Causes (Optional)

1. when user clicks on "snooze" button in error dialog, that dialog was not hidden and a new dialog shown, so when the new dialog is hidden - the error dialog was still there.
2. instead of observing the Current User and updating the dialog state according to it, we were "getting once" the current user and observing the dialog states for that user.

### Solutions

1. hide the E2EI Error Dialog on snooze click
2. observe the Current User and observe all the dialog states for that user, or hide dialogs if there is no valid current user.
