### PR TITLE
fix: reactions padding [WPB-5855]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -297,6 +297,7 @@ fun MessageItem(
                                 }
                             }
                             if (shouldDisplayFooter) {
+                                VerticalSpace.x4()
                                 MessageFooter(
                                     messageFooter = messageFooter,
                                     onReactionClicked = onReactionClicked

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParagraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParagraph.kt
@@ -35,7 +35,7 @@ fun MarkdownParagraph(
     clickable: Boolean,
     onMentionsUpdate: (List<DisplayMention>) -> Unit
 ) {
-        val padding = if (paragraph.parent is Document) dimensions().spacing8x else dimensions().spacing0x
+        val padding = if (paragraph.parent is Document) dimensions().spacing4x else dimensions().spacing0x
         Box(modifier = Modifier.padding(bottom = padding)) {
             val annotatedString = buildAnnotatedString {
                 pushStyle(MaterialTheme.wireTypography.body01.toSpanStyle())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5855" title="WPB-5855" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5855</a>  Missing padding between placeholder boxes and reaction pills
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- fixed reactions padding

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 

| Before | After |
| ----------- | ------------ |
| ![reaction_before](https://github.com/wireapp/wire-android/assets/13151239/8584ec90-341a-432b-8936-4ec92b4aca88)  | ![reaction_after](https://github.com/wireapp/wire-android/assets/13151239/85c63457-d3dc-445c-8fc4-c14a61a9f2ad) |
