### PR TITLE
fix: message item long tap action [WPB-5952]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -25,7 +25,6 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -168,24 +167,25 @@ fun MessageItem(
 
         Box(
             backgroundColorModifier
-                .clickable(enabled = isContentClickable, onClick = {
-                    onMessageClick(message.header.messageId)
-                })
+                .combinedClickable(enabled = true, onClick = {
+                    if (isContentClickable) {
+                        onMessageClick(message.header.messageId)
+                    }
+                },
+                    onLongClick = remember(message) {
+                        {
+                            if (!isContentClickable) {
+                                onLongClicked(message)
+                            }
+                        }
+                    }
+                )
         ) {
             // padding needed to have same top padding for avatar and rest composables in message item
             val fullAvatarOuterPadding = dimensions().avatarClickablePadding + dimensions().avatarStatusBorderSize
             Row(
                 Modifier
                     .fillMaxWidth()
-                    .apply {
-                        if (!isContentClickable) {
-                            combinedClickable(
-                                enabled = message.isAvailable,
-                                onClick = { },
-                                onLongClick = remember(message) { { onLongClicked(message) } }
-                            )
-                        }
-                    }
                     .padding(
                         end = dimensions().messageItemHorizontalPadding,
                         top = if (showAuthor) dimensions().spacing0x else dimensions().spacing4x,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5952" title="WPB-5952" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5952</a>  [Android] When longtapping on whitespace next to message, message menu does not open
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- fixed long tap on message