### PR TITLE
feat: discover legal hold when sending message [WPB-5999]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/ClientModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/ClientModule.kt
@@ -25,12 +25,12 @@ import com.wire.kalium.logic.feature.client.ClientFingerprintUseCase
 import com.wire.kalium.logic.feature.client.ClientScope
 import com.wire.kalium.logic.feature.client.DeleteClientUseCase
 import com.wire.kalium.logic.feature.client.FetchSelfClientsFromRemoteUseCase
+import com.wire.kalium.logic.feature.client.FetchUsersClientsFromRemoteUseCase
 import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
 import com.wire.kalium.logic.feature.client.NeedsToRegisterClientUseCase
 import com.wire.kalium.logic.feature.client.ObserveClientDetailsUseCase
 import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
 import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
-import com.wire.kalium.logic.feature.client.PersistOtherUserClientsUseCase
 import com.wire.kalium.logic.feature.client.UpdateClientVerificationStatusUseCase
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCase
 import com.wire.kalium.logic.sync.slow.RestartSlowSyncProcessForRecoveryUseCase
@@ -72,8 +72,8 @@ class ClientModule {
 
     @ViewModelScoped
     @Provides
-    fun providePersistOtherUsersClients(clientScope: ClientScope): PersistOtherUserClientsUseCase =
-        clientScope.persistOtherUserClients
+    fun provideFetchUsersClientsFromRemoteUseCase(clientScope: ClientScope): FetchUsersClientsFromRemoteUseCase =
+        clientScope.fetchUsersClients
 
     @ViewModelScoped
     @Provides
@@ -82,8 +82,8 @@ class ClientModule {
 
     @ViewModelScoped
     @Provides
-    fun provideSelfClientsUseCase(clientScope: ClientScope): FetchSelfClientsFromRemoteUseCase =
-        clientScope.selfClients
+    fun provideFetchSelfClientsFromRemoteUseCase(clientScope: ClientScope): FetchSelfClientsFromRemoteUseCase =
+        clientScope.fetchSelfClients
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewState.kt
@@ -23,6 +23,7 @@ package com.wire.android.ui.home.conversations
 import com.wire.android.ui.home.messagecomposer.state.MessageBundle
 import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.kalium.logic.data.asset.AttachmentType
+import com.wire.kalium.logic.data.id.MessageId
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
 import kotlin.time.Duration.Companion.ZERO
@@ -51,8 +52,11 @@ sealed class InvalidLinkDialogState {
 
 sealed class SureAboutMessagingDialogState {
     data object Hidden : SureAboutMessagingDialogState()
-    sealed class Visible(open val messageBundleToSend: MessageBundle) : SureAboutMessagingDialogState() {
-        data class ConversationVerificationDegraded(override val messageBundleToSend: MessageBundle) : Visible(messageBundleToSend)
-        data class ConversationUnderLegalHold(override val messageBundleToSend: MessageBundle) : Visible(messageBundleToSend)
+    sealed class Visible : SureAboutMessagingDialogState() {
+        data class ConversationVerificationDegraded(val messageBundleToSend: MessageBundle) : Visible()
+        sealed class ConversationUnderLegalHold : Visible() {
+            data class BeforeSending(val messageBundleToSend: MessageBundle) : ConversationUnderLegalHold()
+            data class AfterSending(val messageId: MessageId) : ConversationUnderLegalHold()
+        }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -55,8 +55,8 @@ import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.client.FetchUsersClientsFromRemoteUseCase
 import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
-import com.wire.kalium.logic.feature.client.PersistOtherUserClientsUseCase
 import com.wire.kalium.logic.feature.connection.BlockUserResult
 import com.wire.kalium.logic.feature.connection.BlockUserUseCase
 import com.wire.kalium.logic.feature.connection.UnblockUserResult
@@ -100,7 +100,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     private val removeMemberFromConversation: RemoveMemberFromConversationUseCase,
     private val updateMemberRole: UpdateConversationMemberRoleUseCase,
     private val observeClientList: ObserveClientsByUserIdUseCase,
-    private val persistOtherUserClients: PersistOtherUserClientsUseCase,
+    private val fetchUsersClients: FetchUsersClientsFromRemoteUseCase,
     private val clearConversationContentUseCase: ClearConversationContentUseCase,
     private val updateConversationArchivedStatus: UpdateConversationArchivedStatusUseCase,
     savedStateHandle: SavedStateHandle
@@ -152,7 +152,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
 
     private fun persistClients() {
         viewModelScope.launch(dispatchers.io()) {
-            persistOtherUserClients(userId)
+            fetchUsersClients(listOf(userId))
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelArrangement.kt
@@ -278,6 +278,16 @@ internal class MessageComposerViewModelArrangement {
             )
         } returns Either.Right(Unit)
     }
+    fun withFailedSendTextMessage(failure: CoreFailure) = apply {
+        coEvery {
+            sendTextMessage(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns Either.Left(failure)
+    }
 
     fun withSuccessfulSendEditTextMessage() = apply {
         coEvery {
@@ -332,6 +342,10 @@ internal class MessageComposerViewModelArrangement {
 
     fun withObserveConversationUnderLegalHoldNotified(flag: Boolean) = apply {
         coEvery { observeConversationUnderLegalHoldNotified(any()) } returns flowOf(flag)
+    }
+
+    fun withSuccessfulRetryFailedMessage() = apply {
+        coEvery { retryFailedMessageUseCase(any(), any()) } returns Either.Right(Unit)
     }
 
     fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -33,6 +33,7 @@ import com.wire.android.ui.home.messagecomposer.state.Ping
 import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
+import com.wire.kalium.logic.failure.LegalHoldEnabledForConversationFailure
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCaseImpl.Companion.ASSET_SIZE_DEFAULT_LIMIT_BYTES
 import io.mockk.coVerify
 import io.mockk.verify
@@ -680,7 +681,7 @@ class MessageComposerViewModelTest {
         }
 
     @Test
-    fun `given that user needs to be informed about enabled legal hold, when invoked sending, then message is not sent and dialog shown`() =
+    fun `given that user needs to be informed about enabled legal hold when sending, then message is not sent and dialog shown`() =
         runTest {
             // given
             val messageBundle = ComposableMessageBundle.SendTextMessageBundle("mocked-text-message", emptyList())
@@ -693,13 +694,13 @@ class MessageComposerViewModelTest {
             // then
             coVerify(exactly = 0) { arrangement.sendTextMessage.invoke(any(), any(), any(), any()) }
             assertEquals(
-                SureAboutMessagingDialogState.Visible.ConversationUnderLegalHold(messageBundle),
+                SureAboutMessagingDialogState.Visible.ConversationUnderLegalHold.BeforeSending(messageBundle),
                 viewModel.sureAboutMessagingDialogState
             )
         }
 
     @Test
-    fun `given that user chose to dismiss when enabled legal hold, when invoked sending, then message is not sent and dialog hidden`() =
+    fun `given that user chose to dismiss when enabled legal hold before sending, then message is not sent and dialog hidden`() =
         runTest {
             // given
             val messageBundle = ComposableMessageBundle.SendTextMessageBundle("mocked-text-message", emptyList())
@@ -718,7 +719,7 @@ class MessageComposerViewModelTest {
         }
 
     @Test
-    fun `given that user chose to send anyway when enabled legal hold, when invoked sending, then message is sent and dialog hidden`() =
+    fun `given that user chose to send anyway when enabled legal hold before sending, then message is sent and dialog hidden`() =
         runTest {
             // given
             val messageBundle = ComposableMessageBundle.SendTextMessageBundle("mocked-text-message", emptyList())
@@ -734,6 +735,66 @@ class MessageComposerViewModelTest {
             advanceUntilIdle()
             // then
             coVerify(exactly = 1) { arrangement.sendTextMessage.invoke(any(), any(), any(), any()) }
+            assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
+        }
+
+    @Test
+    fun `given that user needs to be informed about enabled legal hold when sending fails, then message is not resent and dialog shown`() =
+        runTest {
+            // given
+            val messageBundle = ComposableMessageBundle.SendTextMessageBundle("mocked-text-message", emptyList())
+            val messageId = "messageId"
+            val (arrangement, viewModel) = MessageComposerViewModelArrangement()
+                .withSuccessfulViewModelInit()
+                .withFailedSendTextMessage(LegalHoldEnabledForConversationFailure(messageId))
+                .arrange()
+            // when
+            viewModel.trySendMessage(messageBundle)
+            // then
+            coVerify(exactly = 0) { arrangement.retryFailedMessageUseCase.invoke(eq(messageId), any()) }
+            assertEquals(
+                SureAboutMessagingDialogState.Visible.ConversationUnderLegalHold.AfterSending(messageId),
+                viewModel.sureAboutMessagingDialogState
+            )
+        }
+
+    @Test
+    fun `given that user chose to dismiss when enabled legal hold when sending fails, then message is not resent and dialog hidden`() =
+        runTest {
+            // given
+            val messageBundle = ComposableMessageBundle.SendTextMessageBundle("mocked-text-message", emptyList())
+            val messageId = "messageId"
+            val (arrangement, viewModel) = MessageComposerViewModelArrangement()
+                .withSuccessfulViewModelInit()
+                .withObserveConversationUnderLegalHoldNotified(true)
+                .withFailedSendTextMessage(LegalHoldEnabledForConversationFailure(messageId))
+                .arrange()
+            viewModel.trySendMessage(messageBundle)
+            // when
+            viewModel.dismissSureAboutSendingMessage()
+            advanceUntilIdle()
+            // then
+            coVerify(exactly = 0) { arrangement.retryFailedMessageUseCase.invoke(any(), any()) }
+            assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
+        }
+
+    @Test
+    fun `given that user chose to send anyway when enabled legal hold when sending fails, then message is resent and dialog hidden`() =
+        runTest {
+            // given
+            val messageBundle = ComposableMessageBundle.SendTextMessageBundle("mocked-text-message", emptyList())
+            val messageId = "messageId"
+            val (arrangement, viewModel) = MessageComposerViewModelArrangement()
+                .withSuccessfulViewModelInit()
+                .withFailedSendTextMessage(LegalHoldEnabledForConversationFailure(messageId))
+                .withSuccessfulRetryFailedMessage()
+                .arrange()
+            viewModel.trySendMessage(messageBundle)
+            // when
+            viewModel.acceptSureAboutSendingMessage()
+            advanceUntilIdle()
+            // then
+            coVerify(exactly = 1) { arrangement.retryFailedMessageUseCase.invoke(eq(messageId), any()) }
             assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
         }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -32,8 +32,8 @@ import com.wire.android.ui.userprofile.other.OtherUserProfileScreenViewModelTest
 import com.wire.android.ui.userprofile.other.OtherUserProfileScreenViewModelTest.Companion.USER_ID
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.client.FetchUsersClientsFromRemoteUseCase
 import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
-import com.wire.kalium.logic.feature.client.PersistOtherUserClientsUseCase
 import com.wire.kalium.logic.feature.connection.BlockUserResult
 import com.wire.kalium.logic.feature.connection.BlockUserUseCase
 import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
@@ -96,7 +96,7 @@ internal class OtherUserProfileViewModelArrangement {
     lateinit var observeClientList: ObserveClientsByUserIdUseCase
 
     @MockK
-    lateinit var persistOtherUserClientsUseCase: PersistOtherUserClientsUseCase
+    lateinit var fetchUsersClientsFromRemote: FetchUsersClientsFromRemoteUseCase
 
     @MockK
     lateinit var clearConversationContent: ClearConversationContentUseCase
@@ -118,7 +118,7 @@ internal class OtherUserProfileViewModelArrangement {
             removeMemberFromConversationUseCase,
             updateConversationMemberRoleUseCase,
             observeClientList,
-            persistOtherUserClientsUseCase,
+            fetchUsersClientsFromRemote,
             clearConversationContent,
             updateConversationArchivedStatus,
             savedStateHandle


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5999" title="WPB-5999" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-5999</a>  Discover legal hold when sending messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to discover missing/deleted legal hold clients and changes in legal hold for conversation on Android when sending messages and handle this change properly by showing system messages. If the legal hold status for conversation changed when sending a message, the user needs to be informed about that and decide whether he/she still wants to resend the message.

### Solutions

Handle new type of failure `LegalHoldEnabledForConversationFailure` when sending a message and show a dialog informing the user that this conversation is under legal hold and give him/her option to decide whether he/she still wants to resend that message.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/2333

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Enable legal hold for some other member before logging in and syncing, then login - at this point the app doesn't yet know that a conversation or member is under legal hold, but after sending first message, it should be handled properly.

### Attachments (Optional)

https://github.com/wireapp/kalium/assets/30429749/3bf93acf-7ba9-4c6c-bb10-8306862045e1

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
