### PR TITLE
feat: App soft lock when E2EI is required (WPB-5876)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.message.MarkMessagesAsNotifiedUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
+import com.wire.kalium.logic.feature.user.E2EIRequiredResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -53,6 +54,8 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -305,9 +308,17 @@ class WireNotificationManager @Inject constructor(
     ) {
         appLogger.d("$TAG observe incoming calls")
 
-        coreLogic.getSessionScope(userId)
-            .calls
-            .getIncomingCalls()
+        coreLogic.getSessionScope(userId).observeE2EIRequired()
+            .map { it is E2EIRequiredResult.NoGracePeriod }
+            .distinctUntilChanged()
+            .flatMapLatest { isBlockedByE2EIRequired ->
+                if (isBlockedByE2EIRequired) {
+                    appLogger.d("$TAG calls were blocked as E2EI is required")
+                    flowOf(listOf())
+                } else {
+                    coreLogic.getSessionScope(userId).calls.getIncomingCalls()
+                }
+            }
             .collect { calls ->
                 callNotificationManager.handleIncomingCallNotifications(calls, userId)
             }
@@ -331,33 +342,37 @@ class WireNotificationManager @Inject constructor(
             .distinctUntilChanged()
             .stateIn(scope)
 
+        val isBlockedByE2EIRequiredState = coreLogic.getSessionScope(userId).observeE2EIRequired()
+            .map { it is E2EIRequiredResult.NoGracePeriod }
+            .distinctUntilChanged()
+            .stateIn(scope)
+
         coreLogic.getSessionScope(userId)
             .messages
             .getNotifications()
             .cancellable()
-            .map { newNotifications ->
-                // we don't want to display notifications for the Conversation that user currently in.
-                val notificationsList = filterAccordingToScreenAndUpdateNotifyDate(
-                    currentScreenState.value,
-                    userId,
-                    newNotifications
-                )
-
+            .onEach { newNotifications ->
                 playPingSoundIfNeeded(
                     currentScreen = currentScreenState.value,
                     notifications = newNotifications
                 )
-                val userName = selfUserNameState.value
-
-                // combining all the data that is necessary for Notifications into small data class,
-                // just to make it more readable than
-                // Triple<List<LocalNotification>, QualifiedID, String>
-                MessagesNotificationsData(notificationsList, userId, userName)
+            }
+            .map { newNotifications ->
+                // we don't want to display notifications for the Conversation that user currently in.
+                filterAccordingToScreenAndUpdateNotifyDate(
+                    currentScreenState.value,
+                    userId,
+                    newNotifications
+                )
             }
             .cancellable()
-            .collect { (newNotifications, userId, userName) ->
+            .collect { newNotifications ->
                 appLogger.d("$TAG got ${newNotifications.size} notifications")
-                messagesNotificationManager.handleNotification(newNotifications, userId, userName)
+                if (isBlockedByE2EIRequiredState.value) {
+                    appLogger.d("$TAG notifications were skipped as E2EI is required")
+                } else {
+                    messagesNotificationManager.handleNotification(newNotifications, userId, selfUserNameState.value)
+                }
                 markMessagesAsNotified(userId)
                 markConnectionAsNotified(userId)
             }

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -55,7 +55,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -59,7 +59,9 @@ import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
+import com.wire.kalium.logic.feature.user.E2EIRequiredResult
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveE2EIRequiredUseCase
 import com.wire.kalium.logic.feature.user.UserScope
 import com.wire.kalium.logic.sync.SyncManager
 import io.mockk.MockKAnnotations
@@ -666,6 +668,36 @@ class WireNotificationManagerTest {
             verify(exactly = 1) { arrangement.servicesManager.stopOngoingCallService() }
         }
 
+    @Test
+    fun givenSomeNotificationsAndUserBlockedByE2EIRequired_whenObserveCalled_thenNotificationIsNotShowed() =
+        runTestWithCancellation(dispatcherProvider.main()) {
+            val conversationId = ConversationId("conversation_value", "conversation_domain")
+            val (arrangement, manager) = Arrangement()
+                .withMessageNotifications(
+                    listOf(
+                        provideLocalNotificationConversation(
+                            id = conversationId,
+                            messages = listOf(provideLocalNotificationMessage())
+                        )
+                    )
+                ).withIncomingCalls(listOf())
+                .withCurrentScreen(CurrentScreen.SomeOther)
+                .withObserveE2EIRequired(E2EIRequiredResult.NoGracePeriod.Create)
+                .arrange()
+
+            manager.observeNotificationsAndCallsWhileRunning(listOf(provideUserId(TestUser.SELF_USER.id.value)), this)
+            runCurrent()
+
+            verify(exactly = 0) {
+                arrangement.messageNotificationManager.handleNotification(
+                    listOf(), TestUser.SELF_USER.id, TestUser.SELF_USER.handle!!
+                )
+            }
+            coVerify(atLeast = 1) {
+                arrangement.markMessagesAsNotified(MarkMessagesAsNotifiedUseCase.UpdateTarget.AllConversations)
+            }
+        }
+
     private inner class Arrangement {
         @MockK
         lateinit var coreLogic: CoreLogic
@@ -733,6 +765,9 @@ class WireNotificationManagerTest {
         @MockK
         lateinit var pingRinger: PingRinger
 
+        @MockK
+        lateinit var observeE2EIRequired: ObserveE2EIRequiredUseCase
+
         private val currentSessionChannel = Channel<CurrentSessionResult>(capacity = Channel.UNLIMITED)
 
         val wireNotificationManager by lazy {
@@ -751,11 +786,13 @@ class WireNotificationManagerTest {
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
 
+            coEvery { observeE2EIRequired() } returns flowOf(E2EIRequiredResult.NotRequired)
             coEvery { userSessionScope.calls } returns callsScope
             coEvery { userSessionScope.messages } returns messageScope
             coEvery { userSessionScope.syncManager } returns syncManager
             coEvery { userSessionScope.conversations } returns conversationScope
             coEvery { userSessionScope.users } returns userScope
+            coEvery { userSessionScope.observeE2EIRequired } returns observeE2EIRequired
             coEvery { conversationScope.markConnectionRequestAsNotified } returns markConnectionRequestAsNotified
             coEvery { userScope.getSelfUser } returns getSelfUser
             coEvery { markConnectionRequestAsNotified(any()) } returns Unit
@@ -803,6 +840,7 @@ class WireNotificationManagerTest {
                 coEvery { users } returns mockk {
                     coEvery { getSelfUser() } returns flowOf(selfUser)
                 }
+                coEvery { observeE2EIRequired } returns this@Arrangement.observeE2EIRequired
             }
         }
 
@@ -848,6 +886,10 @@ class WireNotificationManagerTest {
 
         fun withSelfUser(selfUserFlow: Flow<SelfUser>) = apply {
             coEvery { getSelfUser.invoke() } returns selfUserFlow
+        }
+
+        fun withObserveE2EIRequired(result: E2EIRequiredResult) = apply {
+            coEvery { observeE2EIRequired.invoke() } returns flowOf(result)
         }
 
         fun arrange() = this to wireNotificationManager


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5876" title="WPB-5876" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-5876</a>  [Android] App Soft Lock when the Grace Period has passed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


# What's new in this PR?

When the Grace Period for registering the E2EI has passed we need to "block" the app for the user.
- show the un-removable dialog that allows user only register the E2EI (was already implemented)
- block all the message notifications and incoming calls 

### Solutions

Update `NotificationManager` to keep observing and saving the messages and all the event into the DB, but do not notify user about it. 
