### PR TITLE
fix: applock toggle state when enforced and responding to changes [WPB-5751]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -35,7 +35,7 @@ import com.wire.kalium.logic.feature.connection.BlockUserUseCase
 import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveOtherUserSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
-import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
+import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveTeamSettingsSelfDeletingStatusUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
@@ -431,7 +431,7 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun provideIsAppLockEditableUseCase(
+    fun provideObserveIsAppLockEditableUseCase(
         @KaliumCoreLogic coreLogic: CoreLogic
-    ): IsAppLockEditableUseCase = coreLogic.getGlobalScope().isAppLockEditableUseCase
+    ): ObserveIsAppLockEditableUseCase = coreLogic.getGlobalScope().observeIsAppLockEditableUseCase
 }

--- a/app/src/main/kotlin/com/wire/android/feature/DisableAppLockUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/DisableAppLockUseCase.kt
@@ -18,16 +18,17 @@
 package com.wire.android.feature
 
 import com.wire.android.datastore.GlobalDataStore
-import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
+import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCase
 import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
 
 @ViewModelScoped
 class DisableAppLockUseCase @Inject constructor(
     private val dataStore: GlobalDataStore,
-    private val isAppLockEditableUseCase: IsAppLockEditableUseCase
+    private val observeIsAppLockEditableUseCase: ObserveIsAppLockEditableUseCase
 ) {
-    suspend operator fun invoke(): Boolean = if (isAppLockEditableUseCase()) {
+    suspend operator fun invoke(): Boolean = if (observeIsAppLockEditableUseCase().firstOrNull() == true) {
         dataStore.clearAppLockPasscode()
         true
     } else {

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
@@ -29,9 +29,10 @@ import com.wire.android.feature.ObserveAppLockConfigUseCase
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.feature.applock.MarkTeamAppLockStatusAsNotifiedUseCase
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
-import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
+import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -42,7 +43,7 @@ class SetLockScreenViewModel @Inject constructor(
     private val globalDataStore: GlobalDataStore,
     private val dispatchers: DispatcherProvider,
     private val observeAppLockConfig: ObserveAppLockConfigUseCase,
-    private val isAppLockEditable: IsAppLockEditableUseCase,
+    private val observeIsAppLockEditable: ObserveIsAppLockEditableUseCase,
     private val markTeamAppLockStatusAsNotified: MarkTeamAppLockStatusAsNotifiedUseCase
 ) : ViewModel() {
 
@@ -51,14 +52,15 @@ class SetLockScreenViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val isEditable = isAppLockEditable()
-            observeAppLockConfig()
-                .collectLatest {
-                    state = state.copy(
-                        timeout = it.timeout,
-                        isEditable = isEditable
-                    )
-                }
+            combine(
+                observeAppLockConfig(),
+                observeIsAppLockEditable()
+            ) { config, isEditable ->
+                SetLockCodeViewState(
+                    timeout = config.timeout,
+                    isEditable = isEditable
+                )
+            }.collectLatest { state = it }
         }
     }
 
@@ -84,7 +86,7 @@ class SetLockScreenViewModel @Inject constructor(
                 viewModelScope.launch {
                     withContext(dispatchers.io()) {
                         with(globalDataStore) {
-                            val source = if (isAppLockEditable()) {
+                            val source = if (state.isEditable) {
                                 AppLockSource.Manual
                             } else {
                                 AppLockSource.TeamEnforced

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
@@ -116,12 +116,11 @@ fun SettingsScreenContent(
                     }
                     add(SettingsItem.NetworkSettings)
 
+                    appLogger.d("AppLockConfig " +
+                            "isAppLockEditable: ${settingsState.isAppLockEditable} isAppLockEnabled: ${settingsState.isAppLockEnabled}")
                     add(SettingsItem.AppLock(
                         when (settingsState.isAppLockEditable) {
                             true -> {
-                                appLogger.d("AppLockConfig isAooLockEditable: ${settingsState.isAppLockEditable}")
-
-                                appLogger.d("AppLockConfig isAppLockEnabled: ${settingsState.isAppLockEnabled}")
                                 SwitchState.Enabled(
                                     value = settingsState.isAppLockEnabled,
                                     isOnOffVisible = true,
@@ -130,12 +129,8 @@ fun SettingsScreenContent(
                             }
 
                             false -> {
-                                appLogger.d("AppLockConfig isAooLockEditable: ${settingsState.isAppLockEditable}")
-
-                                appLogger.d("AppLockConfig isAppLockEnabled: ${settingsState.isAppLockEnabled}")
-                                SwitchState.Disabled(
+                                SwitchState.TextOnly(
                                     value = settingsState.isAppLockEnabled,
-                                    isOnOffVisible = true,
                                 )
                             }
                         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModel.kt
@@ -26,27 +26,32 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.GlobalDataStore
-import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
+import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val globalDataStore: GlobalDataStore,
-    private val isAppLockEditableUseCase: IsAppLockEditableUseCase
+    private val observeIsAppLockEditable: ObserveIsAppLockEditableUseCase
 ) : ViewModel() {
     var state by mutableStateOf(SettingsState())
         private set
 
     init {
         viewModelScope.launch {
-            isAppLockEditableUseCase().let {
-                state = state.copy(isAppLockEditable = it)
-            }
-            globalDataStore.isAppLockPasscodeSetFlow().collect {
-                state = state.copy(isAppLockEnabled = it)
-            }
+            combine(
+                observeIsAppLockEditable(),
+                globalDataStore.isAppLockPasscodeSetFlow()
+            ) {
+                isAppLockEditable, isAppLockEnabled ->
+                SettingsState(
+                    isAppLockEditable = isAppLockEditable,
+                    isAppLockEnabled = isAppLockEnabled
+                )
+            }.collect { state = it }
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/feature/DisableAppLockUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/DisableAppLockUseCaseTest.kt
@@ -18,11 +18,12 @@
 package com.wire.android.feature
 
 import com.wire.android.datastore.GlobalDataStore
-import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
+import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
@@ -60,15 +61,15 @@ class DisableAppLockUseCaseTest {
         lateinit var dataStore: GlobalDataStore
 
         @MockK
-        lateinit var isAppLockEditableUseCase: IsAppLockEditableUseCase
+        lateinit var observeIsAppLockEditableUseCase: ObserveIsAppLockEditableUseCase
 
         private val useCase = DisableAppLockUseCase(
             dataStore,
-            isAppLockEditableUseCase
+            observeIsAppLockEditableUseCase
         )
 
         fun withAppLockEditable(result: Boolean) = apply {
-            coEvery { isAppLockEditableUseCase() } returns result
+            coEvery { observeIsAppLockEditableUseCase() } returns flowOf(result)
         }
 
         fun withClearAppLockPasscode() = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModelTest.kt
@@ -26,7 +26,7 @@ import com.wire.android.feature.ObserveAppLockConfigUseCase
 import com.wire.kalium.logic.feature.applock.MarkTeamAppLockStatusAsNotifiedUseCase
 import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
-import com.wire.kalium.logic.feature.featureConfig.IsAppLockEditableUseCase
+import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -83,7 +83,7 @@ class SetLockScreenViewModelTest {
         private lateinit var markTeamAppLockStatusAsNotified: MarkTeamAppLockStatusAsNotifiedUseCase
 
         @MockK
-        private lateinit var isAppLockEditableUseCase: IsAppLockEditableUseCase
+        private lateinit var observeIsAppLockEditableUseCase: ObserveIsAppLockEditableUseCase
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
@@ -91,7 +91,7 @@ class SetLockScreenViewModelTest {
             coEvery { observeAppLockConfig() } returns flowOf(
                 AppLockConfig.Disabled(ObserveAppLockConfigUseCase.DEFAULT_APP_LOCK_TIMEOUT)
             )
-            coEvery { isAppLockEditableUseCase() } returns true
+            coEvery { observeIsAppLockEditableUseCase() } returns flowOf(true)
         }
 
         fun withValidPassword() = apply {
@@ -103,7 +103,7 @@ class SetLockScreenViewModelTest {
         }
 
         fun withIsAppLockEditable(result: Boolean) = apply {
-            coEvery { isAppLockEditableUseCase() } returns result
+            coEvery { observeIsAppLockEditableUseCase() } returns flowOf(result)
         }
 
         private val viewModel = SetLockScreenViewModel(
@@ -111,7 +111,7 @@ class SetLockScreenViewModelTest {
             globalDataStore,
             TestDispatcherProvider(),
             observeAppLockConfig,
-            isAppLockEditableUseCase,
+            observeIsAppLockEditableUseCase,
             markTeamAppLockStatusAsNotified
         )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5751" title="WPB-5751" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5751</a>  [Android] App lock toggle is green in settings, when enforced by team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, the app lock toggle is visible with ON value but just disabled when the app lock is enforced by the team admin. According to the designs in that case the toggle should be hidden and only "ON" text should be visible.
Also when the user is on that screen and the team admin changes the setting, it doesn't get updated automatically but only after closing and opening it again.

### Solutions

Change the appearance of the app lock row so that if it's enforced by the team admin then the toggle is not shown but just a text is visible. 
Use the updated use case to observe the editable app lock value changes instead of getting just a single value.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/2337

### Testing

#### How to Test

Open settings screen and change the app lock team settings on team admin panel.

### Attachments (Optional)

https://github.com/wireapp/wire-android/assets/30429749/a2474dc3-abf5-43e9-9df1-8731a8d65611

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
