### PR TITLE
chore: remove deprecated accompanist-navigation dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,7 +120,6 @@ dependencies {
     // Accompanist
     implementation(libs.accompanist.systemUI)
     implementation(libs.accompanist.placeholder)
-    implementation(libs.accompanist.navAnimation)
 
     implementation(libs.androidx.paging3)
     implementation(libs.androidx.paging3Compose)

--- a/app/src/beta/kotlin/com/wire/android/navigation/TrackingNavController.kt
+++ b/app/src/beta/kotlin/com/wire/android/navigation/TrackingNavController.kt
@@ -1,21 +1,22 @@
 package com.wire.android.navigation
 
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavDestination
+import androidx.navigation.compose.rememberNavController
 import com.datadog.android.compose.ExperimentalTrackingApi
 import com.datadog.android.compose.NavigationViewTrackingEffect
 import com.datadog.android.rum.tracking.AcceptAllNavDestinations
-import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 
-@OptIn(ExperimentalAnimationApi::class, ExperimentalTrackingApi::class)
+@OptIn(ExperimentalTrackingApi::class)
 @Composable
-fun rememberTrackingAnimatedNavController(nameFromRoute: (String) -> String?) = rememberAnimatedNavController().apply {
-    NavigationViewTrackingEffect(
-        navController = this,
-        trackArguments = true,
-        destinationPredicate = object : AcceptAllNavDestinations() {
-            override fun getViewName(component: NavDestination): String? = component.route?.let { nameFromRoute(it) }
-        }
-    )
-}
+fun rememberTrackingAnimatedNavController(nameFromRoute: (String) -> String?) =
+    rememberNavController().apply {
+        NavigationViewTrackingEffect(
+            navController = this,
+            trackArguments = true,
+            destinationPredicate = object : AcceptAllNavDestinations() {
+                override fun getViewName(component: NavDestination): String? =
+                    component.route?.let { nameFromRoute(it) }
+            }
+        )
+    }

--- a/app/src/dev/kotlin/com/wire/android/navigation/TrackingNavController.kt
+++ b/app/src/dev/kotlin/com/wire/android/navigation/TrackingNavController.kt
@@ -1,21 +1,22 @@
 package com.wire.android.navigation
 
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavDestination
+import androidx.navigation.compose.rememberNavController
 import com.datadog.android.compose.ExperimentalTrackingApi
 import com.datadog.android.compose.NavigationViewTrackingEffect
 import com.datadog.android.rum.tracking.AcceptAllNavDestinations
-import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 
-@OptIn(ExperimentalAnimationApi::class, ExperimentalTrackingApi::class)
+@OptIn(ExperimentalTrackingApi::class)
 @Composable
-fun rememberTrackingAnimatedNavController(nameFromRoute: (String) -> String?) = rememberAnimatedNavController().apply {
-    NavigationViewTrackingEffect(
-        navController = this,
-        trackArguments = true,
-        destinationPredicate = object : AcceptAllNavDestinations() {
-            override fun getViewName(component: NavDestination): String? = component.route?.let { nameFromRoute(it) }
-        }
-    )
-}
+fun rememberTrackingAnimatedNavController(nameFromRoute: (String) -> String?) =
+    rememberNavController().apply {
+        NavigationViewTrackingEffect(
+            navController = this,
+            trackArguments = true,
+            destinationPredicate = object : AcceptAllNavDestinations() {
+                override fun getViewName(component: NavDestination): String? =
+                    component.route?.let { nameFromRoute(it) }
+            }
+        )
+    }

--- a/app/src/internal/kotlin/com/wire/android/navigation/TrackingNavController.kt
+++ b/app/src/internal/kotlin/com/wire/android/navigation/TrackingNavController.kt
@@ -6,16 +6,18 @@ import androidx.navigation.NavDestination
 import com.datadog.android.compose.ExperimentalTrackingApi
 import com.datadog.android.compose.NavigationViewTrackingEffect
 import com.datadog.android.rum.tracking.AcceptAllNavDestinations
-import com.google.accompanist.navigation.animation.rememberAnimatedNavController
+import androidx.navigation.compose.rememberNavController
 
-@OptIn(ExperimentalAnimationApi::class, ExperimentalTrackingApi::class)
+@OptIn(ExperimentalTrackingApi::class)
 @Composable
-fun rememberTrackingAnimatedNavController(nameFromRoute: (String) -> String?) = rememberAnimatedNavController().apply {
-    NavigationViewTrackingEffect(
-        navController = this,
-        trackArguments = true,
-        destinationPredicate = object : AcceptAllNavDestinations() {
-            override fun getViewName(component: NavDestination): String? = component.route?.let { nameFromRoute(it) }
-        }
-    )
-}
+fun rememberTrackingAnimatedNavController(nameFromRoute: (String) -> String?) =
+    rememberNavController().apply {
+        NavigationViewTrackingEffect(
+            navController = this,
+            trackArguments = true,
+            destinationPredicate = object : AcceptAllNavDestinations() {
+                override fun getViewName(component: NavDestination): String? =
+                    component.route?.let { nameFromRoute(it) }
+            }
+        )
+    }

--- a/app/src/internal/kotlin/com/wire/android/navigation/TrackingNavController.kt
+++ b/app/src/internal/kotlin/com/wire/android/navigation/TrackingNavController.kt
@@ -1,6 +1,5 @@
 package com.wire.android.navigation
 
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavDestination
 import com.datadog.android.compose.ExperimentalTrackingApi

--- a/app/src/prod/kotlin/com/wire/android/navigation/TrackingNavController.kt
+++ b/app/src/prod/kotlin/com/wire/android/navigation/TrackingNavController.kt
@@ -1,9 +1,8 @@
 package com.wire.android.navigation
 
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
-import com.google.accompanist.navigation.animation.rememberAnimatedNavController
+import androidx.navigation.compose.rememberNavController
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
-fun rememberTrackingAnimatedNavController(nameFromRoute: (String) -> String?) = rememberAnimatedNavController()
+fun rememberTrackingAnimatedNavController(nameFromRoute: (String) -> String?) =
+    rememberNavController()

--- a/app/src/staging/kotlin/com/wire/android/navigation/TrackingNavController.kt
+++ b/app/src/staging/kotlin/com/wire/android/navigation/TrackingNavController.kt
@@ -1,21 +1,22 @@
 package com.wire.android.navigation
 
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavDestination
 import com.datadog.android.compose.ExperimentalTrackingApi
 import com.datadog.android.compose.NavigationViewTrackingEffect
 import com.datadog.android.rum.tracking.AcceptAllNavDestinations
-import com.google.accompanist.navigation.animation.rememberAnimatedNavController
+import androidx.navigation.compose.rememberNavController
 
-@OptIn(ExperimentalAnimationApi::class, ExperimentalTrackingApi::class)
+@OptIn(ExperimentalTrackingApi::class)
 @Composable
-fun rememberTrackingAnimatedNavController(nameFromRoute: (String) -> String?) = rememberAnimatedNavController().apply {
-    NavigationViewTrackingEffect(
-        navController = this,
-        trackArguments = true,
-        destinationPredicate = object : AcceptAllNavDestinations() {
-            override fun getViewName(component: NavDestination): String? = component.route?.let { nameFromRoute(it) }
-        }
-    )
-}
+fun rememberTrackingAnimatedNavController(nameFromRoute: (String) -> String?) =
+    rememberNavController().apply {
+        NavigationViewTrackingEffect(
+            navController = this,
+            trackArguments = true,
+            destinationPredicate = object : AcceptAllNavDestinations() {
+                override fun getViewName(component: NavDestination): String? =
+                    component.route?.let { nameFromRoute(it) }
+            }
+        )
+    }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,11 +37,11 @@ androidx-browser = "1.5.0"
 androidx-biometric = "1.1.0"
 
 # Compose
-composeBom = "2023.10.00" # TODO check if in new version [anchoredDraggable] is available
-compose-activity = "1.8.0"
+composeBom = "2023.10.01" # TODO check if in new version [anchoredDraggable] is available
+compose-activity = "1.8.2"
 compose-compiler = "1.5.2"
 compose-constraint = "1.0.1"
-compose-navigation = "2.7.3" # adjusted to work with compose-destinations "1.9.54"
+compose-navigation = "2.7.6" # adjusted to work with compose-destinations "1.9.54"
 compose-destinations = "1.9.54"
 
 # Hilt
@@ -188,7 +188,6 @@ compose-destinations-ksp = { module = "io.github.raamcosta.compose-destinations:
 # Accompanist
 accompanist-systemUI = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 accompanist-placeholder = { module = "com.google.accompanist:accompanist-placeholder", version.ref = "accompanist" }
-accompanist-navAnimation = { module = "com.google.accompanist:accompanist-navigation-animation", version.ref = "accompanist" }
 
 # Image Loading
 coil-core = { module = "io.coil-kt:coil", version.ref = "coil" }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

[accompanist-navigation](https://google.github.io/accompanist/navigation-animation/) is deprecated

### Solutions

Migrate to `androidx.navigation.compose`

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
