### PR TITLE
fix: missing ServerConfig crashes after session expired / logout [WPB-5960]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -20,18 +20,24 @@
 
 package com.wire.android
 
+import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.feature.auth.LogoutCallback
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -46,6 +52,7 @@ class GlobalObserversManager @Inject constructor(
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val notificationManager: WireNotificationManager,
     private val notificationChannelsManager: NotificationChannelsManager,
+    private val userDataStoreProvider: UserDataStoreProvider,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.io())
 
@@ -58,6 +65,7 @@ class GlobalObserversManager @Inject constructor(
                 }
             }
         }
+        scope.handleLogouts()
     }
 
     private suspend fun setUpNotifications() {
@@ -90,5 +98,19 @@ class GlobalObserversManager @Inject constructor(
                 // it would be nice to call all the notification observations in one place,
                 // but we can't start PersistentWebSocketService here, to avoid ForegroundServiceStartNotAllowedException
             }
+    }
+
+    private fun CoroutineScope.handleLogouts() {
+        callbackFlow<Unit> {
+            val callback: LogoutCallback = { userId, logoutReason ->
+                notificationManager.stopObservingOnLogout(userId)
+                notificationChannelsManager.deleteChannelGroup(userId)
+                if (logoutReason != LogoutReason.SELF_SOFT_LOGOUT) {
+                    userDataStoreProvider.getOrCreate(userId).clear()
+                }
+            }
+            coreLogic.getGlobalScope().logoutCallbackManager.register(callback)
+            awaitClose { coreLogic.getGlobalScope().logoutCallbackManager.unregister(callback) }
+        }.launchIn(this)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -41,6 +41,7 @@ import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveTeamSettingsSel
 import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
 import com.wire.kalium.logic.feature.server.ServerConfigForAccountUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.session.UpdateCurrentSessionUseCase
 import com.wire.kalium.logic.feature.user.MarkFileSharingChangeAsNotifiedUseCase
@@ -309,6 +310,11 @@ class UseCaseModule {
     @Provides
     fun provideObserveValidAccountsUseCase(@KaliumCoreLogic coreLogic: CoreLogic): ObserveValidAccountsUseCase =
         coreLogic.getGlobalScope().observeValidAccounts
+
+    @ViewModelScoped
+    @Provides
+    fun provideDoesValidSessionExistsUseCase(@KaliumCoreLogic coreLogic: CoreLogic): DoesValidSessionExistUseCase =
+        coreLogic.getGlobalScope().doesValidSessionExist
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
@@ -20,6 +20,7 @@
 
 package com.wire.android.feature
 
+import com.wire.android.appLogger
 import com.wire.android.di.ApplicationScope
 import com.wire.android.di.AuthServerConfigProvider
 import com.wire.android.navigation.BackStackMode
@@ -40,6 +41,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -64,11 +67,12 @@ class AccountSwitchUseCase @Inject constructor(
         }
 
     suspend operator fun invoke(params: SwitchAccountParam): SwitchAccountResult {
-        val current = currentAccount
+        val current = currentAccount.await()
+        appLogger.i("$TAG Switching account invoked: ${params.toLogString()}, current account: ${current?.userId?.toLogString() ?: "-"}")
         return when (params) {
-            is SwitchAccountParam.SwitchToAccount -> switch(params.userId, current.await())
-            SwitchAccountParam.TryToSwitchToNextAccount -> getNextAccountIfPossibleAndSwitch(current.await())
-            SwitchAccountParam.Clear -> switch(null, current.await())
+            is SwitchAccountParam.SwitchToAccount -> switch(params.userId, current)
+            SwitchAccountParam.TryToSwitchToNextAccount -> getNextAccountIfPossibleAndSwitch(current)
+            SwitchAccountParam.Clear -> switch(null, current)
         }
     }
 
@@ -83,6 +87,8 @@ class AccountSwitchUseCase @Inject constructor(
                     }?.userId
             }
         }
+        if (nextSessionId == null) appLogger.i("$TAG No next account to switch to")
+        else appLogger.i("$TAG Switching to next account: ${nextSessionId.toLogString()}")
         return switch(nextSessionId, current)
     }
 
@@ -104,6 +110,7 @@ class AccountSwitchUseCase @Inject constructor(
     }
 
     private suspend fun updateAuthServer(current: UserId) {
+        appLogger.i("$TAG Updating auth server config for account: ${current.toLogString()}")
         serverConfigForAccountUseCase(current).let {
             when (it) {
                 is ServerConfigForAccountUseCase.Result.Success -> authServerConfigProvider.updateAuthServer(it.config)
@@ -126,6 +133,7 @@ class AccountSwitchUseCase @Inject constructor(
     }
 
     private suspend fun handleInvalidSession(invalidAccount: AccountInfo.Invalid) {
+        appLogger.i("$TAG Handling invalid account: ${invalidAccount.userId.toLogString()}")
         when (invalidAccount.logoutReason) {
             LogoutReason.SELF_SOFT_LOGOUT, LogoutReason.SELF_HARD_LOGOUT -> {
                 deleteSession(invalidAccount.userId)
@@ -137,14 +145,21 @@ class AccountSwitchUseCase @Inject constructor(
     }
 
     private companion object {
+        const val TAG = "AccountSwitch"
         const val DELETE_USER_SESSION_TIMEOUT = 3000L
     }
 }
 
 sealed class SwitchAccountParam {
-    object TryToSwitchToNextAccount : SwitchAccountParam()
+    data object TryToSwitchToNextAccount : SwitchAccountParam()
     data class SwitchToAccount(val userId: UserId) : SwitchAccountParam()
     data object Clear : SwitchAccountParam()
+    private fun toLogMap(): Map<String, String> = when (this) {
+        is Clear ->  mutableMapOf("value" to "CLEAR")
+        is SwitchToAccount ->  mutableMapOf("value" to "SWITCH_TO_ACCOUNT", "userId" to userId.toLogString())
+        is TryToSwitchToNextAccount -> mutableMapOf("value" to "TRY_TO_SWITCH_TO_NEXT_ACCOUNT")
+    }
+    fun toLogString(): String = Json.encodeToString(toLogMap())
 }
 
 sealed class SwitchAccountResult {

--- a/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
@@ -155,8 +155,8 @@ sealed class SwitchAccountParam {
     data class SwitchToAccount(val userId: UserId) : SwitchAccountParam()
     data object Clear : SwitchAccountParam()
     private fun toLogMap(): Map<String, String> = when (this) {
-        is Clear ->  mutableMapOf("value" to "CLEAR")
-        is SwitchToAccount ->  mutableMapOf("value" to "SWITCH_TO_ACCOUNT", "userId" to userId.toLogString())
+        is Clear -> mutableMapOf("value" to "CLEAR")
+        is SwitchToAccount -> mutableMapOf("value" to "SWITCH_TO_ACCOUNT", "userId" to userId.toLogString())
         is TryToSwitchToNextAccount -> mutableMapOf("value" to "TRY_TO_SWITCH_TO_NEXT_ACCOUNT")
     }
     fun toLogString(): String = Json.encodeToString(toLogMap())

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -90,7 +90,6 @@ import com.wire.android.util.debug.FeatureVisibilityFlags
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.ui.updateScreenSettings
-import com.wire.kalium.logic.data.user.UserId
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -196,10 +196,7 @@ class WireActivity : AppCompatActivity() {
                         // and if any NavigationCommand is executed before the graph is fully built, it will cause a NullPointerException.
                         setUpNavigation(navigator.navController, onComplete)
                         handleScreenshotCensoring()
-                        handleDialogs(
-                            navigator::navigate,
-                            viewModel.currentUserId.value
-                        )
+                        handleDialogs(navigator::navigate)
                     }
                 }
             }
@@ -253,10 +250,7 @@ class WireActivity : AppCompatActivity() {
     }
 
     @Composable
-    private fun handleDialogs(navigate: (NavigationCommand) -> Unit, userId: UserId?) {
-        LaunchedEffect(userId) {
-            featureFlagNotificationViewModel.loadInitialSync()
-        }
+    private fun handleDialogs(navigate: (NavigationCommand) -> Unit) {
         with(featureFlagNotificationViewModel.featureFlagState) {
             if (shouldShowTeamAppLockDialog) {
                 TeamAppLockFeatureFlagDialog(

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityDialogs.kt
@@ -26,6 +26,7 @@ import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.DialogProperties
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.appLogger
@@ -296,6 +297,7 @@ private fun accountLoggedOutDialog(reason: CurrentSessionErrorState, navigateAwa
         title = stringResource(id = title),
         text = text,
         onDismiss = remember { { } },
+        properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false, usePlatformDefaultWidth = false),
         optionButton1Properties = WireDialogButtonProperties(
             text = stringResource(R.string.label_ok),
             onClick = navigateAway,

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -66,6 +66,8 @@ import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
@@ -96,6 +98,7 @@ class WireActivityViewModel @Inject constructor(
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val dispatchers: DispatcherProvider,
     private val currentSessionFlow: CurrentSessionFlowUseCase,
+    private val doesValidSessionExist: DoesValidSessionExistUseCase,
     private val getServerConfigUseCase: GetServerConfigUseCase,
     private val deepLinkProcessor: DeepLinkProcessor,
     private val authServerConfigProvider: AuthServerConfigProvider,
@@ -116,12 +119,12 @@ class WireActivityViewModel @Inject constructor(
         private set
 
     private val observeUserId = currentSessionFlow()
+        .distinctUntilChanged()
         .onEach {
             if (it is CurrentSessionResult.Success) {
                 if (it.accountInfo.isValid().not()) {
                     handleInvalidSession((it.accountInfo as AccountInfo.Invalid).logoutReason)
                 }
-                currentUserId.value = it.accountInfo.userId
             }
         }
         .map { result ->
@@ -134,12 +137,13 @@ class WireActivityViewModel @Inject constructor(
             } else {
                 null
             }
-        }.distinctUntilChanged().flowOn(dispatchers.io()).shareIn(viewModelScope, SharingStarted.WhileSubscribed(), 1)
+        }
+        .distinctUntilChanged()
+        .flowOn(dispatchers.io())
+        .shareIn(viewModelScope, SharingStarted.WhileSubscribed(), 1)
 
     private val _observeSyncFlowState: MutableStateFlow<SyncState?> = MutableStateFlow(null)
     val observeSyncFlowState: StateFlow<SyncState?> = _observeSyncFlowState
-
-    val currentUserId: MutableState<UserId?> = mutableStateOf(null)
 
     init {
         observeSyncState()
@@ -290,7 +294,13 @@ class WireActivityViewModel @Inject constructor(
 
     fun dismissNewClientsDialog(userId: UserId) {
         globalAppState = globalAppState.copy(newClientDialog = null)
-        viewModelScope.launch { clearNewClientsForUser(userId) }
+        viewModelScope.launch {
+            doesValidSessionExist(userId).let {
+                if (it is DoesValidSessionExistResult.Success && it.doesValidSessionExist) {
+                    clearNewClientsForUser(userId)
+                }
+            }
+        }
     }
 
     fun switchAccount(userId: UserId, actions: SwitchAccountActions, onComplete: () -> Unit) {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -21,7 +21,6 @@
 package com.wire.android.ui
 
 import android.content.Intent
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
@@ -56,7 +56,7 @@ class SetLockScreenViewModel @Inject constructor(
                 observeAppLockConfig(),
                 observeIsAppLockEditable()
             ) { config, isEditable ->
-                SetLockCodeViewState(
+                state.copy(
                     timeout = config.timeout,
                     isEditable = isEditable
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -87,7 +87,7 @@ class FeatureFlagNotificationViewModel @Inject constructor(
                     is CurrentSessionResult.Failure -> {
                         currentUserId = null
                         appLogger.e("Failure while getting current session from FeatureFlagNotificationViewModel")
-                        featureFlagState = FeatureFlagState(  // no session, clear feature flag state to default and set NO_USER
+                        featureFlagState = FeatureFlagState( // no session, clear feature flag state to default and set NO_USER
                             fileSharingRestrictedState = FeatureFlagState.SharingRestrictedState.NO_USER
                         )
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -81,8 +81,6 @@ fun ImportMediaScreen(
     navigator: Navigator,
     featureFlagNotificationViewModel: FeatureFlagNotificationViewModel = hiltViewModel()
 ) {
-    featureFlagNotificationViewModel.loadInitialSync()
-
     when (val fileSharingRestrictedState =
         featureFlagNotificationViewModel.featureFlagState.fileSharingRestrictedState) {
         FeatureFlagState.SharingRestrictedState.NO_USER -> {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -209,7 +209,7 @@ class SelfUserProfileViewModel @Inject constructor(
             }.join()
 
             val logoutReason = if (wipeData) LogoutReason.SELF_HARD_LOGOUT else LogoutReason.SELF_SOFT_LOGOUT
-            logout(logoutReason)
+            logout(logoutReason, waitUntilCompletes = true)
             if (wipeData) {
                 // TODO this should be moved to some service that will clear all the data in the app
                 dataStore.clear()

--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -3,6 +3,7 @@ package com.wire.android
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
+import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.framework.TestUser
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
@@ -80,12 +81,16 @@ class GlobalObserversManagerTest {
         @MockK
         lateinit var notificationManager: WireNotificationManager
 
+        @MockK
+        lateinit var userDataStoreProvider: UserDataStoreProvider
+
         private val manager by lazy {
             GlobalObserversManager(
                 dispatcherProvider = TestDispatcherProvider(),
                 coreLogic = coreLogic,
                 notificationChannelsManager = notificationChannelsManager,
-                notificationManager = notificationManager
+                notificationManager = notificationManager,
+                userDataStoreProvider = userDataStoreProvider,
             )
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -57,6 +57,8 @@ import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
@@ -517,13 +519,25 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `when dismissNewClientsDialog is called, then cleared NewClients for user`() = runTest {
+    fun `given session exists, when dismissNewClientsDialog is called, then cleared NewClients for user`() = runTest {
         val (arrangement, viewModel) = Arrangement()
+            .withSomeCurrentSession()
             .arrange()
 
         viewModel.dismissNewClientsDialog(USER_ID)
 
         coVerify(exactly = 1) { arrangement.clearNewClientsForUser(USER_ID) }
+    }
+
+    @Test
+    fun `given session does not exist, when dismissNewClientsDialog is called, then do nothing`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .withNoCurrentSession()
+            .arrange()
+
+        viewModel.dismissNewClientsDialog(USER_ID)
+
+        coVerify(exactly = 0) { arrangement.clearNewClientsForUser(USER_ID) }
     }
 
     @Test
@@ -602,6 +616,9 @@ class WireActivityViewModelTest {
         lateinit var currentSessionFlow: CurrentSessionFlowUseCase
 
         @MockK
+        lateinit var doesValidSessionExist: DoesValidSessionExistUseCase
+
+        @MockK
         lateinit var getServerConfigUseCase: GetServerConfigUseCase
 
         @MockK
@@ -662,6 +679,7 @@ class WireActivityViewModelTest {
                 coreLogic = coreLogic,
                 dispatchers = TestDispatcherProvider(),
                 currentSessionFlow = currentSessionFlow,
+                doesValidSessionExist = doesValidSessionExist,
                 getServerConfigUseCase = getServerConfigUseCase,
                 deepLinkProcessor = deepLinkProcessor,
                 authServerConfigProvider = authServerConfigProvider,
@@ -682,11 +700,13 @@ class WireActivityViewModelTest {
         fun withSomeCurrentSession(): Arrangement = apply {
             coEvery { currentSessionFlow() } returns flowOf(CurrentSessionResult.Success(TEST_ACCOUNT_INFO))
             coEvery { coreLogic.getGlobalScope().session.currentSession() } returns CurrentSessionResult.Success(TEST_ACCOUNT_INFO)
+            coEvery { doesValidSessionExist(any()) } returns DoesValidSessionExistResult.Success(true)
         }
 
         fun withNoCurrentSession(): Arrangement {
             coEvery { currentSessionFlow() } returns flowOf(CurrentSessionResult.Failure.SessionNotFound)
             coEvery { coreLogic.getGlobalScope().session.currentSession() } returns CurrentSessionResult.Failure.SessionNotFound
+            coEvery { doesValidSessionExist(any()) } returns DoesValidSessionExistResult.Success(false)
             return this
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5960" title="WPB-5960" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5960</a>  [Android] missing serverConfig crash
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Top crashes types currently are the ones related to missing ServerConfig when making some actions.

### Causes (Optional)

When session is expired (the app receives 403 when trying to refresh a token) there is an infinite loop, because the app tries to logout - deregister token which results in 401 and it triggers the auth token refresh again resulting in 403 and trying to logout again. After each iteration, CurrentSessionFlowUseCase emits the same item again, which triggers multiple actions in the whole app and creates a race condition when logging out (session should be invalid but with all the loop iterations in a fraction of a second the app can still get the previous value).
Some logout actions in Android project are not executed when account is logged out from kalium (when session expires, device is removed from another place or account deleted).
Some actions that require user session are allowed to be executed after the logout when this session is cleared and not existing anymore resulting in crashes.

### Solutions

- use `currentSessionFlow` instead of getting just a single initial value from `currentSession` to not show a state for the previous session when changed
- update `currentUserId` properties when the session changed
- cancel the observing flows for previous session when changed
- do not execute actions (at least dialog dismiss actions) if the current session is invalid or there is no session
- fix issue with continue button on "set app lock" screen not always making actions properly (race condition)
- register for logout callback triggered when the logout happens in kalium to execute all other required logout-related actions in Android
- make `AccountLoggedOutDialog` non-dismissable
- provide logs for `AccountSwitchUseCase`

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/2352

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
