### PR TITLE
feat(e2ei): pass ignore ssl certs for apis in dev build

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -55,6 +55,7 @@ class KaliumConfigsModule {
             lowerKeyingMaterialsUpdateThreshold = BuildConfig.PRIVATE_BUILD,
             isMLSSupportEnabled = BuildConfig.MLS_SUPPORT_ENABLED,
             developmentApiEnabled = BuildConfig.DEVELOPMENT_API_ENABLED,
+            ignoreSSLCertificatesForUnboundCalls = BuildConfig.IGNORE_SSL_CERTIFICATES,
             encryptProteusStorage = runBlocking { globalDataStore.isEncryptedProteusStorageEnabled().first() },
             guestRoomLink = BuildConfig.ENABLE_GUEST_ROOM_LINK,
             selfDeletingMessages = BuildConfig.SELF_DELETING_MESSAGES,

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -59,6 +59,7 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
     WIPE_ON_ROOTED_DEVICE("wipe_on_rooted_device", ConfigType.BOOLEAN),
     WIPE_ON_DEVICE_REMOVAL("wipe_on_device_removal", ConfigType.BOOLEAN),
     SELF_DELETING_MESSAGES("self_deleting_messages", ConfigType.BOOLEAN),
+    IGNORE_SSL_CERTIFICATES("ignore_ssl_certificates", ConfigType.BOOLEAN),
 
     /**
      * 3rd party services API Keys and IDs

--- a/default.json
+++ b/default.json
@@ -14,6 +14,7 @@
             "logging_enabled": true,
             "application_is_private_build": true,
             "development_api_enabled": true,
+            "ignore_ssl_certificates": true,
             "mls_support_enabled": true,
             "firebase_push_sender_id": "723990470614",
             "firebase_app_id": "1:723990470614:android:10cf802bfcc7bb71d28e77",
@@ -26,7 +27,6 @@
             "default_backend_url_blacklist": "https://clientblacklist.wire.com/staging",
             "default_backend_url_website": "https://wire.com",
             "default_backend_title": "wire-staging",
-
             "is_password_protected_guest_link_enabled": true
         },
         "staging": {
@@ -76,6 +76,7 @@
     "file_restriction_enabled": false,
     "file_restriction_list": "3gpp, aac, amr, avi, bmp, css, csv, dib, doc, docx, eml, flac, gif, html, ico, jfif, jpeg, jpg, jpg-large, key, m4a, m4v, md, midi, mkv, mov, mp3, mp4, mpeg, mpeg3, mpg, msg, ods, odt, ogg, pdf, pjp, pjpeg, png, pps, ppt, pptx, psd, pst, rtf, sql, svg, tex, tiff, txt, vcf, vid, wav, webm, webp, wmv, xls, xlsx, xml",
     "force_constant_bitrate_calls": false,
+    "ignore_ssl_certificates": false,
     "mls_support_enabled": true,
     "encrypt_proteus_storage": false,
     "self_deleting_messages": true,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Passing a config to kalium on Dev builds to ignore ssl errors.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
