### PR TITLE
feat(mls): handle unsupported protocol case [WPB-5047]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
@@ -58,8 +57,10 @@ import com.wire.android.ui.home.messagecomposer.state.MessageComposition
 import com.wire.android.ui.home.messagecomposer.state.MessageCompositionHolder
 import com.wire.android.ui.home.messagecomposer.state.MessageCompositionInputStateHolder
 import com.wire.android.ui.home.messagecomposer.state.Ping
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.stringWithStyledArgs
 import com.wire.kalium.logic.data.conversation.Conversation.TypingIndicatorMode
 import com.wire.kalium.logic.data.id.ConversationId
@@ -101,6 +102,18 @@ fun MessageComposer(
                 conversationId = conversationId,
                 warningText = LocalContext.current.resources.stringWithStyledArgs(
                     R.string.label_system_message_user_not_available,
+                    MaterialTheme.wireTypography.body01,
+                    MaterialTheme.wireTypography.body02,
+                    colorsScheme().secondaryText,
+                    colorsScheme().onBackground,
+                ),
+                messageListContent = messageListContent
+            )
+
+            InteractionAvailability.UNSUPPORTED_PROTOCOL -> DisabledInteractionMessageComposer(
+                conversationId = conversationId,
+                warningText = LocalContext.current.resources.stringWithStyledArgs(
+                    R.string.label_system_message_unsupported_protocol,
                     MaterialTheme.wireTypography.body01,
                     MaterialTheme.wireTypography.body02,
                     colorsScheme().secondaryText,
@@ -195,10 +208,17 @@ private fun DisabledInteractionMessageComposer(
     }
 }
 
-@Preview
 @Composable
-fun MessageComposerPreview() {
-    val messageComposerViewState = remember { mutableStateOf(MessageComposerViewState()) }
+private fun BaseComposerPreview(
+    interactionAvailability: InteractionAvailability = InteractionAvailability.ENABLED,
+) = WireTheme {
+    val messageComposerViewState = remember {
+        mutableStateOf(
+            MessageComposerViewState(
+                interactionAvailability = interactionAvailability
+            )
+        )
+    }
     val messageComposition = remember { mutableStateOf(MessageComposition.DEFAULT) }
     val selfDeletionTimer = remember { mutableStateOf(SelfDeletionTimer.Enabled(Duration.ZERO)) }
 
@@ -225,4 +245,16 @@ fun MessageComposerPreview() {
         tempWritableImageUri = null,
         onTypingEvent = { }
     )
+}
+
+@PreviewMultipleThemes
+@Composable
+private fun UnsupportedProtocolComposerPreview() = WireTheme {
+    BaseComposerPreview(interactionAvailability = InteractionAvailability.UNSUPPORTED_PROTOCOL)
+}
+
+@PreviewMultipleThemes
+@Composable
+private fun EnabledComposerPreview() = WireTheme {
+    BaseComposerPreview(interactionAvailability = InteractionAvailability.ENABLED)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -596,6 +596,9 @@
         <item quantity="other">%1$s were removed from the team</item>
     </plurals>
     <string name="label_system_message_user_not_available">This user is no longer available</string>
+    <string name="label_system_message_unsupported_protocol">The conversation is using an encryption protocol that is
+        not supported by this device. Some devices from the involve users might need updating.
+    </string>
     <string name="label_system_message_new_conversation_receipt_mode">Read receipts are %1$s</string>
     <string name="label_system_message_read_receipt_changed_by_self">%1$s turned read receipts %2$s for everyone</string>
     <string name="label_system_message_read_receipt_changed_by_other">%1$s turned read receipts %2$s for everyone</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5047" title="WPB-5047" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-5047</a>  [Android] Make 1-1 conversation readonly when there's no common protocol
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a conversation is using a protocol that the device doesn't support. We need to lock the conversation UI and inform the user the reason.

### Solutions

The `MessageComposer` was been updated to handle an UnsupportedProtocol case. This case renders a disabled message composer with a warning message. This warning informs users that the conversation is using an unsupported encryption protocol.

### Dependencies

Needs releases with:

- https://github.com/wireapp/kalium/pull/2362

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
