### PR TITLE
fix: missing ServerConfig crashes after session expired / logout [WPB-5960]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -18,18 +18,25 @@
 
 package com.wire.android
 
+import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.auth.LogoutCallback
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -43,7 +50,12 @@ class GlobalObserversManager @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val notificationManager: WireNotificationManager,
+<<<<<<< HEAD
     private val notificationChannelsManager: NotificationChannelsManager
+=======
+    private val notificationChannelsManager: NotificationChannelsManager,
+    private val userDataStoreProvider: UserDataStoreProvider,
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
 ) {
     private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.io())
 
@@ -56,6 +68,7 @@ class GlobalObserversManager @Inject constructor(
                 }
             }
         }
+        scope.handleLogouts()
     }
 
     private suspend fun setUpNotifications() {
@@ -88,5 +101,21 @@ class GlobalObserversManager @Inject constructor(
                 // it would be nice to call all the notification observations in one place,
                 // but we can't start PersistentWebSocketService here, to avoid ForegroundServiceStartNotAllowedException
             }
+    }
+
+    private fun CoroutineScope.handleLogouts() {
+        callbackFlow<Unit> {
+            val callback: LogoutCallback = object : LogoutCallback {
+                override suspend fun invoke(userId: UserId, reason: LogoutReason) {
+                    notificationManager.stopObservingOnLogout(userId)
+                    notificationChannelsManager.deleteChannelGroup(userId)
+                    if (reason != LogoutReason.SELF_SOFT_LOGOUT) {
+                        userDataStoreProvider.getOrCreate(userId).clear()
+                    }
+                }
+            }
+            coreLogic.getGlobalScope().logoutCallbackManager.register(callback)
+            awaitClose { coreLogic.getGlobalScope().logoutCallbackManager.unregister(callback) }
+        }.launchIn(this)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -50,12 +50,8 @@ class GlobalObserversManager @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val notificationManager: WireNotificationManager,
-<<<<<<< HEAD
-    private val notificationChannelsManager: NotificationChannelsManager
-=======
     private val notificationChannelsManager: NotificationChannelsManager,
     private val userDataStoreProvider: UserDataStoreProvider,
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
 ) {
     private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.io())
 

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -41,6 +41,7 @@ import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveTeamSettingsSel
 import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
 import com.wire.kalium.logic.feature.server.ServerConfigForAccountUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.session.UpdateCurrentSessionUseCase
 import com.wire.kalium.logic.feature.user.MarkFileSharingChangeAsNotifiedUseCase
@@ -309,6 +310,11 @@ class UseCaseModule {
     @Provides
     fun provideObserveValidAccountsUseCase(@KaliumCoreLogic coreLogic: CoreLogic): ObserveValidAccountsUseCase =
         coreLogic.getGlobalScope().observeValidAccounts
+
+    @ViewModelScoped
+    @Provides
+    fun provideDoesValidSessionExistsUseCase(@KaliumCoreLogic coreLogic: CoreLogic): DoesValidSessionExistUseCase =
+        coreLogic.getGlobalScope().doesValidSessionExist
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.feature
 
+import com.wire.android.appLogger
 import com.wire.android.di.ApplicationScope
 import com.wire.android.di.AuthServerConfigProvider
 import com.wire.android.navigation.BackStackMode
@@ -38,6 +39,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -62,11 +65,12 @@ class AccountSwitchUseCase @Inject constructor(
         }
 
     suspend operator fun invoke(params: SwitchAccountParam): SwitchAccountResult {
-        val current = currentAccount
+        val current = currentAccount.await()
+        appLogger.i("$TAG Switching account invoked: ${params.toLogString()}, current account: ${current?.userId?.toLogString() ?: "-"}")
         return when (params) {
-            is SwitchAccountParam.SwitchToAccount -> switch(params.userId, current.await())
-            SwitchAccountParam.TryToSwitchToNextAccount -> getNextAccountIfPossibleAndSwitch(current.await())
-            SwitchAccountParam.Clear -> switch(null, current.await())
+            is SwitchAccountParam.SwitchToAccount -> switch(params.userId, current)
+            SwitchAccountParam.TryToSwitchToNextAccount -> getNextAccountIfPossibleAndSwitch(current)
+            SwitchAccountParam.Clear -> switch(null, current)
         }
     }
 
@@ -81,6 +85,8 @@ class AccountSwitchUseCase @Inject constructor(
                     }?.userId
             }
         }
+        if (nextSessionId == null) appLogger.i("$TAG No next account to switch to")
+        else appLogger.i("$TAG Switching to next account: ${nextSessionId.toLogString()}")
         return switch(nextSessionId, current)
     }
 
@@ -102,6 +108,7 @@ class AccountSwitchUseCase @Inject constructor(
     }
 
     private suspend fun updateAuthServer(current: UserId) {
+        appLogger.i("$TAG Updating auth server config for account: ${current.toLogString()}")
         serverConfigForAccountUseCase(current).let {
             when (it) {
                 is ServerConfigForAccountUseCase.Result.Success -> authServerConfigProvider.updateAuthServer(it.config)
@@ -124,6 +131,7 @@ class AccountSwitchUseCase @Inject constructor(
     }
 
     private suspend fun handleInvalidSession(invalidAccount: AccountInfo.Invalid) {
+        appLogger.i("$TAG Handling invalid account: ${invalidAccount.userId.toLogString()}")
         when (invalidAccount.logoutReason) {
             LogoutReason.SELF_SOFT_LOGOUT, LogoutReason.SELF_HARD_LOGOUT -> {
                 deleteSession(invalidAccount.userId)
@@ -135,14 +143,21 @@ class AccountSwitchUseCase @Inject constructor(
     }
 
     private companion object {
+        const val TAG = "AccountSwitch"
         const val DELETE_USER_SESSION_TIMEOUT = 3000L
     }
 }
 
 sealed class SwitchAccountParam {
-    object TryToSwitchToNextAccount : SwitchAccountParam()
+    data object TryToSwitchToNextAccount : SwitchAccountParam()
     data class SwitchToAccount(val userId: UserId) : SwitchAccountParam()
     data object Clear : SwitchAccountParam()
+    private fun toLogMap(): Map<String, String> = when (this) {
+        is Clear -> mutableMapOf("value" to "CLEAR")
+        is SwitchToAccount -> mutableMapOf("value" to "SWITCH_TO_ACCOUNT", "userId" to userId.toLogString())
+        is TryToSwitchToNextAccount -> mutableMapOf("value" to "TRY_TO_SWITCH_TO_NEXT_ACCOUNT")
+    }
+    fun toLogString(): String = Json.encodeToString(toLogMap())
 }
 
 sealed class SwitchAccountResult {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -261,10 +261,13 @@ class WireActivity : AppCompatActivity() {
     @Suppress("ComplexMethod")
     @Composable
     private fun handleDialogs(navigate: (NavigationCommand) -> Unit) {
+<<<<<<< HEAD
         LaunchedEffect(Unit) {
             featureFlagNotificationViewModel.loadInitialSync()
         }
         val context = LocalContext.current
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         with(featureFlagNotificationViewModel.featureFlagState) {
             if (shouldShowTeamAppLockDialog) {
                 TeamAppLockFeatureFlagDialog(

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -261,13 +261,7 @@ class WireActivity : AppCompatActivity() {
     @Suppress("ComplexMethod")
     @Composable
     private fun handleDialogs(navigate: (NavigationCommand) -> Unit) {
-<<<<<<< HEAD
-        LaunchedEffect(Unit) {
-            featureFlagNotificationViewModel.loadInitialSync()
-        }
         val context = LocalContext.current
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         with(featureFlagNotificationViewModel.featureFlagState) {
             if (shouldShowTeamAppLockDialog) {
                 TeamAppLockFeatureFlagDialog(

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityDialogs.kt
@@ -24,6 +24,7 @@ import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.DialogProperties
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.appLogger
@@ -294,6 +295,7 @@ private fun accountLoggedOutDialog(reason: CurrentSessionErrorState, navigateAwa
         title = stringResource(id = title),
         text = text,
         onDismiss = remember { { } },
+        properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false, usePlatformDefaultWidth = false),
         optionButton1Properties = WireDialogButtonProperties(
             text = stringResource(R.string.label_ok),
             onClick = navigateAway,

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
@@ -56,7 +56,7 @@ class SetLockScreenViewModel @Inject constructor(
                 observeAppLockConfig(),
                 observeIsAppLockEditable()
             ) { config, isEditable ->
-                SetLockCodeViewState(
+                state.copy(
                     timeout = config.timeout,
                     isEditable = isEditable
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -98,8 +98,6 @@ fun ImportMediaScreen(
     navigator: Navigator,
     featureFlagNotificationViewModel: FeatureFlagNotificationViewModel = hiltViewModel()
 ) {
-    featureFlagNotificationViewModel.loadInitialSync()
-
     when (val fileSharingRestrictedState =
         featureFlagNotificationViewModel.featureFlagState.fileSharingRestrictedState) {
         FeatureFlagState.SharingRestrictedState.NO_USER -> {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -214,7 +214,7 @@ class SelfUserProfileViewModel @Inject constructor(
             }.join()
 
             val logoutReason = if (wipeData) LogoutReason.SELF_HARD_LOGOUT else LogoutReason.SELF_SOFT_LOGOUT
-            logout(logoutReason)
+            logout(logoutReason, waitUntilCompletes = true)
             if (wipeData) {
                 // TODO this should be moved to some service that will clear all the data in the app
                 dataStore.clear()

--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -20,6 +20,7 @@ package com.wire.android
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
+import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.framework.TestUser
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
@@ -97,12 +98,16 @@ class GlobalObserversManagerTest {
         @MockK
         lateinit var notificationManager: WireNotificationManager
 
+        @MockK
+        lateinit var userDataStoreProvider: UserDataStoreProvider
+
         private val manager by lazy {
             GlobalObserversManager(
                 dispatcherProvider = TestDispatcherProvider(),
                 coreLogic = coreLogic,
                 notificationChannelsManager = notificationChannelsManager,
-                notificationManager = notificationManager
+                notificationManager = notificationManager,
+                userDataStoreProvider = userDataStoreProvider,
             )
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
@@ -34,7 +34,6 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.applock.AppLockTeamFeatureConfigObserver
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
-import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.user.E2EIRequiredResult
 import com.wire.kalium.logic.feature.user.MarkEnablingE2EIAsNotifiedUseCase
 import com.wire.kalium.logic.feature.user.MarkSelfDeletionStatusAsNotifiedUseCase
@@ -67,7 +66,10 @@ class FeatureFlagNotificationViewModelTest {
         val (_, viewModel) = Arrangement()
             .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Failure.SessionNotFound))
             .arrange()
+<<<<<<< HEAD
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertEquals(
@@ -82,7 +84,10 @@ class FeatureFlagNotificationViewModelTest {
             .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID))))
             .withFileSharingStatus(flowOf(FileSharingStatus(FileSharingStatus.Value.Disabled, false)))
             .arrange()
+<<<<<<< HEAD
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertEquals(
@@ -97,7 +102,10 @@ class FeatureFlagNotificationViewModelTest {
             .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Success(AccountInfo.Valid(UserId("value", "domain")))))
             .withGuestRoomLinkFeatureFlag(flowOf(GuestRoomLinkStatus(true, false)))
             .arrange()
+<<<<<<< HEAD
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
         viewModel.dismissGuestRoomLinkDialog()
         advanceUntilIdle()
@@ -115,7 +123,10 @@ class FeatureFlagNotificationViewModelTest {
             .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID))))
             .withFileSharingStatus(flowOf(FileSharingStatus(FileSharingStatus.Value.EnabledAll, false)))
             .arrange()
+<<<<<<< HEAD
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertEquals(
@@ -129,7 +140,10 @@ class FeatureFlagNotificationViewModelTest {
         val (arrangement, viewModel) = Arrangement()
             .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Success(AccountInfo.Valid(UserId("value", "domain")))))
             .arrange()
+<<<<<<< HEAD
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
         viewModel.dismissSelfDeletingMessagesDialog()
         advanceUntilIdle()
@@ -145,8 +159,11 @@ class FeatureFlagNotificationViewModelTest {
             .withIsAppLockSetup(false)
             .withTeamAppLockEnforce(AppLockTeamConfig(true, Duration.ZERO, false))
             .arrange()
+<<<<<<< HEAD
 
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertTrue(viewModel.featureFlagState.shouldShowTeamAppLockDialog)
@@ -157,7 +174,10 @@ class FeatureFlagNotificationViewModelTest {
         val (arrangement, viewModel) = Arrangement()
             .withE2EIRequiredSettings(E2EIRequiredResult.NoGracePeriod.Create)
             .arrange()
+<<<<<<< HEAD
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertEquals(FeatureFlagState.E2EIRequired.NoGracePeriod.Create, viewModel.featureFlagState.e2EIRequired)
@@ -169,7 +189,10 @@ class FeatureFlagNotificationViewModelTest {
         val (arrangement, viewModel) = Arrangement()
             .withE2EIRequiredSettings(E2EIRequiredResult.WithGracePeriod.Create(gracePeriod))
             .arrange()
+<<<<<<< HEAD
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         viewModel.snoozeE2EIdRequiredDialog(FeatureFlagState.E2EIRequired.WithGracePeriod.Create(gracePeriod))
@@ -199,7 +222,10 @@ class FeatureFlagNotificationViewModelTest {
         val (arrangement, viewModel) = Arrangement()
             .withE2EIRequiredSettings(E2EIRequiredResult.NoGracePeriod.Renew)
             .arrange()
+<<<<<<< HEAD
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertEquals(FeatureFlagState.E2EIRequired.NoGracePeriod.Renew, viewModel.featureFlagState.e2EIRequired)
@@ -211,7 +237,10 @@ class FeatureFlagNotificationViewModelTest {
         val (arrangement, viewModel) = Arrangement()
             .withE2EIRequiredSettings(E2EIRequiredResult.WithGracePeriod.Renew(gracePeriod))
             .arrange()
+<<<<<<< HEAD
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         viewModel.snoozeE2EIdRequiredDialog(FeatureFlagState.E2EIRequired.WithGracePeriod.Renew(gracePeriod))
@@ -241,8 +270,11 @@ class FeatureFlagNotificationViewModelTest {
         val (_, viewModel) = Arrangement()
             .withEndCallDialog()
             .arrange()
+<<<<<<< HEAD
 
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertEquals(true, viewModel.featureFlagState.showCallEndedBecauseOfConversationDegraded)
@@ -255,7 +287,10 @@ class FeatureFlagNotificationViewModelTest {
             .withAppLockSource(AppLockSource.TeamEnforced)
             .withDisableAppLockUseCase()
             .arrange()
+<<<<<<< HEAD
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         viewModel.confirmAppLockNotEnforced()
@@ -270,7 +305,10 @@ class FeatureFlagNotificationViewModelTest {
             .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID))))
             .withAppLockSource(AppLockSource.Manual)
             .arrange()
+<<<<<<< HEAD
         viewModel.loadInitialSync()
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         viewModel.confirmAppLockNotEnforced()
@@ -302,6 +340,7 @@ class FeatureFlagNotificationViewModelTest {
     }
 
     private inner class Arrangement {
+<<<<<<< HEAD
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
             coEvery { currentSession() } returns CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID))
@@ -309,9 +348,11 @@ class FeatureFlagNotificationViewModelTest {
             coEvery { coreLogic.getSessionScope(any()).observeSyncState() } returns flowOf(SyncState.Live)
             coEvery { coreLogic.getSessionScope(any()).observeTeamSettingsSelfDeletionStatus() } returns flowOf()
         }
+=======
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
 
         @MockK
-        lateinit var currentSession: CurrentSessionUseCase
+        lateinit var currentSession: CurrentSessionFlowUseCase
 
         @MockK
         lateinit var currentSessionFlow: CurrentSessionFlowUseCase
@@ -337,6 +378,7 @@ class FeatureFlagNotificationViewModelTest {
         @MockK
         lateinit var globalDataStore: GlobalDataStore
 
+<<<<<<< HEAD
         val viewModel: FeatureFlagNotificationViewModel = FeatureFlagNotificationViewModel(
             coreLogic = coreLogic,
             currentSessionUseCase = currentSession,
@@ -346,7 +388,21 @@ class FeatureFlagNotificationViewModelTest {
             dispatcherProvider = TestDispatcherProvider()
         )
 
+=======
+        val viewModel: FeatureFlagNotificationViewModel by lazy {
+            FeatureFlagNotificationViewModel(
+                coreLogic = coreLogic,
+                currentSessionFlow = currentSession,
+                globalDataStore = globalDataStore,
+                disableAppLockUseCase = disableAppLockUseCase
+            )
+        }
+>>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+            coEvery { currentSession() } returns flowOf(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID)))
+            coEvery { coreLogic.getSessionScope(any()).observeSyncState() } returns flowOf(SyncState.Live)
+            coEvery { coreLogic.getSessionScope(any()).observeTeamSettingsSelfDeletionStatus() } returns flowOf()
             every { coreLogic.getSessionScope(any()).markGuestLinkFeatureFlagAsNotChanged } returns markGuestLinkFeatureFlagAsNotChanged
             every { coreLogic.getSessionScope(any()).markSelfDeletingMessagesAsNotified } returns markSelfDeletingStatusAsNotified
             every { coreLogic.getSessionScope(any()).markE2EIRequiredAsNotified } returns markE2EIRequiredAsNotified
@@ -359,7 +415,7 @@ class FeatureFlagNotificationViewModelTest {
         }
 
         fun withCurrentSessions(result: CurrentSessionResult) = apply {
-            coEvery { currentSession() } returns result
+            coEvery { currentSession() } returns flowOf(result)
         }
 
         fun withCurrentSessionsFlow(result: Flow<CurrentSessionResult>) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
@@ -66,10 +66,6 @@ class FeatureFlagNotificationViewModelTest {
         val (_, viewModel) = Arrangement()
             .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Failure.SessionNotFound))
             .arrange()
-<<<<<<< HEAD
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertEquals(
@@ -84,10 +80,6 @@ class FeatureFlagNotificationViewModelTest {
             .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID))))
             .withFileSharingStatus(flowOf(FileSharingStatus(FileSharingStatus.Value.Disabled, false)))
             .arrange()
-<<<<<<< HEAD
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertEquals(
@@ -102,10 +94,6 @@ class FeatureFlagNotificationViewModelTest {
             .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Success(AccountInfo.Valid(UserId("value", "domain")))))
             .withGuestRoomLinkFeatureFlag(flowOf(GuestRoomLinkStatus(true, false)))
             .arrange()
-<<<<<<< HEAD
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
         viewModel.dismissGuestRoomLinkDialog()
         advanceUntilIdle()
@@ -123,10 +111,6 @@ class FeatureFlagNotificationViewModelTest {
             .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID))))
             .withFileSharingStatus(flowOf(FileSharingStatus(FileSharingStatus.Value.EnabledAll, false)))
             .arrange()
-<<<<<<< HEAD
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertEquals(
@@ -140,10 +124,6 @@ class FeatureFlagNotificationViewModelTest {
         val (arrangement, viewModel) = Arrangement()
             .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Success(AccountInfo.Valid(UserId("value", "domain")))))
             .arrange()
-<<<<<<< HEAD
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
         viewModel.dismissSelfDeletingMessagesDialog()
         advanceUntilIdle()
@@ -159,11 +139,6 @@ class FeatureFlagNotificationViewModelTest {
             .withIsAppLockSetup(false)
             .withTeamAppLockEnforce(AppLockTeamConfig(true, Duration.ZERO, false))
             .arrange()
-<<<<<<< HEAD
-
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertTrue(viewModel.featureFlagState.shouldShowTeamAppLockDialog)
@@ -174,10 +149,6 @@ class FeatureFlagNotificationViewModelTest {
         val (arrangement, viewModel) = Arrangement()
             .withE2EIRequiredSettings(E2EIRequiredResult.NoGracePeriod.Create)
             .arrange()
-<<<<<<< HEAD
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertEquals(FeatureFlagState.E2EIRequired.NoGracePeriod.Create, viewModel.featureFlagState.e2EIRequired)
@@ -189,10 +160,6 @@ class FeatureFlagNotificationViewModelTest {
         val (arrangement, viewModel) = Arrangement()
             .withE2EIRequiredSettings(E2EIRequiredResult.WithGracePeriod.Create(gracePeriod))
             .arrange()
-<<<<<<< HEAD
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         viewModel.snoozeE2EIdRequiredDialog(FeatureFlagState.E2EIRequired.WithGracePeriod.Create(gracePeriod))
@@ -222,10 +189,6 @@ class FeatureFlagNotificationViewModelTest {
         val (arrangement, viewModel) = Arrangement()
             .withE2EIRequiredSettings(E2EIRequiredResult.NoGracePeriod.Renew)
             .arrange()
-<<<<<<< HEAD
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertEquals(FeatureFlagState.E2EIRequired.NoGracePeriod.Renew, viewModel.featureFlagState.e2EIRequired)
@@ -237,10 +200,6 @@ class FeatureFlagNotificationViewModelTest {
         val (arrangement, viewModel) = Arrangement()
             .withE2EIRequiredSettings(E2EIRequiredResult.WithGracePeriod.Renew(gracePeriod))
             .arrange()
-<<<<<<< HEAD
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         viewModel.snoozeE2EIdRequiredDialog(FeatureFlagState.E2EIRequired.WithGracePeriod.Renew(gracePeriod))
@@ -270,11 +229,6 @@ class FeatureFlagNotificationViewModelTest {
         val (_, viewModel) = Arrangement()
             .withEndCallDialog()
             .arrange()
-<<<<<<< HEAD
-
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         assertEquals(true, viewModel.featureFlagState.showCallEndedBecauseOfConversationDegraded)
@@ -287,10 +241,6 @@ class FeatureFlagNotificationViewModelTest {
             .withAppLockSource(AppLockSource.TeamEnforced)
             .withDisableAppLockUseCase()
             .arrange()
-<<<<<<< HEAD
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         viewModel.confirmAppLockNotEnforced()
@@ -305,10 +255,6 @@ class FeatureFlagNotificationViewModelTest {
             .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID))))
             .withAppLockSource(AppLockSource.Manual)
             .arrange()
-<<<<<<< HEAD
-        viewModel.loadInitialSync()
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         advanceUntilIdle()
 
         viewModel.confirmAppLockNotEnforced()
@@ -324,7 +270,6 @@ class FeatureFlagNotificationViewModelTest {
             .withE2EIRequiredSettings(E2EIRequiredResult.NoGracePeriod.Create)
             .withCurrentSessionsFlow(currentSessionsFlow)
             .arrange()
-        viewModel.loadInitialSync()
 
         currentSessionsFlow.emit(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID)))
         advanceUntilIdle()
@@ -340,19 +285,6 @@ class FeatureFlagNotificationViewModelTest {
     }
 
     private inner class Arrangement {
-<<<<<<< HEAD
-        init {
-            MockKAnnotations.init(this, relaxUnitFun = true)
-            coEvery { currentSession() } returns CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID))
-            coEvery { currentSessionFlow() } returns flowOf(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID)))
-            coEvery { coreLogic.getSessionScope(any()).observeSyncState() } returns flowOf(SyncState.Live)
-            coEvery { coreLogic.getSessionScope(any()).observeTeamSettingsSelfDeletionStatus() } returns flowOf()
-        }
-=======
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
-
-        @MockK
-        lateinit var currentSession: CurrentSessionFlowUseCase
 
         @MockK
         lateinit var currentSessionFlow: CurrentSessionFlowUseCase
@@ -378,29 +310,18 @@ class FeatureFlagNotificationViewModelTest {
         @MockK
         lateinit var globalDataStore: GlobalDataStore
 
-<<<<<<< HEAD
-        val viewModel: FeatureFlagNotificationViewModel = FeatureFlagNotificationViewModel(
-            coreLogic = coreLogic,
-            currentSessionUseCase = currentSession,
-            currentSessionFlow = currentSessionFlow,
-            globalDataStore = globalDataStore,
-            disableAppLockUseCase = disableAppLockUseCase,
-            dispatcherProvider = TestDispatcherProvider()
-        )
-
-=======
         val viewModel: FeatureFlagNotificationViewModel by lazy {
             FeatureFlagNotificationViewModel(
                 coreLogic = coreLogic,
-                currentSessionFlow = currentSession,
+                currentSessionFlow = currentSessionFlow,
                 globalDataStore = globalDataStore,
-                disableAppLockUseCase = disableAppLockUseCase
+                disableAppLockUseCase = disableAppLockUseCase,
+                dispatcherProvider = TestDispatcherProvider()
             )
         }
->>>>>>> 6cb0a6eb2 (fix: missing ServerConfig crashes after session expired / logout [WPB-5960] (#2570))
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
-            coEvery { currentSession() } returns flowOf(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID)))
+            coEvery { currentSessionFlow() } returns flowOf(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID)))
             coEvery { coreLogic.getSessionScope(any()).observeSyncState() } returns flowOf(SyncState.Live)
             coEvery { coreLogic.getSessionScope(any()).observeTeamSettingsSelfDeletionStatus() } returns flowOf()
             every { coreLogic.getSessionScope(any()).markGuestLinkFeatureFlagAsNotChanged } returns markGuestLinkFeatureFlagAsNotChanged
@@ -412,10 +333,6 @@ class FeatureFlagNotificationViewModelTest {
             coEvery { coreLogic.getSessionScope(any()).observeE2EIRequired.invoke() } returns flowOf()
             coEvery { coreLogic.getSessionScope(any()).calls.observeEndCallDialog() } returns flowOf()
             coEvery { ppLockTeamFeatureConfigObserver() } returns flowOf(null)
-        }
-
-        fun withCurrentSessions(result: CurrentSessionResult) = apply {
-            coEvery { currentSession() } returns flowOf(result)
         }
 
         fun withCurrentSessionsFlow(result: Flow<CurrentSessionResult>) = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5960" title="WPB-5960" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5960</a>  [Android] missing serverConfig crash
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2570

---- 

 ⚠️ Conflicts during cherry-pick:
app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Top crashes types currently are the ones related to missing ServerConfig when making some actions.

### Causes (Optional)

When session is expired (the app receives 403 when trying to refresh a token) there is an infinite loop, because the app tries to logout - deregister token which results in 401 and it triggers the auth token refresh again resulting in 403 and trying to logout again. After each iteration, CurrentSessionFlowUseCase emits the same item again, which triggers multiple actions in the whole app and creates a race condition when logging out (session should be invalid but with all the loop iterations in a fraction of a second the app can still get the previous value).
Some logout actions in Android project are not executed when account is logged out from kalium (when session expires, device is removed from another place or account deleted).
Some actions that require user session are allowed to be executed after the logout when this session is cleared and not existing anymore resulting in crashes.

### Solutions

- use  instead of getting just a single initial value from  to not show a state for the previous session when changed
- update  properties when the session changed
- cancel the observing flows for previous session when changed
- do not execute actions (at least dialog dismiss actions) if the current session is invalid or there is no session
- fix issue with continue button on set app lock screen not always making actions properly (race condition)
- register for logout callback triggered when the logout happens in kalium to execute all other required logout-related actions in Android
- make  non-dismissable
- provide logs for 

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/2354

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .
