### PR TITLE
chore: remove (beta) string from protocol details label string (WPB-6112)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,7 +75,7 @@
     <string name="label_value_copied">%s copied</string>
     <string name="label_disable">Disable</string>
     <string name="folder_label_access">Access</string>
-    <string name="folder_label_protocol_details">Protocol details (beta)</string>
+    <string name="folder_label_protocol_details">Protocol details</string>
     <string name="folder_label_messaging">Messaging</string>
     <string name="label_user_blocked">Blocked</string>
     <string name="label_and">and</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6112" title="WPB-6112" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-6112</a>  [Android] Remove “beta” text in group creation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Protocol details when creating a new group is not on beta anymore.

### Solutions

Remove `(beta)` wording from label string
