### PR TITLE
fix: OtherUserProfile snapshot crash

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -137,7 +137,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     }
 
     private fun getMLSVerificationStatus() {
-        viewModelScope.launch(dispatchers.io()) {
+        viewModelScope.launch {
             val isMLSVerified = getUserE2eiCertificateStatus(userId).let {
                 it is GetUserE2eiCertificateStatusResult.Success && it.status == CertificateStatus.VALID
             }


### PR DESCRIPTION
# What's new in this PR?

### Issues

App crashes on opening OtherUserProfile screen with 
` java.lang.IllegalStateException: Reading a state that was created after the snapshot was taken or in a snapshot that has not yet been applied`

### Solutions

remove dispatcher changes on `getUserE2eiCertificateStatus`. 
P.S. No any performance issue as switching to IO dispatcher is already handled in kalium side.