### PR TITLE
fix: set modifier of LazyColumn to fillMaxSize (WPB-6121)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/FileAssetsContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/FileAssetsContent.kt
@@ -19,6 +19,7 @@ package com.wire.android.ui.home.conversations.media
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -75,7 +76,7 @@ private fun AssetMessagesListContent(
     onAudioItemClicked: (String) -> Unit,
     onAssetItemClicked: (String) -> Unit,
 ) {
-    LazyColumn {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
         items(
             count = groupedAssetMessageList.itemCount,
             key = groupedAssetMessageList.itemKey {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6121" title="WPB-6121" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6121</a>  [Android] When selecting "files" tab in Media Gallery, items are jumping from center to top of the screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When opening media gallery and selecting `FILES` tab, the items would jump from the center to the top of the screen (being the top the correct one)

### Causes (Optional)

There was no set for size of `LazyColumn`

### Solutions

Add `fillMaxSize` to modifier of `LazyColumn` so its always the screen size, so no jumping around :)

### Testing

#### How to Test

- Open Media Gallery (with 1 item, so its better visualized)
- Items should not be shown on center of screen and then jumped to the top (check Task video for more info)
- Items should be already at the top of the screen
