### PR TITLE
fix: download asset dialog button order (WPB-5378)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/DownloadedAssetDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/DownloadedAssetDialog.kt
@@ -48,12 +48,12 @@ fun DownloadedAssetDialog(
             text = stringResource(R.string.asset_download_dialog_text),
             buttonsHorizontalAlignment = false,
             onDismiss = { hideOnAssetDownloadedDialog() },
-            optionButton2Properties = WireDialogButtonProperties(
+            optionButton1Properties = WireDialogButtonProperties(
                 text = stringResource(R.string.asset_download_dialog_open_text),
                 type = WireDialogButtonType.Primary,
                 onClick = { onOpenFileWithExternalApp(messageId) }
             ),
-            optionButton1Properties = WireDialogButtonProperties(
+            optionButton2Properties = WireDialogButtonProperties(
                 text = stringResource(R.string.asset_download_dialog_save_text),
                 type = WireDialogButtonType.Primary,
                 onClick = onSaveFileWriteStorageRequest::launch

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -419,7 +419,7 @@
     <string name="asset_message_saved_externally_text">Saved</string>
     <string name="asset_message_failed_download_text">File not available</string>
     <string name="asset_message_failed_upload_text">File upload failed</string>
-    <string name="asset_download_dialog_text">Do you want to open the file or save it to your
+    <string name="asset_download_dialog_text">Do you want to open the file, or save it to your
         device\'s download folder?
  </string>
     <string name="asset_download_dialog_open_text">Open</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5378" title="WPB-5378" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-5378</a>  Files tab in media gallery
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When checking upon QA on Media Gallery, download assets dialog were showing the buttons `SAVE` and `OPEN` in incorrect order, and the label was missing a comma from the string.

### Solutions

- Invert the buttons
- add missing comma to string label

#### How to Test

Either from Media Gallery or normal conversation screen, click to download an asset.


### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <img src="https://github.com/wireapp/wire-android/assets/5890660/270134da-284d-4247-aebf-5a6d73aa03e8" width="200" height="400" alt="after" />  |  <img src="https://github.com/wireapp/wire-android/assets/5890660/d2a5efbc-c673-4f07-888b-7ca3d78758bb" width="200" height="400" alt="after" /> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
