### PR TITLE
test: add sharing location coverage for viewmodel 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerComponent.kt
@@ -42,7 +42,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.zIndex
@@ -60,6 +59,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.spacers.VerticalSpace
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.orDefault
 import com.wire.android.util.permission.PermissionsDeniedRequestDialog
@@ -217,7 +217,7 @@ private fun LocationInformation(geoLocatedAddress: GeoLocatedAddress?) {
 @Composable
 private fun RowScope.LoadingLocation() {
     WireCircularProgressIndicator(
-        progressColor = Color.Black,
+        progressColor = MaterialTheme.wireColorScheme.primary,
         modifier = Modifier.align(alignment = Alignment.CenterVertically)
     )
     HorizontalSpace.x8()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerComponent.kt
@@ -43,7 +43,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.zIndex
@@ -78,12 +77,11 @@ fun LocationPickerComponent(
     onLocationClosed: () -> Unit
 ) {
     val viewModel = hiltViewModel<LocationPickerViewModel>()
-    val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val sheetState = rememberDismissibleWireModalSheetState(initialValue = SheetValue.Expanded, onLocationClosed)
 
     val locationFlow = LocationFlow(
-        onCurrentLocationPicked = { viewModel.getCurrentLocation(context) },
+        onCurrentLocationPicked = { viewModel.getCurrentLocation() },
         onLocationDenied = viewModel::onPermissionsDenied
     )
     LaunchedEffect(Unit) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerComponent.kt
@@ -81,7 +81,7 @@ fun LocationPickerComponent(
     val sheetState = rememberDismissibleWireModalSheetState(initialValue = SheetValue.Expanded, onLocationClosed)
 
     val locationFlow = LocationFlow(
-        onCurrentLocationPicked = { viewModel.getCurrentLocation() },
+        onCurrentLocationPicked = viewModel::getCurrentLocation,
         onLocationDenied = viewModel::onPermissionsDenied
     )
     LaunchedEffect(Unit) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
@@ -88,5 +88,4 @@ class LocationPickerHelper @Inject constructor(@ApplicationContext val context: 
         val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
         return LocationManagerCompat.isLocationEnabled(locationManager)
     }
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
@@ -45,7 +45,7 @@ class LocationPickerHelper @Inject constructor(@ApplicationContext val context: 
      * https://developer.android.com/develop/sensors-and-location/location/retrieve-current#BestEstimate
      */
     @SuppressLint("MissingPermission")
-    suspend inline fun getLocationWithGms(onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
+    suspend fun getLocationWithGms(onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
         if (isLocationServicesEnabled()) {
             val locationProvider = LocationServices.getFusedLocationProviderClient(context)
             val currentLocation =
@@ -58,7 +58,7 @@ class LocationPickerHelper @Inject constructor(@ApplicationContext val context: 
     }
 
     @SuppressLint("MissingPermission")
-    inline fun getLocationWithoutGms(crossinline onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
+    fun getLocationWithoutGms(onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
         if (isLocationServicesEnabled()) {
             val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
             val networkLocationListener: LocationListener = object : LocationListener {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
@@ -36,8 +36,18 @@ import javax.inject.Singleton
 @Singleton
 class LocationPickerHelper @Inject constructor(@ApplicationContext val context: Context) {
 
-    fun isGoogleServicesAvailable(): Boolean {
-        return context.isGoogleServicesAvailable()
+    suspend fun getLocation(onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
+        if (context.isGoogleServicesAvailable()) {
+            getLocationWithGms(
+                onSuccess = onSuccess,
+                onError = onError
+            )
+        } else {
+            getLocationWithoutGms(
+                onSuccess = onSuccess,
+                onError = onError
+            )
+        }
     }
 
     /**
@@ -45,7 +55,7 @@ class LocationPickerHelper @Inject constructor(@ApplicationContext val context: 
      * https://developer.android.com/develop/sensors-and-location/location/retrieve-current#BestEstimate
      */
     @SuppressLint("MissingPermission")
-    suspend fun getLocationWithGms(onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
+    private suspend fun getLocationWithGms(onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
         if (isLocationServicesEnabled()) {
             val locationProvider = LocationServices.getFusedLocationProviderClient(context)
             val currentLocation =
@@ -58,7 +68,7 @@ class LocationPickerHelper @Inject constructor(@ApplicationContext val context: 
     }
 
     @SuppressLint("MissingPermission")
-    fun getLocationWithoutGms(onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
+    private fun getLocationWithoutGms(onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
         if (isLocationServicesEnabled()) {
             val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
             val networkLocationListener: LocationListener = object : LocationListener {
@@ -74,7 +84,7 @@ class LocationPickerHelper @Inject constructor(@ApplicationContext val context: 
         }
     }
 
-    fun isLocationServicesEnabled(): Boolean {
+    private fun isLocationServicesEnabled(): Boolean {
         val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
         return LocationManagerCompat.isLocationEnabled(locationManager)
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
@@ -1,0 +1,82 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.messagecomposer.location
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.location.Geocoder
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import androidx.core.location.LocationManagerCompat
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.google.android.gms.tasks.CancellationTokenSource
+import com.wire.android.util.extension.isGoogleServicesAvailable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LocationPickerHelper @Inject constructor(@ApplicationContext val context: Context) {
+
+    fun isGoogleServicesAvailable(): Boolean {
+        return context.isGoogleServicesAvailable()
+    }
+
+    /**
+     * Choosing the best location estimate by docs.
+     * https://developer.android.com/develop/sensors-and-location/location/retrieve-current#BestEstimate
+     */
+    @SuppressLint("MissingPermission")
+    suspend inline fun getLocationWithGms(onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
+        if (isLocationServicesEnabled()) {
+            val locationProvider = LocationServices.getFusedLocationProviderClient(context)
+            val currentLocation =
+                locationProvider.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, CancellationTokenSource().token).await()
+            val address = Geocoder(context).getFromLocation(currentLocation.latitude, currentLocation.longitude, 1).orEmpty()
+            onSuccess(GeoLocatedAddress(address.firstOrNull(), currentLocation))
+        } else {
+            onError()
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    inline fun getLocationWithoutGms(crossinline onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
+        if (isLocationServicesEnabled()) {
+            val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+            val networkLocationListener: LocationListener = object : LocationListener {
+                override fun onLocationChanged(location: Location) {
+                    val address = Geocoder(context).getFromLocation(location.latitude, location.longitude, 1).orEmpty()
+                    onSuccess(GeoLocatedAddress(address.firstOrNull(), location))
+                    locationManager.removeUpdates(this) // important step, otherwise it will keep listening for location changes
+                }
+            }
+            locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0f, networkLocationListener)
+        } else {
+            onError()
+        }
+    }
+
+    fun isLocationServicesEnabled(): Boolean {
+        val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        return LocationManagerCompat.isLocationEnabled(locationManager)
+    }
+
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModel.kt
@@ -44,6 +44,16 @@ class LocationPickerViewModel @Inject constructor(private val locationPickerHelp
         state = state.copy(showPermissionDeniedDialog = true)
     }
 
+    fun getCurrentLocation() {
+        viewModelScope.launch {
+            toStartLoadingLocationState()
+            locationPickerHelper.getLocation(
+                onSuccess = { toLocationLoadedState(it) },
+                onError = ::toLocationError
+            )
+        }
+    }
+
     private fun toStartLoadingLocationState() {
         state = state.copy(
             showLocationSharingError = false,
@@ -65,14 +75,6 @@ class LocationPickerViewModel @Inject constructor(private val locationPickerHelp
             showLocationSharingError = true,
             isLocationLoading = false,
             geoLocatedAddress = null,
-        )
-    }
-
-    fun getCurrentLocation() = viewModelScope.launch {
-        toStartLoadingLocationState()
-        locationPickerHelper.getLocation(
-            onSuccess = { toLocationLoadedState(it) },
-            onError = ::toLocationError
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModel.kt
@@ -70,17 +70,9 @@ class LocationPickerViewModel @Inject constructor(private val locationPickerHelp
 
     fun getCurrentLocation() = viewModelScope.launch {
         toStartLoadingLocationState()
-        when (locationPickerHelper.isGoogleServicesAvailable()) {
-            true -> locationPickerHelper.getLocationWithGms(
-                onSuccess = { toLocationLoadedState(it) },
-                onError = ::toLocationError
-            )
-
-            false -> locationPickerHelper.getLocationWithoutGms(
-                onSuccess = { toLocationLoadedState(it) },
-                onError = ::toLocationError
-            )
-        }
+        locationPickerHelper.getLocation(
+            onSuccess = { toLocationLoadedState(it) },
+            onError = ::toLocationError
+        )
     }
-
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModelTest.kt
@@ -35,7 +35,7 @@ class LocationPickerViewModelTest {
     fun `given user has device location disabled, when sharing location, then an error message will be shown`() = runTest {
         // given
         val (_, viewModel) = Arrangement()
-            .withGetGeoLocationErrorFrom()
+            .withGetGeoLocationError()
             .arrange()
 
         // when
@@ -77,7 +77,7 @@ class LocationPickerViewModelTest {
             }
         }
 
-        fun withGetGeoLocationErrorFrom() = apply {
+        fun withGetGeoLocationError() = apply {
             coEvery {
                 locationPickerHelper.getLocation(
                     capture(onEngineStartSuccess),

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModelTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.messagecomposer.location
+
+import android.location.Location
+import com.wire.android.config.CoroutineTestExtension
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(CoroutineTestExtension::class)
+class LocationPickerViewModelTest {
+
+    @Test
+    fun `given user has device location disabled, when sharing location, then an error message will be shown`() = runTest {
+        // given
+        val (_, viewModel) = Arrangement()
+            .withLocationServicesState(false)
+            .withIsGoogleServicesAvailable(true)
+            .arrange()
+
+        // when
+        viewModel.getCurrentLocation()
+
+        // then
+        assertEquals(true, viewModel.state.showLocationSharingError)
+    }
+
+    @Test
+    fun `given user has device location enabled, when sharing location, then should load the location`() = runTest {
+        // given
+        val (arrangement, viewModel) = Arrangement()
+            .withLocationServicesState(true)
+            .withIsGoogleServicesAvailable(true)
+            .withGetGeoLocation()
+            .arrange()
+
+        // when
+        viewModel.getCurrentLocation()
+
+        // then
+        assertEquals(false, viewModel.state.showLocationSharingError)
+        assertEquals(true, viewModel.state.geoLocatedAddress != null)
+    }
+
+
+    private class Arrangement {
+
+        val locationPickerHelper = mockk<LocationPickerHelper>(relaxed = true)
+
+        //        val getLocationWithGms = mockk<(GeoLocatedAddress, Unit) -> Unit>(relaxed = true, relaxUnitFun = true)
+        val getLocationWithGms = mockkStatic(LocationPickerHelper::getLocationWithGms)
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true, relaxed = true)
+
+        }
+
+        fun withLocationServicesState(enabled: Boolean = true) = apply {
+            every { locationPickerHelper.isLocationServicesEnabled() } returns enabled
+        }
+
+        fun withIsGoogleServicesAvailable(enabled: Boolean = true) = apply {
+            every { locationPickerHelper.isGoogleServicesAvailable() } returns enabled
+        }
+
+        fun withGetGeoLocation() = apply {
+            coEvery { getLocationWithGms() } returns { Unit }
+            coEvery { locationPickerHelper.getLocationWithGms(any(), any()) } coAnswers {
+                firstArg<(GeoLocatedAddress) -> Unit>().invoke(GeoLocatedAddress(null, Location("")))
+            }
+        }
+
+        fun arrange() = this to LocationPickerViewModel(locationPickerHelper)
+
+    }
+}

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,6 +1,8 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
-  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <ManuallySuppressedIssues>
+    <ID>ModifierOrder:LocationPickerHelper.kt$LocationPickerHelper$@SuppressLint("MissingPermission") inline suspend</ID>
+  </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>CommentSpacing:com.wire.android.ui.home.conversationslist.model.LastConversationEvent.kt:40</ID>
     <ID>CommentSpacing:com.wire.android.ui.theme.ThemeUtils.kt:47</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,8 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" ?>
 <SmellBaseline>
-  <ManuallySuppressedIssues>
-    <ID>ModifierOrder:LocationPickerHelper.kt$LocationPickerHelper$@SuppressLint("MissingPermission") inline suspend</ID>
-  </ManuallySuppressedIssues>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>CommentSpacing:com.wire.android.ui.home.conversationslist.model.LastConversationEvent.kt:40</ID>
     <ID>CommentSpacing:com.wire.android.ui.theme.ThemeUtils.kt:47</ID>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,7 +86,7 @@ androidx-text-archCore = "2.1.0"
 junit4 = "4.13.2"
 junit5 = "5.10.0"
 kluent = "1.73"
-mockk = "1.13.5"
+mockk = "1.13.9"
 okio = "3.6.0"
 turbine = "1.0.0"
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Missing coverage.

### Causes (Optional)

View model was dependent from `Context`

### Solutions

Creates a location helper, and move the dependency down, so we can mock interactions with viewmodel.


### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
