### PR TITLE
test: add sharing location coverage for viewmodel 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerComponent.kt
@@ -42,8 +42,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.zIndex
@@ -61,6 +59,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.spacers.VerticalSpace
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.orDefault
 import com.wire.android.util.permission.PermissionsDeniedRequestDialog
@@ -78,12 +77,11 @@ fun LocationPickerComponent(
     onLocationClosed: () -> Unit
 ) {
     val viewModel = hiltViewModel<LocationPickerViewModel>()
-    val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val sheetState = rememberDismissibleWireModalSheetState(initialValue = SheetValue.Expanded, onLocationClosed)
 
     val locationFlow = LocationFlow(
-        onCurrentLocationPicked = { viewModel.getCurrentLocation(context) },
+        onCurrentLocationPicked = viewModel::getCurrentLocation,
         onLocationDenied = viewModel::onPermissionsDenied
     )
     LaunchedEffect(Unit) {
@@ -219,7 +217,7 @@ private fun LocationInformation(geoLocatedAddress: GeoLocatedAddress?) {
 @Composable
 private fun RowScope.LoadingLocation() {
     WireCircularProgressIndicator(
-        progressColor = Color.Black,
+        progressColor = MaterialTheme.wireColorScheme.primary,
         modifier = Modifier.align(alignment = Alignment.CenterVertically)
     )
     HorizontalSpace.x8()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
@@ -1,0 +1,91 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.messagecomposer.location
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.location.Geocoder
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import androidx.core.location.LocationManagerCompat
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.google.android.gms.tasks.CancellationTokenSource
+import com.wire.android.util.extension.isGoogleServicesAvailable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LocationPickerHelper @Inject constructor(@ApplicationContext val context: Context) {
+
+    suspend fun getLocation(onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
+        if (context.isGoogleServicesAvailable()) {
+            getLocationWithGms(
+                onSuccess = onSuccess,
+                onError = onError
+            )
+        } else {
+            getLocationWithoutGms(
+                onSuccess = onSuccess,
+                onError = onError
+            )
+        }
+    }
+
+    /**
+     * Choosing the best location estimate by docs.
+     * https://developer.android.com/develop/sensors-and-location/location/retrieve-current#BestEstimate
+     */
+    @SuppressLint("MissingPermission")
+    private suspend fun getLocationWithGms(onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
+        if (isLocationServicesEnabled()) {
+            val locationProvider = LocationServices.getFusedLocationProviderClient(context)
+            val currentLocation =
+                locationProvider.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, CancellationTokenSource().token).await()
+            val address = Geocoder(context).getFromLocation(currentLocation.latitude, currentLocation.longitude, 1).orEmpty()
+            onSuccess(GeoLocatedAddress(address.firstOrNull(), currentLocation))
+        } else {
+            onError()
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun getLocationWithoutGms(onSuccess: (GeoLocatedAddress) -> Unit, onError: () -> Unit) {
+        if (isLocationServicesEnabled()) {
+            val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+            val networkLocationListener: LocationListener = object : LocationListener {
+                override fun onLocationChanged(location: Location) {
+                    val address = Geocoder(context).getFromLocation(location.latitude, location.longitude, 1).orEmpty()
+                    onSuccess(GeoLocatedAddress(address.firstOrNull(), location))
+                    locationManager.removeUpdates(this) // important step, otherwise it will keep listening for location changes
+                }
+            }
+            locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0f, networkLocationListener)
+        } else {
+            onError()
+        }
+    }
+
+    private fun isLocationServicesEnabled(): Boolean {
+        val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        return LocationManagerCompat.isLocationEnabled(locationManager)
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModel.kt
@@ -17,30 +17,17 @@
  */
 package com.wire.android.ui.home.messagecomposer.location
 
-import android.annotation.SuppressLint
-import android.content.Context
-import android.location.Geocoder
-import android.location.Location
-import android.location.LocationListener
-import android.location.LocationManager
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.core.location.LocationManagerCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.android.gms.location.LocationServices
-import com.google.android.gms.location.Priority.PRIORITY_HIGH_ACCURACY
-import com.google.android.gms.tasks.CancellationTokenSource
-import com.wire.android.appLogger
-import com.wire.android.util.extension.isGoogleServicesAvailable
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 @HiltViewModel
-class LocationPickerViewModel @Inject constructor() : ViewModel() {
+class LocationPickerViewModel @Inject constructor(private val locationPickerHelper: LocationPickerHelper) : ViewModel() {
 
     var state: LocationPickerState by mutableStateOf(LocationPickerState())
         private set
@@ -55,6 +42,16 @@ class LocationPickerViewModel @Inject constructor() : ViewModel() {
 
     fun onPermissionsDenied() {
         state = state.copy(showPermissionDeniedDialog = true)
+    }
+
+    fun getCurrentLocation() {
+        viewModelScope.launch {
+            toStartLoadingLocationState()
+            locationPickerHelper.getLocation(
+                onSuccess = { toLocationLoadedState(it) },
+                onError = ::toLocationError
+            )
+        }
     }
 
     private fun toStartLoadingLocationState() {
@@ -79,53 +76,5 @@ class LocationPickerViewModel @Inject constructor() : ViewModel() {
             isLocationLoading = false,
             geoLocatedAddress = null,
         )
-    }
-
-    fun getCurrentLocation(context: Context) {
-        toStartLoadingLocationState()
-        when (context.isGoogleServicesAvailable()) {
-            true -> getLocationWithGms(context)
-            false -> getLocationWithoutGms(context)
-        }
-    }
-
-    /**
-     * Choosing the best location estimate by docs.
-     * https://developer.android.com/develop/sensors-and-location/location/retrieve-current#BestEstimate
-     */
-    @SuppressLint("MissingPermission")
-    private fun getLocationWithGms(context: Context) = viewModelScope.launch {
-        appLogger.d("Getting location with GMS")
-        if (isLocationServicesEnabled(context)) {
-            val locationProvider = LocationServices.getFusedLocationProviderClient(context)
-            val currentLocation = locationProvider.getCurrentLocation(PRIORITY_HIGH_ACCURACY, CancellationTokenSource().token).await()
-            val address = Geocoder(context).getFromLocation(currentLocation.latitude, currentLocation.longitude, 1).orEmpty()
-            toLocationLoadedState(GeoLocatedAddress(address.firstOrNull(), currentLocation))
-        } else {
-            toLocationError()
-        }
-    }
-
-    @SuppressLint("MissingPermission")
-    private fun getLocationWithoutGms(context: Context) = viewModelScope.launch {
-        appLogger.d("Getting location without GMS")
-        if (isLocationServicesEnabled(context)) {
-            val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
-            val networkLocationListener: LocationListener = object : LocationListener {
-                override fun onLocationChanged(location: Location) {
-                    val address = Geocoder(context).getFromLocation(location.latitude, location.longitude, 1).orEmpty()
-                    toLocationLoadedState(GeoLocatedAddress(address.firstOrNull(), location))
-                    locationManager.removeUpdates(this) // important step, otherwise it will keep listening for location changes
-                }
-            }
-            locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0f, networkLocationListener)
-        } else {
-            toLocationError()
-        }
-    }
-
-    private fun isLocationServicesEnabled(context: Context): Boolean {
-        val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
-        return LocationManagerCompat.isLocationEnabled(locationManager)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1012,11 +1012,11 @@
     <string name="custom_backend_dialog_body">If you proceed, your client will be redirected to the following on-premises backend:</string>
     <string name="custom_backend_dialog_body_backend_name">Backend name:</string>
     <string name="custom_backend_dialog_body_backend_api">Backend URL:</string>
-    <string name="custom_backend_dialog_body_backend_blacklist">blackListURL:</string>
-    <string name="custom_backend_dialog_body_backend_teams">teamsURL:</string>
-    <string name="custom_backend_dialog_body_backend_accounts">accountsURL:</string>
-    <string name="custom_backend_dialog_body_backend_website">websiteURL:</string>
-    <string name="custom_backend_dialog_body_backend_websocket">backendWSURL:</string>
+    <string name="custom_backend_dialog_body_backend_blacklist">Blacklist URL:</string>
+    <string name="custom_backend_dialog_body_backend_teams">Teams URL:</string>
+    <string name="custom_backend_dialog_body_backend_accounts">Accounts URL:</string>
+    <string name="custom_backend_dialog_body_backend_website">Website URL:</string>
+    <string name="custom_backend_dialog_body_backend_websocket">Backend WSURL:</string>
     <string name="label_fetching_your_messages">Receiving new messages</string>
     <string name="label_text_copied">Text copied to clipboard</string>
     <string name="label_logs_option_title">Logs</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModelTest.kt
@@ -69,8 +69,8 @@ class LocationPickerViewModelTest {
         fun withGetGeoLocationSuccess() = apply {
             coEvery {
                 locationPickerHelper.getLocation(
-                    capture(onEngineStartSuccess),
-                    capture(onEngineStartFailure)
+                    capture(onPickedLocationSuccess),
+                    capture(onPickedLocationFailure)
                 )
             } coAnswers {
                 firstArg<PickedGeoLocation>().invoke(successResponse)
@@ -80,8 +80,8 @@ class LocationPickerViewModelTest {
         fun withGetGeoLocationError() = apply {
             coEvery {
                 locationPickerHelper.getLocation(
-                    capture(onEngineStartSuccess),
-                    capture(onEngineStartFailure)
+                    capture(onPickedLocationSuccess),
+                    capture(onPickedLocationFailure)
                 )
             } coAnswers {
                 secondArg<() -> Unit>().invoke()
@@ -92,8 +92,8 @@ class LocationPickerViewModelTest {
     }
 
     private companion object {
-        val onEngineStartSuccess = slot<PickedGeoLocation>()
-        val onEngineStartFailure = slot<() -> Unit>()
+        val onPickedLocationSuccess = slot<PickedGeoLocation>()
+        val onPickedLocationFailure = slot<() -> Unit>()
         val successResponse = GeoLocatedAddress(null, Location("dummy-location"))
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerViewModelTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.messagecomposer.location
+
+import android.location.Location
+import com.wire.android.config.CoroutineTestExtension
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(CoroutineTestExtension::class)
+class LocationPickerViewModelTest {
+
+    @Test
+    fun `given user has device location disabled, when sharing location, then an error message will be shown`() = runTest {
+        // given
+        val (_, viewModel) = Arrangement()
+            .withGetGeoLocationError()
+            .arrange()
+
+        // when
+        viewModel.getCurrentLocation()
+
+        // then
+        assertEquals(true, viewModel.state.showLocationSharingError)
+        assertEquals(true, viewModel.state.geoLocatedAddress == null)
+    }
+
+    @Test
+    fun `given user has device location enabled, when sharing location, then should load the location`() = runTest {
+        // given
+        val (arrangement, viewModel) = Arrangement()
+            .withGetGeoLocationSuccess()
+            .arrange()
+
+        // when
+        viewModel.getCurrentLocation()
+
+        // then
+        assertEquals(false, viewModel.state.showLocationSharingError)
+        assertEquals(true, viewModel.state.geoLocatedAddress != null)
+        coVerify(exactly = 1) { arrangement.locationPickerHelper.getLocation(any(), any()) }
+    }
+
+    private class Arrangement {
+
+        val locationPickerHelper = mockk<LocationPickerHelper>()
+
+        fun withGetGeoLocationSuccess() = apply {
+            coEvery {
+                locationPickerHelper.getLocation(
+                    capture(onEngineStartSuccess),
+                    capture(onEngineStartFailure)
+                )
+            } coAnswers {
+                firstArg<PickedGeoLocation>().invoke(successResponse)
+            }
+        }
+
+        fun withGetGeoLocationError() = apply {
+            coEvery {
+                locationPickerHelper.getLocation(
+                    capture(onEngineStartSuccess),
+                    capture(onEngineStartFailure)
+                )
+            } coAnswers {
+                secondArg<() -> Unit>().invoke()
+            }
+        }
+
+        fun arrange() = this to LocationPickerViewModel(locationPickerHelper)
+    }
+
+    private companion object {
+        val onEngineStartSuccess = slot<PickedGeoLocation>()
+        val onEngineStartFailure = slot<() -> Unit>()
+        val successResponse = GeoLocatedAddress(null, Location("dummy-location"))
+    }
+}
+
+private typealias PickedGeoLocation = (GeoLocatedAddress) -> Unit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,7 +87,7 @@ androidx-text-archCore = "2.1.0"
 junit4 = "4.13.2"
 junit5 = "5.10.0"
 kluent = "1.73"
-mockk = "1.13.5"
+mockk = "1.13.9"
 okio = "3.6.0"
 turbine = "1.0.0"
 


### PR DESCRIPTION
Cherry pick from the original PR: 
- #2620

---- 

 ⚠️ Conflicts during cherry-pick:


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Missing coverage.

### Causes (Optional)

View model was dependent from 

### Solutions

Creates a location helper, and move the dependency down, so we can mock interactions with viewmodel.


### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .