### PR TITLE
fix: original image path was used images from share extension

### DIFF
--- a/app/src/main/kotlin/com/wire/android/model/ImageAsset.kt
+++ b/app/src/main/kotlin/com/wire/android/model/ImageAsset.kt
@@ -18,13 +18,13 @@
 
 package com.wire.android.model
 
-import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserAssetId
+import okio.Path
 
 @Stable
 sealed class ImageAsset(private val imageLoader: WireSessionImageLoader) {
@@ -50,7 +50,7 @@ sealed class ImageAsset(private val imageLoader: WireSessionImageLoader) {
     @Stable
     data class LocalImageAsset(
         private val imageLoader: WireSessionImageLoader,
-        val dataUri: Uri,
+        val dataPath: Path,
         val idKey: String
     ) : ImageAsset(imageLoader) {
 

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -445,7 +445,6 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
                     size = fileMetadata.sizeInBytes,
                     mimeType = mimeType,
                     dataPath = tempAssetPath,
-                    dataUri = uri,
                     key = assetKey,
                     width = imgWidth,
                     height = imgHeight,
@@ -460,7 +459,6 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
                     size = fileMetadata.sizeInBytes,
                     mimeType = mimeType,
                     dataPath = tempAssetPath,
-                    dataUri = uri,
                     key = assetKey
                 )
             }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportedMediaTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportedMediaTypes.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.android.ui.sharing
 
-import android.net.Uri
 import androidx.compose.runtime.Composable
 import com.wire.android.model.Clickable
 import com.wire.android.model.ImageAsset
@@ -70,7 +69,6 @@ sealed class ImportedMediaAsset(
     open val size: Long,
     open val mimeType: String,
     open val dataPath: Path,
-    open val dataUri: Uri,
     open val key: String
 ) {
     class GenericAsset(
@@ -78,9 +76,8 @@ sealed class ImportedMediaAsset(
         override val size: Long,
         override val mimeType: String,
         override val dataPath: Path,
-        override val dataUri: Uri,
         override val key: String
-    ) : ImportedMediaAsset(name, size, mimeType, dataPath, dataUri, key)
+    ) : ImportedMediaAsset(name, size, mimeType, dataPath, key)
 
     class Image(
         val width: Int,
@@ -89,10 +86,9 @@ sealed class ImportedMediaAsset(
         override val size: Long,
         override val mimeType: String,
         override val dataPath: Path,
-        override val dataUri: Uri,
         override val key: String,
         val wireSessionImageLoader: WireSessionImageLoader
-    ) : ImportedMediaAsset(name, size, mimeType, dataPath, dataUri, key) {
-        val localImageAsset = ImageAsset.LocalImageAsset(wireSessionImageLoader, dataUri, key)
+    ) : ImportedMediaAsset(name, size, mimeType, dataPath, key) {
+        val localImageAsset = ImageAsset.LocalImageAsset(wireSessionImageLoader, dataPath, key)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/ui/AssetImageFetcher.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/AssetImageFetcher.kt
@@ -18,15 +18,11 @@
 
 package com.wire.android.util.ui
 
-import android.content.Context
 import coil.ImageLoader
-import coil.decode.DataSource
-import coil.fetch.DrawableResult
 import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.request.Options
 import com.wire.android.model.ImageAsset
-import com.wire.android.util.toDrawable
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.feature.asset.DeleteAssetUseCase
@@ -36,7 +32,6 @@ import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import com.wire.kalium.logic.feature.asset.PublicAssetResult
 
 internal class AssetImageFetcher(
-    private val context: Context,
     private val assetFetcherParameters: AssetFetcherParameters,
     private val getPublicAsset: GetAvatarAssetUseCase,
     private val getPrivateAsset: GetMessageAssetUseCase,
@@ -79,15 +74,7 @@ internal class AssetImageFetcher(
                     }
                 }
 
-                is ImageAsset.LocalImageAsset -> {
-                    data.dataUri.toDrawable(context)?.let {
-                        DrawableResult(
-                            drawable = it,
-                            isSampled = true,
-                            dataSource = DataSource.DISK
-                        )
-                    }
-                }
+                is ImageAsset.LocalImageAsset -> drawableResultWrapper.toFetchResult(data.dataPath)
             }
         }
     }
@@ -103,7 +90,6 @@ internal class AssetImageFetcher(
         private val getPrivateAssetUseCase: GetMessageAssetUseCase,
         private val deleteAssetUseCase: DeleteAssetUseCase,
         private val drawableResultWrapper: DrawableResultWrapper,
-        private val context: Context
     ) : Fetcher.Factory<ImageAsset> {
         override fun create(
             data: ImageAsset,
@@ -115,7 +101,6 @@ internal class AssetImageFetcher(
             getPrivateAsset = getPrivateAssetUseCase,
             deleteAsset = deleteAssetUseCase,
             drawableResultWrapper = drawableResultWrapper,
-            context = context
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/ui/WireSessionImageLoader.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/WireSessionImageLoader.kt
@@ -136,7 +136,6 @@ class WireSessionImageLoader(
                                 getPrivateAssetUseCase = getPrivateAsset,
                                 deleteAssetUseCase = deleteAsset,
                                 drawableResultWrapper = DrawableResultWrapper(resources),
-                                context = context
                             )
                         )
                         if (SDK_INT >= 28) {

--- a/app/src/test/kotlin/com/wire/android/model/ImageAssetTest.kt
+++ b/app/src/test/kotlin/com/wire/android/model/ImageAssetTest.kt
@@ -19,7 +19,6 @@
 package com.wire.android.model
 
 import android.net.Uri
-import androidx.core.net.toUri
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserAssetId
@@ -28,6 +27,8 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import okio.Path
+import okio.Path.Companion.toPath
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeEqualTo
 import org.junit.jupiter.api.BeforeEach
@@ -46,21 +47,21 @@ class ImageAssetTest {
         every { Uri.parse(any()) } returns mockUri
     }
 
-    fun createUserAvatarAsset(userAssetId: UserAssetId) = ImageAsset.UserAvatarAsset(
+    private fun createUserAvatarAsset(userAssetId: UserAssetId) = ImageAsset.UserAvatarAsset(
         imageLoader, userAssetId
     )
 
-    fun createPrivateAsset(
+    private fun createPrivateAsset(
         conversationId: ConversationId,
         messageId: String,
         isSelfAsset: Boolean
     ) = ImageAsset.PrivateAsset(imageLoader, conversationId, messageId, isSelfAsset)
 
-    fun createLocalAsset(
-        dataUri: Uri,
+    private fun createLocalAsset(
+        dataPath: Path,
         imageKey: String
     ): ImageAsset.LocalImageAsset {
-        return ImageAsset.LocalImageAsset(imageLoader, dataUri, imageKey)
+        return ImageAsset.LocalImageAsset(imageLoader, dataPath, imageKey)
     }
 
     @Test
@@ -138,7 +139,7 @@ class ImageAssetTest {
     @Test
     fun givenEqualUriAndKeyLocalAssets_whenGettingUniqueKey_thenResultsShouldBeEqual() {
         val assetKey = "assetKey"
-        val localAssetUri = "local-uri".toUri()
+        val localAssetUri = "local-uri".toPath()
 
         val subject1 = createLocalAsset(
             localAssetUri,
@@ -154,7 +155,7 @@ class ImageAssetTest {
 
     @Test
     fun givenSameUriButDifferentKeyLocalAssets_whenGettingUniqueKey_thenResultsShouldBeDifferent() {
-        val assetUri = "assetUri".toUri()
+        val assetUri = "assetUri".toPath()
         val assetKey = "assetKey"
 
         val baseSubject = createLocalAsset(
@@ -171,8 +172,8 @@ class ImageAssetTest {
 
     @Test
     fun givenSameKeyButDifferentUriLocalAssets_whenGettingUniqueKey_thenResultsShouldBeTheSame() {
-        val assetUri1 = "assetUri1".toUri()
-        val assetUri2 = "assetUri2".toUri()
+        val assetUri1 = "assetUri1".toPath()
+        val assetUri2 = "assetUri2".toPath()
         val assetKey = "assetKey"
 
         val baseSubject = createLocalAsset(

--- a/app/src/test/kotlin/com/wire/android/util/ui/AssetImageFetcherTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/ui/AssetImageFetcherTest.kt
@@ -372,8 +372,7 @@ internal class AssetImageFetcherTest {
             getPublicAsset = getPublicAsset,
             getPrivateAsset = getPrivateAsset,
             deleteAsset = deleteAsset,
-            drawableResultWrapper = drawableResultWrapper,
-            context = mockContext
+            drawableResultWrapper = drawableResultWrapper
         )
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

app crash when sharing high-res images from the sharing extension

### Causes (Optional)

the image is rescaled but the original path is used to send the image

### Solutions

use the scalded image path to send

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
