### PR TITLE
fix: self-deleting msg in doze mode on ConversationScreen [WPB-5894]

### DIFF
--- a/app/src/androidTest/java/com/wire/android/SelfDeletionTimerTest.kt
+++ b/app/src/androidTest/java/com/wire/android/SelfDeletionTimerTest.kt
@@ -109,7 +109,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneMinuteAndTenPointNineSeconds_whenGettingTheUpdateInterval_ThenIsEqualToTenPointNineSeconds() = runTest(dispatcher) {
+    fun givenTimeLeftIsEqualTo1Min10SecAnd900Millis_whenGettingTheUpdateInterval_ThenIsEqualTo10SecAnd900Millis() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes + 10.seconds + 900.milliseconds,

--- a/app/src/androidTest/java/com/wire/android/SelfDeletionTimerTest.kt
+++ b/app/src/androidTest/java/com/wire/android/SelfDeletionTimerTest.kt
@@ -33,6 +33,7 @@ import org.junit.Before
 import org.junit.Test
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -108,6 +109,19 @@ class SelfDeletionTimerTest {
     }
 
     @Test
+    fun givenTimeLeftIsEqualToOneMinuteAndTenPointNineSeconds_whenGettingTheUpdateInterval_ThenIsEqualToTenPointNineSeconds() = runTest(dispatcher) {
+        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+            ExpirationStatus.Expirable(
+                expireAfter = 1.minutes + 10.seconds + 900.milliseconds,
+                selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
+            )
+        )
+        assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
+        val interval = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).updateInterval()
+        assert(interval == 10.seconds + 900.milliseconds)
+    }
+
+    @Test
     fun givenTimeLeftIsEqualToThirtySeconds_whenGettingTheUpdateInterval_ThenIsEqualToOneSeconds() {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
@@ -147,7 +161,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentySevenDaysAndTwelveHours_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
+    fun givenTimeLeftIsEqualTo27DaysAnd12Hours_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days + 12.hours,
@@ -160,7 +174,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentySevenDaysAndOneSecond_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
+    fun givenTimeLeftIsEqualTo27DaysAnd1Second_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days + 1.seconds,
@@ -173,7 +187,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyEightDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
+    fun givenTimeLeftIsEqualTo28Days_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 28.days,
@@ -186,7 +200,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyOneDays_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyOneLeft() = runTest(dispatcher) {
+    fun givenTimeLeftIsEqualTo21Days_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyOneLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 21.days,
@@ -199,7 +213,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToFourTeenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourTeenDaysLeft() = runTest(dispatcher) {
+    fun givenTimeLeftIsEqualTo14Days_whenGettingThTimeLeftFormatted_ThenIsEqualToFourTeenDaysLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 14.days,
@@ -212,7 +226,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyDays_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyDaysLeft() = runTest(dispatcher) {
+    fun givenTimeLeftIsEqualTo20Days_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyDaysLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 20.days,
@@ -381,7 +395,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneDayAndTwelveHours_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
+    fun givenTimeLeftIs1DayAnd12Hours_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.days + 12.hours,
@@ -401,7 +415,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyThreeHoursAndTwentyThreeMinutes_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
+    fun givenTimeLeftIs23HoursAnd23Minutes_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours + 23.minutes,
@@ -417,7 +431,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneHourAndTwelveMinutes_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
+    fun givenTimeLeftIs1HourAnd12Minutes_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.hours + 12.minutes,
@@ -437,7 +451,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneHourAndTwentyThreeSeconds_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
+    fun givenTimeLeftIs1HourAnd23Seconds_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes + 23.seconds,

--- a/app/src/androidTest/java/com/wire/android/SelfDeletionTimerTest.kt
+++ b/app/src/androidTest/java/com/wire/android/SelfDeletionTimerTest.kt
@@ -21,6 +21,15 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.kalium.logic.data.message.Message
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
@@ -29,12 +38,25 @@ import kotlin.time.Duration.Companion.seconds
 
 class SelfDeletionTimerTest {
 
-    private val selfDeletionTimer = SelfDeletionTimerHelper(
-        context = InstrumentationRegistry.getInstrumentation().targetContext
-    )
+    private val selfDeletionTimer by lazy {
+        SelfDeletionTimerHelper(context = InstrumentationRegistry.getInstrumentation().targetContext)
+    }
+    private val dispatcher = StandardTestDispatcher()
+    private fun currentTime(): Instant = Instant.fromEpochMilliseconds(dispatcher.scheduler.currentTime)
+
+    @Before
+    fun setUp() {
+        mockkObject(SelfDeletionTimerHelper.Companion)
+        every { SelfDeletionTimerHelper.Companion.currentTime() } answers { currentTime() }
+    }
+
+    @After
+    fun cleanUp() {
+        unmockkObject(SelfDeletionTimerHelper.Companion)
+    }
 
     @Test
-    fun givenTimeLeftIsAboveOneHour_whenGettingTheUpdateInterval_ThenIsEqualToMinutesLeftTillWholeHour() {
+    fun givenTimeLeftIsAboveOneHour_whenGettingTheUpdateInterval_ThenIsEqualToMinutesLeftTillWholeHour() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours + 30.minutes,
@@ -47,7 +69,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToWholeHour_whenGettingTheUpdateInterval_ThenIsEqualToOneMinute() {
+    fun givenTimeLeftIsEqualToWholeHour_whenGettingTheUpdateInterval_ThenIsEqualToOneMinute() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours,
@@ -60,7 +82,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneHour_whenGettingTheUpdateInterval_ThenIsEqualToOneMinute() {
+    fun givenTimeLeftIsEqualToOneHour_whenGettingTheUpdateInterval_ThenIsEqualToOneMinute() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.hours,
@@ -73,7 +95,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneMinute_whenGettingTheUpdateInterval_ThenIsEqualToOneSeconds() {
+    fun givenTimeLeftIsEqualToOneMinute_whenGettingTheUpdateInterval_ThenIsEqualToOneSeconds() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes,
@@ -99,7 +121,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToFiftyDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() {
+    fun givenTimeLeftIsEqualToFiftyDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 50.days,
@@ -107,12 +129,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "4 weeks left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentySevenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() {
+    fun givenTimeLeftIsEqualToTwentySevenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days,
@@ -120,12 +142,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "4 weeks left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentySevenDaysAndTwelveHours_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() {
+    fun givenTimeLeftIsEqualToTwentySevenDaysAndTwelveHours_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days + 12.hours,
@@ -133,12 +155,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "4 weeks left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentySevenDaysAndOneSecond_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() {
+    fun givenTimeLeftIsEqualToTwentySevenDaysAndOneSecond_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days + 1.seconds,
@@ -146,12 +168,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "4 weeks left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyEightDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() {
+    fun givenTimeLeftIsEqualToTwentyEightDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 28.days,
@@ -159,12 +181,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "4 weeks left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyOneDays_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyOneLeft() {
+    fun givenTimeLeftIsEqualToTwentyOneDays_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyOneLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 21.days,
@@ -172,12 +194,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "21 days left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToFourTeenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourTeenDaysLeft() {
+    fun givenTimeLeftIsEqualToFourTeenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourTeenDaysLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 14.days,
@@ -185,12 +207,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "14 days left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyDays_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyDaysLeft() {
+    fun givenTimeLeftIsEqualToTwentyDays_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyDaysLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 20.days,
@@ -198,12 +220,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "20 days left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToSevenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() {
+    fun givenTimeLeftIsEqualToSevenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 7.days,
@@ -211,12 +233,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 week left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToSixDays_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() {
+    fun givenTimeLeftIsEqualToSixDays_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 6.days,
@@ -224,12 +246,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 week left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToSixDaysAnd12Hours_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() {
+    fun givenTimeLeftIsEqualToSixDaysAnd12Hours_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 6.days + 12.hours,
@@ -237,12 +259,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 week left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToSixDaysAndOneSecond_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() {
+    fun givenTimeLeftIsEqualToSixDaysAndOneSecond_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 6.days + 1.seconds,
@@ -250,12 +272,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 week left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToThirteenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToThirteenDays() {
+    fun givenTimeLeftIsEqualToThirteenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToThirteenDays() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 13.days,
@@ -263,12 +285,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "13 days left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneDay_whenGettingThTimeLeftFormatted_ThenIsEqualToOneDayLeft() {
+    fun givenTimeLeftIsEqualToOneDay_whenGettingThTimeLeftFormatted_ThenIsEqualToOneDayLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.days,
@@ -276,12 +298,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 day left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyFourHours_whenGettingThTimeLeftFormatted_ThenIsEqualToOneDayLeft() {
+    fun givenTimeLeftIsEqualToTwentyFourHours_whenGettingThTimeLeftFormatted_ThenIsEqualToOneDayLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 24.hours,
@@ -289,12 +311,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 day left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyThreeHours_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyThreeHourLeft() {
+    fun givenTimeLeftIsEqualToTwentyThreeHours_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyThreeHourLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours,
@@ -302,12 +324,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "23 hours left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToSixtyMinutes_whenGettingThTimeLeftFormatted_ThenIsEqualToOneHourLeft() {
+    fun givenTimeLeftIsEqualToSixtyMinutes_whenGettingThTimeLeftFormatted_ThenIsEqualToOneHourLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 60.minutes,
@@ -315,12 +337,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 hour left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneMinute_whenGettingThTimeLeftFormatted_ThenIsEqualToOneMinuteLeft() {
+    fun givenTimeLeftIsEqualToOneMinute_whenGettingThTimeLeftFormatted_ThenIsEqualToOneMinuteLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes,
@@ -328,12 +350,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 minute left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOFiftyNineMinutes_whenGettingThTimeLeftFormatted_ThenIsEqualToFiftyNineMinutes() {
+    fun givenTimeLeftIsEqualToOFiftyNineMinutes_whenGettingThTimeLeftFormatted_ThenIsEqualToFiftyNineMinutes() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 59.minutes,
@@ -341,12 +363,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "59 minutes left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToSixtySeconds_whenGettingThTimeLeftFormatted_ThenIsEqualToOneMinute() {
+    fun givenTimeLeftIsEqualToSixtySeconds_whenGettingThTimeLeftFormatted_ThenIsEqualToOneMinute() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 60.seconds,
@@ -354,12 +376,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 minute left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneDayAndTwelveHours_whenDecreasingTimeWithInterval_thenTimeLeftIsEqualToExpecetedTimeLeft() {
+    fun givenTimeLeftIsEqualToOneDayAndTwelveHours_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.days + 12.hours,
@@ -367,17 +389,19 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).decreaseTimeLeft(
-            selfDeletionTimer.updateInterval()
-        )
-        assert(selfDeletionTimer.timeLeftFormatted() == "1 day left")
+        with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "1 day left")
 
-        selfDeletionTimer.decreaseTimeLeft(selfDeletionTimer.updateInterval())
-        assert(selfDeletionTimer.timeLeftFormatted() == "23 hours left")
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "23 hours left")
+        }
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyThreeHoursAndTwentyThreeMinutes_whenDecreasingTimeWithInterval_thenTimeLeftIsEqualToExpeceted() {
+    fun givenTimeLeftIsEqualToTwentyThreeHoursAndTwentyThreeMinutes_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours + 23.minutes,
@@ -385,16 +409,15 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).decreaseTimeLeft(
-            selfDeletionTimer.updateInterval()
-        )
-
-        val timeLeftLabel = selfDeletionTimer.timeLeftFormatted()
-        assert(timeLeftLabel == "23 hours left")
+        with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "23 hours left")
+        }
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneHourAndTwelveMinutes_whenDecreasingTimeWithInterval_thenTimeLeftIsEqualToExpecetedTimeLeft() {
+    fun givenTimeLeftIsEqualToOneHourAndTwelveMinutes_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.hours + 12.minutes,
@@ -402,18 +425,19 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).decreaseTimeLeft(
-            selfDeletionTimer.updateInterval()
-        )
-        assert(selfDeletionTimer.timeLeftFormatted() == "1 hour left")
-        selfDeletionTimer.decreaseTimeLeft(
-            selfDeletionTimer.updateInterval()
-        )
-        assert(selfDeletionTimer.timeLeftFormatted() == "59 minutes left")
+        with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "1 hour left")
+
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "59 minutes left")
+        }
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneHourAndTwentyThreeSeconds_whenDecreasingTimeWithInterval_thenTimeLeftIsEqualToExpecetedTimeLeft() {
+    fun givenTimeLeftIsEqualToOneHourAndTwentyThreeSeconds_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes + 23.seconds,
@@ -421,13 +445,14 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).decreaseTimeLeft(
-            selfDeletionTimer.updateInterval()
-        )
-        assert(selfDeletionTimer.timeLeftFormatted() == "1 minute left")
-        selfDeletionTimer.decreaseTimeLeft(
-            selfDeletionTimer.updateInterval()
-        )
-        assert(selfDeletionTimer.timeLeftFormatted() == "59 seconds left")
+        with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "1 minute left")
+
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "59 seconds left")
+        }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -132,8 +132,9 @@ class GlobalObserversManager @Inject constructor(
                             .distinctUntilChanged()
                             .filter { it is CurrentSessionResult.Success && it.accountInfo.isValid() }
                             .map { (it as CurrentSessionResult.Success).accountInfo.userId }
+                    } else {
+                        emptyFlow()
                     }
-                    else emptyFlow()
                 }
                 .collect { userId -> coreLogic.getSessionScope(userId).messages.deleteEphemeralMessageEndDate() }
         }

--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -22,11 +22,13 @@ import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
+import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.LogoutCallback
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -35,8 +37,12 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -52,6 +58,7 @@ class GlobalObserversManager @Inject constructor(
     private val notificationManager: WireNotificationManager,
     private val notificationChannelsManager: NotificationChannelsManager,
     private val userDataStoreProvider: UserDataStoreProvider,
+    private val currentScreenManager: CurrentScreenManager,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.io())
 
@@ -65,6 +72,7 @@ class GlobalObserversManager @Inject constructor(
             }
         }
         scope.handleLogouts()
+        scope.handleDeleteEphemeralMessageEndDate()
     }
 
     private suspend fun setUpNotifications() {
@@ -113,5 +121,21 @@ class GlobalObserversManager @Inject constructor(
             coreLogic.getGlobalScope().logoutCallbackManager.register(callback)
             awaitClose { coreLogic.getGlobalScope().logoutCallbackManager.unregister(callback) }
         }.launchIn(this)
+    }
+
+    private fun CoroutineScope.handleDeleteEphemeralMessageEndDate() {
+        launch {
+            currentScreenManager.isAppVisibleFlow()
+                .flatMapLatest { isAppVisible ->
+                    if (isAppVisible) {
+                        coreLogic.getGlobalScope().session.currentSessionFlow()
+                            .distinctUntilChanged()
+                            .filter { it is CurrentSessionResult.Success && it.accountInfo.isValid() }
+                            .map { (it as CurrentSessionResult.Success).accountInfo.userId }
+                    }
+                    else emptyFlow()
+                }
+                .collect { userId -> coreLogic.getSessionScope(userId).messages.deleteEphemeralMessageEndDate() }
+        }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
@@ -19,13 +19,18 @@ package com.wire.android.ui.home.conversations
 
 import android.content.Context
 import android.content.res.Resources
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.wire.android.R
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
@@ -33,12 +38,15 @@ import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.kalium.logic.data.message.Message
 import kotlinx.coroutines.delay
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 @Composable
 fun rememberSelfDeletionTimer(expirationStatus: ExpirationStatus): SelfDeletionTimerHelper.SelfDeletionTimerState {
@@ -54,12 +62,11 @@ class SelfDeletionTimerHelper(private val context: Context) {
     fun fromExpirationStatus(expirationStatus: ExpirationStatus): SelfDeletionTimerState {
         return if (expirationStatus is ExpirationStatus.Expirable) {
             with(expirationStatus) {
-                val timeLeft = calculateTimeLeft(selfDeletionStatus, expireAfter)
+                val expireAt = calculateExpireAt(selfDeletionStatus, expireAfter)
                 SelfDeletionTimerState.Expirable(
                     context.resources,
-                    timeLeft,
                     expireAfter,
-                    selfDeletionStatus is Message.ExpirationData.SelfDeletionStatus.Started
+                    expireAt,
                 )
             }
         } else {
@@ -67,35 +74,22 @@ class SelfDeletionTimerHelper(private val context: Context) {
         }
     }
 
-    private fun calculateTimeLeft(
+    private fun calculateExpireAt(
         selfDeletionStatus: Message.ExpirationData.SelfDeletionStatus?,
-        expireAfter: Duration
-    ): Duration {
-        return if (selfDeletionStatus is Message.ExpirationData.SelfDeletionStatus.Started) {
-            val timeElapsedSinceSelfDeletionStartDate = Clock.System.now() - selfDeletionStatus.selfDeletionStartDate
-            val timeLeft = expireAfter - timeElapsedSinceSelfDeletionStartDate
-
-            /**
-             * time left for deletion, can be a negative value if the time difference between the self deletion start date and
-             * Clock.System.now() is greater then [expireAfter], we normalize it to 0 seconds
-             */
-            if (timeLeft.isNegative()) {
-                ZERO
-            } else {
-                timeLeft
-            }
-        } else {
-            expireAfter
+        expireAfter: Duration,
+    ) =
+        if (selfDeletionStatus is Message.ExpirationData.SelfDeletionStatus.Started) selfDeletionStatus.selfDeletionStartDate + expireAfter
+        else {
+            val currentTime = currentTime()
+            currentTime + expireAfter
         }
-    }
 
     sealed class SelfDeletionTimerState {
 
         class Expirable(
             private val resources: Resources,
-            timeLeft: Duration,
             private val expireAfter: Duration,
-            val timerStarted: Boolean
+            private val expireAt: Instant,
         ) : SelfDeletionTimerState() {
             companion object {
                 /**
@@ -115,67 +109,68 @@ class SelfDeletionTimerHelper(private val context: Context) {
                 private const val OPAQUE_BACKGROUND_COLOR_ALPHA_VALUE = 1F
             }
 
-            var timeLeft by mutableStateOf(timeLeft)
+            var timeLeft by mutableStateOf(calculateTimeLeft())
+                private set
+            val timeLeftFormatted: String by derivedStateOf {
+                when {
+                    timeLeft > 28.days ->
+                        resources.getQuantityString(
+                            R.plurals.weeks_left,
+                            4,
+                            4
+                        )
+                    // 4 weeks
+                    timeLeft >= 27.days && timeLeft <= 28.days ->
+                        resources.getQuantityString(
+                            R.plurals.weeks_left,
+                            4,
+                            4
+                        )
+                    // days below 4 weeks
+                    timeLeft <= 27.days && timeLeft > 7.days ->
+                        resources.getQuantityString(
+                            R.plurals.days_left,
+                            timeLeft.inWholeDays.toInt(),
+                            timeLeft.inWholeDays.toInt()
+                        )
+                    // one week
+                    timeLeft >= 6.days && timeLeft <= 7.days ->
+                        resources.getQuantityString(
+                            R.plurals.weeks_left,
+                            1,
+                            1
+                        )
+                    // days below 1 week
+                    timeLeft < 7.days && timeLeft >= 1.days ->
+                        resources.getQuantityString(
+                            R.plurals.days_left,
+                            timeLeft.inWholeDays.toInt(),
+                            timeLeft.inWholeDays.toInt()
+                        )
+                    // hours below one day
+                    timeLeft >= 1.hours && timeLeft < 24.hours ->
+                        resources.getQuantityString(
+                            R.plurals.hours_left,
+                            timeLeft.inWholeHours.toInt(),
+                            timeLeft.inWholeHours.toInt()
+                        )
+                    // minutes below hour
+                    timeLeft >= 1.minutes && timeLeft < 60.minutes ->
+                        resources.getQuantityString(
+                            R.plurals.minutes_left,
+                            timeLeft.inWholeMinutes.toInt(),
+                            timeLeft.inWholeMinutes.toInt()
+                        )
+                    // seconds below minute
+                    timeLeft < 60.seconds ->
+                        resources.getQuantityString(
+                            R.plurals.seconds_left,
+                            timeLeft.inWholeSeconds.toInt(),
+                            timeLeft.inWholeSeconds.toInt()
+                        )
 
-            @Suppress("MagicNumber", "ComplexMethod")
-            fun timeLeftFormatted(): String = when {
-                timeLeft > 28.days ->
-                    resources.getQuantityString(
-                        R.plurals.weeks_left,
-                        4,
-                        4
-                    )
-                // 4 weeks
-                timeLeft >= 27.days && timeLeft <= 28.days ->
-                    resources.getQuantityString(
-                        R.plurals.weeks_left,
-                        4,
-                        4
-                    )
-                // days below 4 weeks
-                timeLeft <= 27.days && timeLeft > 7.days ->
-                    resources.getQuantityString(
-                        R.plurals.days_left,
-                        timeLeft.inWholeDays.toInt(),
-                        timeLeft.inWholeDays.toInt()
-                    )
-                // one week
-                timeLeft >= 6.days && timeLeft <= 7.days ->
-                    resources.getQuantityString(
-                        R.plurals.weeks_left,
-                        1,
-                        1
-                    )
-                // days below 1 week
-                timeLeft < 7.days && timeLeft >= 1.days ->
-                    resources.getQuantityString(
-                        R.plurals.days_left,
-                        timeLeft.inWholeDays.toInt(),
-                        timeLeft.inWholeDays.toInt()
-                    )
-                // hours below one day
-                timeLeft >= 1.hours && timeLeft < 24.hours ->
-                    resources.getQuantityString(
-                        R.plurals.hours_left,
-                        timeLeft.inWholeHours.toInt(),
-                        timeLeft.inWholeHours.toInt()
-                    )
-                // minutes below hour
-                timeLeft >= 1.minutes && timeLeft < 60.minutes ->
-                    resources.getQuantityString(
-                        R.plurals.minutes_left,
-                        timeLeft.inWholeMinutes.toInt(),
-                        timeLeft.inWholeMinutes.toInt()
-                    )
-                // seconds below minute
-                timeLeft < 60.seconds ->
-                    resources.getQuantityString(
-                        R.plurals.seconds_left,
-                        timeLeft.inWholeSeconds.toInt(),
-                        timeLeft.inWholeSeconds.toInt()
-                    )
-
-                else -> throw IllegalStateException("Not possible state for a time left label")
+                    else -> throw IllegalStateException("Not possible state for a time left label")
+                }
             }
 
             /**
@@ -186,48 +181,41 @@ class SelfDeletionTimerHelper(private val context: Context) {
              * updated every second.
              * @return how long until the next timer update.
              */
-            fun updateInterval(): Duration {
+            @VisibleForTesting
+            internal fun updateInterval(): Duration {
+                fun remainingTimeToDurationUnit(durationUnit: DurationUnit): Duration {
+                    /*
+                     * Function toLong returns the whole part for the given duration unit and then this whole value is converted back to
+                     * Duration and subtracted from the original duration, which gives the remaining time to the next full duration unit.
+                     *
+                     * For example, if the time left is "1 day and 1 hour" and durationUnit is DAYS, then toLong will return 1L
+                     * which means "1 full day" (just like .inWholeDays) and then it will be converted back to Duration type.
+                     * Then this "1 day" will be subtracted from the original duration, returning "1 hour" left ("1d 1h" - "1d" = "1h").
+                     * So in this case it's the same as `timeLeft - timeLeft.inWholeHours.hours`
+                     * because `timeLeft.inWholeDays` is basically `timeLeft.toLong(DurationUnit.DAYS)`
+                     * and `1L.days` is the same as `1L.toDuration(DurationUnit.DAYS)`.
+                     */
+                    val timeLeftForDurationUnit = timeLeft - timeLeft.toLong(durationUnit).toDuration(durationUnit)
+                    return if (timeLeftForDurationUnit == ZERO) 1.toDuration(durationUnit)
+                    else timeLeftForDurationUnit
+                }
+
                 val timeLeftUpdateInterval = when {
-                    timeLeft > 24.hours -> {
-                        val timeLeftTillWholeDay = (timeLeft.inWholeMinutes % 1.days.inWholeMinutes).minutes
-                        if (timeLeftTillWholeDay == ZERO) {
-                            1.days
-                        } else {
-                            timeLeftTillWholeDay
-                        }
-                    }
-
-                    timeLeft <= 24.hours && timeLeft > 1.hours -> {
-                        val timeLeftTillWholeHour = (timeLeft.inWholeSeconds % 1.hours.inWholeSeconds).seconds
-                        if (timeLeftTillWholeHour == ZERO) {
-                            1.hours
-                        } else {
-                            timeLeftTillWholeHour
-                        }
-                    }
-
-                    timeLeft <= 1.hours && timeLeft > 1.minutes -> {
-                        val timeLeftTillWholeMinute = (timeLeft.inWholeSeconds % 1.minutes.inWholeSeconds).seconds
-                        if (timeLeftTillWholeMinute == ZERO) {
-                            1.minutes
-                        } else {
-                            timeLeftTillWholeMinute
-                        }
-                    }
-
-                    timeLeft <= 1.minutes -> {
-                        1.seconds
-                    }
-
+                    timeLeft > 24.hours -> remainingTimeToDurationUnit(DurationUnit.DAYS)
+                    timeLeft <= 24.hours && timeLeft > 1.hours -> remainingTimeToDurationUnit(DurationUnit.HOURS)
+                    timeLeft <= 1.hours && timeLeft > 1.minutes -> remainingTimeToDurationUnit(DurationUnit.MINUTES)
+                    timeLeft <= 1.minutes -> remainingTimeToDurationUnit(DurationUnit.SECONDS)
                     else -> throw IllegalStateException("Not possible state for the interval")
                 }
 
                 return timeLeftUpdateInterval
             }
 
-            fun decreaseTimeLeft(interval: Duration) {
-                if (timeLeft.inWholeSeconds != 0L) timeLeft -= interval
-            }
+            // non-negative value, returns ZERO if message is already expired
+            private fun calculateTimeLeft(): Duration = (expireAt - currentTime()).let { if (it.isNegative()) ZERO else it }
+
+            @VisibleForTesting
+            internal fun recalculateTimeLeft() { timeLeft = calculateTimeLeft() }
 
             /**
              * if the time elapsed ratio is between 0.50 and 0.75
@@ -266,72 +254,80 @@ class SelfDeletionTimerHelper(private val context: Context) {
                     OPAQUE_BACKGROUND_COLOR_ALPHA_VALUE
                 }
             }
-        }
 
-        object NotExpirable : SelfDeletionTimerState()
-    }
-}
+            @Composable
+            fun startDeletionTimer(message: UIMessage, onStartMessageSelfDeletion: (UIMessage) -> Unit) {
+                when (val messageContent = message.messageContent) {
+                    is UIMessageContent.AssetMessage -> startAssetDeletion(
+                        onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
+                        downloadStatus = messageContent.downloadStatus
+                    )
 
-@Composable
-fun startDeletionTimer(
-    message: UIMessage,
-    expirableTimer: SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable,
-    onStartMessageSelfDeletion: (UIMessage) -> Unit
-) {
-    when (val messageContent = message.messageContent) {
-        is UIMessageContent.AssetMessage -> startAssetDeletion(
-            expirableTimer = expirableTimer,
-            onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
-            downloadStatus = messageContent.downloadStatus
-        )
+                    is UIMessageContent.AudioAssetMessage -> startAssetDeletion(
+                        onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
+                        downloadStatus = messageContent.downloadStatus
+                    )
 
-        is UIMessageContent.AudioAssetMessage -> startAssetDeletion(
-            expirableTimer = expirableTimer,
-            onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
-            downloadStatus = messageContent.downloadStatus
-        )
+                    is UIMessageContent.ImageMessage -> startAssetDeletion(
+                        onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
+                        downloadStatus = messageContent.downloadStatus
+                    )
 
-        is UIMessageContent.ImageMessage -> startAssetDeletion(
-            expirableTimer = expirableTimer,
-            onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
-            downloadStatus = messageContent.downloadStatus
-        )
-
-        else -> {
-            LaunchedEffect(Unit) {
-                onStartMessageSelfDeletion(message)
+                    else -> startRegularDeletion(message = message, onStartMessageSelfDeletion = onStartMessageSelfDeletion)
+                }
             }
-            LaunchedEffect(expirableTimer.timeLeft) {
-                with(expirableTimer) {
+
+            @Composable
+            private fun startAssetDeletion(onSelfDeletingMessageRead: () -> Unit, downloadStatus: Message.DownloadStatus) {
+                LaunchedEffect(downloadStatus) {
+                    if (downloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY
+                        || downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY
+                    ) {
+                        onSelfDeletingMessageRead()
+                    }
+                }
+                LaunchedEffect(key1 = timeLeft, key2 = downloadStatus) {
+                    if (downloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY
+                        || downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY
+                    ) {
+                        if (timeLeft != ZERO) {
+                            delay(updateInterval())
+                            recalculateTimeLeft()
+                        }
+                    }
+                }
+                val lifecycleOwner = LocalLifecycleOwner.current
+                LaunchedEffect(lifecycleOwner) {
+                    lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                        recalculateTimeLeft()
+                    }
+                }
+            }
+
+            @Composable
+            private fun startRegularDeletion(message: UIMessage, onStartMessageSelfDeletion: (UIMessage) -> Unit) {
+                LaunchedEffect(Unit) {
+                    onStartMessageSelfDeletion(message)
+                }
+                LaunchedEffect(timeLeft) {
                     if (timeLeft != ZERO) {
                         delay(updateInterval())
-                        decreaseTimeLeft(updateInterval())
+                        recalculateTimeLeft()
+                    }
+                }
+                val lifecycleOwner = LocalLifecycleOwner.current
+                LaunchedEffect(lifecycleOwner) {
+                    lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                        recalculateTimeLeft()
                     }
                 }
             }
         }
-    }
-}
 
-@Composable
-private fun startAssetDeletion(
-    expirableTimer: SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable,
-    onSelfDeletingMessageRead: () -> Unit,
-    downloadStatus: Message.DownloadStatus
-) {
-    LaunchedEffect(downloadStatus) {
-        if (downloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY || downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY) {
-            onSelfDeletingMessageRead()
-        }
+        object NotExpirable : SelfDeletionTimerState()
     }
-    LaunchedEffect(expirableTimer.timeLeft, downloadStatus) {
-        if (downloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY || downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY) {
-            with(expirableTimer) {
-                if (timeLeft != ZERO) {
-                    delay(updateInterval())
-                    decreaseTimeLeft(updateInterval())
-                }
-            }
-        }
+
+    companion object {
+        fun currentTime(): Instant = Clock.System.now()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
@@ -111,6 +111,7 @@ class SelfDeletionTimerHelper(private val context: Context) {
 
             var timeLeft by mutableStateOf(calculateTimeLeft())
                 private set
+            @Suppress("MagicNumber", "ComplexMethod")
             val timeLeftFormatted: String by derivedStateOf {
                 when {
                     timeLeft > 28.days ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -125,9 +125,8 @@ fun MessageItem(
             !message.isPending &&
             !message.sendingFailed
         ) {
-            startDeletionTimer(
+            selfDeletionTimerState.startDeletionTimer(
                 message = message,
-                expirableTimer = selfDeletionTimerState,
                 onStartMessageSelfDeletion = onSelfDeletingMessageRead
             )
         }
@@ -226,7 +225,7 @@ fun MessageItem(
                         MessageAuthorRow(messageHeader = message.header)
                     }
                     if (selfDeletionTimerState is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
-                        MessageExpireLabel(messageContent, selfDeletionTimerState.timeLeftFormatted())
+                        MessageExpireLabel(messageContent, selfDeletionTimerState.timeLeftFormatted)
 
                         // if the message is marked as deleted and is [SelfDeletionTimer.SelfDeletionTimerState.Expirable]
                         // the deletion responsibility belongs to the receiver, therefore we need to wait for the receiver

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -97,9 +97,8 @@ fun SystemMessageItem(
         !message.isPending &&
         !message.sendingFailed
     ) {
-        startDeletionTimer(
+        selfDeletionTimerState.startDeletionTimer(
             message = message,
-            expirableTimer = selfDeletionTimerState,
             onStartMessageSelfDeletion = onSelfDeletingMessageRead
         )
     }

--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -24,10 +24,18 @@ import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.framework.TestUser
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
+import com.wire.android.util.CurrentScreenManager
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.auth.PersistentWebSocketStatus
+import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.feature.UserSessionScope
+import com.wire.kalium.logic.feature.auth.LogoutCallbackManager
+import com.wire.kalium.logic.feature.message.MessageScope
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -35,6 +43,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -87,6 +96,56 @@ class GlobalObserversManagerTest {
         }
     }
 
+    @Test
+    fun `given app visible and valid session, when handling ephemeral messages, then call deleteEphemeralMessageEndDate`() {
+        val (arrangement, manager) = Arrangement()
+            .withCurrentSessionFlow(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
+            .withAppVisibleFlow(true)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 1) { arrangement.messageScope.deleteEphemeralMessageEndDate() }
+    }
+
+    @Test
+    fun `given app not visible and valid session, when handling ephemeral messages, then do not call deleteEphemeralMessageEndDate`() {
+        val (arrangement, manager) = Arrangement()
+            .withCurrentSessionFlow(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
+            .withAppVisibleFlow(false)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 0) { arrangement.messageScope.deleteEphemeralMessageEndDate() }
+    }
+
+    @Test
+    fun `given app visible and invalid session, when handling ephemeral messages, then do not call deleteEphemeralMessageEndDate`() {
+        val (arrangement, manager) = Arrangement()
+            .withCurrentSessionFlow(CurrentSessionResult.Success(AccountInfo.Invalid(TestUser.SELF_USER.id, LogoutReason.DELETED_ACCOUNT)))
+            .withAppVisibleFlow(true)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 0) { arrangement.messageScope.deleteEphemeralMessageEndDate() }
+    }
+
+    @Test
+    fun `given app visible and no session, when handling ephemeral messages, then do not call deleteEphemeralMessageEndDate`() {
+        val (arrangement, manager) = Arrangement()
+            .withCurrentSessionFlow(CurrentSessionResult.Failure.SessionNotFound)
+            .withAppVisibleFlow(true)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 0) { arrangement.messageScope.deleteEphemeralMessageEndDate() }
+    }
+
+    @Test
+    fun `given app visible and session failure, when handling ephemeral messages, then do not call deleteEphemeralMessageEndDate`() {
+        val (arrangement, manager) = Arrangement()
+            .withCurrentSessionFlow(CurrentSessionResult.Failure.Generic(CoreFailure.Unknown(RuntimeException("error"))))
+            .withAppVisibleFlow(true)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 0) { arrangement.messageScope.deleteEphemeralMessageEndDate() }
+    }
+
     private class Arrangement {
 
         @MockK
@@ -101,6 +160,18 @@ class GlobalObserversManagerTest {
         @MockK
         lateinit var userDataStoreProvider: UserDataStoreProvider
 
+        @MockK
+        lateinit var currentScreenManager: CurrentScreenManager
+
+        @MockK
+        lateinit var logoutCallbackManager: LogoutCallbackManager
+
+        @MockK
+        lateinit var userSessionScope: UserSessionScope
+
+        @MockK
+        lateinit var messageScope: MessageScope
+
         private val manager by lazy {
             GlobalObserversManager(
                 dispatcherProvider = TestDispatcherProvider(),
@@ -108,6 +179,7 @@ class GlobalObserversManagerTest {
                 notificationChannelsManager = notificationChannelsManager,
                 notificationManager = notificationManager,
                 userDataStoreProvider = userDataStoreProvider,
+                currentScreenManager = currentScreenManager,
             )
         }
 
@@ -118,6 +190,14 @@ class GlobalObserversManagerTest {
             // Default empty values
             mockUri()
             every { notificationChannelsManager.createUserNotificationChannels(any()) } returns Unit
+            every { coreLogic.getGlobalScope().logoutCallbackManager } returns logoutCallbackManager
+            every { coreLogic.getSessionScope(any()) } returns userSessionScope
+            every { userSessionScope.messages } returns messageScope
+            coEvery { messageScope.deleteEphemeralMessageEndDate() } returns Unit
+            withPersistentWebSocketConnectionStatuses(emptyList())
+            withValidAccounts(emptyList())
+            withCurrentSessionFlow(CurrentSessionResult.Failure.SessionNotFound)
+            withAppVisibleFlow(true)
         }
 
         fun withValidAccounts(list: List<Pair<SelfUser, Team?>>): Arrangement = apply {
@@ -127,6 +207,14 @@ class GlobalObserversManagerTest {
         fun withPersistentWebSocketConnectionStatuses(list: List<PersistentWebSocketStatus>): Arrangement = apply {
             coEvery { coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus() } returns
                     ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(flowOf(list))
+        }
+
+        fun withCurrentSessionFlow(result: CurrentSessionResult): Arrangement = apply {
+            coEvery { coreLogic.getGlobalScope().session.currentSessionFlow() } returns flowOf(result)
+        }
+
+        fun withAppVisibleFlow(isVisible: Boolean) = apply {
+            coEvery { currentScreenManager.isAppVisibleFlow() } returns MutableStateFlow(isVisible)
         }
 
         fun arrange() = this to manager


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5894" title="WPB-5894" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5894</a>  [Android] Self deleting messages timer stops when device is in doze mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the user receives a self-deleting message, leaves the app on `ConversationScreen` and the app is put into background, then the message is not removed after given time when app is opened again, only when the user closes the `ConversationScreen` and opens it again. When the given time is not fully passed, the message counter is not properly updated, it stays on the value it had when the app was put into background. Sometimes this counter doesn't get updated for the next interval, for instance it starts with "4 minutes left" and after a minute passes it's still "4 minutes left" but then after another minute it suddenly goes down to "2 minutes left".

### Causes (Optional)

Previous solution was implemented to check and remove all expired messages when the user opens the `ConversationScreen` so it's not working when the user is still on that screen. For the counter, there's another `delay` which also doesn't work well when in doze mode and the counter composable isn't recomposed because the value is not being passed as a state. Also, the amount of time to be delayed is not calculated properly - it takes only one unit into account, so for instance if the time left for the message is equal to `1:59.900` left (1 minute 59 seconds and 900ms) then it will delay for 59 seconds, omitting the milliseconds value and resulting in next calculation being done when the time left is `1:00.900`, so still over a minute, that's why it can give the result of "1 minute left" for 2 minutes.

### Solutions

Implement a global observer to execute `deleteEphemeralMessageEndDate` each time the app is back in the foreground.
Refactor the `SelfDeletionTimerHelper` to take "end time" when handling self-deleting expiration and recalculate the time again each time the delay ends by comparing "current time" and "end time" instead of just subtracting the "delay time" - thanks to that it has more accurate time left in each iteration.
Fix the `updateInterval` function to return the full remaining time to the next given duration unit (for instance if we want to get time remaining to the next full minute and now the time is `1:59.900` then it should return `59.900`)
Provide `timeLeftFormatted` as a state so that the composable that's showing it gets recomposed each time it's updated.
Implement another `LaunchedEffect` to recalculate the time left and restart the delay when the app is back in the foreground.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Receive a self-deleting message and put the app in the background while still being on the `ConversationScreen`, turn off the screen so that it can enter doze mode and open the app again before or after the time for the self-deleting message passes.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
