### PR TITLE
fix: setting items clickable area [WPB-6225]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceScreen.kt
@@ -188,9 +188,9 @@ private fun RemoveDeviceItemsList(
                 DeviceItem(
                     device = device,
                     placeholder = placeholders,
-                    onRemoveDeviceClick = onItemClicked,
+                    onClickAction = onItemClicked,
                     shouldShowVerifyLabel = false,
-                    leadingIcon = {
+                    icon = {
                         Icon(
                             painterResource(id = R.drawable.ic_remove),
                             stringResource(R.string.content_description_remove_devices_screen_remove_icon)

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
@@ -60,7 +60,7 @@ fun SettingsItem(
     @DrawableRes trailingIcon: Int? = null,
     switchState: SwitchState = SwitchState.None,
     onRowPressed: Clickable = Clickable(false),
-    onIconPressed: Clickable = Clickable(false)
+    onIconPressed: Clickable? = null
 ) {
     RowItemTemplate(
         title = {

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesScreen.kt
@@ -129,9 +129,8 @@ private fun LazyListScope.folderDeviceItems(
             item,
             background = MaterialTheme.wireColorScheme.surface,
             placeholder = false,
-            onRemoveDeviceClick = onDeviceClick,
-            leadingIcon = Icons.Filled.ChevronRight.Icon(),
-            leadingIconBorder = 0.dp,
+            onClickAction = onDeviceClick,
+            icon = Icons.Filled.ChevronRight.Icon(),
             isWholeItemClickable = true,
             shouldShowVerifyLabel = shouldShowVerifyLabel
         )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.ui.authentication.devices.DeviceItem
@@ -121,9 +120,8 @@ private fun OtherUserDevicesContent(
                     placeholder = false,
                     background = MaterialTheme.wireColorScheme.surface,
                     isWholeItemClickable = true,
-                    onRemoveDeviceClick = onDeviceClick,
-                    leadingIcon = Icons.Filled.ChevronRight.Icon(),
-                    leadingIconBorder = 0.dp,
+                    onClickAction = onDeviceClick,
+                    icon = Icons.Filled.ChevronRight.Icon(),
                     shouldShowVerifyLabel = true
                 )
                 if (index < otherUserDevices.lastIndex) WireDivider()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6225" title="WPB-6225" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6225</a>  [Android] Enable the entire space of settings entries clickable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Settings item's chevron icon prevents clicking on the item, icon takes over the click action and nothing happens then.

### Solutions

Make icons not clickable when not needed to be (so that it's not always a button but regular non-clickable icon).

### Testing

#### How to Test

Open settings and try to click on the chevron icon.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
