### PR TITLE
fix: logging level does not reflect in datadog

### DIFF
--- a/app/src/beta/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/beta/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -40,6 +40,14 @@ object DataDogLogger : LogWriter() {
                 "clientId" to userClientData.clientId,
             )
         } ?: emptyMap<String, Any?>()
-        logger.log(severity.ordinal, message, throwable, attributes)
+
+        when (severity) {
+            Severity.Debug -> logger.d(message, throwable, attributes)
+            Severity.Info -> logger.i(message, throwable, attributes)
+            Severity.Warn -> logger.w(message, throwable, attributes)
+            Severity.Error -> logger.e(message, throwable, attributes)
+            Severity.Assert,
+            Severity.Verbose -> logger.v(message, throwable, attributes)
+        }
     }
 }

--- a/app/src/dev/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/dev/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -42,6 +42,14 @@ object DataDogLogger : LogWriter() {
                 "clientId" to userClientData.clientId,
             )
         } ?: emptyMap<String, Any?>()
-        logger.log(severity.ordinal, message, throwable, attributes)
+
+        when (severity) {
+            Severity.Debug -> logger.d(message, throwable, attributes)
+            Severity.Info -> logger.i(message, throwable, attributes)
+            Severity.Warn -> logger.w(message, throwable, attributes)
+            Severity.Error -> logger.e(message, throwable, attributes)
+            Severity.Assert,
+            Severity.Verbose -> logger.v(message, throwable, attributes)
+        }
     }
 }

--- a/app/src/internal/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/internal/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -42,6 +42,14 @@ object DataDogLogger : LogWriter() {
                 "clientId" to userClientData.clientId,
             )
         } ?: emptyMap<String, Any?>()
-        logger.log(severity.ordinal, message, throwable, attributes)
+
+        when (severity) {
+            Severity.Debug -> logger.d(message, throwable, attributes)
+            Severity.Info -> logger.i(message, throwable, attributes)
+            Severity.Warn -> logger.w(message, throwable, attributes)
+            Severity.Error -> logger.e(message, throwable, attributes)
+            Severity.Assert,
+            Severity.Verbose -> logger.v(message, throwable, attributes)
+        }
     }
 }

--- a/app/src/staging/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/staging/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -42,6 +42,14 @@ object DataDogLogger : LogWriter() {
                 "clientId" to userClientData.clientId,
             )
         } ?: emptyMap<String, Any?>()
-        logger.log(severity.ordinal, message, throwable, attributes)
+
+        when (severity) {
+            Severity.Debug -> logger.d(message, throwable, attributes)
+            Severity.Info -> logger.i(message, throwable, attributes)
+            Severity.Warn -> logger.w(message, throwable, attributes)
+            Severity.Error -> logger.e(message, throwable, attributes)
+            Severity.Assert,
+            Severity.Verbose -> logger.v(message, throwable, attributes)
+        }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we are not being able to see correct level of severity in Datadog dashboards for internal builds

### Causes (Optional)

Datadog, does not inform about anomalies spikes automatically. Also, we can not categorize by error level, since now everything is debug and info.

### Solutions

Use a similar approach that Kermit uses for their `Logcat` implementation.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

See logs on datadog, and should see them with colorful statuses 🟥 🟨 🟦  for each logged messages.

### Attachments (Optional)
**Before**:
<img width="738" alt="Screenshot 2024-01-31 at 11 56 31" src="https://github.com/wireapp/wire-android/assets/5806454/3ef663d0-3c91-4e8f-969f-abd1aac34348">
<img width="738" alt="Screenshot 2024-01-31 at 11 56 38" src="https://github.com/wireapp/wire-android/assets/5806454/d9ffb477-f13f-468d-b234-b64b11c65de6">

---- 
**After**:
<img width="738" alt="Screenshot 2024-01-31 at 11 47 12" src="https://github.com/wireapp/wire-android/assets/5806454/d6524564-6a23-43e4-90f1-ce8e6faeb3c9">

Insights autogenerated
<img width="605" alt="Screenshot 2024-01-31 at 12 03 59" src="https://github.com/wireapp/wire-android/assets/5806454/672a5bd2-3302-46e7-b6f9-5383c2ef3109">

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
