### PR TITLE
fix: self-deleting msg in doze mode on ConversationScreen [WPB-5894]

### DIFF
--- a/app/src/androidTest/java/com/wire/android/SelfDeletionTimerTest.kt
+++ b/app/src/androidTest/java/com/wire/android/SelfDeletionTimerTest.kt
@@ -21,20 +21,43 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.kalium.logic.data.message.Message
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 class SelfDeletionTimerTest {
 
-    private val selfDeletionTimer = SelfDeletionTimerHelper(
-        context = InstrumentationRegistry.getInstrumentation().targetContext
-    )
+    private val selfDeletionTimer by lazy {
+        SelfDeletionTimerHelper(context = InstrumentationRegistry.getInstrumentation().targetContext)
+    }
+    private val dispatcher = StandardTestDispatcher()
+    private fun currentTime(): Instant = Instant.fromEpochMilliseconds(dispatcher.scheduler.currentTime)
+
+    @Before
+    fun setUp() {
+        mockkObject(SelfDeletionTimerHelper.Companion)
+        every { SelfDeletionTimerHelper.Companion.currentTime() } answers { currentTime() }
+    }
+
+    @After
+    fun cleanUp() {
+        unmockkObject(SelfDeletionTimerHelper.Companion)
+    }
 
     @Test
-    fun givenTimeLeftIsAboveOneHour_whenGettingTheUpdateInterval_ThenIsEqualToMinutesLeftTillWholeHour() {
+    fun givenTimeLeftIsAboveOneHour_whenGettingTheUpdateInterval_ThenIsEqualToMinutesLeftTillWholeHour() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours + 30.minutes,
@@ -47,7 +70,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToWholeHour_whenGettingTheUpdateInterval_ThenIsEqualToOneMinute() {
+    fun givenTimeLeftIsEqualToWholeHour_whenGettingTheUpdateInterval_ThenIsEqualToOneMinute() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours,
@@ -60,7 +83,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneHour_whenGettingTheUpdateInterval_ThenIsEqualToOneMinute() {
+    fun givenTimeLeftIsEqualToOneHour_whenGettingTheUpdateInterval_ThenIsEqualToOneMinute() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.hours,
@@ -73,7 +96,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneMinute_whenGettingTheUpdateInterval_ThenIsEqualToOneSeconds() {
+    fun givenTimeLeftIsEqualToOneMinute_whenGettingTheUpdateInterval_ThenIsEqualToOneSeconds() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes,
@@ -86,7 +109,20 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToThirtySeconds_whenGettingTheUpdateInterval_ThenIsEqualToOneSeconds() {
+    fun givenTimeLeftIsEqualTo1Min10SecAnd900Millis_whenGettingTheUpdateInterval_ThenIsEqualTo10SecAnd900Millis() = runTest(dispatcher) {
+        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+            ExpirationStatus.Expirable(
+                expireAfter = 1.minutes + 10.seconds + 900.milliseconds,
+                selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
+            )
+        )
+        assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
+        val interval = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).updateInterval()
+        assert(interval == 10.seconds + 900.milliseconds)
+    }
+
+    @Test
+    fun givenTimeLeftIsEqualToThirtySeconds_whenGettingTheUpdateInterval_ThenIsEqualToOneSeconds() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 30.seconds,
@@ -99,7 +135,7 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToFiftyDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() {
+    fun givenTimeLeftIsEqualToFiftyDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 50.days,
@@ -107,12 +143,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "4 weeks left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentySevenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() {
+    fun givenTimeLeftIsEqualToTwentySevenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days,
@@ -120,12 +156,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "4 weeks left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentySevenDaysAndTwelveHours_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() {
+    fun givenTimeLeftIsEqualTo27DaysAnd12Hours_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days + 12.hours,
@@ -133,12 +169,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "4 weeks left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentySevenDaysAndOneSecond_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() {
+    fun givenTimeLeftIsEqualTo27DaysAnd1Second_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days + 1.seconds,
@@ -146,12 +182,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "4 weeks left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyEightDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() {
+    fun givenTimeLeftIsEqualTo28Days_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 28.days,
@@ -159,12 +195,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "4 weeks left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyOneDays_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyOneLeft() {
+    fun givenTimeLeftIsEqualTo21Days_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyOneLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 21.days,
@@ -172,12 +208,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "21 days left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToFourTeenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourTeenDaysLeft() {
+    fun givenTimeLeftIsEqualTo14Days_whenGettingThTimeLeftFormatted_ThenIsEqualToFourTeenDaysLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 14.days,
@@ -185,12 +221,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "14 days left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyDays_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyDaysLeft() {
+    fun givenTimeLeftIsEqualTo20Days_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyDaysLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 20.days,
@@ -198,12 +234,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "20 days left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToSevenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() {
+    fun givenTimeLeftIsEqualToSevenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 7.days,
@@ -211,12 +247,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 week left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToSixDays_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() {
+    fun givenTimeLeftIsEqualToSixDays_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 6.days,
@@ -224,12 +260,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 week left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToSixDaysAnd12Hours_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() {
+    fun givenTimeLeftIsEqualToSixDaysAnd12Hours_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 6.days + 12.hours,
@@ -237,12 +273,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 week left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToSixDaysAndOneSecond_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() {
+    fun givenTimeLeftIsEqualToSixDaysAndOneSecond_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 6.days + 1.seconds,
@@ -250,12 +286,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 week left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToThirteenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToThirteenDays() {
+    fun givenTimeLeftIsEqualToThirteenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToThirteenDays() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 13.days,
@@ -263,12 +299,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "13 days left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneDay_whenGettingThTimeLeftFormatted_ThenIsEqualToOneDayLeft() {
+    fun givenTimeLeftIsEqualToOneDay_whenGettingThTimeLeftFormatted_ThenIsEqualToOneDayLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.days,
@@ -276,12 +312,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 day left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyFourHours_whenGettingThTimeLeftFormatted_ThenIsEqualToOneDayLeft() {
+    fun givenTimeLeftIsEqualToTwentyFourHours_whenGettingThTimeLeftFormatted_ThenIsEqualToOneDayLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 24.hours,
@@ -289,12 +325,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 day left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyThreeHours_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyThreeHourLeft() {
+    fun givenTimeLeftIsEqualToTwentyThreeHours_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyThreeHourLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours,
@@ -302,12 +338,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "23 hours left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToSixtyMinutes_whenGettingThTimeLeftFormatted_ThenIsEqualToOneHourLeft() {
+    fun givenTimeLeftIsEqualToSixtyMinutes_whenGettingThTimeLeftFormatted_ThenIsEqualToOneHourLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 60.minutes,
@@ -315,12 +351,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 hour left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneMinute_whenGettingThTimeLeftFormatted_ThenIsEqualToOneMinuteLeft() {
+    fun givenTimeLeftIsEqualToOneMinute_whenGettingThTimeLeftFormatted_ThenIsEqualToOneMinuteLeft() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes,
@@ -328,12 +364,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 minute left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOFiftyNineMinutes_whenGettingThTimeLeftFormatted_ThenIsEqualToFiftyNineMinutes() {
+    fun givenTimeLeftIsEqualToOFiftyNineMinutes_whenGettingThTimeLeftFormatted_ThenIsEqualToFiftyNineMinutes() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 59.minutes,
@@ -341,12 +377,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "59 minutes left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToSixtySeconds_whenGettingThTimeLeftFormatted_ThenIsEqualToOneMinute() {
+    fun givenTimeLeftIsEqualToSixtySeconds_whenGettingThTimeLeftFormatted_ThenIsEqualToOneMinute() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 60.seconds,
@@ -354,12 +390,12 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted()
+        val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
         assert(timeLeftLabel == "1 minute left")
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneDayAndTwelveHours_whenDecreasingTimeWithInterval_thenTimeLeftIsEqualToExpecetedTimeLeft() {
+    fun givenTimeLeftIs1DayAnd12Hours_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.days + 12.hours,
@@ -367,17 +403,19 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).decreaseTimeLeft(
-            selfDeletionTimer.updateInterval()
-        )
-        assert(selfDeletionTimer.timeLeftFormatted() == "1 day left")
+        with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "1 day left")
 
-        selfDeletionTimer.decreaseTimeLeft(selfDeletionTimer.updateInterval())
-        assert(selfDeletionTimer.timeLeftFormatted() == "23 hours left")
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "23 hours left")
+        }
     }
 
     @Test
-    fun givenTimeLeftIsEqualToTwentyThreeHoursAndTwentyThreeMinutes_whenDecreasingTimeWithInterval_thenTimeLeftIsEqualToExpeceted() {
+    fun givenTimeLeftIs23HoursAnd23Minutes_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours + 23.minutes,
@@ -385,16 +423,15 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).decreaseTimeLeft(
-            selfDeletionTimer.updateInterval()
-        )
-
-        val timeLeftLabel = selfDeletionTimer.timeLeftFormatted()
-        assert(timeLeftLabel == "23 hours left")
+        with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "23 hours left")
+        }
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneHourAndTwelveMinutes_whenDecreasingTimeWithInterval_thenTimeLeftIsEqualToExpecetedTimeLeft() {
+    fun givenTimeLeftIs1HourAnd12Minutes_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.hours + 12.minutes,
@@ -402,18 +439,19 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).decreaseTimeLeft(
-            selfDeletionTimer.updateInterval()
-        )
-        assert(selfDeletionTimer.timeLeftFormatted() == "1 hour left")
-        selfDeletionTimer.decreaseTimeLeft(
-            selfDeletionTimer.updateInterval()
-        )
-        assert(selfDeletionTimer.timeLeftFormatted() == "59 minutes left")
+        with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "1 hour left")
+
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "59 minutes left")
+        }
     }
 
     @Test
-    fun givenTimeLeftIsEqualToOneHourAndTwentyThreeSeconds_whenDecreasingTimeWithInterval_thenTimeLeftIsEqualToExpecetedTimeLeft() {
+    fun givenTimeLeftIs1HourAnd23Seconds_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
         val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes + 23.seconds,
@@ -421,13 +459,14 @@ class SelfDeletionTimerTest {
             )
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
-        (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).decreaseTimeLeft(
-            selfDeletionTimer.updateInterval()
-        )
-        assert(selfDeletionTimer.timeLeftFormatted() == "1 minute left")
-        selfDeletionTimer.decreaseTimeLeft(
-            selfDeletionTimer.updateInterval()
-        )
-        assert(selfDeletionTimer.timeLeftFormatted() == "59 seconds left")
+        with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "1 minute left")
+
+            advanceTimeBy(updateInterval())
+            recalculateTimeLeft()
+            assert(selfDeletionTimer.timeLeftFormatted == "59 seconds left")
+        }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
@@ -17,8 +17,6 @@
  */
 package com.wire.android.ui.home.conversations
 
-import android.content.Context
-import android.content.res.Resources
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -50,23 +48,44 @@ import kotlin.time.toDuration
 
 @Composable
 fun rememberSelfDeletionTimer(expirationStatus: ExpirationStatus): SelfDeletionTimerHelper.SelfDeletionTimerState {
-    val context = LocalContext.current
+    val stringResourceProvider: StringResourceProvider = stringResourceProvider()
+    val currentTimeProvider: CurrentTimeProvider = { Clock.System.now() }
 
-    return remember(
-        (expirationStatus as? ExpirationStatus.Expirable)?.selfDeletionStatus ?: true
-    ) { SelfDeletionTimerHelper(context).fromExpirationStatus(expirationStatus) }
+    return remember((expirationStatus as? ExpirationStatus.Expirable)?.selfDeletionStatus ?: true) {
+        SelfDeletionTimerHelper(stringResourceProvider, currentTimeProvider)
+            .fromExpirationStatus(expirationStatus)
+    }
 }
 
-class SelfDeletionTimerHelper(private val context: Context) {
+@Composable
+private fun stringResourceProvider(): StringResourceProvider {
+    with(LocalContext.current.resources) {
+        return object : StringResourceProvider {
+            override fun quantityString(type: StringResourceType, quantity: Int): String =
+                getQuantityString(
+                    when (type) {
+                        StringResourceType.WEEKS -> R.plurals.weeks_left
+                        StringResourceType.DAYS -> R.plurals.days_left
+                        StringResourceType.HOURS -> R.plurals.hours_left
+                        StringResourceType.MINUTES -> R.plurals.minutes_left
+                        StringResourceType.SECONDS -> R.plurals.seconds_left
+                    }, quantity, quantity
+                )
+        }
+    }
+}
+
+class SelfDeletionTimerHelper(private val stringResourceProvider: StringResourceProvider, private val currentTime: CurrentTimeProvider) {
 
     fun fromExpirationStatus(expirationStatus: ExpirationStatus): SelfDeletionTimerState {
         return if (expirationStatus is ExpirationStatus.Expirable) {
             with(expirationStatus) {
                 val expireAt = calculateExpireAt(selfDeletionStatus, expireAfter)
                 SelfDeletionTimerState.Expirable(
-                    context.resources,
+                    stringResourceProvider,
                     expireAfter,
                     expireAt,
+                    currentTime
                 )
             }
         } else {
@@ -87,9 +106,10 @@ class SelfDeletionTimerHelper(private val context: Context) {
     sealed class SelfDeletionTimerState {
 
         class Expirable(
-            private val resources: Resources,
+            private val stringResourceProvider: StringResourceProvider,
             private val expireAfter: Duration,
             private val expireAt: Instant,
+            private val currentTime: CurrentTimeProvider,
         ) : SelfDeletionTimerState() {
             companion object {
                 /**
@@ -115,60 +135,28 @@ class SelfDeletionTimerHelper(private val context: Context) {
             val timeLeftFormatted: String by derivedStateOf {
                 when {
                     timeLeft > 28.days ->
-                        resources.getQuantityString(
-                            R.plurals.weeks_left,
-                            4,
-                            4
-                        )
+                        stringResourceProvider.quantityString(StringResourceType.WEEKS, 4)
                     // 4 weeks
                     timeLeft >= 27.days && timeLeft <= 28.days ->
-                        resources.getQuantityString(
-                            R.plurals.weeks_left,
-                            4,
-                            4
-                        )
+                        stringResourceProvider.quantityString(StringResourceType.WEEKS, 4)
                     // days below 4 weeks
                     timeLeft <= 27.days && timeLeft > 7.days ->
-                        resources.getQuantityString(
-                            R.plurals.days_left,
-                            timeLeft.inWholeDays.toInt(),
-                            timeLeft.inWholeDays.toInt()
-                        )
+                        stringResourceProvider.quantityString(StringResourceType.DAYS, timeLeft.inWholeDays.toInt())
                     // one week
                     timeLeft >= 6.days && timeLeft <= 7.days ->
-                        resources.getQuantityString(
-                            R.plurals.weeks_left,
-                            1,
-                            1
-                        )
+                        stringResourceProvider.quantityString(StringResourceType.WEEKS, 1)
                     // days below 1 week
                     timeLeft < 7.days && timeLeft >= 1.days ->
-                        resources.getQuantityString(
-                            R.plurals.days_left,
-                            timeLeft.inWholeDays.toInt(),
-                            timeLeft.inWholeDays.toInt()
-                        )
+                        stringResourceProvider.quantityString(StringResourceType.DAYS, timeLeft.inWholeDays.toInt())
                     // hours below one day
                     timeLeft >= 1.hours && timeLeft < 24.hours ->
-                        resources.getQuantityString(
-                            R.plurals.hours_left,
-                            timeLeft.inWholeHours.toInt(),
-                            timeLeft.inWholeHours.toInt()
-                        )
+                        stringResourceProvider.quantityString(StringResourceType.HOURS, timeLeft.inWholeHours.toInt())
                     // minutes below hour
                     timeLeft >= 1.minutes && timeLeft < 60.minutes ->
-                        resources.getQuantityString(
-                            R.plurals.minutes_left,
-                            timeLeft.inWholeMinutes.toInt(),
-                            timeLeft.inWholeMinutes.toInt()
-                        )
+                        stringResourceProvider.quantityString(StringResourceType.MINUTES, timeLeft.inWholeMinutes.toInt())
                     // seconds below minute
                     timeLeft < 60.seconds ->
-                        resources.getQuantityString(
-                            R.plurals.seconds_left,
-                            timeLeft.inWholeSeconds.toInt(),
-                            timeLeft.inWholeSeconds.toInt()
-                        )
+                        stringResourceProvider.quantityString(StringResourceType.SECONDS, timeLeft.inWholeSeconds.toInt())
 
                     else -> throw IllegalStateException("Not possible state for a time left label")
                 }
@@ -327,8 +315,10 @@ class SelfDeletionTimerHelper(private val context: Context) {
 
         object NotExpirable : SelfDeletionTimerState()
     }
+}
 
-    companion object {
-        fun currentTime(): Instant = Clock.System.now()
-    }
+typealias CurrentTimeProvider = () -> Instant
+enum class StringResourceType { WEEKS, DAYS, HOURS, MINUTES, SECONDS; }
+interface StringResourceProvider {
+    fun quantityString(type: StringResourceType, quantity: Int): String
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
@@ -19,13 +19,18 @@ package com.wire.android.ui.home.conversations
 
 import android.content.Context
 import android.content.res.Resources
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.wire.android.R
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
@@ -33,12 +38,15 @@ import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.kalium.logic.data.message.Message
 import kotlinx.coroutines.delay
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 @Composable
 fun rememberSelfDeletionTimer(expirationStatus: ExpirationStatus): SelfDeletionTimerHelper.SelfDeletionTimerState {
@@ -54,12 +62,11 @@ class SelfDeletionTimerHelper(private val context: Context) {
     fun fromExpirationStatus(expirationStatus: ExpirationStatus): SelfDeletionTimerState {
         return if (expirationStatus is ExpirationStatus.Expirable) {
             with(expirationStatus) {
-                val timeLeft = calculateTimeLeft(selfDeletionStatus, expireAfter)
+                val expireAt = calculateExpireAt(selfDeletionStatus, expireAfter)
                 SelfDeletionTimerState.Expirable(
                     context.resources,
-                    timeLeft,
                     expireAfter,
-                    selfDeletionStatus is Message.ExpirationData.SelfDeletionStatus.Started
+                    expireAt,
                 )
             }
         } else {
@@ -67,35 +74,22 @@ class SelfDeletionTimerHelper(private val context: Context) {
         }
     }
 
-    private fun calculateTimeLeft(
+    private fun calculateExpireAt(
         selfDeletionStatus: Message.ExpirationData.SelfDeletionStatus?,
-        expireAfter: Duration
-    ): Duration {
-        return if (selfDeletionStatus is Message.ExpirationData.SelfDeletionStatus.Started) {
-            val timeElapsedSinceSelfDeletionStartDate = Clock.System.now() - selfDeletionStatus.selfDeletionStartDate
-            val timeLeft = expireAfter - timeElapsedSinceSelfDeletionStartDate
-
-            /**
-             * time left for deletion, can be a negative value if the time difference between the self deletion start date and
-             * Clock.System.now() is greater then [expireAfter], we normalize it to 0 seconds
-             */
-            if (timeLeft.isNegative()) {
-                ZERO
-            } else {
-                timeLeft
-            }
-        } else {
-            expireAfter
+        expireAfter: Duration,
+    ) =
+        if (selfDeletionStatus is Message.ExpirationData.SelfDeletionStatus.Started) selfDeletionStatus.selfDeletionStartDate + expireAfter
+        else {
+            val currentTime = currentTime()
+            currentTime + expireAfter
         }
-    }
 
     sealed class SelfDeletionTimerState {
 
         class Expirable(
             private val resources: Resources,
-            timeLeft: Duration,
             private val expireAfter: Duration,
-            val timerStarted: Boolean
+            private val expireAt: Instant,
         ) : SelfDeletionTimerState() {
             companion object {
                 /**
@@ -115,67 +109,69 @@ class SelfDeletionTimerHelper(private val context: Context) {
                 private const val OPAQUE_BACKGROUND_COLOR_ALPHA_VALUE = 1F
             }
 
-            var timeLeft by mutableStateOf(timeLeft)
-
+            var timeLeft by mutableStateOf(calculateTimeLeft())
+                private set
             @Suppress("MagicNumber", "ComplexMethod")
-            fun timeLeftFormatted(): String = when {
-                timeLeft > 28.days ->
-                    resources.getQuantityString(
-                        R.plurals.weeks_left,
-                        4,
-                        4
-                    )
-                // 4 weeks
-                timeLeft >= 27.days && timeLeft <= 28.days ->
-                    resources.getQuantityString(
-                        R.plurals.weeks_left,
-                        4,
-                        4
-                    )
-                // days below 4 weeks
-                timeLeft <= 27.days && timeLeft > 7.days ->
-                    resources.getQuantityString(
-                        R.plurals.days_left,
-                        timeLeft.inWholeDays.toInt(),
-                        timeLeft.inWholeDays.toInt()
-                    )
-                // one week
-                timeLeft >= 6.days && timeLeft <= 7.days ->
-                    resources.getQuantityString(
-                        R.plurals.weeks_left,
-                        1,
-                        1
-                    )
-                // days below 1 week
-                timeLeft < 7.days && timeLeft >= 1.days ->
-                    resources.getQuantityString(
-                        R.plurals.days_left,
-                        timeLeft.inWholeDays.toInt(),
-                        timeLeft.inWholeDays.toInt()
-                    )
-                // hours below one day
-                timeLeft >= 1.hours && timeLeft < 24.hours ->
-                    resources.getQuantityString(
-                        R.plurals.hours_left,
-                        timeLeft.inWholeHours.toInt(),
-                        timeLeft.inWholeHours.toInt()
-                    )
-                // minutes below hour
-                timeLeft >= 1.minutes && timeLeft < 60.minutes ->
-                    resources.getQuantityString(
-                        R.plurals.minutes_left,
-                        timeLeft.inWholeMinutes.toInt(),
-                        timeLeft.inWholeMinutes.toInt()
-                    )
-                // seconds below minute
-                timeLeft < 60.seconds ->
-                    resources.getQuantityString(
-                        R.plurals.seconds_left,
-                        timeLeft.inWholeSeconds.toInt(),
-                        timeLeft.inWholeSeconds.toInt()
-                    )
+            val timeLeftFormatted: String by derivedStateOf {
+                when {
+                    timeLeft > 28.days ->
+                        resources.getQuantityString(
+                            R.plurals.weeks_left,
+                            4,
+                            4
+                        )
+                    // 4 weeks
+                    timeLeft >= 27.days && timeLeft <= 28.days ->
+                        resources.getQuantityString(
+                            R.plurals.weeks_left,
+                            4,
+                            4
+                        )
+                    // days below 4 weeks
+                    timeLeft <= 27.days && timeLeft > 7.days ->
+                        resources.getQuantityString(
+                            R.plurals.days_left,
+                            timeLeft.inWholeDays.toInt(),
+                            timeLeft.inWholeDays.toInt()
+                        )
+                    // one week
+                    timeLeft >= 6.days && timeLeft <= 7.days ->
+                        resources.getQuantityString(
+                            R.plurals.weeks_left,
+                            1,
+                            1
+                        )
+                    // days below 1 week
+                    timeLeft < 7.days && timeLeft >= 1.days ->
+                        resources.getQuantityString(
+                            R.plurals.days_left,
+                            timeLeft.inWholeDays.toInt(),
+                            timeLeft.inWholeDays.toInt()
+                        )
+                    // hours below one day
+                    timeLeft >= 1.hours && timeLeft < 24.hours ->
+                        resources.getQuantityString(
+                            R.plurals.hours_left,
+                            timeLeft.inWholeHours.toInt(),
+                            timeLeft.inWholeHours.toInt()
+                        )
+                    // minutes below hour
+                    timeLeft >= 1.minutes && timeLeft < 60.minutes ->
+                        resources.getQuantityString(
+                            R.plurals.minutes_left,
+                            timeLeft.inWholeMinutes.toInt(),
+                            timeLeft.inWholeMinutes.toInt()
+                        )
+                    // seconds below minute
+                    timeLeft < 60.seconds ->
+                        resources.getQuantityString(
+                            R.plurals.seconds_left,
+                            timeLeft.inWholeSeconds.toInt(),
+                            timeLeft.inWholeSeconds.toInt()
+                        )
 
-                else -> throw IllegalStateException("Not possible state for a time left label")
+                    else -> throw IllegalStateException("Not possible state for a time left label")
+                }
             }
 
             /**
@@ -186,48 +182,41 @@ class SelfDeletionTimerHelper(private val context: Context) {
              * updated every second.
              * @return how long until the next timer update.
              */
-            fun updateInterval(): Duration {
+            @VisibleForTesting
+            internal fun updateInterval(): Duration {
+                fun remainingTimeToDurationUnit(durationUnit: DurationUnit): Duration {
+                    /*
+                     * Function toLong returns the whole part for the given duration unit and then this whole value is converted back to
+                     * Duration and subtracted from the original duration, which gives the remaining time to the next full duration unit.
+                     *
+                     * For example, if the time left is "1 day and 1 hour" and durationUnit is DAYS, then toLong will return 1L
+                     * which means "1 full day" (just like .inWholeDays) and then it will be converted back to Duration type.
+                     * Then this "1 day" will be subtracted from the original duration, returning "1 hour" left ("1d 1h" - "1d" = "1h").
+                     * So in this case it's the same as `timeLeft - timeLeft.inWholeHours.hours`
+                     * because `timeLeft.inWholeDays` is basically `timeLeft.toLong(DurationUnit.DAYS)`
+                     * and `1L.days` is the same as `1L.toDuration(DurationUnit.DAYS)`.
+                     */
+                    val timeLeftForDurationUnit = timeLeft - timeLeft.toLong(durationUnit).toDuration(durationUnit)
+                    return if (timeLeftForDurationUnit == ZERO) 1.toDuration(durationUnit)
+                    else timeLeftForDurationUnit
+                }
+
                 val timeLeftUpdateInterval = when {
-                    timeLeft > 24.hours -> {
-                        val timeLeftTillWholeDay = (timeLeft.inWholeMinutes % 1.days.inWholeMinutes).minutes
-                        if (timeLeftTillWholeDay == ZERO) {
-                            1.days
-                        } else {
-                            timeLeftTillWholeDay
-                        }
-                    }
-
-                    timeLeft <= 24.hours && timeLeft > 1.hours -> {
-                        val timeLeftTillWholeHour = (timeLeft.inWholeSeconds % 1.hours.inWholeSeconds).seconds
-                        if (timeLeftTillWholeHour == ZERO) {
-                            1.hours
-                        } else {
-                            timeLeftTillWholeHour
-                        }
-                    }
-
-                    timeLeft <= 1.hours && timeLeft > 1.minutes -> {
-                        val timeLeftTillWholeMinute = (timeLeft.inWholeSeconds % 1.minutes.inWholeSeconds).seconds
-                        if (timeLeftTillWholeMinute == ZERO) {
-                            1.minutes
-                        } else {
-                            timeLeftTillWholeMinute
-                        }
-                    }
-
-                    timeLeft <= 1.minutes -> {
-                        1.seconds
-                    }
-
+                    timeLeft > 24.hours -> remainingTimeToDurationUnit(DurationUnit.DAYS)
+                    timeLeft <= 24.hours && timeLeft > 1.hours -> remainingTimeToDurationUnit(DurationUnit.HOURS)
+                    timeLeft <= 1.hours && timeLeft > 1.minutes -> remainingTimeToDurationUnit(DurationUnit.MINUTES)
+                    timeLeft <= 1.minutes -> remainingTimeToDurationUnit(DurationUnit.SECONDS)
                     else -> throw IllegalStateException("Not possible state for the interval")
                 }
 
                 return timeLeftUpdateInterval
             }
 
-            fun decreaseTimeLeft(interval: Duration) {
-                if (timeLeft.inWholeSeconds != 0L) timeLeft -= interval
-            }
+            // non-negative value, returns ZERO if message is already expired
+            private fun calculateTimeLeft(): Duration = (expireAt - currentTime()).let { if (it.isNegative()) ZERO else it }
+
+            @VisibleForTesting
+            internal fun recalculateTimeLeft() { timeLeft = calculateTimeLeft() }
 
             /**
              * if the time elapsed ratio is between 0.50 and 0.75
@@ -266,72 +255,80 @@ class SelfDeletionTimerHelper(private val context: Context) {
                     OPAQUE_BACKGROUND_COLOR_ALPHA_VALUE
                 }
             }
-        }
 
-        object NotExpirable : SelfDeletionTimerState()
-    }
-}
+            @Composable
+            fun startDeletionTimer(message: UIMessage, onStartMessageSelfDeletion: (UIMessage) -> Unit) {
+                when (val messageContent = message.messageContent) {
+                    is UIMessageContent.AssetMessage -> startAssetDeletion(
+                        onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
+                        downloadStatus = messageContent.downloadStatus
+                    )
 
-@Composable
-fun startDeletionTimer(
-    message: UIMessage,
-    expirableTimer: SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable,
-    onStartMessageSelfDeletion: (UIMessage) -> Unit
-) {
-    when (val messageContent = message.messageContent) {
-        is UIMessageContent.AssetMessage -> startAssetDeletion(
-            expirableTimer = expirableTimer,
-            onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
-            downloadStatus = messageContent.downloadStatus
-        )
+                    is UIMessageContent.AudioAssetMessage -> startAssetDeletion(
+                        onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
+                        downloadStatus = messageContent.downloadStatus
+                    )
 
-        is UIMessageContent.AudioAssetMessage -> startAssetDeletion(
-            expirableTimer = expirableTimer,
-            onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
-            downloadStatus = messageContent.downloadStatus
-        )
+                    is UIMessageContent.ImageMessage -> startAssetDeletion(
+                        onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
+                        downloadStatus = messageContent.downloadStatus
+                    )
 
-        is UIMessageContent.ImageMessage -> startAssetDeletion(
-            expirableTimer = expirableTimer,
-            onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
-            downloadStatus = messageContent.downloadStatus
-        )
-
-        else -> {
-            LaunchedEffect(Unit) {
-                onStartMessageSelfDeletion(message)
+                    else -> startRegularDeletion(message = message, onStartMessageSelfDeletion = onStartMessageSelfDeletion)
+                }
             }
-            LaunchedEffect(expirableTimer.timeLeft) {
-                with(expirableTimer) {
+
+            @Composable
+            private fun startAssetDeletion(onSelfDeletingMessageRead: () -> Unit, downloadStatus: Message.DownloadStatus) {
+                LaunchedEffect(downloadStatus) {
+                    if (downloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY
+                        || downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY
+                    ) {
+                        onSelfDeletingMessageRead()
+                    }
+                }
+                LaunchedEffect(key1 = timeLeft, key2 = downloadStatus) {
+                    if (downloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY
+                        || downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY
+                    ) {
+                        if (timeLeft != ZERO) {
+                            delay(updateInterval())
+                            recalculateTimeLeft()
+                        }
+                    }
+                }
+                val lifecycleOwner = LocalLifecycleOwner.current
+                LaunchedEffect(lifecycleOwner) {
+                    lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                        recalculateTimeLeft()
+                    }
+                }
+            }
+
+            @Composable
+            private fun startRegularDeletion(message: UIMessage, onStartMessageSelfDeletion: (UIMessage) -> Unit) {
+                LaunchedEffect(Unit) {
+                    onStartMessageSelfDeletion(message)
+                }
+                LaunchedEffect(timeLeft) {
                     if (timeLeft != ZERO) {
                         delay(updateInterval())
-                        decreaseTimeLeft(updateInterval())
+                        recalculateTimeLeft()
+                    }
+                }
+                val lifecycleOwner = LocalLifecycleOwner.current
+                LaunchedEffect(lifecycleOwner) {
+                    lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                        recalculateTimeLeft()
                     }
                 }
             }
         }
-    }
-}
 
-@Composable
-private fun startAssetDeletion(
-    expirableTimer: SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable,
-    onSelfDeletingMessageRead: () -> Unit,
-    downloadStatus: Message.DownloadStatus
-) {
-    LaunchedEffect(downloadStatus) {
-        if (downloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY || downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY) {
-            onSelfDeletingMessageRead()
-        }
+        object NotExpirable : SelfDeletionTimerState()
     }
-    LaunchedEffect(expirableTimer.timeLeft, downloadStatus) {
-        if (downloadStatus == Message.DownloadStatus.SAVED_EXTERNALLY || downloadStatus == Message.DownloadStatus.SAVED_INTERNALLY) {
-            with(expirableTimer) {
-                if (timeLeft != ZERO) {
-                    delay(updateInterval())
-                    decreaseTimeLeft(updateInterval())
-                }
-            }
-        }
+
+    companion object {
+        fun currentTime(): Instant = Clock.System.now()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -125,9 +125,8 @@ fun MessageItem(
             !message.isPending &&
             !message.sendingFailed
         ) {
-            startDeletionTimer(
+            selfDeletionTimerState.startDeletionTimer(
                 message = message,
-                expirableTimer = selfDeletionTimerState,
                 onStartMessageSelfDeletion = onSelfDeletingMessageRead
             )
         }
@@ -226,7 +225,7 @@ fun MessageItem(
                         MessageAuthorRow(messageHeader = message.header)
                     }
                     if (selfDeletionTimerState is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
-                        MessageExpireLabel(messageContent, selfDeletionTimerState.timeLeftFormatted())
+                        MessageExpireLabel(messageContent, selfDeletionTimerState.timeLeftFormatted)
 
                         // if the message is marked as deleted and is [SelfDeletionTimer.SelfDeletionTimerState.Expirable]
                         // the deletion responsibility belongs to the receiver, therefore we need to wait for the receiver

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -97,9 +97,8 @@ fun SystemMessageItem(
         !message.isPending &&
         !message.sendingFailed
     ) {
-        startDeletionTimer(
+        selfDeletionTimerState.startDeletionTimer(
             message = message,
-            expirableTimer = selfDeletionTimerState,
             onStartMessageSelfDeletion = onSelfDeletingMessageRead
         )
     }

--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -24,10 +24,18 @@ import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.framework.TestUser
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
+import com.wire.android.util.CurrentScreenManager
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.auth.PersistentWebSocketStatus
+import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.feature.UserSessionScope
+import com.wire.kalium.logic.feature.auth.LogoutCallbackManager
+import com.wire.kalium.logic.feature.message.MessageScope
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -35,6 +43,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -87,6 +96,56 @@ class GlobalObserversManagerTest {
         }
     }
 
+    @Test
+    fun `given app visible and valid session, when handling ephemeral messages, then call deleteEphemeralMessageEndDate`() {
+        val (arrangement, manager) = Arrangement()
+            .withCurrentSessionFlow(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
+            .withAppVisibleFlow(true)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 1) { arrangement.messageScope.deleteEphemeralMessageEndDate() }
+    }
+
+    @Test
+    fun `given app not visible and valid session, when handling ephemeral messages, then do not call deleteEphemeralMessageEndDate`() {
+        val (arrangement, manager) = Arrangement()
+            .withCurrentSessionFlow(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
+            .withAppVisibleFlow(false)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 0) { arrangement.messageScope.deleteEphemeralMessageEndDate() }
+    }
+
+    @Test
+    fun `given app visible and invalid session, when handling ephemeral messages, then do not call deleteEphemeralMessageEndDate`() {
+        val (arrangement, manager) = Arrangement()
+            .withCurrentSessionFlow(CurrentSessionResult.Success(AccountInfo.Invalid(TestUser.SELF_USER.id, LogoutReason.DELETED_ACCOUNT)))
+            .withAppVisibleFlow(true)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 0) { arrangement.messageScope.deleteEphemeralMessageEndDate() }
+    }
+
+    @Test
+    fun `given app visible and no session, when handling ephemeral messages, then do not call deleteEphemeralMessageEndDate`() {
+        val (arrangement, manager) = Arrangement()
+            .withCurrentSessionFlow(CurrentSessionResult.Failure.SessionNotFound)
+            .withAppVisibleFlow(true)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 0) { arrangement.messageScope.deleteEphemeralMessageEndDate() }
+    }
+
+    @Test
+    fun `given app visible and session failure, when handling ephemeral messages, then do not call deleteEphemeralMessageEndDate`() {
+        val (arrangement, manager) = Arrangement()
+            .withCurrentSessionFlow(CurrentSessionResult.Failure.Generic(CoreFailure.Unknown(RuntimeException("error"))))
+            .withAppVisibleFlow(true)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 0) { arrangement.messageScope.deleteEphemeralMessageEndDate() }
+    }
+
     private class Arrangement {
 
         @MockK
@@ -101,6 +160,18 @@ class GlobalObserversManagerTest {
         @MockK
         lateinit var userDataStoreProvider: UserDataStoreProvider
 
+        @MockK
+        lateinit var currentScreenManager: CurrentScreenManager
+
+        @MockK
+        lateinit var logoutCallbackManager: LogoutCallbackManager
+
+        @MockK
+        lateinit var userSessionScope: UserSessionScope
+
+        @MockK
+        lateinit var messageScope: MessageScope
+
         private val manager by lazy {
             GlobalObserversManager(
                 dispatcherProvider = TestDispatcherProvider(),
@@ -108,6 +179,7 @@ class GlobalObserversManagerTest {
                 notificationChannelsManager = notificationChannelsManager,
                 notificationManager = notificationManager,
                 userDataStoreProvider = userDataStoreProvider,
+                currentScreenManager = currentScreenManager,
             )
         }
 
@@ -118,6 +190,14 @@ class GlobalObserversManagerTest {
             // Default empty values
             mockUri()
             every { notificationChannelsManager.createUserNotificationChannels(any()) } returns Unit
+            every { coreLogic.getGlobalScope().logoutCallbackManager } returns logoutCallbackManager
+            every { coreLogic.getSessionScope(any()) } returns userSessionScope
+            every { userSessionScope.messages } returns messageScope
+            coEvery { messageScope.deleteEphemeralMessageEndDate() } returns Unit
+            withPersistentWebSocketConnectionStatuses(emptyList())
+            withValidAccounts(emptyList())
+            withCurrentSessionFlow(CurrentSessionResult.Failure.SessionNotFound)
+            withAppVisibleFlow(true)
         }
 
         fun withValidAccounts(list: List<Pair<SelfUser, Team?>>): Arrangement = apply {
@@ -127,6 +207,14 @@ class GlobalObserversManagerTest {
         fun withPersistentWebSocketConnectionStatuses(list: List<PersistentWebSocketStatus>): Arrangement = apply {
             coEvery { coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus() } returns
                     ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(flowOf(list))
+        }
+
+        fun withCurrentSessionFlow(result: CurrentSessionResult): Arrangement = apply {
+            coEvery { coreLogic.getGlobalScope().session.currentSessionFlow() } returns flowOf(result)
+        }
+
+        fun withAppVisibleFlow(isVisible: Boolean) = apply {
+            coEvery { currentScreenManager.isAppVisibleFlow() } returns MutableStateFlow(isVisible)
         }
 
         fun arrange() = this to manager

--- a/app/src/test/kotlin/com/wire/android/SelfDeletionTimerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/SelfDeletionTimerTest.kt
@@ -17,20 +17,18 @@
  */
 package com.wire.android
 
-import androidx.test.platform.app.InstrumentationRegistry
+import com.wire.android.ui.home.conversations.CurrentTimeProvider
 import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper
+import com.wire.android.ui.home.conversations.StringResourceProvider
+import com.wire.android.ui.home.conversations.StringResourceType
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.kalium.logic.data.message.Message
-import io.mockk.every
-import io.mockk.mockkObject
-import io.mockk.unmockkObject
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
@@ -39,26 +37,12 @@ import kotlin.time.Duration.Companion.seconds
 
 class SelfDeletionTimerTest {
 
-    private val selfDeletionTimer by lazy {
-        SelfDeletionTimerHelper(context = InstrumentationRegistry.getInstrumentation().targetContext)
-    }
     private val dispatcher = StandardTestDispatcher()
-    private fun currentTime(): Instant = Instant.fromEpochMilliseconds(dispatcher.scheduler.currentTime)
-
-    @Before
-    fun setUp() {
-        mockkObject(SelfDeletionTimerHelper.Companion)
-        every { SelfDeletionTimerHelper.Companion.currentTime() } answers { currentTime() }
-    }
-
-    @After
-    fun cleanUp() {
-        unmockkObject(SelfDeletionTimerHelper.Companion)
-    }
 
     @Test
     fun givenTimeLeftIsAboveOneHour_whenGettingTheUpdateInterval_ThenIsEqualToMinutesLeftTillWholeHour() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (_, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours + 30.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -71,7 +55,8 @@ class SelfDeletionTimerTest {
 
     @Test
     fun givenTimeLeftIsEqualToWholeHour_whenGettingTheUpdateInterval_ThenIsEqualToOneMinute() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (_, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -84,7 +69,8 @@ class SelfDeletionTimerTest {
 
     @Test
     fun givenTimeLeftIsEqualToOneHour_whenGettingTheUpdateInterval_ThenIsEqualToOneMinute() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (_, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -97,7 +83,8 @@ class SelfDeletionTimerTest {
 
     @Test
     fun givenTimeLeftIsEqualToOneMinute_whenGettingTheUpdateInterval_ThenIsEqualToOneSeconds() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (_, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -110,7 +97,8 @@ class SelfDeletionTimerTest {
 
     @Test
     fun givenTimeLeftIsEqualTo1Min10SecAnd900Millis_whenGettingTheUpdateInterval_ThenIsEqualTo10SecAnd900Millis() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (_, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes + 10.seconds + 900.milliseconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -123,7 +111,8 @@ class SelfDeletionTimerTest {
 
     @Test
     fun givenTimeLeftIsEqualToThirtySeconds_whenGettingTheUpdateInterval_ThenIsEqualToOneSeconds() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (_, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 30.seconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -136,7 +125,8 @@ class SelfDeletionTimerTest {
 
     @Test
     fun givenTimeLeftIsEqualToFiftyDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 50.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -144,12 +134,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "4 weeks left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
     fun givenTimeLeftIsEqualToTwentySevenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -157,12 +148,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "4 weeks left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
     fun givenTimeLeftIsEqualTo27DaysAnd12Hours_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days + 12.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -170,12 +162,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "4 weeks left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
     fun givenTimeLeftIsEqualTo27DaysAnd1Second_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days + 1.seconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -183,12 +176,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "4 weeks left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
     fun givenTimeLeftIsEqualTo28Days_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 28.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -196,12 +190,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "4 weeks left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
     fun givenTimeLeftIsEqualTo21Days_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyOneLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 21.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -209,12 +204,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "21 days left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 21))
     }
 
     @Test
     fun givenTimeLeftIsEqualTo14Days_whenGettingThTimeLeftFormatted_ThenIsEqualToFourTeenDaysLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 14.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -222,12 +218,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "14 days left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 14))
     }
 
     @Test
     fun givenTimeLeftIsEqualTo20Days_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyDaysLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 20.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -235,12 +232,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "20 days left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 20))
     }
 
     @Test
     fun givenTimeLeftIsEqualToSevenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 7.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -248,12 +246,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 week left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToSixDays_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 6.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -261,12 +260,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 week left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToSixDaysAnd12Hours_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 6.days + 12.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -274,12 +274,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 week left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToSixDaysAndOneSecond_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 6.days + 1.seconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -287,12 +288,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 week left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToThirteenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToThirteenDays() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 13.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -300,12 +302,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "13 days left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 13))
     }
 
     @Test
     fun givenTimeLeftIsEqualToOneDay_whenGettingThTimeLeftFormatted_ThenIsEqualToOneDayLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -313,12 +316,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 day left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToTwentyFourHours_whenGettingThTimeLeftFormatted_ThenIsEqualToOneDayLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 24.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -326,12 +330,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 day left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToTwentyThreeHours_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyThreeHourLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -339,12 +344,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "23 hours left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.HOURS, 23))
     }
 
     @Test
     fun givenTimeLeftIsEqualToSixtyMinutes_whenGettingThTimeLeftFormatted_ThenIsEqualToOneHourLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 60.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -352,12 +358,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 hour left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.HOURS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToOneMinute_whenGettingThTimeLeftFormatted_ThenIsEqualToOneMinuteLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -365,12 +372,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 minute left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.MINUTES, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToOFiftyNineMinutes_whenGettingThTimeLeftFormatted_ThenIsEqualToFiftyNineMinutes() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 59.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -378,12 +386,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "59 minutes left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.MINUTES, 59))
     }
 
     @Test
     fun givenTimeLeftIsEqualToSixtySeconds_whenGettingThTimeLeftFormatted_ThenIsEqualToOneMinute() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 60.seconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -391,12 +400,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 minute left")
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.MINUTES, 1))
     }
 
     @Test
     fun givenTimeLeftIs1DayAnd12Hours_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.days + 12.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -406,17 +416,18 @@ class SelfDeletionTimerTest {
         with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "1 day left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 1))
 
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "23 hours left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.HOURS, 23))
         }
     }
 
     @Test
     fun givenTimeLeftIs23HoursAnd23Minutes_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours + 23.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -426,13 +437,14 @@ class SelfDeletionTimerTest {
         with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "23 hours left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.HOURS, 23))
         }
     }
 
     @Test
     fun givenTimeLeftIs1HourAnd12Minutes_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.hours + 12.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -442,17 +454,18 @@ class SelfDeletionTimerTest {
         with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "1 hour left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.HOURS, 1))
 
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "59 minutes left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.MINUTES, 59))
         }
     }
 
     @Test
     fun givenTimeLeftIs1HourAnd23Seconds_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes + 23.seconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -462,11 +475,22 @@ class SelfDeletionTimerTest {
         with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "1 minute left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.MINUTES, 1))
 
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "59 seconds left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.SECONDS, 59))
         }
+    }
+
+    internal class Arrangement(val dispatcher: TestDispatcher) {
+
+        val stringsProvider: StringResourceProvider = object : StringResourceProvider {
+            override fun quantityString(type: StringResourceType, quantity: Int): String = "${type.name}: $quantity"
+        }
+        private val currentTime: CurrentTimeProvider = { Instant.fromEpochMilliseconds(dispatcher.scheduler.currentTime) }
+
+        private val selfDeletionTimerHelper by lazy { SelfDeletionTimerHelper(stringsProvider, currentTime) }
+        fun arrange() = this to selfDeletionTimerHelper
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5894" title="WPB-5894" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5894</a>  [Android] Self deleting messages timer stops when device is in doze mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2642

Also contains fixes from this PR:
- #2657

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the user receives a self-deleting message, leaves the app on `ConversationScreen` and the app is put into background, then the message is not removed after given time when app is opened again, only when the user closes the `ConversationScreen` and opens it again. When the given time is not fully passed, the message counter is not properly updated, it stays on the value it had when the app was put into background. Sometimes this counter doesn't get updated for the next interval, for instance it starts with "4 minutes left" and after a minute passes it's still "4 minutes left" but then after another minute it suddenly goes down to "2 minutes left".

### Causes (Optional)

Previous solution was implemented to check and remove all expired messages when the user opens the `ConversationScreen` so it's not working when the user is still on that screen. For the counter, there's another `delay` which also doesn't work well when in doze mode and the counter composable isn't recomposed because the value is not being passed as a state. Also, the amount of time to be delayed is not calculated properly - it takes only one unit into account, so for instance if the time left for the message is equal to `1:59.900` left (1 minute 59 seconds and 900ms) then it will delay for 59 seconds, omitting the milliseconds value and resulting in next calculation being done when the time left is `1:00.900`, so still over a minute, that's why it can give the result of "1 minute left" for 2 minutes.

### Solutions

Implement a global observer to execute `deleteEphemeralMessageEndDate` each time the app is back in the foreground.
Refactor the `SelfDeletionTimerHelper` to take "end time" when handling self-deleting expiration and recalculate the time again each time the delay ends by comparing "current time" and "end time" instead of just subtracting the "delay time" - thanks to that it has more accurate time left in each iteration.
Fix the `updateInterval` function to return the full remaining time to the next given duration unit (for instance if we want to get time remaining to the next full minute and now the time is `1:59.900` then it should return `59.900`)
Provide `timeLeftFormatted` as a state so that the composable that's showing it gets recomposed each time it's updated.
Implement another `LaunchedEffect` to recalculate the time left and restart the delay when the app is back in the foreground.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Receive a self-deleting message and put the app in the background while still being on the `ConversationScreen`, turn off the screen so that it can enter doze mode and open the app again before or after the time for the self-deleting message passes.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
