### PR TITLE
fix: make SelfDeletionTimerTest unit instead of instrumented

### DIFF
--- a/app/src/test/kotlin/com/wire/android/SelfDeletionTimerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/SelfDeletionTimerTest.kt
@@ -485,7 +485,7 @@ class SelfDeletionTimerTest {
 
     internal class Arrangement(val dispatcher: TestDispatcher) {
 
-        val stringResourceHelper: StringResourceHelper = object: StringResourceHelper {
+        val stringResourceHelper: StringResourceHelper = object : StringResourceHelper {
             override fun quantityString(type: StringResourceType, quantity: Int): String = "${type.name}: $quantity"
         }
         private val currentTime: CurrentTimeProvider = { Instant.fromEpochMilliseconds(dispatcher.scheduler.currentTime) }

--- a/app/src/test/kotlin/com/wire/android/SelfDeletionTimerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/SelfDeletionTimerTest.kt
@@ -19,7 +19,7 @@ package com.wire.android
 
 import com.wire.android.ui.home.conversations.CurrentTimeProvider
 import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper
-import com.wire.android.ui.home.conversations.StringResourceHelper
+import com.wire.android.ui.home.conversations.StringResourceProvider
 import com.wire.android.ui.home.conversations.StringResourceType
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.kalium.logic.data.message.Message
@@ -134,7 +134,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 4))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
@@ -148,7 +148,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 4))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
@@ -162,7 +162,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 4))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
@@ -176,7 +176,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 4))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
@@ -190,7 +190,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 4))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
@@ -204,7 +204,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 21))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 21))
     }
 
     @Test
@@ -218,7 +218,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 14))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 14))
     }
 
     @Test
@@ -232,7 +232,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 20))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 20))
     }
 
     @Test
@@ -246,7 +246,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 1))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 1))
     }
 
     @Test
@@ -260,7 +260,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 1))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 1))
     }
 
     @Test
@@ -274,7 +274,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 1))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 1))
     }
 
     @Test
@@ -288,7 +288,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 1))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.WEEKS, 1))
     }
 
     @Test
@@ -302,7 +302,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 13))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 13))
     }
 
     @Test
@@ -316,7 +316,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 1))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 1))
     }
 
     @Test
@@ -330,7 +330,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 1))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 1))
     }
 
     @Test
@@ -344,7 +344,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.HOURS, 23))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.HOURS, 23))
     }
 
     @Test
@@ -358,7 +358,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.HOURS, 1))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.HOURS, 1))
     }
 
     @Test
@@ -372,7 +372,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.MINUTES, 1))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.MINUTES, 1))
     }
 
     @Test
@@ -386,7 +386,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.MINUTES, 59))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.MINUTES, 59))
     }
 
     @Test
@@ -400,7 +400,7 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.MINUTES, 1))
+        assert(timeLeftLabel == arrangement.stringsProvider.quantityString(StringResourceType.MINUTES, 1))
     }
 
     @Test
@@ -416,11 +416,11 @@ class SelfDeletionTimerTest {
         with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 1))
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.DAYS, 1))
 
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.HOURS, 23))
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.HOURS, 23))
         }
     }
 
@@ -437,7 +437,7 @@ class SelfDeletionTimerTest {
         with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.HOURS, 23))
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.HOURS, 23))
         }
     }
 
@@ -454,11 +454,11 @@ class SelfDeletionTimerTest {
         with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.HOURS, 1))
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.HOURS, 1))
 
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.MINUTES, 59))
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.MINUTES, 59))
         }
     }
 
@@ -475,22 +475,22 @@ class SelfDeletionTimerTest {
         with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.MINUTES, 1))
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.MINUTES, 1))
 
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.SECONDS, 59))
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringsProvider.quantityString(StringResourceType.SECONDS, 59))
         }
     }
 
     internal class Arrangement(val dispatcher: TestDispatcher) {
 
-        val stringResourceHelper: StringResourceHelper = object : StringResourceHelper {
+        val stringsProvider: StringResourceProvider = object : StringResourceProvider {
             override fun quantityString(type: StringResourceType, quantity: Int): String = "${type.name}: $quantity"
         }
         private val currentTime: CurrentTimeProvider = { Instant.fromEpochMilliseconds(dispatcher.scheduler.currentTime) }
 
-        private val selfDeletionTimerHelper by lazy { SelfDeletionTimerHelper(stringResourceHelper, currentTime) }
+        private val selfDeletionTimerHelper by lazy { SelfDeletionTimerHelper(stringsProvider, currentTime) }
         fun arrange() = this to selfDeletionTimerHelper
     }
 }

--- a/app/src/test/kotlin/com/wire/android/SelfDeletionTimerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/SelfDeletionTimerTest.kt
@@ -17,20 +17,18 @@
  */
 package com.wire.android
 
-import androidx.test.platform.app.InstrumentationRegistry
+import com.wire.android.ui.home.conversations.CurrentTimeProvider
 import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper
+import com.wire.android.ui.home.conversations.StringResourceHelper
+import com.wire.android.ui.home.conversations.StringResourceType
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.kalium.logic.data.message.Message
-import io.mockk.every
-import io.mockk.mockkObject
-import io.mockk.unmockkObject
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
@@ -39,26 +37,12 @@ import kotlin.time.Duration.Companion.seconds
 
 class SelfDeletionTimerTest {
 
-    private val selfDeletionTimer by lazy {
-        SelfDeletionTimerHelper(context = InstrumentationRegistry.getInstrumentation().targetContext)
-    }
     private val dispatcher = StandardTestDispatcher()
-    private fun currentTime(): Instant = Instant.fromEpochMilliseconds(dispatcher.scheduler.currentTime)
-
-    @Before
-    fun setUp() {
-        mockkObject(SelfDeletionTimerHelper.Companion)
-        every { SelfDeletionTimerHelper.Companion.currentTime() } answers { currentTime() }
-    }
-
-    @After
-    fun cleanUp() {
-        unmockkObject(SelfDeletionTimerHelper.Companion)
-    }
 
     @Test
     fun givenTimeLeftIsAboveOneHour_whenGettingTheUpdateInterval_ThenIsEqualToMinutesLeftTillWholeHour() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (_, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours + 30.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -71,7 +55,8 @@ class SelfDeletionTimerTest {
 
     @Test
     fun givenTimeLeftIsEqualToWholeHour_whenGettingTheUpdateInterval_ThenIsEqualToOneMinute() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (_, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -84,7 +69,8 @@ class SelfDeletionTimerTest {
 
     @Test
     fun givenTimeLeftIsEqualToOneHour_whenGettingTheUpdateInterval_ThenIsEqualToOneMinute() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (_, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -97,7 +83,8 @@ class SelfDeletionTimerTest {
 
     @Test
     fun givenTimeLeftIsEqualToOneMinute_whenGettingTheUpdateInterval_ThenIsEqualToOneSeconds() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (_, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -110,7 +97,8 @@ class SelfDeletionTimerTest {
 
     @Test
     fun givenTimeLeftIsEqualTo1Min10SecAnd900Millis_whenGettingTheUpdateInterval_ThenIsEqualTo10SecAnd900Millis() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (_, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes + 10.seconds + 900.milliseconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -122,8 +110,9 @@ class SelfDeletionTimerTest {
     }
 
     @Test
-    fun givenTimeLeftIsEqualToThirtySeconds_whenGettingTheUpdateInterval_ThenIsEqualToOneSeconds() {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+    fun givenTimeLeftIsEqualToThirtySeconds_whenGettingTheUpdateInterval_ThenIsEqualToOneSeconds() = runTest(dispatcher) {
+        val (_, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 30.seconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -136,7 +125,8 @@ class SelfDeletionTimerTest {
 
     @Test
     fun givenTimeLeftIsEqualToFiftyDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 50.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -144,12 +134,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "4 weeks left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
     fun givenTimeLeftIsEqualToTwentySevenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -157,12 +148,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "4 weeks left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
     fun givenTimeLeftIsEqualTo27DaysAnd12Hours_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days + 12.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -170,12 +162,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "4 weeks left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
     fun givenTimeLeftIsEqualTo27DaysAnd1Second_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 27.days + 1.seconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -183,12 +176,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "4 weeks left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
     fun givenTimeLeftIsEqualTo28Days_whenGettingThTimeLeftFormatted_ThenIsEqualToFourWeeksLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 28.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -196,12 +190,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "4 weeks left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 4))
     }
 
     @Test
     fun givenTimeLeftIsEqualTo21Days_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyOneLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 21.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -209,12 +204,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "21 days left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 21))
     }
 
     @Test
     fun givenTimeLeftIsEqualTo14Days_whenGettingThTimeLeftFormatted_ThenIsEqualToFourTeenDaysLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 14.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -222,12 +218,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "14 days left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 14))
     }
 
     @Test
     fun givenTimeLeftIsEqualTo20Days_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyDaysLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 20.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -235,12 +232,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "20 days left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 20))
     }
 
     @Test
     fun givenTimeLeftIsEqualToSevenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 7.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -248,12 +246,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 week left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToSixDays_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 6.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -261,12 +260,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 week left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToSixDaysAnd12Hours_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 6.days + 12.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -274,12 +274,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 week left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToSixDaysAndOneSecond_whenGettingThTimeLeftFormatted_ThenIsEqualToOneWeekLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 6.days + 1.seconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -287,12 +288,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 week left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.WEEKS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToThirteenDays_whenGettingThTimeLeftFormatted_ThenIsEqualToThirteenDays() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 13.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -300,12 +302,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "13 days left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 13))
     }
 
     @Test
     fun givenTimeLeftIsEqualToOneDay_whenGettingThTimeLeftFormatted_ThenIsEqualToOneDayLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.days,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -313,12 +316,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 day left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToTwentyFourHours_whenGettingThTimeLeftFormatted_ThenIsEqualToOneDayLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 24.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -326,12 +330,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 day left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToTwentyThreeHours_whenGettingThTimeLeftFormatted_ThenIsEqualToTwentyThreeHourLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -339,12 +344,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "23 hours left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.HOURS, 23))
     }
 
     @Test
     fun givenTimeLeftIsEqualToSixtyMinutes_whenGettingThTimeLeftFormatted_ThenIsEqualToOneHourLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 60.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -352,12 +358,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 hour left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.HOURS, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToOneMinute_whenGettingThTimeLeftFormatted_ThenIsEqualToOneMinuteLeft() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -365,12 +372,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 minute left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.MINUTES, 1))
     }
 
     @Test
     fun givenTimeLeftIsEqualToOFiftyNineMinutes_whenGettingThTimeLeftFormatted_ThenIsEqualToFiftyNineMinutes() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 59.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -378,12 +386,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "59 minutes left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.MINUTES, 59))
     }
 
     @Test
     fun givenTimeLeftIsEqualToSixtySeconds_whenGettingThTimeLeftFormatted_ThenIsEqualToOneMinute() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 60.seconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -391,12 +400,13 @@ class SelfDeletionTimerTest {
         )
         assert(selfDeletionTimer is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable)
         val timeLeftLabel = (selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable).timeLeftFormatted
-        assert(timeLeftLabel == "1 minute left")
+        assert(timeLeftLabel == arrangement.stringResourceHelper.quantityString(StringResourceType.MINUTES, 1))
     }
 
     @Test
     fun givenTimeLeftIs1DayAnd12Hours_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.days + 12.hours,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -406,17 +416,18 @@ class SelfDeletionTimerTest {
         with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "1 day left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.DAYS, 1))
 
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "23 hours left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.HOURS, 23))
         }
     }
 
     @Test
     fun givenTimeLeftIs23HoursAnd23Minutes_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 23.hours + 23.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -426,13 +437,14 @@ class SelfDeletionTimerTest {
         with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "23 hours left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.HOURS, 23))
         }
     }
 
     @Test
     fun givenTimeLeftIs1HourAnd12Minutes_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.hours + 12.minutes,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -442,17 +454,18 @@ class SelfDeletionTimerTest {
         with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "1 hour left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.HOURS, 1))
 
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "59 minutes left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.MINUTES, 59))
         }
     }
 
     @Test
     fun givenTimeLeftIs1HourAnd23Seconds_whenRecalculatingTimeAfterIntervals_thenTimeLeftIsEqualToExpected() = runTest(dispatcher) {
-        val selfDeletionTimer = selfDeletionTimer.fromExpirationStatus(
+        val (arrangement, selfDeletionTimerHelper) = Arrangement(dispatcher).arrange()
+        val selfDeletionTimer = selfDeletionTimerHelper.fromExpirationStatus(
             ExpirationStatus.Expirable(
                 expireAfter = 1.minutes + 23.seconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
@@ -462,11 +475,22 @@ class SelfDeletionTimerTest {
         with(selfDeletionTimer as SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "1 minute left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.MINUTES, 1))
 
             advanceTimeBy(updateInterval())
             recalculateTimeLeft()
-            assert(selfDeletionTimer.timeLeftFormatted == "59 seconds left")
+            assert(selfDeletionTimer.timeLeftFormatted == arrangement.stringResourceHelper.quantityString(StringResourceType.SECONDS, 59))
         }
+    }
+
+    internal class Arrangement(val dispatcher: TestDispatcher) {
+
+        val stringResourceHelper: StringResourceHelper = object: StringResourceHelper {
+            override fun quantityString(type: StringResourceType, quantity: Int): String = "${type.name}: $quantity"
+        }
+        private val currentTime: CurrentTimeProvider = { Instant.fromEpochMilliseconds(dispatcher.scheduler.currentTime) }
+
+        private val selfDeletionTimerHelper by lazy { SelfDeletionTimerHelper(stringResourceHelper, currentTime) }
+        fun arrange() = this to selfDeletionTimerHelper
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

These tests are failing on CI on emulator with Android 10, not sure why, but it's also not necessary for these tests to be instrumented just because it uses string resources, so I changed it to be unit test which uses mocked interface to provide string resources.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
