### PR TITLE
fix: remove trim of spaces when searching for messages inside a conversation (WPB-5834)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesViewModel.kt
@@ -96,7 +96,7 @@ class SearchConversationMessagesViewModel @Inject constructor(
         )
         if (textQueryChanged && searchQuery.text.isNotBlank()) {
             viewModelScope.launch {
-                mutableSearchQueryFlow.emit(searchQuery.text.trim())
+                mutableSearchQueryFlow.emit(searchQuery.text)
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5834" title="WPB-5834" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5834</a>  [Android] Searching for a word by keeping space doesn't show proper result.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When searching for messages inside a conversation and the search query had spaces, it was being ignored.

### Causes (Optional)

Before sending the search query to the DB we were trimming the search query.

### Solutions

Remove `.trim()`

### Testing

#### How to Test

- Have two messages in a conversation: {"not a normal text"} and {"this message contains a no message"}
- Open search inside a conversation
- Search for "no" = should return 2 results
- Search for "no " (with the space at the end) = should return only one message
