### PR TITLE
fix: persistent audio state and observe senderId [WPB-4716]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -55,25 +55,25 @@ class MessageMapper @Inject constructor(
 ) {
 
     fun memberIdList(messages: List<Message>): List<UserId> = messages.flatMap { message ->
-        listOf(message.senderUserId).plus(
-            when (message) {
-                is Message.Regular -> {
-                    when (val failureType = message.deliveryStatus) {
-                        is DeliveryStatus.CompleteDelivery -> listOf()
-                        is DeliveryStatus.PartialDelivery ->
-                            failureType.recipientsFailedDelivery + failureType.recipientsFailedWithNoClients
-                    }
+        when (message) {
+            is Message.Regular -> {
+                when (val failureType = message.deliveryStatus) {
+                    is DeliveryStatus.CompleteDelivery -> listOf()
+                    is DeliveryStatus.PartialDelivery ->
+                        failureType.recipientsFailedDelivery + failureType.recipientsFailedWithNoClients
                 }
-                is Message.System -> {
-                    when (val content = message.content) {
-                        is MessageContent.MemberChange -> content.members
-                        is MessageContent.LegalHold.ForMembers -> content.members
-                        else -> listOf()
-                    }
-                }
-                is Message.Signaling -> listOf()
             }
-        )
+
+            is Message.System -> {
+                when (val content = message.content) {
+                    is MessageContent.MemberChange -> content.members
+                    is MessageContent.LegalHold.ForMembers -> content.members
+                    else -> listOf()
+                }
+            }
+
+            is Message.Signaling -> listOf()
+        }
     }.distinct()
 
     @Suppress("LongMethod")
@@ -170,7 +170,7 @@ class MessageMapper @Inject constructor(
             when (val status = message.status) {
                 Message.Status.Pending -> MessageFlowStatus.Sending
                 Message.Status.Sent -> MessageFlowStatus.Sent
-               is Message.Status.Read -> MessageFlowStatus.Read(status.readCount)
+                is Message.Status.Read -> MessageFlowStatus.Read(status.readCount)
                 Message.Status.Failed -> MessageFlowStatus.Failure.Send.Locally(isMessageEdited)
                 Message.Status.FailedRemotely -> MessageFlowStatus.Failure.Send.Remotely(isMessageEdited, message.conversationId.domain)
                 Message.Status.Delivered -> MessageFlowStatus.Delivered

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -144,6 +144,7 @@ import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.ConferenceCallingResult
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
+import kotlinx.collections.immutable.PersistentMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -434,12 +435,12 @@ fun ConversationScreen(
     )
 
     (messageComposerViewModel.sureAboutMessagingDialogState as? SureAboutMessagingDialogState.Visible.ConversationUnderLegalHold)?.let {
-            LegalHoldSubjectMessageDialog(
-                conversationName = conversationInfoViewModel.conversationInfoViewState.conversationName.asString(),
-                dialogDismissed = messageComposerViewModel::dismissSureAboutSendingMessage,
-                sendAnywayClicked = messageComposerViewModel::acceptSureAboutSendingMessage,
-            )
-        }
+        LegalHoldSubjectMessageDialog(
+            conversationName = conversationInfoViewModel.conversationInfoViewState.conversationName.asString(),
+            dialogDismissed = messageComposerViewModel::dismissSureAboutSendingMessage,
+            sendAnywayClicked = messageComposerViewModel::acceptSureAboutSendingMessage,
+        )
+    }
 
     groupDetailsScreenResultRecipient.onNavResult { result ->
         when (result) {
@@ -713,7 +714,7 @@ private fun ConversationScreenContent(
     conversationId: ConversationId,
     lastUnreadMessageInstant: Instant?,
     unreadEventCount: Int,
-    audioMessagesState: Map<String, AudioState>,
+    audioMessagesState: PersistentMap<String, AudioState>,
     selectedMessageId: String?,
     messageComposerStateHolder: MessageComposerStateHolder,
     messages: Flow<PagingData<UIMessage>>,
@@ -820,7 +821,7 @@ fun MessageList(
     lazyPagingMessages: LazyPagingItems<UIMessage>,
     lazyListState: LazyListState,
     lastUnreadMessageInstant: Instant?,
-    audioMessagesState: Map<String, AudioState>,
+    audioMessagesState: PersistentMap<String, AudioState>,
     onUpdateConversationReadDate: (String) -> Unit,
     onAssetItemClicked: (String) -> Unit,
     onImageFullScreenMode: (UIMessage.Regular, Boolean) -> Unit,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -87,6 +87,7 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.launchGeoIntent
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.user.UserId
+import kotlinx.collections.immutable.PersistentMap
 
 // TODO: a definite candidate for a refactor and cleanup
 @Suppress("ComplexMethod")
@@ -98,7 +99,7 @@ fun MessageItem(
     searchQuery: String = "",
     showAuthor: Boolean = true,
     useSmallBottomPadding: Boolean = false,
-    audioMessagesState: Map<String, AudioState>,
+    audioMessagesState: PersistentMap<String, AudioState>,
     onLongClicked: (UIMessage.Regular) -> Unit,
     onAssetMessageClicked: (String) -> Unit,
     onAudioClick: (String) -> Unit,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -137,7 +137,7 @@ fun EditMessageMenuItems(
             onDeleteClick = onDeleteItemClick,
             onDetailsClick = onDetailsItemClick,
             onReactionClick = onReactionItemClick,
-            onEditClick = if (message.isMyMessage) onEditItemClick else null,
+            onEditClick = if (message.isMyMessage && !message.isDeleted) onEditItemClick else null,
             onCopyClick = onCopyItemClick,
             onReplyClick = onReplyItemClick
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
@@ -65,6 +65,8 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.id.ConversationId
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.launch
 
 @RootNavGraph
@@ -120,7 +122,7 @@ private fun Content(
     state: ConversationAssetMessagesViewState,
     onNavigationPressed: () -> Unit = {},
     onImageFullScreenMode: (conversationId: ConversationId, messageId: String, isSelfAsset: Boolean) -> Unit,
-    audioMessagesState: Map<String, AudioState> = emptyMap(),
+    audioMessagesState: PersistentMap<String, AudioState> = persistentMapOf(),
     onAudioItemClicked: (String) -> Unit,
     onAssetItemClicked: (String) -> Unit
 ) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/FileAssetsContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/FileAssetsContent.kt
@@ -44,12 +44,14 @@ import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.usecase.UIPagingItem
 import com.wire.android.ui.home.conversationslist.common.FolderHeader
 import com.wire.android.ui.theme.wireColorScheme
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.flow.Flow
 
 @Composable
 fun FileAssetsContent(
     groupedAssetMessageList: Flow<PagingData<UIPagingItem>>,
-    audioMessagesState: Map<String, AudioState> = emptyMap(),
+    audioMessagesState: PersistentMap<String, AudioState> = persistentMapOf(),
     onAudioItemClicked: (String) -> Unit,
     onAssetItemClicked: (String) -> Unit
 ) {
@@ -72,7 +74,7 @@ fun FileAssetsContent(
 @Composable
 private fun AssetMessagesListContent(
     groupedAssetMessageList: LazyPagingItems<UIPagingItem>,
-    audioMessagesState: Map<String, AudioState>,
+    audioMessagesState: PersistentMap<String, AudioState>,
     onAudioItemClicked: (String) -> Unit,
     onAssetItemClicked: (String) -> Unit,
 ) {
@@ -114,19 +116,19 @@ private fun AssetMessagesListContent(
                                 message = message,
                                 conversationDetailsData = ConversationDetailsData.None,
                                 audioMessagesState = audioMessagesState,
-                                onAudioClick = onAudioItemClicked,
-                                onChangeAudioPosition = { _, _ -> },
                                 onLongClicked = { },
                                 onAssetMessageClicked = onAssetItemClicked,
+                                onAudioClick = onAudioItemClicked,
+                                onChangeAudioPosition = { _, _ -> },
                                 onImageMessageClicked = { _, _ -> },
                                 onOpenProfile = { _ -> },
                                 onReactionClicked = { _, _ -> },
                                 onResetSessionClicked = { _, _ -> },
                                 onSelfDeletingMessageRead = { },
+                                onLinkClick = { },
                                 defaultBackgroundColor = colorsScheme().backgroundVariant,
                                 shouldDisplayMessageStatus = false,
-                                shouldDisplayFooter = false,
-                                onLinkClick = { }
+                                shouldDisplayFooter = false
                             )
                         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -58,6 +58,7 @@ import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionResult
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -119,7 +120,7 @@ class ConversationMessagesViewModel @Inject constructor(
         viewModelScope.launch {
             conversationAudioMessagePlayer.observableAudioMessagesState.collect {
                 conversationViewState = conversationViewState.copy(
-                    audioMessagesState = it
+                    audioMessagesState = it.toPersistentMap()
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewState.kt
@@ -22,6 +22,8 @@ import androidx.paging.PagingData
 import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.UIMessage
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.datetime.Instant
@@ -31,7 +33,7 @@ data class ConversationMessagesViewState(
     val firstUnreadInstant: Instant? = null,
     val firstuUnreadEventIndex: Int = 0,
     val downloadedAssetDialogState: DownloadedAssetDialogVisibilityState = DownloadedAssetDialogVisibilityState.Hidden,
-    val audioMessagesState: Map<String, AudioState> = emptyMap(),
+    val audioMessagesState: PersistentMap<String, AudioState> = persistentMapOf(),
     val searchedMessageId: String? = null
 )
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -524,7 +524,7 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                 ),
                 conversationDetailsData = ConversationDetailsData.None,
                 showAuthor = false,
-                audioMessagesState = emptyMap(),
+                audioMessagesState = persistentMapOf(),
                 onLongClicked = {},
                 onAssetMessageClicked = {},
                 onAudioClick = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -41,6 +41,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.user.UserId
+import kotlinx.collections.immutable.persistentMapOf
 
 private val previewUserId = UserId("value", "domain")
 
@@ -57,7 +58,8 @@ fun PreviewMessage() {
                     )
                 )
             ),
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -67,7 +69,6 @@ fun PreviewMessage() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
         )
     }
 }
@@ -86,7 +87,8 @@ fun PreviewMessageWithReactions() {
                 ),
                 messageFooter = mockFooter
             ),
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -95,8 +97,7 @@ fun PreviewMessageWithReactions() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = {}
         )
     }
 }
@@ -126,7 +127,8 @@ fun PreviewMessageWithReply() {
                     )
                 )
             ),
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -135,8 +137,7 @@ fun PreviewMessageWithReply() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = {}
         )
     }
 }
@@ -156,7 +157,8 @@ fun PreviewDeletedMessage() {
                     )
                 )
             },
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -165,8 +167,7 @@ fun PreviewDeletedMessage() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = { }
         )
     }
 }
@@ -187,7 +188,8 @@ fun PreviewFailedSendMessage() {
                     messageFooter = mockFooter.copy(reactions = emptyMap(), ownReactions = emptySet())
                 )
             },
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -196,8 +198,7 @@ fun PreviewFailedSendMessage() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = { }
         )
     }
 }
@@ -218,7 +219,8 @@ fun PreviewFailedDecryptionMessage() {
                     messageFooter = mockFooter.copy(reactions = emptyMap(), ownReactions = emptySet())
                 )
             },
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -227,8 +229,7 @@ fun PreviewFailedDecryptionMessage() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = { }
         )
     }
 }
@@ -239,7 +240,8 @@ fun PreviewAssetMessageWithReactions() {
     WireTheme {
         MessageItem(
             message = mockAssetMessage().copy(messageFooter = mockFooter),
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -248,8 +250,7 @@ fun PreviewAssetMessageWithReactions() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = { }
         )
     }
 }
@@ -328,7 +329,8 @@ fun PreviewImageMessageUploaded() {
     WireTheme {
         MessageItem(
             message = mockedImageUIMessage(Message.UploadStatus.UPLOADED),
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -337,8 +339,7 @@ fun PreviewImageMessageUploaded() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = { }
         )
     }
 }
@@ -349,7 +350,8 @@ fun PreviewImageMessageUploading() {
     WireTheme {
         MessageItem(
             message = mockedImageUIMessage(Message.UploadStatus.UPLOAD_IN_PROGRESS),
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -358,8 +360,7 @@ fun PreviewImageMessageUploading() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = { }
         )
     }
 }
@@ -376,7 +377,8 @@ fun PreviewImageMessageFailedUpload() {
                     expirationStatus = ExpirationStatus.NotExpirable
                 )
             ),
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -385,8 +387,7 @@ fun PreviewImageMessageFailedUpload() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = { }
         )
     }
 }
@@ -398,7 +399,8 @@ fun PreviewMessageWithSystemMessage() {
         Column {
             MessageItem(
                 message = mockMessageWithText,
-                audioMessagesState = emptyMap(),
+                conversationDetailsData = ConversationDetailsData.None,
+                audioMessagesState = persistentMapOf(),
                 onLongClicked = {},
                 onAssetMessageClicked = {},
                 onAudioClick = {},
@@ -407,8 +409,7 @@ fun PreviewMessageWithSystemMessage() {
                 onOpenProfile = { _ -> },
                 onReactionClicked = { _, _ -> },
                 onResetSessionClicked = { _, _ -> },
-                onSelfDeletingMessageRead = { },
-                conversationDetailsData = ConversationDetailsData.None
+                onSelfDeletingMessageRead = { }
             )
             SystemMessageItem(
                 mockMessageWithKnock.copy(
@@ -442,7 +443,8 @@ fun PreviewMessagesWithUnavailableQuotedMessage() {
                     )
                 )
             ),
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -451,8 +453,7 @@ fun PreviewMessagesWithUnavailableQuotedMessage() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = {}
         )
     }
 }
@@ -464,7 +465,8 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
         Column {
             MessageItem(
                 message = mockMessageWithText,
-                audioMessagesState = emptyMap(),
+                conversationDetailsData = ConversationDetailsData.None,
+                audioMessagesState = persistentMapOf(),
                 onLongClicked = {},
                 onAssetMessageClicked = {},
                 onAudioClick = {},
@@ -473,8 +475,7 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                 onOpenProfile = { _ -> },
                 onReactionClicked = { _, _ -> },
                 onResetSessionClicked = { _, _ -> },
-                onSelfDeletingMessageRead = {},
-                conversationDetailsData = ConversationDetailsData.None
+                onSelfDeletingMessageRead = {}
             )
             MessageItem(
                 message = mockMessageWithText.copy(
@@ -485,8 +486,9 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                         )
                     )
                 ),
+                conversationDetailsData = ConversationDetailsData.None,
                 showAuthor = false,
-                audioMessagesState = emptyMap(),
+                audioMessagesState = persistentMapOf(),
                 onLongClicked = {},
                 onAssetMessageClicked = {},
                 onAudioClick = {},
@@ -495,8 +497,7 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                 onOpenProfile = { _ -> },
                 onReactionClicked = { _, _ -> },
                 onResetSessionClicked = { _, _ -> },
-                onSelfDeletingMessageRead = {},
-                conversationDetailsData = ConversationDetailsData.None
+                onSelfDeletingMessageRead = {}
             )
             MessageItem(
                 message = mockMessageWithText.copy(
@@ -507,8 +508,9 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                         )
                     )
                 ),
+                conversationDetailsData = ConversationDetailsData.None,
                 showAuthor = false,
-                audioMessagesState = emptyMap(),
+                audioMessagesState = persistentMapOf(),
                 onLongClicked = {},
                 onAssetMessageClicked = {},
                 onAudioClick = {},
@@ -518,7 +520,6 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                 onReactionClicked = { _, _ -> },
                 onResetSessionClicked = { _, _ -> },
                 onSelfDeletingMessageRead = {},
-                conversationDetailsData = ConversationDetailsData.None
             )
         }
     }
@@ -530,7 +531,8 @@ fun PreviewMessageWithMarkdownTextAndLinks() {
     WireTheme {
         MessageItem(
             message = mockMessageWithMarkdownTextAndLinks,
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -539,8 +541,7 @@ fun PreviewMessageWithMarkdownTextAndLinks() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = {}
         )
     }
 }
@@ -551,7 +552,8 @@ fun PreviewMessageWithMarkdownListAndImages() {
     WireTheme {
         MessageItem(
             message = mockMessageWithMarkdownListAndImages,
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -560,8 +562,7 @@ fun PreviewMessageWithMarkdownListAndImages() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = {}
         )
     }
 }
@@ -572,7 +573,8 @@ fun PreviewMessageWithMarkdownTablesAndBlocks() {
     WireTheme {
         MessageItem(
             message = mockMessageWithMarkdownTablesAndBlocks,
-            audioMessagesState = emptyMap(),
+            conversationDetailsData = ConversationDetailsData.None,
+            audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
             onAudioClick = {},
@@ -581,8 +583,7 @@ fun PreviewMessageWithMarkdownTablesAndBlocks() {
             onOpenProfile = { _ -> },
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
-            onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            onSelfDeletingMessageRead = {}
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesResultsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesResultsScreen.kt
@@ -31,6 +31,7 @@ import com.wire.android.ui.home.conversations.mock.mockMessageWithText
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
+import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.flow.flowOf
 
 @Composable
@@ -54,7 +55,7 @@ fun SearchConversationMessagesResultsScreen(
                         message = message,
                         conversationDetailsData = ConversationDetailsData.None,
                         searchQuery = searchQuery,
-                        audioMessagesState = mapOf(),
+                        audioMessagesState = persistentMapOf(),
                         onLongClicked = { },
                         onAssetMessageClicked = { },
                         onAudioClick = { },
@@ -64,11 +65,11 @@ fun SearchConversationMessagesResultsScreen(
                         onReactionClicked = { _, _ -> },
                         onResetSessionClicked = { _, _ -> },
                         onSelfDeletingMessageRead = { },
+                        isContentClickable = true,
+                        onMessageClick = onMessageClick,
                         defaultBackgroundColor = colorsScheme().backgroundVariant,
                         shouldDisplayMessageStatus = false,
-                        shouldDisplayFooter = false,
-                        isContentClickable = true,
-                        onMessageClick = onMessageClick
+                        shouldDisplayFooter = false
                     )
                 }
                 is UIMessage.System -> { }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetAssetMessagesFromConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetAssetMessagesFromConversationUseCase.kt
@@ -27,12 +27,9 @@ import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.asset.GetPaginatedFlowOfAssetMessageByConversationIdUseCase
-import com.wire.kalium.logic.feature.conversation.ObserveUserListByIdUseCase
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapLatest
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -41,7 +38,7 @@ import kotlin.math.max
 
 class GetAssetMessagesFromConversationUseCase @Inject constructor(
     private val getAssetMessages: GetPaginatedFlowOfAssetMessageByConversationIdUseCase,
-    private val observeMemberDetailsByIds: ObserveUserListByIdUseCase,
+    private val getUsersForMessage: GetUsersForMessageUseCase,
     private val messageMapper: MessageMapper,
     private val dispatchers: DispatcherProvider
 ) {
@@ -69,12 +66,10 @@ class GetAssetMessagesFromConversationUseCase @Inject constructor(
         ).map { pagingData ->
             val currentTime = TimeZone.currentSystemDefault()
             val uiMessagePagingData: PagingData<UIPagingItem> = pagingData.flatMap { messageItem ->
-                observeMemberDetailsByIds(messageMapper.memberIdList(listOf(messageItem)))
-                    .mapLatest { usersList ->
-                        messageMapper.toUIMessage(usersList, messageItem)
-                            ?.let { listOf(UIPagingItem.Message(it, Instant.parse(messageItem.date))) }
-                            ?: emptyList()
-                    }.first()
+                val usersForMessage = getUsersForMessage(messageItem)
+                messageMapper.toUIMessage(usersForMessage, messageItem)
+                    ?.let { listOf(UIPagingItem.Message(it, Instant.parse(messageItem.date))) }
+                    ?: emptyList()
             }.insertSeparators { before: UIPagingItem.Message?, after: UIPagingItem.Message? ->
                 if (before == null && after != null) {
                     val localDateTime = after.date.toLocalDateTime(currentTime)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationMessagesFromSearchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationMessagesFromSearchUseCase.kt
@@ -24,20 +24,17 @@ import com.wire.android.mapper.MessageMapper
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.conversation.ObserveUserListByIdUseCase
 import com.wire.kalium.logic.feature.message.GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapLatest
 import javax.inject.Inject
 import kotlin.math.max
 
 class GetConversationMessagesFromSearchUseCase @Inject constructor(
     private val getMessagesSearch: GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase,
-    private val observeMemberDetailsByIds: ObserveUserListByIdUseCase,
+    private val getUsersForMessage: GetUsersForMessageUseCase,
     private val messageMapper: MessageMapper,
     private val dispatchers: DispatcherProvider
 ) {
@@ -67,11 +64,8 @@ class GetConversationMessagesFromSearchUseCase @Inject constructor(
                 startingOffset = max(0, lastReadIndex - PREFETCH_DISTANCE).toLong()
             ).map { pagingData ->
                 pagingData.flatMap { messageItem ->
-                    observeMemberDetailsByIds(messageMapper.memberIdList(listOf(messageItem)))
-                        .mapLatest { usersList ->
-                            messageMapper.toUIMessage(usersList, messageItem)?.let { listOf(it) }
-                                ?: emptyList()
-                        }.first()
+                    val usersForMessage = getUsersForMessage(messageItem)
+                    messageMapper.toUIMessage(usersForMessage, messageItem)?.let { listOf(it) } ?: emptyList()
                 }
             }.flowOn(dispatchers.io())
         } else {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetUsersForMessageUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetUsersForMessageUseCase.kt
@@ -1,0 +1,49 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.home.conversations.usecase
+
+import com.wire.android.mapper.MessageMapper
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.user.User
+import com.wire.kalium.logic.feature.conversation.ObserveUserListByIdUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapLatest
+import javax.inject.Inject
+
+class GetUsersForMessageUseCase @Inject constructor(
+    private val observeMemberDetailsByIds: ObserveUserListByIdUseCase,
+    private val messageMapper: MessageMapper
+) {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    suspend operator fun invoke(message: Message): List<User> {
+        val listWithSender: List<User> = message.sender?.let { listOf(it) } ?: listOf()
+        val otherUserIdList = messageMapper.memberIdList(listOf(message))
+
+        return if (otherUserIdList.isNotEmpty()) {
+            observeMemberDetailsByIds(otherUserIdList)
+                .mapLatest { usersList ->
+                    listWithSender.plus(usersList)
+                }.first()
+        } else {
+            listWithSender
+        }
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
@@ -60,16 +60,14 @@ class MessageMapperTest {
     fun givenMessagesList_whenGettingMemberIdList_thenReturnCorrectList() = runTest {
         // Given
         val (_, mapper) = Arrangement().arrange()
-        val clientMessageAuthor = UserId("client-id", "client-domain")
-        val serverMessageAuthor = UserId("server-id", "server-domain")
+        val removedUserId = UserId("server-id", "server-domain")
         val messages = listOf(
-            TestMessage.TEXT_MESSAGE.copy(senderUserId = clientMessageAuthor),
+            TestMessage.TEXT_MESSAGE,
             TestMessage.MEMBER_REMOVED_MESSAGE.copy(
-                senderUserId = serverMessageAuthor,
-                content = MessageContent.MemberChange.Removed(listOf(serverMessageAuthor))
+                content = MessageContent.MemberChange.Removed(listOf(removedUserId))
             )
         )
-        val expected = listOf(clientMessageAuthor, serverMessageAuthor)
+        val expected = listOf(removedUserId)
         // When
         val list = mapper.memberIdList(messages)
         // Then

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationMessagesFromSearchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationMessagesFromSearchUseCaseTest.kt
@@ -36,7 +36,6 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.conversation.ObserveUserListByIdUseCase
 import com.wire.kalium.logic.feature.message.GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -109,7 +108,7 @@ class GetConversationMessagesFromSearchUseCaseTest {
         lateinit var getMessagesSearch: GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase
 
         @MockK
-        lateinit var observeMemberDetailsByIds: ObserveUserListByIdUseCase
+        lateinit var getUsersForMessages: GetUsersForMessageUseCase
 
         @MockK
         lateinit var messageMapper: MessageMapper
@@ -117,7 +116,7 @@ class GetConversationMessagesFromSearchUseCaseTest {
         private val useCase: GetConversationMessagesFromSearchUseCase by lazy {
             GetConversationMessagesFromSearchUseCase(
                 getMessagesSearch,
-                observeMemberDetailsByIds,
+                getUsersForMessages,
                 messageMapper,
                 dispatchers = TestDispatcherProvider(),
             )
@@ -152,9 +151,7 @@ class GetConversationMessagesFromSearchUseCaseTest {
         }
 
         suspend fun withMemberDetails() = apply {
-            coEvery { observeMemberDetailsByIds(any()) } returns flowOf(
-                listOf(user1, user2)
-            )
+            coEvery { getUsersForMessages(any()) } returns listOf(user1, user2)
         }
 
         fun withMappedMessage(user: User, message: Message.Standalone) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetUsersForMessageUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetUsersForMessageUseCaseTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.usecase
+
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.framework.TestMessage
+import com.wire.android.framework.TestUser
+import com.wire.android.mapper.MessageMapper
+import com.wire.kalium.logic.data.user.User
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.conversation.ObserveUserListByIdUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(CoroutineTestExtension::class)
+class GetUsersForMessageUseCaseTest {
+
+    @Test
+    fun givenMessageWithoutAdditionalUserIds_whenInvoke_thenObserveMemberDetailsByIdsIsNotTriggered() = runTest {
+        val sender = TestUser.OTHER_USER
+        val userWithoutOtherUsers = TestMessage.TEXT_MESSAGE.copy(sender = sender, senderUserId = sender.id)
+
+        val (arrangement, useCase) = Arrangement()
+            .withMemberDetails(listOf())
+            .withMemberList(listOf())
+            .arrange()
+
+        val result = useCase(userWithoutOtherUsers)
+
+        assertTrue(result.first() == sender)
+        coVerify(exactly = 0) { arrangement.observeMemberDetailsByIds(any()) }
+    }
+
+    @Test
+    fun givenMessageWithAdditionalUserIds_whenInvoke_thenObserveMemberDetailsByIdsIsTriggered() = runTest {
+        val otherUser = TestUser.OTHER_USER
+        val userWithoutOtherUsers = TestMessage.MEMBER_REMOVED_MESSAGE
+        val user1 = TestUser.OTHER_USER.copy(
+            id = UserId("user-id1", "domain")
+        )
+        val user2 = TestUser.OTHER_USER.copy(
+            id = UserId("user-id2", "domain")
+        )
+
+        val (arrangement, useCase) = Arrangement()
+            .withMemberDetails(listOf(user1, user2))
+            .withMemberList(listOf(otherUser.id))
+            .arrange()
+
+        val result = useCase(userWithoutOtherUsers)
+
+        assertTrue(result.first().equals(user1))
+        coVerify(exactly = 1) { arrangement.observeMemberDetailsByIds(any()) }
+    }
+
+    private class Arrangement {
+
+        @MockK
+        lateinit var observeMemberDetailsByIds: ObserveUserListByIdUseCase
+
+        @MockK
+        lateinit var messageMapper: MessageMapper
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        suspend fun withMemberDetails(userList: List<User>) = apply {
+            coEvery { observeMemberDetailsByIds(any()) } returns flowOf(userList)
+        }
+
+        fun withMemberList(userIdList: List<UserId>) = apply {
+            every { messageMapper.memberIdList(any()) } returns userIdList
+        }
+
+        fun arrange() = this to GetUsersForMessageUseCase(
+            observeMemberDetailsByIds, messageMapper
+        )
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4716" title="WPB-4716" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4716</a>  [ANR] Janky scrolling in a conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2661

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- we were using map instead of persistent map to provide message audio state.
- we are observing unnecessary sender when it's available from message 

### Causes (Optional)

- unnecessary compose rebuild when scrolling messages
- more db executions to get sender user entity

### Solutions

- make audio state as persistent map
- adapt removing messageSenderUserId from mapper to this PR https://github.com/wireapp/kalium/pull/2449

Also fixed crash when user want to edit deleted message