### PR TITLE
chore: remove jacoco and migrate to kover (ACOL-139)

### DIFF
--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -64,19 +64,19 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: report
-          path: app/build/reports/jacoco
+          path: app/build/reports/kover
 
       - name: Download Test Reports Folder
         uses: actions/download-artifact@v4
         with:
           name: report
-          path: app/build/reports/jacoco
+          path: app/build/reports/kover
           merge-multiple: true
 
       - name: Upload Test Report
         uses: codecov/codecov-action@v3
         with:
-          files: "app/build/reports/jacoco/jacocoReport/jacocoReport.xml"
+          files: "app/build/reports/kover/report.xml"
 
       - name: Cleanup Gradle Cache
         # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -540,7 +540,6 @@ pipeline {
                 }
             }
 
-            sh './gradlew jacocoReport'
             wireSend(secret: env.WIRE_BOT_SECRET, message: "**[#${BUILD_NUMBER} Link](${BUILD_URL})** [${SOURCE_BRANCH}] - ✅ SUCCESS 🎉" + "\nLast 5 commits:\n```text\n$lastCommits\n```")
         }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,6 +19,7 @@
 private object Dependencies {
     const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0"
     const val detektGradlePlugin = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.0"
+    const val koverGradlePlugin = "org.jetbrains.kotlinx:kover-gradle-plugin:0.7.5"
     const val junit = "junit:junit:4.13.2"
     const val kluent = "org.amshove.kluent:kluent:1.73"
     const val spotless = "com.diffplug.spotless:spotless-plugin-gradle:6.1.2"
@@ -44,6 +45,7 @@ dependencies {
     implementation("com.android.tools.build:gradle:${klibs.versions.agp.get()}")
     implementation(Dependencies.kotlinGradlePlugin)
     implementation(Dependencies.detektGradlePlugin)
+    implementation(Dependencies.koverGradlePlugin)
     implementation(Dependencies.spotless)
     implementation(Dependencies.junit5)
 

--- a/buildSrc/src/main/kotlin/scripts/quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/quality.gradle.kts
@@ -23,8 +23,8 @@ import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 
 plugins {
     id("com.android.application") apply false
-    id("jacoco")
     id("io.gitlab.arturbosch.detekt")
+    id("org.jetbrains.kotlinx.kover")
 }
 
 dependencies {
@@ -83,71 +83,49 @@ tasks.register("staticCodeAnalysis") {
     dependsOn(detektAll)
 }
 
-// Jacoco Configuration
-val jacocoReport by tasks.registering(JacocoReport::class) {
-    group = "Quality"
-    description = "Reports code coverage on tests within the Wire Android codebase"
-    val buildVariant = "devDebug" // It's not necessary to run unit tests on every variant so we default to "devDebug"
-    dependsOn("test${buildVariant.capitalize()}UnitTest")
-
-    val outputDir = "$buildDir/jacoco/html"
-    val classPathBuildVariant = buildVariant
-
-    reports {
-        xml.required.set(true)
-        html.required.set(true)
-        html.outputLocation.set(file(outputDir))
-    }
-
-    classDirectories.setFrom(
-        fileTree(project.buildDir) {
-            include(
-                "**/classes/**/main/**", // This probably can be removed
-                "**/tmp/kotlin-classes/$classPathBuildVariant/**"
-            )
-            exclude(
-                "**/R.class",
-                "**/R\$*.class",
-                "**/BuildConfig.*",
-                "**/Manifest*.*",
-                "**/Manifest$*.class",
-                "**/*Test*.*",
-                "**/Injector.*",
-                "android/**/*.*",
-                "**/*\$Lambda$*.*",
-                "**/*\$inlined$*.*",
-                "**/di/*.*",
-                "**/*Database.*",
-                "**/*Response.*",
-                "**/*Application.*",
-                "**/*Entity.*",
-                "**/mock/**",
-                "**/*Screen*", // These are composable classes
-                "**/*Kt*", // These are "usually" kotlin generated classes
-                "**/theme/**/*.*", // Ignores jetpack compose theme related code
-                "**/common/**/*.*", // Ignores jetpack compose common components related code
-                "**/navigation/**/*.*" // Ignores jetpack navigation related code
-            )
-        }
-    )
-
-    sourceDirectories.setFrom(
-        fileTree(project.projectDir) {
-            include("src/main/java/**", "src/main/kotlin/**")
-        }
-    )
-
-    executionData.setFrom(
-        fileTree(project.buildDir) {
-            include("**/*.exec", "**/*.ec")
-        }
-    )
-
-    doLast { println("Report file: $outputDir/index.html") }
-}
-
 tasks.register("testCoverage") {
     group = "Quality"
     description = "Reports code coverage on tests within the Wire Android codebase."
-    dependsOn(jacocoReport)
+    dependsOn("koverXmlReport")
+}
+
+koverReport {
+    defaults {
+        mergeWith("devDebug")
+
+        filters {
+            excludes {
+                classes(
+                    "*Fragment",
+                    "*Fragment\$*",
+                    "*Activity",
+                    "*Activity\$*",
+                    "*.databinding.*",
+                    "*.BuildConfig",
+                    "**/R.class",
+                    "**/R\$*.class",
+                    "**/Manifest*.*",
+                    "**/Manifest$*.class",
+                    "**/*Test*.*",
+                    "*NavArgs*",
+                    "*ComposableSingletons*",
+                    "*_HiltModules*",
+                    "*Hilt_*",
+                )
+                packages(
+                    "hilt_aggregated_deps",
+                    "com.wire.android.di",
+                    "dagger.hilt.internal.aggregatedroot.codegen",
+                    "com.wire.android.ui.home.conversations.mock",
+                )
+                annotatedBy(
+                    "*Generated*",
+                    "*HomeNavGraph*",
+                    "*Destination*",
+                    "*Composable*",
+                    "*Preview*",
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACOL-139" title="ACOL-139" target="_blank"><img alt="Topic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />ACOL-139</a>  Min. code coverage thresholds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Follow up of  #2662 to improve test coverage

### Solutions

- Removes jacoco config.
- Use kover for better coverage support and filtering of classes and annotations.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
