### PR TITLE
feat: navigate to original reply message (WPB-1694)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -77,6 +77,7 @@ import com.ramcosta.composedestinations.result.ResultRecipient
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.media.audiomessage.AudioState
+import com.wire.android.model.Clickable
 import com.wire.android.model.SnackBarMessage
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -693,7 +694,8 @@ private fun ConversationScreen(
                     tempWritableImageUri = tempWritableImageUri,
                     tempWritableVideoUri = tempWritableVideoUri,
                     onLinkClick = onLinkClick,
-                    onTypingEvent = onTypingEvent
+                    onTypingEvent = onTypingEvent,
+                    onNavigateToReplyOriginalMessage = conversationMessagesViewModel::navigateToReplyOriginalMessage
                 )
             }
         }
@@ -737,7 +739,8 @@ private fun ConversationScreenContent(
     tempWritableImageUri: Uri?,
     tempWritableVideoUri: Uri?,
     onLinkClick: (String) -> Unit,
-    onTypingEvent: (TypingIndicatorMode) -> Unit
+    onTypingEvent: (TypingIndicatorMode) -> Unit,
+    onNavigateToReplyOriginalMessage: (UIMessage) -> Unit
 ) {
     val lazyPagingMessages = messages.collectAsLazyPagingItems()
 
@@ -768,7 +771,8 @@ private fun ConversationScreenContent(
                 onFailedMessageCancelClicked = onFailedMessageCancelClicked,
                 onFailedMessageRetryClicked = onFailedMessageRetryClicked,
                 onLinkClick = onLinkClick,
-                selectedMessageId = selectedMessageId
+                selectedMessageId = selectedMessageId,
+                onNavigateToReplyOriginalMessage = onNavigateToReplyOriginalMessage
             )
         },
         onChangeSelfDeletionClicked = onChangeSelfDeletionClicked,
@@ -835,7 +839,8 @@ fun MessageList(
     onFailedMessageRetryClicked: (String) -> Unit,
     onFailedMessageCancelClicked: (String) -> Unit,
     onLinkClick: (String) -> Unit,
-    selectedMessageId: String?
+    selectedMessageId: String?,
+    onNavigateToReplyOriginalMessage: (UIMessage) -> Unit
 ) {
     val mostRecentMessage = lazyPagingMessages.itemCount.takeIf { it > 0 }?.let { lazyPagingMessages[0] }
 
@@ -907,6 +912,12 @@ fun MessageList(
                                 onFailedMessageCancelClicked = onFailedMessageCancelClicked,
                                 onFailedMessageRetryClicked = onFailedMessageRetryClicked,
                                 onLinkClick = onLinkClick,
+                                onReplyClickable = Clickable(
+                                    enabled = true,
+                                    onClick = {
+                                        onNavigateToReplyOriginalMessage(message)
+                                    }
+                                ),
                                 isSelectedMessage = (message.header.messageId == selectedMessageId)
                             )
                         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -116,6 +116,7 @@ fun MessageItem(
     defaultBackgroundColor: Color = Color.Transparent,
     shouldDisplayMessageStatus: Boolean = true,
     shouldDisplayFooter: Boolean = true,
+    onReplyClickable: Clickable? = null,
     isSelectedMessage: Boolean = false
 ) {
     with(message) {
@@ -277,7 +278,8 @@ fun MessageItem(
                                         onLongClick = onLongClick,
                                         onOpenProfile = onOpenProfile,
                                         onLinkClick = onLinkClick,
-                                        clickable = !isContentClickable
+                                        clickable = !isContentClickable,
+                                        onReplyClickable = onReplyClickable
                                     )
                                 }
                                 if (isMyMessage && shouldDisplayMessageStatus) {
@@ -507,7 +509,8 @@ private fun MessageContent(
     onLongClick: (() -> Unit)? = null,
     onOpenProfile: (String) -> Unit,
     onLinkClick: (String) -> Unit,
-    clickable: Boolean
+    clickable: Boolean,
+    onReplyClickable: Clickable? = null
 ) {
     when (messageContent) {
         is UIMessageContent.ImageMessage -> {
@@ -528,8 +531,11 @@ private fun MessageContent(
                 messageContent.messageBody.quotedMessage?.let {
                     VerticalSpace.x4()
                     when (it) {
-                        is UIQuotedMessage.UIQuotedData -> QuotedMessage(it)
-                        UIQuotedMessage.UnavailableData -> QuotedUnavailable(QuotedMessageStyle.COMPLETE)
+                        is UIQuotedMessage.UIQuotedData -> QuotedMessage(
+                            messageData = it,
+                            clickable = onReplyClickable
+                        )
+                        UIQuotedMessage.UnavailableData -> QuotedUnavailable(style = QuotedMessageStyle.COMPLETE)
                     }
                     VerticalSpace.x4()
                 }
@@ -553,8 +559,11 @@ private fun MessageContent(
                 messageContent.messageBody?.quotedMessage?.let {
                     VerticalSpace.x4()
                     when (it) {
-                        is UIQuotedMessage.UIQuotedData -> QuotedMessage(it)
-                        UIQuotedMessage.UnavailableData -> QuotedUnavailable(QuotedMessageStyle.COMPLETE)
+                        is UIQuotedMessage.UIQuotedData -> QuotedMessage(
+                            messageData = it,
+                            clickable = onReplyClickable
+                        )
+                        UIQuotedMessage.UnavailableData -> QuotedUnavailable(style = QuotedMessageStyle.COMPLETE)
                     }
                     VerticalSpace.x4()
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/FileAssetsContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/FileAssetsContent.kt
@@ -126,7 +126,8 @@ private fun AssetMessagesListContent(
                                 defaultBackgroundColor = colorsScheme().backgroundVariant,
                                 shouldDisplayMessageStatus = false,
                                 shouldDisplayFooter = false,
-                                onLinkClick = { }
+                                onLinkClick = { },
+                                onReplyClickable = null
                             )
                         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -123,7 +123,6 @@ class ConversationMessagesViewModel @Inject constructor(
                 searchedMessageId = originalMessageId
             )
             loadPaginatedMessages()
-
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -34,6 +34,8 @@ import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.OnResetSession
 import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.UIMessage
+import com.wire.android.ui.home.conversations.model.UIMessageContent
+import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversationUseCase
 import com.wire.android.ui.navArgs
 import com.wire.android.util.FileManager
@@ -109,6 +111,20 @@ class ConversationMessagesViewModel @Inject constructor(
         loadPaginatedMessages()
         loadLastMessageInstant()
         observeAudioPlayerState()
+    }
+
+    fun navigateToReplyOriginalMessage(message: UIMessage) {
+        if (message.messageContent is UIMessageContent.TextMessage) {
+            val originalMessageId =
+                ((message.messageContent as UIMessageContent.TextMessage)
+                    .messageBody.quotedMessage as UIQuotedMessage.UIQuotedData)
+                    .messageId
+            conversationViewState = conversationViewState.copy(
+                searchedMessageId = originalMessageId
+            )
+            loadPaginatedMessages()
+
+        }
     }
 
     private fun clearOrphanedTypingEvents() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -52,8 +52,10 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.wire.android.R
+import com.wire.android.model.Clickable
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.common.StatusBox
+import com.wire.android.ui.common.clickable
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.typography
@@ -89,6 +91,7 @@ enum class QuotedMessageStyle {
 internal fun QuotedMessage(
     messageData: UIQuotedMessage.UIQuotedData,
     style: QuotedMessageStyle = COMPLETE,
+    clickable: Clickable?,
     modifier: Modifier = Modifier,
     startContent: @Composable () -> Unit = {}
 ) {
@@ -101,7 +104,8 @@ internal fun QuotedMessage(
             assetName = quotedContent.assetName,
             modifier = modifier,
             style = style,
-            startContent = startContent
+            startContent = startContent,
+            clickable = clickable
         )
 
         is UIQuotedMessage.UIQuotedData.DisplayableImage -> QuotedImage(
@@ -110,7 +114,8 @@ internal fun QuotedMessage(
             originalDateTimeText = messageData.originalMessageDateDescription,
             modifier = modifier,
             style = style,
-            startContent = startContent
+            startContent = startContent,
+            clickable = clickable
         )
 
         UIQuotedMessage.UIQuotedData.Deleted -> QuotedDeleted(
@@ -118,6 +123,7 @@ internal fun QuotedMessage(
             originalDateDescription = messageData.originalMessageDateDescription,
             modifier = modifier,
             style = style,
+            clickable = clickable
         )
 
         is UIQuotedMessage.UIQuotedData.Text -> QuotedText(
@@ -127,7 +133,8 @@ internal fun QuotedMessage(
             senderName = messageData.senderName,
             modifier = modifier,
             style = style,
-            startContent = startContent
+            startContent = startContent,
+            clickable = clickable
         )
 
         is UIQuotedMessage.UIQuotedData.AudioMessage -> QuotedAudioMessage(
@@ -135,7 +142,8 @@ internal fun QuotedMessage(
             originalDateTimeText = messageData.originalMessageDateDescription,
             modifier = modifier,
             style = style,
-            startContent = startContent
+            startContent = startContent,
+            clickable = clickable
         )
 
         is UIQuotedMessage.UIQuotedData.Location -> QuotedLocation(
@@ -144,7 +152,8 @@ internal fun QuotedMessage(
             locationName = quotedContent.locationName,
             modifier = modifier,
             style = style,
-            startContent = startContent
+            startContent = startContent,
+            clickable = clickable
         )
     }
 }
@@ -154,7 +163,11 @@ fun QuotedMessagePreview(
     quotedMessageData: UIQuotedMessage.UIQuotedData,
     onCancelReply: () -> Unit
 ) {
-    QuotedMessage(quotedMessageData, style = PREVIEW) {
+    QuotedMessage(
+        messageData = quotedMessageData,
+        clickable = null,
+        style = PREVIEW
+    ) {
         Box(
             modifier = Modifier
                 .padding(
@@ -187,7 +200,8 @@ private fun QuotedMessageContent(
     endContent: @Composable () -> Unit = {},
     startContent: @Composable () -> Unit = {},
     footerContent: @Composable () -> Unit = {},
-    centerContent: @Composable () -> Unit = {}
+    centerContent: @Composable () -> Unit = {},
+    clickable: Clickable? = null
 ) {
     val quoteOutlineShape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
     Row(
@@ -205,6 +219,9 @@ private fun QuotedMessageContent(
             .padding(dimensions().spacing4x)
             .fillMaxWidth()
             .height(IntrinsicSize.Min)
+            .let {
+                if (clickable != null) it.clickable(clickable) else it
+            }
     ) {
         Box(modifier = Modifier.padding(start = dimensions().spacing4x)) {
             startContent()
@@ -287,6 +304,7 @@ private fun QuotedDeleted(
     style: QuotedMessageStyle,
     modifier: Modifier = Modifier,
     startContent: @Composable () -> Unit = {},
+    clickable: Clickable?
 ) {
     QuotedMessageContent(
         senderName.asString(),
@@ -298,7 +316,8 @@ private fun QuotedDeleted(
             StatusBox(stringResource(R.string.deleted_message_text))
         }, footerContent = {
             QuotedMessageOriginalDate(originalDateDescription)
-        }
+        },
+        clickable = clickable
     )
 }
 
@@ -310,7 +329,8 @@ private fun QuotedText(
     senderName: UIText,
     modifier: Modifier = Modifier,
     startContent: @Composable () -> Unit = {},
-    style: QuotedMessageStyle
+    style: QuotedMessageStyle,
+    clickable: Clickable?
 ) {
     QuotedMessageContent(
         senderName.asString(),
@@ -327,7 +347,8 @@ private fun QuotedText(
             MainContentText(text)
         }, footerContent = {
             QuotedMessageOriginalDate(originalDateTimeDescription)
-        }
+        },
+        clickable = clickable
     )
 }
 
@@ -349,7 +370,8 @@ private fun QuotedImage(
     originalDateTimeText: UIText,
     startContent: @Composable () -> Unit = {},
     style: QuotedMessageStyle,
-    modifier: Modifier
+    modifier: Modifier,
+    clickable: Clickable?
 ) {
 
     if (style == PREVIEW) {
@@ -373,7 +395,7 @@ private fun QuotedImage(
             MainContentText(stringResource(R.string.notification_shared_picture))
         }, footerContent = {
             QuotedMessageOriginalDate(originalDateTimeText)
-        })
+        }, clickable = clickable)
     } else {
 
         // Similar to the standard layout, but the space for the image stretches
@@ -395,7 +417,7 @@ private fun QuotedImage(
                 .fillMaxWidth()
         ) {
             // This is the composable that does the trick of stretching the image
-            AutosizeContainer(asset = asset) {
+            AutosizeContainer(asset = asset, clickable = clickable) {
                 QuotedMessageTopRow(senderName.asString(), displayReplyArrow = true)
                 MainContentText(stringResource(R.string.notification_shared_picture))
                 QuotedMessageOriginalDate(originalDateTimeText)
@@ -408,6 +430,7 @@ private fun QuotedImage(
 private fun AutosizeContainer(
     modifier: Modifier = Modifier,
     asset: ImageAsset.PrivateAsset,
+    clickable: Clickable? = null,
     content: @Composable () -> Unit
 ) {
     val imageDimension = Dimension.value(dimensions().spacing56x)
@@ -417,6 +440,9 @@ private fun AutosizeContainer(
         modifier = modifier
             .fillMaxWidth()
             .padding(dimensions().spacing8x)
+            .let {
+                if (clickable != null) it.clickable(clickable) else it
+            }
     ) {
         val (leftSide, rightSide) = createRefs()
         Column(
@@ -461,7 +487,8 @@ fun QuotedAudioMessage(
     originalDateTimeText: UIText,
     modifier: Modifier,
     style: QuotedMessageStyle,
-    startContent: @Composable () -> Unit
+    startContent: @Composable () -> Unit,
+    clickable: Clickable?
 ) {
     QuotedMessageContent(
         senderName = senderName.asString(),
@@ -483,7 +510,8 @@ fun QuotedAudioMessage(
                 tint = colorsScheme().secondaryText
             )
         },
-        footerContent = { QuotedMessageOriginalDate(originalDateTimeText) }
+        footerContent = { QuotedMessageOriginalDate(originalDateTimeText) },
+        clickable = clickable
     )
 }
 
@@ -506,7 +534,8 @@ private fun QuotedGenericAsset(
     assetName: String?,
     style: QuotedMessageStyle,
     startContent: @Composable () -> Unit = {},
-    modifier: Modifier
+    modifier: Modifier,
+    clickable: Clickable?
 ) {
     QuotedMessageContent(
         senderName = senderName.asString(), style = style, modifier = modifier, centerContent = {
@@ -523,7 +552,8 @@ private fun QuotedGenericAsset(
                     .size(dimensions().spacing24x),
                 tint = colorsScheme().secondaryText
             )
-        }, footerContent = { QuotedMessageOriginalDate(originalDateTimeText) }
+        }, footerContent = { QuotedMessageOriginalDate(originalDateTimeText) },
+        clickable = clickable
     )
 }
 
@@ -534,7 +564,8 @@ private fun QuotedLocation(
     locationName: String,
     style: QuotedMessageStyle,
     startContent: @Composable () -> Unit = {},
-    modifier: Modifier
+    modifier: Modifier,
+    clickable: Clickable?
 ) {
     QuotedMessageContent(
         senderName = senderName.asString(), style = style, modifier = modifier, centerContent = {
@@ -549,6 +580,7 @@ private fun QuotedLocation(
                     .size(dimensions().spacing24x),
                 tint = colorsScheme().secondaryText
             )
-        }, footerContent = { QuotedMessageOriginalDate(originalDateTimeText) }
+        }, footerContent = { QuotedMessageOriginalDate(originalDateTimeText) },
+        clickable = clickable
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -67,7 +67,8 @@ fun PreviewMessage() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -96,7 +97,8 @@ fun PreviewMessageWithReactions() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -136,7 +138,8 @@ fun PreviewMessageWithReply() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -166,7 +169,8 @@ fun PreviewDeletedMessage() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -197,7 +201,8 @@ fun PreviewFailedSendMessage() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -228,7 +233,8 @@ fun PreviewFailedDecryptionMessage() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -249,7 +255,8 @@ fun PreviewAssetMessageWithReactions() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -338,7 +345,8 @@ fun PreviewImageMessageUploaded() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -359,7 +367,8 @@ fun PreviewImageMessageUploading() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -386,7 +395,8 @@ fun PreviewImageMessageFailedUpload() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = { },
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -408,7 +418,8 @@ fun PreviewMessageWithSystemMessage() {
                 onReactionClicked = { _, _ -> },
                 onResetSessionClicked = { _, _ -> },
                 onSelfDeletingMessageRead = { },
-                conversationDetailsData = ConversationDetailsData.None
+                conversationDetailsData = ConversationDetailsData.None,
+                onReplyClickable = null
             )
             SystemMessageItem(
                 mockMessageWithKnock.copy(
@@ -452,7 +463,8 @@ fun PreviewMessagesWithUnavailableQuotedMessage() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -474,7 +486,8 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                 onReactionClicked = { _, _ -> },
                 onResetSessionClicked = { _, _ -> },
                 onSelfDeletingMessageRead = {},
-                conversationDetailsData = ConversationDetailsData.None
+                conversationDetailsData = ConversationDetailsData.None,
+                onReplyClickable = null
             )
             MessageItem(
                 message = mockMessageWithText.copy(
@@ -496,7 +509,8 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                 onReactionClicked = { _, _ -> },
                 onResetSessionClicked = { _, _ -> },
                 onSelfDeletingMessageRead = {},
-                conversationDetailsData = ConversationDetailsData.None
+                conversationDetailsData = ConversationDetailsData.None,
+                onReplyClickable = null
             )
             MessageItem(
                 message = mockMessageWithText.copy(
@@ -518,7 +532,8 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                 onReactionClicked = { _, _ -> },
                 onResetSessionClicked = { _, _ -> },
                 onSelfDeletingMessageRead = {},
-                conversationDetailsData = ConversationDetailsData.None
+                conversationDetailsData = ConversationDetailsData.None,
+                onReplyClickable = null
             )
         }
     }
@@ -540,7 +555,8 @@ fun PreviewMessageWithMarkdownTextAndLinks() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -561,7 +577,8 @@ fun PreviewMessageWithMarkdownListAndImages() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }
@@ -582,7 +599,8 @@ fun PreviewMessageWithMarkdownTablesAndBlocks() {
             onReactionClicked = { _, _ -> },
             onResetSessionClicked = { _, _ -> },
             onSelfDeletingMessageRead = {},
-            conversationDetailsData = ConversationDetailsData.None
+            conversationDetailsData = ConversationDetailsData.None,
+            onReplyClickable = null
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesResultsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesResultsScreen.kt
@@ -68,7 +68,8 @@ fun SearchConversationMessagesResultsScreen(
                         shouldDisplayMessageStatus = false,
                         shouldDisplayFooter = false,
                         isContentClickable = true,
-                        onMessageClick = onMessageClick
+                        onMessageClick = onMessageClick,
+                        onReplyClickable = null,
                     )
                 }
                 is UIMessage.System -> { }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1694" title="WPB-1694" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-1694</a>  Reply: Go to original message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When having a reply message, and clicking on it nothing happened.

### Causes (Optional)

Because it was not implemented yet.

### Solutions

Implemented this amazing feature 💪🏻 

I have created a function inside `ConversationMessagesViewmodel` (`navigateToReplyOriginalMessage`) which reuses `searchedMessageId` from the state and also `loadPaginatedMessages` so it follows the same logic it was done for navigating to selected message when search inside a conversation :)

### Testing

#### How to Test

- Have a reply message
- Click on the original message inside the reply
- You will travel the world of code and arrive at the original message that it was replied to
- what an amazing trick 🎆 