### PR TITLE
fix: crash when uploading avatar [WPB-5965]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
@@ -67,6 +67,8 @@ class AvatarPickerViewModel @Inject constructor(
     var pictureState by mutableStateOf<PictureState>(PictureState.Empty)
         private set
 
+    private var initialPictureLoadingState by mutableStateOf<InitialPictureLoadingState>(InitialPictureLoadingState.None)
+
     private val _infoMessage = MutableSharedFlow<UIText>()
     val infoMessage = _infoMessage.asSharedFlow()
 
@@ -75,24 +77,27 @@ class AvatarPickerViewModel @Inject constructor(
 
     val temporaryAvatarUri: Uri = avatarImageManager.getShareableTempAvatarUri(defaultAvatarPath)
 
-    private lateinit var currentAvatarUri: Uri
-
     init {
         loadInitialAvatarState()
     }
 
+    @Suppress("TooGenericExceptionCaught")
     fun loadInitialAvatarState() {
         viewModelScope.launch {
+            initialPictureLoadingState = InitialPictureLoadingState.Loading
             try {
                 dataStore.avatarAssetId.first()?.apply {
                     val qualifiedAsset = qualifiedIdMapper.fromStringToQualifiedID(this)
                     val avatarRawPath = (getAvatarAsset(assetKey = qualifiedAsset) as PublicAssetResult.Success).assetPath
-                    currentAvatarUri = avatarImageManager.getWritableAvatarUri(avatarRawPath)
-
-                    pictureState = PictureState.Initial(currentAvatarUri)
+                    val currentAvatarUri = avatarImageManager.getWritableAvatarUri(avatarRawPath)
+                    initialPictureLoadingState = InitialPictureLoadingState.Loaded(currentAvatarUri)
+                    if (pictureState is PictureState.Empty) {
+                        pictureState = PictureState.Initial(currentAvatarUri)
+                    }
                 }
-            } catch (e: ClassCastException) {
+            } catch (e: Exception) {
                 appLogger.e("There was an error loading the user avatar", e)
+                initialPictureLoadingState = InitialPictureLoadingState.None
             }
         }
     }
@@ -109,7 +114,6 @@ class AvatarPickerViewModel @Inject constructor(
 
             val avatarPath = defaultAvatarPath
             val imageDataSize = imgUri.toByteArray(appContext, dispatchers).size.toLong()
-
             when (val result = uploadUserAvatar(avatarPath, imageDataSize)) {
                 is UploadAvatarResult.Success -> {
                     dataStore.updateUserAvatarAssetId(result.userAssetId.toString())
@@ -120,7 +124,12 @@ class AvatarPickerViewModel @Inject constructor(
                         is NetworkFailure.NoNetworkConnection -> showInfoMessage(InfoMessageType.NoNetworkError)
                         else -> showInfoMessage(InfoMessageType.UploadAvatarError)
                     }
-                    pictureState = PictureState.Initial(currentAvatarUri)
+                    with(initialPictureLoadingState) {
+                        pictureState = when (this) {
+                            is InitialPictureLoadingState.Loaded -> PictureState.Initial(avatarUri)
+                            else -> PictureState.Empty
+                        }
+                    }
                 }
             }
         }
@@ -131,15 +140,22 @@ class AvatarPickerViewModel @Inject constructor(
     }
 
     @Stable
+    private sealed class InitialPictureLoadingState {
+        data object None : InitialPictureLoadingState()
+        data object Loading : InitialPictureLoadingState()
+        data class Loaded(val avatarUri: Uri) : InitialPictureLoadingState()
+    }
+
+    @Stable
     sealed class PictureState(open val avatarUri: Uri) {
         data class Uploading(override val avatarUri: Uri) : PictureState(avatarUri)
         data class Initial(override val avatarUri: Uri) : PictureState(avatarUri)
         data class Picked(override val avatarUri: Uri) : PictureState(avatarUri)
-        object Empty : PictureState("".toUri())
+        data object Empty : PictureState("".toUri())
     }
 
     sealed class InfoMessageType(override val uiText: UIText) : SnackBarMessage {
-        object UploadAvatarError : InfoMessageType(UIText.StringResource(R.string.error_uploading_user_avatar))
-        object NoNetworkError : InfoMessageType(UIText.StringResource(R.string.error_no_network_message))
+        data object UploadAvatarError : InfoMessageType(UIText.StringResource(R.string.error_uploading_user_avatar))
+        data object NoNetworkError : InfoMessageType(UIText.StringResource(R.string.error_no_network_message))
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5965" title="WPB-5965" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5965</a>  [Android] crash in AvatarPickerViewModel
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2673

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

It's one of the most frequently occurring crashes right now which happens during uploading new avatar.

### Causes (Optional)

Sometimes, before the current avatar is downloaded, the  is not yet initialized, so when there's an error when uploading a new one, it crashes because it cannot set the current one back on the UI. 
Also happened when someone closed the screen while the avatar was still being uploaded - a nice to have would be an option to upload the avatar in the background.

### Solutions

Provide a state of loading the current avatar and use its url when it's already downloaded, otherwise set it as .
The same can happen the other way around - when current avatar is downloaded later than the new one is uploaded, then it will not be wrongly overwritten. 

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Have an account that doesn't have any avatar set, open the screen to update the avatar, turn off the network, choose an image and click confirm to try to upload a new avatar. Uploading will fail so the snackbar message should appear but the app shouldn't crash.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .