### PR TITLE
fix: add fully qualified handle for external results (WPB-6256)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/ContactMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ContactMapper.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.data.publicuser.model.UserSearchDetails
 import com.wire.kalium.logic.data.service.ServiceDetails
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.OtherUser
+import com.wire.kalium.logic.data.user.type.UserType
 import javax.inject.Inject
 
 class ContactMapper
@@ -76,13 +77,23 @@ class ContactMapper
                 id = id.value,
                 domain = id.domain,
                 name = name ?: String.EMPTY,
-                label = handle ?: String.EMPTY,
+                label = mapUserHandle(user),
                 avatarData = UserAvatarData(
                     asset = previewAssetId?.let { ImageAsset.UserAvatarAsset(wireSessionImageLoader, it) }
                 ),
                 membership = userTypeMapper.toMembership(type),
                 connectionState = connectionStatus
             )
+        }
+    }
+
+    /**
+     * Adds the fully qualified handle to the contact label in case of federated users.
+     */
+    private fun mapUserHandle(user: UserSearchDetails): String {
+        return when (user.type) {
+            UserType.FEDERATED -> "${user.handle}@${user.id.domain}"
+            else -> user.handle ?: String.EMPTY
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6256" title="WPB-6256" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6256</a>  [Android] When searching for another user from another domain, his domain is not shown in search result anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry pick from the original PR: 
- #2676

---- 

 ⚠️ Conflicts during cherry-pick:


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Visual regression in search results.

### Causes (Optional)

Changes introduced recently to the search feature, to make it more reliable and handle big teams.

### Solutions

Display fully qualified handle for external search results.

### Testing

#### How to Test

Manually tested, login in a federated backend, your results should display the domain for not connected users and
highlight should be available too.


### Attachments (Optional)

**Before**
<img width=371 alt=1dc1961b-58f3-4e82-a170-d5d504f0635e src=https://github.com/wireapp/wire-android/assets/5806454/7708c2e2-f3bb-4a02-b7ca-ac73c304e196>

**After**
Check it out in the comment section of the jira [ticket](https://wearezeta.atlassian.net/browse/WPB-6256?focusedCommentId=121704)

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .