### PR TITLE
fix(e2ei): remove E2EI shield from remove device screen (WPB-6519)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
@@ -73,6 +73,7 @@ fun DeviceItem(
     device: Device,
     placeholder: Boolean,
     shouldShowVerifyLabel: Boolean,
+    isCurrentClient: Boolean = false,
     background: Color? = null,
     icon: @Composable (() -> Unit),
     isWholeItemClickable: Boolean = false,
@@ -85,7 +86,8 @@ fun DeviceItem(
         icon = icon,
         onClickAction = onClickAction,
         isWholeItemClickable = isWholeItemClickable,
-        shouldShowVerifyLabel = shouldShowVerifyLabel
+        shouldShowVerifyLabel = shouldShowVerifyLabel,
+        isCurrentClient = isCurrentClient
     )
 }
 
@@ -97,7 +99,8 @@ private fun DeviceItemContent(
     icon: @Composable (() -> Unit),
     onClickAction: ((Device) -> Unit)?,
     isWholeItemClickable: Boolean,
-    shouldShowVerifyLabel: Boolean
+    shouldShowVerifyLabel: Boolean,
+    isCurrentClient: Boolean
 ) {
     Row(
         verticalAlignment = Alignment.Top,
@@ -123,7 +126,7 @@ private fun DeviceItemContent(
                 modifier = Modifier
                     .padding(start = MaterialTheme.wireDimensions.removeDeviceItemPadding)
                     .weight(1f)
-            ) { DeviceItemTexts(device, placeholder, shouldShowVerifyLabel) }
+            ) { DeviceItemTexts(device, placeholder, shouldShowVerifyLabel, isCurrentClient) }
         }
         if (!placeholder) {
             if (onClickAction != null && !isWholeItemClickable) {
@@ -154,6 +157,7 @@ private fun DeviceItemTexts(
     device: Device,
     placeholder: Boolean,
     shouldShowVerifyLabel: Boolean,
+    isCurrentClient: Boolean = false,
     isDebug: Boolean = BuildConfig.DEBUG
 ) {
     val displayZombieIndicator = remember {
@@ -173,10 +177,10 @@ private fun DeviceItemTexts(
                 .wrapContentWidth()
                 .shimmerPlaceholder(visible = placeholder)
         )
-        MLSVerificationIcon(device.e2eiCertificateStatus)
         if (shouldShowVerifyLabel) {
+            MLSVerificationIcon(device.e2eiCertificateStatus)
             Spacer(modifier = Modifier.width(MaterialTheme.wireDimensions.spacing8x))
-            if (device.isVerifiedProteus) ProteusVerifiedIcon(
+            if (device.isVerifiedProteus && !isCurrentClient) ProteusVerifiedIcon(
                 Modifier
                     .wrapContentWidth()
                     .align(Alignment.CenterVertically))
@@ -251,6 +255,7 @@ fun PreviewDeviceItemWithActionIcon() {
             device = Device(name = UIText.DynamicString("name"), isVerifiedProteus = true),
             placeholder = false,
             shouldShowVerifyLabel = true,
+            isCurrentClient = true,
             background = null,
             { Icon(painter = painterResource(id = R.drawable.ic_remove), contentDescription = "") }
         ) {}

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesScreen.kt
@@ -90,17 +90,20 @@ fun SelfDevicesScreenContent(
                     false -> {
                         state.currentDevice?.let { currentDevice ->
                             folderDeviceItems(
-                                context.getString(R.string.current_device_label),
-                                listOf(currentDevice),
-                                false,
-                                onDeviceClick
+                                header = context.getString(R.string.current_device_label),
+                                items = listOf(currentDevice),
+                                shouldShowVerifyLabel = true,
+                                isCurrentClient = true,
+                                onDeviceClick = onDeviceClick,
+
                             )
                         }
                         folderDeviceItems(
-                            context.getString(R.string.other_devices_label),
-                            state.deviceList,
-                            true,
-                            onDeviceClick
+                            header = context.getString(R.string.other_devices_label),
+                            items = state.deviceList,
+                            shouldShowVerifyLabel = true,
+                            isCurrentClient = false,
+                            onDeviceClick = onDeviceClick
                         )
                     }
                 }
@@ -113,6 +116,7 @@ private fun LazyListScope.folderDeviceItems(
     header: String,
     items: List<Device>,
     shouldShowVerifyLabel: Boolean,
+    isCurrentClient: Boolean,
     onDeviceClick: (Device) -> Unit = {}
 ) {
     folderWithElements(
@@ -132,7 +136,8 @@ private fun LazyListScope.folderDeviceItems(
             onClickAction = onDeviceClick,
             icon = Icons.Filled.ChevronRight.Icon(),
             isWholeItemClickable = true,
-            shouldShowVerifyLabel = shouldShowVerifyLabel
+            shouldShowVerifyLabel = shouldShowVerifyLabel,
+            isCurrentClient = isCurrentClient
         )
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6519" title="WPB-6519" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6519</a>  [Android] Remove e2ei shields in remove-devices screen in login flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry pick from the original PR: 
- #2685

---- 

 ⚠️ Conflicts during cherry-pick:


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
During the registration, if the user has too many clients registered, in the remove device screen we shouldn't show the E2EI shield.



#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test
Have an account with too many clients, during the registration the E2EI shield shouldn't be visible in the screen.

### Attachments (Optional)
After:
![screenshot-1707744030013](https://github.com/wireapp/wire-android/assets/9512842/62165c82-a8c5-4f9f-b70a-b719e4621b00)

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .