### PR TITLE
fix: NotificationChannelGroup crash (WPB-6233)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -112,7 +112,6 @@ class GlobalObserversManager @Inject constructor(
             val callback: LogoutCallback = object : LogoutCallback {
                 override suspend fun invoke(userId: UserId, reason: LogoutReason) {
                     notificationManager.stopObservingOnLogout(userId)
-                    notificationChannelsManager.deleteChannelGroup(userId)
                     if (reason != LogoutReason.SELF_SOFT_LOGOUT) {
                         userDataStoreProvider.getOrCreate(userId).clear()
                     }

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
@@ -18,7 +18,6 @@
 
 package com.wire.android.notification
 
-import android.app.NotificationChannelGroup
 import android.content.ContentResolver
 import android.content.Context
 import android.media.AudioAttributes
@@ -26,9 +25,9 @@ import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationChannelGroupCompat
 import androidx.core.app.NotificationManagerCompat
 import com.wire.android.appLogger
-import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserId
 import javax.inject.Inject
@@ -53,7 +52,10 @@ class NotificationChannelsManager @Inject constructor(
         )
     }
 
-    // Creating user-specific NotificationChannels for each user, they will be grouped by User in App Settings.
+    /**
+     *  Creating user-specific NotificationChannels for each user, they will be grouped by User in App Settings.
+     *  And removing the ChannelGroups (with all the channels in it) that are not belongs to any user in a list (user logged out e.x.)
+     */
     fun createUserNotificationChannels(allUsers: List<SelfUser>) {
         appLogger.i("$TAG: creating all the notification channels for ${allUsers.size} users")
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
@@ -68,15 +70,23 @@ class NotificationChannelsManager @Inject constructor(
 
         // OngoingCall is not user specific channel, but common for all users.
         createOngoingNotificationChannel()
+
+        deleteRedundantChannelGroups(allUsers)
     }
 
     /**
-     * Deletes NotificationChanelGroup (and all NotificationChannels that belongs to it) for a specific User.
-     * Use it on logout.
+     * Deletes NotificationChanelGroup (and all NotificationChannels that belongs to it)
+     * for the users that are not in [activeUsers] list.
      */
-    fun deleteChannelGroup(userId: UserId) {
-        appLogger.i("$TAG: deleting notification channels for ${userId.toString().obfuscateId()} user")
-        notificationManagerCompat.deleteNotificationChannelGroup(NotificationConstants.getChanelGroupIdForUser(userId))
+    private fun deleteRedundantChannelGroups(activeUsers: List<SelfUser>) {
+        val groupsToKeep = activeUsers.map { NotificationConstants.getChanelGroupIdForUser(it.id) }
+
+        notificationManagerCompat.notificationChannelGroups
+            .filter { group -> groupsToKeep.none { it == group.id } }
+            .forEach { group ->
+                appLogger.i("$TAG: deleting notification channels for ${group.name} group")
+                notificationManagerCompat.deleteNotificationChannelGroup(group.id)
+            }
     }
 
     /**
@@ -85,10 +95,9 @@ class NotificationChannelsManager @Inject constructor(
     @RequiresApi(Build.VERSION_CODES.O)
     private fun createNotificationChannelGroup(userId: UserId, userName: String): String {
         val chanelGroupId = NotificationConstants.getChanelGroupIdForUser(userId)
-        val channelGroup = NotificationChannelGroup(
-            chanelGroupId,
-            getChanelGroupNameForUser(userName)
-        )
+        val channelGroup = NotificationChannelGroupCompat.Builder(chanelGroupId)
+            .setName(getChanelGroupNameForUser(userName))
+            .build()
         notificationManagerCompat.createNotificationChannelGroup(channelGroup)
         return chanelGroupId
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModel.kt
@@ -201,7 +201,6 @@ class ForgotLockScreenViewModel @Inject constructor(
     // TODO: we should have a dedicated manager to perform these required actions in AR after every LogoutUseCase call
     private suspend fun hardLogoutAccount(userId: UserId) {
         notificationManager.stopObservingOnLogout(userId)
-        notificationChannelsManager.deleteChannelGroup(userId)
         coreLogic.getSessionScope(userId).logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
         userDataStoreProvider.getOrCreate(userId).clear()
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -239,7 +239,6 @@ class SelfUserProfileViewModel @Inject constructor(
             }
 
             notificationManager.stopObservingOnLogout(selfUserId)
-            notificationChannelsManager.deleteChannelGroup(selfUserId)
             accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount).also {
                 if (it == SwitchAccountResult.NoOtherAccountToSwitch) {
                     globalDataStore.clearAppLockPasscode()

--- a/app/src/test/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModelTest.kt
@@ -159,7 +159,6 @@ class ForgotLockScreenViewModelTest {
         val logoutActionsCalledExactly = if (userLogoutActionsCalled) 1 else 0
         coVerify(exactly = logoutActionsCalledExactly) { logoutUseCase(any(), any()) }
         coVerify(exactly = logoutActionsCalledExactly) { notificationManager.stopObservingOnLogout(any()) }
-        coVerify(exactly = logoutActionsCalledExactly) { notificationChannelsManager.deleteChannelGroup(any()) }
         coVerify(exactly = logoutActionsCalledExactly) { userDataStore.clear() }
     }
     private fun testLoggingOut(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6233" title="WPB-6233" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6233</a>  [Android] Notification playstore crash with createNotificationChannel
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2687

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

crash:
https://play.google.com/console/u/2/developers/7098984309886892484/app/4973241010395499500/vitals/crashes/cb7ccba8c13d0a497df6edf45962bb4f/details?days=7&isUserPerceived=true

### Causes (Optional)

Logs says that app is trying to create a NotifcationChannel in a NotifcationChannelGroup that doesn't exist. This looks strange as we create Group first and only after it create channels in that group. 
So it's hard to reproduce the crash. 

From the logs in DataDog found out that at least some part of the crashes happens after logout. 
AND deleting the NotifcationChannelGroup is called from a few places (basically on logout) and launched in a separate CoroutineScope.

So there is a theory that when user logs out,  gets invalid data first (list of users with logged out user) and after some time - valid data. This makes the app create notification group and channels for the user who is logged out. And somewhere during this in another CoroutineScope   is called. 

### Solutions

Move calling  into the same CoroutineScope to escape such conflicts. 
For that update   to not just create Groups and Channels for active users, but also remove the Groups and Channels that don't belong to any active user. 

