### PR TITLE
fix: serverConfig and notification crashes right after user becomes invalid [WPB-6552] [WPB-6233]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -91,14 +91,26 @@ class GlobalObserversManager @Inject constructor(
             }
 
         coreLogic.getGlobalScope().observeValidAccounts()
+            .combine(persistentStatusesFlow) { list, persistentStatuses ->
+                val persistentStatusesMap = persistentStatuses.associate { it.userId to it.isPersistentWebSocketEnabled }
+                /*
+                  Intersect both lists as they can be slightly out of sync because both lists can be updated at slightly different times.
+                  When user is logged out, at this time one of them can still contain this invalid user - make sure that it's ignored.
+                  When user is logged in, at this time one of them can still not contain this new user - ignore for now,
+                  the user will be handled correctly in the next iteration when the second list becomes updated as well.
+                 */
+                list.map { (selfUser, _) -> selfUser }
+                    .filter { persistentStatusesMap.containsKey(it.id) }
+                    .map { it to persistentStatusesMap.getValue(it.id) }
+            }
             .distinctUntilChanged()
-            .combine(persistentStatusesFlow, ::Pair)
-            .collect { (list, persistentStatuses) ->
-                notificationChannelsManager.createUserNotificationChannels(list.map { it.first })
+            .collectLatest {
+                // create notification channels for all valid users
+                notificationChannelsManager.createUserNotificationChannels(it.map { it.first })
 
-                list.map { it.first.id }
-                    // do not observe notifications for users with PersistentWebSocketEnabled, it will be done in PersistentWebSocketService
-                    .filter { userId -> persistentStatuses.none { it.userId == userId && it.isPersistentWebSocketEnabled } }
+                // do not observe notifications for users with PersistentWebSocketEnabled, it will be done in PersistentWebSocketService
+                it.filter { (_, isPersistentWebSocketEnabled) -> !isPersistentWebSocketEnabled }
+                    .map { (selfUser, _) -> selfUser.id }
                     .run {
                         notificationManager.observeNotificationsAndCallsWhileRunning(this, scope)
                     }

--- a/app/src/main/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCase.kt
@@ -37,12 +37,8 @@ class ObserveAppLockConfigUseCase @Inject constructor(
 ) {
     operator fun invoke(): Flow<AppLockConfig> = channelFlow {
         coreLogic.getGlobalScope().session.currentSessionFlow().collectLatest { sessionResult ->
-            when (sessionResult) {
-                is CurrentSessionResult.Failure -> {
-                    send(AppLockConfig.Disabled(DEFAULT_APP_LOCK_TIMEOUT))
-                }
-
-                is CurrentSessionResult.Success -> {
+            when {
+                sessionResult is CurrentSessionResult.Success && sessionResult.accountInfo.isValid() -> {
                     val userId = sessionResult.accountInfo.userId
                     val appLockTeamFeatureConfigFlow =
                         coreLogic.getSessionScope(userId).appLockTeamFeatureConfigObserver
@@ -66,6 +62,10 @@ class ObserveAppLockConfigUseCase @Inject constructor(
                     }.collectLatest {
                         send(it)
                     }
+                }
+
+                else -> {
+                    send(AppLockConfig.Disabled(DEFAULT_APP_LOCK_TIMEOUT))
                 }
             }
         }

--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -146,6 +146,23 @@ class GlobalObserversManagerTest {
         coVerify(exactly = 0) { arrangement.messageScope.deleteEphemeralMessageEndDate() }
     }
 
+    @Test
+    fun `given validAccounts and persistentStatuses are out of sync, when setting up notifications, then ignore invalid users`() {
+        val validAccountsList = listOf(TestUser.SELF_USER)
+        val persistentStatusesList = listOf(
+            PersistentWebSocketStatus(TestUser.SELF_USER.id, false),
+            PersistentWebSocketStatus(TestUser.USER_ID.copy(value = "something else"), true)
+        )
+        val (arrangement, manager) = Arrangement()
+            .withValidAccounts(validAccountsList.map { it to null })
+            .withPersistentWebSocketConnectionStatuses(persistentStatusesList)
+            .arrange()
+        manager.observe()
+        coVerify(exactly = 1) {
+            arrangement.notificationChannelsManager.createUserNotificationChannels(listOf(TestUser.SELF_USER))
+        }
+    }
+
     private class Arrangement {
 
         @MockK

--- a/app/src/test/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCaseTest.kt
@@ -22,6 +22,7 @@ import com.wire.android.datastore.GlobalDataStore
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.AppLockTeamConfig
 import com.wire.kalium.logic.data.auth.AccountInfo
+import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.applock.AppLockTeamFeatureConfigObserver
@@ -42,6 +43,22 @@ class ObserveAppLockConfigUseCaseTest {
     fun givenNoValidSession_whenObservingAppLock_thenSendDisabledStatus() = runTest {
         val (_, useCase) = Arrangement()
             .withNonValidSession()
+            .arrange()
+
+        val result = useCase.invoke()
+
+        result.test {
+            val appLockStatus = awaitItem()
+
+            assertEquals(AppLockConfig.Disabled(timeout), appLockStatus)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenInvalidSession_whenObservingAppLock_thenSendDisabledStatus() = runTest {
+        val (_, useCase) = Arrangement()
+            .withInvalidSession()
             .arrange()
 
         val result = useCase.invoke()
@@ -142,6 +159,11 @@ class ObserveAppLockConfigUseCaseTest {
                     flowOf(CurrentSessionResult.Failure.SessionNotFound)
         }
 
+        fun withInvalidSession() = apply {
+            coEvery { coreLogic.getGlobalScope().session.currentSessionFlow() } returns
+                    flowOf(CurrentSessionResult.Success(accountInfoInvalid))
+        }
+
         fun withValidSession() = apply {
             coEvery { coreLogic.getGlobalScope().session.currentSessionFlow() } returns
                     flowOf(CurrentSessionResult.Success(accountInfo))
@@ -177,7 +199,9 @@ class ObserveAppLockConfigUseCaseTest {
     }
 
     companion object {
-        private val accountInfo = AccountInfo.Valid(UserId("userId", "domain"))
+        private val userId = UserId("userId", "domain")
+        private val accountInfo = AccountInfo.Valid(userId)
+        private val accountInfoInvalid = AccountInfo.Invalid(userId, LogoutReason.DELETED_ACCOUNT)
         private val timeout = 60.seconds
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6552" title="WPB-6552" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6552</a>  [Android] missing serverConfig crashes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2684

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

One of the top crashes currently on the Play Store is still the one related to the missing serverConfig (I counted 6 different instances with around 100 occurrences in last month which makes it second most occurring crash).
The top crash with 124 occurrences is the one about creating notification channels which is caused by the same thing.

### Causes (Optional)

When setting up notifications, we observe two lists and combine the results to have all the required data:  and  (which returns valid accounts and its persistent status flags). When list of accounts is being updated (for instance when someone logs out) then both lists can be updated at a slightly different time so when we combine them both, one of them can still contain this invalid account. There's  operator used which means it'll be calculated when one of the lists is updated and then again when second list is updated, but this first occurrence when both lists are out of sync is very dangerous, because we can create notification channel group or try to access user session scope which is already destroyed resulting in crashes.

### Solutions

Intersect both lists when setting up notifications so that we don't miss any data and don't do anything for the updated accounts until both lists are updated.
When observing for notifications, double check to make sure that this user is still valid so that it doesn't try to get the user session scope resulting in a crash.
In other places where this crash is also happening ( and , instead of just checking if  is , check as well if the user is valid before accessing its session scope.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

It's not 100% reproducible, but according to logs these crashes happen when the user logs out.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .