### PR TITLE
fix: message background highlight colors [WPB-5940]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -147,7 +147,7 @@ fun MessageItem(
         }
 
         val colorAnimation = remember { Animatable(Color.Transparent) }
-        val highlightColor = colorsScheme().selectedMessageHighlightColor
+        val highlightColor = colorsScheme().primaryVariant
         val transparentColor = colorsScheme().primary.copy(alpha = 0F)
         LaunchedEffect(isSelectedMessage) {
             if (isSelectedMessage) {

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -102,7 +102,6 @@ data class WireColorScheme(
     val onScrollToBottomButtonColor: Color,
     val validE2eiStatusColor: Color,
     val mlsVerificationTextColor: Color,
-    val selectedMessageHighlightColor: Color
 ) {
     fun toColorScheme(): ColorScheme = ColorScheme(
         primary = primary,
@@ -237,7 +236,6 @@ private val LightWireColorScheme = WireColorScheme(
     onScrollToBottomButtonColor = Color.White,
     validE2eiStatusColor = WireColorPalette.LightGreen550,
     mlsVerificationTextColor = WireColorPalette.DarkGreen700,
-    selectedMessageHighlightColor = WireColorPalette.DarkBlue50
 )
 
 // Dark WireColorScheme
@@ -346,7 +344,6 @@ private val DarkWireColorScheme = WireColorScheme(
     onScrollToBottomButtonColor = Color.Black,
     validE2eiStatusColor = WireColorPalette.DarkGreen500,
     mlsVerificationTextColor = WireColorPalette.DarkGreen700,
-    selectedMessageHighlightColor = WireColorPalette.DarkBlue50
 )
 
 @PackagePrivate


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5940" title="WPB-5940" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5940</a>  [Android] When searching for a message in dark mode, search result is highlighted in very bright color
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In previous PR text highlight colors were fixed but background colors when the message is highlighted are also wrong.

### Solutions

Use `primaryVariant` for that as specified in the documentation and confirmed by Wolfgang, so there's no need to create a separate color scheme type. `selectedMessageHighlightColor` had wrong colors anyway.

### Testing

#### How to Test

Search for a message and click on it.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| ![highlight_message_before](https://github.com/wireapp/wire-android/assets/30429749/95358218-672f-4106-aa19-3ad230c0a56d) | ![highlight_message_after](https://github.com/wireapp/wire-android/assets/30429749/303a4f1d-5f2e-4d28-9299-5385d750a03c) |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
