### PR TITLE
fix: welcome screen large screen [WPB-6427]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -165,13 +165,7 @@ private fun WelcomeContent(
                 ServerTitle(serverLinks = state, modifier = Modifier.padding(top = dimensions().spacing16x))
             }
 
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-                modifier = Modifier.weight(1f, true)
-            ) {
-                WelcomeCarousel()
-            }
+            WelcomeCarousel(modifier = Modifier.weight(1f, true))
 
             Column(
                 modifier = Modifier
@@ -230,7 +224,7 @@ private fun WelcomeContent(
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun WelcomeCarousel() {
+private fun WelcomeCarousel(modifier: Modifier = Modifier) {
     val delay = integerResource(id = R.integer.welcome_carousel_item_time_ms)
     val icons: List<Int> = typedArrayResource(id = R.array.welcome_carousel_icons).drawableResIdList()
     val texts: List<String> = stringArrayResource(id = R.array.welcome_carousel_texts).toList()
@@ -249,7 +243,7 @@ private fun WelcomeCarousel() {
     CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
         HorizontalPager(
             state = pagerState,
-            modifier = Modifier.fillMaxWidth()
+            modifier = modifier.fillMaxWidth()
         ) { page ->
             val (pageIconResId, pageText) = circularItemsList[page]
             WelcomeCarouselItem(pageIconResId = pageIconResId, pageText = pageText)
@@ -300,6 +294,7 @@ private fun WelcomeCarouselItem(pageIconResId: Int, pageText: String) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
+        modifier = Modifier.fillMaxWidth()
     ) {
         Image(
             painter = painterResource(id = pageIconResId),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6427" title="WPB-6427" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6427</a>  [Android Tablet] Welcome screen not aligned properly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2690

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixed issue that pager content was not centered on large screens

![Screenshot_1707809141](https://github.com/wireapp/wire-android/assets/13151239/578a5f60-0fda-4468-9361-ba9354f4e5b7)
