### PR TITLE
fix: long click on deleted message (WPB-6290)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -172,7 +172,7 @@ fun MessageItem(
                 },
                     onLongClick = remember(message) {
                         {
-                            if (!isContentClickable) {
+                            if (!isContentClickable && !message.isDeleted) {
                                 onLongClicked(message)
                             }
                         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6290" title="WPB-6290" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6290</a>  [Android]  I see reply, delete, reactions and copy options on a deleted message options
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

…d as deleted

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When long clicking on a deleted message, the context menu would show.

### Causes (Optional)

Not checking if message is deleted before showing context menu.

### Solutions

Add verification if message is marked as deleted, then do not show context menu.

### Dependencies (Optional)

### Testing

#### How to Test

- Send a message
- deleted the message for everyone
- long click the deleted message
- context menu should not show up.
