### PR TITLE
fix: 2FA support dark mode

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailVerificationCodeScreen.kt
@@ -38,10 +38,12 @@ import com.wire.android.R
 import com.wire.android.ui.authentication.verificationcode.VerificationCode
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeState
 import com.wire.android.ui.common.Logo
+import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.textfield.CodeFieldValue
 import com.wire.android.ui.common.typography
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 
 @Composable
@@ -111,6 +113,7 @@ private fun MainContent(
 ) {
     Text(
         text = UIText.StringResource(R.string.second_factor_authentication_title).asString(),
+        color = colorsScheme().onBackground,
         style = typography().title01,
         textAlign = TextAlign.Start
     )
@@ -120,6 +123,7 @@ private fun MainContent(
             R.string.second_factor_authentication_instructions_label,
             codeState.emailUsed
         ).asString(),
+        color = colorsScheme().onBackground,
         style = typography().body01,
         textAlign = TextAlign.Start
     )
@@ -135,6 +139,7 @@ private fun MainContent(
 }
 
 @Preview(showBackground = true)
+@PreviewMultipleThemes
 @Composable
 internal fun LoginEmailVerificationCodeScreenPreview() = LoginEmailVerificationCodeContent(
     VerificationCodeState(


### PR DESCRIPTION
# What's new in this PR?

### Issues

Textst in 2FA screen doesn't adopt to DarkMode

### Causes (Optional)

wasn't implemented 

### Solutions

implement it 

### Attachments (Optional)

<img width="285" alt="Screenshot 2024-02-13 at 14 22 38" src="https://github.com/wireapp/wire-android/assets/6539347/59005c10-3a94-48a1-a4d2-2cef93a2bb3b">
