### PR TITLE
fix(e2ei): remove E2EI shield and buttons if it's disabled on your team (WPB-6520)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -263,6 +263,11 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
+    fun provideIsE2EIEnabledUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
+        coreLogic.getSessionScope(currentAccount).isE2EIEnabled
+
+    @ViewModelScoped
+    @Provides
     fun provideIsFileSharingEnabledUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).isFileSharingEnabled
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
@@ -74,6 +74,7 @@ fun DeviceItem(
     placeholder: Boolean,
     shouldShowVerifyLabel: Boolean,
     isCurrentClient: Boolean = false,
+    shouldShowE2EIInfo: Boolean = false,
     background: Color? = null,
     icon: @Composable (() -> Unit),
     isWholeItemClickable: Boolean = false,
@@ -87,7 +88,8 @@ fun DeviceItem(
         onClickAction = onClickAction,
         isWholeItemClickable = isWholeItemClickable,
         shouldShowVerifyLabel = shouldShowVerifyLabel,
-        isCurrentClient = isCurrentClient
+        isCurrentClient = isCurrentClient,
+        shouldShowE2EIInfo = shouldShowE2EIInfo
     )
 }
 
@@ -100,7 +102,8 @@ private fun DeviceItemContent(
     onClickAction: ((Device) -> Unit)?,
     isWholeItemClickable: Boolean,
     shouldShowVerifyLabel: Boolean,
-    isCurrentClient: Boolean
+    isCurrentClient: Boolean,
+    shouldShowE2EIInfo: Boolean
 ) {
     Row(
         verticalAlignment = Alignment.Top,
@@ -126,7 +129,7 @@ private fun DeviceItemContent(
                 modifier = Modifier
                     .padding(start = MaterialTheme.wireDimensions.removeDeviceItemPadding)
                     .weight(1f)
-            ) { DeviceItemTexts(device, placeholder, shouldShowVerifyLabel, isCurrentClient) }
+            ) { DeviceItemTexts(device, placeholder, shouldShowVerifyLabel, isCurrentClient, shouldShowE2EIInfo) }
         }
         if (!placeholder) {
             if (onClickAction != null && !isWholeItemClickable) {
@@ -158,6 +161,7 @@ private fun DeviceItemTexts(
     placeholder: Boolean,
     shouldShowVerifyLabel: Boolean,
     isCurrentClient: Boolean = false,
+    shouldShowE2EIInfo: Boolean = false,
     isDebug: Boolean = BuildConfig.DEBUG
 ) {
     val displayZombieIndicator = remember {
@@ -178,7 +182,9 @@ private fun DeviceItemTexts(
                 .shimmerPlaceholder(visible = placeholder)
         )
         if (shouldShowVerifyLabel) {
-            MLSVerificationIcon(device.e2eiCertificateStatus)
+            if (shouldShowE2EIInfo) {
+                MLSVerificationIcon(device.e2eiCertificateStatus)
+            }
             Spacer(modifier = Modifier.width(MaterialTheme.wireDimensions.spacing8x))
             if (device.isVerifiedProteus && !isCurrentClient) ProteusVerifiedIcon(
                 Modifier
@@ -256,6 +262,7 @@ fun PreviewDeviceItemWithActionIcon() {
             placeholder = false,
             shouldShowVerifyLabel = true,
             isCurrentClient = true,
+            shouldShowE2EIInfo = true,
             background = null,
             { Icon(painter = painterResource(id = R.drawable.ic_remove), contentDescription = "") }
         ) {}

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -139,7 +139,7 @@ fun DeviceDetailsContent(
 ) {
     val screenState = rememberConversationScreenState()
     WireScaffold(
-        topBar = { DeviceDetailsTopBar(onNavigateBack, state.device, state.isCurrentDevice) },
+        topBar = { DeviceDetailsTopBar(onNavigateBack, state.device, state.isCurrentDevice, state.isE2EIEnabled) },
         bottomBar = {
             Column(
                 Modifier
@@ -187,17 +187,19 @@ fun DeviceDetailsContent(
                     Divider(color = MaterialTheme.wireColorScheme.background)
                 }
             }
-            item {
-                EndToEndIdentityCertificateItem(
-                    isE2eiCertificateActivated = state.isE2eiCertificateActivated,
-                    certificate = state.e2eiCertificate,
-                    isCurrentDevice = state.isCurrentDevice,
-                    isLoadingCertificate = state.isLoadingCertificate,
-                    enrollE2eiCertificate = { enrollE2eiCertificate(context) },
-                    updateE2eiCertificate = {},
-                    showCertificate = onNavigateToE2eiCertificateDetailsScreen
-                )
-                Divider(color = colorsScheme().background)
+
+            if (state.isE2EIEnabled) {
+                item {
+                    EndToEndIdentityCertificateItem(
+                        isE2eiCertificateActivated = state.isE2eiCertificateActivated,
+                        certificate = state.e2eiCertificate,
+                        isCurrentDevice = state.isCurrentDevice,
+                        isLoadingCertificate = state.isLoadingCertificate,
+                        enrollE2eiCertificate = { enrollE2eiCertificate(context) },
+                        showCertificate = onNavigateToE2eiCertificateDetailsScreen
+                    )
+                    Divider(color = colorsScheme().background)
+                }
             }
             item {
                 FolderHeader(
@@ -293,7 +295,8 @@ fun DeviceDetailsContent(
 private fun DeviceDetailsTopBar(
     onNavigateBack: () -> Unit,
     device: Device,
-    isCurrentDevice: Boolean
+    isCurrentDevice: Boolean,
+    shouldShowE2EIInfo: Boolean
 ) {
     WireCenterAlignedTopAppBar(
         onNavigationPressed = onNavigateBack,
@@ -306,7 +309,9 @@ private fun DeviceDetailsTopBar(
                     maxLines = 2
                 )
 
-                MLSVerificationIcon(device.e2eiCertificateStatus)
+                if (shouldShowE2EIInfo) {
+                    MLSVerificationIcon(device.e2eiCertificateStatus)
+                }
 
                 if (!isCurrentDevice && device.isVerifiedProteus) {
                     ProteusVerifiedIcon(Modifier.align(Alignment.CenterVertically))

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
@@ -48,6 +48,7 @@ import com.wire.kalium.logic.feature.e2ei.usecase.E2EIEnrollmentResult
 import com.wire.kalium.logic.feature.e2ei.usecase.GetE2EICertificateUseCaseResult
 import com.wire.kalium.logic.feature.e2ei.usecase.GetE2eiCertificateUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
+import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import com.wire.kalium.logic.functional.fold
@@ -68,14 +69,20 @@ class DeviceDetailsViewModel @Inject constructor(
     private val updateClientVerificationStatus: UpdateClientVerificationStatusUseCase,
     private val observeUserInfo: ObserveUserInfoUseCase,
     private val e2eiCertificate: GetE2eiCertificateUseCase,
-    private val enrolE2EICertificateUseCase: GetE2EICertificateUseCase
+    private val enrolE2EICertificateUseCase: GetE2EICertificateUseCase,
+    isE2EIEnabledUseCase: IsE2EIEnabledUseCase
 ) : SavedStateViewModel(savedStateHandle) {
 
     private val deviceDetailsNavArgs: DeviceDetailsNavArgs = savedStateHandle.navArgs()
     private val deviceId: ClientId = deviceDetailsNavArgs.clientId
     private val userId: UserId = deviceDetailsNavArgs.userId
 
-    var state: DeviceDetailsState by mutableStateOf(DeviceDetailsState(isSelfClient = isSelfClient))
+    var state: DeviceDetailsState by mutableStateOf(
+        DeviceDetailsState(
+            isSelfClient = isSelfClient,
+            isE2EIEnabled = isE2EIEnabledUseCase()
+        )
+    )
         private set
 
     init {

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
@@ -50,7 +50,6 @@ fun EndToEndIdentityCertificateItem(
     isCurrentDevice: Boolean,
     isLoadingCertificate: Boolean,
     enrollE2eiCertificate: () -> Unit,
-    updateE2eiCertificate: () -> Unit,
     showCertificate: (String) -> Unit
 ) {
     Column(
@@ -206,7 +205,6 @@ fun PreviewEndToEndIdentityCertificateItem() {
         ),
         isLoadingCertificate = false,
         enrollE2eiCertificate = {},
-        updateE2eiCertificate = {},
         showCertificate = {}
     )
 }
@@ -225,7 +223,6 @@ fun PreviewEndToEndIdentityCertificateSelfItem() {
         ),
         isLoadingCertificate = false,
         enrollE2eiCertificate = {},
-        updateE2eiCertificate = {},
         showCertificate = {}
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesScreen.kt
@@ -94,6 +94,7 @@ fun SelfDevicesScreenContent(
                                 items = listOf(currentDevice),
                                 shouldShowVerifyLabel = true,
                                 isCurrentClient = true,
+                                isE2EIEnabled = state.isE2EIEnabled,
                                 onDeviceClick = onDeviceClick,
 
                             )
@@ -103,6 +104,7 @@ fun SelfDevicesScreenContent(
                             items = state.deviceList,
                             shouldShowVerifyLabel = true,
                             isCurrentClient = false,
+                            isE2EIEnabled = state.isE2EIEnabled,
                             onDeviceClick = onDeviceClick
                         )
                     }
@@ -111,12 +113,13 @@ fun SelfDevicesScreenContent(
         }
     )
 }
-
+@Suppress("LongParameterList")
 private fun LazyListScope.folderDeviceItems(
     header: String,
     items: List<Device>,
     shouldShowVerifyLabel: Boolean,
     isCurrentClient: Boolean,
+    isE2EIEnabled: Boolean,
     onDeviceClick: (Device) -> Unit = {}
 ) {
     folderWithElements(
@@ -137,7 +140,8 @@ private fun LazyListScope.folderDeviceItems(
             icon = Icons.Filled.ChevronRight.Icon(),
             isWholeItemClickable = true,
             shouldShowVerifyLabel = shouldShowVerifyLabel,
-            isCurrentClient = isCurrentClient
+            isCurrentClient = isCurrentClient,
+            shouldShowE2EIInfo = isE2EIEnabled
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModel.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.feature.client.FetchSelfClientsFromRemoteUseCase
 import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
 import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
+import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -43,10 +44,11 @@ class SelfDevicesViewModel @Inject constructor(
     private val observeClientList: ObserveClientsByUserIdUseCase,
     private val currentClientIdUseCase: ObserveCurrentClientIdUseCase,
     private val getUserE2eiCertificates: GetUserE2eiCertificatesUseCase,
+    isE2EIEnabledUseCase: IsE2EIEnabledUseCase
 ) : ViewModel() {
 
     var state: SelfDevicesState by mutableStateOf(
-        SelfDevicesState(deviceList = listOf(), isLoadingClientsList = true, currentDevice = null)
+        SelfDevicesState(deviceList = listOf(), isLoadingClientsList = true, currentDevice = null, isE2EIEnabled = isE2EIEnabledUseCase())
     )
         private set
 

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/DeviceDetailsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/DeviceDetailsState.kt
@@ -36,4 +36,5 @@ data class DeviceDetailsState(
     val isLoadingCertificate: Boolean = false,
     val isE2EICertificateEnrollSuccess: Boolean = false,
     val isE2EICertificateEnrollError: Boolean = false,
+    val isE2EIEnabled: Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/SelfDevicesState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/SelfDevicesState.kt
@@ -23,5 +23,6 @@ import com.wire.android.ui.authentication.devices.model.Device
 data class SelfDevicesState (
     val currentDevice: Device?,
     val deviceList: List<Device>,
-    val isLoadingClientsList: Boolean
+    val isLoadingClientsList: Boolean,
+    val isE2EIEnabled: Boolean = false
 )

--- a/app/src/test/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModelTest.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.logic.feature.client.UpdateClientVerificationStatusUseCas
 import com.wire.kalium.logic.feature.e2ei.usecase.GetE2EICertificateUseCaseResult
 import com.wire.kalium.logic.feature.e2ei.usecase.GetE2eiCertificateUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
+import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import io.mockk.Called
@@ -319,6 +320,9 @@ class DeviceDetailsViewModelTest {
         @MockK(relaxed = true)
         lateinit var onSuccess: () -> Unit
 
+        @MockK
+        lateinit var isE2EIEnabledUseCase: IsE2EIEnabledUseCase
+
         val currentUserId = UserId("currentUserId", "currentUserDomain")
 
         val viewModel by lazy {
@@ -332,7 +336,8 @@ class DeviceDetailsViewModelTest {
                 currentUserId = currentUserId,
                 observeUserInfo = observeUserInfo,
                 e2eiCertificate = getE2eiCertificate,
-                enrolE2EICertificateUseCase = enrolE2EICertificateUseCase
+                enrolE2EICertificateUseCase = enrolE2EICertificateUseCase,
+                isE2EIEnabledUseCase = isE2EIEnabledUseCase
             )
         }
 
@@ -341,6 +346,7 @@ class DeviceDetailsViewModelTest {
             withFingerprintSuccess()
             coEvery { observeUserInfo(any()) } returns flowOf(GetUserInfoResult.Success(TestUser.OTHER_USER, null))
             coEvery { getE2eiCertificate(any()) } returns GetE2EICertificateUseCaseResult.Failure.NotActivated
+            coEvery { isE2EIEnabledUseCase() } returns true
         }
 
         fun withUserRequiresPasswordResult(result: IsPasswordRequiredUseCase.Result = IsPasswordRequiredUseCase.Result.Success(true)) =

--- a/app/src/test/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModelTest.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
 import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.client.SelfClientsResult
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
+import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import io.mockk.coEvery
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK
@@ -70,6 +71,9 @@ class SelfDevicesViewModelTest {
         @MockK
         lateinit var getUserE2eiCertificates: GetUserE2eiCertificatesUseCase
 
+        @MockK
+        lateinit var isE2EIEnabledUseCase: IsE2EIEnabledUseCase
+
         val selfId = UserId("selfId", "domain")
 
         private val viewModel by lazy {
@@ -78,7 +82,8 @@ class SelfDevicesViewModelTest {
                 currentAccountId = selfId,
                 currentClientIdUseCase = currentClientId,
                 fetchSelfClientsFromRemote = fetchSelfClientsFromRemote,
-                getUserE2eiCertificates = getUserE2eiCertificates
+                getUserE2eiCertificates = getUserE2eiCertificates,
+                isE2EIEnabledUseCase = isE2EIEnabledUseCase
             )
         }
 
@@ -95,6 +100,7 @@ class SelfDevicesViewModelTest {
                 )
             )
             coEvery { getUserE2eiCertificates.invoke(any()) } returns mapOf()
+            coEvery { isE2EIEnabledUseCase() } returns true
         }
 
         fun arrange() = this to viewModel


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6520" title="WPB-6520" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6520</a>  [Android] Don't show the e2ei get certificate button if e2ei is disabled 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2695

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
When E2EI is disabled on the user's team, all the info related to e2ei must be hidden.

Needs releases with:

- [ ] [GitHub link to other pull request](https://github.com/wireapp/kalium/pull/2489)

### Testing
Login to the user and if e2ei is disabled, shields and the get certificate on the current device screen shouldn't be visible, and if enable e2ei you should see the data.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .