### PR TITLE
fix: remove browser allow list and skip of https check (WPB-6609)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/e2ei/OAuthUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/e2ei/OAuthUseCase.kt
@@ -89,7 +89,7 @@ class OAuthUseCase(
         }
     }
 
-    fun launchLoginFlow(
+    private fun launchLoginFlow(
         activityResultRegistry: ActivityResultRegistry,
         resultHandler: (OAuthResult) -> Unit
     ) {

--- a/app/src/main/kotlin/com/wire/android/feature/e2ei/OAuthUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/e2ei/OAuthUseCase.kt
@@ -39,8 +39,6 @@ import net.openid.appauth.AuthorizationService
 import net.openid.appauth.AuthorizationServiceConfiguration
 import net.openid.appauth.ClientAuthentication
 import net.openid.appauth.ResponseTypeValues
-import net.openid.appauth.browser.BrowserAllowList
-import net.openid.appauth.browser.VersionedBrowserMatcher
 import org.json.JSONObject
 import java.net.URI
 import java.security.MessageDigest
@@ -60,13 +58,6 @@ class OAuthUseCase(
     private lateinit var authServiceConfig: AuthorizationServiceConfiguration
 
     private var appAuthConfiguration: AppAuthConfiguration = AppAuthConfiguration.Builder()
-        .setBrowserMatcher(
-            BrowserAllowList(
-                VersionedBrowserMatcher.CHROME_CUSTOM_TAB,
-                VersionedBrowserMatcher.SAMSUNG_CUSTOM_TAB
-            )
-        )
-        .setSkipIssuerHttpsCheck(true)
         .build()
 
     init {
@@ -98,7 +89,7 @@ class OAuthUseCase(
         }
     }
 
-    private fun launchLoginFlow(
+    fun launchLoginFlow(
         activityResultRegistry: ActivityResultRegistry,
         resultHandler: (OAuthResult) -> Unit
     ) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6609" title="WPB-6609" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6609</a>  [Android] Crash when returning from IDP login while getting E2EI cert on Graphene OS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When clicking on `Get Certificate` in current device in Devices List, if on Graphene OS or a device that doesn't have Chrome/Samsung/Firefox (most known "default" browsers) it would crash the App for not having/finding the correct browser.

### Causes (Optional)
By having `.setBrowserMatcher` and `BrowserAllowList(..)` it would rule out default phone browsers (such as WebView Browser or Graphene OS default browser) thus leading to a crash.

### Solutions

Remove `setBrowserMatcher` and `BrowserAllowList` and accept any browser/tab available from the device (but still as a tab).
Remove `setSkipIssuerHttpsCheck` as its not needed for testing anymore.

### Testing

#### How to Test

- Run App and Login (on Elna for now)
- Go to Devices Screen and select your active device
- Click on Get Certificate (browser/tab should open you should be able to login)
- App will only crash after login in from the browser/tab as this other issue is been looked up by @mchenani 
