### PR TITLE
fix: MLS degraded dialogs [WPB-6607]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailVerificationCodeScreen.kt
@@ -38,10 +38,12 @@ import com.wire.android.R
 import com.wire.android.ui.authentication.verificationcode.VerificationCode
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeState
 import com.wire.android.ui.common.Logo
+import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.textfield.CodeFieldValue
 import com.wire.android.ui.common.typography
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 
 @Composable
@@ -111,6 +113,7 @@ private fun MainContent(
 ) {
     Text(
         text = UIText.StringResource(R.string.second_factor_authentication_title).asString(),
+        color = colorsScheme().onBackground,
         style = typography().title01,
         textAlign = TextAlign.Start
     )
@@ -120,6 +123,7 @@ private fun MainContent(
             R.string.second_factor_authentication_instructions_label,
             codeState.emailUsed
         ).asString(),
+        color = colorsScheme().onBackground,
         style = typography().body01,
         textAlign = TextAlign.Start
     )
@@ -135,6 +139,7 @@ private fun MainContent(
 }
 
 @Preview(showBackground = true)
+@PreviewMultipleThemes
 @Composable
 internal fun LoginEmailVerificationCodeScreenPreview() = LoginEmailVerificationCodeContent(
     VerificationCodeState(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -281,6 +281,7 @@ fun ConversationScreen(
         ConversationScreenDialogType.VERIFICATION_DEGRADED -> {
             SureAboutCallingInDegradedConversationDialog(
                 callAnyway = {
+                    conversationCallViewModel.onApplyConversationDegradation()
                     startCallIfPossible(
                         conversationCallViewModel,
                         showDialog,
@@ -293,7 +294,6 @@ fun ConversationScreen(
                 },
                 onDialogDismiss = { showDialog.value = ConversationScreenDialogType.NONE }
             )
-            conversationCallViewModel.onConversationDegradedDialogShown()
         }
 
         ConversationScreenDialogType.NONE -> {}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -527,7 +527,10 @@ class MessageComposerViewModel @Inject constructor(
     fun dismissSureAboutSendingMessage() {
         (sureAboutMessagingDialogState as? SureAboutMessagingDialogState.Visible)?.let {
             viewModelScope.launch {
-                it.markAsNotified()
+                if (it is SureAboutMessagingDialogState.Visible.ConversationUnderLegalHold) {
+                    setNotifiedAboutConversationUnderLegalHold(conversationId)
+                }
+                sureAboutMessagingDialogState = SureAboutMessagingDialogState.Hidden
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -525,14 +525,7 @@ class MessageComposerViewModel @Inject constructor(
     }
 
     fun dismissSureAboutSendingMessage() {
-        (sureAboutMessagingDialogState as? SureAboutMessagingDialogState.Visible)?.let {
-            viewModelScope.launch {
-                if (it is SureAboutMessagingDialogState.Visible.ConversationUnderLegalHold) {
-                    setNotifiedAboutConversationUnderLegalHold(conversationId)
-                }
-                sureAboutMessagingDialogState = SureAboutMessagingDialogState.Hidden
-            }
-        }
+        sureAboutMessagingDialogState = SureAboutMessagingDialogState.Hidden
     }
 
     private suspend fun SureAboutMessagingDialogState.markAsNotified() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/ConversationCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/ConversationCallViewModel.kt
@@ -186,7 +186,7 @@ class ConversationCallViewModel @Inject constructor(
     suspend fun isConferenceCallingEnabled(conversationType: Conversation.Type): ConferenceCallingResult =
         isConferenceCallingEnabled.invoke(conversationId, conversationType)
 
-    fun onConversationDegradedDialogShown() {
+    fun onApplyConversationDegradation() {
         viewModelScope.launch {
             setUserInformedAboutVerification.invoke(conversationId)
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6607" title="WPB-6607" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6607</a>  [Android] Show alert message after conversation becomes degraded
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


# What's new in this PR?

### Issues

When a conversation becomes degraded, we must show a message to the user when:

Expected:

they try to send a message
they try to start a call
stop the ongoing call
Actual: None of the above happen!

### Causes (Optional)

Was not implemented on kalium side + this dialog should be shown every time user sends a message AND didn't click "Send anywhere" yet

### Solutions

Update kalium + improve dialog dismiss logic

### Waiting for update kalium 
https://github.com/wireapp/kalium/pull/2501
