### PR TITLE
fix: show connection request with unavailable name [WPB-6247]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -604,7 +604,8 @@ private fun ConversationDetails.toConversationItem(
             ),
             conversationInfo = ConversationInfo(
                 name = otherUser?.name.orEmpty(),
-                membership = userTypeMapper.toMembership(userType)
+                membership = userTypeMapper.toMembership(userType),
+                isSenderUnavailable = otherUser?.isUnavailableUser ?: true
             ),
             lastMessageContent = UILastMessageContent.Connection(
                 connection.status,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -374,6 +374,25 @@ fun PreviewConnectionConversationItemWithSentConnectRequestBadge() {
 
 @Preview
 @Composable
+fun PreviewConnectionConversationItemWithSentConnectRequestBadgeWithUnknownSender() {
+    ConversationItemFactory(
+        conversation = ConversationItem.ConnectionConversation(
+            userAvatarData = UserAvatarData(),
+            conversationId = QualifiedID("value", "domain"),
+            mutedStatus = MutedConversationStatus.OnlyMentionsAndRepliesAllowed,
+            lastMessageContent = null,
+            badgeEventType = BadgeEventType.SentConnectRequest,
+            conversationInfo = ConversationInfo("", isSenderUnavailable = true)
+        ),
+        searchQuery = "",
+        isSelectableItem = false,
+        isChecked = false,
+        {}, {}, {}, {}, {}, {}
+    )
+}
+
+@Preview
+@Composable
 fun PreviewPrivateConversationItemWithBlockedBadge() {
     ConversationItemFactory(
         conversation = ConversationItem.PrivateConversation(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -126,5 +126,6 @@ fun ConversationItem.ConnectionConversation.toUserInfoLabel() =
     UserInfoLabel(
         labelName = conversationInfo.name,
         isLegalHold = isLegalHold,
-        membership = conversationInfo.membership
+        membership = conversationInfo.membership,
+        unavailable = conversationInfo.isSenderUnavailable
     )

--- a/app/src/test/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModelTest.kt
@@ -341,7 +341,7 @@ class DeviceDetailsViewModelTest {
             MockKAnnotations.init(this, relaxUnitFun = true)
             withFingerprintSuccess()
             coEvery { observeUserInfo(any()) } returns flowOf(GetUserInfoResult.Success(TestUser.OTHER_USER, null))
-            coEvery { getE2eiCertificate(any()) } returns GetE2EICertificateUseCaseResult.Failure.NotActivated
+            coEvery { getE2eiCertificate(any()) } returns GetE2EICertificateUseCaseResult.NotActivated
             coEvery { isE2EIEnabledUseCase() } returns true
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6247" title="WPB-6247" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6247</a>  [Android] Incoming connection request from offline backend not displayed when backend is available again
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Connection requests with incomplete user data shows empty text in user name

### Solutions

When user has incomplete data show `name not available` username text

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->

| Before | After |
| ----------- | ------------ |
| ![before](https://github.com/wireapp/wire-android/assets/13151239/dbe2bd11-3cd5-4353-b540-46093060dd7b)  | ![after](https://github.com/wireapp/wire-android/assets/13151239/9cf715bd-ea52-40ea-99dd-16a01df5596c)  |




