### PR TITLE
fix(e2ei): error handling (WPB-6271)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/e2ei/GetE2EICertificateUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/e2ei/GetE2EICertificateUseCase.kt
@@ -20,12 +20,12 @@ package com.wire.android.feature.e2ei
 import android.content.Context
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.extension.getActivity
-import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.E2EIFailure
 import com.wire.kalium.logic.feature.e2ei.usecase.E2EIEnrollmentResult
 import com.wire.kalium.logic.feature.e2ei.usecase.EnrollE2EIUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.left
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
@@ -43,20 +43,18 @@ class GetE2EICertificateUseCase @Inject constructor(
     operator fun invoke(
         context: Context,
         isNewClient: Boolean,
-        enrollmentResultHandler: (Either<CoreFailure, E2EIEnrollmentResult>) -> Unit
+        enrollmentResultHandler: (Either<E2EIFailure, E2EIEnrollmentResult>) -> Unit
     ) {
         this.enrollmentResultHandler = enrollmentResultHandler
         scope.launch {
             enrollE2EI.initialEnrollment(isNewClientRegistration = isNewClient).fold({
                 enrollmentResultHandler(Either.Left(it))
             }, {
-                if (it is E2EIEnrollmentResult.Initialized) {
-                    initialEnrollmentResult = it
-                    OAuthUseCase(context, it.target, it.oAuthClaims, it.oAuthState).launch(
-                        context.getActivity()!!.activityResultRegistry,
-                        ::oAuthResultHandler
-                    )
-                } else enrollmentResultHandler(Either.Right(it))
+                initialEnrollmentResult = it
+                OAuthUseCase(context, it.target, it.oAuthClaims, it.oAuthState).launch(
+                    context.getActivity()!!.activityResultRegistry,
+                    ::oAuthResultHandler
+                )
             })
         }
     }
@@ -75,7 +73,7 @@ class GetE2EICertificateUseCase @Inject constructor(
                 }
 
                 is OAuthUseCase.OAuthResult.Failed -> {
-                    enrollmentResultHandler(Either.Left(E2EIFailure.FailedOAuth(oAuthResult.reason)))
+                    enrollmentResultHandler(E2EIFailure.OAuth(oAuthResult.reason).left())
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -131,12 +131,16 @@ class DebugDataOptionsViewModel
         e2eiCertificateUseCase(context, false) { result ->
             result.fold({
                 state = state.copy(
-                    certificate = (it as E2EIFailure.FailedOAuth).reason, showCertificate = true
+                    certificate = it.toString(), showCertificate = true
                 )
             }, {
-                if (it is E2EIEnrollmentResult.Finalized) {
-                    state = state.copy(
+                state = if (it is E2EIEnrollmentResult.Finalized) {
+                    state.copy(
                         certificate = it.certificate, showCertificate = true
+                    )
+                }else{
+                    state.copy(
+                        certificate = it.toString(), showCertificate = true
                     )
                 }
             })

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -55,7 +55,6 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.getDeviceIdString
 import com.wire.android.util.getGitBuildId
 import com.wire.android.util.ui.PreviewMultipleThemes
-import com.wire.kalium.logic.E2EIFailure
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.debug.DisableEventProcessingUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.E2EIEnrollmentResult
@@ -137,7 +136,7 @@ class DebugDataOptionsViewModel
                     state.copy(
                         certificate = it.certificate, showCertificate = true
                     )
-                }else{
+                } else {
                     state.copy(
                         certificate = it.toString(), showCertificate = true
                     )

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentViewModel.kt
@@ -110,6 +110,11 @@ class E2EIEnrollmentViewModel @Inject constructor(
                         isCertificateEnrollError = false,
                         isLoading = false
                     )
+                }else{
+                    state = state.copy(
+                        isLoading = false,
+                        isCertificateEnrollError = true
+                    )
                 }
             })
         }

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentViewModel.kt
@@ -109,7 +109,7 @@ class E2EIEnrollmentViewModel @Inject constructor(
                         isCertificateEnrollError = false,
                         isLoading = false
                     )
-                }else{
+                } else {
                     state = state.copy(
                         isLoading = false,
                         isCertificateEnrollError = true

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -312,7 +312,7 @@ class FeatureFlagNotificationViewModel @Inject constructor(
                             e2EIRequired = null,
                             e2EIResult = FeatureFlagState.E2EIResult.Success(it.certificate)
                         )
-                    }else {
+                    } else {
                         featureFlagState.copy(
                             isE2EILoading = false,
                             e2EIRequired = null,

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -302,14 +302,14 @@ class FeatureFlagNotificationViewModel @Inject constructor(
                         e2EIResult = FeatureFlagState.E2EIResult.Failure(e2eiRequired)
                     )
                 }, {
-                    if (it is E2EIEnrollmentResult.Finalized) {
-                        featureFlagState = featureFlagState.copy(
+                    featureFlagState = if (it is E2EIEnrollmentResult.Finalized) {
+                        featureFlagState.copy(
                             isE2EILoading = false,
                             e2EIRequired = null,
                             e2EIResult = FeatureFlagState.E2EIResult.Success(it.certificate)
                         )
-                    } else if (it is E2EIEnrollmentResult.Failed) {
-                        featureFlagState = featureFlagState.copy(
+                    }else {
+                        featureFlagState.copy(
                             isE2EILoading = false,
                             e2EIRequired = null,
                             e2EIResult = FeatureFlagState.E2EIResult.Failure(e2eiRequired)

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
@@ -140,7 +140,7 @@ class DeviceDetailsViewModel @Inject constructor(
                 if (it is E2EIEnrollmentResult.Finalized) {
                     getE2eiCertificate()
                     state = state.copy(isE2EICertificateEnrollSuccess = true)
-                } else if (it is E2EIEnrollmentResult.Failed) {
+                } else {
                     state = state.copy(
                         isLoadingCertificate = false,
                         isE2EICertificateEnrollError = true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6271" title="WPB-6271" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6271</a>  [Android] Fix crashes during enrollment and show proper error details
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Fixed and refactored the error handling for E2EI
Needs releases with:

- [ ] https://github.com/wireapp/kalium/pull/2522

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
