### PR TITLE
feat:  implement use case to get default conversation creation protocol (WPB-5475)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -263,6 +263,11 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
+    fun provideGetDefaultProtocol(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
+        coreLogic.getSessionScope(currentAccount).getDefaultProtocol
+
+    @ViewModelScoped
+    @Provides
     fun provideIsE2EIEnabledUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).isE2EIEnabled
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupConversationNameComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupConversationNameComponent.kt
@@ -124,7 +124,7 @@ fun GroupNameScreen(
                         WireDropDown(
                             items =
                             ConversationOptions.Protocol.values().map { it.name },
-                            defaultItemIndex = ConversationOptions.Protocol.PROTEUS.ordinal,
+                            defaultItemIndex = defaultProtocol.ordinal,
                             selectedItemIndex = groupProtocol.ordinal,
                             label = stringResource(R.string.protocol),
                             modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupMetadataState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupMetadataState.kt
@@ -32,6 +32,7 @@ data class GroupMetadataState(
     val animatedGroupNameError: Boolean = false,
     val continueEnabled: Boolean = false,
     val mlsEnabled: Boolean = true,
+    val defaultProtocol: ConversationOptions.Protocol = ConversationOptions.Protocol.PROTEUS,
     val isLoading: Boolean = false,
     val error: NewGroupError = NewGroupError.None,
     val mode: GroupNameMode = GroupNameMode.CREATION,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -36,6 +36,7 @@ import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
+import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsSelfATeamMemberUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -48,13 +49,22 @@ import javax.inject.Inject
 class NewConversationViewModel @Inject constructor(
     private val createGroupConversation: CreateGroupConversationUseCase,
     private val isSelfATeamMember: IsSelfATeamMemberUseCase,
-    isMLSEnabled: IsMLSEnabledUseCase
+    isMLSEnabled: IsMLSEnabledUseCase,
+    getDefaultProtocol: GetDefaultProtocolUseCase
 ) : ViewModel() {
 
     var newGroupState: GroupMetadataState by mutableStateOf(
         GroupMetadataState(
-            mlsEnabled = isMLSEnabled(),
-        )
+            mlsEnabled = isMLSEnabled()
+        ).let {
+            val defaultProtocol = ConversationOptions
+                .Protocol
+                .fromSupportedProtocolToConversationOptionsProtocol(getDefaultProtocol())
+            it.copy(
+                defaultProtocol = defaultProtocol,
+                groupProtocol = defaultProtocol
+            )
+        }
     )
 
     var groupOptionsState: GroupOptionState by mutableStateOf(GroupOptionState())

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -24,11 +24,13 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.ui.home.newconversation.common.CreateGroupState
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationOptions
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.UserId
 import io.mockk.coVerify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.junit.jupiter.api.Test
@@ -143,4 +145,24 @@ class NewConversationViewModelTest {
                 )
             }
         }
+
+    @Test
+    fun `given team settings is MLS default protocol, when getting default protocol, then result is MLS`() = runTest {
+        // given
+        val (_, viewModel) = NewConversationViewModelArrangement()
+            .withDefaultProtocol(SupportedProtocol.MLS)
+            .withIsSelfTeamMember(true)
+            .withServicesEnabled(false)
+            .withGuestEnabled(true)
+            .arrange()
+
+        // when
+        val result = viewModel.newGroupState.defaultProtocol
+
+        // then
+        assertEquals(
+            ConversationOptions.Protocol.MLS,
+            result
+        )
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5475" title="WPB-5475" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5475</a>  [Android] Default Protocol not followed when changes are applied in Team Management
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2722

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like 
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Default Protocol was not correctly displayed when set by team owner.

### Causes (Optional)

Not implemented.

### Solutions

Display default protocol when set by team owner.

Needs releases with:

- [X] https://github.com/wireapp/kalium/pull/2521

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Have a team on diya or elna environment, with TeamOwner A and Member B
- Enable MLS for the team and select user A and B to have MLS permissions
- Login with user B to android
- Login to Team Management with user A
- Select “Default Protocol: MLS” in Team Management MLS configurations
- Create a group on android with user B
- During group creation flow, the default protocol should automatically show “MLS” (and if I tap the protocol option, I have to option to select “Proteus”)

### Attachments (Optional)

<img src=https://github.com/wireapp/wire-android/assets/5890660/23ff45f5-4f97-49b8-a113-d96d89844270 width=200 height=400 />
<img src=https://github.com/wireapp/wire-android/assets/5890660/dad24f08-2385-4189-a87f-73fb68cfcafc width=200 height=400 />
