### PR TITLE
chore: fix tag logging

### DIFF
--- a/app/src/beta/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/beta/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -34,13 +34,15 @@ object DataDogLogger : LogWriter() {
         .build()
 
     override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
-        val attributes = KaliumLogger.UserClientData.getFromTag(tag)?.let { userClientData ->
-            mapOf(
-                "userId" to userClientData.userId,
-                "clientId" to userClientData.clientId,
-            )
-        } ?: emptyMap<String, Any?>()
-
+        val logInfo = KaliumLogger.LogAttributes.getInfoFromTagString(tag)
+        val userAccountData = mapOf(
+            "userId" to logInfo.userClientData?.userId,
+            "clientId" to logInfo.userClientData?.clientId,
+        )
+        val attributes = mapOf(
+            "wireAccount" to userAccountData,
+            "tag" to logInfo.textTag
+        )
         when (severity) {
             Severity.Debug -> logger.d(message, throwable, attributes)
             Severity.Info -> logger.i(message, throwable, attributes)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/typing/TypingIndicatorViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/typing/TypingIndicatorViewModel.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.appLogger
 import com.wire.android.ui.home.conversations.ConversationNavArgs
 import com.wire.android.ui.home.conversations.usecase.ObserveUsersTypingInConversationUseCase
 import com.wire.android.ui.navArgs


### PR DESCRIPTION
Cherry pick from the original PR: 
- #2730

---- 

 ⚠️ Conflicts during cherry-pick:


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. We were not properly passing  to DataDogLogger. So it was harder to find where the logs were coming from.
2. Kalium was buggy and was never returning the user info to append with the logs.

### Solutions

1. Update Kalium that now has a fix
2. Pass the  as a  together with  and  (so it doesn't get confused with DataDog's userId)

### Dependencies

Needs releases with:

- https://github.com/wireapp/kalium/pull/2536

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .