### PR TITLE
chore: fix tag logging for internal and staging flavors

### DIFF
--- a/app/src/internal/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/internal/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -36,13 +36,15 @@ object DataDogLogger : LogWriter() {
         .build()
 
     override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
-        val attributes = KaliumLogger.UserClientData.getFromTag(tag)?.let { userClientData ->
-            mapOf(
-                "userId" to userClientData.userId,
-                "clientId" to userClientData.clientId,
-            )
-        } ?: emptyMap<String, Any?>()
-
+        val logInfo = KaliumLogger.LogAttributes.getInfoFromTagString(tag)
+        val userAccountData = mapOf(
+            "userId" to logInfo.userClientData?.userId,
+            "clientId" to logInfo.userClientData?.clientId,
+        )
+        val attributes = mapOf(
+            "wireAccount" to userAccountData,
+            "tag" to logInfo.textTag
+        )
         when (severity) {
             Severity.Debug -> logger.d(message, throwable, attributes)
             Severity.Info -> logger.i(message, throwable, attributes)

--- a/app/src/staging/kotlin/com/wire/android/util/DataDogLogger.kt
+++ b/app/src/staging/kotlin/com/wire/android/util/DataDogLogger.kt
@@ -36,13 +36,15 @@ object DataDogLogger : LogWriter() {
         .build()
 
     override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
-        val attributes = KaliumLogger.UserClientData.getFromTag(tag)?.let { userClientData ->
-            mapOf(
-                "userId" to userClientData.userId,
-                "clientId" to userClientData.clientId,
-            )
-        } ?: emptyMap<String, Any?>()
-
+        val logInfo = KaliumLogger.LogAttributes.getInfoFromTagString(tag)
+        val userAccountData = mapOf(
+            "userId" to logInfo.userClientData?.userId,
+            "clientId" to logInfo.userClientData?.clientId,
+        )
+        val attributes = mapOf(
+            "wireAccount" to userAccountData,
+            "tag" to logInfo.textTag
+        )
         when (severity) {
             Severity.Debug -> logger.d(message, throwable, attributes)
             Severity.Info -> logger.i(message, throwable, attributes)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This PR: https://github.com/wireapp/wire-android/pull/2733 provided a fix for `beta` flavor, but `DataDogLogger` is still outdated for some other flavors.
This commit fixed it for `dev` flavor only for RC: https://github.com/wireapp/wire-android/commit/e11de8af6b1cb12c2fde112cbfe9b0e0044eeee8

### Solutions

Fix it also for other flavors.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
