### PR TITLE
fix(e2ei): force login to idp to update certificate (WPB-6877)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/e2ei/OAuthUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/e2ei/OAuthUseCase.kt
@@ -69,22 +69,25 @@ class OAuthUseCase(
 
     fun launch(
         activityResultRegistry: ActivityResultRegistry,
-        resultHandler: (OAuthResult) -> Unit
+        forceLoginFlow: Boolean,
+        resultHandler: (OAuthResult) -> Unit,
     ) {
-        authState.performActionWithFreshTokens(authorizationService) { _, idToken, exception ->
-            if (exception != null) {
-                appLogger.e(
-                    message = "OAuthTokenRefreshManager: Error refreshing tokens, continue with login!",
-                    throwable = exception
-                )
-                launchLoginFlow(activityResultRegistry, resultHandler)
-            } else {
-                resultHandler(
-                    OAuthResult.Success(
-                        idToken.toString(),
-                        authState.jsonSerializeString()
+        if (forceLoginFlow) {
+            launchLoginFlow(activityResultRegistry, resultHandler)
+        } else {
+            authState.performActionWithFreshTokens(authorizationService) { _, idToken, exception ->
+                if (exception != null) {
+                    appLogger.e(
+                        message = "OAuthTokenRefreshManager: Error refreshing tokens, continue with login!", throwable = exception
                     )
-                )
+                    launchLoginFlow(activityResultRegistry, resultHandler)
+                } else {
+                    resultHandler(
+                        OAuthResult.Success(
+                            idToken.toString(), authState.jsonSerializeString()
+                        )
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/GetE2EICertificateUI.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/GetE2EICertificateUI.kt
@@ -43,7 +43,7 @@ fun GetE2EICertificateUI(
     LaunchedEffect(Unit) {
         viewModel.requestOAuthFlow.onEach {
             OAuthUseCase(context, it.target, it.oAuthClaims, it.oAuthState).launch(
-                context.getActivity()!!.activityResultRegistry
+                context.getActivity()!!.activityResultRegistry, forceLoginFlow = true
             ) { result -> viewModel.handleOAuthResult(result, it) }
         }.launchIn(coroutineScope)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6877" title="WPB-6877" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6877</a>  [Android] Fix Update E2EI Certificate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Since the update mechanism and design required some extra work, and we already have couple of suggestion about other approaches, we decided to enforce the user to login everytime agains the idp and not using the refresh token.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
