### PR TITLE
fix: crash about persistent websocket being started from background [WPB-6551]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/ShouldStartPersistentWebSocketServiceUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/ShouldStartPersistentWebSocketServiceUseCase.kt
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature
+
+import com.wire.android.di.KaliumCoreLogic
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withTimeoutOrNull
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ShouldStartPersistentWebSocketServiceUseCase @Inject constructor(
+    @KaliumCoreLogic private val coreLogic: CoreLogic
+) {
+    suspend operator fun invoke(): Result {
+        return coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus().let { result ->
+            when (result) {
+                is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> Result.Failure
+
+                is ObservePersistentWebSocketConnectionStatusUseCase.Result.Success -> {
+                    val statusList = withTimeoutOrNull(TIMEOUT) {
+                        val res = result.persistentWebSocketStatusListFlow.firstOrNull()
+                        res
+                    }
+                    if (statusList != null && statusList.map { it.isPersistentWebSocketEnabled }.contains(true)) Result.Success(true)
+                    else Result.Success(false)
+                }
+            }
+        }
+    }
+
+    sealed class Result {
+        data object Failure : Result()
+        data class Success(val shouldStartPersistentWebSocketService: Boolean) : Result()
+    }
+
+    companion object {
+        const val TIMEOUT = 10_000L
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/feature/ShouldStartPersistentWebSocketServiceUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/ShouldStartPersistentWebSocketServiceUseCaseTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature
+
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.auth.PersistentWebSocketStatus
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+
+class ShouldStartPersistentWebSocketServiceUseCaseTest {
+
+    @Test
+    fun givenObservePersistentWebSocketStatusReturnsSuccessAndThereAreUsersWithPersistentFlagOn_whenInvoking_shouldReturnSuccessTrue() =
+        runTest {
+            // given
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(flowOf(listOf(PersistentWebSocketStatus(userId, true))))
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertInstanceOf(ShouldStartPersistentWebSocketServiceUseCase.Result.Success::class.java, result).also {
+                assertEquals(true, it.shouldStartPersistentWebSocketService)
+            }
+        }
+
+    @Test
+    fun givenObservePersistentWebSocketStatusReturnsSuccessAndThereAreNoUsersWithPersistentFlagOn_whenInvoking_shouldReturnSuccessFalse() =
+        runTest {
+            // given
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(flowOf(listOf(PersistentWebSocketStatus(userId, false))))
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertInstanceOf(ShouldStartPersistentWebSocketServiceUseCase.Result.Success::class.java, result).also {
+                assertEquals(false, it.shouldStartPersistentWebSocketService)
+            }
+        }
+
+    @Test
+    fun givenObservePersistentWebSocketStatusReturnsSuccessAndThereAreNoUsers_whenInvoking_shouldReturnSuccessFalse() =
+        runTest {
+            // given
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(flowOf(emptyList()))
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertInstanceOf(ShouldStartPersistentWebSocketServiceUseCase.Result.Success::class.java, result).also {
+                assertEquals(false, it.shouldStartPersistentWebSocketService)
+            }
+        }
+
+    @Test
+    fun givenObservePersistentWebSocketStatusReturnsSuccessAndTheFlowIsEmpty_whenInvoking_shouldReturnSuccessFalse() =
+        runTest {
+            // given
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(emptyFlow())
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertInstanceOf(ShouldStartPersistentWebSocketServiceUseCase.Result.Success::class.java, result).also {
+                assertEquals(false, it.shouldStartPersistentWebSocketService)
+            }
+        }
+
+    @Test
+    fun givenObservePersistentWebSocketStatusReturnsSuccessAndFlowTimesOut_whenInvoking_shouldReturnSuccessFalse() =
+        runTest {
+            // given
+            val sharedFlow = MutableSharedFlow<List<PersistentWebSocketStatus>>() // shared flow doesn't close so we can test the timeout
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(sharedFlow)
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            advanceTimeBy(ShouldStartPersistentWebSocketServiceUseCase.TIMEOUT + 1000L)
+            // then
+            assertInstanceOf(ShouldStartPersistentWebSocketServiceUseCase.Result.Success::class.java, result).also {
+                assertEquals(false, it.shouldStartPersistentWebSocketService)
+            }
+        }
+
+    @Test
+    fun givenObservePersistentWebSocketStatusReturnsFailure_whenInvoking_shouldReturnFailure() =
+        runTest {
+            // given
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusFailure()
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertInstanceOf(ShouldStartPersistentWebSocketServiceUseCase.Result.Failure::class.java, result)
+        }
+
+    inner class Arrangement {
+
+        @MockK
+        private lateinit var coreLogic: CoreLogic
+
+        val useCase by lazy {
+            ShouldStartPersistentWebSocketServiceUseCase(coreLogic)
+        }
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        fun arrange() = this to useCase
+
+        fun withObservePersistentWebSocketConnectionStatusSuccess(flow: Flow<List<PersistentWebSocketStatus>>) = apply {
+            coEvery { coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus() } returns
+                    ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(flow)
+        }
+        fun withObservePersistentWebSocketConnectionStatusFailure() = apply {
+            coEvery { coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus() } returns
+                    ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure.StorageFailure
+        }
+    }
+
+    companion object {
+        private val userId = UserId("userId", "domain")
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6551" title="WPB-6551" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6551</a>  [Android] Crash caused by Foreground services not allowed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2745

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes  for  results in .

### Causes (Optional)

This exception means that  was executed when it's not allowed to, there are multiple restrictions on when foreground service can be started - more here: https://developer.android.com/develop/background-work/services/foreground-services#background-start-restriction-exemptions
For us, we are allowed to start foreground service from Activity when the app is in the foreground and when the device is booted or app is updated (probably within 20 seconds) and we use  for that. The problem is probably that we  in a coroutine, so it's just left hanging and receiving new values even in the background.

### Solutions

When  is called, get the list of persistent websocket statuses only once to make sure that we open the service within the permitted time frame. This persistent websocket flag can be changed only in settings by the user when the app is in the foreground so no need to observe for changes in this receiver - if changed then the service will be started from .
The logic of deciding whether the service should be started or not is extracted to dedicated use case and tested.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

There's no specific reproduction path, from the logs it looks like it could happen when the app was updated in the background and the sync was started so that the user's values in database are updated and  emits new list.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .