### PR TITLE
fix: Do not show waiting network in CertDetails screen (RC) (WPB-6638)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -35,6 +35,7 @@ import com.wire.android.ui.destinations.CreatePersonalAccountOverviewScreenDesti
 import com.wire.android.ui.destinations.CreateTeamAccountOverviewScreenDestination
 import com.wire.android.ui.destinations.Destination
 import com.wire.android.ui.destinations.E2EIEnrollmentScreenDestination
+import com.wire.android.ui.destinations.E2eiCertificateDetailsScreenDestination
 import com.wire.android.ui.destinations.HomeScreenDestination
 import com.wire.android.ui.destinations.ImportMediaScreenDestination
 import com.wire.android.ui.destinations.IncomingCallScreenDestination
@@ -216,6 +217,7 @@ sealed class CurrentScreen {
                 is MigrationScreenDestination,
                 is InitialSyncScreenDestination,
                 is E2EIEnrollmentScreenDestination,
+                is E2eiCertificateDetailsScreenDestination,
                 is RegisterDeviceScreenDestination,
                 is RemoveDeviceScreenDestination -> AuthRelated
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6638" title="WPB-6638" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6638</a>  [Android] Waiting for network banner shown on certificate page
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

When the user has e2ei enabled and logs in for the first time to enrol his certificate and opens the certificate, a “Waiting for network” banner is shown.

### Solutions

Mark that screen as one where such a banner shouldn't be shown
