### PR TITLE
fix: some end points are not routed through the proxy server 4.6

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -208,16 +208,6 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun provideFetchApiVersionUserCase(@KaliumCoreLogic coreLogic: CoreLogic) =
-        coreLogic.getGlobalScope().fetchApiVersion
-
-    @ViewModelScoped
-    @Provides
-    fun provideObserveServerConfigUseCase(@KaliumCoreLogic coreLogic: CoreLogic) =
-        coreLogic.getGlobalScope().observeServerConfig
-
-    @ViewModelScoped
-    @Provides
     fun provideUpdateApiVersionsUseCase(@KaliumCoreLogic coreLogic: CoreLogic) =
         coreLogic.getGlobalScope().updateApiVersions
 

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateActiveAccountsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateActiveAccountsUseCase.kt
@@ -115,7 +115,11 @@ class MigrateActiveAccountsUseCase @Inject constructor(
     private suspend fun handleMissingData(
         serverConfig: ServerConfig,
         refreshToken: String,
-    ): Either<CoreFailure, AccountTokens> = coreLogic.authenticationScope(serverConfig) {
+    ): Either<CoreFailure, AccountTokens> = coreLogic.authenticationScope(
+        serverConfig,
+        // scala did not support proxy mode so we can pass null
+        proxyCredentials = null
+    ) {
         ssoLoginScope.getLoginSession(refreshToken)
     }.let {
         when (it) {

--- a/app/src/main/kotlin/com/wire/android/migration/feature/MigrateServerConfigUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/feature/MigrateServerConfigUseCase.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.configuration.server.CommonApiVersionType
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.failure.ServerConfigFailure
-import com.wire.kalium.logic.feature.server.FetchApiVersionResult
+import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
 import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.StoreServerConfigResult
 import com.wire.kalium.logic.functional.Either
@@ -66,13 +66,13 @@ class MigrateServerConfigUseCase @Inject constructor(
     }
 
     private suspend fun ServerConfig.Links.fetchApiVersionAndStore(): Either<CoreFailure, ServerConfig> =
-        coreLogic.getGlobalScope().fetchApiVersion(this).let { // it also already stores the fetched config
+        // scala did not support proxy mode so we can pass null here
+        coreLogic.versionedAuthenticationScope(this)(null).let { // it also already stores the fetched config
             when (it) {
-                is FetchApiVersionResult.Success -> Either.Right(it.serverConfig)
-                FetchApiVersionResult.Failure.TooNewVersion -> Either.Left(ServerConfigFailure.NewServerVersion)
-                FetchApiVersionResult.Failure.UnknownServerVersion -> Either.Left(ServerConfigFailure.UnknownServerVersion)
-                is FetchApiVersionResult.Failure.Generic -> Either.Left(it.genericFailure)
+                is AutoVersionAuthScopeUseCase.Result.Failure.Generic -> Either.Left(it.genericFailure)
+                AutoVersionAuthScopeUseCase.Result.Failure.TooNewVersion -> Either.Left(ServerConfigFailure.NewServerVersion)
+                AutoVersionAuthScopeUseCase.Result.Failure.UnknownServerVersion -> Either.Left(ServerConfigFailure.UnknownServerVersion)
+                is AutoVersionAuthScopeUseCase.Result.Success -> Either.Right(it.authenticationScope.currentServerConfig())
             }
         }
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityState.kt
@@ -18,10 +18,11 @@
 
 package com.wire.android.ui
 
-sealed class WireActivityState {
+sealed class
+WireActivityState {
 
-    data class NavigationGraph(val startNavigationRoute: String, val navigationArguments: List<Any>): WireActivityState()
-    data class ClientUpdateRequired(val clientUpdateUrl: String): WireActivityState()
-    object ServerVersionNotSupported: WireActivityState()
-    object Loading: WireActivityState()
+    data class NavigationGraph(val startNavigationRoute: String, val navigationArguments: List<Any>) : WireActivityState()
+    data class ClientUpdateRequired(val clientUpdateUrl: String) : WireActivityState()
+    object ServerVersionNotSupported : WireActivityState()
+    object Loading : WireActivityState()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -191,7 +191,7 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun observeUpdateAppState() {
-        viewModelScope.launch(dispatchers.io()) {
+        viewModelScope.launch {
             observeIfAppUpdateRequired(BuildConfig.VERSION_CODE)
                 .distinctUntilChanged()
                 .collect {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/ServerTitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/ServerTitle.kt
@@ -110,9 +110,8 @@ private fun ServerEnrollmentDialogContent(
     onDismiss: () -> Unit,
     onClick: () -> Unit,
 ) {
-    WireDialog(
-        title = stringResource(id = R.string.server_details_dialog_title),
-        text = LocalContext.current.resources.stringWithStyledArgs(
+    val text = if (serverLinks.apiProxy == null) {
+        LocalContext.current.resources.stringWithStyledArgs(
             R.string.server_details_dialog_body,
             MaterialTheme.wireTypography.body02,
             MaterialTheme.wireTypography.body02,
@@ -120,7 +119,23 @@ private fun ServerEnrollmentDialogContent(
             argsColor = colorsScheme().onBackground,
             serverLinks.title,
             serverLinks.api
-        ),
+        )
+    } else {
+        LocalContext.current.resources.stringWithStyledArgs(
+            R.string.server_details_dialog_body_with_proxy,
+            MaterialTheme.wireTypography.body02,
+            MaterialTheme.wireTypography.body02,
+            normalColor = colorsScheme().secondaryText,
+            argsColor = colorsScheme().onBackground,
+            serverLinks.title,
+            serverLinks.api,
+            serverLinks.apiProxy!!.host,
+            serverLinks.apiProxy!!.needsAuthentication.toString()
+        )
+    }
+    WireDialog(
+        title = stringResource(id = R.string.server_details_dialog_title),
+        text = text,
         onDismiss = onDismiss,
         optionButton1Properties = WireDialogButtonProperties(
             stringResource(id = R.string.label_ok),

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeViewModel.kt
@@ -71,7 +71,8 @@ class CreateAccountCodeViewModel @Inject constructor(
     fun resendCode() {
         codeState = codeState.copy(loading = true)
         viewModelScope.launch {
-            val authScope = coreLogic.versionedAuthenticationScope(serverConfig)().let {
+            // create account does not support proxy yet
+            val authScope = coreLogic.versionedAuthenticationScope(serverConfig)(null).let {
                 when (it) {
                     is AutoVersionAuthScopeUseCase.Result.Success -> it.authenticationScope
 
@@ -130,7 +131,8 @@ class CreateAccountCodeViewModel @Inject constructor(
     private fun onCodeContinue(onSuccess: () -> Unit) {
         codeState = codeState.copy(loading = true)
         viewModelScope.launch {
-            val authScope = coreLogic.versionedAuthenticationScope(serverConfig)().let {
+            // create account does not support proxy yet
+            val authScope = coreLogic.versionedAuthenticationScope(serverConfig)(null).let {
                 when (it) {
                     is AutoVersionAuthScopeUseCase.Result.Success -> it.authenticationScope
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailViewModel.kt
@@ -33,8 +33,6 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.feature.auth.ValidateEmailUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
 import com.wire.kalium.logic.feature.register.RequestActivationCodeResult
-import com.wire.kalium.logic.feature.server.FetchApiVersionResult
-import com.wire.kalium.logic.feature.server.FetchApiVersionUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -44,7 +42,6 @@ import javax.inject.Inject
 class CreateAccountEmailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val authServerConfigProvider: AuthServerConfigProvider,
-    private val fetchApiVersion: FetchApiVersionUseCase,
     private val validateEmail: ValidateEmailUseCase,
     @KaliumCoreLogic private val coreLogic: CoreLogic,
 ) : ViewModel() {
@@ -69,25 +66,6 @@ class CreateAccountEmailViewModel @Inject constructor(
     fun onEmailContinue(onSuccess: () -> Unit) {
         emailState = emailState.copy(loading = true, continueEnabled = false)
         viewModelScope.launch {
-            fetchApiVersion(authServerConfigProvider.authServer.value).let {
-                when (it) {
-                    is FetchApiVersionResult.Success -> {}
-                    is FetchApiVersionResult.Failure.UnknownServerVersion -> {
-                        emailState = emailState.copy(showServerVersionNotSupportedDialog = true)
-                        return@launch
-                    }
-
-                    is FetchApiVersionResult.Failure.TooNewVersion -> {
-                        emailState = emailState.copy(showClientUpdateDialog = true)
-                        return@launch
-                    }
-
-                    is FetchApiVersionResult.Failure.Generic -> {
-                        return@launch
-                    }
-                }
-            }
-
             val emailError =
                 if (validateEmail(emailState.email.text.trim().lowercase())) CreateAccountEmailViewState.EmailError.None
                 else CreateAccountEmailViewState.EmailError.TextFieldError.InvalidEmailError
@@ -106,7 +84,7 @@ class CreateAccountEmailViewModel @Inject constructor(
     fun onTermsAccept(onSuccess: () -> Unit) {
         emailState = emailState.copy(loading = true, continueEnabled = false, termsDialogVisible = false, termsAccepted = true)
         viewModelScope.launch {
-            val authScope = coreLogic.versionedAuthenticationScope(serverConfig)().let {
+            val authScope = coreLogic.versionedAuthenticationScope(serverConfig)(null).let {
                 when (it) {
                     is AutoVersionAuthScopeUseCase.Result.Success -> it.authenticationScope
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginState.kt
@@ -20,6 +20,7 @@ package com.wire.android.ui.authentication.login
 
 import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.ui.common.dialogs.CustomServerDialogState
+import com.wire.kalium.logic.data.auth.login.ProxyCredentials
 
 data class LoginState(
     val userIdentifier: TextFieldValue = TextFieldValue(""),
@@ -36,7 +37,14 @@ data class LoginState(
     val loginError: LoginError = LoginError.None,
     val isProxyEnabled: Boolean = false,
     val customServerDialogState: CustomServerDialogState? = null,
-)
+) {
+    fun getProxyCredentials(): ProxyCredentials? =
+        if (proxyIdentifier.text.isNotBlank() && proxyPassword.text.isNotBlank()) {
+            ProxyCredentials(proxyIdentifier.text, proxyPassword.text)
+        } else {
+            null
+        }
+}
 
 fun LoginState.updateEmailLoginEnabled() =
     copy(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -40,7 +40,6 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthenticationResult
 import com.wire.kalium.logic.feature.auth.DomainLookupUseCase
-import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.client.RegisterClientUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -67,8 +66,6 @@ open class LoginViewModel @Inject constructor(
             }
         }
     }
-
-    protected suspend fun authScope(): AutoVersionAuthScopeUseCase.Result = coreLogic.versionedAuthenticationScope(serverConfig)()
 
     private val loginNavArgs: LoginNavArgs = savedStateHandle.navArgs()
     private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle.let {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -36,7 +36,6 @@ import com.wire.android.ui.authentication.verificationcode.VerificationCodeState
 import com.wire.android.ui.common.textfield.CodeFieldValue
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
-import com.wire.kalium.logic.data.auth.login.ProxyCredentials
 import com.wire.kalium.logic.data.auth.verification.VerifiableAction
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthenticationResult
@@ -137,29 +136,27 @@ class LoginEmailViewModel @Inject constructor(
 
     private suspend fun resolveCurrentAuthScope(): AuthenticationScope? =
         coreLogic.versionedAuthenticationScope(serverConfig).invoke(
-        AutoVersionAuthScopeUseCase.ProxyAuthentication.UsernameAndPassword(
-            ProxyCredentials(loginState.proxyIdentifier.text, loginState.proxyPassword.text)
-        )
-    ).let {
-        when (it) {
-            is AutoVersionAuthScopeUseCase.Result.Success -> it.authenticationScope
+            loginState.getProxyCredentials()
+        ).let {
+            when (it) {
+                is AutoVersionAuthScopeUseCase.Result.Success -> it.authenticationScope
 
-            is AutoVersionAuthScopeUseCase.Result.Failure.UnknownServerVersion -> {
-                updateEmailLoginError(LoginError.DialogError.ServerVersionNotSupported)
-                return null
-            }
+                is AutoVersionAuthScopeUseCase.Result.Failure.UnknownServerVersion -> {
+                    updateEmailLoginError(LoginError.DialogError.ServerVersionNotSupported)
+                    return null
+                }
 
-            is AutoVersionAuthScopeUseCase.Result.Failure.TooNewVersion -> {
-                updateEmailLoginError(LoginError.DialogError.ClientUpdateRequired)
-                return null
-            }
+                is AutoVersionAuthScopeUseCase.Result.Failure.TooNewVersion -> {
+                    updateEmailLoginError(LoginError.DialogError.ClientUpdateRequired)
+                    return null
+                }
 
-            is AutoVersionAuthScopeUseCase.Result.Failure.Generic -> {
-                updateEmailLoginError(LoginError.DialogError.GenericError(it.genericFailure))
-                return null
+                is AutoVersionAuthScopeUseCase.Result.Failure.Generic -> {
+                    updateEmailLoginError(LoginError.DialogError.GenericError(it.genericFailure))
+                    return null
+                }
             }
         }
-    }
 
     private suspend fun handleAuthenticationFailure(it: AuthenticationResult.Failure, authScope: AuthenticationScope) {
         when (it) {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -90,7 +90,9 @@ class LoginSSOViewModel @Inject constructor(
             if (loginState.customServerDialogState != null) {
                 authServerConfigProvider.updateAuthServer(loginState.customServerDialogState!!.serverLinks)
 
-                val authScope = coreLogic.versionedAuthenticationScope(loginState.customServerDialogState!!.serverLinks)().let {
+                // sso does not support proxy
+                // TODO: add proxy support
+                val authScope = coreLogic.versionedAuthenticationScope(loginState.customServerDialogState!!.serverLinks)(null).let {
                     when (it) {
                         is AutoVersionAuthScopeUseCase.Result.Failure.Generic,
                         AutoVersionAuthScopeUseCase.Result.Failure.TooNewVersion,
@@ -134,7 +136,9 @@ class LoginSSOViewModel @Inject constructor(
             val defaultAuthScope: AuthenticationScope =
                 coreLogic.versionedAuthenticationScope(
                     authServerConfigProvider.defaultServerLinks()
-                )().let {
+                    // domain lockup does not support proxy
+                    // TODO: add proxy support
+                )(null).let {
                     when (it) {
                         is AutoVersionAuthScopeUseCase.Result.Failure.Generic,
                         AutoVersionAuthScopeUseCase.Result.Failure.TooNewVersion,
@@ -168,7 +172,8 @@ class LoginSSOViewModel @Inject constructor(
     private fun ssoLoginWithCodeFlow() {
         viewModelScope.launch {
             val authScope =
-                authScope().let {
+                // sso does not support proxy
+                coreLogic.versionedAuthenticationScope(serverConfig)(null).let {
                     when (it) {
                         is AutoVersionAuthScopeUseCase.Result.Success -> it.authenticationScope
 
@@ -207,7 +212,7 @@ class LoginSSOViewModel @Inject constructor(
         loginState = loginState.copy(ssoLoginLoading = true, loginError = LoginError.None).updateSSOLoginEnabled()
         viewModelScope.launch {
             val authScope =
-                authScope().let {
+                coreLogic.versionedAuthenticationScope(serverConfig)(null).let {
                     when (it) {
                         is AutoVersionAuthScopeUseCase.Result.Success -> it.authenticationScope
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomServerDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomServerDialog.kt
@@ -86,6 +86,17 @@ internal fun CustomServerDialog(
                     title = stringResource(id = R.string.custom_backend_dialog_body_backend_api),
                     value = serverLinks.api
                 )
+                if (serverLinks.apiProxy != null) {
+                    CustomServerPropertyInfo(
+                        title = stringResource(id = R.string.custom_backend_dialog_body_backend_proxy_url),
+                        value = serverLinks.apiProxy!!.host
+                    )
+
+                    CustomServerPropertyInfo(
+                        title = stringResource(id = R.string.custom_backend_dialog_body_backend_proxy_authentication),
+                        value = serverLinks.apiProxy!!.needsAuthentication.toString()
+                    )
+                }
                 if (showDetails) {
                     CustomServerPropertyInfo(
                         title = stringResource(id = R.string.custom_backend_dialog_body_backend_websocket),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -210,6 +210,7 @@
     <string name="welcome_screen_carousel_item_message_5">Wire wird unabhängig geprüft und ist ISO-, CCPA-, DSGVO- und SOX-konform</string>
     <string name="welcome_button_create_team">Team erstellen</string>
     <string name="server_details_dialog_body">Backend-Name:\n%1$s\n\nBackend-URL:\n%2$s</string>
+    <string name="server_details_dialog_body_with_proxy">Backend name:\n%1$s\n\nBackend URL:\n%2$s\n\nProxy-URL:\n%3$s\n\nProxy-Authentifizierung:\n%4$s</string>
     <string name="server_details_dialog_title">Lokales Backend</string>
     <string name="welcome_migration_dialog_title">Willkommen in unserer neuen App 👋</string>
     <string name="welcome_migration_dialog_content">Wir haben die App überarbeitet, um sie für alle benutzerfreundlicher zu machen.\n\nErfahren Sie mehr über die neu gestaltete App – zusätzliche Optionen und verbesserte Barrierefreiheit bei gleichbleibend hoher Sicherheit.</string>
@@ -990,6 +991,7 @@
     <string name="max_account_reached_dialog_button_open_profile">Profil öffnen</string>
     <string name="cant_switch_account_in_call">Sie können während eines Anrufs nicht das Konto wechseln</string>
     <string name="custom_backend_dialog_title">Umleitung auf ein lokales Backend?</string>
+<<<<<<< HEAD
     <string name="custom_backend_dialog_body">If you proceed, your client will be redirected to the following on-premises backend:</string>
     <string name="custom_backend_dialog_body_backend_name">Backend name:</string>
     <string name="custom_backend_dialog_body_backend_api">Backend URL:</string>
@@ -998,6 +1000,18 @@
     <string name="custom_backend_dialog_body_backend_accounts">accountsURL:</string>
     <string name="custom_backend_dialog_body_backend_website">websiteURL:</string>
     <string name="custom_backend_dialog_body_backend_websocket">backendWSURL:</string>
+=======
+    <string name="custom_backend_dialog_body">Wenn Sie fortfahren, wird Ihr Client an das folgende lokale Backend weitergeleitet:</string>
+    <string name="custom_backend_dialog_body_backend_name">Backend-Name:</string>
+    <string name="custom_backend_dialog_body_backend_api">Backend-URL:</string>
+    <string name="custom_backend_dialog_body_backend_proxy_url">Proxy-URL:</string>
+    <string name="custom_backend_dialog_body_backend_proxy_authentication">Proxy-Authentifizierung:</string>
+    <string name="custom_backend_dialog_body_backend_blacklist">Blacklist-URL:</string>
+    <string name="custom_backend_dialog_body_backend_teams">Teams-URL:</string>
+    <string name="custom_backend_dialog_body_backend_accounts">Accounts-URL:</string>
+    <string name="custom_backend_dialog_body_backend_website">Website-URL:</string>
+    <string name="custom_backend_dialog_body_backend_websocket">Backend-WSURL:</string>
+>>>>>>> fad7763c7 (fix: some end points are not routed through the proxy server 4.6 (#2723))
     <string name="label_fetching_your_messages">Empfang von neuen Nachrichten</string>
     <string name="label_text_copied">Text in Zwischenablage kopiert</string>
     <string name="label_logs_option_title">Protokolle</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,6 +226,7 @@
     <string name="welcome_screen_carousel_item_message_5">Wire is independently audited and ISO, CCPA, GDPR, SOX-compliant</string>
     <string name="welcome_button_create_team">Create a Team</string>
     <string name="server_details_dialog_body">Backend name:\n%1$s\n\nBackend URL:\n%2$s</string>
+    <string name="server_details_dialog_body_with_proxy">Backend name:\n%1$s\n\nBackend URL:\n%2$s\n\nProxy URL:\n%3$s\n\nProxy authentication:\n%4$s</string>
     <string name="server_details_dialog_title">On-premises Backend</string>
     <string name="welcome_migration_dialog_title">Welcome To Our New Android App 👋</string>
     <string name="welcome_migration_dialog_content">We rebuilt the app to make it more usable for everyone.\n\nFind out more about Wire’s redesigned app—new options and improved accessibility, with the same strong security.</string>
@@ -1013,6 +1014,8 @@
     <string name="custom_backend_dialog_body">If you proceed, your client will be redirected to the following on-premises backend:</string>
     <string name="custom_backend_dialog_body_backend_name">Backend name:</string>
     <string name="custom_backend_dialog_body_backend_api">Backend URL:</string>
+    <string name="custom_backend_dialog_body_backend_proxy_url">Proxy URL:</string>
+    <string name="custom_backend_dialog_body_backend_proxy_authentication">Proxy authentication:</string>
     <string name="custom_backend_dialog_body_backend_blacklist">Blacklist URL:</string>
     <string name="custom_backend_dialog_body_backend_teams">Teams URL:</string>
     <string name="custom_backend_dialog_body_backend_accounts">Accounts URL:</string>

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
@@ -139,7 +139,7 @@ class LoginSSOViewModelTest {
         authServerConfigProvider.updateAuthServer(newServerConfig(1).links)
 
         coEvery {
-            autoVersionAuthScopeUseCase()
+            autoVersionAuthScopeUseCase(null)
         } returns AutoVersionAuthScopeUseCase.Result.Success(
             authenticationScope
         )


### PR DESCRIPTION
Cherry pick from the original PR: 
- #2723

---- 

 ⚠️ Conflicts during cherry-pick:
app/src/main/res/values-de/strings.xml


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like 
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
some end points are not routed through the proxy server mainly the api version

### Solutions

refactore the code so every thing is under the unauthenticated container and make sure is does have the proxy info passed correctly

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

run the app connet to wire server via socks proxy (message me if you need the setup) and in the network inspection only proxy link is used

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .