### PR TITLE
fix(e2ei): loading e2ei state during the app initialisation

### DIFF
--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -590,9 +590,6 @@ class WireActivityViewModelTest {
 
     private class Arrangement {
 
-        // TODO add tests for cases when observeIfE2EIIsRequiredDuringLogin emits semothing
-        private val observeIfE2EIIsRequiredDuringLogin = MutableSharedFlow<Boolean?>()
-
         init {
             // Tests setup
             MockKAnnotations.init(this, relaxUnitFun = true)
@@ -614,7 +611,7 @@ class WireActivityViewModelTest {
             coEvery { currentScreenManager.observeCurrentScreen(any()) } returns MutableStateFlow(CurrentScreen.SomeOther)
             coEvery { globalDataStore.selectedThemeOptionFlow() } returns flowOf(ThemeOption.LIGHT)
             coEvery { observeIfE2EIRequiredDuringLoginUseCaseProviderFactory.create(any()).observeIfE2EIIsRequiredDuringLogin() } returns
-                    observeIfE2EIIsRequiredDuringLogin
+                    flowOf(false)
         }
 
         @MockK
@@ -766,6 +763,7 @@ class WireActivityViewModelTest {
 
         fun withCurrentScreen(currentScreenFlow: StateFlow<CurrentScreen>) = apply {
             coEvery { currentScreenManager.observeCurrentScreen(any()) } returns currentScreenFlow
+            coEvery { coreLogic.getSessionScope(TEST_ACCOUNT_INFO.userId).observeIfE2EIRequiredDuringLogin() } returns flowOf(false)
         }
 
         suspend fun withScreenshotCensoringConfig(result: ObserveScreenshotCensoringConfigResult) = apply {


### PR DESCRIPTION
Cherry pick from the original PR: 
- #2664

---- 

 ⚠️ Conflicts during cherry-pick:


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Loading the e2ei state if it's blocking the client registration during login when reopening the app as a blocking value.

### Issues

The value of e2ei state was not loaded in blocking state, causes incorrect behaviour.

#### How to Test

Login with an account that has E2EI enabled on their team, then while getting the E2EI certificate, kill and re open the app; the app must open the enrol certificate screen again to continue from there.
----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .