### PR TITLE
fix: unexpected scrolling on selected message [WPB-6932]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -895,24 +895,14 @@ fun MessageList(
 ) {
     val prevItemCount = remember { mutableStateOf(lazyPagingMessages.itemCount) }
     LaunchedEffect(lazyPagingMessages.itemCount) {
-<<<<<<< HEAD
-        if (lazyPagingMessages.itemCount > prevItemCount.value) {
-            prevItemCount.value = lazyPagingMessages.itemCount
-
-            if (lazyListState.firstVisibleItemIndex > 0
-=======
         if (lazyPagingMessages.itemCount > prevItemCount.value && selectedMessageId == null) {
             if (prevItemCount.value > 0
                 && lazyListState.firstVisibleItemIndex > 0
->>>>>>> b5be8158e (fix: unexpected scrolling on selected message [WPB-6932] (#2753))
                 && lazyListState.firstVisibleItemIndex <= MAXIMUM_SCROLLED_MESSAGES_UNTIL_AUTOSCROLL_STOPS
             ) {
                 lazyListState.animateScrollToItem(0)
             }
-<<<<<<< HEAD
-=======
             prevItemCount.value = lazyPagingMessages.itemCount
->>>>>>> b5be8158e (fix: unexpected scrolling on selected message [WPB-6932] (#2753))
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -895,14 +895,24 @@ fun MessageList(
 ) {
     val prevItemCount = remember { mutableStateOf(lazyPagingMessages.itemCount) }
     LaunchedEffect(lazyPagingMessages.itemCount) {
+<<<<<<< HEAD
         if (lazyPagingMessages.itemCount > prevItemCount.value) {
             prevItemCount.value = lazyPagingMessages.itemCount
 
             if (lazyListState.firstVisibleItemIndex > 0
+=======
+        if (lazyPagingMessages.itemCount > prevItemCount.value && selectedMessageId == null) {
+            if (prevItemCount.value > 0
+                && lazyListState.firstVisibleItemIndex > 0
+>>>>>>> b5be8158e (fix: unexpected scrolling on selected message [WPB-6932] (#2753))
                 && lazyListState.firstVisibleItemIndex <= MAXIMUM_SCROLLED_MESSAGES_UNTIL_AUTOSCROLL_STOPS
             ) {
                 lazyListState.animateScrollToItem(0)
             }
+<<<<<<< HEAD
+=======
+            prevItemCount.value = lazyPagingMessages.itemCount
+>>>>>>> b5be8158e (fix: unexpected scrolling on selected message [WPB-6932] (#2753))
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6932" title="WPB-6932" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6932</a>  On selected message, list unexpected scrolls to latest message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2753

---- 

 ⚠️ Conflicts during cherry-pick:
app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is functionality which automatically scrolls when new message is added but it should not work when user selects message from search

### Causes (Optional)

List scrolls to latest message from search instead of showing selected message

### Solutions

Secure case when we open conversation screen from search

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->

| Before | After |
| ----------- | ------------ |
| https://github.com/wireapp/wire-android/assets/13151239/8ac65d4a-cb07-4921-b0e8-7d771f983421  | https://github.com/wireapp/wire-android/assets/13151239/491c2607-8144-4dd2-9bee-65af82987702  |


