### PR TITLE
fix: network screen is empty on graphene os

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -21,8 +21,8 @@ package com.wire.android.ui.home.settings.appsettings.networkSettings
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import com.wire.android.ui.common.scaffold.WireScaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -33,6 +33,7 @@ import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
+import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.home.conversations.details.options.ArrowType
 import com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsItem
@@ -74,20 +75,30 @@ fun NetworkSettingsScreenContent(
                 .fillMaxSize()
                 .padding(internalPadding)
         ) {
-            if (!isWebsocketEnabledByDefault(LocalContext.current)) {
-                GroupConversationOptionsItem(
-                    title = stringResource(R.string.settings_keep_connection_to_websocket),
-                    subtitle = stringResource(
-                        R.string.settings_keep_connection_to_websocket_description,
-                        backendName
-                    ),
-                    switchState = SwitchState.Enabled(
+            val appContext = LocalContext.current.applicationContext
+            val isWebSocketEnforcedByDefault = remember {
+                isWebsocketEnabledByDefault(appContext)
+            }
+            val switchState = remember {
+                if (isWebSocketEnforcedByDefault) {
+                    SwitchState.TextOnly(true)
+                } else {
+                    SwitchState.Enabled(
                         value = isWebSocketEnabled,
                         onCheckedChange = setWebSocketState
-                    ),
-                    arrowType = ArrowType.NONE
-                )
+                    )
+                }
             }
+
+            GroupConversationOptionsItem(
+                title = stringResource(R.string.settings_keep_connection_to_websocket),
+                subtitle = stringResource(
+                    R.string.settings_keep_connection_to_websocket_description,
+                    backendName
+                ),
+                switchState = switchState,
+                arrowType = ArrowType.NONE
+            )
         }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

network screen is empty on graphene os

### Solutions

display the settings but make is disabled

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
