### PR TITLE
chore(ci): Keep builds on Jenkins if certain branches were build

### DIFF
--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -121,6 +121,16 @@ pipeline {
                         }
                     }
                 }
+
+                stage('Keep builds forever if important') {
+                    steps {
+                        script {
+                            if (params.SOURCE_BRANCH == "develop" || params.SOURCE_BRANCH == "release/candidate" || params.SOURCE_BRANCH == "main" || params.SOURCE_BRANCH == "prod") {
+                                currentBuild.keepLog = true
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/AR-builder.groovy
+++ b/AR-builder.groovy
@@ -125,7 +125,7 @@ pipeline {
                 stage('Keep builds forever if important') {
                     steps {
                         script {
-                            if (params.SOURCE_BRANCH == "develop" || params.SOURCE_BRANCH == "release/candidate" || params.SOURCE_BRANCH == "main" || params.SOURCE_BRANCH == "prod") {
+                            if (params.SOURCE_BRANCH.startsWith("release/") || params.SOURCE_BRANCH == "develop" || params.SOURCE_BRANCH == "main" || params.SOURCE_BRANCH == "prod") {
                                 currentBuild.keepLog = true
                             }
                         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In order to save some disk space on jenkins we will clean up the builds manually. We also want to do this automatically but for this it makes sense to automatically mark builds as "keep build forever" already when a certain branch is used. So that no human interaction is needed.