### PR TITLE
fix: e2e webview close [WPB-6788]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/GetE2EICertificateUI.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/GetE2EICertificateUI.kt
@@ -39,7 +39,6 @@ fun GetE2EICertificateUI(
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
 
-    // FIXME issue happens when this UI is called from WireActivity: WebView is just canceled by itself
     LaunchedEffect(Unit) {
         viewModel.requestOAuthFlow.onEach {
             OAuthUseCase(context, it.target, it.oAuthClaims, it.oAuthState).launch(
@@ -51,6 +50,7 @@ fun GetE2EICertificateUI(
     LaunchedEffect(Unit) {
         viewModel.enrollmentResultFlow.onEach { enrollmentResultHandler(it) }.launchIn(coroutineScope)
     }
-
-    viewModel.getCertificate(isNewClient)
+    LaunchedEffect(Unit) {
+        viewModel.getCertificate(isNewClient)
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6788" title="WPB-6788" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6788</a>  [Android] Fix crash on opening the browser for E2EI IDP authorization
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2762

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

viewModel.getCertificate(isNewClient) was not called from LaunchedEffect, which triggered again on recompose opening webview

### Causes (Optional)

E2E webview opened from dialog was closed after second

### Solutions

Add LaunchedEffect