### PR TITLE
fix: persistent ws not reflected in UI (WPB-7020)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -75,19 +74,16 @@ fun NetworkSettingsScreenContent(
                 .fillMaxSize()
                 .padding(internalPadding)
         ) {
-            val appContext = LocalContext.current.applicationContext
-            val isWebSocketEnforcedByDefault = remember {
-                isWebsocketEnabledByDefault(appContext)
-            }
-            val switchState = remember {
-                if (isWebSocketEnforcedByDefault) {
-                    SwitchState.TextOnly(true)
-                } else {
-                    SwitchState.Enabled(
-                        value = isWebSocketEnabled,
-                        onCheckedChange = setWebSocketState
-                    )
-                }
+            val appContext = LocalContext.current
+            val isWebSocketEnforcedByDefault = isWebsocketEnabledByDefault(appContext)
+
+            val switchState = if (isWebSocketEnforcedByDefault) {
+                SwitchState.TextOnly(true)
+            } else {
+                SwitchState.Enabled(
+                    value = isWebSocketEnabled,
+                    onCheckedChange = setWebSocketState
+                )
             }
 
             GroupConversationOptionsItem(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7020" title="WPB-7020" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7020</a>  [Android] Websocket switch does not turn to ON state anymore (but enabling websocket works)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We had a regression on the websocket button config in network settings.
Even the ws was enabled, the button was always off.

### Testing

Manually tested

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
