### PR TITLE
fix: persistent ws not reflected in UI (WPB-7020)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -74,6 +74,7 @@ fun NetworkSettingsScreenContent(
                 .fillMaxSize()
                 .padding(internalPadding)
         ) {
+<<<<<<< HEAD
             if (!isWebsocketEnabledByDefault(LocalContext.current)) {
                 GroupConversationOptionsItem(
                     title = stringResource(R.string.settings_keep_connection_to_websocket),
@@ -86,6 +87,17 @@ fun NetworkSettingsScreenContent(
                         onCheckedChange = setWebSocketState
                     ),
                     arrowType = ArrowType.NONE
+=======
+            val appContext = LocalContext.current
+            val isWebSocketEnforcedByDefault = isWebsocketEnabledByDefault(appContext)
+
+            val switchState = if (isWebSocketEnforcedByDefault) {
+                SwitchState.TextOnly(true)
+            } else {
+                SwitchState.Enabled(
+                    value = isWebSocketEnabled,
+                    onCheckedChange = setWebSocketState
+>>>>>>> 0ac8117d9 (fix: persistent ws not reflected in UI (WPB-7020) (#2770))
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -21,7 +21,6 @@ package com.wire.android.ui.home.settings.appsettings.networkSettings
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import com.wire.android.ui.common.scaffold.WireScaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -33,6 +32,7 @@ import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
+import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.home.conversations.details.options.ArrowType
 import com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsItem
@@ -74,20 +74,6 @@ fun NetworkSettingsScreenContent(
                 .fillMaxSize()
                 .padding(internalPadding)
         ) {
-<<<<<<< HEAD
-            if (!isWebsocketEnabledByDefault(LocalContext.current)) {
-                GroupConversationOptionsItem(
-                    title = stringResource(R.string.settings_keep_connection_to_websocket),
-                    subtitle = stringResource(
-                        R.string.settings_keep_connection_to_websocket_description,
-                        backendName
-                    ),
-                    switchState = SwitchState.Enabled(
-                        value = isWebSocketEnabled,
-                        onCheckedChange = setWebSocketState
-                    ),
-                    arrowType = ArrowType.NONE
-=======
             val appContext = LocalContext.current
             val isWebSocketEnforcedByDefault = isWebsocketEnabledByDefault(appContext)
 
@@ -97,9 +83,18 @@ fun NetworkSettingsScreenContent(
                 SwitchState.Enabled(
                     value = isWebSocketEnabled,
                     onCheckedChange = setWebSocketState
->>>>>>> 0ac8117d9 (fix: persistent ws not reflected in UI (WPB-7020) (#2770))
                 )
             }
+
+            GroupConversationOptionsItem(
+                title = stringResource(R.string.settings_keep_connection_to_websocket),
+                subtitle = stringResource(
+                    R.string.settings_keep_connection_to_websocket_description,
+                    backendName
+                ),
+                switchState = switchState,
+                arrowType = ArrowType.NONE
+            )
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7020" title="WPB-7020" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7020</a>  [Android] Websocket switch does not turn to ON state anymore (but enabling websocket works)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2770

---- 

 ⚠️ Conflicts during cherry-pick:
app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We had a regression on the websocket button config in network settings.
Even the ws was enabled, the button was always off.

### Testing

Manually tested

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .