### PR TITLE
fix: crash when stopping recording audio [WPB-5961]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -80,18 +80,19 @@ class AudioMediaRecorder @Inject constructor(
         }
     }
 
-    fun startRecording() {
-        try {
+    fun startRecording(): Boolean = try {
             mediaRecorder?.prepare()
             mediaRecorder?.start()
+            true
         } catch (e: IllegalStateException) {
             e.printStackTrace()
             appLogger.e("[RecordAudio] startRecording: IllegalStateException - ${e.message}")
+            false
         } catch (e: IOException) {
             e.printStackTrace()
             appLogger.e("[RecordAudio] startRecording: IOException - ${e.message}")
+            false
         }
-    }
 
     fun stop() {
         mediaRecorder?.stop()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioInfoMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioInfoMessageType.kt
@@ -24,9 +24,16 @@ import com.wire.android.util.ui.UIText
 sealed class RecordAudioInfoMessageType(override val uiText: UIText) : SnackBarMessage {
 
     // Unable to Record Audio due to being in a call
-    object UnableToRecordAudioCall : RecordAudioInfoMessageType(
+    data object UnableToRecordAudioCall : RecordAudioInfoMessageType(
         UIText.StringResource(
             R.string.record_audio_unable_due_to_ongoing_call
+        )
+    )
+
+    // Unable to Record Audio due to error
+    data object UnableToRecordAudioError : RecordAudioInfoMessageType(
+        UIText.StringResource(
+            R.string.record_audio_unable_due_to_error
         )
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -135,17 +135,15 @@ class RecordAudioViewModel @Inject constructor(
             viewModelScope.launch {
                 val assetSizeLimit = getAssetSizeLimit(false)
                 audioMediaRecorder.setUp(assetSizeLimit)
+                if (audioMediaRecorder.startRecording()) {
+                    state = state.copy(
+                        outputFile = audioMediaRecorder.outputFile,
+                        buttonState = RecordAudioButtonState.RECORDING
+                    )
+                } else {
+                    infoMessage.emit(RecordAudioInfoMessageType.UnableToRecordAudioError.uiText)
+                }
             }
-
-            state = state.copy(
-                outputFile = audioMediaRecorder.outputFile
-            )
-
-            audioMediaRecorder.startRecording()
-
-            state = state.copy(
-                buttonState = RecordAudioButtonState.RECORDING
-            )
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1292,6 +1292,7 @@
     <string name="record_audio_max_file_size_reached_title">Recording Stopped</string>
     <string name="record_audio_max_file_size_reached_text">File size for audio messages is limited to %1$d MB.</string>
     <string name="record_audio_unable_due_to_ongoing_call">You can’t record an audio message during a call.</string>
+    <string name="record_audio_unable_due_to_error">Something went wrong while trying to record audio message. Please try again.</string>
     <string name="label_not_now">Not Now</string>
     <string name="last_message_composite_with_missing_text">sent an interactive message</string>
     <string name="join_conversation_dialog_password_label">Conversation Password</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
@@ -224,6 +224,40 @@ class RecordAudioViewModelTest {
             }
         }
 
+    @Test
+    fun `given start recording succeeded, when recording audio, then recording screen is shown`() =
+        runTest {
+            // given
+            val (_, viewModel) = Arrangement()
+                .withStartRecordingSuccessful()
+                .arrange()
+
+            viewModel.getInfoMessage().test {
+                // when
+                viewModel.startRecording()
+                // then
+                assertEquals(RecordAudioButtonState.RECORDING, viewModel.getButtonState())
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `given start recording failed, when recording audio, then info message is shown`() =
+        runTest {
+            // given
+            val (_, viewModel) = Arrangement()
+                .withStartRecordingFailed()
+                .arrange()
+
+            viewModel.getInfoMessage().test {
+                // when
+                viewModel.startRecording()
+                // then
+                assertEquals(RecordAudioButtonState.ENABLED, viewModel.getButtonState())
+                assertEquals(RecordAudioInfoMessageType.UnableToRecordAudioError.uiText, awaitItem())
+            }
+        }
+
     private class Arrangement {
 
         val recordAudioMessagePlayer = mockk<RecordAudioMessagePlayer>()
@@ -249,7 +283,7 @@ class RecordAudioViewModelTest {
 
             coEvery { getAssetSizeLimit.invoke(false) } returns ASSET_SIZE_LIMIT
             every { audioMediaRecorder.setUp(ASSET_SIZE_LIMIT) } returns Unit
-            every { audioMediaRecorder.startRecording() } returns Unit
+            every { audioMediaRecorder.startRecording() } returns true
             every { audioMediaRecorder.stop() } returns Unit
             every { audioMediaRecorder.release() } returns Unit
             every { audioMediaRecorder.outputFile } returns fakeKaliumFileSystem
@@ -283,6 +317,9 @@ class RecordAudioViewModelTest {
                 )
             )
         }
+
+        fun withStartRecordingSuccessful() = apply { every { audioMediaRecorder.startRecording() } returns true }
+        fun withStartRecordingFailed() = apply { every { audioMediaRecorder.startRecording() } returns false }
 
         fun arrange() = this to viewModel
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5961" title="WPB-5961" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5961</a>  [Android] Compose TapGestureDetectorKt crash
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This is a follow-up to this fix https://github.com/wireapp/wire-android/pull/2757

### Issues

After fixing one crash related to starting recording audio, it created another similar when stopping recording.

### Causes (Optional)

`startRecording` is being executed before `setUp` resulting in `mediaRecorder` not being started properly and throwing `IllegalStateException` when stopping if it's called before starting.

### Solutions

Handle `startRecording` in the same coroutine after `setUp`.
Show the info message to the user if something failed to not leave him without any action or information.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Start and stop recording audio message.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
