### PR TITLE
fix: Remove autologin in Keycloak in E2EI [WPB-7061]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/e2ei/OAuthUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/e2ei/OAuthUseCase.kt
@@ -166,6 +166,7 @@ class OAuthUseCase(
         AuthorizationRequest.Scope.PROFILE,
         AuthorizationRequest.Scope.OFFLINE_ACCESS
     ).setClaims(JSONObject(claims.toString()))
+        .setPrompt(AuthorizationRequest.Prompt.LOGIN)
         .build()
 
     private fun AuthorizationRequest.Builder.setCodeVerifier(): AuthorizationRequest.Builder {

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/GetE2EICertificateViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/GetE2EICertificateViewModel.kt
@@ -68,8 +68,7 @@ class GetE2EICertificateViewModel @Inject constructor(
                     .fold({
                         enrollmentResultFlow.emit(Either.Left(it))
                     }, {
-                        if (it is E2EIEnrollmentResult.Initialized) requestOAuthFlow.emit(it)
-                        else enrollmentResultFlow.emit(Either.Right(it))
+                        requestOAuthFlow.emit(it)
                     })
             }
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7061" title="WPB-7061" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7061</a>  [Android] Crash when user tries to register certificate for another email
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

Keyclok and WebView that opens it cache users creds. So if user logs in with the wrong creds in Keyclok and tries to enroll E2EI certificate, he gets an error and no chance to change it and get a certificate (until cache is cleared).

### Solutions

add `AuthorizationRequest.Prompt.LOGIN` parameter into `AuthorizationRequest`, it makes Keycloak force user to enter password (even when the creds are cached) **OR** sing out and sign in with another creds.

### Attachments (Optional)

<img width="377" alt="Screenshot 2024-03-08 at 16 20 31" src="https://github.com/wireapp/wire-android/assets/6539347/887a1502-ad6d-45c2-8b23-e87485be8e39">

