### PR TITLE
fix: legal hold dialogs content [WPB-6469]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -480,7 +480,6 @@ fun ConversationScreen(
 
     (messageComposerViewModel.sureAboutMessagingDialogState as? SureAboutMessagingDialogState.Visible.ConversationUnderLegalHold)?.let {
         LegalHoldSubjectMessageDialog(
-            conversationName = conversationInfoViewModel.conversationInfoViewState.conversationName.asString(),
             dialogDismissed = messageComposerViewModel::dismissSureAboutSendingMessage,
             sendAnywayClicked = messageComposerViewModel::acceptSureAboutSendingMessage,
         )

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/subject/LegalHoldSubjectBaseDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/subject/LegalHoldSubjectBaseDialog.kt
@@ -49,18 +49,18 @@ fun LegalHoldSubjectBaseDialog(
         text = text,
         onDismiss = dialogDismissed,
         buttonsHorizontalAlignment = false,
-        optionButton1Properties = WireDialogButtonProperties(
-            onClick = dialogDismissed,
-            text = cancelText,
-            type = WireDialogButtonType.Secondary,
-        ),
-        optionButton2Properties = action?.let { (actionText, actionClicked) ->
+        optionButton1Properties = action?.let { (actionText, actionClicked) ->
             WireDialogButtonProperties(
                 onClick = actionClicked,
                 text = actionText,
                 type = WireDialogButtonType.Primary,
             )
         },
+        optionButton2Properties = WireDialogButtonProperties(
+            onClick = dialogDismissed,
+            text = cancelText,
+            type = WireDialogButtonType.Secondary,
+        ),
     ) {
         LearnMoreAboutLegalHoldButton(
             modifier = Modifier.padding(bottom = MaterialTheme.wireDimensions.dialogTextsSpacing)

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/subject/LegalHoldSubjectMessageDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/subject/LegalHoldSubjectMessageDialog.kt
@@ -25,12 +25,11 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
 fun LegalHoldSubjectMessageDialog(
-    conversationName: String,
     dialogDismissed: () -> Unit,
     sendAnywayClicked: () -> Unit,
 ) {
     LegalHoldSubjectBaseDialog(
-        title = stringResource(id = R.string.legal_hold_subject_dialog_title, conversationName),
+        title = stringResource(id = R.string.legal_hold_subject_dialog_message_title),
         customInfo = stringResource(id = R.string.legal_hold_subject_dialog_description_message),
         withDefaultInfo = false,
         cancelText = stringResource(id = R.string.label_cancel),
@@ -43,6 +42,6 @@ fun LegalHoldSubjectMessageDialog(
 @PreviewMultipleThemes
 fun PreviewLegalHoldSubjectMessageDialog() {
     WireTheme {
-        LegalHoldSubjectMessageDialog("conversation name", {}, {})
+        LegalHoldSubjectMessageDialog({}, {})
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1337,10 +1337,12 @@
     <string name="legal_hold_deactivated_dialog_title">Legal hold deactivated</string>
     <string name="legal_hold_deactivated_dialog_description">Future messages will not be recorded.</string>
     <string name="legal_hold_subject_dialog_title">%1$s is subject to legal hold</string>
+    <string name="legal_hold_subject_connection_title">Connecting not possible</string>
     <string name="legal_hold_subject_conversation_dialog_title">Conversation is subject to legal hold</string>
     <string name="legal_hold_subject_self_dialog_title">You are subject to legal hold</string>
     <string name="legal_hold_subject_dialog_description">All messages, pictures, and documents will be preserved for future access. It includes deleted, edited, and self-deleting messages.</string>
     <string name="legal_hold_subject_dialog_description_group">At least one person in this conversation is subject to legal hold.</string>
+    <string name="legal_hold_subject_dialog_message_title">The conversation is now subject to legal hold</string>
     <string name="legal_hold_subject_dialog_description_message">Do you still want to send your message?</string>
     <string name="legal_hold_subject_dialog_send_anyway_button">Send Anyway</string>
     <string name="legal_hold_connection_failed_dialog_title">Connecting not possible</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1337,7 +1337,6 @@
     <string name="legal_hold_deactivated_dialog_title">Legal hold deactivated</string>
     <string name="legal_hold_deactivated_dialog_description">Future messages will not be recorded.</string>
     <string name="legal_hold_subject_dialog_title">%1$s is subject to legal hold</string>
-    <string name="legal_hold_subject_connection_title">Connecting not possible</string>
     <string name="legal_hold_subject_conversation_dialog_title">Conversation is subject to legal hold</string>
     <string name="legal_hold_subject_self_dialog_title">You are subject to legal hold</string>
     <string name="legal_hold_subject_dialog_description">All messages, pictures, and documents will be preserved for future access. It includes deleted, edited, and self-deleting messages.</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6469" title="WPB-6469" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6469</a>  The LH member when sending the message to Normal User(Not under LH) showing Normal Member as Under the Legal Hold.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On dialog about 1:1 conversation being under legal hold, the name of the conversation suggests that the user is under legal hold. This dialog takes the conversation name, so for 1:1 conversations it's the other member name, but if I am under legal hold then it can falsely state that "John Doe is under legal hold" when John Doe actually isn't, it's just the conversation between me and John Doe because I am under legal hold.

### Solutions

Adjust the dialog to be exactly like on designs with title without the exact conversation name but more generic one.
Change the order of buttons as well to match the designs.

### Attachments (Optional)

<img width="429" alt="dialogs_after" src="https://github.com/wireapp/wire-android/assets/30429749/78519b16-0883-48b1-a850-3ad3799e95e2">

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
