### PR TITLE
fix(calling): microphone restricted when the app goes into background on Android 14 (WPB-6307)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
@@ -320,8 +321,7 @@
         <service
                 android:name=".services.OngoingCallService"
                 android:exported="false"
-                android:foregroundServiceType="phoneCall" />
-
+                android:foregroundServiceType="phoneCall|microphone" />
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.notification
 
+import android.os.Build
 import androidx.annotation.VisibleForTesting
 import com.wire.android.R
 import com.wire.android.appLogger
@@ -399,7 +400,7 @@ class WireNotificationManager @Inject constructor(
     private suspend fun observeOngoingCalls(currentScreenState: StateFlow<CurrentScreen>) {
         currentScreenState
             .flatMapLatest { currentScreen ->
-                if (currentScreen !is CurrentScreen.InBackground) {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE && currentScreen !is CurrentScreen.InBackground) {
                     flowOf(null)
                 } else {
                     coreLogic.getGlobalScope().session.currentSessionFlow()

--- a/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
@@ -22,6 +22,7 @@ import android.app.Notification
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.IBinder
 import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
@@ -47,6 +48,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
+import androidx.core.app.ServiceCompat
 
 @AndroidEntryPoint
 class OngoingCallService : Service() {
@@ -131,17 +133,38 @@ class OngoingCallService : Service() {
         scope.cancel()
     }
 
-    private fun generateForegroundNotification(callName: String, conversationId: String, userId: UserId) {
+    private fun generateForegroundNotification(
+        callName: String,
+        conversationId: String,
+        userId: UserId
+    ) {
         appLogger.i("$TAG: generating foregroundNotification...")
-        val notification: Notification = callNotificationManager.builder.getOngoingCallNotification(callName, conversationId, userId)
-        startForeground(CALL_ONGOING_NOTIFICATION_ID, notification)
+        val notification: Notification = callNotificationManager.builder.getOngoingCallNotification(
+            callName,
+            conversationId,
+            userId
+        )
+        ServiceCompat.startForeground(
+            this,
+            CALL_ONGOING_NOTIFICATION_ID,
+            notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+        )
+
         appLogger.i("$TAG: started foreground with proper notification")
     }
 
     private fun generatePlaceholderForegroundNotification() {
         appLogger.i("$TAG: generating foregroundNotification placeholder...")
-        val notification: Notification = callNotificationManager.builder.getOngoingCallPlaceholderNotification()
-        startForeground(CALL_ONGOING_NOTIFICATION_ID, notification)
+        val notification: Notification =
+            callNotificationManager.builder.getOngoingCallPlaceholderNotification()
+        ServiceCompat.startForeground(
+            this,
+            CALL_ONGOING_NOTIFICATION_ID,
+            notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+        )
+
         appLogger.i("$TAG: started foreground with placeholder notification")
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6307" title="WPB-6307" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6307</a>  [Android] Bluetooth issue during screen Off
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2780

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Microphone is restricted when the app goes into background during a call on Android 14.

### Causes (Optional)

This issue was introduced when we upgraded the target SDK to API 34 because of some changes added to Android 14.

### Solutions

As phoneCall as foreground service type is not enough to access the microphone in background, we added Microphone type to fix the issue on Android 14.

Needs releases with:

- [ ] GitHub link to other pull request

#### How to Test

Start a call on Android 14 device.
Put the app in the background.
The other person should still hear you.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .