### PR TITLE
fix: list in markdown quote [WPB-6622]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownBlockQuote.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownBlockQuote.kt
@@ -30,6 +30,12 @@ import androidx.compose.ui.text.font.FontStyle
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
+<<<<<<< HEAD
+=======
+import org.commonmark.node.BlockQuote
+import org.commonmark.node.BulletList
+import org.commonmark.node.OrderedList
+>>>>>>> 1ea94ca57 (fix: list in markdown quote [WPB-6622] (#2781))
 
 @Composable
 fun MarkdownBlockQuote(blockQuote: MarkdownNode.Block.BlockQuote, nodeData: NodeData) {
@@ -48,8 +54,15 @@ fun MarkdownBlockQuote(blockQuote: MarkdownNode.Block.BlockQuote, nodeData: Node
 
         blockQuote.children.map { child ->
             when (child) {
+<<<<<<< HEAD
                 is MarkdownNode.Block.BlockQuote -> MarkdownBlockQuote(child, nodeData)
                 is MarkdownNode.Block.Paragraph -> {
+=======
+                is BlockQuote -> MarkdownBlockQuote(child, nodeData)
+                is BulletList -> MarkdownBulletList(child, nodeData)
+                is OrderedList -> MarkdownOrderedList(child, nodeData)
+                else -> {
+>>>>>>> 1ea94ca57 (fix: list in markdown quote [WPB-6622] (#2781))
                     val text = buildAnnotatedString {
                         pushStyle(
                             MaterialTheme.wireTypography.body01.toSpanStyle()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6622" title="WPB-6622" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6622</a>  [Android] quote markdown is not displayed in text messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry pick from the original PR: 
- #2781

---- 

 ⚠️ Conflicts during cherry-pick:
app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownBlockQuote.kt
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like 
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixed markdown list not showed inside markdown quote