### PR TITLE
fix: Localised DateFormat in device info

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityDialogs.kt
@@ -43,7 +43,7 @@ import com.wire.android.ui.joinConversation.JoinConversationViaCodeState
 import com.wire.android.ui.joinConversation.JoinConversationViaDeepLinkDialog
 import com.wire.android.ui.joinConversation.JoinConversationViaInviteLinkError
 import com.wire.android.ui.theme.WireTheme
-import com.wire.android.util.formatMediumDateTime
+import com.wire.android.util.deviceDateTimeFormat
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.configuration.server.ServerConfig
@@ -319,7 +319,7 @@ fun NewClientDialog(
         val devicesList = data.clientsInfo.map {
             stringResource(
                 R.string.new_device_dialog_message_defice_info,
-                it.date.formatMediumDateTime() ?: "",
+                it.date.deviceDateTimeFormat() ?: "",
                 it.deviceInfo.asString()
             )
         }.joinToString("")

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
@@ -64,7 +64,7 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.extension.formatAsFingerPrint
 import com.wire.android.util.extension.formatAsString
-import com.wire.android.util.formatMediumDateTime
+import com.wire.android.util.deviceDateTimeFormat
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 
@@ -227,14 +227,14 @@ private fun DeviceItemTexts(
             stringResource(
                 R.string.remove_device_id_and_time_label_active_label,
                 device.clientId.formatAsString(),
-                device.registrationTime.formatMediumDateTime() ?: "",
+                device.registrationTime.deviceDateTimeFormat() ?: "",
                 device.lastActiveDescription() ?: ""
             )
         } else {
             stringResource(
                 R.string.remove_device_id_and_time_label,
                 device.clientId.formatAsString(),
-                device.registrationTime.formatMediumDateTime() ?: ""
+                device.registrationTime.deviceDateTimeFormat() ?: ""
             )
         }
     } else {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceDialog.kt
@@ -41,7 +41,7 @@ import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.theme.wireDimensions
-import com.wire.android.util.formatMediumDateTime
+import com.wire.android.util.deviceDateTimeFormat
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -63,7 +63,7 @@ fun RemoveDeviceDialog(
             stringResource(
                 R.string.remove_device_id_and_time_label,
                 state.device.clientId.value,
-                state.device.registrationTime?.formatMediumDateTime() ?: ""
+                state.device.registrationTime?.deviceDateTimeFormat() ?: ""
             ),
         onDismiss = onDialogDismissHideKeyboard,
         dismissButtonProperties = WireDialogButtonProperties(

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -86,7 +86,7 @@ import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.dialogErrorStrings
 import com.wire.android.util.extension.formatAsFingerPrint
 import com.wire.android.util.extension.formatAsString
-import com.wire.android.util.formatMediumDateTime
+import com.wire.android.util.deviceDateTimeFormat
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -216,7 +216,7 @@ fun DeviceDetailsContent(
                 Divider(color = MaterialTheme.wireColorScheme.background)
             }
 
-            state.device.registrationTime?.formatMediumDateTime()?.let {
+            state.device.registrationTime?.deviceDateTimeFormat()?.let {
                 item {
                     DeviceDetailSectionContent(
                         stringResource(id = R.string.label_client_added_time),

--- a/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
@@ -34,6 +34,8 @@ private val serverDateTimeFormat = SimpleDateFormat(
 ).apply { timeZone = TimeZone.getTimeZone("UTC") }
 private val mediumDateTimeFormat = DateFormat
     .getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM)
+private val longDateShortTimeFormat = DateFormat
+    .getDateTimeInstance(DateFormat.LONG, DateFormat.SHORT)
 private val mediumOnlyDateTimeFormat = DateFormat
     .getDateInstance(DateFormat.MEDIUM)
 private val messageTimeFormatter = DateFormat
@@ -57,6 +59,13 @@ private val fullDateShortTimeFormatter = DateFormat.getDateTimeInstance(DateForm
 fun String.formatMediumDateTime(): String? =
     try {
         this.serverDate()?.let { mediumDateTimeFormat.format(it) }
+    } catch (e: ParseException) {
+        null
+    }
+
+fun String.deviceDateTimeFormat(): String? =
+    try {
+        this.serverDate()?.let { longDateShortTimeFormat.format(it) }
     } catch (e: ParseException) {
         null
     }

--- a/app/src/test/kotlin/com/wire/android/util/DateTimeUtilKtTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/DateTimeUtilKtTest.kt
@@ -25,8 +25,14 @@ class DateTimeUtilKtTest {
 
     @Test
     fun `given a invalid date, when performing a transformation, then return null`() {
-        val result = "NOT_VALID".formatMediumDateTime()
+        val result = "NOT_VALID".deviceDateTimeFormat()
         assertEquals(null, result)
+    }
+
+    @Test
+    fun `given a valid date, when performing a transformation for device, then return with medium format`() {
+        val result = "2022-03-24T18:02:30.360Z".deviceDateTimeFormat()
+        assertEquals("March 24, 2022, 6:02 PM", result)
     }
 
     @Test


### PR DESCRIPTION
Cherry pick from the original PR: 
- #2783

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


# What's new in this PR?

### Issues

Devices screen - Time and date format not respecting locale

### Causes (Optional)

Was not implemented

### Solutions

implement it

### Attachments (Optional)

<img width=378 alt=Screenshot 2024-03-11 at 23 32 11 src=https://github.com/wireapp/wire-android/assets/6539347/23e06ab6-df18-40f6-a965-6c4c299b958e>