### PR TITLE
feat: show accent-colored user names in conversations [WPB-6891]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -39,6 +39,7 @@ import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.message.DeliveryStatus
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.android.ui.theme.Accent
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.User
@@ -157,7 +158,8 @@ class MessageMapper @Inject constructor(
             is OtherUser -> sender.isUnavailableUser
             is SelfUser, null -> false
         },
-        clientId = (message as? Message.Sendable)?.senderClientId
+        clientId = (message as? Message.Sendable)?.senderClientId,
+        accent = sender?.accentId?.let { Accent.fromAccentId(it) } ?: Accent.Unknown,
     )
 
     private fun getMessageStatus(message: Message.Standalone): MessageStatus {

--- a/app/src/main/kotlin/com/wire/android/model/ImageAsset.kt
+++ b/app/src/main/kotlin/com/wire/android/model/ImageAsset.kt
@@ -20,6 +20,9 @@ package com.wire.android.model
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.painterResource
+import com.wire.android.R
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
@@ -75,7 +78,10 @@ sealed class ImageAsset(private val imageLoader: WireSessionImageLoader) {
     fun paint(
         fallbackData: Any? = null,
         withCrossfadeAnimation: Boolean = false
-    ) = imageLoader.paint(asset = this, fallbackData = fallbackData, withCrossfadeAnimation = withCrossfadeAnimation)
+    ) = when {
+        LocalInspectionMode.current -> painterResource(id = R.drawable.ic_welcome_1)
+        else -> imageLoader.paint(asset = this, fallbackData = fallbackData, withCrossfadeAnimation = withCrossfadeAnimation)
+    }
 }
 
 fun String.parseIntoPrivateImageAsset(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -87,6 +87,7 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.launchGeoIntent
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
 import com.wire.kalium.logic.data.asset.isSaved
+import com.wire.android.ui.theme.Accent
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.collections.immutable.PersistentMap
 
@@ -426,6 +427,7 @@ private fun MessageAuthorRow(messageHeader: MessageHeader) {
             ) {
                 Username(
                     username.asString(),
+                    accent,
                     modifier = Modifier.weight(weight = 1f, fill = false)
                 )
                 UserBadge(
@@ -490,10 +492,11 @@ private fun MessageTimeLabel(
 }
 
 @Composable
-private fun Username(username: String, modifier: Modifier = Modifier) {
+private fun Username(username: String, accent: Accent, modifier: Modifier = Modifier) {
     Text(
         text = username,
         style = MaterialTheme.wireTypography.body02,
+        color = MaterialTheme.wireColorScheme.wireAccentColors.getOrDefault(accent, MaterialTheme.wireColorScheme.onBackground),
         modifier = modifier,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -41,6 +41,7 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
+import com.wire.android.ui.theme.Accent
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.collections.immutable.persistentMapOf
 
@@ -690,6 +691,32 @@ fun PreviewMessageWithMarkdownQuery() {
                 onResetSessionClicked = { _, _ -> },
                 onSelfDeletingMessageRead = {},
                 onReplyClickable = null
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewMessageWithAccents() = WireTheme {
+    Column {
+        Accent.entries.forEach {
+            MessageItem(
+                message = mockMessageWithText.copy(
+                    header = mockHeader.copy(username = UIText.DynamicString(it.name), accent = it),
+                    messageContent = UIMessageContent.TextMessage(MessageBody(UIText.DynamicString("Text")))
+                ),
+                conversationDetailsData = ConversationDetailsData.None,
+                audioMessagesState = persistentMapOf(),
+                onLongClicked = {},
+                onAssetMessageClicked = {},
+                onAudioClick = {},
+                onChangeAudioPosition = { _, _ -> },
+                onImageMessageClicked = { _, _ -> },
+                onOpenProfile = { _ -> },
+                onReactionClicked = { _, _ -> },
+                onResetSessionClicked = { _, _ -> },
+                onSelfDeletingMessageRead = {},
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -36,6 +36,7 @@ import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.android.ui.theme.Accent
 import com.wire.kalium.logic.data.user.AssetId
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
@@ -99,7 +100,8 @@ data class MessageHeader(
     val connectionState: ConnectionState?,
     val isSenderDeleted: Boolean,
     val isSenderUnavailable: Boolean,
-    val clientId: ClientId? = null
+    val clientId: ClientId? = null,
+    val accent: Accent = Accent.Unknown,
 )
 
 @Stable

--- a/app/src/main/kotlin/com/wire/android/ui/theme/Accent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/Accent.kt
@@ -19,6 +19,7 @@ package com.wire.android.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+@Suppress("MagicNumber")
 enum class Accent(val accentId: Int) {
     Amber(5),
     Blue(1),

--- a/app/src/main/kotlin/com/wire/android/ui/theme/Accent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/Accent.kt
@@ -1,0 +1,41 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+enum class Accent(val accentId: Int) {
+    Amber(5),
+    Blue(1),
+    Green(2),
+    Purple(7),
+    Red(4),
+    Petrol(6),
+    Unknown(0);
+
+    companion object {
+        fun fromAccentId(accentId: Int) = entries.firstOrNull { it.accentId == accentId } ?: Unknown
+    }
+}
+
+class WireAccentColors(private val association: (Accent) -> Color) {
+    fun getOrDefault(accent: Accent, default: Color): Color = when (accent) {
+        Accent.Unknown -> default
+        else -> association(accent)
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -102,6 +102,7 @@ data class WireColorScheme(
     val onScrollToBottomButtonColor: Color,
     val validE2eiStatusColor: Color,
     val mlsVerificationTextColor: Color,
+    val wireAccentColors: WireAccentColors,
 ) {
     fun toColorScheme(): ColorScheme = ColorScheme(
         primary = primary,
@@ -236,6 +237,17 @@ private val LightWireColorScheme = WireColorScheme(
     onScrollToBottomButtonColor = Color.White,
     validE2eiStatusColor = WireColorPalette.LightGreen550,
     mlsVerificationTextColor = WireColorPalette.DarkGreen700,
+    wireAccentColors = WireAccentColors {
+        when (it) {
+            Accent.Amber -> WireColorPalette.LightAmber500
+            Accent.Blue -> WireColorPalette.LightBlue500
+            Accent.Green -> WireColorPalette.LightGreen500
+            Accent.Purple -> WireColorPalette.LightPurple500
+            Accent.Red -> WireColorPalette.LightRed500
+            Accent.Petrol -> WireColorPalette.LightPetrol500
+            Accent.Unknown -> WireColorPalette.LightBlue500
+        }
+    }
 )
 
 // Dark WireColorScheme
@@ -344,6 +356,17 @@ private val DarkWireColorScheme = WireColorScheme(
     onScrollToBottomButtonColor = Color.Black,
     validE2eiStatusColor = WireColorPalette.DarkGreen500,
     mlsVerificationTextColor = WireColorPalette.DarkGreen700,
+    wireAccentColors = WireAccentColors {
+        when (it) {
+            Accent.Amber -> WireColorPalette.DarkAmber500
+            Accent.Blue -> WireColorPalette.DarkBlue500
+            Accent.Green -> WireColorPalette.DarkGreen500
+            Accent.Purple -> WireColorPalette.DarkPurple500
+            Accent.Red -> WireColorPalette.DarkRed500
+            Accent.Petrol -> WireColorPalette.DarkPetrol500
+            Accent.Unknown -> WireColorPalette.DarkBlue500
+        }
+    }
 )
 
 @PackagePrivate


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6891" title="WPB-6891" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-6891</a>  [Android] Show profile color
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

As a user, I want the profile color that I previously chose on web or iOS to reflect in my Android client. 
I see the profile colors of other people reflected in their names in the conversation view

Note: this is not about enabling the user to change the profile color on Android. Just reading and displaying the color value. 

### Solutions

Provide enum class to map `accentId` and identify accents, create `WireAccentColors` in `WireColorScheme` to associate proper colors to accents and use it to color the user name on message headers. When no accent color set, default one (the same as until now) is applied.

### Testing

#### How to Test

Have a conversation with user who changed their accent color on web or iOS and receive some messages to see their user name color.

### Attachments (Optional)

<img width="400" src="https://github.com/wireapp/wire-android/assets/30429749/427ceceb-4437-446d-8524-639122c61862"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
