### PR TITLE
fix: stay in call screen after back button from fullscreen [WPB-640]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -271,10 +271,14 @@ private fun OngoingCallContent(
                         hideDoubleTapToast()
                         FullScreenTile(
                             selectedParticipant = selectedParticipantForFullScreen,
-                            height = this@BoxWithConstraints.maxHeight - dimensions().spacing4x
-                        ) {
-                            shouldOpenFullScreen = !shouldOpenFullScreen
-                        }
+                            height = this@BoxWithConstraints.maxHeight - dimensions().spacing4x,
+                            closeFullScreen = {
+                                shouldOpenFullScreen = !shouldOpenFullScreen
+                            },
+                            onBackButtonClicked = {
+                                shouldOpenFullScreen = !shouldOpenFullScreen
+                            }
+                        )
                     } else {
                         VerticalCallingPager(
                             participants = participants,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.android.ui.calling.ongoing.fullscreen
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -50,9 +51,14 @@ fun FullScreenTile(
     sharedCallingViewModel: SharedCallingViewModel = hiltViewModel(),
     selectedParticipant: SelectedParticipant,
     height: Dp,
-    onDoubleTap: (offset: Offset) -> Unit
+    closeFullScreen: (offset: Offset) -> Unit,
+    onBackButtonClicked: () -> Unit
 ) {
     var shouldShowDoubleTapToast by remember { mutableStateOf(false) }
+
+    BackHandler {
+        onBackButtonClicked()
+    }
 
     sharedCallingViewModel.callState.participants.find {
         it.id == selectedParticipant.userId && it.clientId == selectedParticipant.clientId
@@ -64,7 +70,7 @@ fun FullScreenTile(
                     .clipToBounds()
                     .pointerInput(Unit) {
                         detectTapGestures(
-                            onDoubleTap = onDoubleTap
+                            onDoubleTap = closeFullScreen
                         )
                     }
                     .height(height)
@@ -114,6 +120,7 @@ fun PreviewFullScreenVideoCall() {
     FullScreenTile(
         selectedParticipant = SelectedParticipant(),
         height = 100.dp,
-        onDoubleTap = { }
+        closeFullScreen = {},
+        onBackButtonClicked = {}
     )
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-640" title="WPB-640" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-640</a>  When video is maximized and user taps on back button, video should minimise
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user clicks back button on full screen video in call then it closes entire call screen instead stay in it.

### Solutions

Add `BackHandler` in full screen tile to get back to call screen