### PR TITLE
fix: unnecessarily calls to updateVideoState function (WPB-6747)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
@@ -230,7 +230,7 @@ private fun CameraPreview(
             }
         )
     } else {
-        if(isCameraStopped) return
+        if (isCameraStopped) return
         isCameraStopped = true
         onClearSelfUserVideoPreview()
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
@@ -211,7 +211,10 @@ private fun CameraPreview(
     onSelfUserVideoPreviewCreated: (view: View) -> Unit,
     onClearSelfUserVideoPreview: () -> Unit
 ) {
+    var isCameraStopped by remember { mutableStateOf(isCameraOn) }
+
     if (isCameraOn) {
+        isCameraStopped = false
         val context = LocalContext.current
         val backgroundColor = colorsScheme().callingParticipantTileBackgroundColor.value.toInt()
         val videoPreview = remember {
@@ -227,6 +230,8 @@ private fun CameraPreview(
             }
         )
     } else {
+        if(isCameraStopped) return
+        isCameraStopped = true
         onClearSelfUserVideoPreview()
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6747" title="WPB-6747" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6747</a>  Calling `wcall_set_video_send_state` unnecessarily
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

unnecessarily calls to `onClearSelfUserVideoPreview()` function .

### Causes (Optional)

Every time the participant object changes, the screen is recomposing and tries to call `onClearSelfUserVideoPreview()` as the camera is turned off.
This would cause many calls to `wcall_set_video_send_state` of AVS with Stopped state.

### Solutions

Use a boolean value that will be remembered if the screen recompose to ensure a single call to `onClearSelfUserVideoPreview()`


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
