### PR TITLE
fix: Calling video not streamed when enabling camera on preview screen (WPB-7114)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
@@ -37,7 +37,8 @@ import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
-import com.wire.kalium.logic.feature.call.usecase.UpdateVideoStateUseCase
+import com.wire.kalium.logic.feature.call.usecase.video.SetVideoSendStateUseCase
+import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.android.scopes.ViewModelScoped
@@ -166,6 +167,13 @@ class CallsModule {
         callsScope: CallsScope
     ): UpdateVideoStateUseCase =
         callsScope.updateVideoState
+
+    @ViewModelScoped
+    @Provides
+    fun provideSetVideoSendStateUseCase(
+        callsScope: CallsScope
+    ): SetVideoSendStateUseCase =
+        callsScope.setVideoSendState
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -52,7 +52,7 @@ import com.wire.kalium.logic.feature.call.usecase.SetVideoPreviewUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
-import com.wire.kalium.logic.feature.call.usecase.UpdateVideoStateUseCase
+import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.util.PlatformView
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -127,8 +127,9 @@ class SharedCallingViewModel @Inject constructor(
 
     private suspend fun observeScreenState() {
         currentScreenManager.observeCurrentScreen(viewModelScope).collect {
-            if (it == CurrentScreen.InBackground) {
-                stopVideo()
+            // clear video preview when the screen is in background to avoid memory leaks
+            if (it == CurrentScreen.InBackground && callState.isCameraOn) {
+                clearVideoPreview()
             }
         }
     }
@@ -279,6 +280,11 @@ class SharedCallingViewModel @Inject constructor(
             callState = callState.copy(
                 isCameraOn = !callState.isCameraOn
             )
+            if (callState.isCameraOn) {
+                updateVideoState(conversationId, VideoState.STARTED)
+            } else {
+                updateVideoState(conversationId, VideoState.STOPPED)
+            }
         }
     }
 
@@ -286,7 +292,6 @@ class SharedCallingViewModel @Inject constructor(
         viewModelScope.launch {
             appLogger.i("SharedCallingViewModel: clearing video preview..")
             setVideoPreview(conversationId, PlatformView(null))
-            updateVideoState(conversationId, VideoState.STOPPED)
         }
     }
 
@@ -295,18 +300,6 @@ class SharedCallingViewModel @Inject constructor(
             appLogger.i("SharedCallingViewModel: setting video preview..")
             setVideoPreview(conversationId, PlatformView(null))
             setVideoPreview(conversationId, PlatformView(view))
-            updateVideoState(conversationId, VideoState.STARTED)
-        }
-    }
-
-    fun stopVideo() {
-        viewModelScope.launch {
-            if (callState.isCameraOn) {
-                appLogger.i("SharedCallingViewModel: stopping video..")
-                callState = callState.copy(isCameraOn = false, isSpeakerOn = false)
-                clearVideoPreview()
-                turnLoudSpeakerOff()
-            }
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -129,8 +129,14 @@ fun OngoingCallScreen(
             hangUpCall = { sharedCallingViewModel.hangUpCall(navigator::navigateBack) },
             toggleVideo = sharedCallingViewModel::toggleVideo,
             flipCamera = sharedCallingViewModel::flipCamera,
-            setVideoPreview = sharedCallingViewModel::setVideoPreview,
-            clearVideoPreview = sharedCallingViewModel::clearVideoPreview,
+            setVideoPreview = {
+                sharedCallingViewModel.setVideoPreview(it)
+                ongoingCallViewModel.startSendingVideoFeed()
+            },
+            clearVideoPreview = {
+                sharedCallingViewModel.clearVideoPreview()
+                ongoingCallViewModel.stopSendingVideoFeed()
+            },
             navigateBack = navigator::navigateBack,
             requestVideoStreams = ongoingCallViewModel::requestVideoStreams,
             hideDoubleTapToast = ongoingCallViewModel::hideDoubleTapToast,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -85,7 +85,7 @@ class OngoingCallViewModel @Inject constructor(
     private fun initCameraState(calls: List<Call>) {
         val currentCall = calls.find { call -> call.conversationId == conversationId }
         currentCall?.let {
-            if(it.isCameraOn) {
+            if (it.isCameraOn) {
                 startSendingVideoFeed()
             } else {
                 stopSendingVideoFeed()

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -33,11 +33,14 @@ import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.navArgs
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
+import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallClient
+import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.RequestVideoStreamsUseCase
+import com.wire.kalium.logic.feature.call.usecase.video.SetVideoSendStateUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -54,7 +57,8 @@ class OngoingCallViewModel @Inject constructor(
     private val globalDataStore: GlobalDataStore,
     private val establishedCalls: ObserveEstablishedCallsUseCase,
     private val requestVideoStreams: RequestVideoStreamsUseCase,
-    private val currentScreenManager: CurrentScreenManager,
+    private val setVideoSendState: SetVideoSendStateUseCase,
+    private val currentScreenManager: CurrentScreenManager
 ) : ViewModel() {
 
     private val ongoingCallNavArgs: CallingNavArgs = savedStateHandle.navArgs()
@@ -70,11 +74,34 @@ class OngoingCallViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             establishedCalls().first { it.isNotEmpty() }.run {
+                initCameraState(this)
                 // We start observing once we have an ongoing call
                 observeCurrentCall()
             }
         }
         showDoubleTapToast()
+    }
+
+    private fun initCameraState(calls: List<Call>) {
+        val currentCall = calls.find { call -> call.conversationId == conversationId }
+        currentCall?.let {
+            if(it.isCameraOn) {
+                startSendingVideoFeed()
+            } else {
+                stopSendingVideoFeed()
+            }
+        }
+    }
+
+    fun startSendingVideoFeed() {
+        viewModelScope.launch {
+            setVideoSendState(conversationId, VideoState.STARTED)
+        }
+    }
+    fun stopSendingVideoFeed() {
+        viewModelScope.launch {
+            setVideoSendState(conversationId, VideoState.STOPPED)
+        }
     }
 
     private suspend fun observeCurrentCall() {

--- a/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
@@ -100,17 +100,16 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenAnOngoingCall_WhenTurningOnCamera_ThenSetVideoSendStateToStarted() = runTest {
-
         ongoingCallViewModel.startSendingVideoFeed()
 
-        coVerify(exactly = 1) { setVideoSendState(any(), VideoState.STARTED) }
+        coVerify(exactly = 1) { setVideoSendState.invoke(any(), VideoState.STARTED) }
     }
 
     @Test
     fun givenAnOngoingCall_WhenTurningOffCamera_ThenSetVideoSendStateToStopped() = runTest {
         ongoingCallViewModel.stopSendingVideoFeed()
 
-        coVerify(exactly = 1) { setVideoSendState(any(), VideoState.STOPPED) }
+        coVerify { setVideoSendState.invoke(any(), VideoState.STOPPED) }
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
@@ -31,12 +31,14 @@ import com.wire.android.util.CurrentScreenManager
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.RequestVideoStreamsUseCase
+import com.wire.kalium.logic.feature.call.usecase.video.SetVideoSendStateUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -69,6 +71,9 @@ class OngoingCallViewModelTest {
     private lateinit var currentScreenManager: CurrentScreenManager
 
     @MockK
+    private lateinit var setVideoSendState: SetVideoSendStateUseCase
+
+    @MockK
     private lateinit var globalDataStore: GlobalDataStore
 
     private lateinit var ongoingCallViewModel: OngoingCallViewModel
@@ -80,6 +85,7 @@ class OngoingCallViewModelTest {
         coEvery { establishedCall.invoke() } returns flowOf(listOf(provideCall()))
         coEvery { currentScreenManager.observeCurrentScreen(any()) } returns MutableStateFlow(CurrentScreen.SomeOther)
         coEvery { globalDataStore.getShouldShowDoubleTapToast(any()) } returns false
+        coEvery { setVideoSendState.invoke(any(), any()) } returns Unit
 
         ongoingCallViewModel = OngoingCallViewModel(
             savedStateHandle = savedStateHandle,
@@ -87,8 +93,24 @@ class OngoingCallViewModelTest {
             requestVideoStreams = requestVideoStreams,
             currentScreenManager = currentScreenManager,
             currentUserId = currentUserId,
+            setVideoSendState = setVideoSendState,
             globalDataStore = globalDataStore,
         )
+    }
+
+    @Test
+    fun givenAnOngoingCall_WhenTurningOnCamera_ThenSetVideoSendStateToStarted() = runTest {
+
+        ongoingCallViewModel.startSendingVideoFeed()
+
+        coVerify(exactly = 1) { setVideoSendState(any(), VideoState.STARTED) }
+    }
+
+    @Test
+    fun givenAnOngoingCall_WhenTurningOffCamera_ThenSetVideoSendStateToStopped() = runTest {
+        ongoingCallViewModel.stopSendingVideoFeed()
+
+        coVerify(exactly = 1) { setVideoSendState(any(), VideoState.STOPPED) }
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -42,7 +42,7 @@ import com.wire.kalium.logic.feature.call.usecase.SetVideoPreviewUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
-import com.wire.kalium.logic.feature.call.usecase.UpdateVideoStateUseCase
+import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -261,6 +261,7 @@ class SharedCallingViewModelTest {
         advanceUntilIdle()
 
         sharedCallingViewModel.callState.isCameraOn shouldBeEqualTo false
+        coVerify(exactly = 1) { updateVideoState(any(), VideoState.STOPPED) }
     }
 
     @Test
@@ -272,6 +273,7 @@ class SharedCallingViewModelTest {
         advanceUntilIdle()
 
         sharedCallingViewModel.callState.isCameraOn shouldBeEqualTo true
+        coVerify(exactly = 1) { updateVideoState(any(), VideoState.STARTED) }
     }
 
     @Test
@@ -315,57 +317,24 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun `given an active call, when setVideoPreview is called, then set the video preview and update video state to STARTED`() =
+    fun `given a call, when setVideoPreview is called, then set the video preview`() =
         runTest {
             coEvery { setVideoPreview(any(), any()) } returns Unit
-            coEvery { updateVideoState(any(), any()) } returns Unit
 
             sharedCallingViewModel.setVideoPreview(view)
             advanceUntilIdle()
 
             coVerify(exactly = 2) { setVideoPreview(any(), any()) }
-            coVerify(exactly = 1) { updateVideoState(any(), VideoState.STARTED) }
         }
 
     @Test
-    fun `given an active call, when clearVideoPreview is called, then update video state to STOPPED`() =
-        runTest {
-            coEvery { setVideoPreview(any(), any()) } returns Unit
-            coEvery { updateVideoState(any(), any()) } returns Unit
-
-            sharedCallingViewModel.clearVideoPreview()
-            advanceUntilIdle()
-
-            coVerify(exactly = 1) { updateVideoState(any(), VideoState.STOPPED) }
-        }
-
-    @Test
-    fun `given a video call, when stopping video, then clear Video Preview and turn off speaker`() =
-        runTest {
-            sharedCallingViewModel.callState =
-                sharedCallingViewModel.callState.copy(isCameraOn = true)
-            coEvery { setVideoPreview(any(), any()) } returns Unit
-            coEvery { updateVideoState(any(), any()) } returns Unit
-            coEvery { turnLoudSpeakerOff() } returns Unit
-
-            sharedCallingViewModel.stopVideo()
-            advanceUntilIdle()
-
-            coVerify(exactly = 1) { setVideoPreview(any(), any()) }
-            coVerify(exactly = 1) { turnLoudSpeakerOff() }
-        }
-
-    @Test
-    fun `given an audio call, when stopVideo is invoked, then do not do anything`() = runTest {
-        sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isCameraOn = false)
+    fun `given a call, when clearVideoPreview is called, then clear view`() = runTest {
         coEvery { setVideoPreview(any(), any()) } returns Unit
-        coEvery { turnLoudSpeakerOff() } returns Unit
 
-        sharedCallingViewModel.stopVideo()
+        sharedCallingViewModel.clearVideoPreview()
         advanceUntilIdle()
 
-        coVerify(inverse = true) { setVideoPreview(any(), any()) }
-        coVerify(inverse = true) { turnLoudSpeakerOff() }
+        coVerify(exactly = 1) { setVideoPreview(any(), any()) }
     }
 
     companion object {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7114" title="WPB-7114" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7114</a>  [Android] When video is enabled on precall screen, video is not streamed during 1:1 and group call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Calling video not streamed when enabling camera on preview screen of an incoming call.

### Causes (Optional)

TLDR: A race condition.
Establishing an incoming calls takes some times an important time, causing to call the function of video stream before the call get established.

### Solutions

I moved the logic of sending video feed to OngoingCallViewModel, this way we are sure `setVideoSendState` will be called only when the call get established.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Start a call to an android device.
- On Android enable your camera and accept the call
- You should still see your camera on, and the other person see your video feed.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
