### PR TITLE
feat: Remove notifications on read from another client [WPB-1881]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -242,8 +242,6 @@ class MessageNotificationManager
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
                             }
 
-                            is NotificationMessage.ConversationSeen -> {}
-
                             null -> {
                                 val isAppLocked = lockCodeTimeManager.isAppLocked()
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
@@ -425,7 +423,6 @@ class MessageNotificationManager
             is NotificationMessage.ConnectionRequest -> italicTextFromResId(R.string.notification_connection_request)
             is NotificationMessage.ConversationDeleted -> italicTextFromResId(R.string.notification_conversation_deleted)
             is NotificationMessage.Knock -> italicTextFromResId(R.string.notification_knock)
-            is NotificationMessage.ConversationSeen,
             is NotificationMessage.ObfuscatedMessage,
             is NotificationMessage.ObfuscatedKnock -> italicTextFromResId(
                 R.string.notification_obfuscated_message_content

--- a/app/src/main/kotlin/com/wire/android/notification/Models.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/Models.kt
@@ -160,6 +160,7 @@ fun LocalNotification.Conversation.intoNotificationConversation(): NotificationC
     )
 }
 
+@Suppress("LongMethod")
 fun LocalNotificationMessage.intoNotificationMessage(): NotificationMessage {
 
     val notificationMessageTime = time.toEpochMilliseconds()
@@ -227,7 +228,6 @@ fun LocalNotificationMessage.intoNotificationMessage(): NotificationMessage {
         )
 
         is LocalNotificationMessage.ConversationSeen -> NotificationMessage.ConversationSeen(messageId, notificationMessageTime)
-
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/notification/Models.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/Models.kt
@@ -98,15 +98,18 @@ sealed class NotificationMessage(open val messageId: String, open val author: No
         override val author: NotificationMessageAuthor,
         override val time: Long,
         val authorId: String
-    ) :
-        NotificationMessage(messageId, author, time)
+    ) : NotificationMessage(messageId, author, time)
 
     data class ConversationDeleted(
         override val messageId: String,
         override val author: NotificationMessageAuthor,
         override val time: Long
-    ) :
-        NotificationMessage(messageId, author, time)
+    ) : NotificationMessage(messageId, author, time)
+
+    data class ConversationSeen(
+        override val messageId: String,
+        override val time: Long
+    ) : NotificationMessage(messageId, null, time)
 }
 
 data class NotificationMessageAuthor(val name: String, val image: ByteArray?) {
@@ -222,6 +225,9 @@ fun LocalNotificationMessage.intoNotificationMessage(): NotificationMessage {
             messageId,
             notificationMessageTime
         )
+
+        is LocalNotificationMessage.ConversationSeen -> NotificationMessage.ConversationSeen(messageId, notificationMessageTime)
+
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/notification/Models.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/Models.kt
@@ -105,11 +105,6 @@ sealed class NotificationMessage(open val messageId: String, open val author: No
         override val author: NotificationMessageAuthor,
         override val time: Long
     ) : NotificationMessage(messageId, author, time)
-
-    data class ConversationSeen(
-        override val messageId: String,
-        override val time: Long
-    ) : NotificationMessage(messageId, null, time)
 }
 
 data class NotificationMessageAuthor(val name: String, val image: ByteArray?) {
@@ -226,8 +221,6 @@ fun LocalNotificationMessage.intoNotificationMessage(): NotificationMessage {
             messageId,
             notificationMessageTime
         )
-
-        is LocalNotificationMessage.ConversationSeen -> NotificationMessage.ConversationSeen(messageId, notificationMessageTime)
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1881" title="WPB-1881" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-1881</a>  Clearing of notifications after messages are read on another client
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

Added handling for new `LocalNotification.ConversationSeen` - removing the corresponding notification. 

## Needs releases with:

Merge after kalium update 
https://github.com/wireapp/kalium/pull/2671
