### PR TITLE
fix: misleading dialog copy when certificate enrolling fails (WPB-7129)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
@@ -57,7 +57,7 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.destinations.E2eiCertificateDetailsScreenDestination
 import com.wire.android.ui.destinations.InitialSyncScreenDestination
-import com.wire.android.ui.home.E2EIErrorWithDismissDialog
+import com.wire.android.ui.home.E2EIErrorNoSnoozeDialog
 import com.wire.android.ui.home.E2EISuccessDialog
 import com.wire.android.ui.markdown.MarkdownConstants
 import com.wire.android.ui.theme.WireTheme
@@ -193,10 +193,12 @@ private fun E2EIEnrollmentScreenContent(
         }
 
         if (state.isCertificateEnrollError) {
-            E2EIErrorWithDismissDialog(
+            E2EIErrorNoSnoozeDialog(
                 isE2EILoading = state.isLoading,
-                updateCertificate = enrollE2EICertificate,
-                onDismiss = dismissErrorDialog
+                updateCertificate = {
+                    dismissErrorDialog()
+                    enrollE2EICertificate()
+                }
             )
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/E2EIDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/E2EIDialogs.kt
@@ -247,7 +247,7 @@ private fun E2EIErrorWithSnoozeDialog(
 }
 
 @Composable
-private fun E2EIErrorNoSnoozeDialog(
+fun E2EIErrorNoSnoozeDialog(
     isE2EILoading: Boolean,
     updateCertificate: () -> Unit
 ) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7129" title="WPB-7129" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7129</a>  [Android] Misleading dialogue if certificate generation fails after login with e2ei enabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2805

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like 
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When E2EI is already enabled when the user logs in, he is forced to generate his certificate. If this certificate generation fails, we see the wrong copy dialog.

### Solutions

Adjust dialog copy with correct information (correct subtext and removal of  button)

### Testing

#### How to Test

- have a team with e2ei enabled
- login on android and tap on “get certificate” button
- make getting certificate fail (e.g. by providing a wrong acme URL)
- alert is shown with correct copy

### Attachments (Optional)


| Before | After |
| ----------- | ------------ |
| <img src=https://github.com/wireapp/wire-android/assets/5890660/9886e084-d14e-4815-9d71-1b786ab3bb27 width=200 height=400 alt=old dialog copy />  |  <img src=https://github.com/wireapp/wire-android/assets/5890660/f91ecf7f-8186-4e07-b3b3-87f56dd876df width=200 height=400 alt=new dialog copy /> |
----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .