### PR TITLE
fix: Some workers not running when persistent websocket is enabled (WPB-7213)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
@@ -26,10 +26,13 @@ import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.asset.GetAvatarAssetUseCase
 import com.wire.kalium.logic.feature.client.FinalizeMLSClientAfterE2EIEnrollment
 import com.wire.kalium.logic.feature.conversation.GetAllContactsNotInConversationUseCase
+import com.wire.kalium.logic.feature.e2ei.CertificateRevocationListCheckWorker
 import com.wire.kalium.logic.feature.e2ei.usecase.GetE2eiCertificateUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMembersE2EICertificateStatusesUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
+import com.wire.kalium.logic.feature.featureConfig.FeatureFlagsSyncWorker
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
 import com.wire.kalium.logic.feature.publicuser.GetKnownUserUseCase
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
@@ -226,4 +229,19 @@ class UserModule {
     @Provides
     fun provideGetUserE2eiCertificates(userScope: UserScope): GetUserE2eiCertificatesUseCase =
         userScope.getUserE2eiCertificates
+
+    @ViewModelScoped
+    @Provides
+    fun provideCertificateRevocationListCheckWorker(userScope: UserScope): CertificateRevocationListCheckWorker =
+        userScope.certificateRevocationListCheckWorker
+
+    @ViewModelScoped
+    @Provides
+    fun provideFeatureFlagsSyncWorker(userScope: UserScope): FeatureFlagsSyncWorker =
+        userScope.featureFlagsSyncWorker
+
+    @ViewModelScoped
+    @Provides
+    fun provideObserveCertificateRevocationForSelfClientUseCase(userScope: UserScope): ObserveCertificateRevocationForSelfClientUseCase =
+        userScope.observeCertificateRevocationForSelfClient
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
@@ -1,0 +1,49 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.wire.android.navigation.SavedStateViewModel
+import com.wire.kalium.logic.feature.e2ei.CertificateRevocationListCheckWorker
+import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
+import com.wire.kalium.logic.feature.featureConfig.FeatureFlagsSyncWorker
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AppSyncViewModel @Inject constructor(
+    override val savedStateHandle: SavedStateHandle,
+    private val certificateRevocationListCheckWorker: CertificateRevocationListCheckWorker,
+    private val observeCertificateRevocationForSelfClient: ObserveCertificateRevocationForSelfClientUseCase,
+    private val featureFlagsSyncWorker: FeatureFlagsSyncWorker
+) : SavedStateViewModel(savedStateHandle) {
+
+    fun startSyncingAppConfig() {
+        viewModelScope.launch {
+            certificateRevocationListCheckWorker.execute()
+        }
+        viewModelScope.launch {
+            observeCertificateRevocationForSelfClient.invoke()
+        }
+        viewModelScope.launch {
+            featureFlagsSyncWorker.execute()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -52,6 +53,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 import com.ramcosta.composedestinations.DestinationsNavHost
 import com.ramcosta.composedestinations.animations.defaults.RootNavGraphDefaultAnimations
@@ -96,6 +98,7 @@ import kotlinx.coroutines.launch
 fun HomeScreen(
     navigator: Navigator,
     homeViewModel: HomeViewModel = hiltViewModel(),
+    appSyncViewModel: AppSyncViewModel = hiltViewModel(),
     homeDrawerViewModel: HomeDrawerViewModel = hiltViewModel(),
     conversationListViewModel: ConversationListViewModel = hiltViewModel(), // TODO: move required elements from this one to HomeViewModel?,
     groupDetailsScreenResultRecipient: ResultRecipient<ConversationScreenDestination, GroupConversationDetailsNavBackArgs>,
@@ -105,6 +108,21 @@ fun HomeScreen(
     val homeScreenState = rememberHomeScreenState(navigator)
     val showNotificationsFlow = rememberRequestPushNotificationsPermissionFlow(
         onPermissionDenied = { /** TODO: Show a dialog rationale explaining why the permission is needed **/ })
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { source, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                appSyncViewModel.startSyncingAppConfig()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
 
     LaunchedEffect(homeViewModel.savedStateHandle) {
         showNotificationsFlow.launch()
@@ -301,7 +319,10 @@ fun HomeContent(
                                         contentScale = ContentScale.FillBounds,
                                         colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onPrimary),
                                         modifier = Modifier
-                                            .padding(start = dimensions().spacing4x, top = dimensions().spacing2x)
+                                            .padding(
+                                                start = dimensions().spacing4x,
+                                                top = dimensions().spacing2x
+                                            )
                                             .size(dimensions().fabIconSize)
                                     )
                                 },

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -29,12 +29,8 @@ import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.navigation.SavedStateViewModel
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.feature.client.NeedsToRegisterClientUseCase
-<<<<<<< HEAD
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
-=======
-import com.wire.kalium.logic.feature.e2ei.CertificateRevocationListCheckWorker
->>>>>>> 50cc7ec78 (fix: Some workers not running when persistent websocket is enabled (WPB-7213) (#2803))
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
@@ -51,8 +47,7 @@ class HomeViewModel @Inject constructor(
     private val needsToRegisterClient: NeedsToRegisterClientUseCase,
     private val observeLegalHoldStatusForSelfUser: ObserveLegalHoldStateForSelfUserUseCase,
     private val wireSessionImageLoader: WireSessionImageLoader,
-    private val shouldTriggerMigrationForUser: ShouldTriggerMigrationForUserUserCase,
-    private val certificateRevocationListCheckWorker: CertificateRevocationListCheckWorker
+    private val shouldTriggerMigrationForUser: ShouldTriggerMigrationForUserUserCase
 ) : SavedStateViewModel(savedStateHandle) {
 
     var homeState by mutableStateOf(HomeState())
@@ -60,18 +55,16 @@ class HomeViewModel @Inject constructor(
 
     init {
         loadUserAvatar()
-<<<<<<< HEAD
         observeLegalHoldStatus()
     }
 
     private fun observeLegalHoldStatus() {
         viewModelScope.launch {
             observeLegalHoldStatusForSelfUser()
-                .collectLatest { homeState = homeState.copy(shouldDisplayLegalHoldIndicator = it != LegalHoldStateForSelfUser.Disabled) }
-=======
-        viewModelScope.launch {
-            certificateRevocationListCheckWorker.execute()
->>>>>>> 50cc7ec78 (fix: Some workers not running when persistent websocket is enabled (WPB-7213) (#2803))
+                .collectLatest {
+                    homeState =
+                        homeState.copy(shouldDisplayLegalHoldIndicator = it != LegalHoldStateForSelfUser.Disabled)
+                }
         }
     }
 
@@ -81,10 +74,13 @@ class HomeViewModel @Inject constructor(
             when {
                 shouldTriggerMigrationForUser(userId) ->
                     onRequirement(HomeRequirement.Migration(userId))
+
                 needsToRegisterClient() -> // check if the client has been registered and open the proper screen if not
                     onRequirement(HomeRequirement.RegisterDevice)
+
                 getSelf().first().handle.isNullOrEmpty() -> // check if the user handle has been set and open the proper screen if not
                     onRequirement(HomeRequirement.CreateAccountUsername)
+
                 shouldDisplayWelcomeToARScreen() -> {
                     homeState = homeState.copy(shouldDisplayWelcomeMessage = true)
                 }
@@ -99,7 +95,12 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             getSelf().collect { selfUser ->
                 homeState = homeState.copy(
-                    avatarAsset = selfUser.previewPicture?.let { UserAvatarAsset(wireSessionImageLoader, it) },
+                    avatarAsset = selfUser.previewPicture?.let {
+                        UserAvatarAsset(
+                            wireSessionImageLoader,
+                            it
+                        )
+                    },
                     status = selfUser.availabilityStatus
                 )
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -29,8 +29,12 @@ import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.navigation.SavedStateViewModel
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.feature.client.NeedsToRegisterClientUseCase
+<<<<<<< HEAD
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
+=======
+import com.wire.kalium.logic.feature.e2ei.CertificateRevocationListCheckWorker
+>>>>>>> 50cc7ec78 (fix: Some workers not running when persistent websocket is enabled (WPB-7213) (#2803))
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
@@ -47,7 +51,8 @@ class HomeViewModel @Inject constructor(
     private val needsToRegisterClient: NeedsToRegisterClientUseCase,
     private val observeLegalHoldStatusForSelfUser: ObserveLegalHoldStateForSelfUserUseCase,
     private val wireSessionImageLoader: WireSessionImageLoader,
-    private val shouldTriggerMigrationForUser: ShouldTriggerMigrationForUserUserCase
+    private val shouldTriggerMigrationForUser: ShouldTriggerMigrationForUserUserCase,
+    private val certificateRevocationListCheckWorker: CertificateRevocationListCheckWorker
 ) : SavedStateViewModel(savedStateHandle) {
 
     var homeState by mutableStateOf(HomeState())
@@ -55,6 +60,7 @@ class HomeViewModel @Inject constructor(
 
     init {
         loadUserAvatar()
+<<<<<<< HEAD
         observeLegalHoldStatus()
     }
 
@@ -62,6 +68,10 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             observeLegalHoldStatusForSelfUser()
                 .collectLatest { homeState = homeState.copy(shouldDisplayLegalHoldIndicator = it != LegalHoldStateForSelfUser.Disabled) }
+=======
+        viewModelScope.launch {
+            certificateRevocationListCheckWorker.execute()
+>>>>>>> 50cc7ec78 (fix: Some workers not running when persistent websocket is enabled (WPB-7213) (#2803))
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7213" title="WPB-7213" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7213</a>  [Android] CertificateRevocationListCheckWorker n ot running when app is connected to persistent websocket
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2803

---- 

 ⚠️ Conflicts during cherry-pick:
app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

CertificateRevocationListCheckWorker, observeCertificateRevocationForSelfClient and featureFlagsSyncWorker are expected to run after every sync. But in case we have persistent web socket, the app does not perform sync which cause to not run those workers.

### Solutions

Run those worker on every app launch  in ON_RESUME lifecycle from in HomeScreen.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .