### PR TITLE
fix: edit option is stored when selecting another message (WPB-4403)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
@@ -109,6 +109,7 @@ class MessageComposerStateHolder(
     }
 
     fun toReply(message: UIMessage.Regular) {
+        messageCompositionHolder.clearMessage()
         messageCompositionHolder.setReply(message)
         messageCompositionInputStateHolder.toComposing()
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
@@ -70,7 +70,8 @@ class MessageCompositionHolder(
             messageComposition.update {
                 it.copy(
                     quotedMessage = quotedMessage,
-                    quotedMessageId = message.header.messageId
+                    quotedMessageId = message.header.messageId,
+                    editMessageId = null
                 )
             }
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4403" title="WPB-4403" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4403</a>  [Android] Editing option is stored when selecting another message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When firstly selecting a message to edit and while in the process, select another message to reply, when sending the reply message it would edit the previous selected message

### Causes (Optional)

We were not clearing the editMessageId from the composition

### Solutions

Clear text and editMessageId of the composition when selecting reply

### Testing

#### How to Test

- open any chat where you have minimum 1 message A
- send any message B
- longtap on your message B > Select edit
- without editing the message B, longtap on message A
- select “Reply”
- type your reply
- I should see a reply to message A