### PR TITLE
fix: attachment options visible when navigating after searching [WPB-2425]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -19,7 +19,8 @@ package com.wire.android.ui.home.messagecomposer
 
 import android.net.Uri
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -94,17 +95,13 @@ fun EnabledMessageComposer(
 
         LaunchedEffect(offsetY) {
             with(density) {
-                inputStateHolder.handleOffsetChange(
+                inputStateHolder.handleImeOffsetChange(
                     offsetY.toDp(),
                     navBarHeight,
                     imeAnimationSource.toDp(),
                     imeAnimationTarget.toDp()
                 )
             }
-        }
-
-        LaunchedEffect(isImeVisible) {
-            inputStateHolder.handleIMEVisibility(isImeVisible)
         }
 
         LaunchedEffect(modalBottomSheetState.isVisible) {
@@ -262,31 +259,35 @@ fun EnabledMessageComposer(
                                 onCloseRichEditingButtonClicked = additionalOptionStateHolder::toAttachmentAndAdditionalOptionsMenu,
                             )
                         }
-
-                        AdditionalOptionSubMenu(
-                            isFileSharingEnabled = messageComposerViewState.value.isFileSharingEnabled,
-                            additionalOptionsState = additionalOptionStateHolder.additionalOptionsSubMenuState,
-                            onRecordAudioMessageClicked = ::toAudioRecording,
-                            onCloseAdditionalAttachment = ::toInitialAttachmentOptions,
-                            onLocationPickerClicked = ::toLocationPicker,
-                            onAttachmentPicked = onAttachmentPicked,
-                            onAudioRecorded = onAudioRecorded,
-                            onLocationPicked = onLocationPicked,
-                            onCaptureVideoPermissionPermanentlyDenied = onCaptureVideoPermissionPermanentlyDenied,
-                            tempWritableImageUri = tempWritableImageUri,
-                            tempWritableVideoUri = tempWritableVideoUri,
+                        Box(
                             modifier = Modifier
                                 .height(
-                                    inputStateHolder.calculateOptionsMenuHeight(
-                                        additionalOptionStateHolder.additionalOptionsSubMenuState
-                                    )
+                                    inputStateHolder.calculateOptionsMenuHeight(additionalOptionStateHolder.additionalOptionsSubMenuState)
                                 )
                                 .fillMaxWidth()
-                                .background(
-                                    colorsScheme().messageComposerBackgroundColor
+                                .background(colorsScheme().messageComposerBackgroundColor)
+                        ) {
+                            androidx.compose.animation.AnimatedVisibility(
+                                visible = inputStateHolder.subOptionsVisible,
+                                enter = fadeIn(),
+                                exit = fadeOut(),
+                            ) {
+                                AdditionalOptionSubMenu(
+                                    isFileSharingEnabled = messageComposerViewState.value.isFileSharingEnabled,
+                                    additionalOptionsState = additionalOptionStateHolder.additionalOptionsSubMenuState,
+                                    onRecordAudioMessageClicked = ::toAudioRecording,
+                                    onCloseAdditionalAttachment = ::toInitialAttachmentOptions,
+                                    onLocationPickerClicked = ::toLocationPicker,
+                                    onAttachmentPicked = onAttachmentPicked,
+                                    onAudioRecorded = onAudioRecorded,
+                                    onLocationPicked = onLocationPicked,
+                                    onCaptureVideoPermissionPermanentlyDenied = onCaptureVideoPermissionPermanentlyDenied,
+                                    tempWritableImageUri = tempWritableImageUri,
+                                    tempWritableVideoUri = tempWritableVideoUri,
+                                    modifier = Modifier.fillMaxSize()
                                 )
-                                .animateContentSize()
-                        )
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
@@ -85,15 +85,7 @@ class MessageCompositionInputStateHolder(
         )
     )
 
-    fun handleIMEVisibility(isImeVisible: Boolean) {
-        if (isImeVisible) {
-            optionsVisible = true
-        } else if (!subOptionsVisible) {
-            optionsVisible = false
-        }
-    }
-
-    fun handleOffsetChange(offset: Dp, navBarHeight: Dp, source: Dp, target: Dp) {
+    fun handleImeOffsetChange(offset: Dp, navBarHeight: Dp, source: Dp, target: Dp) {
         val actualOffset = max(offset - navBarHeight, 0.dp)
 
         // this check secures that if some additional space will be added to keyboard
@@ -103,10 +95,16 @@ class MessageCompositionInputStateHolder(
         }
 
         if (previousOffset < actualOffset) {
-            optionsVisible = true
-            if (!subOptionsVisible || optionsHeight <= actualOffset) {
-                optionsHeight = actualOffset
-                subOptionsVisible = false
+
+            // only if the real goal of this ime offset increase is to really open the keyboard
+            // otherwise it can mean the keyboard is still in a process of hiding from the previous screen and ultimately won't be shown
+            // in this case we don't want to show and hide the options for a short time as it will only make unwanted blink effect
+            if (target > 0.dp) {
+                optionsVisible = true
+                if (!subOptionsVisible || optionsHeight <= actualOffset) {
+                    optionsHeight = actualOffset
+                    subOptionsVisible = false
+                }
             }
         } else if (previousOffset > actualOffset) {
             if (!subOptionsVisible) {

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
@@ -46,47 +46,9 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when IME is visible, showOptions should be set to true`() {
-        // Given
-        val isImeVisible = true
-
-        // When
-        state.handleIMEVisibility(isImeVisible)
-
-        // Then
-        state.optionsVisible shouldBeEqualTo true
-    }
-
-    @Test
-    fun `when IME is hidden and showSubOptions is true, showOptions remains unchanged`() {
-        // Given
-        val isImeVisible = false
-        state.updateValuesForTesting(showSubOptions = true, showOptions = false)
-
-        // When
-        state.handleIMEVisibility(isImeVisible)
-
-        // Then
-        state.optionsVisible shouldBeEqualTo false
-    }
-
-    @Test
-    fun `when IME is hidden and showSubOptions is false, showOptions should be set to false`() {
-        // Given
-        val isImeVisible = false
-        state.updateValuesForTesting(showSubOptions = false)
-
-        // When
-        state.handleIMEVisibility(isImeVisible)
-
-        // Then
-        state.optionsVisible shouldBeEqualTo false
-    }
-
-    @Test
     fun `when offset increases and is bigger than previous and options height, options height is updated`() {
         // When
-        state.handleOffsetChange(
+        state.handleImeOffsetChange(
             50.dp,
             NAVIGATION_BAR_HEIGHT,
             SOURCE,
@@ -104,7 +66,7 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(previousOffset = 50.dp)
 
         // When
-        state.handleOffsetChange(
+        state.handleImeOffsetChange(
             20.dp,
             NAVIGATION_BAR_HEIGHT,
             SOURCE,
@@ -121,7 +83,7 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(previousOffset = 50.dp)
 
         // When
-        state.handleOffsetChange(
+        state.handleImeOffsetChange(
             0.dp,
             NAVIGATION_BAR_HEIGHT,
             SOURCE,
@@ -139,7 +101,7 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(keyboardHeight = 30.dp)
 
         // When
-        state.handleOffsetChange(
+        state.handleImeOffsetChange(
             30.dp,
             NAVIGATION_BAR_HEIGHT,
             SOURCE,
@@ -156,7 +118,7 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(keyboardHeight = 20.dp)
 
         // When
-        state.handleOffsetChange(
+        state.handleImeOffsetChange(
             30.dp,
             NAVIGATION_BAR_HEIGHT,
             SOURCE,
@@ -173,7 +135,7 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(previousOffset = 50.dp, keyboardHeight = 20.dp)
 
         // When
-        state.handleOffsetChange(
+        state.handleImeOffsetChange(
             30.dp,
             NAVIGATION_BAR_HEIGHT,
             SOURCE,
@@ -196,7 +158,7 @@ class MessageCompositionInputStateHolderTest {
         )
 
         // When
-        state.handleOffsetChange(
+        state.handleImeOffsetChange(
             30.dp,
             NAVIGATION_BAR_HEIGHT,
             SOURCE,
@@ -218,7 +180,7 @@ class MessageCompositionInputStateHolderTest {
         )
 
         // When
-        state.handleOffsetChange(
+        state.handleImeOffsetChange(
             30.dp,
             NAVIGATION_BAR_HEIGHT,
             SOURCE,
@@ -235,7 +197,7 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(previousOffset = 40.dp, keyboardHeight = 20.dp)
 
         // When
-        state.handleOffsetChange(
+        state.handleImeOffsetChange(
             40.dp,
             NAVIGATION_BAR_HEIGHT,
             SOURCE,
@@ -254,7 +216,7 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(initialKeyboardHeight = 0.dp)
 
         // When
-        state.handleOffsetChange(20.dp, NAVIGATION_BAR_HEIGHT, source = imeValue, target = imeValue)
+        state.handleImeOffsetChange(20.dp, NAVIGATION_BAR_HEIGHT, source = imeValue, target = imeValue)
 
         // Then
         state.initialKeyboardHeight shouldBeEqualTo imeValue
@@ -268,7 +230,7 @@ class MessageCompositionInputStateHolderTest {
 
         // When
         state.showOptions()
-        state.handleOffsetChange(0.dp, NAVIGATION_BAR_HEIGHT, source = TARGET, target = SOURCE)
+        state.handleImeOffsetChange(0.dp, NAVIGATION_BAR_HEIGHT, source = TARGET, target = SOURCE)
 
         // Then
         state.keyboardHeight shouldBeEqualTo 20.dp
@@ -281,7 +243,7 @@ class MessageCompositionInputStateHolderTest {
         state.updateValuesForTesting(previousOffset = 50.dp)
 
         // When
-        state.handleOffsetChange(
+        state.handleImeOffsetChange(
             10.dp,
             NAVIGATION_BAR_HEIGHT,
             SOURCE,
@@ -290,6 +252,25 @@ class MessageCompositionInputStateHolderTest {
 
         // Then
         state.optionsHeight shouldBeEqualTo 10.dp
+        state.optionsVisible shouldBeEqualTo false
+        state.isTextExpanded shouldBeEqualTo false
+    }
+
+    @Test
+    fun `when keyboard is still in a process of hiding from the previous screen after navigating, options should not be visible`() {
+        // Given
+        state.updateValuesForTesting(previousOffset = 0.dp)
+
+        // When
+        state.handleImeOffsetChange(
+            offset = 40.dp,
+            navBarHeight = NAVIGATION_BAR_HEIGHT,
+            source = 50.dp,
+            target = 0.dp
+        )
+
+        // Then
+        state.optionsHeight shouldBeEqualTo 0.dp
         state.optionsVisible shouldBeEqualTo false
         state.isTextExpanded shouldBeEqualTo false
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2425" title="WPB-2425" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2425</a>  [Android] When searching a conversation an opening it from search, attachment section is visible for a short time
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the user searches for a conversation and opens it from search, the attachment option is open for a very short moment on the conversation screen and closes again. On older devices it is clearly visible, on newer devices you can see it for a very very short time only.

### Causes (Optional)

When navigating and closing keyboard, the animation still takes some time (it's not possible to tell the system to close the keyboard without the animation) and on the message composer the app observes the keyboard state to place all elements on the screen correctly so during this hiding it assumes that the keyboard is open so it should show the options.

### Solutions

Do not let the options to be shown when the app discovers that the system is already in the process of hiding the keyboard, instead just directly compose the message composer as with a closed keyboard. Also, "suboptions" are wrapped with `AnimatedVisibility` so that they are not visible when `subOptionsVisible` is false, and `handleIMEVisibility` is removed as it's redundant - `handleImeOffsetChange` already does the same thing so it's better performance-wise to reduce the number of actions executed.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Search for a conversation, keep the keyboard open and click on a conversation to open it.

### Attachments (Optional)


| Before | After |
| ----------- | ------------ |
| <video src="https://github.com/wireapp/wire-android/assets/30429749/0800a997-fd6a-449f-a6a1-33034dbf170c"/> | <video src="https://github.com/wireapp/wire-android/assets/30429749/4450c182-04e3-4e33-8873-51604e2b3cd9"/> |
| <video src="https://github.com/wireapp/wire-android/assets/30429749/b44a51ef-3215-4e0f-bf7a-bd156d21fc75"/> | <video src="https://github.com/wireapp/wire-android/assets/30429749/2d70318d-da31-4d6d-aa68-9db5603413df"/> |

----

#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
