### PR TITLE
fix: disable name change when e2ei is enabled

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountScreen.kt
@@ -71,6 +71,9 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.extension.folderWithElements
 import com.wire.android.util.toTitleCase
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -143,11 +146,11 @@ private fun mapToUISections(
     navigateToChangeDisplayName: () -> Unit,
     navigateToChangeHandle: () -> Unit,
     navigateToChangeEmail: () -> Unit
-): List<AccountDetailsItem> {
+): ImmutableList<AccountDetailsItem> {
     return with(state) {
         listOfNotNull(
             if (fullName.isNotBlank()) {
-                DisplayName(fullName, clickableActionIfPossible(state.isReadOnlyAccount, navigateToChangeDisplayName))
+                DisplayName(fullName, clickableActionIfPossible(!state.isEditNameAllowed, navigateToChangeDisplayName))
             } else {
                 null
             },
@@ -162,7 +165,7 @@ private fun mapToUISections(
             ) else null,
             if (!teamName.isNullOrBlank()) Team(teamName) else null,
             if (domain.isNotBlank()) Domain(domain) else null
-        )
+        ).toImmutableList()
     }
 }
 
@@ -171,7 +174,7 @@ private fun clickableActionIfPossible(shouldDisableAction: Boolean, action: () -
 
 @Composable
 fun MyAccountContent(
-    accountDetailItems: List<AccountDetailsItem> = emptyList(),
+    accountDetailItems: ImmutableList<AccountDetailsItem>,
     forgotPasswordUrl: String?,
     canDeleteAccount: Boolean,
     onDeleteAccountClicked: () -> Unit,
@@ -262,7 +265,7 @@ fun MyAccountContent(
 @Composable
 fun PreviewMyAccountScreen() {
     MyAccountContent(
-        accountDetailItems = listOf(
+        accountDetailItems = persistentListOf(
             DisplayName("Bob", Clickable(enabled = true) {}),
             Username("@bob_wire", Clickable(enabled = true) {}),
             Email("bob@wire.com", Clickable(enabled = true) {}),

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountState.kt
@@ -25,7 +25,7 @@ data class MyAccountState(
     val teamName: String? = null,
     val domain: String = "",
     val changePasswordUrl: String? = null,
-    val isReadOnlyAccount: Boolean = true,
+    val isEditNameAllowed: Boolean = false,
     val isEditEmailAllowed: Boolean = false,
     val isEditHandleAllowed: Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
@@ -30,6 +30,7 @@ import com.wire.android.navigation.SavedStateViewModel
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.feature.team.GetUpdatedSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
 import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
@@ -53,7 +54,8 @@ class MyAccountViewModel @Inject constructor(
     private val serverConfig: SelfServerConfigUseCase,
     private val isPasswordRequired: IsPasswordRequiredUseCase,
     private val isReadOnlyAccount: IsReadOnlyAccountUseCase,
-    private val dispatchers: DispatcherProvider
+    private val dispatchers: DispatcherProvider,
+    private val isE2EIEnabledUseCase: IsE2EIEnabledUseCase
 ) : SavedStateViewModel(savedStateHandle) {
 
     var myAccountState by mutableStateOf(MyAccountState())
@@ -64,6 +66,9 @@ class MyAccountViewModel @Inject constructor(
 
     @VisibleForTesting
     var managedByWire by Delegates.notNull<Boolean>()
+
+    @VisibleForTesting
+    var isE2EIEnabled by Delegates.notNull<Boolean>()
 
     init {
         runBlocking {
@@ -76,11 +81,12 @@ class MyAccountViewModel @Inject constructor(
 
             // is the account is read only it means it is not maneged by wire
             managedByWire = !isReadOnlyAccount()
+            isE2EIEnabled = isE2EIEnabledUseCase()
         }
         myAccountState = myAccountState.copy(
-            isReadOnlyAccount = !managedByWire,
             isEditEmailAllowed = isChangeEmailEnabledByBuild() && !hasSAMLCred && managedByWire,
-            isEditHandleAllowed = managedByWire
+            isEditNameAllowed = managedByWire && !isE2EIEnabled,
+            isEditHandleAllowed = managedByWire && !isE2EIEnabled
         )
         viewModelScope.launch {
             fetchSelfUser()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

even tho the backend removed the option to change name when e2ei is enabled we need to disable it from client side to ensure a good UX, since the name/handle update will fail always if e2ei is enabled

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
