### PR TITLE
fix: input is hiding when searching and scrolling [WPB-271]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -263,6 +263,7 @@ fun HomeContent(
                             )
                         }
                     },
+                    isSwipeable = !searchBarState.isSearchActive,
                     content = {
                         /**
                          * This "if" is a workaround, otherwise it can crash because of the SubcomposeLayout's nature.

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchPeopleRouter.kt
@@ -146,6 +146,7 @@ fun SearchUsersAndServicesScreen(
                 }
             }
         },
+        isSwipeable = !searchBarState.isSearchActive,
         content = {
             Crossfade(
                 targetState = searchBarState.isSearchActive, label = ""

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesScreen.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.android.ui.home.conversations.search.messages
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -31,8 +32,8 @@ import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.style.PopUpNavigationAnimation
-import com.wire.android.ui.common.CollapsingTopBarScaffold
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.search.SearchTopBar
 import com.wire.android.ui.destinations.ConversationScreenDestination
 import com.wire.android.ui.home.conversations.ConversationNavArgs
@@ -50,9 +51,8 @@ fun SearchConversationMessagesScreen(
     searchConversationMessagesViewModel: SearchConversationMessagesViewModel = hiltViewModel()
 ) {
     with(searchConversationMessagesViewModel.searchConversationMessagesState) {
-        CollapsingTopBarScaffold(
-            topBarHeader = { },
-            topBarCollapsing = {
+        WireScaffold(
+            topBar = {
                 SearchTopBar(
                     isSearchActive = true, // we want the search to be always active and back arrow visible on this particular screen
                     searchBarHint = stringResource(id = R.string.label_search_messages),
@@ -63,28 +63,27 @@ fun SearchConversationMessagesScreen(
                     isLoading = isLoading
                 )
             },
-            content = {
-                SearchConversationMessagesResultContent(
-                    searchQuery = searchQuery.text,
-                    searchResult = searchResult,
-                    onMessageClick = { messageId ->
-                        navigator.navigate(
-                            NavigationCommand(
-                                ConversationScreenDestination(
-                                    navArgs = ConversationNavArgs(
-                                        conversationId = conversationId,
-                                        searchedMessageId = messageId
-                                    )
-                                ),
-                                BackStackMode.UPDATE_EXISTED
+            content = { internalPadding ->
+                Column(modifier = Modifier.padding(internalPadding)) {
+                    SearchConversationMessagesResultContent(
+                        searchQuery = searchQuery.text,
+                        searchResult = searchResult,
+                        onMessageClick = { messageId ->
+                            navigator.navigate(
+                                NavigationCommand(
+                                    ConversationScreenDestination(
+                                        navArgs = ConversationNavArgs(
+                                            conversationId = conversationId,
+                                            searchedMessageId = messageId
+                                        )
+                                    ),
+                                    BackStackMode.UPDATE_EXISTED
+                                )
                             )
-                        )
-                    }
-                )
-            },
-            bottomBar = { },
-            snapOnFling = false,
-            keepElevationWhenCollapsed = true
+                        }
+                    )
+                }
+            }
         )
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-271" title="WPB-271" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-271</a>  [search for users/new conversation flow] user search field should not auto hide while scrolling
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When searching for conversations, users to add or messages, the search input field collapses when scrolling down the results and the “show more” button can not be reached while the keyboard is open.

### Solutions

Disable "collapsing" when the search is active - when user is searching and wants to scroll the list then the search input is always visible on top, when user is not searching and search input is inactive, it can collapse when scrolling the list to save space on the screen. Message search screen doesn't need a collapsing scaffold as the search input is always active there.

### Testing

#### How to Test

Search for conversation, for users on conversation creation screen or for messages in a conversation and scroll the list to see how the search input behaves.

### Attachments (Optional)

https://github.com/wireapp/wire-android/assets/30429749/a11144a1-0db3-4e02-b649-637e1695c2ce

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
