### PR TITLE
chore: handle uri asset

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -271,6 +271,7 @@ class ConversationMessagesViewModel @Inject constructor(
                 val assetContent = messageContent.value
                 assetDataPath(conversationId, messageId)?.let { (path, _) ->
                     messageId to AssetBundle(
+                        key = assetContent.remoteData.assetId,
                         dataPath = path,
                         fileName = assetContent.name ?: DEFAULT_ASSET_NAME,
                         dataSize = assetContent.sizeInBytes,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/AssetBundle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/AssetBundle.kt
@@ -26,6 +26,7 @@ import okio.Path
  * Represents a set of metadata information of an asset message
  */
 data class AssetBundle(
+    val key: String,
     val mimeType: String,
     val dataPath: Path,
     val dataSize: Long,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -18,7 +18,6 @@
 
 package com.wire.android.ui.home.conversations.sendmessage
 
-import android.net.Uri
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -40,7 +39,6 @@ import com.wire.android.ui.home.messagecomposer.state.ComposableMessageBundle
 import com.wire.android.ui.home.messagecomposer.state.MessageBundle
 import com.wire.android.ui.home.messagecomposer.state.Ping
 import com.wire.android.ui.navArgs
-import com.wire.android.util.FileManager
 import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.getAudioLengthInMs
@@ -90,7 +88,6 @@ class SendMessageViewModel @Inject constructor(
     private val sendTypingEvent: SendTypingEventUseCase,
     private val pingRinger: PingRinger,
     private val imageUtil: ImageUtil,
-    private val fileManager: FileManager,
     private val setUserInformedAboutVerification: SetUserInformedAboutVerificationUseCase,
     private val observeDegradedConversationNotified: ObserveDegradedConversationNotifiedUseCase,
     private val setNotifiedAboutConversationUnderLegalHold: SetNotifiedAboutConversationUnderLegalHoldUseCase,
@@ -98,12 +95,6 @@ class SendMessageViewModel @Inject constructor(
     private val sendLocation: SendLocationUseCase,
     private val removeMessageDraft: RemoveMessageDraftUseCase,
 ) : SavedStateViewModel(savedStateHandle) {
-
-    var tempWritableVideoUri: Uri? = null
-        private set
-
-    var tempWritableImageUri: Uri? = null
-        private set
 
     private val conversationNavArgs: ConversationNavArgs = savedStateHandle.navArgs()
     val conversationId: QualifiedID = conversationNavArgs.conversationId
@@ -118,11 +109,6 @@ class SendMessageViewModel @Inject constructor(
     var sureAboutMessagingDialogState: SureAboutMessagingDialogState by mutableStateOf(
         SureAboutMessagingDialogState.Hidden
     )
-
-    init {
-        initTempWritableVideoUri()
-        initTempWritableImageUri()
-    }
 
     private fun onSnackbarMessage(type: SnackBarMessage) = viewModelScope.launch {
         _infoMessage.emit(type)
@@ -299,20 +285,6 @@ class SendMessageViewModel @Inject constructor(
     fun retrySendingMessage(messageId: String) {
         viewModelScope.launch {
             retryFailedMessage(messageId = messageId, conversationId = conversationId)
-        }
-    }
-
-    private fun initTempWritableVideoUri() {
-        viewModelScope.launch {
-            tempWritableVideoUri =
-                fileManager.getTempWritableVideoUri(kaliumFileSystem.rootCachePath)
-        }
-    }
-
-    private fun initTempWritableImageUri() {
-        viewModelScope.launch {
-            tempWritableImageUri =
-                fileManager.getTempWritableImageUri(kaliumFileSystem.rootCachePath)
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -50,7 +50,6 @@ import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.conversation.Conversation.TypingIndicatorMode
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.failure.LegalHoldEnabledForConversationFailure
-import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageResult
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationUnderLegalHoldNotifiedUseCase

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCase.kt
@@ -1,0 +1,87 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.usecase
+
+import android.net.Uri
+import com.wire.android.ui.home.conversations.model.AssetBundle
+import com.wire.android.util.FileManager
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.asset.AttachmentType
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
+import kotlinx.coroutines.withContext
+import okio.Path
+import javax.inject.Inject
+
+class HandleUriAssetUseCase @Inject constructor(
+    private val getAssetSizeLimit: GetAssetSizeLimitUseCase,
+    private val fileManager: FileManager,
+    private val kaliumFileSystem: KaliumFileSystem,
+    private val dispatchers: DispatcherProvider
+) {
+
+    suspend fun invoke(
+        uri: Uri,
+        saveToDeviceIfInvalid: Boolean = false,
+        audioPath: Path? = null,
+        ): Result = withContext(dispatchers.io()) {
+
+        val tempCachePath = kaliumFileSystem.rootCachePath
+        val assetBundle = fileManager.getAssetBundleFromUri(
+            attachmentUri = uri,
+            tempCachePath = tempCachePath,
+            audioPath = audioPath
+        )
+        if (assetBundle != null) {
+            // The max limit for sending assets changes between user and asset types.
+            // Check [GetAssetSizeLimitUseCase] class for more detailed information about the real limits.
+            val maxSizeLimitInBytes = getAssetSizeLimit(isImage = assetBundle.assetType == AttachmentType.IMAGE)
+
+            if (assetBundle.dataSize <= maxSizeLimitInBytes) {
+                return@withContext Result.Success(assetBundle)
+            } else {
+                if(saveToDeviceIfInvalid) {
+                    with(assetBundle) {
+                        fileManager.saveToExternalMediaStorage(
+                            fileName,
+                            dataPath,
+                            dataSize,
+                            mimeType,
+                            dispatchers
+                        )
+                    }
+                }
+                return@withContext Result.Failure.AssetTooLarge(assetBundle, maxSizeLimitInBytes.div(sizeOf1MB).toInt())
+            }
+        } else {
+            return@withContext Result.Failure.Unknown
+        }
+    }
+
+    companion object {
+        private const val sizeOf1MB = 1024 * 1024
+    }
+
+    sealed class Result {
+        data class Success(val assetBundle: AssetBundle) : Result()
+        sealed class Failure : Result() {
+            data class AssetTooLarge(val assetBundle: AssetBundle, val maxLimitInMB: Int) : Failure()
+            data object Unknown : Failure()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCase.kt
@@ -39,7 +39,7 @@ class HandleUriAssetUseCase @Inject constructor(
         uri: Uri,
         saveToDeviceIfInvalid: Boolean = false,
         audioPath: Path? = null,
-        ): Result = withContext(dispatchers.io()) {
+    ): Result = withContext(dispatchers.io()) {
 
         val tempCachePath = kaliumFileSystem.rootCachePath
         val assetBundle = fileManager.getAssetBundleFromUri(
@@ -55,7 +55,7 @@ class HandleUriAssetUseCase @Inject constructor(
             if (assetBundle.dataSize <= maxSizeLimitInBytes) {
                 return@withContext Result.Success(assetBundle)
             } else {
-                if(saveToDeviceIfInvalid) {
+                if (saveToDeviceIfInvalid) {
                     with(assetBundle) {
                         fileManager.saveToExternalMediaStorage(
                             fileName,

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -275,7 +275,7 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
 
     suspend fun handleReceivedDataFromSharingIntent(activity: AppCompatActivity) {
         val incomingIntent = ShareCompat.IntentReader(activity)
-        appLogger.e("Received data from sharing intent ${incomingIntent.streamCount}")
+        appLogger.i("Received data from sharing intent ${incomingIntent.streamCount}")
         importMediaState = importMediaState.copy(isImporting = true)
         if (incomingIntent.streamCount == 0) {
             handleSharedText(incomingIntent.text.toString())
@@ -313,11 +313,11 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
             val fileUri = it.toString().toUri()
             handleImportedAsset(fileUri)
         } ?: listOf()
+
+        importMediaState = importMediaState.copy(importedAssets = importedMediaAssets)
+
         importedMediaAssets.firstOrNull { it.assetSizeExceeded != null }?.let {
             onSnackbarMessage(ImportMediaSnackbarMessages.MaxAssetSizeExceeded(it.assetSizeExceeded!!))
-        } ?: {
-            // in future show too large assets and filter them before sending
-            importMediaState = importMediaState.copy(importedAssets = importedMediaAssets)
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.android.ui.sharing
 
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Parcelable
@@ -37,7 +36,9 @@ import com.wire.android.mapper.toUIPreview
 import com.wire.android.model.ImageAsset
 import com.wire.android.model.SnackBarMessage
 import com.wire.android.model.UserAvatarData
+import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.search.DEFAULT_SEARCH_QUERY_DEBOUNCE
+import com.wire.android.ui.home.conversations.usecase.HandleUriAssetUseCase
 import com.wire.android.ui.home.conversationslist.model.BlockState
 import com.wire.android.ui.home.conversationslist.model.ConversationInfo
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
@@ -45,22 +46,17 @@ import com.wire.android.ui.home.conversationslist.parseConversationEventType
 import com.wire.android.ui.home.conversationslist.parsePrivateConversationEventType
 import com.wire.android.ui.home.conversationslist.showLegalHoldIndicator
 import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
-import com.wire.android.util.FileManager
 import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.getAudioLengthInMs
-import com.wire.android.util.getMetadataFromUri
-import com.wire.android.util.getMimeType
-import com.wire.android.util.isImageFile
 import com.wire.android.util.parcelableArrayList
-import com.wire.android.util.resampleImageAndCopyToTempPath
 import com.wire.android.util.ui.WireSessionImageLoader
+import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.data.message.SelfDeletionTimer.Companion.SELF_DELETION_LOG_TAG
-import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageResult
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationListDetailsUseCase
@@ -83,7 +79,6 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
@@ -93,11 +88,10 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
     private val getSelf: GetSelfUserUseCase,
     private val userTypeMapper: UserTypeMapper,
     private val observeConversationListDetails: ObserveConversationListDetailsUseCase,
-    private val fileManager: FileManager,
     private val sendAssetMessage: ScheduleNewAssetMessageUseCase,
     private val sendTextMessage: SendTextMessageUseCase,
     private val kaliumFileSystem: KaliumFileSystem,
-    private val getAssetSizeLimit: GetAssetSizeLimitUseCase,
+    private val handleUriAssetUseCase: HandleUriAssetUseCase,
     private val persistNewSelfDeletionTimerUseCase: PersistNewSelfDeletionTimerUseCase,
     private val observeSelfDeletionSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase,
     private val wireSessionImageLoader: WireSessionImageLoader,
@@ -288,7 +282,7 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         } else {
             if (incomingIntent.isSingleShare) {
                 // ACTION_SEND
-                handleSingleIntent(incomingIntent, activity)
+                handleSingleIntent(incomingIntent)
             } else {
                 // ACTION_SEND_MULTIPLE
                 handleMultipleActionIntent(activity)
@@ -301,33 +295,30 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         importMediaState = importMediaState.copy(importedText = text)
     }
 
-    private suspend fun handleSingleIntent(
-        incomingIntent: ShareCompat.IntentReader,
-        activity: AppCompatActivity
-    ) {
+    private suspend fun handleSingleIntent(incomingIntent: ShareCompat.IntentReader) {
         incomingIntent.stream?.let { uri ->
-            uri.getMimeType(activity)?.let { mimeType ->
-                handleImportedAsset(activity, mimeType, uri)?.let { importedAsset ->
-                    importMediaState =
-                        importMediaState.copy(importedAssets = mutableListOf(importedAsset))
+            handleImportedAsset(uri)?.let { importedAsset ->
+                if (importedAsset.assetSizeExceeded != null) {
+                    onSnackbarMessage(
+                        ImportMediaSnackbarMessages.MaxAssetSizeExceeded(importedAsset.assetSizeExceeded!!)
+                    )
                 }
+                importMediaState = importMediaState.copy(importedAssets = mutableListOf(importedAsset))
             }
         }
     }
 
     private suspend fun handleMultipleActionIntent(activity: AppCompatActivity) {
-        val importedMediaAssets = mutableListOf<ImportedMediaAsset>()
-        activity.intent.parcelableArrayList<Parcelable>(Intent.EXTRA_STREAM)?.forEach {
+        val importedMediaAssets = activity.intent.parcelableArrayList<Parcelable>(Intent.EXTRA_STREAM)?.mapNotNull {
             val fileUri = it.toString().toUri()
-            handleImportedAsset(
-                activity,
-                fileUri.getMimeType(activity).toString(),
-                fileUri
-            )?.let { importedAsset ->
-                importedMediaAssets.add(importedAsset)
-            }
+            handleImportedAsset(fileUri)
+        } ?: listOf()
+        importedMediaAssets.firstOrNull { it.assetSizeExceeded != null }?.let {
+            onSnackbarMessage(ImportMediaSnackbarMessages.MaxAssetSizeExceeded(it.assetSizeExceeded!!))
+        } ?: {
+            // in future show too large assets and filter them before sending
+            importMediaState = importMediaState.copy(importedAssets = importedMediaAssets)
         }
-        importMediaState = importMediaState.copy(importedAssets = importedMediaAssets)
     }
 
     fun checkRestrictionsAndSendImportedMedia(onSent: (ConversationId) -> Unit) =
@@ -352,24 +343,28 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
                     val job = viewModelScope.launch {
                         sendAssetMessage(
                             conversationId = conversation.conversationId,
-                            assetDataPath = importedAsset.dataPath,
-                            assetName = importedAsset.name,
-                            assetDataSize = importedAsset.size,
-                            assetMimeType = importedAsset.mimeType,
+                            assetDataPath = importedAsset.assetBundle.dataPath,
+                            assetName = importedAsset.assetBundle.fileName,
+                            assetDataSize = importedAsset.assetBundle.dataSize,
+                            assetMimeType = importedAsset.assetBundle.mimeType,
                             assetWidth = if (isImage) (importedAsset as ImportedMediaAsset.Image).width else 0,
                             assetHeight = if (isImage) (importedAsset as ImportedMediaAsset.Image).height else 0,
                             audioLengthInMs = getAudioLengthInMs(
-                                dataPath = importedAsset.dataPath,
-                                mimeType = importedAsset.mimeType
+                                dataPath = importedAsset.assetBundle.dataPath,
+                                mimeType = importedAsset.assetBundle.mimeType,
                             )
                         ).also {
                             val logConversationId = conversation.conversationId.toLogString()
                             if (it is ScheduleNewAssetMessageResult.Failure) {
-                                appLogger.e("Failed to import asset message to " +
-                                        "conversationId=$logConversationId")
+                                appLogger.e(
+                                    "Failed to import asset message to " +
+                                            "conversationId=$logConversationId"
+                                )
                             } else {
-                                appLogger.d("Success importing asset message to " +
-                                        "conversationId=$logConversationId")
+                                appLogger.d(
+                                    "Success importing asset message to " +
+                                            "conversationId=$logConversationId"
+                                )
                             }
                         }
                     }
@@ -415,68 +410,40 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
             )
         }
 
-    private suspend fun handleImportedAsset(
-        context: Context,
-        importedAssetMimeType: String,
-        uri: Uri
-    ): ImportedMediaAsset? = withContext(dispatchers.io()) {
-        val assetKey = UUID.randomUUID().toString()
-        val fileMetadata = uri.getMetadataFromUri(context)
-        val tempAssetPath = kaliumFileSystem.tempFilePath(assetKey)
-        val mimeType = fileMetadata.mimeType.ifEmpty { importedAssetMimeType }
-        return@withContext when {
-            isAboveLimit(isImageFile(mimeType), fileMetadata.sizeInBytes) -> null
-            isImageFile(mimeType) -> {
-                // Only resample the image if it is too large
-                val resampleSize = uri.resampleImageAndCopyToTempPath(
-                    context,
-                    tempAssetPath,
-                    ImageUtil.ImageSizeClass.Medium
-                )
-                if (resampleSize <= 0) return@withContext null
+    private suspend fun handleImportedAsset(uri: Uri): ImportedMediaAsset? = withContext(dispatchers.io()) {
+        when (val result = handleUriAssetUseCase.invoke(uri, saveToDeviceIfInvalid = false, audioPath = null)) {
+            is HandleUriAssetUseCase.Result.Failure.AssetTooLarge -> mapToImportedAsset(result.assetBundle, result.maxLimitInMB)
 
+            HandleUriAssetUseCase.Result.Failure.Unknown -> null
+            is HandleUriAssetUseCase.Result.Success -> mapToImportedAsset(result.assetBundle, null)
+        }
+    }
+
+    private fun mapToImportedAsset(assetBundle: AssetBundle, assetSizeExceeded: Int?): ImportedMediaAsset {
+        return when (assetBundle.assetType) {
+            AttachmentType.IMAGE -> {
                 val (imgWidth, imgHeight) = ImageUtil.extractImageWidthAndHeight(
                     kaliumFileSystem,
-                    tempAssetPath
+                    assetBundle.dataPath
                 )
-
                 ImportedMediaAsset.Image(
-                    name = fileMetadata.name,
-                    size = fileMetadata.sizeInBytes,
-                    mimeType = mimeType,
-                    dataPath = tempAssetPath,
-                    key = assetKey,
+                    assetBundle = assetBundle,
                     width = imgWidth,
                     height = imgHeight,
+                    assetSizeExceeded = assetSizeExceeded,
                     wireSessionImageLoader = wireSessionImageLoader
                 )
             }
 
-            else -> {
-                fileManager.copyToPath(uri, tempAssetPath)
+            AttachmentType.GENERIC_FILE,
+            AttachmentType.AUDIO,
+            AttachmentType.VIDEO -> {
                 ImportedMediaAsset.GenericAsset(
-                    name = fileMetadata.name,
-                    size = fileMetadata.sizeInBytes,
-                    mimeType = mimeType,
-                    dataPath = tempAssetPath,
-                    key = assetKey
+                    assetBundle = assetBundle,
+                    assetSizeExceeded = assetSizeExceeded
                 )
             }
         }
-    }
-
-    private suspend fun isAboveLimit(isImage: Boolean, sizeInBytes: Long): Boolean {
-        val assetLimitInBytesForCurrentUser = getAssetSizeLimit(isImage).toInt()
-        val sizeOf1MB = SIZE_OF_1_MB
-        val isAboveLimit = sizeInBytes > assetLimitInBytesForCurrentUser
-        if (isAboveLimit) {
-            onSnackbarMessage(
-                ImportMediaSnackbarMessages.MaxAssetSizeExceeded(
-                    assetLimitInBytesForCurrentUser.div(sizeOf1MB)
-                )
-            )
-        }
-        return isAboveLimit
     }
 
     fun onSnackbarMessage(type: SnackBarMessage) = viewModelScope.launch {
@@ -485,7 +452,6 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
 
     private companion object {
         const val MAX_LIMIT_MEDIA_IMPORT = 20
-        const val SIZE_OF_1_MB = 1024 * 1024
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -91,7 +91,7 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
     private val sendAssetMessage: ScheduleNewAssetMessageUseCase,
     private val sendTextMessage: SendTextMessageUseCase,
     private val kaliumFileSystem: KaliumFileSystem,
-    private val handleUriAssetUseCase: HandleUriAssetUseCase,
+    private val handleUriAsset: HandleUriAssetUseCase,
     private val persistNewSelfDeletionTimerUseCase: PersistNewSelfDeletionTimerUseCase,
     private val observeSelfDeletionSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase,
     private val wireSessionImageLoader: WireSessionImageLoader,
@@ -411,7 +411,7 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         }
 
     private suspend fun handleImportedAsset(uri: Uri): ImportedMediaAsset? = withContext(dispatchers.io()) {
-        when (val result = handleUriAssetUseCase.invoke(uri, saveToDeviceIfInvalid = false, audioPath = null)) {
+        when (val result = handleUriAsset.invoke(uri, saveToDeviceIfInvalid = false, audioPath = null)) {
             is HandleUriAssetUseCase.Result.Failure.AssetTooLarge -> mapToImportedAsset(result.assetBundle, result.maxLimitInMB)
 
             HandleUriAssetUseCase.Result.Failure.Unknown -> null

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -68,6 +68,7 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.scaffold.WireScaffold
+import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.topappbar.search.SearchBarState
 import com.wire.android.ui.common.topappbar.search.SearchTopBar
@@ -103,7 +104,7 @@ fun ImportMediaScreen(
         FeatureFlagState.SharingRestrictedState.NO_USER -> {
             ImportMediaLoggedOutContent(
                 fileSharingRestrictedState = fileSharingRestrictedState,
-                navigateBack = navigator::navigateBack
+                navigateBack = navigator.finish
             )
         }
 
@@ -112,7 +113,7 @@ fun ImportMediaScreen(
             ImportMediaRestrictedContent(
                 fileSharingRestrictedState = fileSharingRestrictedState,
                 importMediaAuthenticatedState = importMediaViewModel.importMediaState,
-                navigateBack = navigator::navigateBack
+                navigateBack = navigator.finish
             )
         }
 
@@ -127,14 +128,14 @@ fun ImportMediaScreen(
                         navigator.navigate(
                             NavigationCommand(
                                 ConversationScreenDestination(it),
-                                BackStackMode.CLEAR_TILL_START
+                                BackStackMode.REMOVE_CURRENT
                             )
                         )
                     }
                 },
                 onNewSelfDeletionTimerPicked = importMediaViewModel::onNewSelfDeletionTimerPicked,
                 infoMessage = importMediaViewModel.infoMessage,
-                navigateBack = navigator::navigateBack,
+                navigateBack = navigator.finish,
             )
             val context = LocalContext.current
             LaunchedEffect(importMediaViewModel.importMediaState.importedAssets) {
@@ -150,7 +151,7 @@ fun ImportMediaScreen(
         }
     }
 
-    BackHandler { navigator.navigateBack() }
+    BackHandler { navigator.finish() }
 }
 
 @Composable
@@ -165,6 +166,7 @@ fun ImportMediaRestrictedContent(
                 WireCenterAlignedTopAppBar(
                     elevation = 0.dp,
                     onNavigationPressed = navigateBack,
+                    navigationIconType = NavigationIconType.Close,
                     title = stringResource(id = R.string.import_media_content_title),
                     actions = {
                         UserProfileAvatar(
@@ -205,6 +207,7 @@ fun ImportMediaRegularContent(
                 WireCenterAlignedTopAppBar(
                     elevation = 0.dp,
                     onNavigationPressed = navigateBack,
+                    navigationIconType = NavigationIconType.Close,
                     title = stringResource(id = R.string.import_media_content_title),
                     actions = {
                         UserProfileAvatar(
@@ -255,6 +258,7 @@ fun ImportMediaLoggedOutContent(
             WireCenterAlignedTopAppBar(
                 elevation = 0.dp,
                 onNavigationPressed = navigateBack,
+                navigationIconType = NavigationIconType.Close,
                 title = stringResource(id = R.string.import_media_content_title),
             )
         },

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportedMediaAsset.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportedMediaAsset.kt
@@ -1,0 +1,42 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.sharing
+
+import com.wire.android.model.ImageAsset
+import com.wire.android.ui.home.conversations.model.AssetBundle
+import com.wire.android.util.ui.WireSessionImageLoader
+
+sealed class ImportedMediaAsset(
+    open val assetBundle: AssetBundle,
+    open val assetSizeExceeded: Int?
+) {
+    class GenericAsset(
+        override val assetBundle: AssetBundle,
+        override val assetSizeExceeded: Int?,
+    ) : ImportedMediaAsset(assetBundle, assetSizeExceeded)
+
+    class Image(
+        val width: Int,
+        val height: Int,
+        override val assetBundle: AssetBundle,
+        override val assetSizeExceeded: Int?,
+        val wireSessionImageLoader: WireSessionImageLoader
+    ) : ImportedMediaAsset(assetBundle, assetSizeExceeded) {
+        val localImageAsset = ImageAsset.LocalImageAsset(wireSessionImageLoader, assetBundle.dataPath, assetBundle.key)
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportedMediaTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportedMediaTypes.kt
@@ -52,41 +52,12 @@ fun ImportedImageView(item: ImportedMediaAsset.Image, isMultipleImport: Boolean)
 @Composable
 fun ImportedGenericAssetView(item: ImportedMediaAsset.GenericAsset, isMultipleImport: Boolean) {
     MessageGenericAsset(
-        assetName = item.name.splitFileExtension().first,
-        assetExtension = item.name.fileExtension() ?: "",
-        assetSizeInBytes = item.size,
+        assetName = item.assetBundle.fileName.splitFileExtension().first,
+        assetExtension = item.assetBundle.fileName.fileExtension() ?: "",
+        assetSizeInBytes = item.assetBundle.dataSize,
         onAssetClick = Clickable(enabled = false),
         assetTransferStatus = AssetTransferStatus.NOT_DOWNLOADED,
         shouldFillMaxWidth = !isMultipleImport,
         isImportedMediaAsset = true
     )
-}
-
-sealed class ImportedMediaAsset(
-    open val name: String,
-    open val size: Long,
-    open val mimeType: String,
-    open val dataPath: Path,
-    open val key: String
-) {
-    class GenericAsset(
-        override val name: String,
-        override val size: Long,
-        override val mimeType: String,
-        override val dataPath: Path,
-        override val key: String
-    ) : ImportedMediaAsset(name, size, mimeType, dataPath, key)
-
-    class Image(
-        val width: Int,
-        val height: Int,
-        override val name: String,
-        override val size: Long,
-        override val mimeType: String,
-        override val dataPath: Path,
-        override val key: String,
-        val wireSessionImageLoader: WireSessionImageLoader
-    ) : ImportedMediaAsset(name, size, mimeType, dataPath, key) {
-        val localImageAsset = ImageAsset.LocalImageAsset(wireSessionImageLoader, dataPath, key)
-    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportedMediaTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportedMediaTypes.kt
@@ -19,15 +19,12 @@ package com.wire.android.ui.sharing
 
 import androidx.compose.runtime.Composable
 import com.wire.android.model.Clickable
-import com.wire.android.model.ImageAsset
 import com.wire.android.ui.home.conversations.model.MessageGenericAsset
 import com.wire.android.ui.home.conversations.model.MessageImage
 import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMessageParams
-import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
 import com.wire.kalium.logic.util.fileExtension
 import com.wire.kalium.logic.util.splitFileExtension
-import okio.Path
 
 @Composable
 fun ImportedMediaItemView(item: ImportedMediaAsset, isMultipleImport: Boolean) {

--- a/app/src/main/kotlin/com/wire/android/util/FileManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileManager.kt
@@ -105,6 +105,7 @@ class FileManager @Inject constructor(@ApplicationContext private val context: C
     }
 
     // TODO we should handle those errors more user friendly
+    @Suppress("TooGenericExceptionCaught")
     suspend fun getAssetBundleFromUri(
         attachmentUri: Uri,
         tempCachePath: Path,

--- a/app/src/main/kotlin/com/wire/android/util/FileManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileManager.kt
@@ -104,6 +104,7 @@ class FileManager @Inject constructor(@ApplicationContext private val context: C
         return@withContext getTempWritableAttachmentUri(context, tempImagePath)
     }
 
+    // TODO we should handle those errors more user friendly
     suspend fun getAssetBundleFromUri(
         attachmentUri: Uri,
         tempCachePath: Path,
@@ -111,6 +112,7 @@ class FileManager @Inject constructor(@ApplicationContext private val context: C
         dispatcher: DispatcherProvider = DefaultDispatcherProvider(),
     ): AssetBundle? = withContext(dispatcher.io()) {
         try {
+            val assetKey = UUID.randomUUID().toString()
             val assetFileName = context.getFileName(attachmentUri)
                 ?: throw IOException("The selected asset has an invalid name")
             val fullTempAssetPath = "$tempCachePath/${UUID.randomUUID()}".toPath()
@@ -126,9 +128,12 @@ class FileManager @Inject constructor(@ApplicationContext private val context: C
                 //  of video assets hitting the max limit.
                 copyToPath(attachmentUri, fullTempAssetPath)
             }
-            AssetBundle(mimeType, assetPath, assetSize, assetFileName, attachmentType)
+            AssetBundle(assetKey, mimeType, assetPath, assetSize, assetFileName, attachmentType)
         } catch (e: IOException) {
             appLogger.e("There was an error while obtaining the file from disk", e)
+            null
+        } catch (e: Exception) {
+            appLogger.e("There was an error while handling file from disk", e)
             null
         }
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -161,7 +161,8 @@ class ConversationMessagesViewModelArrangement {
         assetSize: Long,
         messageId: String
     ) = apply {
-        val assetBundle = AssetBundle(assetMimeType, assetDataPath, assetSize, assetName, AttachmentType.fromMimeTypeString(assetMimeType))
+        val assetBundle =
+            AssetBundle("key", assetMimeType, assetDataPath, assetSize, assetName, AttachmentType.fromMimeTypeString(assetMimeType))
         viewModel.showOnAssetDownloadedDialog(assetBundle, messageId)
         every { fileManager.openWithExternalApp(any(), any(), any()) }.answers {
             viewModel.hideOnAssetDownloadedDialog()
@@ -205,7 +206,10 @@ class ConversationMessagesViewModelArrangement {
         assetSize: Long,
         messageId: String
     ) = apply {
-        val assetBundle = AssetBundle(assetMimeType, assetDataPath, assetSize, assetName, AttachmentType.fromMimeTypeString(assetMimeType))
+        val assetBundle = AssetBundle(
+            "key",
+            assetMimeType, assetDataPath, assetSize, assetName, AttachmentType.fromMimeTypeString(assetMimeType)
+        )
         viewModel.showOnAssetDownloadedDialog(assetBundle, messageId)
         coEvery { fileManager.saveToExternalStorage(any(), any(), any(), any(), any()) }.answers {
             viewModel.hideOnAssetDownloadedDialog()

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelArrangement.kt
@@ -26,13 +26,13 @@ import com.wire.android.framework.FakeKaliumFileSystem
 import com.wire.android.media.PingRinger
 import com.wire.android.ui.home.conversations.ConversationNavArgs
 import com.wire.android.ui.home.conversations.model.AssetBundle
+import com.wire.android.ui.home.conversations.usecase.HandleUriAssetUseCase
 import com.wire.android.ui.navArgs
 import com.wire.android.util.FileManager
 import com.wire.android.util.ImageUtil
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.sync.SyncState
-import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageResult
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
@@ -117,7 +117,7 @@ internal class SendMessageViewModelArrangement {
     private lateinit var imageUtil: ImageUtil
 
     @MockK
-    private lateinit var getAssetSizeLimitUseCase: GetAssetSizeLimitUseCase
+    private lateinit var handleUriAssetUseCase: HandleUriAssetUseCase
 
     @MockK
     lateinit var retryFailedMessageUseCase: RetryFailedMessageUseCase
@@ -153,7 +153,7 @@ internal class SendMessageViewModelArrangement {
             sendAssetMessage = sendAssetMessage,
             dispatchers = TestDispatcherProvider(),
             kaliumFileSystem = fakeKaliumFileSystem,
-            getAssetSizeLimit = getAssetSizeLimitUseCase,
+            handleUriAsset = handleUriAssetUseCase,
             imageUtil = imageUtil,
             pingRinger = pingRinger,
             sendKnockUseCase = sendKnockUseCase,
@@ -242,9 +242,8 @@ internal class SendMessageViewModelArrangement {
         } returns Either.Right(Unit)
     }
 
-    fun withGetAssetSizeLimitUseCase(isImage: Boolean, assetSizeLimit: Long) = apply {
-        coEvery { getAssetSizeLimitUseCase(eq(isImage)) } returns assetSizeLimit
-        return this
+    fun withHandleUriAsset(result: HandleUriAssetUseCase.Result) = apply {
+        coEvery { handleUriAssetUseCase.invoke(any(), any(), any()) } returns result
     }
 
     fun withGetAssetBundleFromUri(assetBundle: AssetBundle?) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelArrangement.kt
@@ -18,17 +18,14 @@
 
 package com.wire.android.ui.home.conversations.sendmessage
 
-import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.framework.FakeKaliumFileSystem
 import com.wire.android.media.PingRinger
 import com.wire.android.ui.home.conversations.ConversationNavArgs
-import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.usecase.HandleUriAssetUseCase
 import com.wire.android.ui.navArgs
-import com.wire.android.util.FileManager
 import com.wire.android.util.ImageUtil
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
@@ -75,8 +72,6 @@ internal class SendMessageViewModelArrangement {
         coEvery { observeSyncState() } returns flowOf(SyncState.Live)
         every { pingRinger.ping(any(), any()) } returns Unit
         coEvery { sendKnockUseCase(any(), any()) } returns Either.Right(Unit)
-        coEvery { fileManager.getTempWritableVideoUri(any(), any()) } returns Uri.parse("video.mp4")
-        coEvery { fileManager.getTempWritableImageUri(any(), any()) } returns Uri.parse("image.jpg")
         coEvery { setUserInformedAboutVerificationUseCase(any()) } returns Unit
         coEvery { observeDegradedConversationNotifiedUseCase(any()) } returns flowOf(true)
         coEvery { setNotifiedAboutConversationUnderLegalHold(any()) } returns Unit
@@ -103,9 +98,6 @@ internal class SendMessageViewModelArrangement {
 
     @MockK
     lateinit var sendKnockUseCase: SendKnockUseCase
-
-    @MockK
-    lateinit var fileManager: FileManager
 
     @MockK
     private lateinit var observeSyncState: ObserveSyncStateUseCase
@@ -157,7 +149,6 @@ internal class SendMessageViewModelArrangement {
             imageUtil = imageUtil,
             pingRinger = pingRinger,
             sendKnockUseCase = sendKnockUseCase,
-            fileManager = fileManager,
             retryFailedMessage = retryFailedMessageUseCase,
             sendTypingEvent = sendTypingEvent,
             setUserInformedAboutVerification = setUserInformedAboutVerificationUseCase,
@@ -244,14 +235,6 @@ internal class SendMessageViewModelArrangement {
 
     fun withHandleUriAsset(result: HandleUriAssetUseCase.Result) = apply {
         coEvery { handleUriAssetUseCase.invoke(any(), any(), any()) } returns result
-    }
-
-    fun withGetAssetBundleFromUri(assetBundle: AssetBundle?) = apply {
-        coEvery { fileManager.getAssetBundleFromUri(any(), any(), any(), any()) } returns assetBundle
-    }
-
-    fun withSaveToExternalMediaStorage(resultFileName: String?) = apply {
-        coEvery { fileManager.saveToExternalMediaStorage(any(), any(), any(), any(), any()) } returns resultFileName
     }
 
     fun withInformAboutVerificationBeforeMessagingFlag(flag: Boolean) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelTest.kt
@@ -34,7 +34,6 @@ import com.wire.android.ui.home.messagecomposer.state.Ping
 import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.failure.LegalHoldEnabledForConversationFailure
-import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCaseImpl.Companion.ASSET_SIZE_DEFAULT_LIMIT_BYTES
 import io.mockk.coVerify
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -168,7 +167,6 @@ class SendMessageViewModelTest {
                 .withSuccessfulViewModelInit()
                 .withSuccessfulSendAttachmentMessage()
                 .withHandleUriAsset(HandleUriAssetUseCase.Result.Failure.AssetTooLarge(mockedAttachment, 25))
-                .withGetAssetBundleFromUri(mockedAttachment)
                 .arrange()
             val mockedMessageBundle = ComposableMessageBundle.AttachmentPickedBundle(
                 attachmentUri = UriAsset("mocked_image.jpeg".toUri(), false)
@@ -210,7 +208,6 @@ class SendMessageViewModelTest {
                 .withSuccessfulViewModelInit()
                 .withSuccessfulSendAttachmentMessage()
                 .withHandleUriAsset(HandleUriAssetUseCase.Result.Failure.AssetTooLarge(mockedAttachment, limit))
-                .withGetAssetBundleFromUri(mockedAttachment)
                 .arrange()
             val mockedMessageBundle = ComposableMessageBundle.AttachmentPickedBundle(
                 attachmentUri = UriAsset("mocked_image.jpeg".toUri(), false)
@@ -243,8 +240,6 @@ class SendMessageViewModelTest {
                 .withSuccessfulViewModelInit()
                 .withSuccessfulSendAttachmentMessage()
                 .withHandleUriAsset(HandleUriAssetUseCase.Result.Failure.Unknown)
-                .withGetAssetBundleFromUri(null)
-                .withSaveToExternalMediaStorage("mocked_image.jpeg")
                 .arrange()
             val mockedMessageBundle = ComposableMessageBundle.AttachmentPickedBundle(
                 attachmentUri = UriAsset("mocked_image.jpeg".toUri(), false)
@@ -293,7 +288,6 @@ class SendMessageViewModelTest {
     fun `given the user sends an audio message, when invoked, then sendAssetMessageUseCase gets called`() =
         runTest {
             // Given
-            val limit = ASSET_SIZE_DEFAULT_LIMIT_BYTES
             val assetPath = "mocked-asset-data-path".toPath()
             val assetContent = "some-dummy-audio".toByteArray()
             val assetName = "mocked_audio.m4a"

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCaseTest.kt
@@ -1,0 +1,180 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.usecase
+
+import androidx.core.net.toUri
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.TestDispatcherProvider
+import com.wire.android.framework.FakeKaliumFileSystem
+import com.wire.android.ui.home.conversations.model.AssetBundle
+import com.wire.android.util.FileManager
+import com.wire.kalium.logic.data.asset.AttachmentType
+import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
+import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCaseImpl
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(CoroutineTestExtension::class)
+class HandleUriAssetUseCaseTest {
+
+    @Test
+    fun `given a user picks an image asset less than limit, when invoked, then result should succeed`() =
+        runTest {
+            // Given
+            val limit = GetAssetSizeLimitUseCaseImpl.ASSET_SIZE_DEFAULT_LIMIT_BYTES
+            val mockedAttachment = AssetBundle(
+                "key",
+                "image/jpeg",
+                "some-data-path".toPath(),
+                limit - 1L,
+                "mocked_image.jpeg",
+                AttachmentType.IMAGE
+            )
+            val (_, useCase) = Arrangement()
+                .withGetAssetSizeLimitUseCase(true, limit)
+                .withGetAssetBundleFromUri(mockedAttachment)
+                .arrange()
+
+            // When
+            val result = useCase.invoke("mocked_image.jpeg".toUri(), false)
+
+            // Then
+            assert(result is HandleUriAssetUseCase.Result.Success)
+        }
+
+    @Test
+    fun `given a user picks an image asset larger than limit, when invoked, then result is asset too large failure`() =
+        runTest {
+            // Given
+            val limit = GetAssetSizeLimitUseCaseImpl.ASSET_SIZE_DEFAULT_LIMIT_BYTES
+            val mockedAttachment = AssetBundle(
+                "key",
+                "image/jpeg",
+                "some-data-path".toPath(),
+                limit + 1L,
+                "mocked_image.jpeg",
+                AttachmentType.IMAGE
+            )
+            val (_, useCase) = Arrangement()
+                .withGetAssetSizeLimitUseCase(true, limit)
+                .withGetAssetBundleFromUri(mockedAttachment)
+                .arrange()
+
+            // When
+            val result = useCase.invoke("mocked_image.jpeg".toUri(), false)
+
+            // Then
+            assert(result is HandleUriAssetUseCase.Result.Failure.AssetTooLarge)
+        }
+
+    @Test
+    fun `given that a user picks too large asset that needs saving if invalid, when invoked, then saveToExternalMediaStorage is called`() =
+        runTest {
+            // Given
+            val limit = GetAssetSizeLimitUseCaseImpl.ASSET_SIZE_DEFAULT_LIMIT_BYTES
+            val mockedAttachment = AssetBundle(
+                "key",
+                "file/x-zip",
+                "some-data-path".toPath(),
+                limit + 1L,
+                "mocked_asset.zip",
+                AttachmentType.GENERIC_FILE
+            )
+            val (arrangement, useCase) = Arrangement()
+                .withGetAssetBundleFromUri(mockedAttachment)
+                .withGetAssetSizeLimitUseCase(false, limit)
+                .withSaveToExternalMediaStorage("mocked_image.jpeg")
+                .arrange()
+
+            // When
+            val result = useCase.invoke("mocked_image.jpeg".toUri(), true)
+
+            // Then
+            coVerify {
+                arrangement.fileManager.saveToExternalMediaStorage(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            }
+            assert(result is HandleUriAssetUseCase.Result.Failure.AssetTooLarge)
+        }
+
+    @Test
+    fun `given that a user picks asset, when getting uri returns null, then it should return error`() =
+        runTest {
+            // Given
+            val limit = GetAssetSizeLimitUseCaseImpl.ASSET_SIZE_DEFAULT_LIMIT_BYTES
+            val (_, useCase) = Arrangement()
+                .withGetAssetBundleFromUri(null)
+                .withGetAssetSizeLimitUseCase(false, limit)
+                .withSaveToExternalMediaStorage("mocked_image.jpeg")
+                .arrange()
+
+            // When
+            val result = useCase.invoke("mocked_image.jpeg".toUri(), false)
+
+            // Then
+            assert(result is HandleUriAssetUseCase.Result.Failure.Unknown)
+        }
+
+    private class Arrangement {
+
+        @MockK
+        lateinit var getAssetSizeLimitUseCase: GetAssetSizeLimitUseCase
+
+        @MockK
+        lateinit var fileManager: FileManager
+
+        private val fakeKaliumFileSystem = FakeKaliumFileSystem()
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        fun withGetAssetBundleFromUri(assetBundle: AssetBundle?) = apply {
+            coEvery { fileManager.getAssetBundleFromUri(any(), any(), any(), any()) } returns assetBundle
+        }
+
+        fun withGetAssetSizeLimitUseCase(isImage: Boolean, assetSizeLimit: Long) = apply {
+            coEvery { getAssetSizeLimitUseCase(eq(isImage)) } returns assetSizeLimit
+            return this
+        }
+
+        fun withSaveToExternalMediaStorage(resultFileName: String?) = apply {
+            coEvery { fileManager.saveToExternalMediaStorage(any(), any(), any(), any(), any()) } returns resultFileName
+        }
+
+        fun arrange() = this to HandleUriAssetUseCase(
+            getAssetSizeLimitUseCase,
+            fileManager,
+            fakeKaliumFileSystem,
+            TestDispatcherProvider(),
+        )
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- moved handling asset uri functionality to separate use case to make same functionality for SendMessageViewModel and ImportMediaAuthenticatedViewModel 
- made AssetBundle more universal 