### PR TITLE
chore: remove conversation id from send message viewmodel to make it reausable

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -98,6 +98,7 @@ class MessageMapper @Inject constructor(
         return when (content) {
             is UIMessageContent.Regular ->
                 UIMessage.Regular(
+                    conversationId = message.conversationId,
                     messageContent = content,
                     source = if (sender is SelfUser) MessageSource.Self else MessageSource.OtherUser,
                     header = provideMessageHeader(sender, message),
@@ -107,6 +108,7 @@ class MessageMapper @Inject constructor(
 
             is UIMessageContent.SystemMessage ->
                 UIMessage.System(
+                    conversationId = message.conversationId,
                     messageContent = content,
                     source = if (sender is SelfUser) MessageSource.Self else MessageSource.OtherUser,
                     header = provideMessageHeader(sender, message),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -1105,7 +1105,7 @@ fun PreviewConversationScreen() {
         onNewSelfDeletingMessagesStatus = {},
         tempWritableImageUri = null,
         tempWritableVideoUri = null,
-        onFailedMessageRetryClicked = {_, _ -> },
+        onFailedMessageRetryClicked = { _, _ -> },
         requestMentions = {},
         onClearMentionSearchResult = {},
         onPermissionPermanentlyDenied = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -135,8 +135,8 @@ import com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
 import com.wire.android.ui.home.gallery.MediaGalleryActionType
 import com.wire.android.ui.home.gallery.MediaGalleryNavBackArgs
 import com.wire.android.ui.home.messagecomposer.MessageComposer
+import com.wire.android.ui.home.messagecomposer.model.MessageBundle
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
-import com.wire.android.ui.home.messagecomposer.state.MessageBundle
 import com.wire.android.ui.home.messagecomposer.state.MessageComposerStateHolder
 import com.wire.android.ui.home.messagecomposer.state.rememberMessageComposerStateHolder
 import com.wire.android.ui.legalhold.dialog.subject.LegalHoldSubjectMessageDialog
@@ -643,7 +643,7 @@ private fun ConversationScreen(
     onNewSelfDeletingMessagesStatus: (SelfDeletionTimer) -> Unit,
     tempWritableImageUri: Uri?,
     tempWritableVideoUri: Uri?,
-    onFailedMessageRetryClicked: (String) -> Unit,
+    onFailedMessageRetryClicked: (String, ConversationId) -> Unit,
     requestMentions: (String) -> Unit,
     onClearMentionSearchResult: () -> Unit,
     onPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit,
@@ -796,7 +796,7 @@ private fun ConversationScreenContent(
     onShowEditingOptions: (UIMessage.Regular) -> Unit,
     onSelfDeletingMessageRead: (UIMessage) -> Unit,
     conversationDetailsData: ConversationDetailsData,
-    onFailedMessageRetryClicked: (String) -> Unit,
+    onFailedMessageRetryClicked: (String, ConversationId) -> Unit,
     onFailedMessageCancelClicked: (String) -> Unit,
     onChangeSelfDeletionClicked: () -> Unit,
     onSearchMentionQueryChanged: (String) -> Unit,
@@ -906,7 +906,7 @@ fun MessageList(
     onShowEditingOption: (UIMessage.Regular) -> Unit,
     onSelfDeletingMessageRead: (UIMessage) -> Unit,
     conversationDetailsData: ConversationDetailsData,
-    onFailedMessageRetryClicked: (String) -> Unit,
+    onFailedMessageRetryClicked: (String, ConversationId) -> Unit,
     onFailedMessageCancelClicked: (String) -> Unit,
     onLinkClick: (String) -> Unit,
     selectedMessageId: String?,
@@ -1105,7 +1105,7 @@ fun PreviewConversationScreen() {
         onNewSelfDeletingMessagesStatus = {},
         tempWritableImageUri = null,
         tempWritableVideoUri = null,
-        onFailedMessageRetryClicked = {},
+        onFailedMessageRetryClicked = {_, _ -> },
         requestMentions = {},
         onClearMentionSearchResult = {},
         onPermissionPermanentlyDenied = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewState.kt
@@ -18,9 +18,10 @@
 
 package com.wire.android.ui.home.conversations
 
-import com.wire.android.ui.home.messagecomposer.state.MessageBundle
+import com.wire.android.ui.home.messagecomposer.model.MessageBundle
 import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.kalium.logic.data.asset.AttachmentType
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.MessageId
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
@@ -50,11 +51,16 @@ sealed class InvalidLinkDialogState {
 
 sealed class SureAboutMessagingDialogState {
     data object Hidden : SureAboutMessagingDialogState()
-    sealed class Visible : SureAboutMessagingDialogState() {
-        data class ConversationVerificationDegraded(val messageBundleToSend: MessageBundle) : Visible()
-        sealed class ConversationUnderLegalHold : Visible() {
-            data class BeforeSending(val messageBundleToSend: MessageBundle) : ConversationUnderLegalHold()
-            data class AfterSending(val messageId: MessageId) : ConversationUnderLegalHold()
+    sealed class Visible(open val conversationId: ConversationId) : SureAboutMessagingDialogState() {
+        data class ConversationVerificationDegraded(val messageBundleToSend: MessageBundle) : Visible(messageBundleToSend.conversationId)
+
+        sealed class ConversationUnderLegalHold(override val conversationId: ConversationId) : Visible(conversationId) {
+            data class BeforeSending(
+                val messageBundleToSend: MessageBundle
+            ) : ConversationUnderLegalHold(messageBundleToSend.conversationId)
+
+            data class AfterSending(val messageId: MessageId, override val conversationId: ConversationId) :
+                ConversationUnderLegalHold(conversationId)
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -113,7 +113,7 @@ fun MessageItem(
     onReactionClicked: (String, String) -> Unit,
     onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit,
     onSelfDeletingMessageRead: (UIMessage) -> Unit,
-    onFailedMessageRetryClicked: (String, ConversationId) -> Unit = {_, _ -> },
+    onFailedMessageRetryClicked: (String, ConversationId) -> Unit = { _, _ -> },
     onFailedMessageCancelClicked: (String) -> Unit = {},
     onLinkClick: (String) -> Unit = {},
     isContentClickable: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -88,6 +88,7 @@ import com.wire.android.util.launchGeoIntent
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
 import com.wire.kalium.logic.data.asset.isSaved
 import com.wire.android.ui.theme.Accent
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.collections.immutable.PersistentMap
 
@@ -112,7 +113,7 @@ fun MessageItem(
     onReactionClicked: (String, String) -> Unit,
     onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit,
     onSelfDeletingMessageRead: (UIMessage) -> Unit,
-    onFailedMessageRetryClicked: (String) -> Unit = {},
+    onFailedMessageRetryClicked: (String, ConversationId) -> Unit = {_, _ -> },
     onFailedMessageCancelClicked: (String) -> Unit = {},
     onLinkClick: (String) -> Unit = {},
     isContentClickable: Boolean = false,
@@ -320,7 +321,7 @@ fun MessageItem(
                             MessageSendFailureWarning(
                                 messageStatus = header.messageStatus.flowStatus as MessageFlowStatus.Failure.Send,
                                 isInteractionAvailable = isInteractionAvailable,
-                                onRetryClick = remember { { onFailedMessageRetryClicked(header.messageId) } },
+                                onRetryClick = remember { { onFailedMessageRetryClicked(header.messageId, message.conversationId) } },
                                 onCancelClick = remember { { onFailedMessageCancelClicked(header.messageId) } }
                             )
                         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -80,6 +80,7 @@ import com.wire.android.util.ui.markdownBold
 import com.wire.android.util.ui.markdownText
 import com.wire.android.util.ui.toUIText
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
 import kotlin.math.roundToInt
 
 @Suppress("ComplexMethod")
@@ -88,7 +89,7 @@ fun SystemMessageItem(
     message: UIMessage.System,
     initiallyExpanded: Boolean = false,
     isInteractionAvailable: Boolean = true,
-    onFailedMessageRetryClicked: (String) -> Unit = {},
+    onFailedMessageRetryClicked: (String, ConversationId) -> Unit = { _, _ -> },
     onFailedMessageCancelClicked: (String) -> Unit = {},
     onSelfDeletingMessageRead: (UIMessage) -> Unit = {}
 ) {
@@ -216,7 +217,7 @@ fun SystemMessageItem(
                 MessageSendFailureWarning(
                     messageStatus = message.header.messageStatus.flowStatus as MessageFlowStatus.Failure.Send,
                     isInteractionAvailable = isInteractionAvailable,
-                    onRetryClick = remember { { onFailedMessageRetryClicked(message.header.messageId) } },
+                    onRetryClick = remember { { onFailedMessageRetryClicked(message.header.messageId, message.conversationId) } },
                     onCancelClick = remember { { onFailedMessageCancelClicked(message.header.messageId) } }
                 )
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
@@ -72,6 +72,7 @@ val mockHeader = MessageHeader(
 )
 
 val mockMessageWithText = UIMessage.Regular(
+    conversationId = ConversationId("value", "domain"),
     userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
     header = mockHeader,
     messageContent = UIMessageContent.TextMessage(
@@ -89,6 +90,7 @@ val mockMessageWithText = UIMessage.Regular(
 )
 
 val mockMessageWithTextLoremIpsum = UIMessage.Regular(
+    conversationId = ConversationId("value", "domain"),
     userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
     header = mockHeader,
     messageContent = UIMessageContent.TextMessage(
@@ -110,6 +112,7 @@ val mockMessageWithTextLoremIpsum = UIMessage.Regular(
 )
 
 val mockMessageWithMarkdownTextAndLinks = UIMessage.Regular(
+    conversationId = ConversationId("value", "domain"),
     userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
     header = mockHeader,
     messageContent = UIMessageContent.TextMessage(
@@ -157,6 +160,7 @@ Autoconverted link https://github.com/wireapp/kalium/pulls
 )
 
 val mockMessageWithMarkdownListAndImages = UIMessage.Regular(
+    conversationId = ConversationId("value", "domain"),
     userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
     header = mockHeader,
     messageContent = UIMessageContent.TextMessage(
@@ -212,6 +216,7 @@ Png
 )
 
 val mockMessageWithMarkdownTablesAndBlocks = UIMessage.Regular(
+    conversationId = ConversationId("value", "domain"),
     userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
     header = mockHeader,
     messageContent = UIMessageContent.TextMessage(
@@ -256,6 +261,7 @@ Enable typographer option to see result.
 )
 
 val mockMessageWithKnock = UIMessage.System(
+    conversationId = ConversationId("value", "domain"),
     header = mockHeader,
     messageContent = UIMessageContent.SystemMessage.Knock(UIText.DynamicString("John Doe pinged"), true),
     source = MessageSource.Self,
@@ -287,6 +293,7 @@ val mockImageLoader = WireSessionImageLoader(object : ImageLoader {
 )
 
 fun mockAssetMessage() = UIMessage.Regular(
+    conversationId = ConversationId("value", "domain"),
     userAvatarData = UserAvatarData(
         UserAvatarAsset(mockImageLoader, UserAssetId("a", "domain")),
         UserAvailabilityStatus.AVAILABLE
@@ -330,6 +337,7 @@ fun mockedImageUIMessage(
         expirationStatus = ExpirationStatus.NotExpirable
     )
 ) = UIMessage.Regular(
+    conversationId = ConversationId("value", "domain"),
     userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
     header = MessageHeader(
         username = UIText.DynamicString("John Doe"),
@@ -350,6 +358,7 @@ fun mockedImageUIMessage(
 @Suppress("LongMethod", "MagicNumber")
 fun getMockedMessages(): List<UIMessage> = listOf(
     UIMessage.Regular(
+        conversationId = ConversationId("value", "domain"),
         userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
         header = MessageHeader(
             username = UIText.DynamicString("John Doe"),
@@ -379,6 +388,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
         messageFooter = mockFooter
     ),
     UIMessage.Regular(
+        conversationId = ConversationId("value", "domain"),
         userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
         header = MessageHeader(
             username = UIText.DynamicString("John Doe"),
@@ -399,6 +409,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
         messageFooter = mockFooter
     ),
     UIMessage.Regular(
+        conversationId = ConversationId("value", "domain"),
         userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
         header = MessageHeader(
             username = UIText.DynamicString("John Doe"),
@@ -420,6 +431,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
         messageFooter = mockFooter
     ),
     UIMessage.Regular(
+        conversationId = ConversationId("value", "domain"),
         userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
         header = MessageHeader(
             username = UIText.DynamicString("John Doe"),
@@ -441,6 +453,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
         messageFooter = mockFooter
     ),
     UIMessage.Regular(
+        conversationId = ConversationId("value", "domain"),
         userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
         header = MessageHeader(
             username = UIText.DynamicString("John Doe"),
@@ -471,6 +484,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
         messageFooter = mockFooter
     ),
     UIMessage.Regular(
+        conversationId = ConversationId("value", "domain"),
         userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
         header = MessageHeader(
             username = UIText.DynamicString("John Doe"),
@@ -492,6 +506,7 @@ fun getMockedMessages(): List<UIMessage> = listOf(
         messageFooter = mockFooter
     ),
     UIMessage.Regular(
+        conversationId = ConversationId("value", "domain"),
         userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
         header = MessageHeader(
             username = UIText.DynamicString("John Doe"),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.android.ui.theme.Accent
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.AssetId
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
@@ -49,6 +50,7 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlin.time.Duration
 
 sealed interface UIMessage {
+    val conversationId: ConversationId
     val header: MessageHeader
     val source: MessageSource
     val messageContent: UIMessageContent?
@@ -57,6 +59,7 @@ sealed interface UIMessage {
     val isPending: Boolean
 
     data class Regular(
+        override val conversationId: ConversationId,
         override val header: MessageHeader,
         override val source: MessageSource,
         val userAvatarData: UserAvatarData,
@@ -77,6 +80,7 @@ sealed interface UIMessage {
     }
 
     data class System(
+        override val conversationId: ConversationId,
         override val header: MessageHeader,
         override val source: MessageSource,
         override val messageContent: UIMessageContent.SystemMessage

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -52,16 +52,14 @@ import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.MessageComposerViewState
+import com.wire.android.ui.home.messagecomposer.model.ComposableMessageBundle
+import com.wire.android.ui.home.messagecomposer.model.MessageBundle
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
+import com.wire.android.ui.home.messagecomposer.model.Ping
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionStateHolder
-import com.wire.android.ui.home.messagecomposer.state.ComposableMessageBundle.AttachmentPickedBundle
-import com.wire.android.ui.home.messagecomposer.state.ComposableMessageBundle.AudioMessageBundle
-import com.wire.android.ui.home.messagecomposer.state.ComposableMessageBundle.LocationBundle
-import com.wire.android.ui.home.messagecomposer.state.MessageBundle
 import com.wire.android.ui.home.messagecomposer.state.MessageComposerStateHolder
 import com.wire.android.ui.home.messagecomposer.state.MessageCompositionHolder
 import com.wire.android.ui.home.messagecomposer.state.MessageCompositionInputStateHolder
-import com.wire.android.ui.home.messagecomposer.state.Ping
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
@@ -133,14 +131,22 @@ fun MessageComposer(
                     messageComposerStateHolder = messageComposerStateHolder,
                     messageListContent = messageListContent,
                     onSendButtonClicked = {
-                        onSendMessageBundle(messageCompositionHolder.toMessageBundle())
+                        onSendMessageBundle(messageCompositionHolder.toMessageBundle(conversationId))
                         onClearMentionSearchResult()
                         clearMessage()
                     },
-                    onPingOptionClicked = { onSendMessageBundle(Ping) },
-                    onAttachmentPicked = { onSendMessageBundle(AttachmentPickedBundle(it)) },
-                    onAudioRecorded = { onSendMessageBundle(AudioMessageBundle(it)) },
-                    onLocationPicked = { onSendMessageBundle(LocationBundle(it.getFormattedAddress(), it.location)) },
+                    onPingOptionClicked = { onSendMessageBundle(Ping(conversationId)) },
+                    onAttachmentPicked = { onSendMessageBundle(ComposableMessageBundle.AttachmentPickedBundle(conversationId, it)) },
+                    onAudioRecorded = { onSendMessageBundle(ComposableMessageBundle.AudioMessageBundle(conversationId, it)) },
+                    onLocationPicked = {
+                        onSendMessageBundle(
+                            ComposableMessageBundle.LocationBundle(
+                                conversationId,
+                                it.getFormattedAddress(),
+                                it.location
+                            )
+                        )
+                    },
                     onChangeSelfDeletionClicked = onChangeSelfDeletionClicked,
                     onSearchMentionQueryChanged = onSearchMentionQueryChanged,
                     onClearMentionSearchResult = onClearMentionSearchResult,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/model/MessageBundle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/model/MessageBundle.kt
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.messagecomposer.model
+
+import android.location.Location
+import com.wire.android.ui.home.conversations.model.UIMention
+import com.wire.android.ui.home.conversations.model.UriAsset
+import com.wire.kalium.logic.data.id.ConversationId
+
+sealed class MessageBundle(open val conversationId: ConversationId)
+
+sealed class ComposableMessageBundle(override val conversationId: ConversationId) : MessageBundle(conversationId) {
+    data class EditMessageBundle(
+        override val conversationId: ConversationId,
+        val originalMessageId: String,
+        val newContent: String,
+        val newMentions: List<UIMention>
+    ) : ComposableMessageBundle(conversationId)
+
+    data class SendTextMessageBundle(
+        override val conversationId: ConversationId,
+        val message: String,
+        val mentions: List<UIMention>,
+        val quotedMessageId: String? = null
+    ) : ComposableMessageBundle(conversationId)
+
+    data class AttachmentPickedBundle(
+        override val conversationId: ConversationId,
+        val attachmentUri: UriAsset
+    ) : ComposableMessageBundle(conversationId)
+
+    data class AudioMessageBundle(
+        override val conversationId: ConversationId,
+        val attachmentUri: UriAsset
+    ) : ComposableMessageBundle(conversationId)
+
+    data class LocationBundle(
+        override val conversationId: ConversationId,
+        val locationName: String,
+        val location: Location,
+        val zoom: Int = 20
+    ) : ComposableMessageBundle(conversationId)
+}
+
+data class Ping(override val conversationId: ConversationId) : MessageBundle(conversationId)

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/model/MessageComposition.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/model/MessageComposition.kt
@@ -22,11 +22,11 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.ui.home.conversations.model.UIMention
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
-import com.wire.android.ui.home.messagecomposer.state.ComposableMessageBundle
 import com.wire.android.util.EMPTY
 import com.wire.android.util.MENTION_SYMBOL
 import com.wire.android.util.NEW_LINE_SYMBOL
 import com.wire.android.util.WHITE_SPACE
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.draft.MessageDraft
 
 data class MessageComposition(
@@ -126,15 +126,17 @@ data class MessageComposition(
         return result.toList()
     }
 
-    fun toMessageBundle(): ComposableMessageBundle {
+    fun toMessageBundle(conversationId: ConversationId): ComposableMessageBundle {
         return if (editMessageId != null) {
             ComposableMessageBundle.EditMessageBundle(
+                conversationId = conversationId,
                 originalMessageId = editMessageId,
                 newContent = messageTextFieldValue.text,
                 newMentions = selectedMentions
             )
         } else {
             ComposableMessageBundle.SendTextMessageBundle(
+                conversationId = conversationId,
                 message = messageTextFieldValue.text,
                 mentions = selectedMentions,
                 quotedMessageId = quotedMessageId

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.android.ui.home.messagecomposer.state
 
-import android.location.Location
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
@@ -25,7 +24,6 @@ import androidx.compose.ui.text.input.getSelectedText
 import com.wire.android.ui.home.conversations.model.UIMention
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
-import com.wire.android.ui.home.conversations.model.UriAsset
 import com.wire.android.ui.home.conversations.model.mapToQuotedContent
 import com.wire.android.ui.home.conversations.model.toUiMention
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
@@ -38,6 +36,7 @@ import com.wire.android.util.NEW_LINE_SYMBOL
 import com.wire.android.util.WHITE_SPACE
 import com.wire.android.util.ui.toUIText
 import com.wire.kalium.logic.data.conversation.Conversation.TypingIndicatorMode
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.draft.MessageDraft
 import com.wire.kalium.logic.data.message.mention.MessageMention
 import com.wire.kalium.logic.data.user.UserId
@@ -260,7 +259,7 @@ class MessageCompositionHolder(
         onSaveDraft(messageComposition.value.toDraft())
     }
 
-    fun toMessageBundle() = messageComposition.value.toMessageBundle()
+    fun toMessageBundle(conversationId: ConversationId) = messageComposition.value.toMessageBundle(conversationId)
 }
 
 private fun TextFieldValue.currentMentionStartIndex(): Int {
@@ -277,38 +276,6 @@ private fun TextFieldValue.currentMentionStartIndex(): Int {
         else -> -1
     }
 }
-
-interface MessageBundle
-
-sealed class ComposableMessageBundle : MessageBundle {
-    data class EditMessageBundle(
-        val originalMessageId: String,
-        val newContent: String,
-        val newMentions: List<UIMention>
-    ) : ComposableMessageBundle()
-
-    data class SendTextMessageBundle(
-        val message: String,
-        val mentions: List<UIMention>,
-        val quotedMessageId: String? = null
-    ) : ComposableMessageBundle()
-
-    data class AttachmentPickedBundle(
-        val attachmentUri: UriAsset
-    ) : ComposableMessageBundle()
-
-    data class AudioMessageBundle(
-        val attachmentUri: UriAsset
-    ) : ComposableMessageBundle()
-
-    data class LocationBundle(
-        val locationName: String,
-        val location: Location,
-        val zoom: Int = 20
-    ) : ComposableMessageBundle()
-}
-
-object Ping : MessageBundle
 
 enum class RichTextMarkdown(val value: String) {
     Header("# "),

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelperTest.kt
@@ -26,6 +26,7 @@ import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.util.DateTimeUtil
@@ -336,11 +337,13 @@ class AuthorHeaderHelperTest {
     companion object {
         private val SELF_USER_ID = UserId("self", "domain")
         private val OTHER_USER_ID = UserId("other", "domain")
+        private val CONVERSATION_ID = ConversationId("value", "domain")
 
         private fun testSystemMessage(
             userId: UserId? = null,
             timestamp: String = "2021-01-01T00:00:00.000Z"
         ) = UIMessage.System(
+            conversationId = CONVERSATION_ID,
             header = TestMessage.UI_MESSAGE_HEADER.copy(
                 messageTime = TestMessage.UI_MESSAGE_HEADER.messageTime.copy(
                     utcISO = timestamp
@@ -356,6 +359,7 @@ class AuthorHeaderHelperTest {
             userId: UserId? = null,
             timestamp: String = "2021-01-01T00:00:00.000Z"
         ) = UIMessage.System(
+            conversationId = CONVERSATION_ID,
             header = TestMessage.UI_MESSAGE_HEADER.copy(
                 messageTime = TestMessage.UI_MESSAGE_HEADER.messageTime.copy(
                     utcISO = timestamp
@@ -371,6 +375,7 @@ class AuthorHeaderHelperTest {
             userId: UserId? = null,
             timestamp: String = "2021-01-01T00:00:00.000Z"
         ) = UIMessage.Regular(
+            conversationId = CONVERSATION_ID,
             userAvatarData = UserAvatarData(asset = null, availabilityStatus = UserAvailabilityStatus.NONE),
             source = if (userId == SELF_USER_ID) MessageSource.Self else MessageSource.OtherUser,
             header = TestMessage.UI_MESSAGE_HEADER.copy(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelArrangement.kt
@@ -23,12 +23,9 @@ import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.framework.FakeKaliumFileSystem
 import com.wire.android.media.PingRinger
-import com.wire.android.ui.home.conversations.ConversationNavArgs
 import com.wire.android.ui.home.conversations.usecase.HandleUriAssetUseCase
-import com.wire.android.ui.navArgs
 import com.wire.android.util.ImageUtil
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageResult
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageUseCase

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelArrangement.kt
@@ -58,13 +58,10 @@ import okio.buffer
 
 internal class SendMessageViewModelArrangement {
 
-    val conversationId: ConversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-
     init {
         // Tests setup
         MockKAnnotations.init(this, relaxUnitFun = true)
         mockUri()
-        every { savedStateHandle.navArgs<ConversationNavArgs>() } returns ConversationNavArgs(conversationId = conversationId)
 
         // Default empty values
         coEvery { observeOngoingCallsUseCase() } returns flowOf(listOf())
@@ -139,7 +136,6 @@ internal class SendMessageViewModelArrangement {
 
     private val viewModel by lazy {
         SendMessageViewModel(
-            savedStateHandle = savedStateHandle,
             sendTextMessage = sendTextMessage,
             sendEditTextMessage = sendEditTextMessage,
             sendAssetMessage = sendAssetMessage,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationMessagesFromSearchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationMessagesFromSearchUseCaseTest.kt
@@ -156,6 +156,7 @@ class GetConversationMessagesFromSearchUseCaseTest {
 
         fun withMappedMessage(user: User, message: Message.Standalone) = apply {
             every { messageMapper.toUIMessage(any(), message) } returns UIMessage.Regular(
+                conversationId = conversationId,
                 userAvatarData = UserAvatarData(
                     asset = null,
                     availabilityStatus = UserAvailabilityStatus.NONE
@@ -198,6 +199,7 @@ class GetConversationMessagesFromSearchUseCaseTest {
                 senderUserId = user2.id
             )
             val messages = listOf(message1, message2)
+            val conversationId = ConversationId("value", "domain")
         }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- removed conversation Id and savedStateHandle from SendMessageViewModel to make it reusable in ImportMediaScreen where user can select conversation to which he can send assets
- added conversationId do UIMessages