### PR TITLE
fix: init temp writable uri

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModel.kt
@@ -32,8 +32,10 @@ import com.wire.android.ui.home.conversations.MessageComposerViewState
 import com.wire.android.ui.home.conversations.VisitLinkDialogState
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.navArgs
+import com.wire.android.util.FileManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.configuration.FileSharingStatus
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.conversation.Conversation.TypingIndicatorMode
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
@@ -69,7 +71,9 @@ class MessageComposerViewModel @Inject constructor(
     private val observeSelfDeletingMessages: ObserveSelfDeletionTimerSettingsForConversationUseCase,
     private val persistNewSelfDeletingStatus: PersistNewSelfDeletionTimerUseCase,
     private val sendTypingEvent: SendTypingEventUseCase,
-    private val saveMessageDraft: SaveMessageDraftUseCase
+    private val saveMessageDraft: SaveMessageDraftUseCase,
+    private val fileManager: FileManager,
+    private val kaliumFileSystem: KaliumFileSystem,
 ) : SavedStateViewModel(savedStateHandle) {
 
     var messageComposerViewState = mutableStateOf(MessageComposerViewState())
@@ -93,9 +97,25 @@ class MessageComposerViewModel @Inject constructor(
     )
 
     init {
+        initTempWritableVideoUri()
+        initTempWritableImageUri()
         observeIsTypingAvailable()
         observeSelfDeletingMessagesStatus()
         setFileSharingStatus()
+    }
+
+    private fun initTempWritableVideoUri() {
+        viewModelScope.launch {
+            tempWritableVideoUri =
+                fileManager.getTempWritableVideoUri(kaliumFileSystem.rootCachePath)
+        }
+    }
+
+    private fun initTempWritableImageUri() {
+        viewModelScope.launch {
+            tempWritableImageUri =
+                fileManager.getTempWritableImageUri(kaliumFileSystem.rootCachePath)
+        }
     }
 
     private fun observeIsTypingAvailable() = viewModelScope.launch {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelArrangement.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.ui.home.conversations.composer
 
+import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
@@ -34,6 +35,7 @@ import com.wire.android.ui.home.conversations.model.MessageStatus
 import com.wire.android.ui.home.conversations.model.MessageTime
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.navArgs
+import com.wire.android.util.FileManager
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.configuration.FileSharingStatus
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -86,6 +88,8 @@ internal class MessageComposerViewModelArrangement {
         coEvery { observeOngoingCallsUseCase() } returns flowOf(listOf())
         coEvery { observeEstablishedCallsUseCase() } returns flowOf(listOf())
         coEvery { observeSyncState() } returns flowOf(SyncState.Live)
+        coEvery { fileManager.getTempWritableVideoUri(any(), any()) } returns Uri.parse("video.mp4")
+        coEvery { fileManager.getTempWritableImageUri(any(), any()) } returns Uri.parse("image.jpg")
     }
 
     @MockK
@@ -130,6 +134,9 @@ internal class MessageComposerViewModelArrangement {
     @MockK
     lateinit var saveMessageDraftUseCase: SaveMessageDraftUseCase
 
+    @MockK
+    lateinit var fileManager: FileManager
+
     private val fakeKaliumFileSystem = FakeKaliumFileSystem()
 
     private val viewModel by lazy {
@@ -146,6 +153,8 @@ internal class MessageComposerViewModelArrangement {
             persistNewSelfDeletingStatus = persistSelfDeletionStatus,
             sendTypingEvent = sendTypingEvent,
             saveMessageDraft = saveMessageDraftUseCase,
+            kaliumFileSystem = fakeKaliumFileSystem,
+            fileManager = fileManager
         )
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

After splitting MessageComposerViewModel I by mistake removed initialisation functions for temp file for camera and video 