### PR TITLE
fix: conversation options divider [WPB-3985]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/divider/WireDivider.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/divider/WireDivider.kt
@@ -18,7 +18,7 @@
 
 package com.wire.android.ui.common.divider
 
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -27,5 +27,5 @@ import com.wire.android.ui.common.colorsScheme
 
 @Composable
 fun WireDivider(color: Color = colorsScheme().divider, modifier: Modifier = Modifier) {
-    Divider(color = color, thickness = Dp.Hairline, modifier = modifier)
+    HorizontalDivider(color = color, thickness = Dp.Hairline, modifier = modifier)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -41,6 +41,7 @@ import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.collectAsStateLifecycleAware
+import com.wire.android.ui.common.divider.WireDivider
 import com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel
 import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
 import com.wire.android.ui.home.conversationslist.common.FolderHeader
@@ -114,6 +115,8 @@ fun GroupConversationSettings(
                 )
             }
 
+            item { WireDivider() }
+
             item {
                 ServicesOption(
                     isSwitchEnabledAndVisible = state.isUpdatingServicesAllowed,
@@ -148,6 +151,7 @@ fun GroupConversationSettings(
                 )
             }
         }
+        item { WireDivider() }
         item {
             ReadReceiptOption(
                 isSwitchEnabled = state.isUpdatingReadReceiptAllowed,
@@ -361,7 +365,7 @@ fun PreviewGuestAdminTeamGroupConversationOptions() = WireTheme {
 @PreviewMultipleThemes
 @Composable
 fun PreviewExternalMemberAdminTeamGroupConversationOptions() = WireTheme {
-GroupConversationSettings(
+    GroupConversationSettings(
         GroupConversationOptionsState(
             conversationId = ConversationId("someValue", "someDomain"),
             groupName = "Team Group Conversation",
@@ -382,7 +386,7 @@ GroupConversationSettings(
 @PreviewMultipleThemes
 @Composable
 fun PreviewMemberTeamGroupConversationOptions() = WireTheme {
-GroupConversationSettings(
+    GroupConversationSettings(
         GroupConversationOptionsState(
             conversationId = ConversationId("someValue", "someDomain"),
             groupName = "Normal Group Conversation",

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -41,6 +41,7 @@ import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.collectAsStateLifecycleAware
+import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.divider.WireDivider
 import com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel
 import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
@@ -115,7 +116,7 @@ fun GroupConversationSettings(
                 )
             }
 
-            item { WireDivider() }
+            item { WireDivider(color = colorsScheme().outline) }
 
             item {
                 ServicesOption(
@@ -151,7 +152,7 @@ fun GroupConversationSettings(
                 )
             }
         }
-        item { WireDivider() }
+        item { WireDivider(color = colorsScheme().outline) }
         item {
             ReadReceiptOption(
                 isSwitchEnabled = state.isUpdatingReadReceiptAllowed,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
@@ -20,14 +20,11 @@ package com.wire.android.ui.home.conversations.details.participants
 
 import android.content.Context
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.material3.Divider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.remember
-import androidx.compose.ui.unit.Dp
 import com.wire.android.R
 import com.wire.android.model.Clickable
+import com.wire.android.ui.common.divider.WireDivider
 import com.wire.android.ui.home.conversations.details.participants.model.UIParticipant
-import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.extension.folderWithElements
 
 fun LazyListScope.participantsFoldersWithElements(
@@ -62,10 +59,5 @@ fun LazyListScope.folderWithElements(
             showRightArrow = showRightArrow
         )
     },
-    divider = {
-        Divider(
-            color = MaterialTheme.wireColorScheme.background,
-            thickness = Dp.Hairline
-        )
-    }
+    divider = { WireDivider() }
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
@@ -101,10 +100,7 @@ fun MessageDetailsScreen(
     )
 }
 
-@OptIn(
-    ExperimentalComposeUiApi::class,
-    ExperimentalFoundationApi::class
-)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun MessageDetailsScreenContent(
     messageDetailsState: MessageDetailsState,
@@ -154,7 +150,7 @@ private fun MessageDetailsScreenContent(
                     .fillMaxWidth()
                     .padding(internalPadding)
             ) { pageIndex ->
-                when (MessageDetailsTab.values()[pageIndex]) {
+                when (MessageDetailsTab.entries[pageIndex]) {
                     MessageDetailsTab.REACTIONS -> MessageDetailsReactions(
                         reactionsData = messageDetailsState.reactionsData,
                         lazyListState = lazyListStates[pageIndex],

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -405,7 +405,7 @@ private fun ImportMediaContent(
                 }
             }
         }
-        Divider(
+        HorizontalDivider(
             color = colorsScheme().outline,
             thickness = 1.dp,
             modifier = Modifier.padding(top = dimensions().spacing12x)

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.Divider
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -48,9 +47,9 @@ import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.scaffold.WireScaffold
+import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.home.conversationslist.model.Membership
-import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -190,7 +191,7 @@ private fun ServiceDetailsAddOrRemoveButton(
             color = MaterialTheme.wireColorScheme.background,
             shadowElevation = MaterialTheme.wireDimensions.bottomNavigationShadowElevation
         ) {
-            Divider(color = colorsScheme().outline)
+            HorizontalDivider(color = colorsScheme().outline)
             Row(
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3985" title="WPB-3985" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3985</a>  [Android] Divider lines are missing in conversation details / options view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- added dividers to conversation options
- updated some deprecated Dividers