### PR TITLE
fix: padding for single asset in import media [WPB-1839]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -373,10 +373,15 @@ private fun ImportMediaContent(
         val itemWidth =
             if (isMultipleImport) dimensions().importedMediaAssetSize + horizontalPadding.times(2)
             else screenWidth - (horizontalPadding * 2)
-        val contentPadding = PaddingValues(
-            start = horizontalPadding,
-            end = (screenWidth - itemWidth + horizontalPadding)
-        )
+        val contentPadding = if (isMultipleImport) {
+            PaddingValues(
+                start = horizontalPadding,
+                end = (screenWidth - itemWidth + horizontalPadding)
+            )
+        } else {
+            val totalPadding = screenWidth - itemWidth
+            PaddingValues(start = totalPadding / 2, end = totalPadding / 2)
+        }
         val lazyListState = rememberLazyListState()
         if (state.isImporting) {
             Box(
@@ -405,7 +410,7 @@ private fun ImportMediaContent(
                 }
             }
         }
-        Divider(
+        HorizontalDivider(
             color = colorsScheme().outline,
             thickness = 1.dp,
             modifier = Modifier.padding(top = dimensions().spacing12x)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1839" title="WPB-1839" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-1839</a>  [Import to Wire Dialog] Preview thumbnail on top is misaligned
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- fixed padding for single asset in import media preview