### PR TITLE
fix: audio message filter toggle (WPB-6406)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayer.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayer.kt
@@ -118,7 +118,7 @@ class RecordAudioMessagePlayer @Inject constructor(
     suspend fun playAudio(
         audioFile: File
     ) {
-        if (currentAudioFile != null) {
+        if (currentAudioFile != null && audioFile.name == currentAudioFile?.name) {
             resumeOrPauseAudio()
         } else {
             stopCurrentlyPlayingAudioMessage()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/GenerateAudioFileWithEffectsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/GenerateAudioFileWithEffectsUseCase.kt
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.messagecomposer.recordaudio
+
+import android.content.Context
+import com.waz.audioeffect.AudioEffect
+import com.wire.android.appLogger
+import javax.inject.Singleton
+import javax.inject.Inject
+
+@Singleton
+class GenerateAudioFileWithEffectsUseCase @Inject constructor()  {
+    /**
+     * Note: This UseCase can't be tested as we cannot mock `AudioEffect` from AVS.
+     * Generates audio file with effects on received path from the original file path.
+     *
+     * @return Unit, as the content of audio with effects will be saved directly to received file path.
+     */
+    operator fun invoke(
+        context: Context,
+        originalFilePath: String,
+        effectsFilePath: String
+    ) {
+        val audioEffectsResult = AudioEffect(context)
+            .applyEffectM4A(
+                originalFilePath,
+                effectsFilePath,
+                AudioEffect.AVS_AUDIO_EFFECT_VOCODER_MED,
+                true
+            )
+
+        if (audioEffectsResult > -1) {
+            appLogger.i("[$TAG] -> Audio file with effects generated successfully.")
+        } else {
+            appLogger.w("[$TAG] -> There was an issue with generating audio file with effects.")
+        }
+    }
+
+    private companion object {
+        const val TAG = "GenerateAudioFileWithEffectsUseCase"
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/GenerateAudioFileWithEffectsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/GenerateAudioFileWithEffectsUseCase.kt
@@ -24,7 +24,7 @@ import javax.inject.Singleton
 import javax.inject.Inject
 
 @Singleton
-class GenerateAudioFileWithEffectsUseCase @Inject constructor()  {
+class GenerateAudioFileWithEffectsUseCase @Inject constructor() {
     /**
      * Note: This UseCase can't be tested as we cannot mock `AudioEffect` from AVS.
      * Generates audio file with effects on received path from the original file path.

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
@@ -97,8 +97,7 @@ fun RecordAudioButtonEnabled(
         buttonColor = colorsScheme().recordAudioStartColor,
         bottomText = R.string.record_audio_start_label,
         applyAudioFilterState = applyAudioFilterState,
-        applyAudioFilterClick = applyAudioFilterClick,
-        isAudioFilterEnabled = true
+        applyAudioFilterClick = applyAudioFilterClick
     )
 }
 
@@ -144,6 +143,7 @@ fun RecordAudioButtonRecording(
         buttonColor = colorsScheme().recordAudioStopColor,
         bottomText = R.string.record_audio_recording_label,
         buttonState = if (seconds > 0) WireButtonState.Default else WireButtonState.Disabled,
+        isAudioFilterEnabled = false,
         applyAudioFilterState = applyAudioFilterState,
         applyAudioFilterClick = { }
     )
@@ -157,7 +157,8 @@ fun RecordAudioButtonSend(
     modifier: Modifier,
     outputFile: File?,
     onPlayAudio: () -> Unit,
-    onSliderPositionChange: (Int) -> Unit
+    onSliderPositionChange: (Int) -> Unit,
+    applyAudioFilterClick: (Boolean) -> Unit
 ) {
     RecordAudioButton(
         onClick = onClick,
@@ -180,7 +181,7 @@ fun RecordAudioButtonSend(
         buttonColor = colorsScheme().recordAudioStartColor,
         bottomText = R.string.record_audio_send_label,
         applyAudioFilterState = applyAudioFilterState,
-        applyAudioFilterClick = { }
+        applyAudioFilterClick = applyAudioFilterClick
     )
 }
 
@@ -196,7 +197,7 @@ private fun RecordAudioButton(
     buttonState: WireButtonState = WireButtonState.Default,
     applyAudioFilterState: Boolean,
     applyAudioFilterClick: (Boolean) -> Unit,
-    isAudioFilterEnabled: Boolean = false
+    isAudioFilterEnabled: Boolean = true
 ) {
     Column(
         modifier = modifier,
@@ -296,7 +297,8 @@ fun PreviewRecordAudioButtonSend() {
             outputFile = null,
             onPlayAudio = {},
             onSliderPositionChange = {},
-            applyAudioFilterState = false
+            applyAudioFilterState = false,
+            applyAudioFilterClick = {}
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioComponent.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -37,6 +36,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.sebaslogen.resaca.hilt.hiltViewModelScoped
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.divider.WireDivider
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.home.conversations.model.UriAsset
 import com.wire.android.ui.theme.wireColorScheme
@@ -92,7 +92,7 @@ fun RecordAudioComponent(
             .fillMaxHeight()
             .background(colorsScheme().background)
     ) {
-        Divider(color = MaterialTheme.wireColorScheme.outline)
+        WireDivider(color = MaterialTheme.wireColorScheme.outline)
         RecordAudioButtonClose(
             onClick = { viewModel.showDiscardRecordingDialog(onCloseRecordAudio) },
             modifier = Modifier
@@ -120,6 +120,7 @@ fun RecordAudioComponent(
 
             RecordAudioButtonState.READY_TO_SEND -> RecordAudioButtonSend(
                 applyAudioFilterState = viewModel.state.shouldApplyEffects,
+                applyAudioFilterClick = viewModel::setApplyEffectsAndPlayAudio,
                 audioState = viewModel.state.audioState,
                 onClick = {
                     viewModel.sendRecording(onAudioRecorded = onAudioRecorded) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.setValue
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.waz.audioeffect.AudioEffect
 import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.media.audiomessage.AudioMediaPlayingState
@@ -57,6 +56,7 @@ class RecordAudioViewModel @Inject constructor(
     private val recordAudioMessagePlayer: RecordAudioMessagePlayer,
     private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
     private val getAssetSizeLimit: GetAssetSizeLimitUseCase,
+    private val generateAudioFileWithEffects: GenerateAudioFileWithEffectsUseCase,
     private val currentScreenManager: CurrentScreenManager,
     private val audioMediaRecorder: AudioMediaRecorder,
     private val globalDataStore: GlobalDataStore
@@ -175,19 +175,11 @@ class RecordAudioViewModel @Inject constructor(
         audioMediaRecorder.release()
 
         if (state.originalOutputFile != null && state.effectsOutputFile != null) {
-            val audioEffectsResult = AudioEffect(context)
-                .applyEffectM4A(
-                    state.originalOutputFile!!.path,
-                    state.effectsOutputFile!!.path,
-                    AudioEffect.AVS_AUDIO_EFFECT_VOCODER_MED,
-                    true
-                )
-
-            if (audioEffectsResult > -1) {
-                appLogger.i("[$tag] -> Audio file with effects generated successfully.")
-            } else {
-                appLogger.w("[$tag] -> There was an issue with generating audio file with effects.")
-            }
+            generateAudioFileWithEffects(
+                context = context,
+                originalFilePath = state.originalOutputFile!!.path,
+                effectsFilePath = state.effectsOutputFile!!.path
+            )
 
             state = state.copy(
                 buttonState = RecordAudioButtonState.READY_TO_SEND,

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
@@ -96,7 +96,7 @@ class RecordAudioViewModelTest {
     fun `given user is recording audio, when stopping the recording, then send audio button is shown`() =
         runTest {
             // given
-            val (_, viewModel) = Arrangement()
+            val (arrangement, viewModel) = Arrangement()
                 .arrange()
 
             viewModel.startRecording()
@@ -109,6 +109,13 @@ class RecordAudioViewModelTest {
                 RecordAudioButtonState.READY_TO_SEND,
                 viewModel.state.buttonState
             )
+            verify(exactly = 1) {
+                arrangement.generateAudioFileWithEffects(
+                    context = any(),
+                    originalFilePath = viewModel.state.originalOutputFile!!.path,
+                    effectsFilePath = viewModel.state.effectsOutputFile!!.path
+                )
+            }
         }
 
     @Test
@@ -268,6 +275,7 @@ class RecordAudioViewModelTest {
         val currentScreenManager = mockk<CurrentScreenManager>()
         val getAssetSizeLimit = mockk<GetAssetSizeLimitUseCase>()
         val globalDataStore = mockk<GlobalDataStore>()
+        val generateAudioFileWithEffects = mockk<GenerateAudioFileWithEffectsUseCase>()
         val context = mockk<Context>()
 
         val viewModel by lazy {
@@ -278,6 +286,7 @@ class RecordAudioViewModelTest {
                 currentScreenManager = currentScreenManager,
                 audioMediaRecorder = audioMediaRecorder,
                 getAssetSizeLimit = getAssetSizeLimit,
+                generateAudioFileWithEffects = generateAudioFileWithEffects,
                 globalDataStore = globalDataStore
             )
         }
@@ -304,6 +313,7 @@ class RecordAudioViewModelTest {
                     maxSize = GetAssetSizeLimitUseCaseImpl.ASSET_SIZE_DEFAULT_LIMIT_BYTES
                 )
             )
+            every { generateAudioFileWithEffects(any(), any(), any()) } returns Unit
 
             coEvery { currentScreenManager.observeCurrentScreen(any()) } returns MutableStateFlow(
                 CurrentScreen.Conversation(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6406" title="WPB-6406" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-6406</a>  [Android] Apply Filters to Audio Recording
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Wrong handling of checkbox to apply filters

### Causes (Optional)

Misunderstood of ACs caught only after design review

### Solutions

- Checkbox on last state (ready to send audio file) is now enabled.
- Checkbox is also enabled whilst playing the preview audio, which will also change the preview audio played.
- Moved `AudioEffect.applyEffectM4A(..)` to a separate use case in order to fully test the view model (as we cannot mock/test this class)

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Record Audio (can check or not the apply filters options in the beginning)
- on the last state (ready to send audio), can listen to recorded audio in original form (no selected checkbox) or with effects (selected checkbox)

Note: audio will continue from last position when selecting/unselecting the checkbox (meaning if audio is 50% listen and checkbox is selected, then it will continue from 50% of it)