### PR TITLE
fix: crash when checking audio file size limit (WPB-5961) (#2757)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -80,18 +80,19 @@ class AudioMediaRecorder @Inject constructor(
         }
     }
 
-    fun startRecording() {
-        try {
+    fun startRecording(): Boolean = try {
             mediaRecorder?.prepare()
             mediaRecorder?.start()
+            true
         } catch (e: IllegalStateException) {
             e.printStackTrace()
             appLogger.e("[RecordAudio] startRecording: IllegalStateException - ${e.message}")
+            false
         } catch (e: IOException) {
             e.printStackTrace()
             appLogger.e("[RecordAudio] startRecording: IOException - ${e.message}")
+            false
         }
-    }
 
     fun stop() {
         mediaRecorder?.stop()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioInfoMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioInfoMessageType.kt
@@ -24,9 +24,16 @@ import com.wire.android.util.ui.UIText
 sealed class RecordAudioInfoMessageType(override val uiText: UIText) : SnackBarMessage {
 
     // Unable to Record Audio due to being in a call
-    object UnableToRecordAudioCall : RecordAudioInfoMessageType(
+    data object UnableToRecordAudioCall : RecordAudioInfoMessageType(
         UIText.StringResource(
             R.string.record_audio_unable_due_to_ongoing_call
+        )
+    )
+
+    // Unable to Record Audio due to error
+    data object UnableToRecordAudioError : RecordAudioInfoMessageType(
+        UIText.StringResource(
+            R.string.record_audio_unable_due_to_error
         )
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -31,6 +31,7 @@ import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.getAudioLengthInMs
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -47,6 +48,7 @@ import kotlin.io.path.deleteIfExists
 class RecordAudioViewModel @Inject constructor(
     private val recordAudioMessagePlayer: RecordAudioMessagePlayer,
     private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
+    private val getAssetSizeLimit: GetAssetSizeLimitUseCase,
     private val currentScreenManager: CurrentScreenManager,
     private val audioMediaRecorder: AudioMediaRecorder
 ) : ViewModel() {
@@ -130,7 +132,10 @@ class RecordAudioViewModel @Inject constructor(
                 infoMessage.emit(RecordAudioInfoMessageType.UnableToRecordAudioCall.uiText)
             }
         } else {
-            audioMediaRecorder.setUp()
+            viewModelScope.launch {
+                val assetSizeLimit = getAssetSizeLimit(false)
+                audioMediaRecorder.setUp(assetSizeLimit)
+            }
 
             state = state.copy(
                 outputFile = audioMediaRecorder.outputFile

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -135,17 +135,15 @@ class RecordAudioViewModel @Inject constructor(
             viewModelScope.launch {
                 val assetSizeLimit = getAssetSizeLimit(false)
                 audioMediaRecorder.setUp(assetSizeLimit)
+                if (audioMediaRecorder.startRecording()) {
+                    state = state.copy(
+                        outputFile = audioMediaRecorder.outputFile,
+                        buttonState = RecordAudioButtonState.RECORDING
+                    )
+                } else {
+                    infoMessage.emit(RecordAudioInfoMessageType.UnableToRecordAudioError.uiText)
+                }
             }
-
-            state = state.copy(
-                outputFile = audioMediaRecorder.outputFile
-            )
-
-            audioMediaRecorder.startRecording()
-
-            state = state.copy(
-                buttonState = RecordAudioButtonState.RECORDING
-            )
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1295,6 +1295,7 @@
     <string name="record_audio_max_file_size_reached_title">Recording Stopped</string>
     <string name="record_audio_max_file_size_reached_text">File size for audio messages is limited to %1$d MB.</string>
     <string name="record_audio_unable_due_to_ongoing_call">You can’t record an audio message during a call.</string>
+    <string name="record_audio_unable_due_to_error">Something went wrong while trying to record audio message. Please try again.</string>
     <string name="call_permission_dialog_title">App permission</string>
     <string name="call_permission_dialog_description">To make a call, allow Wire to access your microphone in your device settings.</string>
     <string name="label_not_now">Not Now</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
@@ -22,18 +22,22 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.framework.FakeKaliumFileSystem
 import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.media.audiomessage.RecordAudioMessagePlayer
+import com.wire.android.ui.home.messagecomposer.recordaudio.RecordAudioViewModelTest.Arrangement.Companion.ASSET_SIZE_LIMIT
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -69,7 +73,7 @@ class RecordAudioViewModelTest {
     fun `given user is not in a call, when start recording audio, then recording screen is shown`() =
         runTest {
             // given
-            val (_, viewModel) = Arrangement()
+            val (arrangement, viewModel) = Arrangement()
                 .arrange()
 
             // when
@@ -80,6 +84,10 @@ class RecordAudioViewModelTest {
                 RecordAudioButtonState.RECORDING,
                 viewModel.getButtonState()
             )
+            coVerify(exactly = 1) { arrangement.getAssetSizeLimit(false) }
+            verify(exactly = 1) { arrangement.audioMediaRecorder.setUp(ASSET_SIZE_LIMIT) }
+            verify(exactly = 1) { arrangement.audioMediaRecorder.setUp(ASSET_SIZE_LIMIT) }
+            verify(exactly = 1) { arrangement.audioMediaRecorder.startRecording() }
         }
 
     @Test
@@ -222,13 +230,15 @@ class RecordAudioViewModelTest {
         val audioMediaRecorder = mockk<AudioMediaRecorder>()
         val observeEstablishedCalls = mockk<ObserveEstablishedCallsUseCase>()
         val currentScreenManager = mockk<CurrentScreenManager>()
+        val getAssetSizeLimit = mockk<GetAssetSizeLimitUseCase>()
 
         val viewModel by lazy {
             RecordAudioViewModel(
                 recordAudioMessagePlayer = recordAudioMessagePlayer,
                 observeEstablishedCalls = observeEstablishedCalls,
                 currentScreenManager = currentScreenManager,
-                audioMediaRecorder = audioMediaRecorder
+                audioMediaRecorder = audioMediaRecorder,
+                getAssetSizeLimit = getAssetSizeLimit,
             )
         }
 
@@ -237,7 +247,8 @@ class RecordAudioViewModelTest {
 
             val fakeKaliumFileSystem = FakeKaliumFileSystem()
 
-            every { audioMediaRecorder.setUp() } returns Unit
+            coEvery { getAssetSizeLimit.invoke(false) } returns ASSET_SIZE_LIMIT
+            every { audioMediaRecorder.setUp(ASSET_SIZE_LIMIT) } returns Unit
             every { audioMediaRecorder.startRecording() } returns Unit
             every { audioMediaRecorder.stop() } returns Unit
             every { audioMediaRecorder.release() } returns Unit
@@ -276,6 +287,7 @@ class RecordAudioViewModelTest {
         fun arrange() = this to viewModel
 
         companion object {
+            const val ASSET_SIZE_LIMIT = 5L
             val DUMMY_CALL = Call(
                 conversationId = ConversationId(
                     value = "conversationId",

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
@@ -224,6 +224,40 @@ class RecordAudioViewModelTest {
             }
         }
 
+    @Test
+    fun `given start recording succeeded, when recording audio, then recording screen is shown`() =
+        runTest {
+            // given
+            val (_, viewModel) = Arrangement()
+                .withStartRecordingSuccessful()
+                .arrange()
+
+            viewModel.getInfoMessage().test {
+                // when
+                viewModel.startRecording()
+                // then
+                assertEquals(RecordAudioButtonState.RECORDING, viewModel.getButtonState())
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `given start recording failed, when recording audio, then info message is shown`() =
+        runTest {
+            // given
+            val (_, viewModel) = Arrangement()
+                .withStartRecordingFailed()
+                .arrange()
+
+            viewModel.getInfoMessage().test {
+                // when
+                viewModel.startRecording()
+                // then
+                assertEquals(RecordAudioButtonState.ENABLED, viewModel.getButtonState())
+                assertEquals(RecordAudioInfoMessageType.UnableToRecordAudioError.uiText, awaitItem())
+            }
+        }
+
     private class Arrangement {
 
         val recordAudioMessagePlayer = mockk<RecordAudioMessagePlayer>()
@@ -249,7 +283,7 @@ class RecordAudioViewModelTest {
 
             coEvery { getAssetSizeLimit.invoke(false) } returns ASSET_SIZE_LIMIT
             every { audioMediaRecorder.setUp(ASSET_SIZE_LIMIT) } returns Unit
-            every { audioMediaRecorder.startRecording() } returns Unit
+            every { audioMediaRecorder.startRecording() } returns true
             every { audioMediaRecorder.stop() } returns Unit
             every { audioMediaRecorder.release() } returns Unit
             every { audioMediaRecorder.outputFile } returns fakeKaliumFileSystem
@@ -283,6 +317,9 @@ class RecordAudioViewModelTest {
                 )
             )
         }
+
+        fun withStartRecordingSuccessful() = apply { every { audioMediaRecorder.startRecording() } returns true }
+        fun withStartRecordingFailed() = apply { every { audioMediaRecorder.startRecording() } returns false }
 
         fun arrange() = this to viewModel
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5961" title="WPB-5961" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5961</a>  [Android] Compose TapGestureDetectorKt crash
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

(cherry picked from commit c8e59aff8cf4815e329c16423b9c38c1df990f3f)

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App is crashing sometimes when checking audio file size when recording voice.

### Causes (Optional)

We were trying to use `assetLimitInMegabyte`  before it get initialized

> Property assetLimitInMegabyte should be initialized before get.

### Solutions

Pass the audio size limit as function param when we setup `audioMediaRecorder` .

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
