### PR TITLE
fix: Revoked Certificate dialog undismissable [WPB-7226]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/E2EIDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/E2EIDialogs.kt
@@ -383,7 +383,11 @@ fun E2EICertificateRevokedDialog(
             type = WireDialogButtonType.Secondary,
         ),
         buttonsHorizontalAlignment = false,
-        properties = DialogProperties(usePlatformDefaultWidth = false)
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        )
     )
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7226" title="WPB-7226" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7226</a>  [Android] Revoked certificate dialogue can be dismissed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

When the user has a revoked certificate, the dialogue informing the user about this can be dismissed by tapping somewhere on the screen. But it should not not be dismissible so that the user has to use one of the buttons.

### Causes (Optional)

dismissable flags were missed in dialog 

### Solutions

add dismissable flags into that dialog
