### PR TITLE
fix: crash when checking audio file size limit (WPB-5961) (#2757)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -49,8 +49,12 @@ class AudioMediaRecorder @Inject constructor(
 
     private var mediaRecorder: MediaRecorder? = null
 
+<<<<<<< HEAD
     var originalOutputFile: File? = null
     var effectsOutputFile: File? = null
+=======
+    var outputFile: File? = null
+>>>>>>> 0ae13d386 (fix: crash when checking audio file size limit (WPB-5961) (#2757) (#2852))
 
     private val _maxFileSizeReached = MutableSharedFlow<RecordAudioDialogState>()
     fun getMaxFileSizeReached(): Flow<RecordAudioDialogState> =

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -56,7 +56,10 @@ class RecordAudioViewModel @Inject constructor(
     private val recordAudioMessagePlayer: RecordAudioMessagePlayer,
     private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
     private val getAssetSizeLimit: GetAssetSizeLimitUseCase,
+<<<<<<< HEAD
     private val generateAudioFileWithEffects: GenerateAudioFileWithEffectsUseCase,
+=======
+>>>>>>> 0ae13d386 (fix: crash when checking audio file size limit (WPB-5961) (#2757) (#2852))
     private val currentScreenManager: CurrentScreenManager,
     private val audioMediaRecorder: AudioMediaRecorder,
     private val globalDataStore: GlobalDataStore
@@ -157,8 +160,12 @@ class RecordAudioViewModel @Inject constructor(
                 audioMediaRecorder.setUp(assetSizeLimit)
                 if (audioMediaRecorder.startRecording()) {
                     state = state.copy(
+<<<<<<< HEAD
                         originalOutputFile = audioMediaRecorder.originalOutputFile,
                         effectsOutputFile = audioMediaRecorder.effectsOutputFile,
+=======
+                        outputFile = audioMediaRecorder.outputFile,
+>>>>>>> 0ae13d386 (fix: crash when checking audio file size limit (WPB-5961) (#2757) (#2852))
                         buttonState = RecordAudioButtonState.RECORDING
                     )
                 } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1297,6 +1297,11 @@
     <string name="record_audio_max_file_size_reached_text">File size for audio messages is limited to %1$d MB.</string>
     <string name="record_audio_unable_due_to_ongoing_call">You can’t record an audio message during a call.</string>
     <string name="record_audio_unable_due_to_error">Something went wrong while trying to record audio message. Please try again.</string>
+<<<<<<< HEAD
+=======
+    <string name="call_permission_dialog_title">App permission</string>
+    <string name="call_permission_dialog_description">To make a call, allow Wire to access your microphone in your device settings.</string>
+>>>>>>> 0ae13d386 (fix: crash when checking audio file size limit (WPB-5961) (#2757) (#2852))
     <string name="label_not_now">Not Now</string>
     <string name="last_message_composite_with_missing_text">sent an interactive message</string>
     <string name="join_conversation_dialog_password_label">Conversation Password</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
@@ -245,7 +245,11 @@ class RecordAudioViewModelTest {
                 // when
                 viewModel.startRecording()
                 // then
+<<<<<<< HEAD
                 assertEquals(RecordAudioButtonState.RECORDING, viewModel.state.buttonState)
+=======
+                assertEquals(RecordAudioButtonState.RECORDING, viewModel.getButtonState())
+>>>>>>> 0ae13d386 (fix: crash when checking audio file size limit (WPB-5961) (#2757) (#2852))
                 expectNoEvents()
             }
         }
@@ -262,7 +266,11 @@ class RecordAudioViewModelTest {
                 // when
                 viewModel.startRecording()
                 // then
+<<<<<<< HEAD
                 assertEquals(RecordAudioButtonState.ENABLED, viewModel.state.buttonState)
+=======
+                assertEquals(RecordAudioButtonState.ENABLED, viewModel.getButtonState())
+>>>>>>> 0ae13d386 (fix: crash when checking audio file size limit (WPB-5961) (#2757) (#2852))
                 assertEquals(RecordAudioInfoMessageType.UnableToRecordAudioError.uiText, awaitItem())
             }
         }
@@ -274,9 +282,12 @@ class RecordAudioViewModelTest {
         val observeEstablishedCalls = mockk<ObserveEstablishedCallsUseCase>()
         val currentScreenManager = mockk<CurrentScreenManager>()
         val getAssetSizeLimit = mockk<GetAssetSizeLimitUseCase>()
+<<<<<<< HEAD
         val globalDataStore = mockk<GlobalDataStore>()
         val generateAudioFileWithEffects = mockk<GenerateAudioFileWithEffectsUseCase>()
         val context = mockk<Context>()
+=======
+>>>>>>> 0ae13d386 (fix: crash when checking audio file size limit (WPB-5961) (#2757) (#2852))
 
         val viewModel by lazy {
             RecordAudioViewModel(
@@ -286,8 +297,11 @@ class RecordAudioViewModelTest {
                 currentScreenManager = currentScreenManager,
                 audioMediaRecorder = audioMediaRecorder,
                 getAssetSizeLimit = getAssetSizeLimit,
+<<<<<<< HEAD
                 generateAudioFileWithEffects = generateAudioFileWithEffects,
                 globalDataStore = globalDataStore
+=======
+>>>>>>> 0ae13d386 (fix: crash when checking audio file size limit (WPB-5961) (#2757) (#2852))
             )
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5961" title="WPB-5961" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5961</a>  [Android] Compose TapGestureDetectorKt crash
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry pick from the original PR: 
- #2852

---- 

 ⚠️ Conflicts during cherry-pick:
app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
app/src/main/res/values/strings.xml
app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

(cherry picked from commit c8e59aff8cf4815e329c16423b9c38c1df990f3f)

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like 
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App is crashing sometimes when checking audio file size when recording voice.

### Causes (Optional)

We were trying to use   before it get initialized

> Property assetLimitInMegabyte should be initialized before get.

### Solutions

Pass the audio size limit as function param when we setup  .

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .