### PR TITLE
fix: Remove NotificationDot for some notifications RC

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationChannelsManager.kt
@@ -130,6 +130,7 @@ class NotificationChannelsManager @Inject constructor(
             .setVibrationEnabled(false)
             .setImportance(NotificationManagerCompat.IMPORTANCE_DEFAULT)
             .setSound(null, null)
+            .setShowBadge(false)
             .build()
 
         notificationManagerCompat.createNotificationChannel(notificationChannel)
@@ -165,6 +166,7 @@ class NotificationChannelsManager @Inject constructor(
         val notificationChannel = NotificationChannelCompat
             .Builder(channelId, NotificationManagerCompat.IMPORTANCE_HIGH)
             .setName(channelName)
+            .setShowBadge(false)
             .build()
 
         notificationManagerCompat.createNotificationChannel(notificationChannel)


### PR DESCRIPTION
# What's new in this PR?

### Issues

NotificationDot (on app icon) shouldn't be shown for the notifications: OngoingCall, PersistentWebSocket, MigrationWorker, NotificationFetchWorker, SingleUserMigrationWorker

### Causes (Optional)

flag `ShowBadge` wasn't set to false for those notifications.

### Solutions

set `ShowBadge` flag to `false` for the channels of those notifications.


