### PR TITLE
fix: run observers on workers thread to avoid ANRs (WPB-6051)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6051" title="WPB-6051" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6051</a>  [ANR][Android]com.wire.android.ui.WireActivity.onCreate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app is doing a lot on UI thread on app launch, which can lead to many ANRs.

```
StrictMode policy violation; ~duration=448 ms: android.os.strictmode.DiskReadViolation
      at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1659)
      at libcore.io.BlockGuardOs.access(BlockGuardOs.java:74)
      at libcore.io.ForwardingOs.access(ForwardingOs.java:128)
      at android.app.ActivityThread$AndroidOs.access(ActivityThread.java:7747)
      at java.io.UnixFileSystem.checkAccess(UnixFileSystem.java:313)
      at java.io.File.exists(File.java:813)
      at android.app.ContextImpl.getDataDir(ContextImpl.java:2909)
      at android.app.ContextImpl.getDir(ContextImpl.java:2928)
      at android.content.ContextWrapper.getDir(ContextWrapper.java:326)
      at com.wire.android.di.CoreLogicModule.provideCoreLogic(CoreLogicModule.kt:95)
      at com.wire.android.di.CoreLogicModule_ProvideCoreLogicFactory.provideCoreLogic(CoreLogicModule_ProvideCoreLogicFactory.java:62)
      at com.wire.android.DaggerWireApplication_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get(DaggerWireApplication_HiltComponents_SingletonC.java:3654)
      at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
      at com.wire.android.DaggerWireApplication_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get(DaggerWireApplication_HiltComponents_SingletonC.java:3729)
      at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
      at com.wire.android.DaggerWireApplication_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get(DaggerWireApplication_HiltComponents_SingletonC.java:3726)
      at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
      at com.wire.android.WireApplication.getWorkManagerConfiguration(WireApplication.kt:74)
      at androidx.work.impl.WorkManagerImpl.getInstance(WorkManagerImpl.java:167)
      at androidx.work.impl.background.systemjob.SystemJobService.onCreate(SystemJobService.java:85)
      at android.app.ActivityThread.handleCreateService(ActivityThread.java:4554)
      at android.app.ActivityThread.access$1700(ActivityThread.java:256)
      at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2110)
      at android.os.Handler.dispatchMessage(Handler.java:106)
      at android.os.Looper.loopOnce(Looper.java:201)
      at android.os.Looper.loop(Looper.java:288)
      at android.app.ActivityThread.main(ActivityThread.java:7870)
      at java.lang.reflect.Method.invoke(Native Method)
      at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

### Causes (Optional)

We are doing some operations on UI thread in kalium.
Example:
- Getting the roothPath in CoreLogicModule class
`        val rootPath = context.getDir("accounts", Context.MODE_PRIVATE).path
`

### Solutions

To avoid a lot refactoring in lower level, I just changed the dispatcher here.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
