### PR TITLE
fix: crash on GrapheneOS when downloading certificate (WPB-7407)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -21,7 +21,7 @@ import android.content.Context
 import android.media.MediaRecorder
 import android.os.Build
 import com.wire.android.appLogger
-import com.wire.android.util.audioFileDateTime
+import com.wire.android.util.fileDateTime
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
@@ -128,7 +128,7 @@ class AudioMediaRecorder @Inject constructor(
 
     private companion object {
         fun getRecordingAudioFileName(): String =
-            "wire-audio-${DateTimeUtil.currentInstant().audioFileDateTime()}.m4a"
+            "wire-audio-${DateTimeUtil.currentInstant().fileDateTime()}.m4a"
         const val SIZE_OF_1MB = 1024 * 1024
         const val AUDIO_CHANNELS = 1
         const val SAMPLING_RATE = 44100

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
@@ -48,7 +48,6 @@ import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.util.copyLinkToClipboard
 import com.wire.android.util.createPemFile
-import com.wire.android.util.permission.rememberWriteStorageRequestFlow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
@@ -66,25 +66,6 @@ fun E2eiCertificateDetailsScreen(
     val snackbarHostState = LocalSnackbarHostState.current
     val scope = rememberCoroutineScope()
     val downloadedString = stringResource(id = R.string.media_gallery_on_image_downloaded)
-    val errorDownloadedString = stringResource(id = R.string.certificate_download_error)
-
-    val downloadCertificateRequestFlow = rememberWriteStorageRequestFlow(
-        onGranted = {
-            scope.launch {
-                withContext(Dispatchers.IO) {
-                    createPemFile(
-                        pathname = e2eiCertificateDetailsViewModel.getCertificateName(),
-                        content = e2eiCertificateDetailsViewModel.getCertificate()
-                    )
-                }
-                e2eiCertificateDetailsViewModel.state.wireModalSheetState.hide()
-                snackbarHostState.showSnackbar(downloadedString)
-            }
-        }, onDenied = {
-            scope.launch {
-                snackbarHostState.showSnackbar(errorDownloadedString)
-            }
-        })
 
     WireScaffold(
         topBar = {
@@ -123,7 +104,18 @@ fun E2eiCertificateDetailsScreen(
                         snackbarHostState.showSnackbar(copiedToClipboardString)
                     }
                 },
-                onDownload = downloadCertificateRequestFlow::launch
+                onDownload = {
+                    scope.launch {
+                        withContext(Dispatchers.IO) {
+                            createPemFile(
+                                pathname = e2eiCertificateDetailsViewModel.getCertificateName(),
+                                content = e2eiCertificateDetailsViewModel.getCertificate()
+                            )
+                        }
+                        e2eiCertificateDetailsViewModel.state.wireModalSheetState.hide()
+                        snackbarHostState.showSnackbar(downloadedString)
+                    }
+                }
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
@@ -66,25 +66,6 @@ fun E2eiCertificateDetailsScreen(
     val snackbarHostState = LocalSnackbarHostState.current
     val scope = rememberCoroutineScope()
     val downloadedString = stringResource(id = R.string.media_gallery_on_image_downloaded)
-    val errorDownloadedString = stringResource(id = R.string.certificate_download_error)
-
-    val downloadCertificateRequestFlow = rememberWriteStorageRequestFlow(
-        onGranted = {
-            scope.launch {
-                withContext(Dispatchers.IO) {
-                    createPemFile(
-                        pathname = e2eiCertificateDetailsViewModel.getCertificateName(),
-                        content = e2eiCertificateDetailsViewModel.getCertificate()
-                    )
-                }
-                e2eiCertificateDetailsViewModel.state.wireModalSheetState.hide()
-                snackbarHostState.showSnackbar(downloadedString)
-            }
-        }, onDenied = {
-            scope.launch {
-                snackbarHostState.showSnackbar(errorDownloadedString)
-            }
-        })
 
     WireScaffold(
         topBar = {
@@ -123,7 +104,18 @@ fun E2eiCertificateDetailsScreen(
                         snackbarHostState.showSnackbar(copiedToClipboardString)
                     }
                 },
-                onDownload = downloadCertificateRequestFlow::launch
+                onDownload = {
+                    scope.launch {
+                        withContext(Dispatchers.IO) {
+                            createPemFile(
+                                pathname = getCertificateName(),
+                                content = getCertificate()
+                            )
+                        }
+                        state.wireModalSheetState.hide()
+                        snackbarHostState.showSnackbar(downloadedString)
+                    }
+                }
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
@@ -22,14 +22,21 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.navArgs
+import com.wire.android.util.fileDateTime
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.util.DateTimeUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class E2eiCertificateDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    private val observerSelfUser: GetSelfUserUseCase,
 ) : ViewModel() {
 
     var state: E2eiCertificateDetailsState by mutableStateOf(E2eiCertificateDetailsState())
@@ -38,7 +45,24 @@ class E2eiCertificateDetailsViewModel @Inject constructor(
     private val e2eiCertificateDetailsScreenNavArgs: E2eiCertificateDetailsScreenNavArgs =
         savedStateHandle.navArgs()
 
+    private var selfUserHandle: String? = null
+
+    init {
+        getSelfUserId()
+    }
+
+    private fun getSelfUserId() {
+        viewModelScope.launch {
+            selfUserHandle = observerSelfUser().first().handle
+        }
+    }
+
     fun getCertificate() = e2eiCertificateDetailsScreenNavArgs.certificateString
+
+    fun getCertificateName(): String {
+        val date = DateTimeUtil.currentInstant().fileDateTime()
+        return "wire-certificate-${selfUserHandle}-${date}.txt"
+    }
 }
 
 data class E2eiCertificateDetailsState(

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
@@ -61,7 +61,7 @@ class E2eiCertificateDetailsViewModel @Inject constructor(
 
     fun getCertificateName(): String {
         val date = DateTimeUtil.currentInstant().fileDateTime()
-        return "wire-certificate-${selfUserHandle}-${date}.txt"
+        return "wire-certificate-$selfUserHandle-$date.txt"
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
@@ -50,7 +50,7 @@ private val readReceiptDateTimeFormat = SimpleDateFormat(
     Locale.getDefault()
 ).apply { timeZone = TimeZone.getDefault() }
 
-private val audioFileDateTimeFormat = SimpleDateFormat(
+private val fileDateTimeFormat = SimpleDateFormat(
     "yyyy-MM-dd-hh-mm-ss",
     Locale.getDefault()
 ).apply { timeZone = TimeZone.getDefault() }
@@ -96,7 +96,7 @@ fun Date.toMediumOnlyDateTime(): String = mediumOnlyDateTimeFormat.format(this)
 
 fun Instant.uiReadReceiptDateTime(): String = readReceiptDateTimeFormat.format(Date(this.toEpochMilliseconds()))
 
-fun Instant.audioFileDateTime(): String = audioFileDateTimeFormat
+fun Instant.fileDateTime(): String = fileDateTimeFormat
     .format(Date(this.toEpochMilliseconds()))
 
 fun getCurrentParsedDateTime(): String = mediumDateTimeFormat.format(System.currentTimeMillis())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -876,8 +876,6 @@
     <string name="media_gallery_on_image_download_error">There was an error when saving the image to
         Downloads folder. Please check your Internet connection and try again
     </string>
-    <string name="certificate_download_error">There was an error when saving the certificate to
-        Downloads folder. Please check your Internet connection and try again</string>
     <!--sso dialog-->
     <string name="sso_error_dialog_title">Unable to log in with SSO</string>
     <string name="sso_error_dialog_message">Please try again. If this does not help, contact your

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -876,6 +876,8 @@
     <string name="media_gallery_on_image_download_error">There was an error when saving the image to
         Downloads folder. Please check your Internet connection and try again
     </string>
+    <string name="certificate_download_error">There was an error when saving the certificate to
+        Downloads folder. Please check your Internet connection and try again</string>
     <!--sso dialog-->
     <string name="sso_error_dialog_title">Unable to log in with SSO</string>
     <string name="sso_error_dialog_message">Please try again. If this does not help, contact your


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7407" title="WPB-7407" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7407</a>  [Android] Crash on graphene OS when downloading own or another users certificate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is 2 issues:
- When downloading certificate when user is in GrapheneOS it would crash the app
- When downloading certificate it would download twice (double files)

### Causes (Optional)

- Crash : we need to ask file writing permissions for users in GrapheneOS.
- double files : We generate the certificate file and was downloading the generated file again.

### Solutions

- Crash : Add verification to ask users permission to write files into external storage (/Downloads folder)
- double files : remove second download of generated certificate file and change its name:

From: `certificate.txt`
To: `wire-certificate-{user_handle}-{date-time}.txt`

### Testing

#### How to Test

- Login to environment with MLS + E2EI enabled
- Generate certificate
- Go to : Settings -> Devices -> Current Device -> Certificate Details -> 3 dots at top-right corner -> download
- Success message should appear, app should NOT crash and when checking /Downloads folder it should contain only 1 certificate file
