### PR TITLE
fix: Display verified E2EI icon other user devices list [WPB-6974]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
@@ -50,6 +50,7 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.LinkText
 import com.wire.android.util.ui.LinkTextData
+import com.wire.kalium.logic.feature.e2ei.CertificateStatus
 
 @Composable
 fun OtherUserDevicesScreen(
@@ -122,7 +123,8 @@ private fun OtherUserDevicesContent(
                     isWholeItemClickable = true,
                     onClickAction = onDeviceClick,
                     icon = Icons.Filled.ChevronRight.Icon(),
-                    shouldShowVerifyLabel = true
+                    shouldShowVerifyLabel = true,
+                    shouldShowE2EIInfo = item.e2eiCertificateStatus == CertificateStatus.VALID
                 )
                 if (index < otherUserDevices.lastIndex) WireDivider()
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6974" title="WPB-6974" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6974</a>  [Android] No green shield visible on devices list from other users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

No green shield visible on devices list from other users

### Causes (Optional)

Compose flag in DeviceItem element was set into `false` 

### Solutions

update that flag 


