### PR TITLE
fix: close properly keyboard in conversation screen [WPB-7630]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -56,9 +56,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -188,7 +186,6 @@ fun ConversationScreen(
     val coroutineScope = rememberCoroutineScope()
     val uriHandler = LocalUriHandler.current
     val showDialog = remember { mutableStateOf(ConversationScreenDialogType.NONE) }
-    val focusManager = LocalFocusManager.current
     val conversationScreenState = rememberConversationScreenState()
     val messageComposerViewState = messageComposerViewModel.messageComposerViewState
     val messageComposerStateHolder = rememberMessageComposerStateHolder(
@@ -374,7 +371,7 @@ fun ConversationScreen(
                 }
             }
         },
-        onBackButtonClick = { conversationScreenOnBackButtonClick(messageComposerViewModel, focusManager, navigator) },
+        onBackButtonClick = { conversationScreenOnBackButtonClick(messageComposerViewModel, messageComposerStateHolder, navigator) },
         composerMessages = messageComposerViewModel.infoMessage,
         conversationMessages = conversationMessagesViewModel.infoMessage,
         conversationMessagesViewModel = conversationMessagesViewModel,
@@ -403,7 +400,7 @@ fun ConversationScreen(
         },
         onTypingEvent = messageComposerViewModel::sendTypingEvent
     )
-    BackHandler { conversationScreenOnBackButtonClick(messageComposerViewModel, focusManager, navigator) }
+    BackHandler { conversationScreenOnBackButtonClick(messageComposerViewModel, messageComposerStateHolder, navigator) }
     DeleteMessageDialog(
         state = messageComposerViewModel.deleteMessageDialogsState,
         actions = messageComposerViewModel.deleteMessageHelper
@@ -499,11 +496,11 @@ fun ConversationScreen(
 
 private fun conversationScreenOnBackButtonClick(
     messageComposerViewModel: MessageComposerViewModel,
-    focusManager: FocusManager,
+    messageComposerStateHolder: MessageComposerStateHolder,
     navigator: Navigator
 ) {
     messageComposerViewModel.sendTypingEvent(TypingIndicatorMode.STOPPED)
-    focusManager.clearFocus(true)
+    messageComposerStateHolder.messageCompositionInputStateHolder.collapseComposer(null)
     navigator.navigateBack()
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -111,7 +111,7 @@ fun EnabledMessageComposer(
                 messageCompositionInputStateHolder.clearFocus()
             } else if (additionalOptionStateHolder.selectedOption == AdditionalOptionSelectItem.SelfDeleting) {
                 messageCompositionInputStateHolder.requestFocus()
-                additionalOptionStateHolder.hideAdditionalOptionsMenu()
+                additionalOptionStateHolder.unselectAdditionalOptionsMenu()
             }
         }
 
@@ -178,6 +178,7 @@ fun EnabledMessageComposer(
                                 inputFocused = messageCompositionInputStateHolder.inputFocused,
                                 onInputFocusedChanged = ::onInputFocusedChanged,
                                 onToggleInputSize = messageCompositionInputStateHolder::toggleInputSize,
+                                onTextCollapse = messageCompositionInputStateHolder::collapseText,
                                 onCancelReply = messageCompositionHolder::clearReply,
                                 onCancelEdit = ::cancelEdit,
                                 onMessageTextChanged = {
@@ -247,7 +248,7 @@ fun EnabledMessageComposer(
                                 onAdditionalOptionsMenuClicked = {
                                     if (!isKeyboardMoving) {
                                         if (additionalOptionStateHolder.selectedOption == AdditionalOptionSelectItem.AttachFile) {
-                                            additionalOptionStateHolder.hideAdditionalOptionsMenu()
+                                            additionalOptionStateHolder.unselectAdditionalOptionsMenu()
                                             messageCompositionInputStateHolder.toComposing()
                                         } else {
                                             showAdditionalOptionsMenu()
@@ -293,10 +294,7 @@ fun EnabledMessageComposer(
                 cancelEdit()
             }
             BackHandler(isImeVisible || inputStateHolder.optionsVisible) {
-                inputStateHolder.handleBackPressed(
-                    isImeVisible,
-                    additionalOptionStateHolder.additionalOptionsSubMenuState
-                )
+                inputStateHolder.collapseComposer(additionalOptionStateHolder.additionalOptionsSubMenuState)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/AdditionalOptionMenuState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/AdditionalOptionMenuState.kt
@@ -64,7 +64,7 @@ class AdditionalOptionStateHolder {
         additionalOptionsSubMenuState = AdditionalOptionSubMenuState.AttachFile
     }
 
-    fun hideAdditionalOptionsMenu() {
+    fun unselectAdditionalOptionsMenu() {
         selectedOption = AdditionalOptionSelectItem.None
     }
 
@@ -88,6 +88,7 @@ class AdditionalOptionStateHolder {
 
     fun toAttachmentAndAdditionalOptionsMenu() {
         additionalOptionState = AdditionalOptionMenuState.AttachmentAndAdditionalOptionsMenu
+        unselectAdditionalOptionsMenu()
     }
 
     fun toSelfDeletingOptionsMenu() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
@@ -112,7 +112,7 @@ class MessageComposerStateHolder(
 
     fun onInputFocusedChanged(onFocused: Boolean) {
         if (onFocused) {
-            additionalOptionStateHolder.hideAdditionalOptionsMenu()
+            additionalOptionStateHolder.unselectAdditionalOptionsMenu()
             messageCompositionInputStateHolder.requestFocus()
         } else {
             messageCompositionInputStateHolder.clearFocus()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
@@ -149,6 +149,10 @@ class MessageCompositionInputStateHolder(
         isTextExpanded = !isTextExpanded
     }
 
+    fun collapseText() {
+        isTextExpanded = false
+    }
+
     fun clearFocus() {
         inputFocused = false
     }
@@ -168,8 +172,8 @@ class MessageCompositionInputStateHolder(
         clearFocus()
     }
 
-    fun handleBackPressed(isImeVisible: Boolean, additionalOptionsSubMenuState: AdditionalOptionSubMenuState) {
-        if ((isImeVisible || optionsVisible) && additionalOptionsSubMenuState != AdditionalOptionSubMenuState.RecordAudio) {
+    fun collapseComposer(additionalOptionsSubMenuState: AdditionalOptionSubMenuState? = null) {
+        if (additionalOptionsSubMenuState != AdditionalOptionSubMenuState.RecordAudio) {
             optionsVisible = false
             subOptionsVisible = false
             isTextExpanded = false

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
@@ -187,48 +187,50 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset decreases, showSubOptions is true, and actualOffset is greater than optionsHeight, values remain unchanged`() = runTest {
-        // Given
-        state.updateValuesForTesting(
-            previousOffset = 50.dp,
-            keyboardHeight = 20.dp,
-            showSubOptions = true,
-            optionsHeight = 10.dp
-        )
+    fun `when offset decreases, showSubOptions is true, and actualOffset is greater than optionsHeight, values remain unchanged`() =
+        runTest {
+            // Given
+            state.updateValuesForTesting(
+                previousOffset = 50.dp,
+                keyboardHeight = 20.dp,
+                showSubOptions = true,
+                optionsHeight = 10.dp
+            )
 
-        // When
-        state.handleOffsetChange(
-            30.dp,
-            NAVIGATION_BAR_HEIGHT,
-            SOURCE,
-            TARGET
-        )
+            // When
+            state.handleOffsetChange(
+                30.dp,
+                NAVIGATION_BAR_HEIGHT,
+                SOURCE,
+                TARGET
+            )
 
-        // Then
-        state.optionsHeight shouldBeEqualTo 10.dp
-    }
+            // Then
+            state.optionsHeight shouldBeEqualTo 10.dp
+        }
 
     @Test
-    fun `when offset decreases, showSubOptions is false, and actualOffset is greater than optionsHeight, optionsHeight is updated`() = runTest {
-        // Given
-        state.updateValuesForTesting(
-            previousOffset = 50.dp,
-            keyboardHeight = 20.dp,
-            showSubOptions = false,
-            optionsHeight = 10.dp
-        )
+    fun `when offset decreases, showSubOptions is false, and actualOffset is greater than optionsHeight, optionsHeight is updated`() =
+        runTest {
+            // Given
+            state.updateValuesForTesting(
+                previousOffset = 50.dp,
+                keyboardHeight = 20.dp,
+                showSubOptions = false,
+                optionsHeight = 10.dp
+            )
 
-        // When
-        state.handleOffsetChange(
-            30.dp,
-            NAVIGATION_BAR_HEIGHT,
-            SOURCE,
-            TARGET
-        )
+            // When
+            state.handleOffsetChange(
+                30.dp,
+                NAVIGATION_BAR_HEIGHT,
+                SOURCE,
+                TARGET
+            )
 
-        // Then
-        state.optionsHeight shouldBeEqualTo 30.dp
-    }
+            // Then
+            state.optionsHeight shouldBeEqualTo 30.dp
+        }
 
     @Test
     fun `when offset is the same as previousOffset and greater than current keyboardHeight, keyboardHeight is updated`() = runTest {
@@ -262,19 +264,20 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `given extended keyboard height when attachment button is clicked, then keyboardHeight is set to initialKeyboardHeight`() = runTest {
-        // Given
-        val initialKeyboardHeight = 10.dp
-        state.updateValuesForTesting(previousOffset = 40.dp, keyboardHeight = 20.dp, initialKeyboardHeight = initialKeyboardHeight)
+    fun `given extended keyboard height when attachment button is clicked, then keyboardHeight is set to initialKeyboardHeight`() =
+        runTest {
+            // Given
+            val initialKeyboardHeight = 10.dp
+            state.updateValuesForTesting(previousOffset = 40.dp, keyboardHeight = 20.dp, initialKeyboardHeight = initialKeyboardHeight)
 
-        // When
-        state.showOptions()
-        state.handleOffsetChange(0.dp, NAVIGATION_BAR_HEIGHT, source = TARGET, target = SOURCE)
+            // When
+            state.showOptions()
+            state.handleOffsetChange(0.dp, NAVIGATION_BAR_HEIGHT, source = TARGET, target = SOURCE)
 
-        // Then
-        state.keyboardHeight shouldBeEqualTo 20.dp
-        state.optionsHeight shouldBeEqualTo initialKeyboardHeight
-    }
+            // Then
+            state.keyboardHeight shouldBeEqualTo 20.dp
+            state.optionsHeight shouldBeEqualTo initialKeyboardHeight
+        }
 
     @Test
     fun `when offset decreases but is not zero, only optionsHeight is updated`() = runTest {

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -46,7 +47,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when IME is visible, showOptions should be set to true`() {
+    fun `when IME is visible, showOptions should be set to true`() = runTest {
         // Given
         val isImeVisible = true
 
@@ -58,7 +59,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when IME is hidden and showSubOptions is true, showOptions remains unchanged`() {
+    fun `when IME is hidden and showSubOptions is true, showOptions remains unchanged`() = runTest {
         // Given
         val isImeVisible = false
         state.updateValuesForTesting(showSubOptions = true, showOptions = false)
@@ -71,7 +72,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when IME is hidden and showSubOptions is false, showOptions should be set to false`() {
+    fun `when IME is hidden and showSubOptions is false, showOptions should be set to false`() = runTest {
         // Given
         val isImeVisible = false
         state.updateValuesForTesting(showSubOptions = false)
@@ -84,7 +85,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset increases and is bigger than previous and options height, options height is updated`() {
+    fun `when offset increases and is bigger than previous and options height, options height is updated`() = runTest {
         // When
         state.handleOffsetChange(
             50.dp,
@@ -99,7 +100,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset decreases and showSubOptions is false, options height is updated`() {
+    fun `when offset decreases and showSubOptions is false, options height is updated`() = runTest {
         // Given
         state.updateValuesForTesting(previousOffset = 50.dp)
 
@@ -116,7 +117,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset decreases to zero, showOptions and isTextExpanded are set to false`() {
+    fun `when offset decreases to zero, showOptions and isTextExpanded are set to false`() = runTest {
         // Given
         state.updateValuesForTesting(previousOffset = 50.dp)
 
@@ -134,7 +135,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset equals keyboard height, showSubOptions is set to false`() {
+    fun `when offset equals keyboard height, showSubOptions is set to false`() = runTest {
         // Given
         state.updateValuesForTesting(keyboardHeight = 30.dp)
 
@@ -151,7 +152,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset is greater than keyboard height, keyboardHeight is updated`() {
+    fun `when offset is greater than keyboard height, keyboardHeight is updated`() = runTest {
         // Given
         state.updateValuesForTesting(keyboardHeight = 20.dp)
 
@@ -168,7 +169,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset increases and is greater than keyboardHeight but is less than previousOffset, keyboardHeight is updated`() {
+    fun `when offset increases and is greater than keyboardHeight but is less than previousOffset, keyboardHeight is updated`() = runTest {
         // Given
         state.updateValuesForTesting(previousOffset = 50.dp, keyboardHeight = 20.dp)
 
@@ -186,7 +187,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset decreases, showSubOptions is true, and actualOffset is greater than optionsHeight, values remain unchanged`() {
+    fun `when offset decreases, showSubOptions is true, and actualOffset is greater than optionsHeight, values remain unchanged`() = runTest {
         // Given
         state.updateValuesForTesting(
             previousOffset = 50.dp,
@@ -208,7 +209,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset decreases, showSubOptions is false, and actualOffset is greater than optionsHeight, optionsHeight is updated`() {
+    fun `when offset decreases, showSubOptions is false, and actualOffset is greater than optionsHeight, optionsHeight is updated`() = runTest {
         // Given
         state.updateValuesForTesting(
             previousOffset = 50.dp,
@@ -230,7 +231,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset is the same as previousOffset and greater than current keyboardHeight, keyboardHeight is updated`() {
+    fun `when offset is the same as previousOffset and greater than current keyboardHeight, keyboardHeight is updated`() = runTest {
         // Given
         state.updateValuesForTesting(previousOffset = 40.dp, keyboardHeight = 20.dp)
 
@@ -248,7 +249,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `given first keyboard appear when source equals target, then initialKeyboardHeight is set`() {
+    fun `given first keyboard appear when source equals target, then initialKeyboardHeight is set`() = runTest {
         // Given
         val imeValue = 50.dp
         state.updateValuesForTesting(initialKeyboardHeight = 0.dp)
@@ -261,7 +262,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `given extended keyboard height when attachment button is clicked, then keyboardHeight is set to initialKeyboardHeight`() {
+    fun `given extended keyboard height when attachment button is clicked, then keyboardHeight is set to initialKeyboardHeight`() = runTest {
         // Given
         val initialKeyboardHeight = 10.dp
         state.updateValuesForTesting(previousOffset = 40.dp, keyboardHeight = 20.dp, initialKeyboardHeight = initialKeyboardHeight)
@@ -276,7 +277,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset decreases but is not zero, only optionsHeight is updated`() {
+    fun `when offset decreases but is not zero, only optionsHeight is updated`() = runTest {
         // Given
         state.updateValuesForTesting(previousOffset = 50.dp)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7630" title="WPB-7630" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7630</a>  [Android] Keyboard shows for a short time on conversation list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- keyboard was focusing when conversation was closing -> added `collapseComposer` to disable it
- added `onPreInterceptKeyBeforeSoftKeyboard` to avoid keyboard blinking when textfield collapses

Before

https://github.com/wireapp/wire-android/assets/13151239/56b0a84b-cdc3-410f-a39a-cc74bac2d367


https://github.com/wireapp/wire-android/assets/13151239/6d25461e-a663-4fef-87fb-78f9b9a56959

After

https://github.com/wireapp/wire-android/assets/13151239/7b9b091b-b095-4b45-92fc-ee0a125e7eaf


