### PR TITLE
fix: test for multimodule

### DIFF
--- a/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -40,6 +40,14 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             configureCompose(this)
 
             configureAndroidKotlinTests()
+
+            buildTypes {
+                // libraries can skip minification, since the app will do it
+                release {
+                    isMinifyEnabled = false
+                    proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+                }
+            }
         }
     }
 }

--- a/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -42,7 +42,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             configureAndroidKotlinTests()
 
             buildTypes {
-                // libraries can skip minification, since the app will do it
+                // submodules using this plugin can skip minification, since the app will do it
                 release {
                     isMinifyEnabled = false
                     proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")

--- a/buildSrc/src/main/kotlin/scripts/infrastructure.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/infrastructure.gradle.kts
@@ -40,7 +40,7 @@ tasks.register("runUnitTests") {
     val validSubprojects = setOf("core", "features")
     rootProject.subprojects {
         if (validSubprojects.contains(parent?.name)) {
-            dependsOn(":${parent?.name}:$name:test${Default.BUILD_TYPE.capitalized()}UnitTest")
+            dependsOn(":${parent?.name}:$name:testDebugUnitTest")
         }
     }
 }

--- a/buildSrc/src/main/kotlin/scripts/infrastructure.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/infrastructure.gradle.kts
@@ -35,12 +35,15 @@ tasks.named<Wrapper>("wrapper") {
 tasks.register("runUnitTests") {
     description = "Runs all Unit Tests."
     dependsOn(":app:test${Default.BUILD_VARIANT}UnitTest")
+    val buildType =
+        if (Default.BUILD_TYPE == Variants_gradle.BuildTypes.DEBUG) Default.BUILD_TYPE.capitalized()
+        else Variants_gradle.BuildTypes.RELEASE.capitalized()
 
     // valid submodules path to run unit tests
     val validSubprojects = setOf("core", "features")
     rootProject.subprojects {
         if (validSubprojects.contains(parent?.name)) {
-            dependsOn(":${parent?.name}:$name:testDebugUnitTest")
+            dependsOn(":${parent?.name}:$name:test${buildType}UnitTest")
         }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Multimodule configuration to run tests does not work for all build types

### Causes (Optional)

Breaks CI

### Solutions

Configure the task correctly.

### Testing

#### Test Coverage (Optional)

N/a

#### How to Test

The CI build should work.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
