### PR TITLE
fix: close properly keyboard in conversation screen [WPB-7630]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -58,9 +58,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -201,7 +199,6 @@ fun ConversationScreen(
     val coroutineScope = rememberCoroutineScope()
     val uriHandler = LocalUriHandler.current
     val showDialog = remember { mutableStateOf(ConversationScreenDialogType.NONE) }
-    val focusManager = LocalFocusManager.current
     val conversationScreenState = rememberConversationScreenState()
     val messageComposerViewState = messageComposerViewModel.messageComposerViewState
     val messageComposerStateHolder = rememberMessageComposerStateHolder(
@@ -392,8 +389,13 @@ fun ConversationScreen(
                 }
             }
         },
+<<<<<<< HEAD
         onBackButtonClick = { conversationScreenOnBackButtonClick(messageComposerViewModel, focusManager, navigator) },
         composerMessages = sendMessageViewModel.infoMessage,
+=======
+        onBackButtonClick = { conversationScreenOnBackButtonClick(messageComposerViewModel, messageComposerStateHolder, navigator) },
+        composerMessages = messageComposerViewModel.infoMessage,
+>>>>>>> eca268278 (fix: close properly keyboard in conversation screen [WPB-7630] (#2872))
         conversationMessages = conversationMessagesViewModel.infoMessage,
         conversationMessagesViewModel = conversationMessagesViewModel,
         onSelfDeletingMessageRead = messageComposerViewModel::startSelfDeletion,
@@ -454,7 +456,7 @@ fun ConversationScreen(
         },
         onTypingEvent = messageComposerViewModel::sendTypingEvent
     )
-    BackHandler { conversationScreenOnBackButtonClick(messageComposerViewModel, focusManager, navigator) }
+    BackHandler { conversationScreenOnBackButtonClick(messageComposerViewModel, messageComposerStateHolder, navigator) }
     DeleteMessageDialog(
         state = conversationMessagesViewModel.deleteMessageDialogsState,
         actions = conversationMessagesViewModel.deleteMessageHelper
@@ -562,11 +564,11 @@ fun ConversationScreen(
 
 private fun conversationScreenOnBackButtonClick(
     messageComposerViewModel: MessageComposerViewModel,
-    focusManager: FocusManager,
+    messageComposerStateHolder: MessageComposerStateHolder,
     navigator: Navigator
 ) {
     messageComposerViewModel.sendTypingEvent(TypingIndicatorMode.STOPPED)
-    focusManager.clearFocus(true)
+    messageComposerStateHolder.messageCompositionInputStateHolder.collapseComposer(null)
     navigator.navigateBack()
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -389,7 +389,9 @@ fun ConversationScreen(
                 }
             }
         },
-        onBackButtonClick = { conversationScreenOnBackButtonClick(messageComposerViewModel, messageComposerStateHolder, navigator) },
+        onBackButtonClick = {
+            conversationScreenOnBackButtonClick(messageComposerViewModel, messageComposerStateHolder, navigator)
+        },
         composerMessages = sendMessageViewModel.infoMessage,
         conversationMessages = conversationMessagesViewModel.infoMessage,
         conversationMessagesViewModel = conversationMessagesViewModel,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -18,7 +18,6 @@
 
 package com.wire.android.ui.home.conversations
 
-import com.wire.android.ui.common.snackbar.SwipeableSnackbar
 import android.annotation.SuppressLint
 import android.net.Uri
 import androidx.activity.compose.BackHandler
@@ -98,6 +97,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.error.CoreFailureErrorDialog
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
+import com.wire.android.ui.common.snackbar.SwipeableSnackbar
 import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.destinations.ConversationScreenDestination
 import com.wire.android.ui.destinations.GroupConversationDetailsScreenDestination
@@ -389,13 +389,8 @@ fun ConversationScreen(
                 }
             }
         },
-<<<<<<< HEAD
-        onBackButtonClick = { conversationScreenOnBackButtonClick(messageComposerViewModel, focusManager, navigator) },
-        composerMessages = sendMessageViewModel.infoMessage,
-=======
         onBackButtonClick = { conversationScreenOnBackButtonClick(messageComposerViewModel, messageComposerStateHolder, navigator) },
-        composerMessages = messageComposerViewModel.infoMessage,
->>>>>>> eca268278 (fix: close properly keyboard in conversation screen [WPB-7630] (#2872))
+        composerMessages = sendMessageViewModel.infoMessage,
         conversationMessages = conversationMessagesViewModel.infoMessage,
         conversationMessagesViewModel = conversationMessagesViewModel,
         onSelfDeletingMessageRead = messageComposerViewModel::startSelfDeletion,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -259,7 +259,10 @@ fun EnabledMessageComposer(
                                     additionalOptionStateHolder.toRichTextEditing()
                                 },
                                 onCloseRichEditingButtonClicked = additionalOptionStateHolder::toAttachmentAndAdditionalOptionsMenu,
-                                onDrawingModeClicked = additionalOptionStateHolder::toDrawingMode
+                                onDrawingModeClicked = {
+                                    inputStateHolder.collapseComposer()
+                                    additionalOptionStateHolder.toDrawingMode()
+                                }
                             )
                         }
                         Box(
@@ -295,10 +298,7 @@ fun EnabledMessageComposer(
                         if (additionalOptionStateHolder.selectedOption == AdditionalOptionSelectItem.DrawingMode) {
                             DrawingCanvasBottomSheet(
                                 onDismissSketch = {
-                                    inputStateHolder.handleBackPressed(
-                                        isImeVisible,
-                                        additionalOptionStateHolder.additionalOptionsSubMenuState
-                                    )
+                                    inputStateHolder.collapseComposer(additionalOptionStateHolder.additionalOptionsSubMenuState)
                                 },
                                 onSendSketch = onSendButtonClicked
                             )

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -110,7 +110,7 @@ fun EnabledMessageComposer(
                 messageCompositionInputStateHolder.clearFocus()
             } else if (additionalOptionStateHolder.selectedOption == AdditionalOptionSelectItem.SelfDeleting) {
                 messageCompositionInputStateHolder.requestFocus()
-                additionalOptionStateHolder.hideAdditionalOptionsMenu()
+                additionalOptionStateHolder.unselectAdditionalOptionsMenu()
             }
         }
 
@@ -177,6 +177,7 @@ fun EnabledMessageComposer(
                                 inputFocused = messageCompositionInputStateHolder.inputFocused,
                                 onInputFocusedChanged = ::onInputFocusedChanged,
                                 onToggleInputSize = messageCompositionInputStateHolder::toggleInputSize,
+                                onTextCollapse = messageCompositionInputStateHolder::collapseText,
                                 onCancelReply = messageCompositionHolder::clearReply,
                                 onCancelEdit = ::cancelEdit,
                                 onMessageTextChanged = {
@@ -246,7 +247,7 @@ fun EnabledMessageComposer(
                                 onAdditionalOptionsMenuClicked = {
                                     if (!isKeyboardMoving) {
                                         if (additionalOptionStateHolder.selectedOption == AdditionalOptionSelectItem.AttachFile) {
-                                            additionalOptionStateHolder.hideAdditionalOptionsMenu()
+                                            additionalOptionStateHolder.unselectAdditionalOptionsMenu()
                                             messageCompositionInputStateHolder.toComposing()
                                         } else {
                                             showAdditionalOptionsMenu()
@@ -310,10 +311,7 @@ fun EnabledMessageComposer(
                 cancelEdit()
             }
             BackHandler(isImeVisible || inputStateHolder.optionsVisible) {
-                inputStateHolder.handleBackPressed(
-                    isImeVisible,
-                    additionalOptionStateHolder.additionalOptionsSubMenuState
-                )
+                inputStateHolder.collapseComposer(additionalOptionStateHolder.additionalOptionsSubMenuState)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -47,6 +47,9 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.nativeKeyCode
+import androidx.compose.ui.input.key.onPreInterceptKeyBeforeSoftKeyboard
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -80,6 +83,7 @@ fun ActiveMessageComposerInput(
     onEditButtonClicked: () -> Unit,
     onChangeSelfDeletionClicked: () -> Unit,
     onToggleInputSize: () -> Unit,
+    onTextCollapse: () -> Unit,
     onCancelReply: () -> Unit,
     onCancelEdit: () -> Unit,
     onInputFocusedChanged: (Boolean) -> Unit,
@@ -140,6 +144,7 @@ fun ActiveMessageComposerInput(
                     onLineBottomYCoordinateChanged = onLineBottomYCoordinateChanged,
                     showOptions = showOptions,
                     onPlusClick = onPlusClick,
+                    onTextCollapse = onTextCollapse,
                     modifier = stretchToMaxParentConstraintHeightOrWithInBoundary,
                 )
             }
@@ -164,6 +169,7 @@ fun ActiveMessageComposerInput(
                     onLineBottomYCoordinateChanged = onLineBottomYCoordinateChanged,
                     showOptions = showOptions,
                     onPlusClick = onPlusClick,
+                    onTextCollapse = onTextCollapse,
                     modifier = stretchToMaxParentConstraintHeightOrWithInBoundary
                 )
             }
@@ -198,6 +204,7 @@ private fun InputContent(
     onLineBottomYCoordinateChanged: (Float) -> Unit,
     showOptions: Boolean,
     onPlusClick: () -> Unit,
+    onTextCollapse: () -> Unit,
     modifier: Modifier,
 ) {
     if (!showOptions && inputType is MessageCompositionType.Composing) {
@@ -211,6 +218,7 @@ private fun InputContent(
     }
 
     MessageComposerTextInput(
+        isTextExpanded = isTextExpanded,
         inputFocused = inputFocused,
         colors = inputType.inputTextColor(),
         messageText = messageComposition.messageTextFieldValue,
@@ -220,6 +228,7 @@ private fun InputContent(
         onFocusChanged = onInputFocusedChanged,
         onSelectedLineIndexChanged = onSelectedLineIndexChanged,
         onLineBottomYCoordinateChanged = onLineBottomYCoordinateChanged,
+        onTextCollapse = onTextCollapse,
         modifier = modifier
     )
 
@@ -256,6 +265,7 @@ private fun InputContent(
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun MessageComposerTextInput(
+    isTextExpanded: Boolean,
     inputFocused: Boolean,
     colors: WireTextFieldColors,
     singleLine: Boolean,
@@ -265,6 +275,7 @@ private fun MessageComposerTextInput(
     onFocusChanged: (Boolean) -> Unit = {},
     onSelectedLineIndexChanged: (Int) -> Unit = { },
     onLineBottomYCoordinateChanged: (Float) -> Unit = { },
+    onTextCollapse: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -305,6 +316,18 @@ private fun MessageComposerTextInput(
             .onFocusChanged { focusState ->
                 if (focusState.isFocused) {
                     onFocusChanged(focusState.isFocused)
+                }
+            }
+            .onPreInterceptKeyBeforeSoftKeyboard { event ->
+                if (event.key.nativeKeyCode == android.view.KeyEvent.KEYCODE_BACK) {
+                    if (isTextExpanded) {
+                        onTextCollapse()
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    false
                 }
             },
         interactionSource = interactionSource,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/AdditionalOptionMenuState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/AdditionalOptionMenuState.kt
@@ -65,7 +65,7 @@ class AdditionalOptionStateHolder {
         additionalOptionsSubMenuState = AdditionalOptionSubMenuState.AttachFile
     }
 
-    fun hideAdditionalOptionsMenu() {
+    fun unselectAdditionalOptionsMenu() {
         selectedOption = AdditionalOptionSelectItem.None
     }
 
@@ -89,6 +89,7 @@ class AdditionalOptionStateHolder {
 
     fun toAttachmentAndAdditionalOptionsMenu() {
         additionalOptionState = AdditionalOptionMenuState.AttachmentAndAdditionalOptionsMenu
+        unselectAdditionalOptionsMenu()
     }
 
     fun toSelfDeletingOptionsMenu() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
@@ -116,7 +116,7 @@ class MessageComposerStateHolder(
 
     fun onInputFocusedChanged(onFocused: Boolean) {
         if (onFocused) {
-            additionalOptionStateHolder.hideAdditionalOptionsMenu()
+            additionalOptionStateHolder.unselectAdditionalOptionsMenu()
             messageCompositionInputStateHolder.requestFocus()
         } else {
             messageCompositionInputStateHolder.clearFocus()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
@@ -148,6 +148,10 @@ class MessageCompositionInputStateHolder(
         isTextExpanded = !isTextExpanded
     }
 
+    fun collapseText() {
+        isTextExpanded = false
+    }
+
     fun clearFocus() {
         inputFocused = false
     }
@@ -167,8 +171,8 @@ class MessageCompositionInputStateHolder(
         clearFocus()
     }
 
-    fun handleBackPressed(isImeVisible: Boolean, additionalOptionsSubMenuState: AdditionalOptionSubMenuState) {
-        if ((isImeVisible || optionsVisible) && additionalOptionsSubMenuState != AdditionalOptionSubMenuState.RecordAudio) {
+    fun collapseComposer(additionalOptionsSubMenuState: AdditionalOptionSubMenuState? = null) {
+        if (additionalOptionsSubMenuState != AdditionalOptionSubMenuState.RecordAudio) {
             optionsVisible = false
             subOptionsVisible = false
             isTextExpanded = false

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
@@ -24,6 +24,7 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -47,7 +48,49 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
+<<<<<<< HEAD
     fun `when offset increases and is bigger than previous and options height, options height is updated`() {
+=======
+    fun `when IME is visible, showOptions should be set to true`() = runTest {
+        // Given
+        val isImeVisible = true
+
+        // When
+        state.handleIMEVisibility(isImeVisible)
+
+        // Then
+        state.optionsVisible shouldBeEqualTo true
+    }
+
+    @Test
+    fun `when IME is hidden and showSubOptions is true, showOptions remains unchanged`() = runTest {
+        // Given
+        val isImeVisible = false
+        state.updateValuesForTesting(showSubOptions = true, showOptions = false)
+
+        // When
+        state.handleIMEVisibility(isImeVisible)
+
+        // Then
+        state.optionsVisible shouldBeEqualTo false
+    }
+
+    @Test
+    fun `when IME is hidden and showSubOptions is false, showOptions should be set to false`() = runTest {
+        // Given
+        val isImeVisible = false
+        state.updateValuesForTesting(showSubOptions = false)
+
+        // When
+        state.handleIMEVisibility(isImeVisible)
+
+        // Then
+        state.optionsVisible shouldBeEqualTo false
+    }
+
+    @Test
+    fun `when offset increases and is bigger than previous and options height, options height is updated`() = runTest {
+>>>>>>> eca268278 (fix: close properly keyboard in conversation screen [WPB-7630] (#2872))
         // When
         state.handleImeOffsetChange(
             50.dp,
@@ -62,7 +105,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset decreases and showSubOptions is false, options height is updated`() {
+    fun `when offset decreases and showSubOptions is false, options height is updated`() = runTest {
         // Given
         state.updateValuesForTesting(previousOffset = 50.dp)
 
@@ -79,7 +122,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset decreases to zero, showOptions and isTextExpanded are set to false`() {
+    fun `when offset decreases to zero, showOptions and isTextExpanded are set to false`() = runTest {
         // Given
         state.updateValuesForTesting(previousOffset = 50.dp)
 
@@ -97,7 +140,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset equals keyboard height, showSubOptions is set to false`() {
+    fun `when offset equals keyboard height, showSubOptions is set to false`() = runTest {
         // Given
         state.updateValuesForTesting(keyboardHeight = 30.dp)
 
@@ -114,7 +157,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset is greater than keyboard height, keyboardHeight is updated`() {
+    fun `when offset is greater than keyboard height, keyboardHeight is updated`() = runTest {
         // Given
         state.updateValuesForTesting(keyboardHeight = 20.dp)
 
@@ -131,7 +174,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset increases and is greater than keyboardHeight but is less than previousOffset, keyboardHeight is updated`() {
+    fun `when offset increases and is greater than keyboardHeight but is less than previousOffset, keyboardHeight is updated`() = runTest {
         // Given
         state.updateValuesForTesting(previousOffset = 50.dp, keyboardHeight = 20.dp)
 
@@ -149,15 +192,17 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when offset decreases, showSubOptions is true, and actualOffset is greater than optionsHeight, values remain unchanged`() {
-        // Given
-        state.updateValuesForTesting(
-            previousOffset = 50.dp,
-            keyboardHeight = 20.dp,
-            showSubOptions = true,
-            optionsHeight = 10.dp
-        )
+    fun `when offset decreases, showSubOptions is true, and actualOffset is greater than optionsHeight, values remain unchanged`() =
+        runTest {
+            // Given
+            state.updateValuesForTesting(
+                previousOffset = 50.dp,
+                keyboardHeight = 20.dp,
+                showSubOptions = true,
+                optionsHeight = 10.dp
+            )
 
+<<<<<<< HEAD
         // When
         state.handleImeOffsetChange(
             30.dp,
@@ -165,21 +210,32 @@ class MessageCompositionInputStateHolderTest {
             SOURCE,
             TARGET
         )
+=======
+            // When
+            state.handleOffsetChange(
+                30.dp,
+                NAVIGATION_BAR_HEIGHT,
+                SOURCE,
+                TARGET
+            )
+>>>>>>> eca268278 (fix: close properly keyboard in conversation screen [WPB-7630] (#2872))
 
-        // Then
-        state.optionsHeight shouldBeEqualTo 10.dp
-    }
+            // Then
+            state.optionsHeight shouldBeEqualTo 10.dp
+        }
 
     @Test
-    fun `when offset decreases, showSubOptions is false, and actualOffset is greater than optionsHeight, optionsHeight is updated`() {
-        // Given
-        state.updateValuesForTesting(
-            previousOffset = 50.dp,
-            keyboardHeight = 20.dp,
-            showSubOptions = false,
-            optionsHeight = 10.dp
-        )
+    fun `when offset decreases, showSubOptions is false, and actualOffset is greater than optionsHeight, optionsHeight is updated`() =
+        runTest {
+            // Given
+            state.updateValuesForTesting(
+                previousOffset = 50.dp,
+                keyboardHeight = 20.dp,
+                showSubOptions = false,
+                optionsHeight = 10.dp
+            )
 
+<<<<<<< HEAD
         // When
         state.handleImeOffsetChange(
             30.dp,
@@ -187,13 +243,22 @@ class MessageCompositionInputStateHolderTest {
             SOURCE,
             TARGET
         )
+=======
+            // When
+            state.handleOffsetChange(
+                30.dp,
+                NAVIGATION_BAR_HEIGHT,
+                SOURCE,
+                TARGET
+            )
+>>>>>>> eca268278 (fix: close properly keyboard in conversation screen [WPB-7630] (#2872))
 
-        // Then
-        state.optionsHeight shouldBeEqualTo 30.dp
-    }
+            // Then
+            state.optionsHeight shouldBeEqualTo 30.dp
+        }
 
     @Test
-    fun `when offset is the same as previousOffset and greater than current keyboardHeight, keyboardHeight is updated`() {
+    fun `when offset is the same as previousOffset and greater than current keyboardHeight, keyboardHeight is updated`() = runTest {
         // Given
         state.updateValuesForTesting(previousOffset = 40.dp, keyboardHeight = 20.dp)
 
@@ -211,7 +276,7 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `given first keyboard appear when source equals target, then initialKeyboardHeight is set`() {
+    fun `given first keyboard appear when source equals target, then initialKeyboardHeight is set`() = runTest {
         // Given
         val imeValue = 50.dp
         state.updateValuesForTesting(initialKeyboardHeight = 0.dp)
@@ -224,22 +289,29 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `given extended keyboard height when attachment button is clicked, then keyboardHeight is set to initialKeyboardHeight`() {
-        // Given
-        val initialKeyboardHeight = 10.dp
-        state.updateValuesForTesting(previousOffset = 40.dp, keyboardHeight = 20.dp, initialKeyboardHeight = initialKeyboardHeight)
+    fun `given extended keyboard height when attachment button is clicked, then keyboardHeight is set to initialKeyboardHeight`() =
+        runTest {
+            // Given
+            val initialKeyboardHeight = 10.dp
+            state.updateValuesForTesting(previousOffset = 40.dp, keyboardHeight = 20.dp, initialKeyboardHeight = initialKeyboardHeight)
 
+<<<<<<< HEAD
         // When
         state.showOptions()
         state.handleImeOffsetChange(0.dp, NAVIGATION_BAR_HEIGHT, source = TARGET, target = SOURCE)
+=======
+            // When
+            state.showOptions()
+            state.handleOffsetChange(0.dp, NAVIGATION_BAR_HEIGHT, source = TARGET, target = SOURCE)
+>>>>>>> eca268278 (fix: close properly keyboard in conversation screen [WPB-7630] (#2872))
 
-        // Then
-        state.keyboardHeight shouldBeEqualTo 20.dp
-        state.optionsHeight shouldBeEqualTo initialKeyboardHeight
-    }
+            // Then
+            state.keyboardHeight shouldBeEqualTo 20.dp
+            state.optionsHeight shouldBeEqualTo initialKeyboardHeight
+        }
 
     @Test
-    fun `when offset decreases but is not zero, only optionsHeight is updated`() {
+    fun `when offset decreases but is not zero, only optionsHeight is updated`() = runTest {
         // Given
         state.updateValuesForTesting(previousOffset = 50.dp)
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
@@ -48,49 +48,8 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-<<<<<<< HEAD
-    fun `when offset increases and is bigger than previous and options height, options height is updated`() {
-=======
-    fun `when IME is visible, showOptions should be set to true`() = runTest {
-        // Given
-        val isImeVisible = true
-
-        // When
-        state.handleIMEVisibility(isImeVisible)
-
-        // Then
-        state.optionsVisible shouldBeEqualTo true
-    }
-
-    @Test
-    fun `when IME is hidden and showSubOptions is true, showOptions remains unchanged`() = runTest {
-        // Given
-        val isImeVisible = false
-        state.updateValuesForTesting(showSubOptions = true, showOptions = false)
-
-        // When
-        state.handleIMEVisibility(isImeVisible)
-
-        // Then
-        state.optionsVisible shouldBeEqualTo false
-    }
-
-    @Test
-    fun `when IME is hidden and showSubOptions is false, showOptions should be set to false`() = runTest {
-        // Given
-        val isImeVisible = false
-        state.updateValuesForTesting(showSubOptions = false)
-
-        // When
-        state.handleIMEVisibility(isImeVisible)
-
-        // Then
-        state.optionsVisible shouldBeEqualTo false
-    }
-
-    @Test
     fun `when offset increases and is bigger than previous and options height, options height is updated`() = runTest {
->>>>>>> eca268278 (fix: close properly keyboard in conversation screen [WPB-7630] (#2872))
+
         // When
         state.handleImeOffsetChange(
             50.dp,
@@ -202,23 +161,13 @@ class MessageCompositionInputStateHolderTest {
                 optionsHeight = 10.dp
             )
 
-<<<<<<< HEAD
-        // When
-        state.handleImeOffsetChange(
-            30.dp,
-            NAVIGATION_BAR_HEIGHT,
-            SOURCE,
-            TARGET
-        )
-=======
             // When
-            state.handleOffsetChange(
+            state.handleImeOffsetChange(
                 30.dp,
                 NAVIGATION_BAR_HEIGHT,
                 SOURCE,
                 TARGET
             )
->>>>>>> eca268278 (fix: close properly keyboard in conversation screen [WPB-7630] (#2872))
 
             // Then
             state.optionsHeight shouldBeEqualTo 10.dp
@@ -235,23 +184,13 @@ class MessageCompositionInputStateHolderTest {
                 optionsHeight = 10.dp
             )
 
-<<<<<<< HEAD
-        // When
-        state.handleImeOffsetChange(
-            30.dp,
-            NAVIGATION_BAR_HEIGHT,
-            SOURCE,
-            TARGET
-        )
-=======
             // When
-            state.handleOffsetChange(
+            state.handleImeOffsetChange(
                 30.dp,
                 NAVIGATION_BAR_HEIGHT,
                 SOURCE,
                 TARGET
             )
->>>>>>> eca268278 (fix: close properly keyboard in conversation screen [WPB-7630] (#2872))
 
             // Then
             state.optionsHeight shouldBeEqualTo 30.dp
@@ -295,15 +234,9 @@ class MessageCompositionInputStateHolderTest {
             val initialKeyboardHeight = 10.dp
             state.updateValuesForTesting(previousOffset = 40.dp, keyboardHeight = 20.dp, initialKeyboardHeight = initialKeyboardHeight)
 
-<<<<<<< HEAD
-        // When
-        state.showOptions()
-        state.handleImeOffsetChange(0.dp, NAVIGATION_BAR_HEIGHT, source = TARGET, target = SOURCE)
-=======
             // When
             state.showOptions()
-            state.handleOffsetChange(0.dp, NAVIGATION_BAR_HEIGHT, source = TARGET, target = SOURCE)
->>>>>>> eca268278 (fix: close properly keyboard in conversation screen [WPB-7630] (#2872))
+            state.handleImeOffsetChange(0.dp, NAVIGATION_BAR_HEIGHT, source = TARGET, target = SOURCE)
 
             // Then
             state.keyboardHeight shouldBeEqualTo 20.dp
@@ -330,23 +263,24 @@ class MessageCompositionInputStateHolderTest {
     }
 
     @Test
-    fun `when keyboard is still in a process of hiding from the previous screen after navigating, options should not be visible`() {
-        // Given
-        state.updateValuesForTesting(previousOffset = 0.dp)
+    fun `when keyboard is still in a process of hiding from the previous screen after navigating, options should not be visible`() =
+        runTest {
+            // Given
+            state.updateValuesForTesting(previousOffset = 0.dp)
 
-        // When
-        state.handleImeOffsetChange(
-            offset = 40.dp,
-            navBarHeight = NAVIGATION_BAR_HEIGHT,
-            source = 50.dp,
-            target = 0.dp
-        )
+            // When
+            state.handleImeOffsetChange(
+                offset = 40.dp,
+                navBarHeight = NAVIGATION_BAR_HEIGHT,
+                source = 50.dp,
+                target = 0.dp
+            )
 
-        // Then
-        state.optionsHeight shouldBeEqualTo 0.dp
-        state.optionsVisible shouldBeEqualTo false
-        state.isTextExpanded shouldBeEqualTo false
-    }
+            // Then
+            state.optionsHeight shouldBeEqualTo 0.dp
+            state.optionsVisible shouldBeEqualTo false
+            state.isTextExpanded shouldBeEqualTo false
+        }
 
     companion object {
         // I set it 0 to make tests more straight forward


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7630" title="WPB-7630" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7630</a>  [Android] Keyboard shows for a short time on conversation list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2872

---- 

 ⚠️ Conflicts during cherry-pick:
app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- keyboard was focusing when conversation was closing -> added  to disable it
- added  to avoid keyboard blinking when textfield collapses

Before

https://github.com/wireapp/wire-android/assets/13151239/56b0a84b-cdc3-410f-a39a-cc74bac2d367


https://github.com/wireapp/wire-android/assets/13151239/6d25461e-a663-4fef-87fb-78f9b9a56959

After

https://github.com/wireapp/wire-android/assets/13151239/7b9b091b-b095-4b45-92fc-ee0a125e7eaf

