### PR TITLE
fix: read conversation on short list [WPB-7432]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/AuthorHeaderHelper.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.util.DateTimeUtil
 object AuthorHeaderHelper {
 
     @VisibleForTesting
-    internal const val AGGREGATION_TIME_WINDOW: Int = 30_000 // millis
+    internal const val AGGREGATION_TIME_WINDOW: Int = 30_000 // in millis
 
     private fun LazyPagingItems<UIMessage>.peekOrNull(index: Int) =
         if (index in 0 until this.itemCount) this.peek(index) else null

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -888,7 +888,7 @@ private fun SnackBarMessage(
     }
 }
 
-@Suppress("ComplexMethod")
+@Suppress("ComplexMethod", "ComplexCondition")
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun MessageList(
@@ -938,11 +938,15 @@ fun MessageList(
         }
     }
 
-    // update last read message on start
+    // update last read message on start or when list is not scrollable
     LaunchedEffect(lazyPagingMessages.itemCount) {
-        if (!readLastMessageAtStartTriggered.value && lazyPagingMessages.itemSnapshotList.items.isNotEmpty()) {
+        if ((!readLastMessageAtStartTriggered.value || (!lazyListState.canScrollBackward && !lazyListState.canScrollForward))
+            && lazyPagingMessages.itemSnapshotList.items.isNotEmpty()
+        ) {
             val lastVisibleMessage = lazyPagingMessages[lazyListState.firstVisibleItemIndex] ?: return@LaunchedEffect
-            readLastMessageAtStartTriggered.value = true
+            if (!readLastMessageAtStartTriggered.value) {
+                readLastMessageAtStartTriggered.value = true
+            }
             updateLastReadMessage(lastVisibleMessage, lastUnreadMessageInstant, onUpdateConversationReadDate)
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7432" title="WPB-7432" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7432</a>  [Android] Message not marked as read when received in empty conversation when screen is open
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2876

---- 

 ⚠️ Conflicts during cherry-pick:
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When list was not scrollable and new message appears being in Conversation Screen conversation was not marked as read

### Solutions

Add additional condition to check if list is not scrollable to mark conversation as read when new message appears