### PR TITLE
fix: misleading e2ei certificate error dialog (WPB-7129)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
@@ -57,7 +57,7 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.destinations.E2eiCertificateDetailsScreenDestination
 import com.wire.android.ui.destinations.InitialSyncScreenDestination
-import com.wire.android.ui.home.E2EIErrorNoSnoozeDialog
+import com.wire.android.ui.home.E2EIEnrollmentErrorWithDismissDialog
 import com.wire.android.ui.home.E2EISuccessDialog
 import com.wire.android.ui.markdown.MarkdownConstants
 import com.wire.android.ui.theme.WireTheme
@@ -193,12 +193,10 @@ private fun E2EIEnrollmentScreenContent(
         }
 
         if (state.isCertificateEnrollError) {
-            E2EIErrorNoSnoozeDialog(
+            E2EIEnrollmentErrorWithDismissDialog(
                 isE2EILoading = state.isLoading,
-                updateCertificate = {
-                    dismissErrorDialog()
-                    enrollE2EICertificate()
-                }
+                onClick = enrollE2EICertificate,
+                onDismiss = dismissErrorDialog
             )
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/E2EIDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/E2EIDialogs.kt
@@ -195,14 +195,46 @@ fun E2EISuccessDialog(
 }
 
 @Composable
-fun E2EIErrorWithDismissDialog(
+fun E2EIUpdateErrorWithDismissDialog(
+    isE2EILoading: Boolean,
+    updateCertificate: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    E2EIErrorWithDismissDialog(
+        title = stringResource(id = R.string.end_to_end_identity_renew_error_dialog_title),
+        text = stringResource(id = R.string.end_to_end_identity_renew_error_dialog_text),
+        isE2EILoading = isE2EILoading,
+        updateCertificate = updateCertificate,
+        onDismiss = onDismiss
+    )
+}
+
+@Composable
+fun E2EIEnrollmentErrorWithDismissDialog(
+    isE2EILoading: Boolean,
+    onClick: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    E2EIErrorWithDismissDialog(
+        title = stringResource(id = R.string.end_to_end_identity_enrollment_error_dialog_title),
+        text = stringResource(id = R.string.end_to_end_identity_enrollment_error_dialog_text),
+        isE2EILoading = isE2EILoading,
+        updateCertificate = onClick,
+        onDismiss = onDismiss
+    )
+}
+
+@Composable
+private fun E2EIErrorWithDismissDialog(
+    title: String,
+    text: String,
     isE2EILoading: Boolean,
     updateCertificate: () -> Unit,
     onDismiss: () -> Unit
 ) {
     WireDialog(
-        title = stringResource(id = R.string.end_to_end_identity_renew_error_dialog_title),
-        text = stringResource(id = R.string.end_to_end_identity_renew_error_dialog_text),
+        title = title,
+        text = text,
         onDismiss = onDismiss,
         optionButton1Properties = WireDialogButtonProperties(
             onClick = updateCertificate,
@@ -247,7 +279,7 @@ private fun E2EIErrorWithSnoozeDialog(
 }
 
 @Composable
-fun E2EIErrorNoSnoozeDialog(
+private fun E2EIErrorNoSnoozeDialog(
     isE2EILoading: Boolean,
     updateCertificate: () -> Unit
 ) {

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -75,8 +75,8 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.topappbar.WireTopAppBarTitle
 import com.wire.android.ui.destinations.E2eiCertificateDetailsScreenDestination
 import com.wire.android.ui.e2eiEnrollment.GetE2EICertificateUI
-import com.wire.android.ui.home.E2EIErrorWithDismissDialog
 import com.wire.android.ui.home.E2EISuccessDialog
+import com.wire.android.ui.home.E2EIUpdateErrorWithDismissDialog
 import com.wire.android.ui.home.conversationslist.common.FolderHeader
 import com.wire.android.ui.settings.devices.model.DeviceDetailsState
 import com.wire.android.ui.theme.wireColorScheme
@@ -279,7 +279,7 @@ fun DeviceDetailsContent(
         }
 
         if (state.isE2EICertificateEnrollError) {
-            E2EIErrorWithDismissDialog(
+            E2EIUpdateErrorWithDismissDialog(
                 isE2EILoading = state.isLoadingCertificate,
                 updateCertificate = { enrollE2eiCertificate() },
                 onDismiss = onEnrollE2EIErrorDismiss

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1277,6 +1277,8 @@
     <string name="end_to_end_identity_renew_success_dialog_title">Certificate updated</string>
     <string name="end_to_end_identity_renew_success_dialog_text">The certificate is updated and your device is verified.</string>
     <string name="end_to_end_identity_renew_success_dialog_second_button">Certificate Details</string>
+    <string name="end_to_end_identity_enrollment_error_dialog_title">Certificate couldn’t be issued.</string>
+    <string name="end_to_end_identity_enrollment_error_dialog_text">Please try again, or reach out to your team admin.</string>
     <string name="end_to_end_identity_ceritifcate">Certificate Details</string>
     <string name="end_to_end_identity_certificate_revoked_dialog_title">End-to-end certificate revoked</string>
     <string name="end_to_end_identity_certificate_revoked_dialog_description">Log out to reduce security risks. Then log in again, get a new certificate, and reset your password.\n\nIf you keep using this device, your conversations are no longer verified.</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7129" title="WPB-7129" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7129</a>  [Android] Misleading dialogue if certificate generation fails after login with e2ei enabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The old copy for error when getting certificate was wrong.

### Solutions

Adjust dialog with new copy

### Dependencies (Optional)

Needs releases with:

- [X] #2805 

### Testing

#### How to Test

- Have env. with E2EI enabled and wrong ACME URL
- login and try to generate certificate
- error dialog will popup with correct copy

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
|  <img src="https://github.com/wireapp/wire-android/assets/5890660/f91ecf7f-8186-4e07-b3b3-87f56dd876df" width="200" height="400" alt="old dialog copy" /> |  <img src="https://github.com/wireapp/wire-android/assets/5890660/fab644d3-48bb-4678-be9d-3441ad572144" width="200" height="400" alt="new dialog copy" /> |
----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
