### PR TITLE
fix: Fetch MLS status on every conversation opening [WPB-8610]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.feature.connection.BlockUserUseCase
 import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveOtherUserSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.FetchConversationMLSVerificationStatusUseCase
 import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveTeamSettingsSelfDeletingStatusUseCase
@@ -445,4 +446,11 @@ class UseCaseModule {
     fun provideObserveIsAppLockEditableUseCase(
         @KaliumCoreLogic coreLogic: CoreLogic
     ): ObserveIsAppLockEditableUseCase = coreLogic.getGlobalScope().observeIsAppLockEditableUseCase
+
+    @ViewModelScoped
+    @Provides
+    fun provideFetchConversationMLSVerificationStatusUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): FetchConversationMLSVerificationStatusUseCase = coreLogic.getSessionScope(currentAccount).fetchConversationMLSVerificationStatus
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.FetchConversationMLSVerificationStatusUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.first
@@ -52,6 +53,7 @@ class ConversationInfoViewModel @Inject constructor(
     override val savedStateHandle: SavedStateHandle,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
     private val observerSelfUser: GetSelfUserUseCase,
+    private val fetchConversationMLSVerificationStatus: FetchConversationMLSVerificationStatusUseCase,
     private val wireSessionImageLoader: WireSessionImageLoader,
 ) : SavedStateViewModel(savedStateHandle) {
 
@@ -64,6 +66,13 @@ class ConversationInfoViewModel @Inject constructor(
 
     init {
         getSelfUserId()
+        fetchMLSVerificationStatus()
+    }
+
+    private fun fetchMLSVerificationStatus() {
+        viewModelScope.launch {
+            fetchConversationMLSVerificationStatus(conversationId)
+        }
     }
 
     private fun getSelfUserId() {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.FetchConversationMLSVerificationStatusUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -60,6 +61,9 @@ class ConversationInfoViewModelArrangement {
     lateinit var observerSelfUser: GetSelfUserUseCase
 
     @MockK
+    lateinit var fetchConversationMLSVerificationStatus: FetchConversationMLSVerificationStatusUseCase
+
+    @MockK
     private lateinit var wireSessionImageLoader: WireSessionImageLoader
 
     @MockK(relaxed = true)
@@ -71,6 +75,7 @@ class ConversationInfoViewModelArrangement {
             savedStateHandle,
             observeConversationDetails,
             observerSelfUser,
+            fetchConversationMLSVerificationStatus,
             wireSessionImageLoader
         )
     }
@@ -86,6 +91,7 @@ class ConversationInfoViewModelArrangement {
         coEvery { observeConversationDetails(any()) } returns conversationDetailsChannel.consumeAsFlow().map {
             ObserveConversationDetailsUseCase.Result.Success(it)
         }
+        coEvery { fetchConversationMLSVerificationStatus.invoke(any()) } returns Unit
     }
 
     suspend fun withConversationDetailUpdate(conversationDetails: ConversationDetails) = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8610" title="WPB-8610" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8610</a>  [Android] Every time when we open a conversation, we need to verify the conversation state
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

Every time when we open a conversation, we need to verify the conversation state

### Causes (Optional)

Was not implemented

### Solutions

Implement it, by using new kalim UseCase

### Dependencies (Optional)

waiting for kalium PR https://github.com/wireapp/kalium/pull/2701
