### PR TITLE
feat: last message markdown [WPB-7413]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -256,7 +256,7 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                 is WithUser.Text -> UILastMessageContent.SenderWithMessage(
                     sender = userUIText,
                     message = (content as WithUser.Text).messageBody.let { UIText.DynamicString(it) },
-                    separator = ":${MarkdownConstants.EMPTY_SPACE}"
+                    separator = ":${MarkdownConstants.NON_BREAKING_SPACE}"
                 )
 
                 is WithUser.Composite -> {
@@ -265,7 +265,7 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                     UILastMessageContent.SenderWithMessage(
                         sender = userUIText,
                         message = text,
-                        separator = ":${MarkdownConstants.EMPTY_SPACE}"
+                        separator = ":${MarkdownConstants.NON_BREAKING_SPACE}"
                     )
                 }
 
@@ -340,7 +340,7 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
         is MessagePreviewContent.Draft -> UILastMessageContent.SenderWithMessage(
             UIText.StringResource(R.string.label_draft),
             (content as MessagePreviewContent.Draft).message.toUIText(),
-            separator = ":${MarkdownConstants.EMPTY_SPACE}"
+            separator = ":${MarkdownConstants.NON_BREAKING_SPACE}"
         )
 
         Unknown -> UILastMessageContent.None

--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -21,7 +21,9 @@ package com.wire.android.mapper
 import com.wire.android.R
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.UILastMessageContent
+import com.wire.android.ui.markdown.MarkdownConstants
 import com.wire.android.util.ui.UIText
+import com.wire.android.util.ui.toUIText
 import com.wire.kalium.logic.data.conversation.UnreadEventCount
 import com.wire.kalium.logic.data.message.AssetType
 import com.wire.kalium.logic.data.message.MessagePreview
@@ -254,7 +256,7 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                 is WithUser.Text -> UILastMessageContent.SenderWithMessage(
                     sender = userUIText,
                     message = (content as WithUser.Text).messageBody.let { UIText.DynamicString(it) },
-                    separator = ": "
+                    separator = ":${MarkdownConstants.EMPTY_SPACE}"
                 )
 
                 is WithUser.Composite -> {
@@ -263,7 +265,7 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
                     UILastMessageContent.SenderWithMessage(
                         sender = userUIText,
                         message = text,
-                        separator = ": "
+                        separator = ":${MarkdownConstants.EMPTY_SPACE}"
                     )
                 }
 
@@ -334,6 +336,12 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
 
         MessagePreviewContent.VerificationChanged.DegradedProteus ->
             UILastMessageContent.VerificationChanged(R.string.last_message_conversations_verification_degraded_proteus)
+
+        is MessagePreviewContent.Draft -> UILastMessageContent.SenderWithMessage(
+            UIText.StringResource(R.string.label_draft),
+            (content as MessagePreviewContent.Draft).message.toUIText(),
+            separator = ":${MarkdownConstants.EMPTY_SPACE}"
+        )
 
         Unknown -> UILastMessageContent.None
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -1075,8 +1075,9 @@ private fun CoroutineScope.withSmoothScreenLoad(block: () -> Unit) = launch {
 @Preview
 @Composable
 fun PreviewConversationScreen() {
+    val conversationId = ConversationId("value", "domain")
     val messageComposerViewState = remember { mutableStateOf(MessageComposerViewState()) }
-    val messageCompositionState = remember { mutableStateOf(MessageComposition.DEFAULT) }
+    val messageCompositionState = remember { mutableStateOf(MessageComposition(conversationId)) }
     val conversationScreenState = rememberConversationScreenState()
     val messageComposerStateHolder = rememberMessageComposerStateHolder(
         messageComposerViewState = messageComposerViewState,
@@ -1089,7 +1090,7 @@ fun PreviewConversationScreen() {
         messageComposerViewState = messageComposerViewState,
         conversationCallViewState = ConversationCallViewState(),
         conversationInfoViewState = ConversationInfoViewState(
-            conversationId = ConversationId("value", "domain"),
+            conversationId = conversationId,
             conversationName = UIText.DynamicString("Some test conversation")
         ),
         conversationMessagesViewState = ConversationMessagesViewState(),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModel.kt
@@ -202,7 +202,7 @@ class MessageComposerViewModel @Inject constructor(
 
     fun saveDraft(messageDraft: MessageDraft) {
         viewModelScope.launch {
-            saveMessageDraft(conversationId, messageDraft)
+            saveMessageDraft(messageDraft)
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
@@ -45,7 +45,7 @@ class MessageDraftViewModel @Inject constructor(
     private val conversationNavArgs: ConversationNavArgs = savedStateHandle.navArgs()
     val conversationId: QualifiedID = conversationNavArgs.conversationId
 
-    var state = mutableStateOf(MessageComposition.DEFAULT.copy(messageTextFieldValue = TextFieldValue("")))
+    var state = mutableStateOf(MessageComposition(conversationId))
         private set
 
     init {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -56,9 +56,9 @@ import com.wire.android.ui.home.conversations.model.messagetypes.image.ImportedI
 import com.wire.android.ui.markdown.DisplayMention
 import com.wire.android.ui.markdown.MarkdownConstants.MENTION_MARK
 import com.wire.android.ui.markdown.MarkdownDocument
-import com.wire.android.ui.markdown.MarkdownNode
+import com.wire.android.ui.markdown.NodeActions
 import com.wire.android.ui.markdown.NodeData
-import com.wire.android.ui.markdown.toContent
+import com.wire.android.ui.markdown.toMarkdownDocument
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
@@ -71,11 +71,6 @@ import com.wire.kalium.logic.data.asset.AssetTransferStatus.NOT_FOUND
 import com.wire.kalium.logic.data.asset.AssetTransferStatus.UPLOAD_IN_PROGRESS
 import kotlinx.collections.immutable.PersistentList
 import okio.Path
-import org.commonmark.Extension
-import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension
-import org.commonmark.ext.gfm.tables.TablesExtension
-import org.commonmark.node.Document
-import org.commonmark.parser.Parser
 
 // TODO: Here we actually need to implement some logic that will distinguish MentionLabel with Body of the message,
 //       waiting for the backend to implement mapping logic for the MessageBody
@@ -103,19 +98,16 @@ internal fun MessageBody(
         typography = MaterialTheme.wireTypography,
         searchQuery = searchQuery,
         mentions = displayMentions,
-        onLongClick = onLongClick,
-        onOpenProfile = onOpenProfile,
-        onLinkClick = onLinkClick
+        actions = NodeActions(
+            onLongClick = onLongClick,
+            onOpenProfile = onOpenProfile,
+            onLinkClick = onLinkClick
+        )
     )
 
-    val extensions: List<Extension> = listOf(
-        StrikethroughExtension.builder().requireTwoTildes(true).build(),
-        TablesExtension.create()
-    )
     text?.also {
-        val document = (Parser.builder().extensions(extensions).build().parse(it) as Document).toContent() as MarkdownNode.Document
         MarkdownDocument(
-            document,
+            it.toMarkdownDocument(),
             nodeData,
             clickable
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -28,6 +28,7 @@ import com.wire.android.model.ImageAsset
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
+import com.wire.android.ui.markdown.MarkdownConstants
 import com.wire.android.ui.theme.Accent
 import com.wire.android.util.Copyable
 import com.wire.android.util.ui.LocalizedStringResource
@@ -194,9 +195,16 @@ sealed class UILastMessageContent {
 
     data class TextMessage(val messageBody: MessageBody) : UILastMessageContent()
 
-    data class SenderWithMessage(val sender: UIText, val message: UIText, val separator: String = " ") : UILastMessageContent()
+    data class SenderWithMessage(
+        val sender: UIText,
+        val message: UIText,
+        val separator: String = MarkdownConstants.EMPTY_SPACE
+    ) : UILastMessageContent()
 
-    data class MultipleMessage(val messages: List<UIText>, val separator: String = " ") : UILastMessageContent()
+    data class MultipleMessage(
+        val messages: List<UIText>,
+        val separator: String = MarkdownConstants.EMPTY_SPACE
+    ) : UILastMessageContent()
 
     data class Connection(val connectionState: ConnectionState, val userId: UserId) : UILastMessageContent()
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -199,12 +199,12 @@ sealed class UILastMessageContent {
     data class SenderWithMessage(
         val sender: UIText,
         val message: UIText,
-        val separator: String = MarkdownConstants.EMPTY_SPACE
+        val separator: String = MarkdownConstants.NON_BREAKING_SPACE
     ) : UILastMessageContent()
 
     data class MultipleMessage(
         val messages: List<UIText>,
-        val separator: String = MarkdownConstants.EMPTY_SPACE
+        val separator: String = MarkdownConstants.NON_BREAKING_SPACE
     ) : UILastMessageContent()
 
     data class Connection(val connectionState: ConnectionState, val userId: UserId) : UILastMessageContent()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
@@ -69,7 +69,7 @@ private fun LastMessageMarkdown(text: String, leadingText: String = "") {
         )
     } else {
         Text(
-            text = leadingText.replace(MarkdownConstants.EMPTY_SPACE, " ") + text,
+            text = leadingText.replace(MarkdownConstants.NON_BREAKING_SPACE, " ") + text,
             style = nodeData.style,
             color = nodeData.color,
             maxLines = 1,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
@@ -62,7 +62,7 @@ private fun LastMessageMarkdown(text: String, leadingText: String = "") {
     val markdownPreview = text.toMarkdownDocument().getFirstInlines()
     val leadingInlines = leadingText.toMarkdownDocument().getFirstInlines()?.children ?: persistentListOf()
 
-    if(markdownPreview != null) {
+    if (markdownPreview != null) {
         MarkdownInline(
             inlines = leadingInlines.plus(markdownPreview.children),
             nodeData = nodeData

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
@@ -21,44 +21,59 @@ package com.wire.android.ui.home.conversationslist.common
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
+import com.wire.android.ui.markdown.MarkdownConstants
+import com.wire.android.ui.markdown.MarkdownInline
+import com.wire.android.ui.markdown.NodeData
+import com.wire.android.ui.markdown.getFirstInlines
+import com.wire.android.ui.markdown.toMarkdownDocument
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.UIText
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun LastMessageSubtitle(text: UIText) {
-    Text(
-        text = text.asString(LocalContext.current.resources),
-        style = MaterialTheme.wireTypography.subline01.copy(
-            color = MaterialTheme.wireColorScheme.secondaryText
-        ),
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis
-    )
+    LastMessageMarkdown(text = text.asString())
 }
 
 @Composable
 fun LastMessageSubtitleWithAuthor(author: UIText, text: UIText, separator: String) {
-    Text(
-        text = "${author.asString(LocalContext.current.resources)}$separator${text.asString(LocalContext.current.resources)}",
-        style = MaterialTheme.wireTypography.subline01.copy(
-            color = MaterialTheme.wireColorScheme.secondaryText
-        ),
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis
-    )
+    LastMessageMarkdown(text = text.asString(), leadingText = "${author.asString()}$separator")
 }
 
 @Composable
 fun LastMultipleMessages(messages: List<UIText>, separator: String) {
-    Text(
-        text = messages.map { it.asString() }.joinToString(separator = separator),
-        style = MaterialTheme.wireTypography.subline01.copy(
-            color = MaterialTheme.wireColorScheme.secondaryText
-        ),
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis
+    LastMessageMarkdown(text = messages.map { it.asString() }.joinToString(separator = separator))
+}
+
+@Composable
+private fun LastMessageMarkdown(text: String, leadingText: String = "") {
+    val nodeData = NodeData(
+        color = MaterialTheme.wireColorScheme.secondaryText,
+        style = MaterialTheme.wireTypography.subline01,
+        colorScheme = MaterialTheme.wireColorScheme,
+        typography = MaterialTheme.wireTypography,
+        searchQuery = "",
+        mentions = listOf(),
+        disableLinks = true
     )
+
+    val markdownPreview = text.toMarkdownDocument().getFirstInlines()
+    val leadingInlines = leadingText.toMarkdownDocument().getFirstInlines()?.children ?: persistentListOf()
+
+    if(markdownPreview != null) {
+        MarkdownInline(
+            inlines = leadingInlines.plus(markdownPreview.children),
+            nodeData = nodeData
+        )
+    } else {
+        Text(
+            text = leadingText.replace(MarkdownConstants.EMPTY_SPACE, " ") + text,
+            style = nodeData.style,
+            color = nodeData.color,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -253,7 +253,7 @@ private fun BaseComposerPreview(
             )
         )
     }
-    val messageComposition = remember { mutableStateOf(MessageComposition.DEFAULT) }
+    val messageComposition = remember { mutableStateOf(MessageComposition(ConversationId("value", "domain"))) }
     val selfDeletionTimer = remember { mutableStateOf(SelfDeletionTimer.Enabled(Duration.ZERO)) }
 
     MessageComposer(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/model/MessageComposition.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/model/MessageComposition.kt
@@ -30,19 +30,13 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.draft.MessageDraft
 
 data class MessageComposition(
+    val conversationId: ConversationId,
     val messageTextFieldValue: TextFieldValue = TextFieldValue(""),
     val editMessageId: String? = null,
     val quotedMessage: UIQuotedMessage.UIQuotedData? = null,
     val quotedMessageId: String? = null,
     val selectedMentions: List<UIMention> = emptyList(),
 ) {
-    companion object {
-        val DEFAULT = MessageComposition(
-            messageTextFieldValue = TextFieldValue(text = ""),
-            quotedMessage = null,
-            selectedMentions = emptyList()
-        )
-    }
 
     val messageText: String
         get() = messageTextFieldValue.text
@@ -152,6 +146,7 @@ fun MutableState<MessageComposition>.update(block: (MessageComposition) -> Messa
 
 fun MessageComposition.toDraft(): MessageDraft {
     return MessageDraft(
+        conversationId = conversationId,
         text = messageTextFieldValue.text,
         editMessageId = editMessageId,
         quotedMessageId = quotedMessageId,

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownBlockQuote.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownBlockQuote.kt
@@ -60,8 +60,8 @@ fun MarkdownBlockQuote(blockQuote: MarkdownNode.Block.BlockQuote, nodeData: Node
                     }
                     MarkdownText(
                         text,
-                        onLongClick = nodeData.onLongClick,
-                        onOpenProfile = nodeData.onOpenProfile
+                        onLongClick = nodeData.actions?.onLongClick,
+                        onOpenProfile = nodeData.actions?.onOpenProfile
                     )
                 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownCodeBlock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownCodeBlock.kt
@@ -18,7 +18,6 @@
 package com.wire.android.ui.markdown
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownCodeBlock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownCodeBlock.kt
@@ -39,13 +39,9 @@ fun MarkdownIndentedCodeBlock(indentedCodeBlock: MarkdownNode.Block.IntendedCode
         fontFamily = FontFamily.Monospace,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(dimensions().spacing4x)
-            .background(MaterialTheme.wireColorScheme.outlineVariant)
-            .border(
-                dimensions().spacing1x, MaterialTheme.wireColorScheme.outline,
-                shape = RoundedCornerShape(dimensions().spacing4x)
-            )
-            .padding(dimensions().spacing4x)
+            .padding(vertical = dimensions().spacing4x)
+            .background(MaterialTheme.wireColorScheme.surfaceVariant, shape = RoundedCornerShape(dimensions().spacing16x))
+            .padding(dimensions().spacing8x)
     )
 }
 
@@ -57,12 +53,8 @@ fun MarkdownFencedCodeBlock(fencedCodeBlock: MarkdownNode.Block.FencedCode, node
         fontFamily = FontFamily.Monospace,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(dimensions().spacing4x)
-            .background(MaterialTheme.wireColorScheme.outlineVariant)
-            .border(
-                dimensions().spacing1x, MaterialTheme.wireColorScheme.outline,
-                shape = RoundedCornerShape(dimensions().spacing4x)
-            )
-            .padding(dimensions().spacing4x)
+            .padding(vertical = dimensions().spacing4x)
+            .background(MaterialTheme.wireColorScheme.surfaceVariant, shape = RoundedCornerShape(dimensions().spacing16x))
+            .padding(dimensions().spacing8x)
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownComposer.kt
@@ -110,19 +110,27 @@ fun inlineNodeChildren(
     children.forEach { child ->
         when (child) {
             is MarkdownNode.Inline.Text -> {
-                updatedMentions = appendLinksAndMentions(
-                    annotatedString,
-                    convertTypoGraphs(child.literal),
-                    nodeData.copy(mentions = updatedMentions)
-                )
+                if(nodeData.disableLinks) {
+                    annotatedString.append(convertTypoGraphs(child.literal))
+                } else {
+                    updatedMentions = appendLinksAndMentions(
+                        annotatedString,
+                        convertTypoGraphs(child.literal),
+                        nodeData.copy(mentions = updatedMentions)
+                    )
+                }
             }
 
             is MarkdownNode.Inline.Image -> {
-                updatedMentions = appendLinksAndMentions(
-                    annotatedString,
-                    child.destination,
-                    nodeData.copy(mentions = updatedMentions)
-                )
+                if(nodeData.disableLinks) {
+                    annotatedString.append(child.destination)
+                } else {
+                    updatedMentions = appendLinksAndMentions(
+                        annotatedString,
+                        child.destination,
+                        nodeData.copy(mentions = updatedMentions)
+                    )
+                }
             }
 
             is MarkdownNode.Inline.Emphasis -> {
@@ -162,20 +170,24 @@ fun inlineNodeChildren(
             }
 
             is MarkdownNode.Inline.Link -> {
-                annotatedString.pushStyle(
-                    SpanStyle(
-                        color = nodeData.colorScheme.primary,
-                        textDecoration = TextDecoration.Underline
+                if (nodeData.disableLinks) {
+                    annotatedString.append(child.destination)
+                } else {
+                    annotatedString.pushStyle(
+                        SpanStyle(
+                            color = nodeData.colorScheme.primary,
+                            textDecoration = TextDecoration.Underline
+                        )
                     )
-                )
-                annotatedString.pushStringAnnotation(TAG_URL, child.destination)
-                updatedMentions = inlineNodeChildren(
-                    child.children,
-                    annotatedString,
-                    nodeData
-                )
-                annotatedString.pop()
-                annotatedString.pop()
+                    annotatedString.pushStringAnnotation(TAG_URL, child.destination)
+                    updatedMentions = inlineNodeChildren(
+                        child.children,
+                        annotatedString,
+                        nodeData
+                    )
+                    annotatedString.pop()
+                    annotatedString.pop()
+                }
             }
 
             is MarkdownNode.Inline.Strikethrough -> {

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownComposer.kt
@@ -110,7 +110,7 @@ fun inlineNodeChildren(
     children.forEach { child ->
         when (child) {
             is MarkdownNode.Inline.Text -> {
-                if(nodeData.disableLinks) {
+                if (nodeData.disableLinks) {
                     annotatedString.append(convertTypoGraphs(child.literal))
                 } else {
                     updatedMentions = appendLinksAndMentions(
@@ -122,7 +122,7 @@ fun inlineNodeChildren(
             }
 
             is MarkdownNode.Inline.Image -> {
-                if(nodeData.disableLinks) {
+                if (nodeData.disableLinks) {
                     annotatedString.append(child.destination)
                 } else {
                     updatedMentions = appendLinksAndMentions(

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownConstants.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownConstants.kt
@@ -26,7 +26,7 @@ object MarkdownConstants {
     const val TAG_MENTION = "mentionTag"
     const val MENTION_MARK = "&&"
     const val BULLET_MARK = "\u2022"
-    const val EMPTY_SPACE = "&nbsp;"
+    const val NON_BREAKING_SPACE = "&nbsp;"
 
     val supportedExtensions: List<Extension> = listOf(
         StrikethroughExtension.builder().requireTwoTildes(true).build(),

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHeading.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHeading.kt
@@ -47,8 +47,8 @@ fun MarkdownHeading(heading: MarkdownNode.Block.Heading, nodeData: NodeData) {
         MarkdownText(
             annotatedString = text,
             style = style,
-            onLongClick = nodeData.onLongClick,
-            onOpenProfile = nodeData.onOpenProfile
+            onLongClick = nodeData.actions?.onLongClick,
+            onOpenProfile = nodeData.actions?.onOpenProfile
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHelper.kt
@@ -15,7 +15,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-@file:Suppress("ComplexMethod")
+@file:Suppress("ComplexMethod", "TooManyFunctions")
+
 package com.wire.android.ui.markdown
 
 import kotlinx.collections.immutable.persistentListOf

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHelper.kt
@@ -18,6 +18,8 @@
 @file:Suppress("ComplexMethod")
 package com.wire.android.ui.markdown
 
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import org.commonmark.ext.gfm.strikethrough.Strikethrough
 import org.commonmark.ext.gfm.tables.TableBlock
 import org.commonmark.ext.gfm.tables.TableBody
@@ -45,6 +47,8 @@ import org.commonmark.node.SoftLineBreak
 import org.commonmark.node.StrongEmphasis
 import org.commonmark.node.Text
 import org.commonmark.node.ThematicBreak
+
+fun String.toMarkdownDocument(): MarkdownNode.Document = MarkdownParser.parse(this)
 
 fun <T : Node> T.toContent(isParentDocument: Boolean = false): MarkdownNode {
     return when (this) {
@@ -160,6 +164,38 @@ fun MarkdownNode.filterNodesContainingQuery(query: String): MarkdownNode? {
         is MarkdownNode.Block.ThematicBreak -> null
         is MarkdownNode.Inline.Break -> this
     }
+}
+
+fun MarkdownNode.getFirstInlines(): MarkdownPreview? {
+    return when (this) {
+        is MarkdownNode.Document -> children.firstOrNull()?.getFirstInlines()
+        is MarkdownNode.Block.BlockQuote -> children.firstOrNull()?.getFirstInlines()
+        is MarkdownNode.Block.FencedCode -> literal.toPreview()
+        is MarkdownNode.Block.Heading -> children.toPreview()
+        is MarkdownNode.Block.IntendedCode -> literal.toPreview()
+        is MarkdownNode.Block.ListBlock.Bullet -> children.firstOrNull()?.getFirstInlines()
+        is MarkdownNode.Block.ListBlock.Ordered -> children.firstOrNull()?.getFirstInlines()
+        is MarkdownNode.Block.ListItem -> children.firstOrNull()?.getFirstInlines()
+        is MarkdownNode.Block.Paragraph -> children.toPreview()
+        is MarkdownNode.Block.Table -> children.firstOrNull()?.getFirstInlines()
+        is MarkdownNode.Block.TableContent.Body -> children.firstOrNull()?.getFirstInlines()
+        is MarkdownNode.Block.TableContent.Head -> children.firstOrNull()?.getFirstInlines()
+        is MarkdownNode.Block.ThematicBreak -> null
+        is MarkdownNode.Inline -> {
+            throw IllegalArgumentException("It should not go to inline children!")
+        }
+
+        is MarkdownNode.TableCell -> children.toPreview()
+        is MarkdownNode.TableRow -> children.firstOrNull()?.children?.toPreview()
+    }
+}
+
+private fun List<MarkdownNode.Inline>.toPreview(): MarkdownPreview {
+    return MarkdownPreview(this.toPersistentList())
+}
+
+private fun String.toPreview(): MarkdownPreview {
+    return MarkdownPreview(persistentListOf(MarkdownNode.Inline.Text(this)))
 }
 
 private fun MarkdownNode.containsQuery(query: String): Boolean {

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownInline.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownInline.kt
@@ -17,19 +17,26 @@
  */
 package com.wire.android.ui.markdown
 
-import org.commonmark.Extension
-import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension
-import org.commonmark.ext.gfm.tables.TablesExtension
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
 
-object MarkdownConstants {
-    const val TAG_URL = "linkTag"
-    const val TAG_MENTION = "mentionTag"
-    const val MENTION_MARK = "&&"
-    const val BULLET_MARK = "\u2022"
-    const val EMPTY_SPACE = "&nbsp;"
-
-    val supportedExtensions: List<Extension> = listOf(
-        StrikethroughExtension.builder().requireTwoTildes(true).build(),
-        TablesExtension.create()
+@Composable
+fun MarkdownInline(
+    inlines: List<MarkdownNode.Inline>,
+    nodeData: NodeData
+) {
+    val annotatedString = buildAnnotatedString {
+        pushStyle(nodeData.style.toSpanStyle())
+        inlineNodeChildren(inlines, this, nodeData)
+        pop()
+    }
+    MarkdownText(
+        annotatedString,
+        style = nodeData.style,
+        color = nodeData.color,
+        clickable = false,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownList.kt
@@ -44,8 +44,8 @@ fun MarkdownBulletList(bulletList: MarkdownNode.Block.ListBlock.Bullet, nodeData
                 MarkdownText(
                     annotatedString = text,
                     style = MaterialTheme.wireTypography.body01,
-                    onLongClick = nodeData.onLongClick,
-                    onOpenProfile = nodeData.onOpenProfile
+                    onLongClick = nodeData.actions?.onLongClick,
+                    onOpenProfile = nodeData.actions?.onOpenProfile
                 )
                 MarkdownNodeBlockChildren(children = listItem.children, nodeData = nodeData)
             }
@@ -69,8 +69,8 @@ fun MarkdownOrderedList(orderedList: MarkdownNode.Block.ListBlock.Ordered, nodeD
                 MarkdownText(
                     annotatedString = text,
                     style = MaterialTheme.wireTypography.body01,
-                    onLongClick = nodeData.onLongClick,
-                    onOpenProfile = nodeData.onOpenProfile
+                    onLongClick = nodeData.actions?.onLongClick,
+                    onOpenProfile = nodeData.actions?.onOpenProfile
                 )
                 MarkdownNodeBlockChildren(children = listItem.children, nodeData = nodeData)
             }

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownNode.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownNode.kt
@@ -17,6 +17,8 @@
  */
 package com.wire.android.ui.markdown
 
+import kotlinx.collections.immutable.PersistentList
+
 sealed class MarkdownNode {
     abstract val children: List<MarkdownNode>
     abstract val isParentDocument: Boolean
@@ -142,3 +144,5 @@ sealed class MarkdownNode {
         override val isParentDocument: Boolean = false
     ) : MarkdownNode()
 }
+
+data class MarkdownPreview(val children: PersistentList<MarkdownNode.Inline>)

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParagraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParagraph.kt
@@ -44,9 +44,9 @@ fun MarkdownParagraph(
         MarkdownText(
             annotatedString,
             style = nodeData.style,
-            onLongClick = nodeData.onLongClick,
-            onOpenProfile = nodeData.onOpenProfile,
-            onClickLink = nodeData.onLinkClick,
+            onLongClick = nodeData.actions?.onLongClick,
+            onOpenProfile = nodeData.actions?.onOpenProfile,
+            onClickLink = nodeData.actions?.onLinkClick,
             clickable = clickable
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParser.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParser.kt
@@ -24,5 +24,4 @@ object MarkdownParser {
     private val parser = Parser.builder().extensions(MarkdownConstants.supportedExtensions).build()
 
     fun parse(text: String) = (parser.parse(text) as Document).toContent() as MarkdownNode.Document
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParser.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParser.kt
@@ -17,19 +17,12 @@
  */
 package com.wire.android.ui.markdown
 
-import org.commonmark.Extension
-import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension
-import org.commonmark.ext.gfm.tables.TablesExtension
+import org.commonmark.node.Document
+import org.commonmark.parser.Parser
 
-object MarkdownConstants {
-    const val TAG_URL = "linkTag"
-    const val TAG_MENTION = "mentionTag"
-    const val MENTION_MARK = "&&"
-    const val BULLET_MARK = "\u2022"
-    const val EMPTY_SPACE = "&nbsp;"
+object MarkdownParser {
+    private val parser = Parser.builder().extensions(MarkdownConstants.supportedExtensions).build()
 
-    val supportedExtensions: List<Extension> = listOf(
-        StrikethroughExtension.builder().requireTwoTildes(true).build(),
-        TablesExtension.create()
-    )
+    fun parse(text: String) = (parser.parse(text) as Document).toContent() as MarkdownNode.Document
+
 }

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownTable.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownTable.kt
@@ -78,8 +78,8 @@ fun MarkdownTable(tableBlock: MarkdownNode.Block.Table, nodeData: NodeData, onMe
                         modifier = Modifier
                             .weight(1f)
                             .padding(dimensions().spacing8x),
-                        onLongClick = nodeData.onLongClick,
-                        onOpenProfile = nodeData.onOpenProfile
+                        onLongClick = nodeData.actions?.onLongClick,
+                        onOpenProfile = nodeData.actions?.onOpenProfile
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownText.kt
@@ -46,8 +46,8 @@ fun MarkdownText(
     style: TextStyle = LocalTextStyle.current,
     clickable: Boolean = true,
     onClickLink: ((linkText: String) -> Unit)? = null,
-    onLongClick: (() -> Unit)?,
-    onOpenProfile: (String) -> Unit
+    onLongClick: (() -> Unit)? = null,
+    onOpenProfile: ((String) -> Unit)? = null
 ) {
 
     if (clickable) {
@@ -75,7 +75,7 @@ fun MarkdownText(
                     start = offset,
                     end = offset
                 ).firstOrNull()?.let { result ->
-                    onOpenProfile(result.item)
+                    onOpenProfile?.invoke(result.item)
                 }
             },
             onLongClick = onLongClick

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/NodeData.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/NodeData.kt
@@ -32,6 +32,11 @@ data class NodeData(
     val typography: WireTypography,
     val mentions: List<DisplayMention>,
     val searchQuery: String,
+    val disableLinks: Boolean = false,
+    val actions: NodeActions? = null
+)
+
+data class NodeActions(
     val onLongClick: (() -> Unit)? = null,
     val onOpenProfile: (String) -> Unit,
     val onLinkClick: (String) -> Unit

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="label_user_blocked">Blocked</string>
     <string name="label_and">and</string>
     <string name="label_retry">Retry</string>
+    <string name="label_draft">*Draft*</string>
     <!-- Content descriptions https://wearezeta.atlassian.net/wiki/spaces/AR/pages/122520039/Code+Style+Guideline#Content-description-strings -->
     <string name="content_description_app_logo">App Logo</string>
     <string name="content_description_reveal_password">Show password</string>

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -179,7 +179,6 @@ object TestMessage {
         conversationId = ConversationId("value", "domain"),
         content = MessagePreviewContent.WithUser.MissedCall(TestUser.OTHER_USER.name),
         isSelfMessage = false,
-        date = "2022-03-30T15:36:00.000Z",
         visibility = Message.Visibility.VISIBLE,
         senderUserId = TestUser.USER_ID
     )

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelArrangement.kt
@@ -185,7 +185,7 @@ internal class MessageComposerViewModelArrangement {
     }
 
     fun withSaveDraftMessage() = apply {
-        coEvery { saveMessageDraftUseCase(any(), any()) } returns Unit
+        coEvery { saveMessageDraftUseCase(any()) } returns Unit
     }
 
     fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelTest.kt
@@ -21,6 +21,7 @@ package com.wire.android.ui.home.conversations.composer
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.data.message.draft.MessageDraft
 import io.mockk.coVerify
@@ -113,6 +114,7 @@ class MessageComposerViewModelTest {
         runTest {
             // given
             val messageDraft = MessageDraft(
+                conversationId = ConversationId("value", "domain"),
                 text = "hello",
                 editMessageId = null,
                 quotedMessageId = null,
@@ -128,6 +130,6 @@ class MessageComposerViewModelTest {
             advanceUntilIdle()
 
             // then
-            coVerify(exactly = 1) { arrangement.saveMessageDraftUseCase.invoke(eq(viewModel.conversationId), eq(messageDraft)) }
+            coVerify(exactly = 1) { arrangement.saveMessageDraftUseCase.invoke(eq(messageDraft)) }
         }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModelTest.kt
@@ -22,12 +22,12 @@ import com.wire.android.R
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
 import com.wire.android.config.mockUri
+import com.wire.android.framework.TestConversation
 import com.wire.android.ui.home.conversations.ConversationNavArgs
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.home.conversations.usecase.GetQuoteMessageForConversationUseCase
 import com.wire.android.ui.navArgs
 import com.wire.android.util.ui.UIText
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.draft.MessageDraft
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.message.draft.GetMessageDraftUseCase
@@ -53,6 +53,7 @@ class MessageDraftViewModelTest {
     fun `given message draft, when init, then state is properly updated`() = runTest {
         // given
         val messageDraft = MessageDraft(
+            conversationId = TestConversation.ID,
             text = "hello",
             editMessageId = null,
             quotedMessageId = null,
@@ -93,6 +94,7 @@ class MessageDraftViewModelTest {
     fun `given message draft with quoted message, when init, then state is updated`() = runTest {
         // given
         val messageDraft = MessageDraft(
+            conversationId = TestConversation.ID,
             text = "hello",
             editMessageId = null,
             quotedMessageId = "quoted_message_id",
@@ -131,6 +133,7 @@ class MessageDraftViewModelTest {
     fun `given message draft with unavailable quoted message, when init, then quoted data is not updated`() = runTest {
         // given
         val messageDraft = MessageDraft(
+            conversationId = TestConversation.ID,
             text = "hello",
             editMessageId = null,
             quotedMessageId = "quoted_message_id",
@@ -160,13 +163,11 @@ class MessageDraftViewModelTest {
 
     private class Arrangement {
 
-        val conversationId: ConversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-
         init {
             // Tests setup
             MockKAnnotations.init(this, relaxUnitFun = true)
             mockUri()
-            every { savedStateHandle.navArgs<ConversationNavArgs>() } returns ConversationNavArgs(conversationId = conversationId)
+            every { savedStateHandle.navArgs<ConversationNavArgs>() } returns ConversationNavArgs(conversationId = TestConversation.ID)
         }
 
         @MockK

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModelTest.kt
@@ -167,7 +167,9 @@ class MessageDraftViewModelTest {
             // Tests setup
             MockKAnnotations.init(this, relaxUnitFun = true)
             mockUri()
-            every { savedStateHandle.navArgs<ConversationNavArgs>() } returns ConversationNavArgs(conversationId = TestConversation.ID)
+            every {
+                savedStateHandle.navArgs<ConversationNavArgs>()
+            } returns ConversationNavArgs(conversationId = TestConversation.ID)
         }
 
         @MockK

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerStateHolderTest.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.framework.TestConversation
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.home.conversations.MessageComposerViewState
 import com.wire.android.ui.home.conversations.mock.mockMessageWithText
@@ -69,7 +70,7 @@ class MessageComposerStateHolderTest {
     fun before() {
         MockKAnnotations.init(this, relaxUnitFun = true)
         messageComposerViewState = mutableStateOf(MessageComposerViewState())
-        messageComposition = mutableStateOf(MessageComposition())
+        messageComposition = mutableStateOf(MessageComposition(TestConversation.ID))
         messageCompositionInputStateHolder = MessageCompositionInputStateHolder(
             messageComposition = messageComposition,
             selfDeletionTimer = mutableStateOf(SelfDeletionTimer.Disabled)

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolderTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import com.wire.android.framework.TestConversation
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
 import com.wire.android.ui.home.messagecomposer.model.update
 import io.mockk.MockKAnnotations
@@ -44,7 +45,7 @@ class MessageCompositionHolderTest {
     fun before() {
         MockKAnnotations.init(this, relaxUnitFun = true)
 
-        messageComposition = mutableStateOf(MessageComposition())
+        messageComposition = mutableStateOf(MessageComposition(TestConversation.ID))
         state = MessageCompositionHolder(messageComposition = messageComposition, {})
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.unit.dp
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.framework.TestConversation
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -40,7 +41,7 @@ class MessageCompositionInputStateHolderTest {
 
     @BeforeEach
     fun before() {
-        messageComposition = mutableStateOf(MessageComposition())
+        messageComposition = mutableStateOf(MessageComposition(TestConversation.ID))
         state = MessageCompositionInputStateHolder(
             messageComposition = messageComposition,
             selfDeletionTimer = mutableStateOf(SelfDeletionTimer.Disabled)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7413" title="WPB-7413" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-7413</a>  [Android] Make drafts visible on conversation list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- implemented markdown in `LastMessageSubtitle`
- UI improvements in code block
- option to disable links and mentions actions in `inlineNodeChildren`
- implemented MarkdownParser to have single source of true for parsing markdowns
- removed unused date variable from MessagePreview 
- removed unnecessary `MessageComposition.DEFAULT` and moved default values to constructor
- added new `MessagePreviewContent.Draft`
- added `EMPTY_SPACE = "&nbsp;"` to handle properly empty space for MarkdownInline

<img width="438" alt="markdown" src="https://github.com/wireapp/wire-android/assets/13151239/9a08b698-a10b-4dfb-a9e6-7abcad5d6ec6">

