### PR TITLE
feat: reply markdown [WPB-3558]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -62,7 +63,12 @@ import com.wire.android.ui.common.typography
 import com.wire.android.ui.home.conversations.messages.QuotedMessageStyle.COMPLETE
 import com.wire.android.ui.home.conversations.messages.QuotedMessageStyle.PREVIEW
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
+import com.wire.android.ui.markdown.MarkdownInline
+import com.wire.android.ui.markdown.NodeData
+import com.wire.android.ui.markdown.getFirstInlines
+import com.wire.android.ui.markdown.toMarkdownDocument
 import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.UIText
 
 private const val TEXT_QUOTE_MAX_LINES = 7
@@ -344,7 +350,7 @@ private fun QuotedText(
                     StatusBox(it.asString())
                 }
             }
-            MainContentText(text)
+            MainMarkdownText(text)
         }, footerContent = {
             QuotedMessageOriginalDate(originalDateTimeDescription)
         },
@@ -513,6 +519,33 @@ fun QuotedAudioMessage(
         footerContent = { QuotedMessageOriginalDate(originalDateTimeText) },
         clickable = clickable
     )
+}
+
+@Composable
+private fun MainMarkdownText(text: String, fontStyle: FontStyle = FontStyle.Normal) {
+    val nodeData = NodeData(
+        color = colorsScheme().onSurfaceVariant,
+        style = MaterialTheme.wireTypography.subline01.copy(fontStyle = fontStyle),
+        colorScheme = MaterialTheme.wireColorScheme,
+        typography = MaterialTheme.wireTypography,
+        searchQuery = "",
+        mentions = listOf(),
+        disableLinks = true,
+    )
+
+    val markdownPreview = remember(text) {
+        text.toMarkdownDocument().getFirstInlines()
+    }
+
+    if (markdownPreview != null) {
+        MarkdownInline(
+            inlines = markdownPreview.children,
+            maxLines = TEXT_QUOTE_MAX_LINES,
+            nodeData = nodeData
+        )
+    } else {
+        MainContentText(text, fontStyle)
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -344,14 +344,16 @@ private fun QuotedText(
         modifier = modifier,
         startContent = {
             startContent()
-        }, centerContent = {
+        },
+        centerContent = {
             editedTimeDescription?.let {
                 if (style == COMPLETE) {
                     StatusBox(it.asString())
                 }
             }
             MainMarkdownText(text)
-        }, footerContent = {
+        },
+        footerContent = {
             QuotedMessageOriginalDate(originalDateTimeDescription)
         },
         clickable = clickable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -105,9 +105,13 @@ internal fun MessageBody(
         )
     )
 
-    text?.also {
+    val markdownDocument = remember(text) {
+        text?.toMarkdownDocument()
+    }
+
+    markdownDocument?.also {
         MarkdownDocument(
-            it.toMarkdownDocument(),
+            it,
             nodeData,
             clickable
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
@@ -21,6 +21,7 @@ package com.wire.android.ui.home.conversationslist.common
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.text.style.TextOverflow
 import com.wire.android.ui.markdown.MarkdownConstants
 import com.wire.android.ui.markdown.MarkdownInline
@@ -59,8 +60,13 @@ private fun LastMessageMarkdown(text: String, leadingText: String = "") {
         disableLinks = true
     )
 
-    val markdownPreview = text.toMarkdownDocument().getFirstInlines()
-    val leadingInlines = leadingText.toMarkdownDocument().getFirstInlines()?.children ?: persistentListOf()
+    val markdownPreview = remember(text) {
+        text.toMarkdownDocument().getFirstInlines()
+    }
+
+    val leadingInlines = remember(leadingText) {
+        leadingText.toMarkdownDocument().getFirstInlines()?.children ?: persistentListOf()
+    }
 
     if (markdownPreview != null) {
         MarkdownInline(

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownInline.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownInline.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.style.TextOverflow
 @Composable
 fun MarkdownInline(
     inlines: List<MarkdownNode.Inline>,
+    maxLines: Int = 1,
     nodeData: NodeData
 ) {
     val annotatedString = buildAnnotatedString {
@@ -36,7 +37,7 @@ fun MarkdownInline(
         style = nodeData.style,
         color = nodeData.color,
         clickable = false,
-        maxLines = 1,
+        maxLines = maxLines,
         overflow = TextOverflow.Ellipsis
     )
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3558" title="WPB-3558" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3558</a>  Android - For reply messages markdowns doesn't work
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Implemented markdown for handling reply

![Wire 2024-04-17 at 11_18 AM](https://github.com/wireapp/wire-android/assets/13151239/d555a389-684f-4976-a859-84ebe9ff11a8)
