### PR TITLE
fix: secure switching to invalid account and disable composer [WPB-7369]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
@@ -46,7 +46,7 @@ import javax.inject.Singleton
 
 @Suppress("LongParameterList")
 @Singleton
-class  AccountSwitchUseCase @Inject constructor(
+class AccountSwitchUseCase @Inject constructor(
     private val updateCurrentSession: UpdateCurrentSessionUseCase,
     private val getSessions: GetSessionsUseCase,
     private val getCurrentSession: CurrentSessionUseCase,

--- a/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
@@ -97,7 +97,6 @@ class AccountSwitchUseCase @Inject constructor(
                     appLogger.i("$TAG Given account is not found: ${userId.toLogString()}")
                     SwitchAccountResult.GivenAccountIsInvalid
                 }
-
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
@@ -74,8 +74,8 @@ class AccountSwitchUseCase @Inject constructor(
         }
     }
 
-    private suspend fun checkAccountAndSwitchIfPossible(userId: UserId, current: AccountInfo?): SwitchAccountResult {
-        return getSessions().let {
+    private suspend fun checkAccountAndSwitchIfPossible(userId: UserId, current: AccountInfo?): SwitchAccountResult =
+        getSessions().let {
             when (it) {
                 is GetAllSessionsResult.Success -> {
                     it.sessions
@@ -89,17 +89,18 @@ class AccountSwitchUseCase @Inject constructor(
                             }
                         }
                 }
+
                 is GetAllSessionsResult.Failure.Generic -> {
                     appLogger.i("$TAG Failure when switching account to: ${userId.toLogString()}")
                     SwitchAccountResult.Failure
                 }
+
                 GetAllSessionsResult.Failure.NoSessionFound -> {
                     appLogger.i("$TAG Given account is not found: ${userId.toLogString()}")
                     SwitchAccountResult.GivenAccountIsInvalid
                 }
             }
         }
-    }
 
     private suspend fun getNextAccountIfPossibleAndSwitch(current: AccountInfo?): SwitchAccountResult {
         val nextSessionId: UserId? = getSessions().let {

--- a/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
@@ -78,16 +78,15 @@ class AccountSwitchUseCase @Inject constructor(
         getSessions().let {
             when (it) {
                 is GetAllSessionsResult.Success -> {
-                    it.sessions
-                        .any { accountInfo -> (accountInfo is AccountInfo.Valid) && (accountInfo.userId == userId) }
-                        .let { isAccountLoggedInAndValid ->
-                            if (isAccountLoggedInAndValid) {
-                                switch(userId, current)
-                            } else {
-                                appLogger.i("$TAG Given account is not logged in or invalid: ${userId.toLogString()}")
-                                return SwitchAccountResult.GivenAccountIsInvalid
-                            }
-                        }
+                    val isAccountLoggedInAndValid = it.sessions.any {
+                        accountInfo -> (accountInfo is AccountInfo.Valid) && (accountInfo.userId == userId)
+                    }
+                    if (isAccountLoggedInAndValid) {
+                        switch(userId, current)
+                    } else {
+                        appLogger.i("$TAG Given account is not logged in or invalid: ${userId.toLogString()}")
+                        return SwitchAccountResult.GivenAccountIsInvalid
+                    }
                 }
 
                 is GetAllSessionsResult.Failure.Generic -> {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModel.kt
@@ -76,13 +76,19 @@ import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.onFailure
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
@@ -120,6 +126,7 @@ class MessageComposerViewModel @Inject constructor(
     private val setNotifiedAboutConversationUnderLegalHold: SetNotifiedAboutConversationUnderLegalHoldUseCase,
     private val observeConversationUnderLegalHoldNotified: ObserveConversationUnderLegalHoldNotifiedUseCase,
     private val sendLocation: SendLocationUseCase,
+    private val currentSessionFlowUseCase: CurrentSessionFlowUseCase,
 ) : SavedStateViewModel(savedStateHandle) {
 
     var messageComposerViewState = mutableStateOf(MessageComposerViewState())
@@ -188,14 +195,24 @@ class MessageComposerViewModel @Inject constructor(
     }
 
     private fun observeIsTypingAvailable() = viewModelScope.launch {
-        observeConversationInteractionAvailability(conversationId).collect { result ->
-            messageComposerViewState.value = messageComposerViewState.value.copy(
-                interactionAvailability = when (result) {
-                    is IsInteractionAvailableResult.Failure -> InteractionAvailability.DISABLED
-                    is IsInteractionAvailableResult.Success -> result.interactionAvailability
+        currentSessionFlowUseCase()
+            .flatMapLatest {
+                when (it) {
+                    is CurrentSessionResult.Success -> {
+                        observeConversationInteractionAvailability(conversationId)
+                            .mapLatest { result ->
+                                when (result) {
+                                    is IsInteractionAvailableResult.Failure -> InteractionAvailability.DISABLED
+                                    is IsInteractionAvailableResult.Success -> result.interactionAvailability
+                                }
+                            }
+                    }
+                    else -> flowOf(InteractionAvailability.DISABLED)
                 }
-            )
-        }
+            }
+            .collectLatest {
+                messageComposerViewState.value = messageComposerViewState.value.copy(interactionAvailability = it)
+            }
     }
 
     private fun observeSelfDeletingMessagesStatus() = viewModelScope.launch {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewModelTest.kt
@@ -34,9 +34,12 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.failure.LegalHoldEnabledForConversationFailure
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCaseImpl.Companion.ASSET_SIZE_DEFAULT_LIMIT_BYTES
+import com.wire.kalium.logic.feature.conversation.InteractionAvailability
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import io.mockk.coVerify
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
@@ -818,4 +821,16 @@ class MessageComposerViewModelTest {
             coVerify(exactly = 1) { arrangement.sendLocation.invoke(any(), any(), any(), any(), any()) }
             assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
         }
+
+    @Test
+    fun `given no current session, then disable interaction`() = runTest {
+        // given
+        val (_, viewModel) = MessageComposerViewModelArrangement()
+            .withSuccessfulViewModelInit()
+            .withCurrentSessionFlowResult(flowOf(CurrentSessionResult.Failure.SessionNotFound))
+            .arrange()
+        advanceUntilIdle()
+        // then
+        assertEquals(InteractionAvailability.DISABLED, viewModel.messageComposerViewState.value.interactionAvailability)
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7369" title="WPB-7369" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7369</a>  [Android] Playstore crash - DI provide current session
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is a common crash on Play Store Console about providing current session, which means that the current session is missing in DB when trying to initialise some ViewModels which require user session, in this case it crashes when trying to create a scoped ViewModel for `AdditionalOptionButton`.

### Solutions

Couldn't reproduce that but found out that when switching account, for instance when handling deep links, we can provide any user id, even the one that's invalid or not even in the db, and it will set this id as a current session user, so this PR secures the `AccountSwitchUseCase` to block switching if the given user id is invalid. Also, secured the composer so that it shouldn't recompose the `AdditionalOptionButton` when there's no current session.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
