### PR TITLE
fix: message details tab counter [WPB-8798]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
@@ -180,8 +180,9 @@ private fun MessageDetailsScreenContent(
     }
 }
 
-sealed class MessageDetailsTabItem(@StringRes val titleResId: Int, open val count: Int) : TabItem {
-    override val title: UIText = UIText.StringResource(titleResId)
-    data class Reactions(override val count: Int) : MessageDetailsTabItem(R.string.message_details_reactions_tab, count)
-    data class ReadReceipts(override val count: Int) : MessageDetailsTabItem(R.string.message_details_read_receipts_tab, count)
+sealed class MessageDetailsTabItem(@StringRes val titleResId: Int, argument: String) : TabItem {
+    override val title: UIText = UIText.StringResource(titleResId, argument)
+
+    data class Reactions(val count: Int) : MessageDetailsTabItem(R.string.message_details_reactions_tab, "$count")
+    data class ReadReceipts(val count: Int) : MessageDetailsTabItem(R.string.message_details_read_receipts_tab, "$count")
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8798" title="WPB-8798" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8798</a>  [Android] Crash when opening message details
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Count arguments were not properly passed to tab title string resource