### PR TITLE
refactor: make learn more links clickable for automation [WPB-5888]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -242,22 +243,22 @@ fun LoginErrorDialog(
 ) {
     val dialogErrorData: LoginDialogErrorData = when (error) {
         is LoginError.DialogError.InvalidCredentialsError -> LoginDialogErrorData(
-            stringResource(R.string.login_error_invalid_credentials_title),
-            stringResource(R.string.login_error_invalid_credentials_message),
-            onDialogDismiss
+            title = stringResource(R.string.login_error_invalid_credentials_title),
+            body = AnnotatedString(stringResource(R.string.login_error_invalid_credentials_message)),
+            onDismiss = onDialogDismiss
         )
 
         is LoginError.DialogError.UserAlreadyExists -> LoginDialogErrorData(
-            stringResource(R.string.login_error_user_already_logged_in_title),
-            stringResource(R.string.login_error_user_already_logged_in_message),
-            onDialogDismiss
+            title = stringResource(R.string.login_error_user_already_logged_in_title),
+            body = AnnotatedString(stringResource(R.string.login_error_user_already_logged_in_message)),
+            onDismiss = onDialogDismiss
         )
 
         is LoginError.DialogError.ProxyError -> {
             LoginDialogErrorData(
-                stringResource(R.string.error_socket_title),
-                stringResource(R.string.error_socket_message),
-                onDialogDismiss
+                title = stringResource(R.string.error_socket_title),
+                body = AnnotatedString(stringResource(R.string.error_socket_message)),
+                onDismiss = onDialogDismiss
             )
         }
 
@@ -265,36 +266,36 @@ fun LoginErrorDialog(
             val strings = error.coreFailure.dialogErrorStrings(LocalContext.current.resources)
             LoginDialogErrorData(
                 strings.title,
-                strings.message,
+                strings.annotatedMessage,
                 onDialogDismiss
             )
         }
 
         is LoginError.DialogError.InvalidSSOCodeError -> LoginDialogErrorData(
-            stringResource(R.string.login_error_invalid_credentials_title),
-            stringResource(R.string.login_error_invalid_sso_code),
-            onDialogDismiss
+            title = stringResource(R.string.login_error_invalid_credentials_title),
+            body = AnnotatedString(stringResource(R.string.login_error_invalid_sso_code)),
+            onDismiss = onDialogDismiss
         )
 
         is LoginError.DialogError.InvalidSSOCookie -> LoginDialogErrorData(
-            stringResource(R.string.login_sso_error_invalid_cookie_title),
-            stringResource(R.string.login_sso_error_invalid_cookie_message),
-            onDialogDismiss
+            title = stringResource(R.string.login_sso_error_invalid_cookie_title),
+            body = AnnotatedString(stringResource(R.string.login_sso_error_invalid_cookie_message)),
+            onDismiss = onDialogDismiss
         )
 
         is LoginError.DialogError.SSOResultError -> {
             with(ssoLoginResult as DeepLinkResult.SSOLogin.Failure) {
                 LoginDialogErrorData(
-                    stringResource(R.string.sso_error_dialog_title),
-                    stringResource(R.string.sso_error_dialog_message, this.ssoError.errorCode),
-                    onDialogDismiss
+                    title = stringResource(R.string.sso_error_dialog_title),
+                    body = AnnotatedString(stringResource(R.string.sso_error_dialog_message, this.ssoError.errorCode)),
+                    onDismiss = onDialogDismiss
                 )
             }
         }
 
         is LoginError.DialogError.ServerVersionNotSupported -> LoginDialogErrorData(
             title = stringResource(R.string.api_versioning_server_version_not_supported_title),
-            body = stringResource(R.string.api_versioning_server_version_not_supported_message),
+            body = AnnotatedString(stringResource(R.string.api_versioning_server_version_not_supported_message)),
             onDismiss = onDialogDismiss,
             actionTextId = R.string.label_close,
             dismissOnClickOutside = false
@@ -302,7 +303,7 @@ fun LoginErrorDialog(
 
         is LoginError.DialogError.ClientUpdateRequired -> LoginDialogErrorData(
             title = stringResource(R.string.api_versioning_client_update_required_title),
-            body = stringResource(R.string.api_versioning_client_update_required_message),
+            body = AnnotatedString(stringResource(R.string.api_versioning_client_update_required_message)),
             onDismiss = onDialogDismiss,
             actionTextId = R.string.label_update,
             onAction = updateTheApp,
@@ -312,9 +313,9 @@ fun LoginErrorDialog(
         LoginError.DialogError.PasswordNeededToRegisterClient -> TODO()
 
         else -> LoginDialogErrorData(
-            stringResource(R.string.error_unknown_title),
-            stringResource(R.string.error_unknown_message),
-            onDialogDismiss
+            title = stringResource(R.string.error_unknown_title),
+            body = AnnotatedString(stringResource(R.string.error_unknown_message)),
+            onDismiss = onDialogDismiss
         )
     }
 
@@ -337,7 +338,7 @@ fun LoginErrorDialog(
 
 data class LoginDialogErrorData(
     val title: String,
-    val body: String,
+    val body: AnnotatedString,
     val onDismiss: () -> Unit,
     @StringRes val actionTextId: Int = R.string.label_ok,
     val onAction: () -> Unit = onDismiss,

--- a/app/src/main/kotlin/com/wire/android/ui/common/TextWithLinkSuffix.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/TextWithLinkSuffix.kt
@@ -1,0 +1,167 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.common
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.Dp
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
+
+@Composable
+fun TextWithLinkSuffix(
+    text: AnnotatedString,
+    linkText: String? = null,
+    onLinkClick: () -> Unit = {},
+    linkTag: String = "link",
+    textStyle: TextStyle = MaterialTheme.wireTypography.body01,
+    textColor: Color = MaterialTheme.wireColorScheme.onBackground,
+    linkStyle: TextStyle = MaterialTheme.wireTypography.body02,
+    linkColor: Color = MaterialTheme.wireColorScheme.primary,
+    linkDecoration: TextDecoration = TextDecoration.Underline,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    val textMeasurer = rememberTextMeasurer()
+    val linkId = "link"
+    val inlineText = if (linkText != null) {
+        text.plus(
+            buildAnnotatedString {
+                append(" ")
+                appendInlineContent(linkId, "[link]")
+            }
+        )
+    } else text
+    val inlineContent = buildMap {
+        if (linkText != null) {
+            val textLayoutResult: TextLayoutResult = textMeasurer.measure(
+                text = linkText,
+                style = linkStyle.copy(textDecoration = linkDecoration),
+            )
+            val textSize = textLayoutResult.size
+            val density = LocalDensity.current
+            val (linkWidthSp, linkHeightSp) = with(density) { textSize.width.toSp() to textSize.height.toSp() }
+
+            put(linkId, InlineTextContent(
+                placeholder = Placeholder(
+                    width = linkWidthSp,
+                    height = linkHeightSp,
+                    placeholderVerticalAlign = PlaceholderVerticalAlign.Bottom
+                ),
+                children = {
+                    Text(
+                        text = linkText,
+                        style = linkStyle,
+                        color = linkColor,
+                        textDecoration = linkDecoration,
+                        modifier = Modifier
+                            .testTag(linkTag)
+                            .clickable(onClick = onLinkClick)
+                    )
+                }
+            )
+            )
+        }
+    }
+
+    Text(
+        text = inlineText,
+        style = textStyle,
+        color = textColor,
+        inlineContent = inlineContent,
+        onTextLayout = onTextLayout,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun PreviewTextWithLinkSuffixBuilder(
+    textLines: List<String> = listOf("This is a text with a link"),
+    linkText: String = "link",
+    calculateWidth: (lastTextLineWidthDp: Dp, linkWidthDp: Dp) -> Dp
+) {
+    val textStyle = MaterialTheme.wireTypography.body01
+    val linkStyle = MaterialTheme.wireTypography.body02.copy(textDecoration = TextDecoration.Underline)
+    val textMeasurer = rememberTextMeasurer()
+    val lastTextLineLayoutResult = textMeasurer.measure(text = "${textLines.last()} ", style = textStyle)
+    val linkLayoutResult = textMeasurer.measure(text = linkText, style = linkStyle)
+    val density = LocalDensity.current
+    val lastTextLineWidthDp = with(density) { lastTextLineLayoutResult.size.width.toDp() }
+    val linkWidthDp = with(density) { linkLayoutResult.size.width.toDp() }
+    TextWithLinkSuffix(
+        text = AnnotatedString(textLines.joinToString(separator = "\n")),
+        linkText = linkText,
+        onLinkClick = {},
+        modifier = Modifier.width(calculateWidth(lastTextLineWidthDp, linkWidthDp))
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewTextWithLinkSuffixWithoutALink() = WireTheme {
+    TextWithLinkSuffix(text = AnnotatedString("This is a text without a link"))
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewTextWithLinkSuffixFittingInSameLine() = WireTheme {
+    PreviewTextWithLinkSuffixBuilder { lastTextLineWidthDp, linkWidthDp -> lastTextLineWidthDp + linkWidthDp }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewTextWithLinkSuffixNotFittingInSameLine() = WireTheme {
+    PreviewTextWithLinkSuffixBuilder { lastTextLineWidthDp, linkWidthDp -> lastTextLineWidthDp + (linkWidthDp / 2) }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewTextWithLinkSuffixMultilineFittingInLastLine() = WireTheme {
+    PreviewTextWithLinkSuffixBuilder(
+        textLines = listOf("This is a text with a link", "This is a text with a"),
+        linkText = "link",
+    ) { lastTextLineWidthDp, linkWidthDp -> lastTextLineWidthDp + linkWidthDp }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewTextWithLinkSuffixMultilineNotFittingInLastLine() = WireTheme {
+    PreviewTextWithLinkSuffixBuilder(
+        textLines = listOf("This is a text with a", "This is a text with a"),
+        linkText = "link"
+    ) { lastTextLineWidthDp, linkWidthDp -> lastTextLineWidthDp + (linkWidthDp / 2) }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
@@ -41,7 +41,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalUriHandler
@@ -51,7 +50,6 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.wire.android.ui.common.button.WireButtonState
@@ -60,11 +58,11 @@ import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.button.WireTertiaryButton
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.textfield.WirePasswordTextField
-import com.wire.android.ui.markdown.MarkdownConstants
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Stable
 fun wireDialogPropertiesBuilder(
@@ -81,6 +79,7 @@ fun wireDialogPropertiesBuilder(
 fun WireDialog(
     title: String,
     text: String,
+    textSuffixLink: DialogTextSuffixLink? = null,
     onDismiss: () -> Unit,
     optionButton1Properties: WireDialogButtonProperties? = null,
     optionButton2Properties: WireDialogButtonProperties? = null,
@@ -116,6 +115,7 @@ fun WireDialog(
             )
             withStyle(style) { append(text) }
         },
+        textSuffixLink = textSuffixLink,
         centerContent = centerContent,
         content = content
     )
@@ -125,6 +125,7 @@ fun WireDialog(
 fun WireDialog(
     title: String,
     text: AnnotatedString? = null,
+    textSuffixLink: DialogTextSuffixLink? = null,
     onDismiss: () -> Unit,
     optionButton1Properties: WireDialogButtonProperties? = null,
     optionButton2Properties: WireDialogButtonProperties? = null,
@@ -153,6 +154,7 @@ fun WireDialog(
             title = title,
             titleLoading = titleLoading,
             text = text,
+            textSuffixLink = textSuffixLink,
             centerContent = centerContent,
             content = content
         )
@@ -164,6 +166,7 @@ private fun WireDialogContent(
     title: String,
     titleLoading: Boolean = false,
     text: AnnotatedString? = null,
+    textSuffixLink: DialogTextSuffixLink? = null,
     optionButton1Properties: WireDialogButtonProperties? = null,
     optionButton2Properties: WireDialogButtonProperties? = null,
     dismissButtonProperties: WireDialogButtonProperties? = null,
@@ -203,17 +206,11 @@ private fun WireDialogContent(
             ) {
                 text?.let {
                     item {
-                        ClickableText(
+                        TextWithLinkSuffix(
                             text = text,
-                            style = MaterialTheme.wireTypography.body01,
-                            modifier = Modifier.padding(bottom = MaterialTheme.wireDimensions.dialogTextsSpacing),
-                            onClick = { offset ->
-                                text.getStringAnnotations(
-                                    tag = MarkdownConstants.TAG_URL,
-                                    start = offset,
-                                    end = offset,
-                                ).firstOrNull()?.let { result -> uriHandler.openUri(result.item) }
-                            }
+                            linkText = textSuffixLink?.linkText,
+                            onLinkClick = { textSuffixLink?.linkUrl?.let { uriHandler.openUri(it) } },
+                            modifier = Modifier.padding(bottom = MaterialTheme.wireDimensions.dialogTextsSpacing)
                         )
                     }
                 }
@@ -299,8 +296,7 @@ private fun WireDialogButtonProperties?.getButton(modifier: Modifier = Modifier)
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
-@Preview(showBackground = true)
+@PreviewMultipleThemes
 @Composable
 fun PreviewWireDialog() {
     var password by remember { mutableStateOf(TextFieldValue("")) }
@@ -342,8 +338,29 @@ fun PreviewWireDialog() {
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
-@Preview(showBackground = true)
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewWireDialogWithSuffixLink() {
+    WireTheme {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            WireDialogContent(
+                dismissButtonProperties = WireDialogButtonProperties(
+                    text = "OK",
+                    onClick = { }
+                ),
+                title = "title",
+                text = AnnotatedString("This is a long text with a link on a second line.\nThis is a second line."),
+                textSuffixLink = DialogTextSuffixLink("link", "https://www.wire.com"),
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
 @Composable
 fun PreviewWireDialogWith2OptionButtons() {
     var password by remember { mutableStateOf(TextFieldValue("")) }
@@ -392,8 +409,7 @@ fun PreviewWireDialogWith2OptionButtons() {
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
-@Preview(showBackground = true)
+@PreviewMultipleThemes
 @Composable
 fun PreviewWireDialogCentered() {
     var password by remember { mutableStateOf(TextFieldValue("")) }
@@ -445,3 +461,5 @@ data class WireDialogButtonProperties(
     val type: WireDialogButtonType = WireDialogButtonType.Secondary,
     val loading: Boolean = false
 )
+
+data class DialogTextSuffixLink(val linkText: String, val linkUrl: String)

--- a/app/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
@@ -338,7 +338,6 @@ fun PreviewWireDialog() {
     }
 }
 
-
 @PreviewMultipleThemes
 @Composable
 fun PreviewWireDialogWithSuffixLink() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -38,7 +38,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -55,11 +54,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.style.TextDecoration
 import com.wire.android.R
+import com.wire.android.ui.common.TextWithLinkSuffix
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
@@ -162,37 +159,18 @@ fun SystemMessageItem(
                 errorColor = MaterialTheme.wireColorScheme.error,
                 isErrorString = message.addingFailed,
             )
-            val learnMoreAnnotatedString = message.messageContent.learnMoreResId?.let {
-                val learnMoreLink = stringResource(id = message.messageContent.learnMoreResId)
-                val learnMoreText = stringResource(id = R.string.label_learn_more)
-                buildAnnotatedString {
-                    append(learnMoreText)
-                    addStyle(
-                        style = SpanStyle(
-                            color = MaterialTheme.colorScheme.primary,
-                            textDecoration = TextDecoration.Underline
-                        ),
-                        start = 0,
-                        end = learnMoreText.length
-                    )
-                    addStringAnnotation(tag = TAG_LEARN_MORE, annotation = learnMoreLink, start = 0, end = learnMoreText.length)
-                }
-            }
-            val fullAnnotatedString =
-                if (learnMoreAnnotatedString != null) annotatedString + AnnotatedString(" ") + learnMoreAnnotatedString
-                else annotatedString
+            val learnMoreLink = message.messageContent.learnMoreResId?.let { stringResource(id = it) }
 
-            ClickableText(
-                modifier = Modifier.defaultMinSize(minHeight = dimensions().spacing20x),
-                text = fullAnnotatedString,
-                onClick = { offset ->
-                    fullAnnotatedString.getStringAnnotations(TAG_LEARN_MORE, offset, offset)
-                        .firstOrNull()?.let { result -> CustomTabsHelper.launchUrl(context, result.item) }
-                },
-                style = MaterialTheme.wireTypography.body02,
+            TextWithLinkSuffix(
+                text = annotatedString,
+                linkText = learnMoreLink?.let { stringResource(id = R.string.label_learn_more) },
+                textColor = MaterialTheme.wireColorScheme.secondaryText,
+                linkColor = MaterialTheme.wireColorScheme.onBackground,
+                onLinkClick = { learnMoreLink?.let { CustomTabsHelper.launchUrl(context, it) } },
                 onTextLayout = {
                     centerOfFirstLine = if (it.lineCount == 0) 0f else ((it.getLineTop(0) + it.getLineBottom(0)) / 2)
-                }
+                },
+                modifier = Modifier.defaultMinSize(minHeight = dimensions().spacing20x),
             )
 
             if ((message.addingFailed && expanded) || message.singleUserAddFailed) {
@@ -794,4 +772,3 @@ private fun SystemMessage.MemberFailedToAdd.toFailedToAddMarkdownText(
 
 private const val EXPANDABLE_THRESHOLD = 4
 private const val SINGLE_EXPANDABLE_THRESHOLD = 1
-private const val TAG_LEARN_MORE = "tag_learn_more"

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
@@ -19,18 +19,13 @@ package com.wire.android.ui.home.newconversation.common
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.text.withStyle
 import com.wire.android.R
+import com.wire.android.ui.common.DialogTextSuffixLink
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
-import com.wire.android.ui.common.colorsScheme
-import com.wire.android.ui.markdown.MarkdownConstants
 import com.wire.android.ui.theme.WireTheme
-import com.wire.android.util.DialogAnnotatedErrorStrings
+import com.wire.android.util.DialogErrorStrings
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
@@ -40,51 +35,34 @@ fun CreateGroupErrorDialog(
     onAccept: () -> Unit,
     onCancel: () -> Unit
 ) {
-    val dialogStrings = when (error) {
-        is CreateGroupState.Error.LackingConnection -> DialogAnnotatedErrorStrings(
-            stringResource(R.string.error_no_network_title),
-            buildAnnotatedString { append(stringResource(R.string.error_no_network_message)) }
-        )
+    val (dialogStrings, dialogSuffixLink) = when (error) {
+        is CreateGroupState.Error.LackingConnection -> DialogErrorStrings(
+            title = stringResource(R.string.error_no_network_title),
+            message = stringResource(R.string.error_no_network_message),
+        ) to null
 
-        is CreateGroupState.Error.Unknown -> DialogAnnotatedErrorStrings(
-            stringResource(R.string.error_unknown_title),
-            buildAnnotatedString { append(stringResource(R.string.error_unknown_message)) }
-        )
+        is CreateGroupState.Error.Unknown -> DialogErrorStrings(
+            title = stringResource(R.string.error_unknown_title),
+            message = stringResource(R.string.error_unknown_message),
+        ) to null
 
-        is CreateGroupState.Error.ConflictedBackends -> DialogAnnotatedErrorStrings(
+        is CreateGroupState.Error.ConflictedBackends -> DialogErrorStrings(
             title = stringResource(id = R.string.group_can_not_be_created_title),
-            annotatedMessage = buildAnnotatedString {
-                val description = stringResource(
+            message = stringResource(
                     id = R.string.group_can_not_be_created_federation_conflict_description,
                     error.domains.dropLast(1).joinToString(", "),
                     error.domains.last()
-                )
-                val learnMore = stringResource(id = R.string.label_learn_more)
-
-                append(description)
-                append(' ')
-
-                withStyle(
-                    style = SpanStyle(
-                        color = colorsScheme().primary,
-                        textDecoration = TextDecoration.Underline
-                    )
-                ) {
-                    append(learnMore)
-                }
-                addStringAnnotation(
-                    tag = MarkdownConstants.TAG_URL,
-                    annotation = stringResource(id = R.string.url_message_details_offline_backends_learn_more),
-                    start = description.length + 1,
-                    end = description.length + 1 + learnMore.length
-                )
-            }
+                ),
+        ) to DialogTextSuffixLink(
+            linkText = stringResource(id = R.string.label_learn_more),
+            linkUrl = stringResource(id = R.string.url_message_details_offline_backends_learn_more)
         )
     }
 
     WireDialog(
-        dialogStrings.title,
-        dialogStrings.annotatedMessage,
+        title = dialogStrings.title,
+        text = dialogStrings.annotatedMessage,
+        textSuffixLink = dialogSuffixLink,
         onDismiss = onDismiss,
         buttonsHorizontalAlignment = false,
         optionButton1Properties = WireDialogButtonProperties(

--- a/app/src/main/kotlin/com/wire/android/util/CoreFailureUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CoreFailureUtil.kt
@@ -48,5 +48,6 @@ fun CoreFailure.uiText(): UIText = when (this) {
     else -> UIText.StringResource(R.string.error_unknown_message)
 }
 
-data class DialogErrorStrings(val title: String, val message: String)
-data class DialogAnnotatedErrorStrings(val title: String, val annotatedMessage: AnnotatedString)
+data class DialogErrorStrings(val title: String, val annotatedMessage: AnnotatedString) {
+    constructor(title: String, message: String) : this(title, AnnotatedString(message))
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5888" title="WPB-5888" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-5888</a>  [Android] Separate links from dialogs - enabling automated testing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Links at the end of the text like "learn more" are not clickable by the automation.

### Solutions

Extract these links into a separate `Text` composable by using `InlineTextContent`. 
It's not perfect as it won't split the link text part and move part to the second line if doesn't fit but it will then move the whole link text to the next line, but it's the best compromise.
Created `TextWithLinkSuffix` to make it very easy to use in the app.

### Attachments (Optional)

<img width="814" alt="image" src="https://github.com/wireapp/wire-android/assets/30429749/221ad5db-1361-49c1-bd99-e5fbd49c5c48">

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
