### PR TITLE
fix: create group contacts selection, hide show less button [WPB-6975] [WPB-8813]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchAllPeopleScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchAllPeopleScreen.kt
@@ -230,11 +230,10 @@ private fun LazyListScope.internalSuccessItem(
     onOpenUserProfile: (Contact) -> Unit
 ) {
     if (searchResult.isNotEmpty()) {
-        folderWithElements(header = searchTitle,
-            items = (if (allItemsVisible) searchResult else searchResult.take(
-                DEFAULT_SEARCH_RESULT_ITEM_SIZE
-            ))
-                .associateBy { it.id }) { contact ->
+        folderWithElements(
+            header = searchTitle,
+            items = (if (allItemsVisible) searchResult else searchResult.take(DEFAULT_SEARCH_RESULT_ITEM_SIZE)).associateBy { it.id }
+        ) { contact ->
             with(contact) {
                 val onClick = remember { { isChecked: Boolean -> onChecked(isChecked, this) } }
                 InternalContactSearchResultItem(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchAllPeopleScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchAllPeopleScreen.kt
@@ -126,7 +126,8 @@ private fun SearchResult(
                     onChecked = onChecked,
                     isLoading = isLoading,
                     contactSearchResult = contactsSearchResult,
-                    showAllItems = !isSearchActive || searchPeopleScreenState.contactsAllResultsCollapsed,
+                    allItemsVisible = !isSearchActive || searchPeopleScreenState.contactsAllResultsCollapsed,
+                    showMoreOrLessButtonVisible = isSearchActive,
                     onShowAllButtonClicked = searchPeopleScreenState::toggleShowAllContactsResult,
                     onOpenUserProfile = onOpenUserProfile,
                     actionType = actionType,
@@ -139,7 +140,8 @@ private fun SearchResult(
                     searchQuery = searchQuery,
                     contactSearchResult = publicSearchResult,
                     isLoading = isLoading,
-                    showAllItems = searchPeopleScreenState.publicResultsCollapsed,
+                    allItemsVisible = searchPeopleScreenState.publicResultsCollapsed,
+                    showMoreOrLessButtonVisible = isSearchActive,
                     onShowAllButtonClicked = searchPeopleScreenState::toggleShowAllPublicResult,
                     onOpenUserProfile = onOpenUserProfile,
                 )
@@ -157,7 +159,8 @@ private fun LazyListScope.internalSearchResults(
     actionType: ItemActionType,
     isLoading: Boolean,
     contactSearchResult: ImmutableList<Contact>,
-    showAllItems: Boolean,
+    allItemsVisible: Boolean,
+    showMoreOrLessButtonVisible: Boolean,
     onShowAllButtonClicked: () -> Unit,
     onOpenUserProfile: (Contact) -> Unit
 ) {
@@ -169,7 +172,8 @@ private fun LazyListScope.internalSearchResults(
         else -> {
             internalSuccessItem(
                 searchTitle = searchTitle,
-                showAllItems = showAllItems,
+                allItemsVisible = allItemsVisible,
+                showMoreOrLessButtonVisible = showMoreOrLessButtonVisible,
                 contactsAddedToGroup = contactsAddedToGroup,
                 onChecked = onChecked,
                 searchResult = contactSearchResult,
@@ -188,7 +192,8 @@ private fun LazyListScope.externalSearchResults(
     searchQuery: String,
     contactSearchResult: ImmutableList<Contact>,
     isLoading: Boolean,
-    showAllItems: Boolean,
+    allItemsVisible: Boolean,
+    showMoreOrLessButtonVisible: Boolean,
     onShowAllButtonClicked: () -> Unit,
     onOpenUserProfile: (Contact) -> Unit,
 ) {
@@ -200,7 +205,8 @@ private fun LazyListScope.externalSearchResults(
         else -> {
             externalSuccessItem(
                 searchTitle = searchTitle,
-                showAllItems = showAllItems,
+                allItemsVisible = allItemsVisible,
+                showMoreOrLessButtonVisible = showMoreOrLessButtonVisible,
                 searchResult = contactSearchResult,
                 searchQuery = searchQuery,
                 onShowAllButtonClicked = onShowAllButtonClicked,
@@ -213,7 +219,8 @@ private fun LazyListScope.externalSearchResults(
 @Suppress("LongParameterList")
 private fun LazyListScope.internalSuccessItem(
     searchTitle: String,
-    showAllItems: Boolean,
+    allItemsVisible: Boolean,
+    showMoreOrLessButtonVisible: Boolean,
     actionType: ItemActionType,
     contactsAddedToGroup: ImmutableSet<Contact>,
     onChecked: (Boolean, Contact) -> Unit,
@@ -224,7 +231,7 @@ private fun LazyListScope.internalSuccessItem(
 ) {
     if (searchResult.isNotEmpty()) {
         folderWithElements(header = searchTitle,
-            items = (if (showAllItems) searchResult else searchResult.take(
+            items = (if (allItemsVisible) searchResult else searchResult.take(
                 DEFAULT_SEARCH_RESULT_ITEM_SIZE
             ))
                 .associateBy { it.id }) { contact ->
@@ -237,7 +244,7 @@ private fun LazyListScope.internalSuccessItem(
                     membership = membership,
                     searchQuery = searchQuery,
                     connectionState = connectionState,
-                    isAddedToGroup = contactsAddedToGroup.contains(contact),
+                    isAddedToGroup = contactsAddedToGroup.any { it.id == contact.id },
                     onCheckChange = onClick,
                     actionType = actionType,
                     clickable = remember { Clickable(enabled = true) { onOpenUserProfile(contact) } }
@@ -246,7 +253,7 @@ private fun LazyListScope.internalSuccessItem(
         }
     }
 
-    if (searchResult.size > DEFAULT_SEARCH_RESULT_ITEM_SIZE) {
+    if (searchResult.size > DEFAULT_SEARCH_RESULT_ITEM_SIZE && showMoreOrLessButtonVisible) {
         item {
             Box(
                 Modifier
@@ -254,7 +261,7 @@ private fun LazyListScope.internalSuccessItem(
                     .wrapContentHeight()
             ) {
                 ShowButton(
-                    isShownAll = showAllItems,
+                    isShownAll = allItemsVisible,
                     onShowButtonClicked = onShowAllButtonClicked,
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
@@ -268,14 +275,15 @@ private fun LazyListScope.internalSuccessItem(
 @Suppress("LongParameterList")
 private fun LazyListScope.externalSuccessItem(
     searchTitle: String,
-    showAllItems: Boolean,
+    allItemsVisible: Boolean,
+    showMoreOrLessButtonVisible: Boolean,
     searchResult: List<Contact>,
     searchQuery: String,
     onShowAllButtonClicked: () -> Unit,
     onOpenUserProfile: (Contact) -> Unit,
 ) {
     val itemsList =
-        if (showAllItems) searchResult else searchResult.take(DEFAULT_SEARCH_RESULT_ITEM_SIZE)
+        if (allItemsVisible) searchResult else searchResult.take(DEFAULT_SEARCH_RESULT_ITEM_SIZE)
 
     folderWithElements(
         header = searchTitle,
@@ -295,7 +303,7 @@ private fun LazyListScope.externalSuccessItem(
         }
     }
 
-    if (searchResult.size > DEFAULT_SEARCH_RESULT_ITEM_SIZE) {
+    if (searchResult.size > DEFAULT_SEARCH_RESULT_ITEM_SIZE && showMoreOrLessButtonVisible) {
         item {
             Box(
                 Modifier
@@ -303,7 +311,7 @@ private fun LazyListScope.externalSuccessItem(
                     .wrapContentHeight()
             ) {
                 ShowButton(
-                    isShownAll = showAllItems,
+                    isShownAll = allItemsVisible,
                     onShowButtonClicked = onShowAllButtonClicked,
                     modifier = Modifier
                         .align(Alignment.BottomEnd)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchAllPeopleScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchAllPeopleScreen.kt
@@ -232,7 +232,9 @@ private fun LazyListScope.internalSuccessItem(
     if (searchResult.isNotEmpty()) {
         folderWithElements(
             header = searchTitle,
-            items = (if (allItemsVisible) searchResult else searchResult.take(DEFAULT_SEARCH_RESULT_ITEM_SIZE)).associateBy { it.id }
+            items = (if (allItemsVisible) searchResult else searchResult.take(DEFAULT_SEARCH_RESULT_ITEM_SIZE)).associateBy {
+                it.id
+            }
         ) { contact ->
             with(contact) {
                 val onClick = remember { { isChecked: Boolean -> onChecked(isChecked, this) } }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6975" title="WPB-6975" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6975</a>  [Android] Show less button should be hidden if list can't be minimised
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When creating group, when you choose contacts, navigate back and forth back to choose contacts screen, button "continue" shows that there are some contacts still selected but their checkboxes are unchecked.
On contacts list, when there's more than 4, "show less" button is visible but it does nothing.

### Solutions

Change the way to check if contact checkbox should be selected to compare contact's ID.
Hide "show more" / "show less" button for the default contacts list which now shows all contacts.

### Testing

#### How to Test

Try to create new group and select some contacts and navigate back and forth like described in the `Issues` section.

### Attachments (Optional)


| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/wireapp/wire-android/assets/30429749/95daaa46-eecf-4935-87e4-695f703234cd"/> | <video width="400" src="https://github.com/wireapp/wire-android/assets/30429749/f26c8ffd-fc22-41f2-b039-c107b72266c5"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
