### PR TITLE
fix: sketch general issues (WPB-8810) (WPB-8811) (WPB-8812)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -261,7 +261,10 @@ fun EnabledMessageComposer(
                                     additionalOptionStateHolder.toRichTextEditing()
                                 },
                                 onCloseRichEditingButtonClicked = additionalOptionStateHolder::toAttachmentAndAdditionalOptionsMenu,
-                                onDrawingModeClicked = additionalOptionStateHolder::toDrawingMode
+                                onDrawingModeClicked = {
+                                    showAdditionalOptionsMenu()
+                                    additionalOptionStateHolder.toDrawingMode()
+                                }
                             )
                         }
                         Box(

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
@@ -21,12 +21,7 @@ package com.wire.android.ui.common.bottomsheet
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.absoluteOffset
-import androidx.compose.foundation.layout.navigationBarsIgnoringVisibility
-import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -88,7 +83,6 @@ fun MenuModalSheetLayout(
     )
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun MenuModalSheetContent(
     header: MenuModalSheetHeader = MenuModalSheetHeader.Gone,
@@ -97,10 +91,5 @@ fun MenuModalSheetContent(
     Column {
         ModalSheetHeaderItem(header = header)
         buildMenuSheetItems(items = menuItems)
-        Spacer(
-            Modifier.windowInsetsBottomHeight(
-                WindowInsets.navigationBarsIgnoringVisibility
-            )
-        )
     }
 }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
@@ -21,7 +21,12 @@ package com.wire.android.ui.common.bottomsheet
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.navigationBarsIgnoringVisibility
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -83,6 +88,7 @@ fun MenuModalSheetLayout(
     )
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun MenuModalSheetContent(
     header: MenuModalSheetHeader = MenuModalSheetHeader.Gone,
@@ -91,5 +97,10 @@ fun MenuModalSheetContent(
     Column {
         ModalSheetHeaderItem(header = header)
         buildMenuSheetItems(items = menuItems)
+        Spacer(
+            Modifier.windowInsetsBottomHeight(
+                WindowInsets.navigationBarsIgnoringVisibility
+            )
+        )
     }
 }

--- a/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingCanvasBottomSheet.kt
+++ b/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingCanvasBottomSheet.kt
@@ -104,7 +104,7 @@ fun DrawingCanvasBottomSheet(
         onDismissRequest = onDismissEvent,
         properties = ModalBottomSheetProperties(
             isFocusable = true,
-            securePolicy = SecureFlagPolicy.SecureOn,
+            securePolicy = SecureFlagPolicy.Inherit,
             shouldDismissOnBackPress = false
         )
     ) {
@@ -162,6 +162,7 @@ internal fun DrawingTopBar(
         Text(
             text = conversationTitle,
             style = MaterialTheme.wireTypography.title01,
+            color = colorsScheme().onBackground,
             modifier = Modifier.align(Alignment.CenterVertically),
             maxLines = MAX_LINES_TOPBAR,
             overflow = TextOverflow.Ellipsis

--- a/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingCanvasBottomSheet.kt
+++ b/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingCanvasBottomSheet.kt
@@ -62,6 +62,7 @@ import com.wire.android.ui.common.button.WireTertiaryIconButton
 import com.wire.android.ui.common.button.wireSendPrimaryButtonColors
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import kotlinx.coroutines.launch
@@ -162,7 +163,7 @@ internal fun DrawingTopBar(
         Text(
             text = conversationTitle,
             style = MaterialTheme.wireTypography.title01,
-            color = colorsScheme().onBackground,
+            color = MaterialTheme.wireColorScheme.onBackground,
             modifier = Modifier.align(Alignment.CenterVertically),
             maxLines = MAX_LINES_TOPBAR,
             overflow = TextOverflow.Ellipsis

--- a/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingCanvasComponent.kt
+++ b/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingCanvasComponent.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.input.pointer.positionChangedIgnoreConsumed
+import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.res.stringResource
@@ -172,7 +172,7 @@ private suspend fun AwaitPointerEventScope.handleGestures(
     do {
         val event = awaitPointerEvent()
         onDraw(event.changes.first().position)
-        val hasNewLineDraw = event.changes.first().positionChangedIgnoreConsumed()
+        val hasNewLineDraw = event.changes.first().positionChanged()
         if (hasNewLineDraw) {
             event.changes.first().consume()
         }

--- a/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingToolPicker.kt
+++ b/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingToolPicker.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
@@ -179,7 +180,7 @@ private const val GRID_CELLS = 6
 private fun Color.isWhite() = this == Color.White
 
 @OptIn(ExperimentalMaterial3Api::class)
-@Preview
+@Preview(showSystemUi = true, device = Devices.NEXUS_5)
 @Composable
 fun PreviewDrawingToolPickerSelectedNonWhite() {
     WireTheme {

--- a/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingToolPicker.kt
+++ b/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingToolPicker.kt
@@ -24,11 +24,16 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsIgnoringVisibility
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -58,6 +63,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireColorPalette
 import com.wire.android.ui.theme.WireTheme
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun DrawingToolPicker(
     sheetState: WireModalSheetState,
@@ -107,6 +113,13 @@ fun DrawingToolPicker(
                 }
             )
         }
+        Spacer(
+            Modifier
+                .background(colorsScheme().background)
+                .windowInsetsBottomHeight(
+                    WindowInsets.navigationBarsIgnoringVisibility
+                )
+        )
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8810" title="WPB-8810" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8810</a>  [Android] Sketcher Undo button works on 3rd tap
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Color picker, didn't consider the status bar padding
- When Keyboard open, the drawing showed a loop collapsing keyboard and no drawing mode.
- Undo button took at least 3 taps to perform action.
- Darkmode title not visible

### Solutions

- Add padding to common component, to consider status bar on modal sheet if not consumed.
- Ignore consumed paths that are irrelevant, so undo perform is consistent with drew paths.
- Set title color accordingly to theme.


### Attachments (Optional)

<img src="https://github.com/wireapp/wire-android/assets/5806454/1115ccc5-ecde-480f-81d7-bcf20ce01e98" width="300" />

<img src="https://github.com/wireapp/wire-android/assets/5806454/fb4f03bc-d631-4548-9f6b-f808bfa1085e" width="300" />

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
