### PR TITLE
fix: prevent screenshots when it's enabled in CallActivity

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
@@ -23,6 +23,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.togetherWith
@@ -33,6 +34,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.lifecycleScope
 import com.wire.android.appLogger
 import com.wire.android.navigation.style.TransitionAnimationType
 import com.wire.android.notification.CallNotificationManager
@@ -45,6 +47,7 @@ import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.theme.WireTheme
 import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -56,6 +59,8 @@ class CallActivity : AppCompatActivity() {
     @Inject
     lateinit var proximitySensorManager: ProximitySensorManager
 
+    val callActivityViewModel: CallActivityViewModel by viewModels()
+
     private val qualifiedIdMapper = QualifiedIdMapperImpl(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -63,6 +68,7 @@ class CallActivity : AppCompatActivity() {
 
         callNotificationManager.hideAllNotifications()
 
+        setUpScreenShootPreventionFlag()
         setUpCallingFlags()
 
         appLogger.i("$TAG Initializing proximity sensor..")
@@ -146,6 +152,16 @@ fun CallActivity.setUpCallingFlags() {
             WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
                     or WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON,
         )
+    }
+}
+
+fun CallActivity.setUpScreenShootPreventionFlag() {
+    lifecycleScope.launch {
+        if (callActivityViewModel.isScreenshotCensoringConfigEnabled().await()) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivityViewModel.kt
@@ -1,0 +1,54 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.calling
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.di.ObserveScreenshotCensoringConfigUseCaseProvider
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
+import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@HiltViewModel
+class CallActivityViewModel @Inject constructor(
+    private val dispatchers: DispatcherProvider,
+    private val currentSession: CurrentSessionUseCase,
+    private val observeScreenshotCensoringConfigUseCaseProviderFactory: ObserveScreenshotCensoringConfigUseCaseProvider.Factory
+) : ViewModel() {
+
+    fun isScreenshotCensoringConfigEnabled(): Deferred<Boolean> =
+        viewModelScope.async(dispatchers.io()) {
+            val currentSession = currentSession()
+            if (currentSession is CurrentSessionResult.Success) {
+                return@async observeScreenshotCensoringConfigUseCaseProviderFactory.create(
+                    currentSession.accountInfo.userId
+                ).observeScreenshotCensoringConfig().map {
+                    it is ObserveScreenshotCensoringConfigResult.Enabled
+                }.first()
+            } else {
+                return@async false
+            }
+        }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivityViewModel.kt
@@ -35,7 +35,8 @@ import javax.inject.Inject
 class CallActivityViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val currentSession: CurrentSessionUseCase,
-    private val observeScreenshotCensoringConfigUseCaseProviderFactory: ObserveScreenshotCensoringConfigUseCaseProvider.Factory
+    private val observeScreenshotCensoringConfigUseCaseProviderFactory:
+    ObserveScreenshotCensoringConfigUseCaseProvider.Factory
 ) : ViewModel() {
 
     fun isScreenshotCensoringConfigEnabled(): Deferred<Boolean> =

--- a/app/src/test/kotlin/com/wire/android/ui/CallActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/CallActivityViewModelTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui
+
+import com.wire.android.config.TestDispatcherProvider
+import com.wire.android.di.ObserveScreenshotCensoringConfigUseCaseProvider
+import com.wire.android.ui.calling.CallActivityViewModel
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
+import io.mockk.coEvery
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+import com.wire.kalium.logic.data.auth.AccountInfo
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
+import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import kotlinx.coroutines.flow.flowOf
+
+class CallActivityViewModelTest {
+
+    @Test
+    fun `given no current, when checking screenshot censoring config, then return false`() =
+        runTest {
+            val (_, viewModel) = Arrangement()
+                .withCurrentSessionReturning(CurrentSessionResult.Failure.SessionNotFound)
+                .arrange()
+
+            val result = viewModel.isScreenshotCensoringConfigEnabled()
+
+            assertEquals(false, result.await())
+        }
+
+    @Test
+    fun `given screenshot censoring enabled, when checking screenshot censoring config, then return true`() =
+        runTest {
+            val (_, viewModel) = Arrangement()
+                .withCurrentSessionReturning(CurrentSessionResult.Success(accountInfo))
+                .withScreenshotCensoringConfigReturning(ObserveScreenshotCensoringConfigResult.Enabled.ChosenByUser)
+                .arrange()
+
+            val result = viewModel.isScreenshotCensoringConfigEnabled()
+
+            assertEquals(true, result.await())
+        }
+
+
+    @Test
+    fun `given screenshot censoring disabled, when checking screenshot censoring config, then return false`() =
+        runTest {
+            val (_, viewModel) = Arrangement()
+                .withCurrentSessionReturning(CurrentSessionResult.Success(accountInfo))
+                .withScreenshotCensoringConfigReturning(ObserveScreenshotCensoringConfigResult.Disabled)
+                .arrange()
+
+            val result = viewModel.isScreenshotCensoringConfigEnabled()
+
+            assertEquals(false, result.await())
+        }
+
+
+    private class Arrangement {
+
+        @MockK
+        private lateinit var observeScreenshotCensoringConfigUseCaseProviderFactory: ObserveScreenshotCensoringConfigUseCaseProvider.Factory
+
+        @MockK
+        private lateinit var currentSession: CurrentSessionUseCase
+
+        @MockK
+        private lateinit var observeScreenshotCensoringConfig: ObserveScreenshotCensoringConfigUseCase
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+
+            every { observeScreenshotCensoringConfigUseCaseProviderFactory.create(any()).observeScreenshotCensoringConfig } returns
+                    observeScreenshotCensoringConfig
+        }
+
+        private val viewModel by lazy {
+            CallActivityViewModel(
+                dispatchers = TestDispatcherProvider(),
+                currentSession = currentSession,
+                observeScreenshotCensoringConfigUseCaseProviderFactory = observeScreenshotCensoringConfigUseCaseProviderFactory,
+            )
+        }
+
+        fun arrange() = this to viewModel
+
+        suspend fun withCurrentSessionReturning(result: CurrentSessionResult) = apply {
+            coEvery { currentSession() } returns result
+        }
+
+        suspend fun withScreenshotCensoringConfigReturning(result: ObserveScreenshotCensoringConfigResult) = apply {
+            coEvery { observeScreenshotCensoringConfig() } returns flowOf(result)
+        }
+    }
+
+    companion object {
+        val accountInfo  = AccountInfo.Valid(userId = UserId("userId", "domain"))
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/CallActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/CallActivityViewModelTest.kt
@@ -20,20 +20,20 @@ package com.wire.android.ui
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.di.ObserveScreenshotCensoringConfigUseCaseProvider
 import com.wire.android.ui.calling.CallActivityViewModel
-import com.wire.kalium.logic.feature.session.CurrentSessionResult
-import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
-import io.mockk.coEvery
-import io.mockk.impl.annotations.MockK
-import kotlinx.coroutines.test.runTest
-import org.amshove.kluent.internal.assertEquals
-import org.junit.jupiter.api.Test
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
 import io.mockk.MockKAnnotations
+import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
 
 class CallActivityViewModelTest {
 
@@ -62,7 +62,6 @@ class CallActivityViewModelTest {
             assertEquals(true, result.await())
         }
 
-
     @Test
     fun `given screenshot censoring disabled, when checking screenshot censoring config, then return false`() =
         runTest {
@@ -76,11 +75,11 @@ class CallActivityViewModelTest {
             assertEquals(false, result.await())
         }
 
-
     private class Arrangement {
 
         @MockK
-        private lateinit var observeScreenshotCensoringConfigUseCaseProviderFactory: ObserveScreenshotCensoringConfigUseCaseProvider.Factory
+        private lateinit var observeScreenshotCensoringConfigUseCaseProviderFactory:
+                ObserveScreenshotCensoringConfigUseCaseProvider.Factory
 
         @MockK
         private lateinit var currentSession: CurrentSessionUseCase
@@ -109,12 +108,13 @@ class CallActivityViewModelTest {
             coEvery { currentSession() } returns result
         }
 
-        suspend fun withScreenshotCensoringConfigReturning(result: ObserveScreenshotCensoringConfigResult) = apply {
-            coEvery { observeScreenshotCensoringConfig() } returns flowOf(result)
-        }
+        suspend fun withScreenshotCensoringConfigReturning(result: ObserveScreenshotCensoringConfigResult) =
+            apply {
+                coEvery { observeScreenshotCensoringConfig() } returns flowOf(result)
+            }
     }
 
     companion object {
-        val accountInfo  = AccountInfo.Valid(userId = UserId("userId", "domain"))
+        val accountInfo = AccountInfo.Valid(userId = UserId("userId", "domain"))
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After this refactor #2882, screen censoring is no longer working in CallActivity.

### Solutions

Set FLAG_SECURE flag depending on screenshot config if it's enabled or not

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
