### PR TITLE
fix: message reaction details crash [WPB-8802]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
@@ -65,7 +65,7 @@ fun LazyListScope.folderWithElements(
 
 fun LazyListScope.folderWithElements(
     header: String,
-    items: Map<String,UIParticipant>,
+    items: Map<String, UIParticipant>,
     onRowItemClicked: (UIParticipant) -> Unit,
     showRightArrow: Boolean = true
 ) = folderWithElements(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
@@ -62,3 +62,22 @@ fun LazyListScope.folderWithElements(
     },
     divider = { WireDivider() }
 )
+
+fun LazyListScope.folderWithElements(
+    header: String,
+    items: Map<String,UIParticipant>,
+    onRowItemClicked: (UIParticipant) -> Unit,
+    showRightArrow: Boolean = true
+) = folderWithElements(
+    header = header,
+    items = items,
+    animateItemPlacement = false,
+    factory = {
+        ConversationParticipantItem(
+            uiParticipant = it,
+            clickable = remember { Clickable(enabled = true) { onRowItemClicked(it) } },
+            showRightArrow = showRightArrow
+        )
+    },
+    divider = { WireDivider() }
+)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsReactions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsReactions.kt
@@ -52,10 +52,10 @@ fun MessageDetailsReactions(
                 state = lazyListState,
                 modifier = Modifier.weight(weight = 1f, fill = true)
             ) {
-                reactionsData.reactions.forEach {
+                reactionsData.reactions.forEach { entry ->
                     folderWithElements(
-                        header = "${it.key} ${it.value.size}",
-                        items = it.value,
+                        header = "${entry.key} ${entry.value.size}",
+                        items = entry.value.associateBy { "${entry.key}_${it.id}" },
                         onRowItemClicked = { },
                         showRightArrow = false
                     )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8802" title="WPB-8802" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8802</a>  [Android] Crash when opening message details for messages with multiple reactions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Problem:
When user adds more than one reaction in reaction list there are items with the same key causing crash. 

Solution:
Combine recipe key with user Id to ensure that keys are unique 