### PR TITLE
fix: remove duplicated debug id in settings screen [WPB-8626]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -139,16 +139,6 @@ fun DebugDataOptionsContent(
                 trailingIcon = R.drawable.ic_copy,
                 onIconPressed = Clickable(
                     enabled = true,
-                    onClick = { }
-                )
-            )
-
-            SettingsItem(
-                title = stringResource(R.string.debug_id),
-                text = state.debugId,
-                trailingIcon = R.drawable.ic_copy,
-                onIconPressed = Clickable(
-                    enabled = true,
                     onClick = { onCopyText(state.debugId) }
                 )
             )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8626" title="WPB-8626" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8626</a>  [Android] Duplicated debug identifier in settings screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On debug settings screen there is a duplicated remove identifier, and one of them is not working the copy button.

### Solutions

Remove one of them, the one that doesn't have "on click" properly working.

### Testing

#### How to Test

Open debug settings screen.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
