### PR TITLE
fix: Handle 1o1 conversations when no key packages [WPB-6936]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/ConversationModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/ConversationModule.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
 import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
+import com.wire.kalium.logic.feature.conversation.IsOneToOneConversationCreatedUseCase
 import com.wire.kalium.logic.feature.conversation.JoinConversationViaCodeUseCase
 import com.wire.kalium.logic.feature.conversation.LeaveConversationUseCase
 import com.wire.kalium.logic.feature.conversation.NotifyConversationIsOpenUseCase
@@ -38,9 +39,9 @@ import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseC
 import com.wire.kalium.logic.feature.conversation.ObserveConversationInteractionAvailabilityUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationListDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationUnderLegalHoldNotifiedUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveDegradedConversationNotifiedUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveIsSelfUserMemberUseCase
-import com.wire.kalium.logic.feature.conversation.ObserveConversationUnderLegalHoldNotifiedUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveUserListByIdUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveUsersTypingUseCase
 import com.wire.kalium.logic.feature.conversation.RefreshConversationsWithoutMetadataUseCase
@@ -288,4 +289,9 @@ class ConversationModule {
     fun provideObserveLegalHoldWithChangeNotifiedForConversationUseCase(
         conversationScope: ConversationScope,
     ): ObserveConversationUnderLegalHoldNotifiedUseCase = conversationScope.observeConversationUnderLegalHoldNotified
+
+    @ViewModelScoped
+    @Provides
+    fun provideIsOneToOneConversationCreatedUseCase(conversationScope: ConversationScope): IsOneToOneConversationCreatedUseCase =
+        conversationScope.isOneToOneConversationCreatedUseCase
 }

--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
@@ -23,24 +23,34 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.di.hiltViewModelScoped
 import com.wire.android.model.ClickBlockParams
+import com.wire.android.ui.common.VisibilityState
+import com.wire.android.ui.common.WireDialog
+import com.wire.android.ui.common.WireDialogButtonProperties
+import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
+import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dialogs.UnblockUserDialogContent
 import com.wire.android.ui.common.dialogs.UnblockUserDialogState
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.snackbar.collectAndShowSnackbar
+import com.wire.android.ui.common.visbility.VisibilityState
 import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.theme.WireTheme
+import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
+import com.wire.android.util.ui.stringWithStyledArgs
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
@@ -49,7 +59,9 @@ import com.wire.kalium.logic.data.user.UserId
 fun ConnectionActionButton(
     userId: UserId,
     userName: String,
+    fullName: String,
     connectionStatus: ConnectionState,
+    isConversationStarted: Boolean,
     onConnectionRequestIgnored: (String) -> Unit = {},
     onOpenConversation: (ConversationId) -> Unit = {},
     viewModel: ConnectionActionButtonViewModel =
@@ -59,12 +71,15 @@ fun ConnectionActionButton(
 ) {
     LocalSnackbarHostState.current.collectAndShowSnackbar(snackbarFlow = viewModel.infoMessage)
     val unblockUserDialogState = rememberVisibilityState<UnblockUserDialogState>()
+    val unableStartConversationDialogState = rememberVisibilityState<UnableStartConversationDialogState>()
 
     UnblockUserDialogContent(
         dialogState = unblockUserDialogState,
         onUnblock = { viewModel.onUnblockUser() },
         isLoading = viewModel.actionableState().isPerformingAction,
     )
+
+    UnableStartConversationDialogContent(dialogState = unableStartConversationDialogState)
 
     if (!viewModel.actionableState().isPerformingAction) {
         unblockUserDialogState.dismiss()
@@ -79,9 +94,13 @@ fun ConnectionActionButton(
         )
 
         ConnectionState.ACCEPTED -> WirePrimaryButton(
-            text = stringResource(R.string.label_open_conversation),
+            text = stringResource(if (isConversationStarted) R.string.label_open_conversation else R.string.label_start_conversation),
             loading = viewModel.actionableState().isPerformingAction,
-            onClick = { viewModel.onOpenConversation(onOpenConversation) },
+            onClick = {
+                viewModel.onOpenConversation(onOpenConversation) {
+                    unableStartConversationDialogState.show(UnableStartConversationDialogState(fullName))
+                }
+            },
         )
 
         ConnectionState.IGNORED -> WirePrimaryButton(
@@ -168,13 +187,40 @@ fun ConnectionActionButton(
 }
 
 @Composable
+fun UnableStartConversationDialogContent(dialogState: VisibilityState<UnableStartConversationDialogState>) {
+    VisibilityState(dialogState) { state ->
+        WireDialog(
+            title = stringResource(id = R.string.missing_keypackage_dialog_title),
+            text = LocalContext.current.resources.stringWithStyledArgs(
+                R.string.missing_keypackage_dialog_body,
+                MaterialTheme.wireTypography.body01,
+                MaterialTheme.wireTypography.body02,
+                colorsScheme().onBackground,
+                colorsScheme().onBackground,
+                state.userName
+            ),
+            onDismiss = dialogState::dismiss,
+            optionButton1Properties = WireDialogButtonProperties(
+                onClick = dialogState::dismiss,
+                text = stringResource(id = R.string.label_ok),
+                type = WireDialogButtonType.Primary,
+            ),
+        )
+    }
+}
+
+data class UnableStartConversationDialogState(val userName: String)
+
+@Composable
 @PreviewMultipleThemes
 fun PreviewOtherUserConnectionActionButtonPending() {
     WireTheme {
         ConnectionActionButton(
             userId = UserId("value", "domain"),
             userName = "Username",
+            fullName = "some user",
             connectionStatus = ConnectionState.PENDING,
+            isConversationStarted = false
         )
     }
 }
@@ -186,7 +232,9 @@ fun PreviewOtherUserConnectionActionButtonNotConnected() {
         ConnectionActionButton(
             userId = UserId("value", "domain"),
             userName = "Username",
+            fullName = "some user",
             connectionStatus = ConnectionState.NOT_CONNECTED,
+            isConversationStarted = false
         )
     }
 }
@@ -198,7 +246,9 @@ fun PreviewOtherUserConnectionActionButtonBlocked() {
         ConnectionActionButton(
             userId = UserId("value", "domain"),
             userName = "Username",
+            fullName = "some user",
             connectionStatus = ConnectionState.BLOCKED,
+            isConversationStarted = false
         )
     }
 }
@@ -210,7 +260,9 @@ fun PreviewOtherUserConnectionActionButtonCanceled() {
         ConnectionActionButton(
             userId = UserId("value", "domain"),
             userName = "Username",
+            fullName = "some user",
             connectionStatus = ConnectionState.CANCELLED,
+            isConversationStarted = false
         )
     }
 }
@@ -222,7 +274,9 @@ fun PreviewOtherUserConnectionActionButtonAccepted() {
         ConnectionActionButton(
             userId = UserId("value", "domain"),
             userName = "Username",
+            fullName = "some user",
             connectionStatus = ConnectionState.ACCEPTED,
+            isConversationStarted = false
         )
     }
 }
@@ -234,7 +288,9 @@ fun PreviewOtherUserConnectionActionButtonSent() {
         ConnectionActionButton(
             userId = UserId("value", "domain"),
             userName = "Username",
+            fullName = "some user",
             connectionStatus = ConnectionState.SENT,
+            isConversationStarted = false
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
@@ -203,7 +203,7 @@ class ConnectionActionButtonViewModelImpl @Inject constructor(
                     if (result.coreFailure is CoreFailure.MissingKeyPackages) onMissingKeyPackages()
                 }
 
-                is CreateConversationResult.Success -> onMissingKeyPackages()//onSuccess(result.conversation.id)
+                is CreateConversationResult.Success -> onSuccess(result.conversation.id)
             }
             state.finishAction()
         }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -531,7 +531,9 @@ private fun ContentFooter(
                     ConnectionActionButton(
                         state.userId,
                         state.userName,
+                        state.fullName,
                         state.connectionState,
+                        state.isConversationStarted,
                         onIgnoreConnectionRequest,
                         onOpenConversation
                     )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -63,6 +63,7 @@ import com.wire.kalium.logic.feature.conversation.ArchiveStatusUpdateResult
 import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCase
 import com.wire.kalium.logic.feature.conversation.ConversationUpdateStatusResult
 import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationUseCase
+import com.wire.kalium.logic.feature.conversation.IsOneToOneConversationCreatedUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationArchivedStatusUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
@@ -107,6 +108,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     private val updateConversationArchivedStatus: UpdateConversationArchivedStatusUseCase,
     private val getUserE2eiCertificateStatus: GetUserE2eiCertificateStatusUseCase,
     private val getUserE2eiCertificates: GetUserE2eiCertificatesUseCase,
+    private val isOneToOneConversationCreated: IsOneToOneConversationCreatedUseCase,
     savedStateHandle: SavedStateHandle
 ) : ViewModel(), OtherUserProfileEventsHandler, OtherUserProfileBottomSheetEventsHandler {
 
@@ -134,6 +136,13 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         observeUserInfoAndUpdateViewState()
         persistClients()
         getMLSVerificationStatus()
+        getIfConversationExist()
+    }
+
+    private fun getIfConversationExist() {
+        viewModelScope.launch {
+            state = state.copy(isConversationStarted = isOneToOneConversationCreated(userId))
+        }
     }
 
     private fun getMLSVerificationStatus() {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -49,7 +49,8 @@ data class OtherUserProfileState(
     val otherUserDevices: List<Device> = listOf(),
     val blockingState: BlockingState = BlockingState.CAN_NOT_BE_BLOCKED,
     val isProteusVerified: Boolean = false,
-    val isMLSVerified: Boolean = false
+    val isMLSVerified: Boolean = false,
+    val isConversationStarted: Boolean = false
 ) {
     fun updateMuteStatus(status: MutedConversationStatus): OtherUserProfileState {
         return conversationSheetContent?.let {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -789,6 +789,7 @@
     <string name="animation_label_typing_indicator_horizontal_transition" translatable="false">HorizontalBouncingWritingPen transition</string>
     <string name="animation_label_button_rotation_degree_transition" translatable="false">Collapse button rotation degree transition</string>
     <string name="label_open_conversation">Open Conversation</string>
+    <string name="label_start_conversation">Start Conversation</string>
     <string name="email_label">Email</string>
     <string name="phone_label">Phone</string>
     <!-- Notifications -->
@@ -871,6 +872,9 @@
     <string name="connection_label_ignore">Ignore</string>
     <string name="connection_label_send_unverified_warning">Get certainty about the identity of %s\'s before connecting.</string>
     <string name="connection_label_received_unverified_warning">Please verify the person\'s identity before accepting the connection request.</string>
+    <!-- Missing keyPackages dialog -->
+    <string name="missing_keypackage_dialog_title">Unable to start conversation</string>
+    <string name="missing_keypackage_dialog_body">You can’t start the conversation with %1$s right now. %1$s needs to open Wire or log in again first. Please try again later.</string>
     <!-- Gallery -->
     <string name="media_gallery_default_title_name">Media Gallery</string>
     <string name="media_gallery_on_image_downloaded">Saved to Downloads folder</string>

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.ArchiveStatusUpdateResult
 import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCase
 import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationUseCase
+import com.wire.kalium.logic.feature.conversation.IsOneToOneConversationCreatedUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationArchivedStatusUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
@@ -112,6 +113,9 @@ internal class OtherUserProfileViewModelArrangement {
     @MockK
     lateinit var getUserE2eiCertificates: GetUserE2eiCertificatesUseCase
 
+    @MockK
+    lateinit var isOneToOneConversationCreated: IsOneToOneConversationCreatedUseCase
+
     private val viewModel by lazy {
         OtherUserProfileScreenViewModel(
             TestDispatcherProvider(),
@@ -131,6 +135,7 @@ internal class OtherUserProfileViewModelArrangement {
             updateConversationArchivedStatus,
             getUserE2eiCertificateStatus,
             getUserE2eiCertificates,
+            isOneToOneConversationCreated,
             savedStateHandle,
         )
     }
@@ -161,6 +166,7 @@ internal class OtherUserProfileViewModelArrangement {
         )
         coEvery { getUserE2eiCertificateStatus.invoke(any()) } returns GetUserE2eiCertificateStatusResult.Success(CertificateStatus.VALID)
         coEvery { getUserE2eiCertificates.invoke(any()) } returns mapOf()
+        coEvery { isOneToOneConversationCreated.invoke(any()) } returns true
     }
 
     suspend fun withBlockUserResult(result: BlockUserResult) = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6936" title="WPB-6936" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6936</a>  [Android] Handle 1:1 conversations when no key packages are available
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

1. when user try to start the MLS conversation with the user has no KeyPackages (not any device registered yet) then we need to show corresponding dialog informing user why conversation couldn't be started
2. when user open the profile of the user that has no 1o1 conversation yet, then the bottom button should say "Start conversation" instead of "open conversation"

### Solutions

implement it :) 

### Dependencies (Optional)

waiting for the kalium PR https://github.com/wireapp/kalium/pull/2713

### Attachments (Optional)


<img width="280" alt="Screenshot 2024-04-24 at 15 25 46" src="https://github.com/wireapp/wire-android/assets/6539347/d1fe3cda-bc96-4666-9167-821765e57886">
