### PR TITLE
fix: get identities only for newly emitted members [WPB-8753]

### DIFF
--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
@@ -27,16 +27,19 @@ import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.conversation.Conversation.Member
 import com.wire.kalium.logic.data.conversation.MemberDetails
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMembersE2EICertificateStatusesUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.Test
@@ -82,6 +85,99 @@ class ObserveParticipantsForConversationUseCaseTest {
             assert(data.allParticipantsCount == members.size)
         }
     }
+
+    @Test
+    fun givenGroup_whenVisibleMembersListChanges_thenGetE2EICertificateOnlyForNewOnes() = runTest {
+        // Given
+        val members: List<MemberDetails> = buildList {
+            for (i in 1..6) {
+                add(MemberDetails(testOtherUser(i).copy(userType = UserType.INTERNAL), Member.Role.Member))
+            }
+        }
+        val members1 = members.subList(0, 4)
+        val members2 = members.subList(4, 6)
+        val (arrangement, useCase) = ObserveParticipantsForConversationUseCaseArrangement()
+            .withConversationParticipantsUpdate(members1)
+            .arrange()
+        // When - Then
+        useCase(ConversationId("", "")).test {
+            val result1 = awaitItem()
+            assertEquals(result1.participants.size, members1.size)
+            assertEquals(result1.allParticipantsCount, members1.size)
+            // emit updated members list with new members that should also be visible because there is no limit set
+            arrangement.withConversationParticipantsUpdate(members1 + members2)
+            advanceUntilIdle()
+            val result2 = awaitItem()
+            assertEquals(result2.participants.size, members1.size + members2.size)
+            assertEquals(result2.allParticipantsCount, members1.size + members2.size)
+
+            // certificate statuses are fetched once for the initial visible members list
+            coVerify(exactly = 1) { arrangement.getMembersE2EICertificateStatuses(any(), eq(members1.map { it.user.id })) }
+            // and then second time only for newly emitted visible members
+            coVerify(exactly = 1) { arrangement.getMembersE2EICertificateStatuses(any(), eq(members2.map { it.user.id })) }
+        }
+    }
+
+    @Test
+    fun givenGroup_whenVisibleMembersDoesNotChange_thenDoNotGetE2EICertificateForNonVisibleMembers() = runTest {
+        // Given
+        val members: List<MemberDetails> = buildList {
+            for (i in 1..6) {
+                add(MemberDetails(testOtherUser(i).copy(userType = UserType.INTERNAL), Member.Role.Member))
+            }
+        }
+        val limit = 4
+        val members1 = members.subList(0, limit)
+        val members2 = members.subList(limit, limit + 2)
+        val (arrangement, useCase) = ObserveParticipantsForConversationUseCaseArrangement()
+            .withConversationParticipantsUpdate(members1)
+            .arrange()
+        // When - Then
+        useCase(ConversationId("", ""), limit = limit).test {
+            val result1 = awaitItem()
+            assertEquals(result1.participants.size, members1.size)
+            assertEquals(result1.allParticipantsCount, members1.size)
+            // emit updated members list with new members that should not be visible because there is no limit set
+            arrangement.withConversationParticipantsUpdate(members1 + members2)
+            advanceUntilIdle()
+            val result2 = awaitItem()
+            assertEquals(result2.participants.size, members1.size)
+            assertEquals(result2.allParticipantsCount, members1.size + members2.size)
+
+            // certificate statuses are fetched once for the initial visible members list
+            coVerify(exactly = 1) { arrangement.getMembersE2EICertificateStatuses(any(), eq(members1.map { it.user.id })) }
+            // and then newly emitted members are non-visible (because of the limit) and should not be fetched
+            coVerify(exactly = 0) { arrangement.getMembersE2EICertificateStatuses(any(), eq(members2.map { it.user.id })) }
+        }
+    }
+
+    @Test
+    fun givenGroup_whenVisibleMembersDoesNotChange_thenDoNotGetE2EICertificateAgainForTheSameList() = runTest {
+        // Given
+        val members: List<MemberDetails> = buildList {
+            for (i in 1..6) {
+                add(MemberDetails(testOtherUser(i).copy(userType = UserType.INTERNAL), Member.Role.Member))
+            }
+        }
+        val (arrangement, useCase) = ObserveParticipantsForConversationUseCaseArrangement()
+            .withConversationParticipantsUpdate(members)
+            .arrange()
+        // When - Then
+        useCase(ConversationId("", "")).test {
+            val result1 = awaitItem()
+            assertEquals(result1.participants.size, members.size)
+            assertEquals(result1.allParticipantsCount, members.size)
+            // emit the same members list again
+            arrangement.withConversationParticipantsUpdate(members)
+            advanceUntilIdle()
+            val result2 = awaitItem()
+            assertEquals(result2.participants.size, members.size)
+            assertEquals(result2.allParticipantsCount, members.size)
+
+            // executed only once for visible members list even if the same list was emitted twice
+            coVerify(exactly = 1) { arrangement.getMembersE2EICertificateStatuses(any(), eq(members.map { it.user.id })) }
+        }
+    }
 }
 
 internal class ObserveParticipantsForConversationUseCaseArrangement {
@@ -110,7 +206,7 @@ internal class ObserveParticipantsForConversationUseCaseArrangement {
         MockKAnnotations.init(this, relaxUnitFun = true)
         // Default empty values
         coEvery { observeConversationMembersUseCase(any()) } returns flowOf()
-        coEvery { getMembersE2EICertificateStatuses(any(), any()) } returns mapOf()
+        coEvery { getMembersE2EICertificateStatuses(any(), any()) } answers { secondArg<List<UserId>>().associateWith { null } }
     }
 
     suspend fun withConversationParticipantsUpdate(members: List<MemberDetails>): ObserveParticipantsForConversationUseCaseArrangement {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8753" title="WPB-8753" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8753</a>  [Android] Crash when going left menu from first time opened 1:1 conv
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

ANR when trying to get user or device identities.

### Solutions

To limit the amount of user identities fetched at a given time, keep the already fetched values using `scan` and only fetch user identities for newly emitted visible members.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/2718

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Navigate: group conversation -> details -> participants -> user profile -> 1:1 conversation -> back or conversation details

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
