### PR TITLE
fix: get identities only for newly emitted members [WPB-8753]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
@@ -72,8 +72,11 @@ class ObserveParticipantsForConversationUseCase @Inject constructor(
                 // only fetch certificate statuses for newly emitted users and get the rest from previous iterations
                 val newlyEmittedVisibleUserIds = visibleUserIds - previousMlsVerificationMap.keys
                 val mlsVerificationMap = previousMlsVerificationMap.plus(
-                    if (newlyEmittedVisibleUserIds.isEmpty()) emptyMap()
-                    else getMembersE2EICertificateStatuses(conversationId, newlyEmittedVisibleUserIds)
+                    if (newlyEmittedVisibleUserIds.isEmpty()) {
+                        emptyMap()
+                    } else {
+                        getMembersE2EICertificateStatuses(conversationId, newlyEmittedVisibleUserIds)
+                    }
                 )
                 val legalHoldList = membersHavingLegalHoldClientUseCase(conversationId).getOrElse(emptyList())
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
@@ -69,36 +69,27 @@ class ObserveParticipantsForConversationUseCase @Inject constructor(
                 val visibleUserIds = visibleParticipants.map { it.userId }
                     .plus(visibleAdminsWithoutServices.map { it.userId })
 
-<<<<<<< HEAD
-                val mlsVerificationMap = getMembersE2EICertificateStatuses(conversationId, visibleUserIds)
-                val legalHoldList = membersHavingLegalHoldClientUseCase(conversationId).getOrElse(emptyList())
-
-                fun List<MemberDetails>.toUIParticipants() = this.map {
-                    uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.userId], legalHoldList.contains(it.userId))
-                }
-                val selfUser = (allParticipants + allAdminsWithoutServices).firstOrNull { it.user is SelfUser }
-=======
                 // only fetch certificate statuses for newly emitted users and get the rest from previous iterations
                 val newlyEmittedVisibleUserIds = visibleUserIds - previousMlsVerificationMap.keys
                 val mlsVerificationMap = previousMlsVerificationMap.plus(
                     if (newlyEmittedVisibleUserIds.isEmpty()) emptyMap()
                     else getMembersE2EICertificateStatuses(conversationId, newlyEmittedVisibleUserIds)
                 )
->>>>>>> dcfe4f07f (fix: get identities only for newly emitted members [WPB-8753] (#2942))
+                val legalHoldList = membersHavingLegalHoldClientUseCase(conversationId).getOrElse(emptyList())
+
+                fun List<MemberDetails>.toUIParticipants() = this.map {
+                    uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.userId], legalHoldList.contains(it.userId))
+                }
+                val selfUser = (allParticipants + allAdminsWithoutServices).firstOrNull { it.user is SelfUser }
 
                 ConversationParticipantsData(
                     admins = visibleAdminsWithoutServices.toUIParticipants(),
                     participants = visibleParticipants.toUIParticipants(),
                     allAdminsCount = allAdminsWithoutServices.size,
                     allParticipantsCount = allParticipants.size,
-<<<<<<< HEAD
                     isSelfAnAdmin = allAdminsWithoutServices.any { it.user is SelfUser },
                     isSelfExternalMember = selfUser?.user?.userType == UserType.EXTERNAL,
-                )
-=======
-                    isSelfAnAdmin = allAdminsWithoutServices.any { it.user is SelfUser }
                 ) to mlsVerificationMap
->>>>>>> dcfe4f07f (fix: get identities only for newly emitted members [WPB-8753] (#2942))
             }
             .drop(1) // ignore the initial value from scan
             .map { (data, _) -> data }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
@@ -35,11 +35,13 @@ import com.wire.kalium.logic.feature.legalhold.MembersHavingLegalHoldClientUseCa
 import com.wire.kalium.logic.functional.Either
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.Test
@@ -87,6 +89,7 @@ class ObserveParticipantsForConversationUseCaseTest {
     }
 
     @Test
+<<<<<<< HEAD
     fun givenGroupMembersUnderLegalHold_whenSolvingTheParticipantsList_thenPassCorrectLegalHoldValues() = runTest {
         // Given
         val memberUnderLegalHold = MemberDetails(testOtherUser(0).copy(userType = UserType.INTERNAL), Member.Role.Member)
@@ -102,6 +105,97 @@ class ObserveParticipantsForConversationUseCaseTest {
                 val expected = participant.id == memberUnderLegalHold.user.id
                 assertEquals(expected, participant.isUnderLegalHold)
             }
+=======
+    fun givenGroup_whenVisibleMembersListChanges_thenGetE2EICertificateOnlyForNewOnes() = runTest {
+        // Given
+        val members: List<MemberDetails> = buildList {
+            for (i in 1..6) {
+                add(MemberDetails(testOtherUser(i).copy(userType = UserType.INTERNAL), Member.Role.Member))
+            }
+        }
+        val members1 = members.subList(0, 4)
+        val members2 = members.subList(4, 6)
+        val (arrangement, useCase) = ObserveParticipantsForConversationUseCaseArrangement()
+            .withConversationParticipantsUpdate(members1)
+            .arrange()
+        // When - Then
+        useCase(ConversationId("", "")).test {
+            val result1 = awaitItem()
+            assertEquals(result1.participants.size, members1.size)
+            assertEquals(result1.allParticipantsCount, members1.size)
+            // emit updated members list with new members that should also be visible because there is no limit set
+            arrangement.withConversationParticipantsUpdate(members1 + members2)
+            advanceUntilIdle()
+            val result2 = awaitItem()
+            assertEquals(result2.participants.size, members1.size + members2.size)
+            assertEquals(result2.allParticipantsCount, members1.size + members2.size)
+
+            // certificate statuses are fetched once for the initial visible members list
+            coVerify(exactly = 1) { arrangement.getMembersE2EICertificateStatuses(any(), eq(members1.map { it.user.id })) }
+            // and then second time only for newly emitted visible members
+            coVerify(exactly = 1) { arrangement.getMembersE2EICertificateStatuses(any(), eq(members2.map { it.user.id })) }
+        }
+    }
+
+    @Test
+    fun givenGroup_whenVisibleMembersDoesNotChange_thenDoNotGetE2EICertificateForNonVisibleMembers() = runTest {
+        // Given
+        val members: List<MemberDetails> = buildList {
+            for (i in 1..6) {
+                add(MemberDetails(testOtherUser(i).copy(userType = UserType.INTERNAL), Member.Role.Member))
+            }
+        }
+        val limit = 4
+        val members1 = members.subList(0, limit)
+        val members2 = members.subList(limit, limit + 2)
+        val (arrangement, useCase) = ObserveParticipantsForConversationUseCaseArrangement()
+            .withConversationParticipantsUpdate(members1)
+            .arrange()
+        // When - Then
+        useCase(ConversationId("", ""), limit = limit).test {
+            val result1 = awaitItem()
+            assertEquals(result1.participants.size, members1.size)
+            assertEquals(result1.allParticipantsCount, members1.size)
+            // emit updated members list with new members that should not be visible because there is no limit set
+            arrangement.withConversationParticipantsUpdate(members1 + members2)
+            advanceUntilIdle()
+            val result2 = awaitItem()
+            assertEquals(result2.participants.size, members1.size)
+            assertEquals(result2.allParticipantsCount, members1.size + members2.size)
+
+            // certificate statuses are fetched once for the initial visible members list
+            coVerify(exactly = 1) { arrangement.getMembersE2EICertificateStatuses(any(), eq(members1.map { it.user.id })) }
+            // and then newly emitted members are non-visible (because of the limit) and should not be fetched
+            coVerify(exactly = 0) { arrangement.getMembersE2EICertificateStatuses(any(), eq(members2.map { it.user.id })) }
+        }
+    }
+
+    @Test
+    fun givenGroup_whenVisibleMembersDoesNotChange_thenDoNotGetE2EICertificateAgainForTheSameList() = runTest {
+        // Given
+        val members: List<MemberDetails> = buildList {
+            for (i in 1..6) {
+                add(MemberDetails(testOtherUser(i).copy(userType = UserType.INTERNAL), Member.Role.Member))
+            }
+        }
+        val (arrangement, useCase) = ObserveParticipantsForConversationUseCaseArrangement()
+            .withConversationParticipantsUpdate(members)
+            .arrange()
+        // When - Then
+        useCase(ConversationId("", "")).test {
+            val result1 = awaitItem()
+            assertEquals(result1.participants.size, members.size)
+            assertEquals(result1.allParticipantsCount, members.size)
+            // emit the same members list again
+            arrangement.withConversationParticipantsUpdate(members)
+            advanceUntilIdle()
+            val result2 = awaitItem()
+            assertEquals(result2.participants.size, members.size)
+            assertEquals(result2.allParticipantsCount, members.size)
+
+            // executed only once for visible members list even if the same list was emitted twice
+            coVerify(exactly = 1) { arrangement.getMembersE2EICertificateStatuses(any(), eq(members.map { it.user.id })) }
+>>>>>>> dcfe4f07f (fix: get identities only for newly emitted members [WPB-8753] (#2942))
         }
     }
 }
@@ -136,8 +230,12 @@ internal class ObserveParticipantsForConversationUseCaseArrangement {
         MockKAnnotations.init(this, relaxUnitFun = true)
         // Default empty values
         coEvery { observeConversationMembersUseCase(any()) } returns flowOf()
+<<<<<<< HEAD
         coEvery { getMembersE2EICertificateStatuses(any(), any()) } returns mapOf()
         coEvery { membersHavingLegalHoldClientUseCase(any()) } returns Either.Right(emptyList())
+=======
+        coEvery { getMembersE2EICertificateStatuses(any(), any()) } answers { secondArg<List<UserId>>().associateWith { null } }
+>>>>>>> dcfe4f07f (fix: get identities only for newly emitted members [WPB-8753] (#2942))
     }
 
     suspend fun withConversationParticipantsUpdate(members: List<MemberDetails>): ObserveParticipantsForConversationUseCaseArrangement {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
@@ -89,7 +89,6 @@ class ObserveParticipantsForConversationUseCaseTest {
     }
 
     @Test
-<<<<<<< HEAD
     fun givenGroupMembersUnderLegalHold_whenSolvingTheParticipantsList_thenPassCorrectLegalHoldValues() = runTest {
         // Given
         val memberUnderLegalHold = MemberDetails(testOtherUser(0).copy(userType = UserType.INTERNAL), Member.Role.Member)
@@ -105,7 +104,10 @@ class ObserveParticipantsForConversationUseCaseTest {
                 val expected = participant.id == memberUnderLegalHold.user.id
                 assertEquals(expected, participant.isUnderLegalHold)
             }
-=======
+        }
+    }
+
+    @Test
     fun givenGroup_whenVisibleMembersListChanges_thenGetE2EICertificateOnlyForNewOnes() = runTest {
         // Given
         val members: List<MemberDetails> = buildList {
@@ -195,7 +197,6 @@ class ObserveParticipantsForConversationUseCaseTest {
 
             // executed only once for visible members list even if the same list was emitted twice
             coVerify(exactly = 1) { arrangement.getMembersE2EICertificateStatuses(any(), eq(members.map { it.user.id })) }
->>>>>>> dcfe4f07f (fix: get identities only for newly emitted members [WPB-8753] (#2942))
         }
     }
 }
@@ -230,12 +231,8 @@ internal class ObserveParticipantsForConversationUseCaseArrangement {
         MockKAnnotations.init(this, relaxUnitFun = true)
         // Default empty values
         coEvery { observeConversationMembersUseCase(any()) } returns flowOf()
-<<<<<<< HEAD
-        coEvery { getMembersE2EICertificateStatuses(any(), any()) } returns mapOf()
         coEvery { membersHavingLegalHoldClientUseCase(any()) } returns Either.Right(emptyList())
-=======
         coEvery { getMembersE2EICertificateStatuses(any(), any()) } answers { secondArg<List<UserId>>().associateWith { null } }
->>>>>>> dcfe4f07f (fix: get identities only for newly emitted members [WPB-8753] (#2942))
     }
 
     suspend fun withConversationParticipantsUpdate(members: List<MemberDetails>): ObserveParticipantsForConversationUseCaseArrangement {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8753" title="WPB-8753" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8753</a>  [Android] Crash when going left menu from first time opened 1:1 conv
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Cherry pick from the original PR: 
- #2942

---- 

 ⚠️ Conflicts during cherry-pick:
app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
kalium


<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like 
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

ANR when trying to get user or device identities.

### Solutions

To limit the amount of user identities fetched at a given time, keep the already fetched values using  and only fetch user identities for newly emitted visible members.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/2721

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Navigate: group conversation -> details -> participants -> user profile -> 1:1 conversation -> back or conversation details

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. .
