### PR TITLE
fix: text changes for the new group creation flow [WPB-1630]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -153,7 +154,8 @@ fun SelectParticipantsButtonsRow(
                 .padding(horizontal = dimensions().spacing16x)
                 .height(dimensions().groupButtonHeight),
         ) {
-            val buttonText = if (showTotalSelectedItemsCount) "$mainButtonText ($selectedParticipantsCount)" else mainButtonText
+            val countText = pluralStringResource(R.plurals.label_x_participants, selectedParticipantsCount, selectedParticipantsCount)
+            val buttonText = if (showTotalSelectedItemsCount) "$mainButtonText ($countText)" else mainButtonText
             WirePrimaryButton(
                 text = buttonText,
                 leadingIcon = leadingIcon,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
@@ -154,7 +154,11 @@ fun SelectParticipantsButtonsRow(
                 .padding(horizontal = dimensions().spacing16x)
                 .height(dimensions().groupButtonHeight),
         ) {
-            val countText = pluralStringResource(R.plurals.label_x_participants, selectedParticipantsCount, selectedParticipantsCount)
+            val countText = pluralStringResource(
+                R.plurals.label_x_participants,
+                selectedParticipantsCount,
+                selectedParticipantsCount
+            )
             val buttonText = if (showTotalSelectedItemsCount) "$mainButtonText ($countText)" else mainButtonText
             WirePrimaryButton(
                 text = buttonText,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/NewConversationSearchPeopleScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/NewConversationSearchPeopleScreen.kt
@@ -53,7 +53,7 @@ fun NewConversationSearchPeopleScreen(
         userSearchSignal = userSearchSignal,
         serviceSearchSignal = serviceSearchSignal,
         searchTitle = stringResource(id = R.string.label_new_conversation),
-        actionButtonTitle = stringResource(id = R.string.label_new_group),
+        actionButtonTitle = stringResource(id = R.string.label_create_new_group),
         onServicesSearchQueryChanged = searchBarViewModel::onServiceSearchQueryChanged,
         onUsersSearchQueryChanged = searchBarViewModel::onUserSearchQueryChanged,
         onOpenUserProfile = { contact ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -748,6 +748,11 @@
     <!-- Search Contact-->
     <string name="label_contacts">CONTACTS</string>
     <string name="label_new_group">New Group</string>
+    <string name="label_create_new_group">Create New Group</string>
+    <plurals name="label_x_participants">
+        <item quantity="one">%1$d Participant</item>
+        <item quantity="other">%1$d Participants</item>
+    </plurals>
     <string name="label_new_conversation">New Conversation</string>
     <string name="label_search_people">Search people</string>
     <string name="label_public_wire">PUBLIC WIRE</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1630" title="WPB-1630" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-1630</a>  Create new group conversation (new flow)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some texts on the new group creation flow are not updated according to the new designs for this flow.

### Solutions

Updated texts.

### Testing

#### How to Test

Create a new group.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/wireapp/wire-android/assets/30429749/236a2574-a000-4c82-b628-2f6b245dffde"/> | <video width="400" src="https://github.com/wireapp/wire-android/assets/30429749/e0cbb8b1-2934-4ebf-93e8-c8c7ceac6294"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
