### PR TITLE
fix: incoming call screen is not shown on second account

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
@@ -218,11 +218,11 @@ class CallNotificationBuilder @Inject constructor(
             .setAutoCancel(false)
             .setOngoing(true)
             .setVibrate(VIBRATE_PATTERN)
-            .setFullScreenIntent(fullScreenIncomingCallPendingIntent(context, conversationIdString), true)
+            .setFullScreenIntent(fullScreenIncomingCallPendingIntent(context, conversationIdString, userIdString), true)
             .addAction(getDeclineCallAction(context, conversationIdString, userIdString))
-            .addAction(getOpenIncomingCallAction(context, conversationIdString))
+            .addAction(getOpenIncomingCallAction(context, conversationIdString, userIdString))
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-            .setContentIntent(fullScreenIncomingCallPendingIntent(context, conversationIdString))
+            .setContentIntent(fullScreenIncomingCallPendingIntent(context, conversationIdString, userIdString))
             .build()
 
         // Added FLAG_INSISTENT so the ringing sound repeats itself until an action is done.

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationActions.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationActions.kt
@@ -49,9 +49,9 @@ fun getActionReply(
     }
 }
 
-fun getOpenIncomingCallAction(context: Context, conversationId: String) = getAction(
+fun getOpenIncomingCallAction(context: Context, conversationId: String, userId: String) = getAction(
     context.getString(R.string.notification_action_open_call),
-    fullScreenIncomingCallPendingIntent(context, conversationId)
+    fullScreenIncomingCallPendingIntent(context, conversationId, userId)
 )
 
 fun getDeclineCallAction(context: Context, conversationId: String, userId: String) = getAction(

--- a/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
@@ -128,8 +128,8 @@ fun outgoingCallPendingIntent(context: Context, conversationId: String): Pending
     )
 }
 
-fun fullScreenIncomingCallPendingIntent(context: Context, conversationId: String): PendingIntent {
-    val intent = getIncomingCallIntent(context, conversationId)
+fun fullScreenIncomingCallPendingIntent(context: Context, conversationId: String, userId: String): PendingIntent {
+    val intent = getIncomingCallIntent(context, conversationId, userId)
 
     return PendingIntent.getActivity(
         context,

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -219,7 +219,7 @@ class WireActivity : AppCompatActivity() {
                                 }
                             },
                             onReturnToIncomingCallClick = {
-                                getIncomingCallIntent(this@WireActivity, it.conversationId.toString()).run {
+                                getIncomingCallIntent(this@WireActivity, it.conversationId.toString(), null).run {
                                     startActivity(this)
                                 }
                             },

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
@@ -193,8 +193,9 @@ fun getOutgoingCallIntent(
     putExtra(CallActivity.EXTRA_SCREEN_TYPE, CallScreenType.Outgoing.name)
 }
 
-fun getIncomingCallIntent(context: Context, conversationId: String) =
+fun getIncomingCallIntent(context: Context, conversationId: String, userId: String?) =
     Intent(context.applicationContext, CallActivity::class.java).apply {
+        putExtra(CallActivity.EXTRA_USER_ID, userId)
         putExtra(CallActivity.EXTRA_CONVERSATION_ID, conversationId)
         putExtra(CallActivity.EXTRA_SCREEN_TYPE, CallScreenType.Incoming.name)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issue

The app does not show incoming call screen for the second account.

### Cause

Some changes from this PR https://github.com/wireapp/wire-android/pull/2929 were removed after resolving conflicts of this PR https://github.com/wireapp/wire-android/pull/2912

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
