### PR TITLE
fix(e2ei): download certificate name (WPB-8606)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -93,6 +93,7 @@ import com.wire.android.ui.legalhold.dialog.deactivated.LegalHoldDeactivatedView
 import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedDialog
 import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedState
 import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedViewModel
+import com.wire.android.ui.settings.devices.e2ei.E2EICertificateDetails
 import com.wire.android.ui.theme.ThemeOption
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.userprofile.self.dialog.LogoutOptionsDialog
@@ -388,7 +389,15 @@ class WireActivity : AppCompatActivity() {
                         result = e2EIResult,
                         updateCertificate = featureFlagNotificationViewModel::enrollE2EICertificate,
                         snoozeDialog = featureFlagNotificationViewModel::snoozeE2EIdRequiredDialog,
-                        openCertificateDetails = { navigate(NavigationCommand(E2eiCertificateDetailsScreenDestination(it))) },
+                        openCertificateDetails = {
+                            navigate(
+                                NavigationCommand(
+                                    E2eiCertificateDetailsScreenDestination(
+                                        E2EICertificateDetails.DuringLoginCertificateDetails(it)
+                                    )
+                                )
+                            )
+                        },
                         dismissSuccessDialog = featureFlagNotificationViewModel::dismissSuccessE2EIdDialog,
                         isE2EILoading = isE2EILoading
                     )

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
@@ -60,6 +60,7 @@ import com.wire.android.ui.destinations.InitialSyncScreenDestination
 import com.wire.android.ui.home.E2EIEnrollmentErrorWithDismissDialog
 import com.wire.android.ui.home.E2EISuccessDialog
 import com.wire.android.ui.markdown.MarkdownConstants
+import com.wire.android.ui.settings.devices.e2ei.E2EICertificateDetails
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
@@ -89,7 +90,15 @@ fun E2EIEnrollmentScreen(
         enrollE2EICertificate = viewModel::enrollE2EICertificate,
         handleE2EIEnrollmentResult = viewModel::handleE2EIEnrollmentResult,
         openCertificateDetails = {
-            navigator.navigate(NavigationCommand(E2eiCertificateDetailsScreenDestination(state.certificate)))
+            navigator.navigate(
+                NavigationCommand(
+                    E2eiCertificateDetailsScreenDestination(
+                        E2EICertificateDetails.DuringLoginCertificateDetails(
+                            state.certificate
+                        )
+                    )
+                )
+            )
         },
         onBackButtonClicked = viewModel::onBackButtonClicked,
         onCancelEnrollmentClicked = { viewModel.onCancelEnrollmentClicked(NavigationSwitchAccountActions(navigator::navigate)) },

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -78,6 +78,7 @@ import com.wire.android.ui.e2eiEnrollment.GetE2EICertificateUI
 import com.wire.android.ui.home.E2EISuccessDialog
 import com.wire.android.ui.home.E2EIUpdateErrorWithDismissDialog
 import com.wire.android.ui.home.conversationslist.common.FolderHeader
+import com.wire.android.ui.settings.devices.e2ei.E2EICertificateDetails
 import com.wire.android.ui.settings.devices.model.DeviceDetailsState
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -90,6 +91,7 @@ import com.wire.android.util.deviceDateTimeFormat
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
 import com.wire.kalium.logic.feature.e2ei.usecase.E2EIEnrollmentResult
 import com.wire.kalium.logic.functional.Either
 
@@ -117,7 +119,7 @@ fun DeviceDetailsScreen(
             handleE2EIEnrollmentResult = viewModel::handleE2EIEnrollmentResult,
             onNavigateToE2eiCertificateDetailsScreen = {
                 navigator.navigate(
-                    NavigationCommand(E2eiCertificateDetailsScreenDestination(it))
+                    NavigationCommand(E2eiCertificateDetailsScreenDestination(E2EICertificateDetails.AfterLoginCertificateDetails(it)))
                 )
             },
             onEnrollE2EIErrorDismiss = viewModel::hideEnrollE2EICertificateError,
@@ -131,7 +133,7 @@ fun DeviceDetailsContent(
     state: DeviceDetailsState,
     onDeleteDevice: () -> Unit = {},
     onNavigateBack: () -> Unit = {},
-    onNavigateToE2eiCertificateDetailsScreen: (String) -> Unit = {},
+    onNavigateToE2eiCertificateDetailsScreen: (E2eiCertificate) -> Unit = {},
     onPasswordChange: (TextFieldValue) -> Unit = {},
     onRemoveConfirm: () -> Unit = {},
     onDialogDismiss: () -> Unit = {},
@@ -192,7 +194,7 @@ fun DeviceDetailsContent(
                 }
             }
 
-            if (state.isE2EIEnabled) {
+            if (state.isE2EIEnabled && state.e2eiCertificate !=null) {
                 item {
                     EndToEndIdentityCertificateItem(
                         isE2eiCertificateActivated = state.isE2eiCertificateActivated,
@@ -286,9 +288,9 @@ fun DeviceDetailsContent(
             )
         }
 
-        if (state.isE2EICertificateEnrollSuccess) {
+        if (state.isE2EICertificateEnrollSuccess && state.e2eiCertificate !=null) {
             E2EISuccessDialog(
-                openCertificateDetails = { onNavigateToE2eiCertificateDetailsScreen(state.e2eiCertificate.certificateDetail) },
+                openCertificateDetails = { onNavigateToE2eiCertificateDetailsScreen(state.e2eiCertificate) },
                 dismissDialog = onEnrollE2EISuccessDismiss
             )
         }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -84,10 +84,10 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.deviceDateTimeFormat
 import com.wire.android.util.dialogErrorStrings
 import com.wire.android.util.extension.formatAsFingerPrint
 import com.wire.android.util.extension.formatAsString
-import com.wire.android.util.deviceDateTimeFormat
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -127,7 +127,7 @@ fun DeviceDetailsScreen(
         )
     }
 }
-
+@Suppress("ComplexMethod")
 @Composable
 fun DeviceDetailsContent(
     state: DeviceDetailsState,
@@ -194,7 +194,7 @@ fun DeviceDetailsContent(
                 }
             }
 
-            if (state.isE2EIEnabled && state.e2eiCertificate !=null) {
+            if (state.isE2EIEnabled && state.e2eiCertificate != null) {
                 item {
                     EndToEndIdentityCertificateItem(
                         isE2eiCertificateActivated = state.isE2eiCertificateActivated,
@@ -288,7 +288,7 @@ fun DeviceDetailsContent(
             )
         }
 
-        if (state.isE2EICertificateEnrollSuccess && state.e2eiCertificate !=null) {
+        if (state.isE2EICertificateEnrollSuccess && state.e2eiCertificate != null) {
             E2EISuccessDialog(
                 openCertificateDetails = { onNavigateToE2eiCertificateDetailsScreen(state.e2eiCertificate) },
                 dismissDialog = onEnrollE2EISuccessDismiss

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
@@ -51,7 +51,7 @@ fun EndToEndIdentityCertificateItem(
     isCurrentDevice: Boolean,
     isLoadingCertificate: Boolean,
     enrollE2eiCertificate: () -> Unit,
-    showCertificate: (String) -> Unit
+    showCertificate: (E2eiCertificate) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -124,7 +124,7 @@ fun EndToEndIdentityCertificateItem(
                     enabled = true,
                     isLoading = false,
                     onShowCertificateClicked = {
-                        showCertificate(certificate.certificateDetail)
+                        showCertificate(certificate)
                     }
                 )
             } else {
@@ -199,9 +199,11 @@ fun PreviewEndToEndIdentityCertificateItem() {
         isE2eiCertificateActivated = true,
         isCurrentDevice = false,
         certificate = E2eiCertificate(
+            userHandle = "userHandle",
             status = CertificateStatus.VALID,
             serialNumber = "e5:d5:e6:75:7e:04:86:07:14:3c:a0:ed:9a:8d:e4:fd",
             certificateDetail = "",
+            thumbprint = "thumbprint",
             endAt = Instant.DISTANT_FUTURE
         ),
         isLoadingCertificate = false,
@@ -217,9 +219,11 @@ fun PreviewEndToEndIdentityCertificateSelfItem() {
         isE2eiCertificateActivated = true,
         isCurrentDevice = true,
         certificate = E2eiCertificate(
+            userHandle = "userHandle",
             status = CertificateStatus.VALID,
             serialNumber = "e5:d5:e6:75:7e:04:86:07:14:3c:a0:ed:9a:8d:e4:fd",
             certificateDetail = "",
+            thumbprint = "thumbprint",
             endAt = Instant.DISTANT_FUTURE
         ),
         isLoadingCertificate = false,

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreenNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreenNavArgs.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.Serializable
 data class E2eiCertificateDetailsScreenNavArgs(val certificateDetails: E2EICertificateDetails)
 
 @Serializable
-sealed class E2EICertificateDetails() {
+sealed class E2EICertificateDetails {
     data class AfterLoginCertificateDetails(val certificate: E2eiCertificate) : E2EICertificateDetails()
     data class DuringLoginCertificateDetails(val certificate: String) : E2EICertificateDetails()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreenNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreenNavArgs.kt
@@ -17,6 +17,13 @@
  */
 package com.wire.android.ui.settings.devices.e2ei
 
-data class E2eiCertificateDetailsScreenNavArgs(
-    val certificateString: String
-)
+import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
+import kotlinx.serialization.Serializable
+
+data class E2eiCertificateDetailsScreenNavArgs(val certificateDetails: E2EICertificateDetails)
+
+@Serializable
+sealed class E2EICertificateDetails() {
+    data class AfterLoginCertificateDetails(val certificate: E2eiCertificate) : E2EICertificateDetails()
+    data class DuringLoginCertificateDetails(val certificate: String) : E2EICertificateDetails()
+}

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
@@ -42,7 +42,7 @@ class E2eiCertificateDetailsViewModel @Inject constructor(
     var state: E2eiCertificateDetailsState by mutableStateOf(E2eiCertificateDetailsState())
         private set
 
-    private val e2eiCertificateDetailsScreenNavArgs: E2eiCertificateDetailsScreenNavArgs =
+    private val navArgs: E2eiCertificateDetailsScreenNavArgs =
         savedStateHandle.navArgs()
 
     private var selfUserHandle: String? = null
@@ -57,11 +57,27 @@ class E2eiCertificateDetailsViewModel @Inject constructor(
         }
     }
 
-    fun getCertificate() = e2eiCertificateDetailsScreenNavArgs.certificateString
+    fun getCertificate() =
+        when (navArgs.certificateDetails) {
+            is E2EICertificateDetails.DuringLoginCertificateDetails ->
+                navArgs.certificateDetails.certificate
+
+            is E2EICertificateDetails.AfterLoginCertificateDetails ->
+                navArgs.certificateDetails.certificate.certificateDetail
+        }
+
+    fun userHandle() =
+        when (navArgs.certificateDetails) {
+            is E2EICertificateDetails.DuringLoginCertificateDetails ->
+                selfUserHandle
+
+            is E2EICertificateDetails.AfterLoginCertificateDetails ->
+                navArgs.certificateDetails.certificate.userHandle
+        }
 
     fun getCertificateName(): String {
         val date = DateTimeUtil.currentInstant().fileDateTime()
-        return "wire-certificate-$selfUserHandle-$date.txt"
+        return "wire-certificate-${userHandle()}-$date.txt"
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/DeviceDetailsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/DeviceDetailsState.kt
@@ -33,12 +33,7 @@ data class DeviceDetailsState(
     val isSelfClient: Boolean = false,
     val userName: String? = null,
     val isE2eiCertificateActivated: Boolean = false,
-    val e2eiCertificate: E2eiCertificate = E2eiCertificate(
-        status = CertificateStatus.EXPIRED,
-        serialNumber = "",
-        certificateDetail = "",
-        endAt = Instant.DISTANT_FUTURE
-    ),
+    val e2eiCertificate: E2eiCertificate? = null,
     val canBeRemoved: Boolean = false,
     val isLoadingCertificate: Boolean = false,
     val isE2EICertificateEnrollSuccess: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/DeviceDetailsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/DeviceDetailsState.kt
@@ -20,9 +20,7 @@ package com.wire.android.ui.settings.devices.model
 import com.wire.android.ui.authentication.devices.model.Device
 import com.wire.android.ui.authentication.devices.remove.RemoveDeviceDialogState
 import com.wire.android.ui.authentication.devices.remove.RemoveDeviceError
-import com.wire.kalium.logic.feature.e2ei.CertificateStatus
 import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
-import kotlinx.datetime.Instant
 
 data class DeviceDetailsState(
     val device: Device = Device(),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8606" title="WPB-8606" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8606</a>  [Android] When downloading another users certificate, saved file has wrong name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Set the userHandle exposed with E2EI as the certificate download file.
### Issues

Wrong userHandle was set, the current userHandle was set as the file name.

### Causes (Optional)

Miss implementation.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
