### PR TITLE
fix: Crash after fresh install

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -78,6 +78,7 @@ import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSo
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -117,8 +118,7 @@ class WireActivityViewModel @Inject constructor(
     private val observeScreenshotCensoringConfigUseCaseProviderFactory: ObserveScreenshotCensoringConfigUseCaseProvider.Factory,
     private val globalDataStore: GlobalDataStore,
     private val observeIfE2EIRequiredDuringLoginUseCaseProviderFactory: ObserveIfE2EIRequiredDuringLoginUseCaseProvider.Factory,
-    private val workManager: WorkManager,
-    private val observeEstablishedCalls: ObserveEstablishedCallsUseCase
+    private val workManager: WorkManager
 ) : ViewModel() {
 
     var globalAppState: GlobalAppState by mutableStateOf(GlobalAppState())
@@ -257,7 +257,14 @@ class WireActivityViewModel @Inject constructor(
         return intent?.action == Intent.ACTION_SEND || intent?.action == Intent.ACTION_SEND_MULTIPLE
     }
 
-    private suspend fun canLoginThroughDeepLinks() = observeEstablishedCalls().first().isEmpty()
+    private suspend fun canLoginThroughDeepLinks() = viewModelScope.async {
+        coreLogic.getGlobalScope().session.currentSession().takeIf {
+            it is CurrentSessionResult.Success
+        }?.let {
+            val currentUserId = (it as CurrentSessionResult.Success).accountInfo.userId
+            coreLogic.getSessionScope(currentUserId).calls.establishedCall().first().isEmpty()
+        } ?: true
+    }
 
     @Suppress("ComplexMethod")
     fun handleDeepLink(
@@ -276,7 +283,7 @@ class WireActivityViewModel @Inject constructor(
             val result = intent?.data?.let { deepLinkProcessor(it) }
             when {
                 result is DeepLinkResult.SSOLogin -> {
-                    if (canLoginThroughDeepLinks()) {
+                    if (canLoginThroughDeepLinks().await()) {
                         onResult(result)
                     } else {
                         onCannotLoginDuringACall()
@@ -284,7 +291,7 @@ class WireActivityViewModel @Inject constructor(
                 }
                 result is DeepLinkResult.MigrationLogin -> onResult(result)
                 result is DeepLinkResult.CustomServerConfig -> {
-                    if (canLoginThroughDeepLinks()) {
+                    if (canLoginThroughDeepLinks().await()) {
                         onCustomServerConfig(result)
                     } else {
                         onCannotLoginDuringACall()

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -19,6 +19,7 @@
 package com.wire.android.ui
 
 import android.content.Intent
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -60,7 +61,6 @@ import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.appVersioning.ObserveIfAppUpdateRequiredUseCase
-import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.client.ClearNewClientsForUserUseCase
 import com.wire.kalium.logic.feature.client.NewClientResult
 import com.wire.kalium.logic.feature.client.ObserveNewClientsUseCase
@@ -257,7 +257,8 @@ class WireActivityViewModel @Inject constructor(
         return intent?.action == Intent.ACTION_SEND || intent?.action == Intent.ACTION_SEND_MULTIPLE
     }
 
-    private suspend fun canLoginThroughDeepLinks() = viewModelScope.async {
+    @VisibleForTesting
+    internal suspend fun canLoginThroughDeepLinks() = viewModelScope.async {
         coreLogic.getGlobalScope().session.currentSession().takeIf {
             it is CurrentSessionResult.Success
         }?.let {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -207,7 +207,7 @@ class SharedCallingViewModel @AssistedInject constructor(
         if (callState.isCameraOn) {
             flipToFrontCamera(conversationId)
         }
-        if (callState.isCameraOn || callState.isSpeakerOn) {
+        if (callState.isSpeakerOn) {
             turnLoudSpeakerOff()
         }
     }

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -598,39 +598,44 @@ class WireActivityViewModelTest {
         advanceUntilIdle()
         assertEquals(ThemeOption.DARK, viewModel.globalAppState.themeOption)
     }
-    @Test
-    fun `given no active session, when canLoginThroughDeepLinks is called, then return true`() = runTest {
-        val (_, viewModel) = Arrangement()
-            .withNoCurrentSession()
-            .arrange()
-
-        val result = viewModel.canLoginThroughDeepLinks()
-
-        result.await() `should be equal to` true
-    }
 
     @Test
-    fun `given an established call, when canLoginThroughDeepLinks is called, then return false`() = runTest {
-        val (_, viewModel) = Arrangement()
-            .withSomeCurrentSession()
-            .withOngoingCall()
-            .arrange()
+    fun `given no active session, when canLoginThroughDeepLinks is called, then return true`() =
+        runTest {
+            val (_, viewModel) = Arrangement()
+                .withNoCurrentSession()
+                .arrange()
 
-        val result = viewModel.canLoginThroughDeepLinks()
+            val result = viewModel.canLoginThroughDeepLinks()
 
-        result.await() `should be equal to` false
-    }
+            result.await() `should be equal to` true
+        }
+
     @Test
-    fun `given no established call, when canLoginThroughDeepLinks is called, then return true`() = runTest {
-        val (_, viewModel) = Arrangement()
-            .withNoCurrentSession()
-            .withNoOngoingCall()
-            .arrange()
+    fun `given an established call, when canLoginThroughDeepLinks is called, then return false`() =
+        runTest {
+            val (_, viewModel) = Arrangement()
+                .withSomeCurrentSession()
+                .withOngoingCall()
+                .arrange()
 
-        val result = viewModel.canLoginThroughDeepLinks()
+            val result = viewModel.canLoginThroughDeepLinks()
 
-        result.await() `should be equal to` true
-    }
+            result.await() `should be equal to` false
+        }
+
+    @Test
+    fun `given no established call, when canLoginThroughDeepLinks is called, then return true`() =
+        runTest {
+            val (_, viewModel) = Arrangement()
+                .withNoCurrentSession()
+                .withNoOngoingCall()
+                .arrange()
+
+            val result = viewModel.canLoginThroughDeepLinks()
+
+            result.await() `should be equal to` true
+        }
 
     private class Arrangement {
 

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -598,6 +598,39 @@ class WireActivityViewModelTest {
         advanceUntilIdle()
         assertEquals(ThemeOption.DARK, viewModel.globalAppState.themeOption)
     }
+    @Test
+    fun `given no active session, when canLoginThroughDeepLinks is called, then return true`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withNoCurrentSession()
+            .arrange()
+
+        val result = viewModel.canLoginThroughDeepLinks()
+
+        result.await() `should be equal to` true
+    }
+
+    @Test
+    fun `given an established call, when canLoginThroughDeepLinks is called, then return false`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withSomeCurrentSession()
+            .withOngoingCall()
+            .arrange()
+
+        val result = viewModel.canLoginThroughDeepLinks()
+
+        result.await() `should be equal to` false
+    }
+    @Test
+    fun `given no established call, when canLoginThroughDeepLinks is called, then return true`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withNoCurrentSession()
+            .withNoOngoingCall()
+            .arrange()
+
+        val result = viewModel.canLoginThroughDeepLinks()
+
+        result.await() `should be equal to` true
+    }
 
     private class Arrangement {
 
@@ -722,8 +755,7 @@ class WireActivityViewModelTest {
                 observeScreenshotCensoringConfigUseCaseProviderFactory = observeScreenshotCensoringConfigUseCaseProviderFactory,
                 globalDataStore = globalDataStore,
                 observeIfE2EIRequiredDuringLoginUseCaseProviderFactory = observeIfE2EIRequiredDuringLoginUseCaseProviderFactory,
-                workManager = workManager,
-                observeEstablishedCalls = observeEstablishedCalls
+                workManager = workManager
             )
         }
 
@@ -746,10 +778,12 @@ class WireActivityViewModelTest {
         }
 
         fun withNoOngoingCall(): Arrangement {
+            coEvery { coreLogic.getSessionScope(any()).calls.establishedCall } returns observeEstablishedCalls
             coEvery { observeEstablishedCalls() } returns flowOf(emptyList())
             return this
         }
         fun withOngoingCall(): Arrangement {
+            coEvery { coreLogic.getSessionScope(any()).calls.establishedCall } returns observeEstablishedCalls
             coEvery { observeEstablishedCalls() } returns flowOf(listOf(ongoingCall))
             return this
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app is crashing after a fresh install

### Causes (Optional)

Caused by this PR https://github.com/wireapp/wire-android/pull/2954
We are injecting `ObserveEstablishedCallsUseCase` to `WireActivityViewModel` while there is no active session

### Solutions

Check if there is a session before invoking `ObserveEstablishedCallsUseCase`

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
