### PR TITLE
fix: keep the composed message when replying [WPB-982]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
@@ -109,7 +109,6 @@ class MessageComposerStateHolder(
     }
 
     fun toReply(message: UIMessage.Regular) {
-        messageCompositionHolder.clearMessage()
         messageCompositionHolder.setReply(message)
         messageCompositionInputStateHolder.toComposing()
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerStateHolderTest.kt
@@ -116,9 +116,7 @@ class MessageComposerStateHolderTest {
         runTest {
             // given
             // when
-            state.toReply(
-                message = mockMessageWithText
-            )
+            state.toReply(mockMessageWithText)
 
             // then
             assertEquals(
@@ -132,6 +130,22 @@ class MessageComposerStateHolderTest {
                     .value
             )
         }
+
+    @Test
+    fun `given some message was being composed, when setting toReply, then input continues with the current text`() = runTest {
+        // given
+        val currentTextField = TextFieldValue("Potato")
+        messageCompositionHolder.setMessageText(currentTextField, {}, {}, {})
+
+        // when
+        state.toReply(mockMessageWithText)
+
+        // then
+        assertEquals(
+            currentTextField.text,
+            messageCompositionHolder.messageComposition.value.messageTextFieldValue.text
+        )
+    }
 
     @Test
     fun `given state, when input focus change to false, then clear focus`() = runTest {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-982" title="WPB-982" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-982</a>  Swipe right to reply to a message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a user types something and then decides to reply to a message, the current text input is cleared and the user needs to type everything again.

This affects both swiping to reply and long-click on message -> reply.

### Solutions

When replying, do _not_ clear the text.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
