### PR TITLE
fix: divider thickness [WPB-3985]

### DIFF
--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/divider/WireDivider.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/divider/WireDivider.kt
@@ -18,14 +18,14 @@
 
 package com.wire.android.ui.common.divider
 
+import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
 import com.wire.android.ui.common.colorsScheme
 
 @Composable
 fun WireDivider(color: Color = colorsScheme().divider, modifier: Modifier = Modifier) {
-    HorizontalDivider(color = color, thickness = Dp.Hairline, modifier = modifier)
+    HorizontalDivider(color = color, thickness = DividerDefaults.Thickness, modifier = modifier)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3985" title="WPB-3985" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3985</a>  [Android] Divider lines are missing in conversation details / options view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixed default thickness for `WireDivider`

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->

| Before | After |
| ----------- | ------------ |
| ![divider_before](https://github.com/wireapp/wire-android/assets/13151239/4a6c53ae-6a9c-4556-8c62-cc91b54072f1)  | ![divider_after](https://github.com/wireapp/wire-android/assets/13151239/d6076240-2951-442e-9deb-66863ce880aa)  |




----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
