### PR TITLE
fix: call dropped when turning camera on (WPB-9013)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -169,39 +169,19 @@ fun OngoingCallScreen(
         hideDialog = permissionPermanentlyDeniedDialogState::dismiss
     )
 
-    handleVideoPreviewOnLifecycleChange(
-        isCameraOn = sharedCallingViewModel.callState.isCameraOn,
-        callStatus = sharedCallingViewModel.callState.callStatus,
-        startSendingVideoFeed = ongoingCallViewModel::startSendingVideoFeed,
-        pauseSendingVideoFeed = ongoingCallViewModel::pauseSendingVideoFeed,
-        onClearVideoPreview = sharedCallingViewModel::clearVideoPreview
-    )
-}
-
-/**
- * This function is responsible for handling the lifecycle changes of the video preview.
- * It will pause the video feed when the lifecycle is paused and resume it when the lifecycle is resumed.
- */
-@Composable
-private fun handleVideoPreviewOnLifecycleChange(
-    isCameraOn: Boolean,
-    callStatus: CallStatus,
-    startSendingVideoFeed: () -> Unit,
-    pauseSendingVideoFeed: () -> Unit,
-    onClearVideoPreview: () -> Unit
-) {
+    // Pause the video feed when the lifecycle is paused and resume it when the lifecycle is resumed.
     val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner, isCameraOn, callStatus) {
+    DisposableEffect(lifecycleOwner) {
 
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_PAUSE && callStatus == CallStatus.ESTABLISHED && isCameraOn) {
-                pauseSendingVideoFeed()
+            if (event == Lifecycle.Event.ON_PAUSE && sharedCallingViewModel.callState.callStatus == CallStatus.ESTABLISHED && sharedCallingViewModel.callState.isCameraOn) {
+                ongoingCallViewModel.pauseSendingVideoFeed()
             }
-            if (event == Lifecycle.Event.ON_RESUME && callStatus == CallStatus.ESTABLISHED && isCameraOn) {
-                startSendingVideoFeed()
+            if (event == Lifecycle.Event.ON_RESUME && sharedCallingViewModel.callState.callStatus == CallStatus.ESTABLISHED && sharedCallingViewModel.callState.isCameraOn) {
+                ongoingCallViewModel.startSendingVideoFeed()
             }
             if (event == Lifecycle.Event.ON_DESTROY) {
-                onClearVideoPreview()
+                sharedCallingViewModel.clearVideoPreview()
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -174,10 +174,16 @@ fun OngoingCallScreen(
     DisposableEffect(lifecycleOwner) {
 
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_PAUSE && sharedCallingViewModel.callState.callStatus == CallStatus.ESTABLISHED && sharedCallingViewModel.callState.isCameraOn) {
+            if (event == Lifecycle.Event.ON_PAUSE &&
+                sharedCallingViewModel.callState.callStatus == CallStatus.ESTABLISHED &&
+                sharedCallingViewModel.callState.isCameraOn
+            ) {
                 ongoingCallViewModel.pauseSendingVideoFeed()
             }
-            if (event == Lifecycle.Event.ON_RESUME && sharedCallingViewModel.callState.callStatus == CallStatus.ESTABLISHED && sharedCallingViewModel.callState.isCameraOn) {
+            if (event == Lifecycle.Event.ON_RESUME &&
+                sharedCallingViewModel.callState.callStatus == CallStatus.ESTABLISHED &&
+                sharedCallingViewModel.callState.isCameraOn
+            ) {
                 ongoingCallViewModel.startSendingVideoFeed()
             }
             if (event == Lifecycle.Event.ON_DESTROY) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9013" title="WPB-9013" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9013</a>  [Android] No audio received/sent until i minize and maximize the call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- No audio received/sent until i minimise and maximize the call
- Remote can see my video only after minimising and maximising the call
- I can see remote videos only after minimising and maximising the call

### Causes (Optional)

When the user tries to turn the camera on, the call drops and this is because we are calling wcall_set_video_send_state() twice:
The Lifecycle Event Observer does not trigger when we lifecycle state is changed, but only trigger when the camera is changed or callStatus is changed

### Solutions

Move LifecycleEventObserver part to the parent composable

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
