### PR TITLE
fix: No red shields visible on devices list from other users [WPB-8677]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
@@ -50,7 +50,6 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.LinkText
 import com.wire.android.util.ui.LinkTextData
-import com.wire.kalium.logic.feature.e2ei.CertificateStatus
 
 @Composable
 fun OtherUserDevicesScreen(
@@ -124,7 +123,7 @@ private fun OtherUserDevicesContent(
                     onClickAction = onDeviceClick,
                     icon = Icons.Filled.ChevronRight.Icon(),
                     shouldShowVerifyLabel = true,
-                    shouldShowE2EIInfo = item.e2eiCertificateStatus == CertificateStatus.VALID
+                    shouldShowE2EIInfo = item.e2eiCertificateStatus != null
                 )
                 if (index < otherUserDevices.lastIndex) WireDivider()
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8677" title="WPB-8677" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8677</a>  [Android] No red shields visible on devices list from other users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

Icons for "Revoked" and "Expired" E2EI certificates are not displayed in DevicesList in OtherUserProfile screen

### Causes (Optional)

Were hidden (misunderstanding with designs)

### Solutions

Show them when needed
