### PR TITLE
fix: heavy sketch file

### DIFF
--- a/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingCanvasViewModel.kt
+++ b/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingCanvasViewModel.kt
@@ -157,7 +157,7 @@ class DrawingCanvasViewModel : ViewModel() {
                         Bitmap.Config.ARGB_8888
                     )
                     val canvas = Canvas(bitmap).apply { drawPaint(Paint().apply { color = Color.White.toArgb() }) }
-                    context.contentResolver.openFileDescriptor(tempSketchFile, "rw")?.use { fileDescriptor ->
+                    context.contentResolver.openFileDescriptor(tempSketchFile, "rwt")?.use { fileDescriptor ->
                         FileOutputStream(fileDescriptor.fileDescriptor).use { fileOutputStream ->
                             paths.forEach { path -> path.drawNative(canvas) }
                             bitmap.compress(Bitmap.CompressFormat.JPEG, QUALITY, fileOutputStream)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sketch can take up even a multiple megabytes, but shouldn't.

### Causes (Optional)

We have a single file `image_attachment` for keeping all temporary images that are about to be uploaded and sent.
When we take a photo, this file is cleared completely but when we create a sketch, we write to that file but not clear it first. This makes it so that the file's metadata can still have the size of the previous sent image, for instance photo that user took to send.

### Solutions

Use `rwt` mode instead of `rw` when opening file descriptor to write sketch paths to this temporary file, this way it will be truncated before creating a new sketch.

### Testing

#### How to Test

Take a big photo to send and then send a sketch - check how big is this sketch file.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
