### PR TITLE
chore: file access crashes [WPB-7368]

### DIFF
--- a/app/src/beta/kotlin/com/wire/android/ExternalLoggerManager.kt
+++ b/app/src/beta/kotlin/com/wire/android/ExternalLoggerManager.kt
@@ -29,6 +29,7 @@ import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.rum.tracking.ComponentPredicate
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.ui.WireActivity
+import com.wire.android.util.DeviceUtil
 import com.wire.android.util.getDeviceIdString
 import com.wire.android.util.getGitBuildId
 import com.wire.android.util.sha256
@@ -72,10 +73,15 @@ object ExternalLoggerManager {
             .useSite(DatadogSite.EU1)
             .build()
 
+        val availableMemorySize = DeviceUtil.getAvailableInternalMemorySize()
+        val totalMemorySize = DeviceUtil.getTotalInternalMemorySize()
+        val deviceParams = mapOf("available_memory_size" to availableMemorySize, "total_memory_size" to totalMemorySize)
+
         val credentials = Credentials(clientToken, environmentName, appVariantName, applicationId)
         val extraInfo = mapOf(
             "encrypted_proteus_storage_enabled" to runBlocking { globalDataStore.isEncryptedProteusStorageEnabled().first() },
-            "git_commit_hash" to context.getGitBuildId()
+            "git_commit_hash" to context.getGitBuildId(),
+            "device_params" to deviceParams
         )
 
         Datadog.initialize(context, credentials, configuration, TrackingConsent.GRANTED)

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
@@ -137,6 +137,7 @@ class AvatarPickerViewModel @Inject constructor(
                     }
                 }
             } catch (e: FileNotFoundException) {
+                appLogger.e("[AvatarPickerViewModel] Could not find a file", e)
                 showInfoMessage(InfoMessageType.ImageProcessError)
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
@@ -49,6 +49,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import okio.Path
+import java.io.FileNotFoundException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -113,24 +114,30 @@ class AvatarPickerViewModel @Inject constructor(
             pictureState = PictureState.Uploading(imgUri)
 
             val avatarPath = defaultAvatarPath
-            val imageDataSize = imgUri.toByteArray(appContext, dispatchers).size.toLong()
-            when (val result = uploadUserAvatar(avatarPath, imageDataSize)) {
-                is UploadAvatarResult.Success -> {
-                    dataStore.updateUserAvatarAssetId(result.userAssetId.toString())
-                    onComplete(dataStore.avatarAssetId.first())
-                }
-                is UploadAvatarResult.Failure -> {
-                    when (result.coreFailure) {
-                        is NetworkFailure.NoNetworkConnection -> showInfoMessage(InfoMessageType.NoNetworkError)
-                        else -> showInfoMessage(InfoMessageType.UploadAvatarError)
+            try {
+                val imageDataSize = imgUri.toByteArray(appContext, dispatchers).size.toLong()
+
+                when (val result = uploadUserAvatar(avatarPath, imageDataSize)) {
+                    is UploadAvatarResult.Success -> {
+                        dataStore.updateUserAvatarAssetId(result.userAssetId.toString())
+                        onComplete(dataStore.avatarAssetId.first())
                     }
-                    with(initialPictureLoadingState) {
-                        pictureState = when (this) {
-                            is InitialPictureLoadingState.Loaded -> PictureState.Initial(avatarUri)
-                            else -> PictureState.Empty
+
+                    is UploadAvatarResult.Failure -> {
+                        when (result.coreFailure) {
+                            is NetworkFailure.NoNetworkConnection -> showInfoMessage(InfoMessageType.NoNetworkError)
+                            else -> showInfoMessage(InfoMessageType.UploadAvatarError)
+                        }
+                        with(initialPictureLoadingState) {
+                            pictureState = when (this) {
+                                is InitialPictureLoadingState.Loaded -> PictureState.Initial(avatarUri)
+                                else -> PictureState.Empty
+                            }
                         }
                     }
                 }
+            } catch (e: FileNotFoundException) {
+                showInfoMessage(InfoMessageType.ImageProcessError)
             }
         }
     }
@@ -157,5 +164,6 @@ class AvatarPickerViewModel @Inject constructor(
     sealed class InfoMessageType(override val uiText: UIText) : SnackBarMessage {
         data object UploadAvatarError : InfoMessageType(UIText.StringResource(R.string.error_uploading_user_avatar))
         data object NoNetworkError : InfoMessageType(UIText.StringResource(R.string.error_no_network_message))
+        data object ImageProcessError : InfoMessageType(UIText.StringResource(R.string.error_process_user_avatar))
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/DeviceUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/DeviceUtil.kt
@@ -20,55 +20,58 @@ package com.wire.android.util
 import android.os.Environment
 import android.os.StatFs
 
-class DeviceUtil {
-    companion object {
-        fun getAvailableInternalMemorySize(): String {
-            return try {
-                val path = Environment.getDataDirectory()
-                val stat = StatFs(path.path)
-                val blockSize = stat.blockSizeLong
-                val availableBlocks = stat.availableBlocksLong
-                formatSize(availableBlocks * blockSize)
-            } catch (e: IllegalArgumentException) {
-                ""
-            }
-        }
+object DeviceUtil {
+    private const val BYTES_IN_KILOBYTE = 1024
+    private const val BYTES_IN_MEGABYTE = BYTES_IN_KILOBYTE * 1024
+    private const val BYTES_IN_GIGABYTE = BYTES_IN_MEGABYTE * 1024
+    private const val DIGITS_GROUP_SIZE = 3  // Number of digits between commas in formatted size.
 
-        fun getTotalInternalMemorySize(): String {
-            return try {
-                val path = Environment.getDataDirectory()
-                val stat = StatFs(path.path)
-                val blockSize = stat.blockSizeLong
-                val totalBlocks = stat.blockCountLong
-                formatSize(totalBlocks * blockSize)
-            } catch (e: IllegalArgumentException) {
-                ""
-            }
-        }
+    fun getAvailableInternalMemorySize(): String = try {
+        val path = Environment.getDataDirectory()
+        val stat = StatFs(path.path)
+        val blockSize = stat.blockSizeLong
+        val availableBlocks = stat.availableBlocksLong
+        formatSize(availableBlocks * blockSize)
+    } catch (e: IllegalArgumentException) {
+        ""
+    }
 
-        private fun formatSize(sizeInBytes: Long): String {
-            var size = sizeInBytes
-            var suffix: String? = null
-            if (size >= 1024) {
+    fun getTotalInternalMemorySize(): String = try {
+        val path = Environment.getDataDirectory()
+        val stat = StatFs(path.path)
+        val blockSize = stat.blockSizeLong
+        val totalBlocks = stat.blockCountLong
+        formatSize(totalBlocks * blockSize)
+    } catch (e: IllegalArgumentException) {
+        ""
+    }
+
+    private fun formatSize(sizeInBytes: Long): String {
+        var size = sizeInBytes
+        var suffix: String? = null
+        when {
+            size >= BYTES_IN_GIGABYTE -> {
+                suffix = "GB"
+                size /= BYTES_IN_GIGABYTE
+            }
+
+            size >= BYTES_IN_MEGABYTE -> {
+                suffix = "MB"
+                size /= BYTES_IN_MEGABYTE
+            }
+
+            size >= BYTES_IN_KILOBYTE -> {
                 suffix = "KB"
-                size /= 1024
-                if (size >= 1024) {
-                    suffix = "MB"
-                    size /= 1024
-                    if (size >= 1024) {
-                        suffix = "GB"
-                        size /= 1024
-                    }
-                }
+                size /= BYTES_IN_KILOBYTE
             }
-            val resultBuffer = StringBuilder(size.toString())
-            var commaOffset = resultBuffer.length - 3
-            while (commaOffset > 0) {
-                resultBuffer.insert(commaOffset, ',')
-                commaOffset -= 3
-            }
-            if (suffix != null) resultBuffer.append(suffix)
-            return resultBuffer.toString()
         }
+        val resultBuffer = StringBuilder(size.toString())
+        var commaOffset = resultBuffer.length - DIGITS_GROUP_SIZE
+        while (commaOffset > 0) {
+            resultBuffer.insert(commaOffset, ',')
+            commaOffset -= DIGITS_GROUP_SIZE
+        }
+        suffix?.let { resultBuffer.append(it) }
+        return resultBuffer.toString()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/DeviceUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/DeviceUtil.kt
@@ -24,7 +24,7 @@ object DeviceUtil {
     private const val BYTES_IN_KILOBYTE = 1024
     private const val BYTES_IN_MEGABYTE = BYTES_IN_KILOBYTE * 1024
     private const val BYTES_IN_GIGABYTE = BYTES_IN_MEGABYTE * 1024
-    private const val DIGITS_GROUP_SIZE = 3  // Number of digits between commas in formatted size.
+    private const val DIGITS_GROUP_SIZE = 3 // Number of digits between commas in formatted size.
 
     fun getAvailableInternalMemorySize(): String = try {
         val path = Environment.getDataDirectory()

--- a/app/src/main/kotlin/com/wire/android/util/DeviceUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/DeviceUtil.kt
@@ -1,0 +1,74 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import android.os.Environment
+import android.os.StatFs
+
+class DeviceUtil {
+    companion object {
+        fun getAvailableInternalMemorySize(): String {
+            return try {
+                val path = Environment.getDataDirectory()
+                val stat = StatFs(path.path)
+                val blockSize = stat.blockSizeLong
+                val availableBlocks = stat.availableBlocksLong
+                formatSize(availableBlocks * blockSize)
+            } catch (e: IllegalArgumentException) {
+                ""
+            }
+        }
+
+        fun getTotalInternalMemorySize(): String {
+            return try {
+                val path = Environment.getDataDirectory()
+                val stat = StatFs(path.path)
+                val blockSize = stat.blockSizeLong
+                val totalBlocks = stat.blockCountLong
+                formatSize(totalBlocks * blockSize)
+            } catch (e: IllegalArgumentException) {
+                ""
+            }
+        }
+
+        private fun formatSize(sizeInBytes: Long): String {
+            var size = sizeInBytes
+            var suffix: String? = null
+            if (size >= 1024) {
+                suffix = "KB"
+                size /= 1024
+                if (size >= 1024) {
+                    suffix = "MB"
+                    size /= 1024
+                    if (size >= 1024) {
+                        suffix = "GB"
+                        size /= 1024
+                    }
+                }
+            }
+            val resultBuffer = StringBuilder(size.toString())
+            var commaOffset = resultBuffer.length - 3
+            while (commaOffset > 0) {
+                resultBuffer.insert(commaOffset, ',')
+                commaOffset -= 3
+            }
+            if (suffix != null) resultBuffer.append(suffix)
+            return resultBuffer.toString()
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -774,6 +774,7 @@
     <string name="error_no_network_message">Please check your Internet connection and try again</string>
     <string name="error_downloading_self_user_profile_picture">There was an error downloading your profile picture. Please check your Internet connection</string>
     <string name="error_uploading_user_avatar">Picture could not be uploaded</string>
+    <string name="error_process_user_avatar">Picture could not be processed</string>
     <string name="error_uploading_image_message">Image upload failed</string>
     <string name="error_downloading_image_message">Image download failed</string>
     <string name="error_updating_muting_setting">Notifications could not be updated</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7368" title="WPB-7368" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7368</a>  [Android] Playstore crash - Resample Image and File handling
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- added information about about available space and total device space to datadog
- added snackbar message when access to file on avatar upload fails
- added more logs when resampling images
- code cleanup