### PR TITLE
fix: Websocket toggle always off [WBP-8669]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -79,7 +79,7 @@ fun NetworkSettingsScreenContent(
             val isWebSocketEnforcedByDefault = remember {
                 isWebsocketEnabledByDefault(appContext)
             }
-            val switchState = remember {
+            val switchState = remember(isWebSocketEnabled) {
                 if (isWebSocketEnforcedByDefault) {
                     SwitchState.TextOnly(true)
                 } else {


### PR DESCRIPTION
# What's new in this PR?

### Issues

In NetworkSetting screen: toggle of Persistent Websocket connection is always off, even when Persistent  Connection is on.

### Causes (Optional)

The state of toggle is remembered and is not re-composed after state changing.

### Solutions

Fix it

