### PR TITLE
fix(e2ei): crash on downloading certificates  (WPB-9097)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreenNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreenNavArgs.kt
@@ -18,6 +18,7 @@
 package com.wire.android.ui.settings.devices.e2ei
 
 import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 data class E2eiCertificateDetailsScreenNavArgs(val certificateDetails: E2EICertificateDetails)
@@ -25,7 +26,7 @@ data class E2eiCertificateDetailsScreenNavArgs(val certificateDetails: E2EICerti
 @Serializable
 sealed class E2EICertificateDetails {
     @Serializable
-    data class AfterLoginCertificateDetails(val certificate: E2eiCertificate) : E2EICertificateDetails()
+    data class AfterLoginCertificateDetails(@SerialName("certificate") val certificate: E2eiCertificate) : E2EICertificateDetails()
     @Serializable
-    data class DuringLoginCertificateDetails(val certificate: String) : E2EICertificateDetails()
+    data class DuringLoginCertificateDetails(@SerialName("certificate") val certificate: String) : E2EICertificateDetails()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreenNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreenNavArgs.kt
@@ -24,6 +24,8 @@ data class E2eiCertificateDetailsScreenNavArgs(val certificateDetails: E2EICerti
 
 @Serializable
 sealed class E2EICertificateDetails {
+    @Serializable
     data class AfterLoginCertificateDetails(val certificate: E2eiCertificate) : E2EICertificateDetails()
+    @Serializable
     data class DuringLoginCertificateDetails(val certificate: String) : E2EICertificateDetails()
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9097" title="WPB-9097" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9097</a>  [Android] App crashing when viewing own or another users certificate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Adding serialisation annotation to serialisable classes.
### Issues

Was missing for android navigation arguments.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
