### PR TITLE
feat: add privacy policy (WPB-8846)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
@@ -57,6 +57,16 @@ object SupportScreenDestination : ExternalUriDirection {
         get() = Uri.parse(BuildConfig.URL_SUPPORT)
 }
 
+object PrivacyPolicyScreenDestination : ExternalUriStringResDirection {
+    override val uriStringRes: Int
+        get() = R.string.url_privacy_policy
+}
+
+object TermsOfUseScreenDestination : ExternalUriStringResDirection {
+    override val uriStringRes: Int
+        get() = R.string.url_terms_of_use
+}
+
 object GiveFeedbackDestination : IntentDirection {
     override fun intent(context: Context): Intent {
         val intent = Intent(Intent.ACTION_SEND)

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
@@ -33,11 +33,14 @@ import com.ramcosta.composedestinations.spec.Direction
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.navigation.GiveFeedbackDestination
+import com.wire.android.navigation.PrivacyPolicyScreenDestination
 import com.wire.android.navigation.ReportBugDestination
 import com.wire.android.navigation.SupportScreenDestination
+import com.wire.android.navigation.TermsOfUseScreenDestination
 import com.wire.android.ui.common.RowItemTemplate
 import com.wire.android.ui.common.clickable
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.destinations.AboutThisAppScreenDestination
 import com.wire.android.ui.destinations.AppSettingsScreenDestination
 import com.wire.android.ui.destinations.AppearanceScreenDestination
 import com.wire.android.ui.destinations.BackupAndRestoreScreenDestination
@@ -147,6 +150,18 @@ sealed class SettingsItem(open val id: String, open val title: UIText) {
         direction = PrivacySettingsConfigScreenDestination
     )
 
+    data object TermsOfUse : DirectionItem(
+        id = "terms_of_use",
+        title = UIText.StringResource(R.string.settings_terms_of_use_label),
+        direction = TermsOfUseScreenDestination
+    )
+
+    data object PrivacyPolicy : DirectionItem(
+        id = "privacy_policy",
+        title = UIText.StringResource(R.string.settings_privacy_policy_label),
+        direction = PrivacyPolicyScreenDestination
+    )
+
     data object Licenses : DirectionItem(
         id = "other_licenses",
         title = UIText.StringResource(R.string.settings_licenses_settings_label),
@@ -187,6 +202,12 @@ sealed class SettingsItem(open val id: String, open val title: UIText) {
         switchState = switchState,
         id = "app_lock",
         title = UIText.StringResource(R.string.settings_app_lock_title),
+    )
+
+    data object AboutApp : DirectionItem(
+        id = "about_app",
+        title = UIText.StringResource(R.string.about_app_screen_title),
+        direction = AboutThisAppScreenDestination
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
@@ -144,9 +144,9 @@ fun SettingsScreenContent(
                     if (BuildConfig.DEBUG_SCREEN_ENABLED) {
                         add(SettingsItem.DebugSettings)
                     }
-                    add(SettingsItem.Licenses)
                     add(SettingsItem.GiveFeedback)
                     add(SettingsItem.ReportBug)
+                    add(SettingsItem.AboutApp)
                 },
 
                 onItemClicked = onItemClicked

--- a/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppScreen.kt
@@ -1,0 +1,185 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.settings.about
+
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.annotation.RootNavGraph
+import com.wire.android.BuildConfig
+import com.wire.android.R
+import com.wire.android.model.Clickable
+import com.wire.android.navigation.NavigationCommand
+import com.wire.android.navigation.Navigator
+import com.wire.android.navigation.handleNavigation
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.scaffold.WireScaffold
+import com.wire.android.ui.common.topappbar.NavigationIconType
+import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.home.settings.SettingsItem
+
+@RootNavGraph
+@Destination
+@Composable
+fun AboutThisAppScreen(
+    viewModel: AboutThisAppViewModel = hiltViewModel(),
+    navigator: Navigator
+) {
+    val context = LocalContext.current
+    AboutThisAppContent(
+        state = viewModel.state,
+        onBackPressed = navigator::navigateBack,
+        onItemClicked = remember {
+            {
+                it.direction.handleNavigation(
+                    context = context,
+                    handleOtherDirection = { navigator.navigate(NavigationCommand(it)) }
+                )
+            }
+        }
+    )
+}
+
+@Composable
+private fun AboutThisAppContent(
+    state: AboutThisAppState,
+    onBackPressed: () -> Unit,
+    onItemClicked: (SettingsItem.DirectionItem) -> Unit
+) {
+    val aboutThisAppContentState: AboutThisAppContentState = rememberAboutThisAppContentState()
+
+    WireScaffold(
+        topBar = {
+            WireCenterAlignedTopAppBar(
+                title = stringResource(id = R.string.about_app_screen_title),
+                elevation = dimensions().spacing0x,
+                navigationIconType = NavigationIconType.Back,
+                onNavigationPressed = onBackPressed
+            )
+        }
+    ) { internalPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(aboutThisAppContentState.scrollState)
+                .padding(internalPadding)
+        ) {
+            SettingsItem(
+                text = stringResource(id = R.string.settings_terms_of_use_label),
+                trailingIcon = R.drawable.ic_arrow_right,
+                onRowPressed = Clickable(
+                    enabled = true,
+                    onClick = {
+                        onItemClicked(SettingsItem.TermsOfUse)
+                    }
+                )
+            )
+            SettingsItem(
+                text = stringResource(id = R.string.settings_privacy_policy_label),
+                trailingIcon = R.drawable.ic_arrow_right,
+                onRowPressed = Clickable(
+                    enabled = true,
+                    onClick = {
+                        onItemClicked(SettingsItem.PrivacyPolicy)
+                    }
+                )
+            )
+            SettingsItem(
+                text = stringResource(id = R.string.settings_licenses_settings_label),
+                trailingIcon = R.drawable.ic_arrow_right,
+                onRowPressed = Clickable(
+                    enabled = true,
+                    onClick = {
+                        onItemClicked(SettingsItem.Licenses)
+                    }
+                )
+            )
+            SettingsItem(
+                title = stringResource(R.string.label_code_commit_id),
+                text = state.commitish,
+                trailingIcon = R.drawable.ic_copy,
+                onIconPressed = Clickable(
+                    enabled = true,
+                    onClick = {
+                        aboutThisAppContentState.copyToClipboard(state.commitish)
+                    }
+                )
+            )
+            SettingsItem(
+                title = stringResource(R.string.app_version),
+                text = BuildConfig.VERSION_NAME,
+                trailingIcon = R.drawable.ic_copy,
+                onIconPressed = Clickable(
+                    enabled = true,
+                    onClick = {
+                        aboutThisAppContentState.copyToClipboard(BuildConfig.VERSION_NAME)
+                    }
+                )
+            )
+            SettingsItem(
+                title = stringResource(R.string.label_copyright),
+                text = stringResource(id = R.string.label_copyright_value)
+            )
+        }
+    }
+}
+
+@Composable
+fun rememberAboutThisAppContentState(): AboutThisAppContentState {
+    val context = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
+    val scrollState = rememberScrollState()
+
+    return remember {
+        AboutThisAppContentState(
+            context = context,
+            clipboardManager = clipboardManager,
+            scrollState = scrollState
+        )
+    }
+}
+
+data class AboutThisAppContentState(
+    val context: Context,
+    val clipboardManager: ClipboardManager,
+    val scrollState: ScrollState
+) {
+    fun copyToClipboard(text: String) {
+        clipboardManager.setText(AnnotatedString(text))
+        Toast.makeText(
+            context,
+            context.getText(R.string.label_text_copied),
+            Toast.LENGTH_SHORT
+        ).show()
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppScreen.kt
@@ -47,6 +47,8 @@ import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.home.settings.SettingsItem
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.ui.PreviewMultipleThemes
 
 @RootNavGraph
 @Destination
@@ -182,4 +184,14 @@ data class AboutThisAppContentState(
             Toast.LENGTH_SHORT
         ).show()
     }
+}
+
+@PreviewMultipleThemes
+@Composable
+private fun PreviewAboutThisAppScreen() = WireTheme {
+    AboutThisAppContent(
+        state = AboutThisAppState(commitish = "abcd-1234"),
+        onBackPressed = { },
+        onItemClicked = { }
+    )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppState.kt
@@ -1,0 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.settings.about
+
+data class AboutThisAppState(
+    val commitish: String = "null"
+)

--- a/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppViewModel.kt
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.settings.about
+
+import android.content.Context
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.util.getGitBuildId
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AboutThisAppViewModel @Inject constructor(
+    @ApplicationContext private val context: Context
+) : ViewModel() {
+
+    var state by mutableStateOf(
+        AboutThisAppState()
+    )
+
+    init {
+        setGitHash()
+    }
+
+    private fun setGitHash() {
+        viewModelScope.launch {
+            val gitBuildId = context.getGitBuildId()
+            state = state.copy(
+                commitish = gitBuildId
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,7 +203,7 @@
     <string name="settings_privacy_policy_label">Privacy Policy</string>
     <string name="settings_terms_of_use_label">Terms of Use</string>
     <string name="label_copyright">Copyright</string>
-    <string name="label_copyright_value">© Wire Swiss GmbH</string>
+    <string translatable="false" name="label_copyright_value">© Wire Swiss GmbH</string>
     <string name="debug_settings_screen_title">Debug Settings</string>
     <string name="debug_settings_api_versioning_title" translatable="false">API VERSIONING</string>
     <string name="debug_settings_e2ei_enrollment_title" translatable="false">E2EI Manual Enrollment</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,6 +187,8 @@
     <string name="url_create_account_learn_more" translatable="false">https://support.wire.com/hc/articles/115004082129</string>
     <string name="url_android_release_notes" translatable="false">https://medium.com/wire-news/android-updates/home</string>
     <string name="url_maps_location_coordinates_fallback" translatable="false">http://maps.google.com/maps?z=%1d&amp;q=loc:%2f+%2f</string>
+    <string name="url_privacy_policy" translatable="false">https://wire.com/privacy-policy#:~:text=We%20process%20individual%20data%20about,%C2%A7%201%20a)%20GDPR).</string>
+    <string name="url_terms_of_use" translatable="false">https://wire.com/legal#:~:text=Wire%20is%20used%20for%20private,disable%20your%20access%20to%20Wire.</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="archive_screen_title">Archive</string>
@@ -197,6 +199,11 @@
     <string name="app_settings_screen_title">App Settings</string>
     <string name="give_feedback_screen_title">Give Feedback</string>
     <string name="report_bug_screen_title">Report Bug</string>
+    <string name="about_app_screen_title">About This App</string>
+    <string name="settings_privacy_policy_label">Privacy Policy</string>
+    <string name="settings_terms_of_use_label">Terms of Use</string>
+    <string name="label_copyright">Copyright</string>
+    <string name="label_copyright_value">© Wire Swiss GmbH</string>
     <string name="debug_settings_screen_title">Debug Settings</string>
     <string name="debug_settings_api_versioning_title" translatable="false">API VERSIONING</string>
     <string name="debug_settings_e2ei_enrollment_title" translatable="false">E2EI Manual Enrollment</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8846" title="WPB-8846" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8846</a>  [Android] Add privacy policy and terms of use section to Android  
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was no `Privacy Policy` / `Terms of Use` linking from the App Settings.

### Causes (Optional)

Not implemented.

### Solutions

- Add a new screen : `About this App` from the Settings screen (at the bottom)
- Add Privacy Policy / Terms of Use / Licenses / Current Version GIT commit / Current App Version / Copyright on About this App screen
- Remove Licenses from Settings screen

### Testing

#### How to Test

- Open App
- Open Settings Screen (from top-left menu)
- Scroll to the bottom and open `About this App`
- Should contain items mentioned in `Solutions` and:
   - Privacy Policy should open on the web
   - Terms of Use should open on the web
   - Licenses should open another screen
   - Git commit / App version should be able to copy to clipboard

### Attachments (Optional)
<img src="https://github.com/wireapp/wire-android/assets/5890660/b85c7544-58b2-42c0-896c-3c1b83a7f9dc" width="200" height="400" alt="Settings Screen" />
<img src="https://github.com/wireapp/wire-android/assets/5890660/828e6874-d8c6-459f-875b-852fbe2c0069" width="200" height="400" alt="About this App Screen" />
