### PR TITLE
fix: GetE2EICertificate button when no certificate

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -194,7 +194,7 @@ fun DeviceDetailsContent(
                 }
             }
 
-            if (state.isE2EIEnabled && state.e2eiCertificate != null) {
+            if (state.isE2EIEnabled) {
                 item {
                     EndToEndIdentityCertificateItem(
                         isE2eiCertificateActivated = state.isE2eiCertificateActivated,

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
@@ -47,7 +47,7 @@ import kotlinx.datetime.Instant
 @Composable
 fun EndToEndIdentityCertificateItem(
     isE2eiCertificateActivated: Boolean,
-    certificate: E2eiCertificate,
+    certificate: E2eiCertificate?,
     isCurrentDevice: Boolean,
     isLoadingCertificate: Boolean,
     enrollE2eiCertificate: () -> Unit,
@@ -77,7 +77,7 @@ fun EndToEndIdentityCertificateItem(
             color = MaterialTheme.wireColorScheme.secondaryText,
         )
         Column {
-            if (isE2eiCertificateActivated) {
+            if (isE2eiCertificateActivated && certificate != null) {
                 when (certificate.status) {
                     CertificateStatus.REVOKED -> {
                         E2EIStatusRow(


### PR DESCRIPTION
# What's new in this PR?

### Issues

In Device details screen: button for enrolling the E2EI certificate is hidden when user has no certificate

### Causes (Optional)

It was hidden

### Solutions

show it for the case when user has no certificate and E2EI is activated

### Attachments (Optional)

<img width="256" alt="Screenshot 2024-05-14 at 17 41 54" src="https://github.com/wireapp/wire-android/assets/6539347/e51bc989-5fdc-4e81-8155-85877c76409b">
