### PR TITLE
fix: recreate cache directories in case cache is cleared [WPB-7368] 🍒

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -36,6 +36,7 @@ import com.wire.android.ui.home.conversations.usecase.HandleUriAssetUseCase
 import com.wire.android.ui.home.messagecomposer.model.ComposableMessageBundle
 import com.wire.android.ui.home.messagecomposer.model.MessageBundle
 import com.wire.android.ui.home.messagecomposer.model.Ping
+import com.wire.android.util.AUDIO_MIME_TYPE
 import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.getAudioLengthInMs
@@ -67,8 +68,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import okio.Path
-import okio.Path.Companion.toPath
 import javax.inject.Inject
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -165,8 +164,8 @@ class SendMessageViewModel @Inject constructor(
             is ComposableMessageBundle.AudioMessageBundle -> {
                 handleAssetMessageBundle(
                     attachmentUri = messageBundle.attachmentUri,
-                    audioPath = messageBundle.attachmentUri.uri.path?.toPath(),
-                    conversationId = messageBundle.conversationId
+                    conversationId = messageBundle.conversationId,
+                    specifiedMimeType = AUDIO_MIME_TYPE,
                 )
             }
 
@@ -208,12 +207,12 @@ class SendMessageViewModel @Inject constructor(
     private suspend fun handleAssetMessageBundle(
         conversationId: ConversationId,
         attachmentUri: UriAsset,
-        audioPath: Path? = null
+        specifiedMimeType: String? = null, // specify a particular mimetype, otherwise it will be taken from the uri / file extension
     ) {
         when (val result = handleUriAsset.invoke(
             uri = attachmentUri.uri,
             saveToDeviceIfInvalid = attachmentUri.saveToDeviceIfInvalid,
-            audioPath = audioPath
+            specifiedMimeType = specifiedMimeType
         )) {
             is HandleUriAssetUseCase.Result.Failure.AssetTooLarge -> {
                 assetTooLargeDialogState = AssetTooLargeDialogState.Visible(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCase.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import kotlinx.coroutines.withContext
-import okio.Path
+import java.util.UUID
 import javax.inject.Inject
 
 class HandleUriAssetUseCase @Inject constructor(
@@ -38,14 +38,13 @@ class HandleUriAssetUseCase @Inject constructor(
     suspend fun invoke(
         uri: Uri,
         saveToDeviceIfInvalid: Boolean = false,
-        audioPath: Path? = null,
+        specifiedMimeType: String? = null, // specify a particular mimetype, otherwise it will be taken from the uri / file extension
     ): Result = withContext(dispatchers.io()) {
-
-        val tempCachePath = kaliumFileSystem.rootCachePath
+        val tempAssetPath = kaliumFileSystem.tempFilePath(UUID.randomUUID().toString())
         val assetBundle = fileManager.getAssetBundleFromUri(
             attachmentUri = uri,
-            tempCachePath = tempCachePath,
-            audioPath = audioPath
+            assetDestinationPath = tempAssetPath,
+            specifiedMimeType = specifiedMimeType,
         )
         if (assetBundle != null) {
             // The max limit for sending assets changes between user and asset types.

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -414,7 +414,7 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
         }
 
     private suspend fun handleImportedAsset(uri: Uri): ImportedMediaAsset? = withContext(dispatchers.io()) {
-        when (val result = handleUriAsset.invoke(uri, saveToDeviceIfInvalid = false, audioPath = null)) {
+        when (val result = handleUriAsset.invoke(uri, saveToDeviceIfInvalid = false)) {
             is HandleUriAssetUseCase.Result.Failure.AssetTooLarge -> mapToImportedAsset(result.assetBundle, result.maxLimitInMB)
 
             HandleUriAssetUseCase.Result.Failure.Unknown -> null


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7368" title="WPB-7368" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7368</a>  [Android] Playstore crash - Resample Image and File handling
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This PR was manually cherry-picked based on the following PR (automatic cherry pick failed): 
 - #3013 

Original PR description:

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We get multiple crashes when accessing cache files (ENOENT errors) which potentially suggest that the cache is fully cleared and the app cannot find needed directories for the given user in cache to create a temporary file for that user.

### Solutions

Refactor code to have only single source of temporary file paths - `kaliumFileSystem.tempFilePath`, and use updated kalium version where cache directories are being recreated when getting a temporary cache file path in case cache is cleared.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/2773

### Testing

#### How to Test

Open the app, clear app cache and try to send or download asset.

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
