### PR TITLE
fix: bring back 'show password' button on password text input

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
@@ -208,7 +209,7 @@ private fun VisibilityIconButton(isVisible: Boolean, onVisibleChange: (Boolean) 
                 else R.string.content_description_reveal_password
             ),
             modifier = Modifier
-                .size(20.dp)
+                .size(dimensions().spacing20x)
                 .testTag("hidePassword")
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicSecureTextField
@@ -31,14 +32,23 @@ import androidx.compose.foundation.text.input.TextObfuscationMode
 import androidx.compose.foundation.text.input.maxLength
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
@@ -65,7 +75,6 @@ fun WirePasswordTextField(
     state: WireTextFieldState = WireTextFieldState.Default,
     autoFill: Boolean = false,
     inputTransformation: InputTransformation = InputTransformation.maxLength(8000),
-    textObfuscationMode: TextObfuscationMode = TextObfuscationMode.RevealLastTyped,
     imeAction: ImeAction = ImeAction.Default,
     onImeAction: (() -> Unit)? = null,
     scrollState: ScrollState = rememberScrollState(),
@@ -81,6 +90,7 @@ fun WirePasswordTextField(
     testTag: String = String.EMPTY,
 ) {
     val autoFillType = if (autoFill) WireAutoFillType.Password else WireAutoFillType.None
+    var passwordVisibility by remember { mutableStateOf(false) }
     WireTextFieldLayout(
         shouldShowPlaceholder = textState.text.isEmpty(),
         placeholderText = placeholderText,
@@ -94,6 +104,7 @@ fun WirePasswordTextField(
         inputMinHeight = inputMinHeight,
         shape = shape,
         colors = colors,
+        trailingIcon = { VisibilityIconButton(passwordVisibility) { passwordVisibility = it } },
         modifier = modifier.autoFill(autoFillType, textState::setTextAndPlaceCursorAtEnd),
         testTag = testTag,
         onTap = onTap,
@@ -104,7 +115,7 @@ fun WirePasswordTextField(
                 imeAction = imeAction,
                 onSubmit = { onImeAction?.invoke().let { onImeAction != null } },
                 inputTransformation = inputTransformation,
-                textObfuscationMode = textObfuscationMode,
+                textObfuscationMode = if (passwordVisibility) TextObfuscationMode.Visible else TextObfuscationMode.RevealLastTyped,
                 scrollState = scrollState,
                 enabled = state !is WireTextFieldState.Disabled,
                 cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
@@ -150,6 +161,7 @@ fun WirePasswordTextField(
 ) {
     val textState = remember { TextFieldState(value.text, value.selection) }
     val autoFillType = if (autofill) WireAutoFillType.Password else WireAutoFillType.None
+    var passwordVisibility by remember { mutableStateOf(false) }
     WireTextFieldLayout(
         shouldShowPlaceholder = textState.text.isEmpty(),
         placeholderText = placeholderText,
@@ -163,6 +175,7 @@ fun WirePasswordTextField(
         inputMinHeight = inputMinHeight,
         shape = shape,
         colors = colors,
+        trailingIcon = { VisibilityIconButton(passwordVisibility) { passwordVisibility = it } },
         modifier = modifier.autoFill(autoFillType, textState::setTextAndPlaceCursorAtEnd),
         testTag = testTag,
         onTap = onTap,
@@ -173,6 +186,7 @@ fun WirePasswordTextField(
                 imeAction = imeAction,
                 onSubmit = { onImeAction?.invoke().let { onImeAction != null } },
                 inputTransformation = InputTransformation.maxLength(maxTextLength),
+                textObfuscationMode = if (passwordVisibility) TextObfuscationMode.Visible else TextObfuscationMode.RevealLastTyped,
                 scrollState = scrollState,
                 enabled = state !is WireTextFieldState.Disabled,
                 cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
@@ -182,6 +196,22 @@ fun WirePasswordTextField(
             )
         }
     )
+}
+
+@Composable
+private fun VisibilityIconButton(isVisible: Boolean, onVisibleChange: (Boolean) -> Unit) {
+    IconButton(onClick = { onVisibleChange(!isVisible) }) {
+        Icon(
+            imageVector = if (isVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff,
+            contentDescription = stringResource(
+                if (isVisible) R.string.content_description_hide_password
+                else R.string.content_description_reveal_password
+            ),
+            modifier = Modifier
+                .size(20.dp)
+                .testTag("hidePassword")
+        )
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After updating text fields to v2, "show password" button (the one with eye icon) is missing on password text fields.

### Solutions

Bring it back.

### Testing

#### How to Test

Open login screen and enter a password.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| ![Screenshot_20240521_093459](https://github.com/wireapp/wire-android/assets/30429749/c5ef9068-df18-4903-b4b8-d70f285117fe) | ![Screenshot_20240521_095239](https://github.com/wireapp/wire-android/assets/30429749/6de39d8f-26e5-45c1-923b-3ce4117401cf) | 

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
