### PR TITLE
fix: markdown support link reference [WPB-9220]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHelper.kt
@@ -92,7 +92,7 @@ fun <T : Node> T.toContent(isParentDocument: Boolean = false): MarkdownNode {
         is Strikethrough -> MarkdownNode.Inline.Strikethrough(convertChildren<MarkdownNode.Inline>())
         is HardLineBreak, is SoftLineBreak -> MarkdownNode.Inline.Break(convertChildren<MarkdownNode.Inline>())
         is LinkReferenceDefinition -> MarkdownNode.Block.Paragraph(
-            listOf(MarkdownNode.Inline.Text("[${label}]: ${this.destination} ${this.title}")),
+            listOf(MarkdownNode.Inline.Text("[$label]: $destination $title")),
             isParentDocument
         )
 

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHelper.kt
@@ -19,6 +19,7 @@
 
 package com.wire.android.ui.markdown
 
+import com.wire.android.appLogger
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import org.commonmark.ext.gfm.strikethrough.Strikethrough
@@ -40,6 +41,7 @@ import org.commonmark.node.HtmlInline
 import org.commonmark.node.Image
 import org.commonmark.node.IndentedCodeBlock
 import org.commonmark.node.Link
+import org.commonmark.node.LinkReferenceDefinition
 import org.commonmark.node.ListItem
 import org.commonmark.node.Node
 import org.commonmark.node.OrderedList
@@ -89,7 +91,20 @@ fun <T : Node> T.toContent(isParentDocument: Boolean = false): MarkdownNode {
         is ThematicBreak -> MarkdownNode.Block.ThematicBreak(convertChildren<MarkdownNode.Inline>(), isParentDocument)
         is Strikethrough -> MarkdownNode.Inline.Strikethrough(convertChildren<MarkdownNode.Inline>())
         is HardLineBreak, is SoftLineBreak -> MarkdownNode.Inline.Break(convertChildren<MarkdownNode.Inline>())
-        else -> throw IllegalArgumentException("Unsupported node type: ${this.javaClass.simpleName}")
+        is LinkReferenceDefinition -> {
+            MarkdownNode.Block.Paragraph(
+                listOf(MarkdownNode.Inline.Text("[${label}]: ${this.destination} ${this.title}")),
+                isParentDocument
+            )
+        }
+
+        else -> {
+            appLogger.e(
+                "Unsupported markdown",
+                IllegalArgumentException("Unsupported node type: ${this.javaClass.simpleName}")
+            )
+            MarkdownNode.Unsupported(isParentDocument = isParentDocument)
+        }
     }
 }
 
@@ -167,6 +182,7 @@ fun MarkdownNode.filterNodesContainingQuery(query: String): MarkdownNode? {
 
         is MarkdownNode.Block.ThematicBreak -> null
         is MarkdownNode.Inline.Break -> this
+        is MarkdownNode.Unsupported -> null
     }
 }
 
@@ -191,6 +207,7 @@ fun MarkdownNode.getFirstInlines(): MarkdownPreview? {
 
         is MarkdownNode.TableCell -> children.toPreview()
         is MarkdownNode.TableRow -> children.firstOrNull()?.children?.toPreview()
+        is MarkdownNode.Unsupported -> null
     }
 }
 
@@ -307,6 +324,7 @@ private fun MarkdownNode.copy(children: List<MarkdownNode>): MarkdownNode {
         // Custom nodes
         is MarkdownNode.TableRow -> this.copy(children = children.filterIsInstance<MarkdownNode.TableCell>())
         is MarkdownNode.TableCell -> this.copy(children = children.filterIsInstance<MarkdownNode.Inline>())
+        is MarkdownNode.Unsupported -> this
     }
 }
 
@@ -348,6 +366,7 @@ fun printMarkdownNodeTree(node: MarkdownNode?, indentLevel: Int = 0) {
         is MarkdownNode.Inline.Code -> "${indent}Code: '${node.literal}'"
         is MarkdownNode.Inline.Strikethrough -> "${indent}Strikethrough: [${node.children.size} children]"
         is MarkdownNode.Inline.Break -> "${indent}Break"
+        is MarkdownNode.Unsupported -> "${indent}Unsupported"
     }
     println(printLog)
 

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHelper.kt
@@ -91,12 +91,10 @@ fun <T : Node> T.toContent(isParentDocument: Boolean = false): MarkdownNode {
         is ThematicBreak -> MarkdownNode.Block.ThematicBreak(convertChildren<MarkdownNode.Inline>(), isParentDocument)
         is Strikethrough -> MarkdownNode.Inline.Strikethrough(convertChildren<MarkdownNode.Inline>())
         is HardLineBreak, is SoftLineBreak -> MarkdownNode.Inline.Break(convertChildren<MarkdownNode.Inline>())
-        is LinkReferenceDefinition -> {
-            MarkdownNode.Block.Paragraph(
-                listOf(MarkdownNode.Inline.Text("[${label}]: ${this.destination} ${this.title}")),
-                isParentDocument
-            )
-        }
+        is LinkReferenceDefinition -> MarkdownNode.Block.Paragraph(
+            listOf(MarkdownNode.Inline.Text("[${label}]: ${this.destination} ${this.title}")),
+            isParentDocument
+        )
 
         else -> {
             appLogger.e(

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownNode.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownNode.kt
@@ -143,6 +143,8 @@ sealed class MarkdownNode {
         override val children: List<Inline> = listOf(),
         override val isParentDocument: Boolean = false
     ) : MarkdownNode()
+
+    data class Unsupported(override val children: List<MarkdownNode> = listOf(), override val isParentDocument: Boolean) : MarkdownNode()
 }
 
 data class MarkdownPreview(val children: PersistentList<MarkdownNode.Inline>)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9220" title="WPB-9220" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9220</a>  [Android] Crash in markdown parser when last message has invalid node
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was unsupported `LinkReferenceDefinition` node for markdown

### Causes (Optional)

Crash

### Solutions

- Handle node and show it as a normal text
- Don't crash for other unsupported nodes, just log them as an error 