### PR TITLE
fix: jumping keyboard behavior (WPB-9357)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -301,11 +301,11 @@ fun EnabledMessageComposer(
                         if (additionalOptionStateHolder.selectedOption == AdditionalOptionSelectItem.DrawingMode) {
                             DrawingCanvasBottomSheet(
                                 onDismissSketch = {
-                                    inputStateHolder.collapseComposer(additionalOptionStateHolder.additionalOptionsSubMenuState)
+                                    showAdditionalOptionsMenu()
                                 },
                                 onSendSketch = {
                                     onAttachmentPicked(UriAsset(it))
-                                    inputStateHolder.collapseComposer(additionalOptionStateHolder.additionalOptionsSubMenuState)
+                                    showAdditionalOptionsMenu()
                                 },
                                 conversationTitle = CurrentConversationDetailsCache.conversationName.asString(),
                                 tempWritableImageUri = tempWritableImageUri

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -297,22 +297,22 @@ fun EnabledMessageComposer(
                                 )
                             }
                         }
-
-                        if (additionalOptionStateHolder.selectedOption == AdditionalOptionSelectItem.DrawingMode) {
-                            DrawingCanvasBottomSheet(
-                                onDismissSketch = {
-                                    showAdditionalOptionsMenu()
-                                },
-                                onSendSketch = {
-                                    onAttachmentPicked(UriAsset(it))
-                                    showAdditionalOptionsMenu()
-                                },
-                                conversationTitle = CurrentConversationDetailsCache.conversationName.asString(),
-                                tempWritableImageUri = tempWritableImageUri
-                            )
-                        }
                     }
                 }
+            }
+
+            if (additionalOptionStateHolder.selectedOption == AdditionalOptionSelectItem.DrawingMode) {
+                DrawingCanvasBottomSheet(
+                    onDismissSketch = {
+                        showAdditionalOptionsMenu()
+                    },
+                    onSendSketch = {
+                        onAttachmentPicked(UriAsset(it))
+                        showAdditionalOptionsMenu()
+                    },
+                    conversationTitle = CurrentConversationDetailsCache.conversationName.asString(),
+                    tempWritableImageUri = tempWritableImageUri
+                )
             }
 
             BackHandler(inputStateHolder.inputType is MessageCompositionType.Editing) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9357" title="WPB-9357" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9357</a>  [Android] Keyboard jumping when trying to send a sketch
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When opening the sketch and discarding the drawing, sometimes, the keyboard behavior while closing had an anomaly.

### Causes (Optional)

Jumping keyboard effect.

### Solutions

Instead of collapsing manually the keyboard, jump back to the attachment options, this handles and orchestrate other actions needed, to display correctly the attachments.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Manually you can have many messages, open the drawing, draw, discard.
Then the keyboard should close correctly

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
