### PR TITLE
fix: OtherUser devices: wrong MLS data [WPB-8908]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
@@ -183,13 +183,12 @@ private fun DeviceItemTexts(
         )
         if (shouldShowVerifyLabel) {
             if (shouldShowE2EIInfo) {
-                MLSVerificationIcon(device.e2eiCertificateStatus)
+                MLSVerificationIcon(device.e2eiCertificate?.status)
             }
             Spacer(modifier = Modifier.width(MaterialTheme.wireDimensions.spacing8x))
             if (device.isVerifiedProteus && !isCurrentClient) ProteusVerifiedIcon(
-                Modifier
-                    .wrapContentWidth()
-                    .align(Alignment.CenterVertically))
+                Modifier.wrapContentWidth().align(Alignment.CenterVertically)
+            )
         }
     }
 
@@ -206,7 +205,7 @@ private fun DeviceItemTexts(
 
     Spacer(modifier = Modifier.height(MaterialTheme.wireDimensions.removeDeviceItemTitleVerticalPadding))
 
-    device.mlsPublicKeys?.values?.firstOrNull()?.let { mlsThumbprint ->
+    device.e2eiCertificate?.let { certificate ->
         Text(
             style = MaterialTheme.wireTypography.subline01,
             color = MaterialTheme.wireColorScheme.labelText,
@@ -214,7 +213,7 @@ private fun DeviceItemTexts(
             overflow = TextOverflow.Ellipsis,
             text = stringResource(
                 R.string.remove_device_mls_thumbprint_label,
-                mlsThumbprint.formatAsFingerPrint()
+                certificate.thumbprint.formatAsFingerPrint()
             ),
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/model/Device.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/model/Device.kt
@@ -26,7 +26,7 @@ import com.wire.android.R
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.conversation.ClientId
-import com.wire.kalium.logic.feature.e2ei.CertificateStatus
+import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
 import com.wire.kalium.logic.util.inWholeWeeks
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.datetime.Clock
@@ -38,18 +38,16 @@ data class Device(
     val lastActiveInWholeWeeks: Int? = null,
     val isValid: Boolean = true,
     val isVerifiedProteus: Boolean = false,
-    val mlsPublicKeys: Map<String, String>? = null,
-    val e2eiCertificateStatus: CertificateStatus? = null
+    val e2eiCertificate: E2eiCertificate? = null
 ) {
-    constructor(client: Client, e2eiCertificateStatus: CertificateStatus? = null) : this(
+    constructor(client: Client, e2eiCertificate: E2eiCertificate? = null) : this(
         name = client.displayName(),
         clientId = client.id,
         registrationTime = client.registrationTime?.toIsoDateTimeString(),
         lastActiveInWholeWeeks = client.lastActiveInWholeWeeks(),
         isValid = client.isValid,
         isVerifiedProteus = client.isVerified,
-        mlsPublicKeys = client.mlsPublicKeys,
-        e2eiCertificateStatus = e2eiCertificateStatus
+        e2eiCertificate = e2eiCertificate
     )
 
     fun updateFromClient(client: Client): Device = copy(
@@ -59,11 +57,11 @@ data class Device(
         lastActiveInWholeWeeks = client.lastActiveInWholeWeeks(),
         isValid = client.isValid,
         isVerifiedProteus = client.isVerified,
-        mlsPublicKeys = client.mlsPublicKeys,
+        e2eiCertificate = null,
     )
 
-    fun updateE2EICertificateStatus(e2eiCertificateStatus: CertificateStatus): Device = copy(
-        e2eiCertificateStatus = e2eiCertificateStatus
+    fun updateE2EICertificate(e2eiCertificate: E2eiCertificate): Device = copy(
+        e2eiCertificate = e2eiCertificate
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -577,7 +577,7 @@ fun PreviewDeviceDetailsScreen() {
                     "handler",
                     CertificateStatus.VALID,
                     "serial",
-                    "date",
+                    "Details",
                     "Thumbprint",
                     Instant.DISTANT_FUTURE
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -91,9 +91,11 @@ import com.wire.android.util.extension.formatAsString
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.feature.e2ei.CertificateStatus
 import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
 import com.wire.kalium.logic.feature.e2ei.usecase.E2EIEnrollmentResult
 import com.wire.kalium.logic.functional.Either
+import kotlinx.datetime.Instant
 
 @RootNavGraph
 @Destination(
@@ -127,6 +129,7 @@ fun DeviceDetailsScreen(
         )
     }
 }
+
 @Suppress("ComplexMethod")
 @Composable
 fun DeviceDetailsContent(
@@ -187,9 +190,9 @@ fun DeviceDetailsContent(
                 .background(MaterialTheme.wireColorScheme.surface)
         ) {
 
-            state.device.mlsPublicKeys?.forEach { (mlsProtocolType, mlsThumbprint) ->
+            state.device.e2eiCertificate?.let { certificate ->
                 item {
-                    DeviceMLSSignatureItem(mlsThumbprint, mlsProtocolType, screenState::copyMessage)
+                    DeviceMLSSignatureItem(certificate.thumbprint, screenState::copyMessage)
                     Divider(color = MaterialTheme.wireColorScheme.background)
                 }
             }
@@ -323,7 +326,7 @@ private fun DeviceDetailsTopBar(
                 )
 
                 if (shouldShowE2EIInfo) {
-                    MLSVerificationIcon(device.e2eiCertificateStatus)
+                    MLSVerificationIcon(device.e2eiCertificate?.status)
                 }
 
                 if (!isCurrentDevice && device.isVerifiedProteus) {
@@ -373,16 +376,8 @@ fun DeviceKeyFingerprintItem(
 @Composable
 fun DeviceMLSSignatureItem(
     mlsThumbprint: String,
-    mlsProtocolType: String,
     onCopy: (String) -> Unit
 ) {
-
-    FolderHeader(
-        name = stringResource(id = R.string.label_mls_signature, mlsProtocolType).uppercase(),
-        modifier = Modifier
-            .background(MaterialTheme.wireColorScheme.background)
-            .fillMaxWidth()
-    )
 
     DeviceDetailSectionContent(
         stringResource(id = R.string.label_mls_thumbprint),
@@ -578,7 +573,14 @@ fun PreviewDeviceDetailsScreen() {
                 clientId = ClientId(""),
                 name = UIText.DynamicString("My Device"),
                 registrationTime = "2022-03-24T18:02:30.360Z",
-                mlsPublicKeys = mapOf("Ed25519" to "lekvmrlkgvnrelkmvrlgkvlknrgb0348gi34t09gj34v034ithjoievw")
+                e2eiCertificate = E2eiCertificate(
+                    "handler",
+                    CertificateStatus.VALID,
+                    "serial",
+                    "date",
+                    "Thumbprint",
+                    Instant.DISTANT_FUTURE
+                )
             ),
             isCurrentDevice = false
         ),

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
@@ -119,7 +119,7 @@ class DeviceDetailsViewModel @Inject constructor(
                     isE2eiCertificateActivated = true,
                     e2eiCertificate = certificate.certificate,
                     isLoadingCertificate = false,
-                    device = state.device.updateE2EICertificateStatus(certificate.certificate.status)
+                    device = state.device.updateE2EICertificate(certificate.certificate)
                 )
             } else {
                 state.copy(isE2eiCertificateActivated = false, isLoadingCertificate = false)

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
@@ -104,6 +104,8 @@ fun EndToEndIdentityCertificateItem(
                         }
                     }
 
+                    // Show cyka data here
+
                     CertificateStatus.VALID -> {
                         E2EIStatusRow(
                             label = stringResource(id = R.string.e2ei_certificat_status_valid),

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
@@ -104,8 +104,6 @@ fun EndToEndIdentityCertificateItem(
                         }
                     }
 
-                    // Show cyka data here
-
                     CertificateStatus.VALID -> {
                         E2EIStatusRow(
                             label = stringResource(id = R.string.e2ei_certificat_status_valid),

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModel.kt
@@ -70,10 +70,10 @@ class SelfDevicesViewModel @Inject constructor(
                             isLoadingClientsList = false,
                             currentDevice = result.clients
                                 .firstOrNull { it.id == currentClientId }
-                                ?.let { Device(it, e2eiCertificates[it.id.value]?.status) },
+                                ?.let { Device(it, e2eiCertificates[it.id.value]) },
                             deviceList = result.clients
                                 .filter { it.id != currentClientId }
-                                .map { Device(it, e2eiCertificates[it.id.value]?.status) }
+                                .map { Device(it, e2eiCertificates[it.id.value]) }
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
@@ -123,7 +123,7 @@ private fun OtherUserDevicesContent(
                     onClickAction = onDeviceClick,
                     icon = Icons.Filled.ChevronRight.Icon(),
                     shouldShowVerifyLabel = true,
-                    shouldShowE2EIInfo = item.e2eiCertificateStatus != null
+                    shouldShowE2EIInfo = item.e2eiCertificate != null
                 )
                 if (index < otherUserDevices.lastIndex) WireDivider()
             }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -166,7 +166,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
 
                         is ObserveClientsByUserIdUseCase.Result.Success -> {
                             state = state.copy(otherUserDevices = it.clients.map { item ->
-                                Device(item, e2eiCertificates[item.id.value]?.status)
+                                Device(item, e2eiCertificates[item.id.value])
                             })
                         }
                     }

--- a/app/src/test/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModelTest.kt
@@ -37,12 +37,15 @@ import com.wire.kalium.logic.feature.client.GetClientDetailsResult
 import com.wire.kalium.logic.feature.client.ObserveClientDetailsUseCase
 import com.wire.kalium.logic.feature.client.Result
 import com.wire.kalium.logic.feature.client.UpdateClientVerificationStatusUseCase
+import com.wire.kalium.logic.feature.e2ei.CertificateStatus
+import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
 import com.wire.kalium.logic.feature.e2ei.usecase.GetE2EICertificateUseCaseResult
 import com.wire.kalium.logic.feature.e2ei.usecase.GetE2eiCertificateUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
+import com.wire.kalium.util.DateTimeUtil
 import io.mockk.Called
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -60,6 +63,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.time.Duration.Companion.days
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
@@ -281,6 +285,30 @@ class DeviceDetailsViewModelTest {
             assertTrue(viewModel.state.startGettingE2EICertificate)
         }
 
+
+    @Test
+    fun `given a client with E2EI certificate, when fetching details, then returns device information`() {
+        val certificate = E2eiCertificate(
+            userHandle = "userHandle",
+            serialNumber = "serialNumber",
+            certificateDetail = "certificateDetail",
+            status = CertificateStatus.VALID,
+            thumbprint = "thumbprint",
+            endAt = DateTimeUtil.currentInstant().plus(1.days)
+        )
+        runTest {
+            // given
+            val (_, viewModel) = Arrangement()
+                .withRequiredMockSetup()
+                .withClientDetailsResult(GetClientDetailsResult.Success(TestClient.CLIENT, true))
+                .withE2eiCertificate(GetE2EICertificateUseCaseResult.Success(certificate))
+                .arrange()
+
+            // then
+            assertEquals(certificate, viewModel.state.device.e2eiCertificate)
+        }
+    }
+
     private class Arrangement {
 
         @MockK
@@ -368,6 +396,10 @@ class DeviceDetailsViewModelTest {
                 userId = userId,
                 clientId = CLIENT_ID
             )
+        }
+
+        fun withE2eiCertificate(result: GetE2EICertificateUseCaseResult) = apply {
+            coEvery { getE2eiCertificate(any()) } returns result
         }
 
         fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModelTest.kt
@@ -285,7 +285,6 @@ class DeviceDetailsViewModelTest {
             assertTrue(viewModel.state.startGettingE2EICertificate)
         }
 
-
     @Test
     fun `given a client with E2EI certificate, when fetching details, then returns device information`() {
         val certificate = E2eiCertificate(

--- a/app/src/test/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModelTest.kt
@@ -30,8 +30,8 @@ import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.client.SelfClientsResult
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
-import io.mockk.coEvery
 import io.mockk.MockKAnnotations
+import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8908" title="WPB-8908" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8908</a>  [Android] MLS Client data not loaded correctly for other users devices
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

In OtherUserProfile screen: MLS data in devices is wrong (no MLS thumbprint)
The same in DeviceDetails screen

### Causes (Optional)

MLS thumbprint should be gotten from the `com.wire.kalium.logic.feature.e2ei.E2eiCertificate` not `com.wire.kalium.logic.data.client.Client`.

### Solutions

Use the proper source of trues. 

### Attachments (Optional)

<img width="286" alt="Screenshot 2024-05-27 at 15 18 04" src="https://github.com/wireapp/wire-android/assets/6539347/813a6447-8be4-4cb6-9d05-e0b12a643416">


<img width="284" alt="Screenshot 2024-05-27 at 15 18 15" src="https://github.com/wireapp/wire-android/assets/6539347/0d742ccf-3b3a-4b8f-b36d-a37eda3df167">

