### PR TITLE
fix: proximity sensor keeps turning the screen off even when there is no call (WPB-9215)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ProximitySensorManager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ProximitySensorManager.kt
@@ -63,6 +63,9 @@ class ProximitySensorManager @Inject constructor(
     }
 
     fun unRegisterListener() {
+        if (wakeLock.isHeld) {
+            wakeLock.release()
+        }
         sensorManager.unregisterListener(sensorEventListener)
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9215" title="WPB-9215" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9215</a>  [Android] Screen dimming is on even when there are no active calls
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Proximity sensor keeps turning the screen off even when there is no call 

### Causes (Optional)

We are not releasing `wakeLock` when unregistering the sensor listener

### Solutions

Release `wakeLock` if it's held when unregistering the listener

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

STR:
- Receive an incoming call
- Turn off the screen by hiding the sensor
- The caller should end the call 
--> the phone will keep dimming the screen even the app is not open

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
