### PR TITLE
fix(ci): github action deadlock in merge_group

### DIFF
--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -6,10 +6,6 @@ on: [ workflow_call ]
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   ui-tests:
     runs-on: buildjet-8vcpu-ubuntu-2204


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are having a "gh action deadlock" while trying to cancel concurrent workflows.

### Solutions

Remove from, `ui-test` workflow the concurrent cancellation, since now is only triggered by workflow call, the concurrent handling is done on the caller side, ie: build flows.

### Attachments
<img width="1125" alt="Wire 2024-05-28 at 4_39 PM" src="https://github.com/wireapp/wire-android/assets/5806454/e87c20f3-3872-4c2c-9709-a3b3aecdb92f">

https://github.com/wireapp/wire-android/actions/runs/9270149211

#### How to Test

We need to test manually, the workflows should not be stuck on `merge_group`

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
