### PR TITLE
ci: add env variables for key store path

### DIFF
--- a/.github/workflows/build-rc-app.yml
+++ b/.github/workflows/build-rc-app.yml
@@ -50,7 +50,10 @@ jobs:
         run:
           ./gradlew app:assembleInternalCompat
         env:
+          KEYSTORE_FILE_PATH_DEBUG: ${{ vars.KEYSTORE_FILE_PATH }}
+          KEYSTORE_FILE_PATH_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_COMPAT: ${{ vars.KEYSTORE_FILE_PATH }}
+          KEYSTORE_FILE_PATH_COMPAT_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_KEY_NAME_COMPAT: ${{ secrets.SIGNING_KEY_ALIAS_INTERNAL_RELEASE }}
           KEYPWD_COMPAT: ${{ secrets.SIGNING_KEY_PASSWORD_INTERNAL_RELEASE }}
           KEYSTOREPWD_COMPAT: ${{ secrets.SIGNING_STORE_PASSWORD_INTERNAL_RELEASE }}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

CI is failing when trying to build internal apk

```
* Where:
Build file '/home/runner/work/wire-android/wire-android/app/build.gradle.kts' line: 21

* What went wrong:
An exception occurred applying plugin request [id: 'scripts.variants']
> Failed to apply plugin 'scripts.variants'.
   > getenv("KEYSTORE_FILE_PATH_RELEASE") must not be null
```
### Causes (Optional)

Some env variables are missing 

### Solutions

Add those variable for different build types


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
