### PR TITLE
refactor: update text input logic to v2 TextFieldState, part 3 [WPB-8779]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt
@@ -35,8 +35,6 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -53,6 +55,7 @@ import com.wire.android.ui.common.dialogs.CancelLoginDialogContent
 import com.wire.android.ui.common.dialogs.CancelLoginDialogState
 import com.wire.android.ui.common.error.CoreFailureErrorDialog
 import com.wire.android.ui.common.scaffold.WireScaffold
+import com.wire.android.ui.common.textfield.DefaultPassword
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.textfield.clearAutofillTree
@@ -63,18 +66,21 @@ import com.wire.android.ui.destinations.E2EIEnrollmentScreenDestination
 import com.wire.android.ui.destinations.HomeScreenDestination
 import com.wire.android.ui.destinations.InitialSyncScreenDestination
 import com.wire.android.ui.destinations.RemoveDeviceScreenDestination
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
 
 @RootNavGraph
 @Destination(
     style = PopUpNavigationAnimation::class,
 )
 @Composable
-fun RegisterDeviceScreen(navigator: Navigator) {
-    val viewModel: RegisterDeviceViewModel = hiltViewModel()
-    val clearSessionViewModel: ClearSessionViewModel = hiltViewModel()
-    val clearSessionState: ClearSessionState = clearSessionViewModel.state
+fun RegisterDeviceScreen(
+    navigator: Navigator,
+    viewModel: RegisterDeviceViewModel = hiltViewModel(),
+    clearSessionViewModel: ClearSessionViewModel = hiltViewModel(),
+) {
     clearAutofillTree()
     when (val flowState = viewModel.state.flowState) {
         is RegisterDeviceFlowState.Success -> {
@@ -92,8 +98,8 @@ fun RegisterDeviceScreen(navigator: Navigator) {
         else ->
             RegisterDeviceContent(
                 state = viewModel.state,
-                clearSessionState = clearSessionState,
-                onPasswordChange = viewModel::onPasswordChange,
+                passwordTextState = viewModel.passwordTextState,
+                clearSessionState = clearSessionViewModel.state,
                 onContinuePressed = viewModel::onContinue,
                 onErrorDismiss = viewModel::onErrorDismiss,
                 onBackButtonClicked = clearSessionViewModel::onBackButtonClicked,
@@ -106,13 +112,14 @@ fun RegisterDeviceScreen(navigator: Navigator) {
 @Composable
 private fun RegisterDeviceContent(
     state: RegisterDeviceState,
+    passwordTextState: TextFieldState,
     clearSessionState: ClearSessionState,
-    onPasswordChange: (TextFieldValue) -> Unit,
     onContinuePressed: () -> Unit,
     onErrorDismiss: () -> Unit,
     onBackButtonClicked: () -> Unit,
     onCancelLoginClicked: () -> Unit,
-    onProceedLoginClicked: () -> Unit
+    onProceedLoginClicked: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     BackHandler {
         onBackButtonClicked()
@@ -136,6 +143,7 @@ private fun RegisterDeviceContent(
     }
 
     WireScaffold(
+        modifier = modifier,
         topBar = {
             WireCenterAlignedTopAppBar(
                 elevation = 0.dp,
@@ -161,7 +169,7 @@ private fun RegisterDeviceContent(
                     )
                     .testTag("registerText")
             )
-            PasswordTextField(state = state, onPasswordChange = onPasswordChange)
+            PasswordTextField(state = state, passwordTextState = passwordTextState)
             Spacer(modifier = Modifier.weight(1f))
             WirePrimaryButton(
                 text = stringResource(R.string.label_add_device),
@@ -182,28 +190,31 @@ private fun RegisterDeviceContent(
 }
 
 @Composable
-private fun PasswordTextField(state: RegisterDeviceState, onPasswordChange: (TextFieldValue) -> Unit) {
+private fun PasswordTextField(
+    state: RegisterDeviceState,
+    passwordTextState: TextFieldState,
+    modifier: Modifier = Modifier,
+) {
     val keyboardController = LocalSoftwareKeyboardController.current
     WirePasswordTextField(
-        value = state.password,
-        onValueChange = onPasswordChange,
+        textState = passwordTextState,
         state = when (state.flowState) {
             is RegisterDeviceFlowState.Error.InvalidCredentialsError ->
                 WireTextFieldState.Error(stringResource(id = R.string.remove_device_invalid_password))
 
             else -> WireTextFieldState.Default
         },
-        imeAction = ImeAction.Done,
-        onImeAction = { keyboardController?.hide() },
-        modifier = Modifier
+        keyboardOptions = KeyboardOptions.DefaultPassword.copy(imeAction = ImeAction.Done),
+        onKeyboardAction = { keyboardController?.hide() },
+        modifier = modifier
             .padding(horizontal = MaterialTheme.wireDimensions.spacing16x)
             .testTag("password field"),
-        autofill = true
+        autoFill = true
     )
 }
 
 @Composable
-@Preview
-fun PreviewRegisterDeviceScreen() {
-    RegisterDeviceContent(RegisterDeviceState(), ClearSessionState(), {}, {}, {}, {}, {}, {})
+@PreviewMultipleThemes
+fun PreviewRegisterDeviceScreen() = WireTheme {
+    RegisterDeviceContent(RegisterDeviceState(), TextFieldState(), ClearSessionState(), {}, {}, {}, {}, {})
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceState.kt
@@ -18,21 +18,19 @@
 
 package com.wire.android.ui.authentication.devices.register
 
-import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.user.UserId
 
 data class RegisterDeviceState(
-    val password: TextFieldValue = TextFieldValue(""),
     val continueEnabled: Boolean = false,
     val flowState: RegisterDeviceFlowState = RegisterDeviceFlowState.Default
 )
 
 sealed class RegisterDeviceFlowState {
-    object Default : RegisterDeviceFlowState()
-    object Loading : RegisterDeviceFlowState()
-    object TooManyDevices : RegisterDeviceFlowState()
+    data object Default : RegisterDeviceFlowState()
+    data object Loading : RegisterDeviceFlowState()
+    data object TooManyDevices : RegisterDeviceFlowState()
     data class Success(
         val initialSyncCompleted: Boolean,
         val isE2EIRequired: Boolean,
@@ -41,7 +39,7 @@ sealed class RegisterDeviceFlowState {
     ) : RegisterDeviceFlowState()
 
     sealed class Error : RegisterDeviceFlowState() {
-        object InvalidCredentialsError : Error()
+        data object InvalidCredentialsError : Error()
         data class GenericError(val coreFailure: CoreFailure) : Error()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.BuildConfig

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceDialog.kt
@@ -18,6 +18,8 @@
 package com.wire.android.ui.authentication.devices.remove
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -30,12 +32,12 @@ import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.R
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.button.WireButtonState
+import com.wire.android.ui.common.textfield.DefaultPassword
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.theme.wireDimensions
@@ -45,9 +47,10 @@ import com.wire.android.util.deviceDateTimeFormat
 fun RemoveDeviceDialog(
     errorState: RemoveDeviceError,
     state: RemoveDeviceDialogState.Visible,
-    onPasswordChange: (TextFieldValue) -> Unit,
+    passwordTextState: TextFieldState,
     onDialogDismiss: () -> Unit,
-    onRemoveConfirm: () -> Unit
+    onRemoveConfirm: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     var keyboardController: SoftwareKeyboardController? = null
     val onDialogDismissHideKeyboard: () -> Unit = {
@@ -55,6 +58,7 @@ fun RemoveDeviceDialog(
         onDialogDismiss()
     }
     WireDialog(
+        modifier = modifier,
         title = stringResource(R.string.remove_device_dialog_title),
         text = state.device.name.asString() + "\n" +
             stringResource(
@@ -84,8 +88,7 @@ fun RemoveDeviceDialog(
             keyboardController = LocalSoftwareKeyboardController.current
             val focusRequester = remember { FocusRequester() }
             WirePasswordTextField(
-                value = state.password,
-                onValueChange = onPasswordChange,
+                textState = passwordTextState,
                 state = when {
                     errorState is RemoveDeviceError.InvalidCredentialsError ->
                         WireTextFieldState.Error(stringResource(id = R.string.remove_device_invalid_password))
@@ -93,13 +96,13 @@ fun RemoveDeviceDialog(
                     state.loading -> WireTextFieldState.Disabled
                     else -> WireTextFieldState.Default
                 },
-                imeAction = ImeAction.Done,
-                onImeAction = { keyboardController?.hide() },
+                keyboardOptions = KeyboardOptions.DefaultPassword.copy(imeAction = ImeAction.Done),
+                onKeyboardAction = { keyboardController?.hide() },
                 modifier = Modifier
                     .focusRequester(focusRequester)
                     .padding(bottom = MaterialTheme.wireDimensions.spacing8x)
                     .testTag("remove device password field"),
-                autofill = true
+                autoFill = true
             )
             LaunchedEffect(Unit) { // executed only once when showing the dialog
                 focusRequester.requestFocus()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceState.kt
@@ -18,7 +18,6 @@
 
 package com.wire.android.ui.authentication.devices.remove
 
-import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.ui.authentication.devices.model.Device
 import com.wire.kalium.logic.CoreFailure
 
@@ -30,18 +29,18 @@ data class RemoveDeviceState(
 )
 
 sealed class RemoveDeviceDialogState {
-    object Hidden : RemoveDeviceDialogState()
+    data object Hidden : RemoveDeviceDialogState()
     data class Visible(
         val device: Device,
-        val password: TextFieldValue = TextFieldValue(""),
         val loading: Boolean = false,
         val removeEnabled: Boolean = false
     ) : RemoveDeviceDialogState()
 }
 
 sealed class RemoveDeviceError {
-    object None : RemoveDeviceError()
-    object InvalidCredentialsError : RemoveDeviceError()
-    object InitError : RemoveDeviceError()
+    data object None : RemoveDeviceError()
+    data object InvalidCredentialsError : RemoveDeviceError()
+    data object InitError : RemoveDeviceError()
     data class GenericError(val coreFailure: CoreFailure) : RemoveDeviceError()
 }
+

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceState.kt
@@ -43,4 +43,3 @@ sealed class RemoveDeviceError {
     data object InitError : RemoveDeviceError()
     data class GenericError(val coreFailure: CoreFailure) : RemoveDeviceError()
 }
-

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModel.kt
@@ -64,6 +64,7 @@ class RemoveDeviceViewModel @Inject constructor(
 
     init {
         loadClientsList()
+        observePasswordTextChanges()
     }
 
     private fun observePasswordTextChanges() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeResetDeviceDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeResetDeviceDialog.kt
@@ -121,11 +121,12 @@ fun ForgotLockCodeResettingDeviceDialog() {
         onDismiss = {},
     )
 }
+
 @PreviewMultipleThemes
 @Composable
 fun PreviewForgotLockCodeResetDeviceDialog() {
     WireTheme {
-        ForgotLockCodeResetDeviceDialog(TextFieldState(),"Username", false, true, true, {}, {})
+        ForgotLockCodeResetDeviceDialog(TextFieldState(), "Username", false, true, true, {}, {})
     }
 }
 
@@ -133,7 +134,7 @@ fun PreviewForgotLockCodeResetDeviceDialog() {
 @Composable
 fun PreviewForgotLockCodeResetDeviceWithoutPasswordDialog() {
     WireTheme {
-        ForgotLockCodeResetDeviceDialog(TextFieldState(),"Username", true, true, true, {}, {})
+        ForgotLockCodeResetDeviceDialog(TextFieldState(), "Username", true, true, true, {}, {})
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeResetDeviceDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeResetDeviceDialog.kt
@@ -18,19 +18,17 @@
 package com.wire.android.ui.home.appLock.forgot
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.window.DialogProperties
 import com.wire.android.R
 import com.wire.android.ui.common.WireDialog
@@ -39,6 +37,7 @@ import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.textfield.DefaultPassword
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.theme.WireTheme
@@ -48,21 +47,22 @@ import com.wire.android.util.ui.stringWithStyledArgs
 
 @Composable
 fun ForgotLockCodeResetDeviceDialog(
+    passwordTextState: TextFieldState,
     username: String,
     isPasswordRequired: Boolean,
     isPasswordValid: Boolean,
     isResetDeviceEnabled: Boolean,
-    onPasswordChanged: (TextFieldValue) -> Unit,
     onResetDeviceClicked: () -> Unit,
-    onDialogDismissed: () -> Unit
+    onDialogDismissed: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    var backupPassword by remember { mutableStateOf(TextFieldValue("")) }
     var keyboardController: SoftwareKeyboardController? = null
     val onDialogDismissHideKeyboard: () -> Unit = {
         keyboardController?.hide()
         onDialogDismissed()
     }
     WireDialog(
+        modifier = modifier,
         title = stringResource(R.string.settings_forgot_lock_screen_reset_device),
         text = if (isPasswordRequired) {
             LocalContext.current.resources.stringWithStyledArgs(
@@ -98,17 +98,14 @@ fun ForgotLockCodeResetDeviceDialog(
             // to the dialog's content and use keyboard controller from there
             keyboardController = LocalSoftwareKeyboardController.current
             WirePasswordTextField(
+                textState = passwordTextState,
                 state = when {
                     !isPasswordValid -> WireTextFieldState.Error(stringResource(id = R.string.remove_device_invalid_password))
                     else -> WireTextFieldState.Default
                 },
-                value = backupPassword,
-                onValueChange = {
-                    backupPassword = it
-                    onPasswordChanged(it)
-                },
-                autofill = false,
-                onImeAction = { keyboardController?.hide() },
+                autoFill = false,
+                keyboardOptions = KeyboardOptions.DefaultPassword.copy(imeAction = ImeAction.Done),
+                onKeyboardAction = { keyboardController?.hide() },
                 modifier = Modifier.padding(bottom = dimensions().spacing16x)
             )
         }
@@ -124,12 +121,11 @@ fun ForgotLockCodeResettingDeviceDialog() {
         onDismiss = {},
     )
 }
-
 @PreviewMultipleThemes
 @Composable
 fun PreviewForgotLockCodeResetDeviceDialog() {
     WireTheme {
-        ForgotLockCodeResetDeviceDialog("Username", false, true, true, {}, {}, {})
+        ForgotLockCodeResetDeviceDialog(TextFieldState(),"Username", false, true, true, {}, {})
     }
 }
 
@@ -137,7 +133,7 @@ fun PreviewForgotLockCodeResetDeviceDialog() {
 @Composable
 fun PreviewForgotLockCodeResetDeviceWithoutPasswordDialog() {
     WireTheme {
-        ForgotLockCodeResetDeviceDialog("Username", true, true, true, {}, {}, {})
+        ForgotLockCodeResetDeviceDialog(TextFieldState(),"Username", true, true, true, {}, {})
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
@@ -85,11 +85,11 @@ fun ForgotLockCodeScreen(
         if (dialogState is ForgotLockCodeDialogState.Visible) {
             if (dialogState.loading) ForgotLockCodeResettingDeviceDialog()
             else ForgotLockCodeResetDeviceDialog(
+                passwordTextState = viewModel.passwordTextState,
                 username = dialogState.username,
                 isPasswordRequired = dialogState.passwordRequired,
                 isPasswordValid = dialogState.passwordValid,
                 isResetDeviceEnabled = dialogState.resetDeviceEnabled,
-                onPasswordChanged = viewModel::onPasswordChanged,
                 onResetDeviceClicked = viewModel::onResetDeviceConfirmed,
                 onDialogDismissed = viewModel::onDialogDismissed,
             )
@@ -115,10 +115,11 @@ fun ForgotLockCodeScreen(
 fun ForgotLockCodeScreenContent(
     scrollState: ScrollState,
     onResetDevice: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     WireScaffold { internalPadding ->
         Column(
-            modifier = Modifier
+            modifier = modifier
                 .fillMaxSize()
                 .padding(internalPadding)
         ) {
@@ -183,9 +184,9 @@ fun ForgotLockCodeScreenContent(
 
 @Composable
 private fun ContinueButton(
-    modifier: Modifier = Modifier.fillMaxWidth(),
     enabled: Boolean,
-    onContinue: () -> Unit
+    onContinue: () -> Unit,
+    modifier: Modifier = Modifier.fillMaxWidth(),
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     Column(modifier = modifier) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
@@ -83,16 +83,19 @@ fun ForgotLockCodeScreen(
             onResetDevice = viewModel::onResetDevice,
         )
         if (dialogState is ForgotLockCodeDialogState.Visible) {
-            if (dialogState.loading) ForgotLockCodeResettingDeviceDialog()
-            else ForgotLockCodeResetDeviceDialog(
-                passwordTextState = viewModel.passwordTextState,
-                username = dialogState.username,
-                isPasswordRequired = dialogState.passwordRequired,
-                isPasswordValid = dialogState.passwordValid,
-                isResetDeviceEnabled = dialogState.resetDeviceEnabled,
-                onResetDeviceClicked = viewModel::onResetDeviceConfirmed,
-                onDialogDismissed = viewModel::onDialogDismissed,
-            )
+            if (dialogState.loading) {
+                ForgotLockCodeResettingDeviceDialog()
+            } else {
+                ForgotLockCodeResetDeviceDialog(
+                    passwordTextState = viewModel.passwordTextState,
+                    username = dialogState.username,
+                    isPasswordRequired = dialogState.passwordRequired,
+                    isPasswordValid = dialogState.passwordValid,
+                    isResetDeviceEnabled = dialogState.resetDeviceEnabled,
+                    onResetDeviceClicked = viewModel::onResetDeviceConfirmed,
+                    onDialogDismissed = viewModel::onDialogDismissed,
+                )
+            }
         }
         if (error != null) {
             val (title, message) = error.dialogErrorStrings(LocalContext.current.resources)

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeViewState.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.android.ui.home.appLock.forgot
 
-import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.kalium.logic.CoreFailure
 
 data class ForgotLockCodeViewState(
@@ -30,7 +29,6 @@ sealed class ForgotLockCodeDialogState {
     data object Hidden : ForgotLockCodeDialogState()
     data class Visible(
         val username: String,
-        val password: TextFieldValue = TextFieldValue(""),
         val passwordRequired: Boolean = false,
         val passwordValid: Boolean = true,
         val resetDeviceEnabled: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
@@ -119,7 +119,8 @@ fun SetLockCodeScreenContent(
                 elevation = dimensions().spacing0x,
                 title = stringResource(id = R.string.settings_set_lock_screen_title)
             )
-    }) { internalPadding ->
+        }
+    ) { internalPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -60,6 +62,7 @@ import com.wire.android.ui.common.rememberBottomBarElevationState
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.spacers.VerticalSpace
+import com.wire.android.ui.common.textfield.DefaultPassword
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.topappbar.NavigationIconType
@@ -77,14 +80,14 @@ import java.util.Locale
 @Destination
 @Composable
 fun SetLockCodeScreen(
+    navigator: Navigator,
     viewModel: SetLockScreenViewModel = hiltViewModel(),
-    navigator: Navigator
 ) {
     SetLockCodeScreenContent(
         navigator = navigator,
         state = viewModel.state,
+        passwordTextState = viewModel.passwordTextState,
         scrollState = rememberScrollState(),
-        onPasswordChanged = viewModel::onPasswordChanged,
         onBackPress = navigator::navigateBack,
         onContinue = viewModel::onContinue
     )
@@ -95,10 +98,11 @@ fun SetLockCodeScreen(
 fun SetLockCodeScreenContent(
     navigator: Navigator,
     state: SetLockCodeViewState,
+    passwordTextState: TextFieldState,
     scrollState: ScrollState,
-    onPasswordChanged: (TextFieldValue) -> Unit,
-    onBackPress: () -> Unit = {},
-    onContinue: () -> Unit
+    onBackPress: () -> Unit,
+    onContinue: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     LaunchedEffect(state.done) {
         if (state.done) {
@@ -107,6 +111,7 @@ fun SetLockCodeScreenContent(
     }
 
     WireScaffold(
+        modifier = modifier,
         snackbarHost = {},
         topBar = {
             WireCenterAlignedTopAppBar(
@@ -144,14 +149,13 @@ fun SetLockCodeScreenContent(
                         .testTag("registerText")
                 )
                 WirePasswordTextField(
-                    value = state.password,
-                    onValueChange = onPasswordChanged,
+                    textState = passwordTextState,
                     labelMandatoryIcon = true,
-                    imeAction = ImeAction.Done,
+                    keyboardOptions = KeyboardOptions.DefaultPassword.copy(imeAction = ImeAction.Done),
                     modifier = Modifier
                         .testTag("password"),
                     state = WireTextFieldState.Default,
-                    autofill = false,
+                    autoFill = false,
                     placeholderText = stringResource(R.string.settings_set_lock_screen_passcode_label),
                     labelText = stringResource(R.string.settings_set_lock_screen_passcode_label).uppercase(Locale.getDefault())
                 )
@@ -168,7 +172,7 @@ fun SetLockCodeScreenContent(
                 }
             ) {
                 Box(modifier = Modifier.padding(MaterialTheme.wireDimensions.spacing16x)) {
-                    val enabled = state.password.text.isNotBlank() && state.passwordValidation.isValid
+                    val enabled = passwordTextState.text.isNotBlank() && state.passwordValidation.isValid && !state.loading
                     ContinueButton(
                         enabled = enabled,
                         onContinue = onContinue
@@ -232,9 +236,9 @@ private fun PasswordVerificationItem(isInvalid: Boolean, text: String) {
 
 @Composable
 private fun ContinueButton(
-    modifier: Modifier = Modifier.fillMaxWidth(),
     enabled: Boolean,
-    onContinue: () -> Unit
+    onContinue: () -> Unit,
+    modifier: Modifier = Modifier.fillMaxWidth(),
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     Column(modifier = modifier) {
@@ -273,8 +277,8 @@ fun PreviewSetLockCodeScreen() {
         SetLockCodeScreenContent(
             navigator = rememberNavigator {},
             state = SetLockCodeViewState(),
+            passwordTextState = TextFieldState(),
             scrollState = rememberScrollState(),
-            onPasswordChanged = {},
             onBackPress = {},
             onContinue = {}
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeViewState.kt
@@ -17,15 +17,12 @@
  */
 package com.wire.android.ui.home.appLock.set
 
-import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.feature.ObserveAppLockConfigUseCase
-
 import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
 import kotlin.time.Duration
 
 data class SetLockCodeViewState(
-    val continueEnabled: Boolean = false,
-    val password: TextFieldValue = TextFieldValue(),
+    val loading: Boolean = false,
     val passwordValidation: ValidatePasswordResult = ValidatePasswordResult.Invalid(),
     val timeout: Duration = ObserveAppLockConfigUseCase.DEFAULT_APP_LOCK_TIMEOUT,
     val done: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.GlobalDataStore

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/unlock/EnterLockCodeViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/unlock/EnterLockCodeViewState.kt
@@ -17,11 +17,8 @@
  */
 package com.wire.android.ui.home.appLock.unlock
 
-import androidx.compose.ui.text.input.TextFieldValue
-
 data class EnterLockCodeViewState(
-    val continueEnabled: Boolean = false,
-    val password: TextFieldValue = TextFieldValue(),
+    val loading: Boolean = false,
     val isUnlockEnabled: Boolean = false,
     val error: EnterLockCodeError = EnterLockCodeError.None,
     val done: Boolean = false

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -141,7 +141,6 @@ fun DeviceDetailsContent(
     onErrorDialogDismiss: () -> Unit = {},
     enrollE2eiCertificate: () -> Unit = {},
     onUpdateClientVerification: (Boolean) -> Unit = {},
-    onPasswordChange: (TextFieldValue) -> Unit = {},
     onEnrollE2EIErrorDismiss: () -> Unit = {},
     onEnrollE2EISuccessDismiss: () -> Unit = {}
 ) {

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
@@ -17,10 +17,11 @@
  */
 package com.wire.android.ui.settings.devices
 
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
@@ -29,6 +30,7 @@ import com.wire.android.navigation.SavedStateViewModel
 import com.wire.android.ui.authentication.devices.model.Device
 import com.wire.android.ui.authentication.devices.remove.RemoveDeviceDialogState
 import com.wire.android.ui.authentication.devices.remove.RemoveDeviceError
+import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.ui.navArgs
 import com.wire.android.ui.settings.devices.model.DeviceDetailsState
 import com.wire.kalium.logic.CoreFailure
@@ -53,6 +55,8 @@ import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -76,6 +80,7 @@ class DeviceDetailsViewModel @Inject constructor(
     private val deviceId: ClientId = deviceDetailsNavArgs.clientId
     private val userId: UserId = deviceDetailsNavArgs.userId
 
+    val passwordTextState: TextFieldState = TextFieldState()
     var state: DeviceDetailsState by mutableStateOf(
         DeviceDetailsState(
             isSelfClient = isSelfClient,
@@ -89,10 +94,24 @@ class DeviceDetailsViewModel @Inject constructor(
         getClientFingerPrint()
         observeUserName()
         getE2eiCertificate()
+        observePasswordTextChanges()
     }
 
     private val isSelfClient: Boolean
         get() = currentUserId == userId
+
+    private fun observePasswordTextChanges() {
+        viewModelScope.launch {
+            passwordTextState.textAsFlow().distinctUntilChanged().collectLatest { newPassword ->
+                updateStateIfDialogVisible {
+                    state.copy(
+                        removeDeviceDialogState = it.copy(removeEnabled = newPassword.isNotEmpty()),
+                        error = RemoveDeviceError.None
+                    )
+                }
+            }
+        }
+    }
 
     private fun observeUserName() {
         if (!isSelfClient) {
@@ -204,6 +223,7 @@ class DeviceDetailsViewModel @Inject constructor(
     }
 
     private fun showDeleteClientDialog(device: Device) {
+        passwordTextState.clearText()
         state = device.let { RemoveDeviceDialogState.Visible(it) }.let {
             state.copy(
                 error = RemoveDeviceError.None,
@@ -227,22 +247,6 @@ class DeviceDetailsViewModel @Inject constructor(
         }
     }
 
-    fun onPasswordChange(newText: TextFieldValue) {
-        updateStateIfDialogVisible {
-            if (it.password == newText) {
-                state
-            } else {
-                state.copy(
-                    removeDeviceDialogState = it.copy(
-                        password = newText,
-                        removeEnabled = newText.text.isNotEmpty()
-                    ),
-                    error = RemoveDeviceError.None
-                )
-            }
-        }
-    }
-
     fun onRemoveConfirmed(onSuccess: () -> Unit) {
         (state.removeDeviceDialogState as? RemoveDeviceDialogState.Visible)?.let { dialogStateVisible ->
             updateStateIfDialogVisible {
@@ -251,7 +255,7 @@ class DeviceDetailsViewModel @Inject constructor(
                 )
             }
             viewModelScope.launch {
-                deleteDevice(dialogStateVisible.password.text, onSuccess)
+                deleteDevice(passwordTextState.text.toString(), onSuccess)
                 updateStateIfDialogVisible { state.copy(removeDeviceDialogState = it.copy(loading = false)) }
             }
         }
@@ -270,6 +274,7 @@ class DeviceDetailsViewModel @Inject constructor(
     }
 
     fun onDialogDismissed() {
+        passwordTextState.clearText()
         state = state.copy(removeDeviceDialogState = RemoveDeviceDialogState.Hidden)
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
@@ -18,8 +18,9 @@
 
 package com.wire.android.ui.authentication.devices.register
 
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.SnapshotExtension
 import com.wire.android.config.mockUri
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.framework.TestClient
@@ -45,7 +46,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(CoroutineTestExtension::class)
+@ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class)
 class RegisterDeviceViewModelTest {
 
     @MockK
@@ -73,15 +74,15 @@ class RegisterDeviceViewModelTest {
     }
 
     @Test
-    fun `given empty string, when entering the password to register, then button is disabled`() {
-        registerDeviceViewModel.onPasswordChange(TextFieldValue(String.EMPTY))
+    fun `given empty string, when entering the password to register, then button is disabled`() = runTest {
+        registerDeviceViewModel.passwordTextState.setTextAndPlaceCursorAtEnd(String.EMPTY)
         registerDeviceViewModel.state.continueEnabled shouldBeEqualTo false
         registerDeviceViewModel.state.flowState shouldBeInstanceOf RegisterDeviceFlowState.Default::class
     }
 
     @Test
     fun `given non-empty string, when entering the password to register, then button is disabled`() {
-        registerDeviceViewModel.onPasswordChange(TextFieldValue("abc"))
+        registerDeviceViewModel.passwordTextState.setTextAndPlaceCursorAtEnd("abc")
         registerDeviceViewModel.state.continueEnabled shouldBeEqualTo true
         registerDeviceViewModel.state.flowState shouldBeInstanceOf RegisterDeviceFlowState.Default::class
     }
@@ -95,7 +96,7 @@ class RegisterDeviceViewModelTest {
             )
         } returns RegisterClientResult.Success(CLIENT)
 
-        registerDeviceViewModel.onPasswordChange(TextFieldValue(password))
+        registerDeviceViewModel.passwordTextState.setTextAndPlaceCursorAtEnd(password)
 
         registerDeviceViewModel.onContinue()
         advanceUntilIdle()
@@ -111,7 +112,7 @@ class RegisterDeviceViewModelTest {
         coEvery {
             registerClientUseCase(any())
         } returns RegisterClientResult.Failure.TooManyClients
-        registerDeviceViewModel.onPasswordChange(TextFieldValue(password))
+        registerDeviceViewModel.passwordTextState.setTextAndPlaceCursorAtEnd(password)
 
         registerDeviceViewModel.onContinue()
         advanceUntilIdle()

--- a/app/src/test/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModelTest.kt
@@ -18,6 +18,7 @@
 package com.wire.android.ui.home.appLock.forgot
 
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.SnapshotExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.datastore.UserDataStore
@@ -25,7 +26,6 @@ import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
 import com.wire.android.feature.SwitchAccountResult
-import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.StorageFailure
@@ -63,7 +63,7 @@ import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(CoroutineTestExtension::class)
+@ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class)
 class ForgotLockScreenViewModelTest {
     private val dispatcher = TestDispatcherProvider()
 
@@ -216,7 +216,6 @@ class ForgotLockScreenViewModelTest {
         @MockK lateinit var globalDataStore: GlobalDataStore
         @MockK lateinit var userDataStoreProvider: UserDataStoreProvider
         @MockK lateinit var userDataStore: UserDataStore
-        @MockK lateinit var notificationChannelsManager: NotificationChannelsManager
         @MockK lateinit var notificationManager: WireNotificationManager
         @MockK lateinit var getSelfUserUseCase: GetSelfUserUseCase
         @MockK lateinit var isPasswordRequiredUseCase: IsPasswordRequiredUseCase
@@ -230,7 +229,7 @@ class ForgotLockScreenViewModelTest {
 
         private val viewModel: ForgotLockScreenViewModel by lazy {
             ForgotLockScreenViewModel(
-                coreLogic, globalDataStore, userDataStoreProvider, notificationChannelsManager, notificationManager, getSelfUserUseCase,
+                coreLogic, globalDataStore, userDataStoreProvider, notificationManager, getSelfUserUseCase,
                 isPasswordRequiredUseCase, validatePasswordUseCase, observeCurrentClientIdUseCase, deleteClientUseCase, getSessionsUseCase,
                 observeEstablishedCallsUseCase, endCallUseCase, accountSwitchUseCase
             )

--- a/app/src/test/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModelTest.kt
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 class SetLockScreenViewModelTest {
 
     @Test
-    fun `given new password input, when valid,then should update state`()  {
+    fun `given new password input, when valid,then should update state`() = runTest {
         val (arrangement, viewModel) = Arrangement()
             .withValidPassword()
             .arrange()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8779" title="WPB-8779" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8779</a>  Introduce BasicTextField2
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Android Compose has new v2 version of text field inputs, and with that, they are going away from the previous approach with `TextFieldValue` and `onValueChanged` and replacing it with `TextFieldState`.
We already updated text fields to v2 but still are using "hybrid" solution which synchronises between `TextFieldValue/onValueChanged` and `TextFieldState`.

In this PR, following screens, their ViewModels logic and tests are updated to use `TextFieldState`:
- EnterLockCodeScreen 
- SetLockCodeScreen 
- ForgotLockCodeScreen 
- RegisterDeviceScreen 
- RemoveDeviceScreen 
- DeviceDetailsScreen

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Use text fields from any of listed screens.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
