### PR TITLE
refactor: update text input logic to v2 TextFieldState, part 4 [WPB-8779]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -327,7 +327,7 @@ class WireActivity : AppCompatActivity() {
                 if (legalHoldRequestedViewModel.state is LegalHoldRequestedState.Visible) {
                     LegalHoldRequestedDialog(
                         state = legalHoldRequestedViewModel.state as LegalHoldRequestedState.Visible,
-                        passwordChanged = legalHoldRequestedViewModel::passwordChanged,
+                        passwordTextState = legalHoldRequestedViewModel.passwordTextState,
                         notNowClicked = legalHoldRequestedViewModel::notNowClicked,
                         acceptClicked = legalHoldRequestedViewModel::acceptClicked,
                     )

--- a/app/src/main/kotlin/com/wire/android/ui/common/PreviewWireDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/PreviewWireDialog.kt
@@ -19,29 +19,24 @@ package com.wire.android.ui.common
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
 
-@Preview(showBackground = true)
+@PreviewMultipleThemes
 @Composable
-fun PreviewWireDialog() {
-    var password by remember { mutableStateOf(TextFieldValue("")) }
+fun PreviewWireDialog() = WireTheme {
+    val password = rememberTextFieldState()
     WireTheme {
         Box(
             contentAlignment = Alignment.Center,
@@ -71,20 +66,18 @@ fun PreviewWireDialog() {
                 },
             ) {
                 WirePasswordTextField(
-                    value = password,
-                    onValueChange = { password = it },
-                    autofill = false
+                    textState = password,
+                    autoFill = false
                 )
             }
         }
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
-@Preview(showBackground = true)
+@PreviewMultipleThemes
 @Composable
-fun PreviewWireDialogWith2OptionButtons() {
-    var password by remember { mutableStateOf(TextFieldValue("")) }
+fun PreviewWireDialogWith2OptionButtons() = WireTheme {
+    val password = rememberTextFieldState()
     WireTheme {
         Box(
             contentAlignment = Alignment.Center,
@@ -121,19 +114,18 @@ fun PreviewWireDialogWith2OptionButtons() {
                 buttonsHorizontalAlignment = false
             ) {
                 WirePasswordTextField(
-                    value = password,
-                    onValueChange = { password = it },
-                    autofill = true
+                    textState = password,
+                    autoFill = false
                 )
             }
         }
     }
 }
 
-@Preview(showBackground = true)
+@PreviewMultipleThemes
 @Composable
-fun PreviewWireDialogCentered() {
-    var password by remember { mutableStateOf(TextFieldValue("")) }
+fun PreviewWireDialogCentered() = WireTheme {
+    val password = rememberTextFieldState()
     WireTheme {
         Box(
             contentAlignment = Alignment.Center,
@@ -164,9 +156,8 @@ fun PreviewWireDialogCentered() {
                 },
             ) {
                 WirePasswordTextField(
-                    value = password,
-                    onValueChange = { password = it },
-                    autofill = false
+                    textState = password,
+                    autoFill = false
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupConversationNameComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupConversationNameComponent.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
@@ -34,14 +35,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.common.Icon
 import com.wire.android.ui.common.ShakeAnimation
@@ -54,29 +52,34 @@ import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.textfield.WireTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun GroupNameScreen(
     newGroupState: GroupMetadataState,
-    onGroupNameChange: (TextFieldValue) -> Unit,
+    newGroupNameTextState: TextFieldState,
     onContinuePressed: () -> Unit,
     onGroupNameErrorAnimated: () -> Unit,
     onBackPressed: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     with(newGroupState) {
         val scrollState = rememberScrollState()
 
-        WireScaffold(topBar = {
-            WireCenterAlignedTopAppBar(
-                elevation = scrollState.rememberTopBarElevationState().value,
-                onNavigationPressed = onBackPressed,
-                title = stringResource(id = if (mode == CREATION) R.string.new_group_title else R.string.group_name_title)
-            )
-        }) { internalPadding ->
+        WireScaffold(
+            modifier = modifier,
+            topBar = {
+                WireCenterAlignedTopAppBar(
+                    elevation = scrollState.rememberTopBarElevationState().value,
+                    onNavigationPressed = onBackPressed,
+                    title = stringResource(id = if (mode == CREATION) R.string.new_group_title else R.string.group_name_title)
+                )
+            }
+        ) { internalPadding ->
 
             Column(
                 modifier = Modifier
@@ -107,8 +110,7 @@ fun GroupNameScreen(
                                 onGroupNameErrorAnimated()
                             }
                             WireTextField(
-                                value = groupName,
-                                onValueChange = onGroupNameChange,
+                                textState = newGroupNameTextState,
                                 placeholderText = stringResource(R.string.group_name_placeholder),
                                 labelText = stringResource(R.string.group_name_title).uppercase(),
                                 state = computeGroupMetadataState(error),
@@ -174,12 +176,12 @@ private fun computeGroupMetadataState(error: GroupMetadataState.NewGroupError) =
         WireTextFieldState.Default
     }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
-fun PreviewGroupNameScreenEdit() {
+fun PreviewGroupNameScreenEdit() = WireTheme {
     GroupNameScreen(
-        GroupMetadataState(groupName = TextFieldValue("group name")),
-        onGroupNameChange = {},
+        newGroupState = GroupMetadataState(),
+        newGroupNameTextState = TextFieldState("group name"),
         onContinuePressed = {},
         onGroupNameErrorAnimated = {},
         onBackPressed = {}

--- a/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupMetadataState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupMetadataState.kt
@@ -18,7 +18,6 @@
 
 package com.wire.android.ui.common.groupname
 
-import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.kalium.logic.data.conversation.ConversationOptions
 import kotlinx.collections.immutable.ImmutableSet
@@ -27,7 +26,6 @@ import kotlinx.collections.immutable.persistentSetOf
 data class GroupMetadataState(
     val originalGroupName: String = "",
     val selectedUsers: ImmutableSet<Contact> = persistentSetOf(),
-    val groupName: TextFieldValue = TextFieldValue(""),
     val groupProtocol: ConversationOptions.Protocol = ConversationOptions.Protocol.PROTEUS,
     val animatedGroupNameError: Boolean = false,
     val continueEnabled: Boolean = false,
@@ -38,10 +36,10 @@ data class GroupMetadataState(
     val isGroupCreatingAllowed: Boolean? = null,
 ) {
     sealed interface NewGroupError {
-        object None : NewGroupError
+        data object None : NewGroupError
         sealed interface TextFieldError : NewGroupError {
-            object GroupNameEmptyError : TextFieldError
-            object GroupNameExceedLimitError : TextFieldError
+            data object GroupNameEmptyError : TextFieldError
+            data object GroupNameExceedLimitError : TextFieldError
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupNameValidator.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupNameValidator.kt
@@ -18,21 +18,18 @@
 
 package com.wire.android.ui.common.groupname
 
-import androidx.compose.ui.text.input.TextFieldValue
-
 object GroupNameValidator {
     private const val GROUP_NAME_MAX_COUNT = 64
 
     /**
      * Receives a group field and state and returns the new state after validation
      */
-    fun onGroupNameChange(newText: TextFieldValue, currentGroupState: GroupMetadataState): GroupMetadataState {
-        val cleanText = newText.text.trim()
+    fun onGroupNameChange(newText: String, currentGroupState: GroupMetadataState): GroupMetadataState {
+        val cleanText = newText.trim()
         return when {
             cleanText.isEmpty() -> {
                 currentGroupState.copy(
                     animatedGroupNameError = true,
-                    groupName = newText,
                     continueEnabled = false,
                     error = GroupMetadataState.NewGroupError.TextFieldError.GroupNameEmptyError
                 )
@@ -40,7 +37,6 @@ object GroupNameValidator {
             cleanText.count() > GROUP_NAME_MAX_COUNT -> {
                 currentGroupState.copy(
                     animatedGroupNameError = true,
-                    groupName = newText,
                     continueEnabled = false,
                     error = GroupMetadataState.NewGroupError.TextFieldError.GroupNameExceedLimitError
                 )
@@ -48,7 +44,6 @@ object GroupNameValidator {
             cleanText == currentGroupState.originalGroupName -> {
                 currentGroupState.copy(
                     animatedGroupNameError = false,
-                    groupName = newText,
                     continueEnabled = false,
                     error = GroupMetadataState.NewGroupError.None
                 )
@@ -56,7 +51,6 @@ object GroupNameValidator {
             else -> {
                 currentGroupState.copy(
                     animatedGroupNameError = false,
-                    groupName = newText,
                     continueEnabled = true,
                     error = GroupMetadataState.NewGroupError.None
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
@@ -38,9 +38,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -54,7 +54,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.Dp
@@ -70,6 +69,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 @Composable
 fun WirePasswordTextField(
     textState: TextFieldState,
+    modifier: Modifier = Modifier,
     placeholderText: String? = stringResource(R.string.login_password_placeholder),
     labelText: String? = stringResource(R.string.login_password_label),
     labelMandatoryIcon: Boolean = false,
@@ -86,9 +86,8 @@ fun WirePasswordTextField(
     inputMinHeight: Dp = MaterialTheme.wireDimensions.textFieldMinHeight,
     shape: Shape = RoundedCornerShape(MaterialTheme.wireDimensions.textFieldCornerSize),
     colors: WireTextFieldColors = wireTextFieldColors(),
-    modifier: Modifier = Modifier,
     onTap: ((Offset) -> Unit)? = null,
-    testTag: String = String.EMPTY,
+    testTag: String = String.EMPTY
 ) {
     val autoFillType = if (autoFill) WireAutoFillType.Password else WireAutoFillType.None
     var passwordVisibility by remember { mutableStateOf(false) }
@@ -121,74 +120,6 @@ fun WirePasswordTextField(
                 cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                 interactionSource = interactionSource,
                 modifier = textFieldModifier,
-                decorator = decorator,
-            )
-        }
-    )
-}
-
-/*
-TODO: BasicSecureTextField (value, onValueChange) overload is removed completely in compose foundation 1.7.0,
-      for now we can use our custom StateSyncingModifier to sync TextFieldValue with TextFieldState,
-      but eventually we should migrate and remove this function when all usages are replaced with the TextFieldState.
-*/
-@Deprecated("Use the new one with TextFieldState.")
-@Composable
-fun WirePasswordTextField(
-    value: TextFieldValue,
-    onValueChange: (TextFieldValue) -> Unit,
-    placeholderText: String? = stringResource(R.string.login_password_placeholder),
-    labelText: String? = stringResource(R.string.login_password_label),
-    labelMandatoryIcon: Boolean = false,
-    descriptionText: String? = null,
-    state: WireTextFieldState = WireTextFieldState.Default,
-    autofill: Boolean,
-    maxTextLength: Int = 8000,
-    imeAction: ImeAction = ImeAction.Default,
-    onImeAction: KeyboardActionHandler? = null,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    textStyle: TextStyle = MaterialTheme.wireTypography.body01.copy(textAlign = TextAlign.Start),
-    placeholderTextStyle: TextStyle = MaterialTheme.wireTypography.body01.copy(textAlign = TextAlign.Start),
-    placeholderAlignment: Alignment.Horizontal = Alignment.Start,
-    inputMinHeight: Dp = MaterialTheme.wireDimensions.textFieldMinHeight,
-    shape: Shape = RoundedCornerShape(MaterialTheme.wireDimensions.textFieldCornerSize),
-    colors: WireTextFieldColors = wireTextFieldColors(),
-    modifier: Modifier = Modifier,
-    onTap: ((Offset) -> Unit)? = null,
-    testTag: String = String.EMPTY,
-) {
-    val textState = remember { TextFieldState(value.text, value.selection) }
-    val autoFillType = if (autofill) WireAutoFillType.Password else WireAutoFillType.None
-    var passwordVisibility by remember { mutableStateOf(false) }
-    WireTextFieldLayout(
-        shouldShowPlaceholder = textState.text.isEmpty(),
-        placeholderText = placeholderText,
-        labelText = labelText,
-        labelMandatoryIcon = labelMandatoryIcon,
-        descriptionText = descriptionText,
-        state = state,
-        interactionSource = interactionSource,
-        placeholderTextStyle = placeholderTextStyle,
-        placeholderAlignment = placeholderAlignment,
-        inputMinHeight = inputMinHeight,
-        shape = shape,
-        colors = colors,
-        trailingIcon = { VisibilityIconButton(passwordVisibility) { passwordVisibility = it } },
-        modifier = modifier.autoFill(autoFillType, textState::setTextAndPlaceCursorAtEnd),
-        testTag = testTag,
-        onTap = onTap,
-        innerBasicTextField = { decorator, textFieldModifier ->
-            BasicSecureTextField(
-                state = textState,
-                textStyle = textStyle.copy(color = colors.textColor(state = state).value, textDirection = TextDirection.ContentOrLtr),
-                keyboardOptions = KeyboardOptions.Default.copy(imeAction = imeAction),
-                onKeyboardAction = onImeAction,
-                inputTransformation = InputTransformation.maxLength(maxTextLength),
-                textObfuscationMode = if (passwordVisibility) TextObfuscationMode.Visible else TextObfuscationMode.RevealLastTyped,
-                enabled = state !is WireTextFieldState.Disabled,
-                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-                interactionSource = interactionSource,
-                modifier = textFieldModifier.then(StateSyncingModifier(textState, value, onValueChange)),
                 decorator = decorator,
             )
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordGuestLinkState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordGuestLinkState.kt
@@ -17,12 +17,9 @@
  */
 package com.wire.android.ui.home.conversations.details.editguestaccess.createPasswordProtectedGuestLink
 
-import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.kalium.logic.CoreFailure
 
 data class CreatePasswordGuestLinkState(
-    val password: TextFieldValue = TextFieldValue(""),
-    val passwordConfirm: TextFieldValue = TextFieldValue(""),
     val isLoading: Boolean = false,
     val error: CoreFailure? = null,
     val isPasswordValid: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordGuestLinkViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordGuestLinkViewModel.kt
@@ -18,20 +18,25 @@
 package com.wire.android.ui.home.conversations.details.editguestaccess.createPasswordProtectedGuestLink
 
 import androidx.annotation.VisibleForTesting
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.feature.GenerateRandomPasswordUseCase
+import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.ui.navArgs
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
 import com.wire.kalium.logic.feature.conversation.guestroomlink.GenerateGuestRoomLinkResult
 import com.wire.kalium.logic.feature.conversation.guestroomlink.GenerateGuestRoomLinkUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -46,15 +51,27 @@ class CreatePasswordGuestLinkViewModel @Inject constructor(
     private val editGuestAccessNavArgs: CreatePasswordGuestLinkNavArgs = savedStateHandle.navArgs<CreatePasswordGuestLinkNavArgs>()
     private val conversationId: QualifiedID = editGuestAccessNavArgs.conversationId
 
+    val passwordTextState: TextFieldState = TextFieldState()
+    val confirmPasswordTextState: TextFieldState = TextFieldState()
     var state by mutableStateOf(CreatePasswordGuestLinkState())
         @VisibleForTesting set
+
+    init {
+        viewModelScope.launch {
+            combine(passwordTextState.textAsFlow(), confirmPasswordTextState.textAsFlow(), ::Pair)
+                .distinctUntilChanged()
+                .collectLatest { (password, confirmPassword) ->
+                    state = state.copy(isPasswordValid = validatePassword(password.toString()).isValid && password == confirmPassword)
+                }
+        }
+    }
 
     fun onGenerateLink() {
         state = state.copy(isLoading = true)
         viewModelScope.launch {
             generateGuestRoomLink(
                 conversationId = conversationId,
-                password = state.password.text
+                password = passwordTextState.text.toString()
             ).also { result ->
                 state = if (result is GenerateGuestRoomLinkResult.Failure) {
                     state.copy(error = result.cause, isLoading = false)
@@ -65,39 +82,13 @@ class CreatePasswordGuestLinkViewModel @Inject constructor(
         }
     }
 
-    fun onPasswordUpdated(password: TextFieldValue) {
-        if (password.text != state.password.text) {
-            state = state.copy(password = password)
-            checkIfPasswordIsValidAndConfirmed()
-        } else {
-            state = state.copy(password = password)
-        }
-    }
-
-    fun onPasswordConfirmUpdated(password: TextFieldValue) {
-        if (password.text != state.passwordConfirm.text) {
-            state = state.copy(passwordConfirm = password)
-            checkIfPasswordIsValidAndConfirmed()
-        } else {
-            state = state.copy(passwordConfirm = password)
-        }
-    }
-
-    private fun checkIfPasswordIsValidAndConfirmed() {
-        state = if (validatePassword(state.password.text).isValid && state.password.text == state.passwordConfirm.text) {
-            state.copy(isPasswordValid = true)
-        } else {
-            state.copy(isPasswordValid = false)
-        }
-    }
-
     fun onErrorDialogDismissed() {
         state = state.copy(error = null)
     }
 
     fun onGenerateRandomPassword() {
         val password = generateRandomPasswordUseCase()
-        state = state.copy(password = TextFieldValue(password), passwordConfirm = TextFieldValue(password))
-        checkIfPasswordIsValidAndConfirmed()
+        passwordTextState.setTextAndPlaceCursorAtEnd(password)
+        confirmPasswordTextState.setTextAndPlaceCursorAtEnd(password)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordProtectedGuestLinkScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordProtectedGuestLinkScreen.kt
@@ -126,7 +126,8 @@ fun CreatePasswordProtectedGuestLinkScreenContent(
                 onNavigationPressed = navigateBack,
                 title = stringResource(id = R.string.conversation_options_create_password_protected_guest_link_title),
             )
-        }) { internalPadding ->
+        }
+    ) { internalPadding ->
         Column {
             LazyColumn(
                 modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordProtectedGuestLinkScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordProtectedGuestLinkScreen.kt
@@ -27,20 +27,24 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.input.ImeAction
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.R
@@ -50,12 +54,15 @@ import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.rememberTopBarElevationState
 import com.wire.android.ui.common.scaffold.WireScaffold
+import com.wire.android.ui.common.textfield.DefaultPassword
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.home.conversations.details.editguestaccess.GenerateGuestRoomLinkFailureDialog
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
 
 @RootNavGraph
 @Destination(
@@ -66,13 +73,36 @@ fun CreatePasswordProtectedGuestLinkScreen(
     navigator: Navigator,
     viewModel: CreatePasswordGuestLinkViewModel = hiltViewModel(),
 ) {
+    CreatePasswordProtectedGuestLinkScreenContent(
+        state = viewModel.state,
+        passwordTextState = viewModel.passwordTextState,
+        confirmPasswordTextState = viewModel.confirmPasswordTextState,
+        navigateBack = navigator::navigateBack,
+        onGenerateRandomPassword = viewModel::onGenerateRandomPassword,
+        onGenerateLink = viewModel::onGenerateLink,
+        onErrorDialogDismissed = viewModel::onErrorDialogDismissed,
+    )
+}
+
+@Composable
+fun CreatePasswordProtectedGuestLinkScreenContent(
+    state: CreatePasswordGuestLinkState,
+    passwordTextState: TextFieldState,
+    confirmPasswordTextState: TextFieldState,
+    navigateBack: () -> Unit,
+    onGenerateRandomPassword: () -> Unit,
+    onGenerateLink: () -> Unit,
+    onErrorDialogDismissed: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val scrollState = rememberScrollState()
     val context = LocalContext.current
     val clipboardManager = LocalClipboardManager.current
-    val onCopyClick = remember(viewModel.state.password.text) {
+    val passwordCurrentState by rememberUpdatedState(newValue = passwordTextState.text.toString())
+    val onCopyClick = remember {
         {
-            if (viewModel.state.isPasswordValid) {
-                clipboardManager.setText(viewModel.state.password.annotatedString)
+            if (state.isPasswordValid) {
+                clipboardManager.setText(AnnotatedString(passwordCurrentState))
                 Toast.makeText(
                     context,
                     context.getString(R.string.conversation_options_create_password_protected_guest_link_password_copied),
@@ -81,20 +111,22 @@ fun CreatePasswordProtectedGuestLinkScreen(
             }
         }
     }
-    LaunchedEffect(viewModel.state.isLinkCreationSuccessful) {
-        if (viewModel.state.isLinkCreationSuccessful) {
+    LaunchedEffect(state.isLinkCreationSuccessful) {
+        if (state.isLinkCreationSuccessful) {
             onCopyClick()
-            navigator.navigateBack()
+            navigateBack()
         }
     }
 
-    WireScaffold(topBar = {
-        WireCenterAlignedTopAppBar(
-            elevation = scrollState.rememberTopBarElevationState().value,
-            onNavigationPressed = navigator::navigateBack,
-            title = stringResource(id = R.string.conversation_options_create_password_protected_guest_link_title),
-        )
-    }) { internalPadding ->
+    WireScaffold(
+        modifier = modifier,
+        topBar = {
+            WireCenterAlignedTopAppBar(
+                elevation = scrollState.rememberTopBarElevationState().value,
+                onNavigationPressed = navigateBack,
+                title = stringResource(id = R.string.conversation_options_create_password_protected_guest_link_title),
+            )
+        }) { internalPadding ->
         Column {
             LazyColumn(
                 modifier = Modifier
@@ -127,9 +159,9 @@ fun CreatePasswordProtectedGuestLinkScreen(
                     Spacer(modifier = Modifier.height(dimensions().spacing24x))
                 }
                 item {
-                    val onClick = remember(viewModel.state.password.text) {
+                    val onClick = remember {
                         {
-                            viewModel.onGenerateRandomPassword()
+                            onGenerateRandomPassword()
                             Toast.makeText(
                                 context,
                                 context.getString(R.string.conversation_options_create_password_protected_guest_link_password_generated),
@@ -147,12 +179,12 @@ fun CreatePasswordProtectedGuestLinkScreen(
                         labelText = stringResource(
                             id = R.string.conversation_options_create_password_protected_guest_link_password_label
                         ),
-                        value = viewModel.state.password,
+                        textState = passwordTextState,
                         placeholderText = stringResource(
                             id = R.string.conversation_options_create_password_protected_guest_link_button_placeholder_text
                         ),
-                        onValueChange = viewModel::onPasswordUpdated,
-                        autofill = false
+                        keyboardOptions = KeyboardOptions.DefaultPassword.copy(imeAction = ImeAction.Next),
+                        autoFill = false,
                     )
                     Spacer(modifier = Modifier.height(dimensions().spacing8x))
                 }
@@ -174,9 +206,9 @@ fun CreatePasswordProtectedGuestLinkScreen(
                         placeholderText = stringResource(
                             id = R.string.conversation_options_create_password_protected_guest_link_button_placeholder_text
                         ),
-                        value = viewModel.state.passwordConfirm,
-                        onValueChange = viewModel::onPasswordConfirmUpdated,
-                        autofill = false
+                        textState = confirmPasswordTextState,
+                        keyboardOptions = KeyboardOptions.DefaultPassword.copy(imeAction = ImeAction.Done),
+                        autoFill = false
                     )
                     Spacer(modifier = Modifier.height(dimensions().spacing24x))
                 }
@@ -187,16 +219,16 @@ fun CreatePasswordProtectedGuestLinkScreen(
                 shadowElevation = dimensions().spacing8x
             ) {
                 CreateButton(
-                    enabled = viewModel.state.isPasswordValid,
-                    isLoading = viewModel.state.isLoading,
-                    onCreateLink = viewModel::onGenerateLink
+                    enabled = state.isPasswordValid,
+                    isLoading = state.isLoading,
+                    onCreateLink = onGenerateLink
                 )
             }
         }
 
-        if (viewModel.state.error != null) {
+        if (state.error != null) {
             GenerateGuestRoomLinkFailureDialog(
-                onDismiss = viewModel::onErrorDialogDismissed
+                onDismiss = onErrorDialogDismissed
             )
         }
     }
@@ -223,8 +255,16 @@ private fun CreateButton(
     )
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
-fun PreviewCreatePasswordProtectedGuestLinkScreen() {
-    CreatePasswordProtectedGuestLinkScreen(navigator = Navigator(finish = {}, navController = NavHostController(LocalContext.current)))
+fun PreviewCreatePasswordProtectedGuestLinkScreen() = WireTheme {
+    CreatePasswordProtectedGuestLinkScreenContent(
+        state = CreatePasswordGuestLinkState(),
+        passwordTextState = TextFieldState(),
+        confirmPasswordTextState = TextFieldState(),
+        navigateBack = {},
+        onGenerateRandomPassword = {},
+        onGenerateLink = {},
+        onErrorDialogDismissed = {},
+    )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationMetadataViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationMetadataViewModel.kt
@@ -105,7 +105,9 @@ class EditConversationMetadataViewModel @Inject constructor(
         onSuccess: () -> Unit,
     ) {
         viewModelScope.launch {
-            when (withContext(dispatcher.io()) { renameConversation(conversationId, editConversationNameTextState.text.toString()) }) {
+            when (withContext(dispatcher.io()) {
+                renameConversation(conversationId, editConversationNameTextState.text.toString())
+            }) {
                 is RenamingResult.Failure -> onFailure()
                 is RenamingResult.Success -> onSuccess()
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationMetadataViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationMetadataViewModel.kt
@@ -18,16 +18,18 @@
 
 package com.wire.android.ui.home.conversations.details.metadata
 
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.wire.android.navigation.SavedStateViewModel
 import com.wire.android.ui.common.groupname.GroupMetadataState
 import com.wire.android.ui.common.groupname.GroupNameMode
 import com.wire.android.ui.common.groupname.GroupNameValidator
+import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.ui.navArgs
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -38,6 +40,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -57,11 +60,13 @@ class EditConversationMetadataViewModel @Inject constructor(
     private val editConversationNameNavArgs: EditConversationNameNavArgs = savedStateHandle.navArgs()
     private val conversationId: QualifiedID = editConversationNameNavArgs.conversationId
 
+    val editConversationNameTextState: TextFieldState = TextFieldState()
     var editConversationState by mutableStateOf(GroupMetadataState(mode = GroupNameMode.EDITION))
         private set
 
     init {
         observeConversationDetails()
+        observeConversationNameChanges()
     }
 
     private fun observeConversationDetails() {
@@ -73,16 +78,22 @@ class EditConversationMetadataViewModel @Inject constructor(
                 .flowOn(dispatcher.io())
                 .shareIn(this, SharingStarted.WhileSubscribed(), 1)
                 .collectLatest {
+                    editConversationNameTextState.setTextAndPlaceCursorAtEnd(it.conversation.name.orEmpty())
                     editConversationState = editConversationState.copy(
-                        groupName = TextFieldValue(it.conversation.name.orEmpty()),
                         originalGroupName = it.conversation.name.orEmpty()
                     )
                 }
         }
     }
 
-    fun onGroupNameChange(newText: TextFieldValue) {
-        editConversationState = GroupNameValidator.onGroupNameChange(newText, editConversationState)
+    private fun observeConversationNameChanges() {
+        viewModelScope.launch {
+            editConversationNameTextState.textAsFlow()
+                .dropWhile { it.isEmpty() } // ignore first empty value to not show the error before the user typed anything
+                .collectLatest {
+                editConversationState = GroupNameValidator.onGroupNameChange(it.toString(), editConversationState)
+            }
+        }
     }
 
     fun onGroupNameErrorAnimated() {
@@ -94,7 +105,7 @@ class EditConversationMetadataViewModel @Inject constructor(
         onSuccess: () -> Unit,
     ) {
         viewModelScope.launch {
-            when (withContext(dispatcher.io()) { renameConversation(conversationId, editConversationState.groupName.text) }) {
+            when (withContext(dispatcher.io()) { renameConversation(conversationId, editConversationNameTextState.text.toString()) }) {
                 is RenamingResult.Failure -> onFailure()
                 is RenamingResult.Success -> onSuccess()
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationMetadataViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationMetadataViewModel.kt
@@ -105,11 +105,13 @@ class EditConversationMetadataViewModel @Inject constructor(
         onSuccess: () -> Unit,
     ) {
         viewModelScope.launch {
-            when (withContext(dispatcher.io()) {
+            withContext(dispatcher.io()) {
                 renameConversation(conversationId, editConversationNameTextState.text.toString())
-            }) {
-                is RenamingResult.Failure -> onFailure()
-                is RenamingResult.Success -> onSuccess()
+            }.let { renamingResult ->
+                when (renamingResult) {
+                    is RenamingResult.Failure -> onFailure()
+                    is RenamingResult.Success -> onSuccess()
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationNameScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationNameScreen.kt
@@ -18,13 +18,18 @@
 
 package com.wire.android.ui.home.conversations.details.metadata
 
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.navigation.Navigator
+import com.wire.android.ui.common.groupname.GroupMetadataState
+import com.wire.android.ui.common.groupname.GroupNameMode
 import com.wire.android.ui.common.groupname.GroupNameScreen
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.ui.PreviewMultipleThemes
 
 @RootNavGraph
 @Destination(
@@ -33,13 +38,13 @@ import com.wire.android.ui.common.groupname.GroupNameScreen
 @Composable
 fun EditConversationNameScreen(
     navigator: Navigator,
+    resultNavigator: ResultBackNavigator<Boolean>,
     viewModel: EditConversationMetadataViewModel = hiltViewModel(),
-    resultNavigator: ResultBackNavigator<Boolean>
 ) {
     with(viewModel) {
         GroupNameScreen(
             newGroupState = editConversationState,
-            onGroupNameChange = ::onGroupNameChange,
+            newGroupNameTextState = editConversationNameTextState,
             onGroupNameErrorAnimated = ::onGroupNameErrorAnimated,
             onContinuePressed = {
                 saveNewGroupName(
@@ -56,4 +61,10 @@ fun EditConversationNameScreen(
             onBackPressed = navigator::navigateBack
         )
     }
+}
+
+@Composable
+@PreviewMultipleThemes
+fun PreviewNewGroupScreen() = WireTheme {
+    GroupNameScreen(GroupMetadataState(mode = GroupNameMode.EDITION), TextFieldState(), {}, {}, {})
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupname/NewGroupNameScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupname/NewGroupNameScreen.kt
@@ -18,13 +18,14 @@
 
 package com.wire.android.ui.home.newconversation.groupname
 
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
 import com.ramcosta.composedestinations.annotation.Destination
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.groupname.GroupMetadataState
+import com.wire.android.ui.common.groupname.GroupNameMode
 import com.wire.android.ui.common.groupname.GroupNameScreen
 import com.wire.android.ui.destinations.ConversationScreenDestination
 import com.wire.android.ui.destinations.GroupOptionScreenDestination
@@ -33,6 +34,8 @@ import com.wire.android.ui.destinations.NewConversationSearchPeopleScreenDestina
 import com.wire.android.ui.home.newconversation.NewConversationViewModel
 import com.wire.android.ui.home.newconversation.common.CreateGroupErrorDialog
 import com.wire.android.ui.home.newconversation.common.NewConversationNavGraph
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.id.ConversationId
 
 @NewConversationNavGraph
@@ -47,7 +50,7 @@ fun NewGroupNameScreen(
 
     GroupNameScreen(
         newGroupState = newConversationViewModel.newGroupState,
-        onGroupNameChange = newConversationViewModel::onGroupNameChange,
+        newGroupNameTextState = newConversationViewModel.newGroupNameTextState,
         onContinuePressed = {
             if (newConversationViewModel.newGroupState.isSelfTeamMember == true) {
                 navigator.navigate(NavigationCommand(GroupOptionScreenDestination))
@@ -75,7 +78,7 @@ fun NewGroupNameScreen(
 }
 
 @Composable
-@Preview
-fun PreviewNewGroupScreen() {
-    GroupNameScreen(GroupMetadataState(), {}, {}, {}, {})
+@PreviewMultipleThemes
+fun PreviewNewGroupScreen() = WireTheme {
+    GroupNameScreen(GroupMetadataState(mode = GroupNameMode.CREATION), TextFieldState(), {}, {}, {})
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -35,8 +36,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
@@ -55,11 +54,13 @@ import com.wire.android.ui.destinations.HomeScreenDestination
 import com.wire.android.ui.home.conversations.PermissionPermanentlyDeniedDialogState
 import com.wire.android.ui.home.settings.backup.dialog.create.CreateBackupDialogFlow
 import com.wire.android.ui.home.settings.backup.dialog.restore.RestoreBackupDialogFlow
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.permission.PermissionDenialType
 import com.wire.android.util.time.convertTimestampToDateTime
+import com.wire.android.util.ui.PreviewMultipleThemes
 
 @RootNavGraph
 @Destination
@@ -70,7 +71,8 @@ fun BackupAndRestoreScreen(
 ) {
     BackupAndRestoreContent(
         backUpAndRestoreState = viewModel.state,
-        onValidateBackupPassword = viewModel::validateBackupCreationPassword,
+        createBackupPasswordTextState = viewModel.createBackupPasswordState,
+        restoreBackupPasswordTextState = viewModel.restoreBackupPasswordState,
         onCreateBackup = viewModel::createBackup,
         onSaveBackup = viewModel::saveBackup,
         onShareBackup = viewModel::shareBackup,
@@ -86,16 +88,18 @@ fun BackupAndRestoreScreen(
 @Composable
 fun BackupAndRestoreContent(
     backUpAndRestoreState: BackupAndRestoreState,
-    onValidateBackupPassword: (TextFieldValue) -> Unit,
-    onCreateBackup: (String) -> Unit,
+    createBackupPasswordTextState: TextFieldState,
+    restoreBackupPasswordTextState: TextFieldState,
+    onCreateBackup: () -> Unit,
     onSaveBackup: (Uri) -> Unit,
     onShareBackup: () -> Unit,
     onCancelBackupCreation: () -> Unit,
     onCancelBackupRestore: () -> Unit,
     onChooseBackupFile: (Uri) -> Unit,
-    onRestoreBackup: (String) -> Unit,
+    onRestoreBackup: () -> Unit,
     onOpenConversations: () -> Unit,
-    onBackPressed: () -> Unit
+    onBackPressed: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val permissionPermanentlyDeniedDialogState =
         rememberVisibilityState<PermissionPermanentlyDeniedDialogState>()
@@ -111,17 +115,17 @@ fun BackupAndRestoreContent(
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Top,
-            modifier = Modifier
+            modifier = modifier
                 .fillMaxHeight()
                 .padding(internalPadding)
         ) {
 
-            backupAndRestoreText(
+            BackupAndRestoreText(
+                lastBackupTime = backUpAndRestoreState.lastBackupData,
                 modifier = Modifier
                     .weight(1f)
                     .padding(MaterialTheme.wireDimensions.spacing16x)
                     .fillMaxWidth(),
-                backUpAndRestoreState.lastBackupData
             )
 
             Surface(
@@ -151,7 +155,7 @@ fun BackupAndRestoreContent(
         is BackupAndRestoreDialog.CreateBackup -> {
             CreateBackupDialogFlow(
                 backUpAndRestoreState = backUpAndRestoreState,
-                onValidateBackupPassword = onValidateBackupPassword,
+                backupPasswordTextState = createBackupPasswordTextState,
                 onCreateBackup = onCreateBackup,
                 onSaveBackup = onSaveBackup,
                 onShareBackup = onShareBackup,
@@ -175,6 +179,7 @@ fun BackupAndRestoreContent(
         is BackupAndRestoreDialog.RestoreBackup -> {
             RestoreBackupDialogFlow(
                 backUpAndRestoreState = backUpAndRestoreState,
+                backupPasswordTextState = restoreBackupPasswordTextState,
                 onChooseBackupFile = onChooseBackupFile,
                 onRestoreBackup = onRestoreBackup,
                 onCancelBackupRestore = {
@@ -205,7 +210,7 @@ fun BackupAndRestoreContent(
 }
 
 @Composable
-private fun backupAndRestoreText(modifier: Modifier, lastBackupTime: Long?) {
+private fun BackupAndRestoreText(lastBackupTime: Long?, modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
     ) {
@@ -258,12 +263,13 @@ private fun backupAndRestoreText(modifier: Modifier, lastBackupTime: Long?) {
     }
 }
 
-@Preview
+@PreviewMultipleThemes
 @Composable
-fun PreviewBackupAndRestoreScreen() {
+fun PreviewBackupAndRestoreScreen() = WireTheme {
     BackupAndRestoreContent(
         backUpAndRestoreState = BackupAndRestoreState.INITIAL_STATE,
-        onValidateBackupPassword = {},
+        createBackupPasswordTextState = TextFieldState(),
+        restoreBackupPasswordTextState = TextFieldState(),
         onCreateBackup = {},
         onSaveBackup = {},
         onShareBackup = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
@@ -20,15 +20,17 @@ package com.wire.android.ui.home.settings.backup
 
 import android.net.Uri
 import androidx.annotation.VisibleForTesting
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.BuildConfig
 import com.wire.android.appLogger
 import com.wire.android.datastore.UserDataStore
+import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.util.FileManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
@@ -48,6 +50,7 @@ import com.wire.kalium.logic.feature.backup.VerifyBackupUseCase
 import com.wire.kalium.util.DateTimeUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okio.Path
@@ -67,6 +70,8 @@ class BackupAndRestoreViewModel
     private val dispatcher: DispatcherProvider
 ) : ViewModel() {
 
+    val createBackupPasswordState: TextFieldState = TextFieldState()
+    val restoreBackupPasswordState: TextFieldState = TextFieldState()
     var state by mutableStateOf(BackupAndRestoreState.INITIAL_STATE)
 
     @VisibleForTesting
@@ -77,6 +82,15 @@ class BackupAndRestoreViewModel
 
     init {
         observeLastBackupDate()
+        observeCreateBackupPasswordChanges()
+    }
+
+    private fun observeCreateBackupPasswordChanges() {
+        viewModelScope.launch {
+            createBackupPasswordState.textAsFlow().collectLatest {
+                validateBackupCreationPassword(it.toString())
+            }
+        }
     }
 
     private fun observeLastBackupDate() {
@@ -87,7 +101,7 @@ class BackupAndRestoreViewModel
         }
     }
 
-    fun createBackup(password: String) = viewModelScope.launch {
+    fun createBackup() = viewModelScope.launch {
         // TODO: Find a way to update the creation progress more faithfully. For now we will just show this small delays to mimic the
         //  progress also for small backups
         updateCreationProgress(PROGRESS_25)
@@ -95,15 +109,16 @@ class BackupAndRestoreViewModel
         updateCreationProgress(PROGRESS_50)
         delay(SMALL_DELAY)
 
-        when (val result = createBackupFile(password)) {
+        when (val result = createBackupFile(createBackupPasswordState.text.toString())) {
             is CreateBackupResult.Success -> {
                 state = state.copy(backupCreationProgress = BackupCreationProgress.Finished(result.backupFileName))
                 latestCreatedBackup = BackupAndRestoreState.CreatedBackup(
                     result.backupFilePath,
                     result.backupFileName,
                     result.backupFileSize,
-                    password.isNotEmpty()
+                    createBackupPasswordState.text.isNotEmpty()
                 )
+                createBackupPasswordState.clearText()
             }
 
             is CreateBackupResult.Failure -> {
@@ -211,7 +226,7 @@ class BackupAndRestoreViewModel
         }
     }
 
-    fun restorePasswordProtectedBackup(restorePassword: String) = viewModelScope.launch(dispatcher.main()) {
+    fun restorePasswordProtectedBackup() = viewModelScope.launch(dispatcher.main()) {
         state = state.copy(
             backupRestoreProgress = BackupRestoreProgress.InProgress(PROGRESS_50),
             restorePasswordValidation = PasswordValidation.NotVerified
@@ -220,12 +235,13 @@ class BackupAndRestoreViewModel
         val fileValidationState = state.restoreFileValidation
         if (fileValidationState is RestoreFileValidation.PasswordRequired) {
             state = state.copy(restorePasswordValidation = PasswordValidation.Entered)
-            when (val result = importBackup(latestImportedBackupTempPath, restorePassword)) {
+            when (val result = importBackup(latestImportedBackupTempPath, restoreBackupPasswordState.text.toString())) {
                 RestoreBackupResult.Success -> {
                     state = state.copy(
                         backupRestoreProgress = BackupRestoreProgress.Finished,
                         restorePasswordValidation = PasswordValidation.Valid
                     )
+                    restoreBackupPasswordState.clearText()
                 }
 
                 is RestoreBackupResult.Failure -> {
@@ -263,21 +279,23 @@ class BackupAndRestoreViewModel
         )
     }
 
-    fun validateBackupCreationPassword(backupPassword: TextFieldValue) {
+    fun validateBackupCreationPassword(backupPassword: String) {
         state = state.copy(
-            passwordValidation = if (backupPassword.text.isEmpty()) {
+            passwordValidation = if (backupPassword.isEmpty()) {
                 ValidatePasswordResult.Valid
             } else {
-                validatePassword(backupPassword.text)
+                validatePassword(backupPassword)
             }
         )
     }
 
     fun cancelBackupCreation() = viewModelScope.launch(dispatcher.main()) {
+        createBackupPasswordState.clearText()
         updateCreationProgress(0f)
     }
 
     fun cancelBackupRestore() = viewModelScope.launch {
+        restoreBackupPasswordState.clearText()
         state = state.copy(
             restoreFileValidation = RestoreFileValidation.Initial,
             backupRestoreProgress = BackupRestoreProgress.InProgress(),

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogFlow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogFlow.kt
@@ -20,10 +20,10 @@ package com.wire.android.ui.home.settings.backup.dialog.create
 
 import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.R
 import com.wire.android.ui.home.settings.backup.BackupAndRestoreState
 import com.wire.android.ui.home.settings.backup.BackupCreationProgress
@@ -33,8 +33,8 @@ import com.wire.android.util.permission.PermissionDenialType
 @Composable
 fun CreateBackupDialogFlow(
     backUpAndRestoreState: BackupAndRestoreState,
-    onValidateBackupPassword: (TextFieldValue) -> Unit,
-    onCreateBackup: (String) -> Unit,
+    backupPasswordTextState: TextFieldState,
+    onCreateBackup: () -> Unit,
     onSaveBackup: (Uri) -> Unit,
     onShareBackup: () -> Unit,
     onCancelCreateBackup: () -> Unit,
@@ -47,10 +47,10 @@ fun CreateBackupDialogFlow(
             BackUpDialogStep.SetPassword -> {
                 SetBackupPasswordDialog(
                     passwordValidation = backUpAndRestoreState.passwordValidation,
-                    onBackupPasswordChanged = onValidateBackupPassword,
-                    onCreateBackup = { password ->
+                    backupPasswordTextState = backupPasswordTextState,
+                    onCreateBackup = {
                         toCreatingBackup()
-                        onCreateBackup(password)
+                        onCreateBackup()
                     },
                     onDismissDialog = onCancelCreateBackup
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
@@ -24,17 +24,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.R
 import com.wire.android.ui.common.WireCheckIcon
 import com.wire.android.ui.common.WireDialog
@@ -55,14 +52,15 @@ import kotlin.math.roundToInt
 
 @Composable
 fun SetBackupPasswordDialog(
+    backupPasswordTextState: TextFieldState,
     passwordValidation: ValidatePasswordResult,
-    onBackupPasswordChanged: (TextFieldValue) -> Unit,
-    onCreateBackup: (String) -> Unit,
-    onDismissDialog: () -> Unit
+    onCreateBackup: () -> Unit,
+    onDismissDialog: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    var backupPassword by remember { mutableStateOf(TextFieldValue("")) }
 
     WireDialog(
+        modifier = modifier,
         title = stringResource(R.string.backup_dialog_create_backup_set_password_title),
         text = stringResource(R.string.backup_dialog_create_backup_set_password_message),
         onDismiss = onDismissDialog,
@@ -72,7 +70,7 @@ fun SetBackupPasswordDialog(
             state = WireButtonState.Default
         ),
         optionButton1Properties = WireDialogButtonProperties(
-            onClick = { onCreateBackup(backupPassword.text) },
+            onClick = onCreateBackup,
             text = stringResource(id = R.string.backup_dialog_create_backup_now),
             type = WireDialogButtonType.Primary,
             state = if (passwordValidation.isValid) WireButtonState.Default else WireButtonState.Disabled
@@ -83,12 +81,8 @@ fun SetBackupPasswordDialog(
             labelText = stringResource(R.string.label_textfield_optional_password).uppercase(Locale.getDefault()),
             descriptionText = stringResource(R.string.create_account_details_password_description),
             state = if (passwordValidation.isValid) WireTextFieldState.Default else WireTextFieldState.Error(),
-            value = backupPassword,
-            onValueChange = {
-                backupPassword = it
-                onBackupPasswordChanged(it)
-            },
-            autofill = false
+            textState = backupPasswordTextState,
+            autoFill = false
         )
     }
 }
@@ -101,7 +95,8 @@ fun CreateBackupDialog(
     onPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit,
     onSaveBackup: (Uri) -> Unit,
     onShareBackup: () -> Unit,
-    onDismissDialog: () -> Unit
+    onDismissDialog: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val progress by animateFloatAsState(targetValue = createBackupProgress)
     val fileStep = rememberCreateFileFlow(
@@ -114,6 +109,7 @@ fun CreateBackupDialog(
         fileName = backupFileName
     )
     WireDialog(
+        modifier = modifier,
         title = stringResource(R.string.backup_dialog_create_backup_title),
         onDismiss = onDismissDialog,
         buttonsHorizontalAlignment = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogFlow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogFlow.kt
@@ -20,6 +20,7 @@ package com.wire.android.ui.home.settings.backup.dialog.restore
 
 import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -38,8 +39,9 @@ import com.wire.android.util.permission.PermissionDenialType
 @Composable
 fun RestoreBackupDialogFlow(
     backUpAndRestoreState: BackupAndRestoreState,
+    backupPasswordTextState: TextFieldState,
     onChooseBackupFile: (Uri) -> Unit,
-    onRestoreBackup: (String) -> Unit,
+    onRestoreBackup: () -> Unit,
     onOpenConversations: () -> Unit,
     onCancelBackupRestore: () -> Unit,
     onPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit
@@ -60,6 +62,7 @@ fun RestoreBackupDialogFlow(
 
             is RestoreDialogStep.EnterPassword -> {
                 EnterPasswordStep(
+                    backupPasswordTextState = backupPasswordTextState,
                     backUpAndRestoreState = backUpAndRestoreState,
                     restoreDialogStateHolder = restoreDialogStateHolder,
                     onRestoreBackup = onRestoreBackup,
@@ -133,8 +136,9 @@ private fun ChooseBackupFileStep(
 @Composable
 fun EnterPasswordStep(
     backUpAndRestoreState: BackupAndRestoreState,
+    backupPasswordTextState: TextFieldState,
     restoreDialogStateHolder: RestoreDialogStateHolder,
-    onRestoreBackup: (String) -> Unit,
+    onRestoreBackup: () -> Unit,
     onCancelBackupRestore: () -> Unit
 ) {
     var showWrongPassword by remember { mutableStateOf(false) }
@@ -150,10 +154,11 @@ fun EnterPasswordStep(
     }
 
     EnterRestorePasswordDialog(
+        backupPasswordTextState = backupPasswordTextState,
         isWrongPassword = showWrongPassword,
-        onRestoreBackupFile = { password ->
+        onRestoreBackupFile = {
             showWrongPassword = false
-            onRestoreBackup(password)
+            onRestoreBackup()
         },
         onAcknowledgeWrongPassword = { showWrongPassword = false },
         onCancelBackupRestore = onCancelBackupRestore

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
@@ -29,12 +29,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.R
 import com.wire.android.ui.common.WireCheckIcon
 import com.wire.android.ui.common.WireDialog
@@ -80,8 +76,6 @@ fun EnterRestorePasswordDialog(
     onCancelBackupRestore: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var restorePassword by remember { mutableStateOf(TextFieldValue((""))) }
-
     if (!isWrongPassword) {
         WireDialog(
             modifier = modifier,

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
@@ -23,6 +23,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -31,7 +32,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
@@ -53,11 +53,13 @@ import kotlin.math.roundToInt
 fun PickRestoreFileDialog(
     onChooseBackupFile: (Uri) -> Unit,
     onCancelBackupRestore: () -> Unit,
-    onPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit
+    onPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val fileFlow = FileBrowserFlow(onChooseBackupFile, onPermissionPermanentlyDenied)
 
     WireDialog(
+        modifier = modifier,
         title = stringResource(R.string.backup_dialog_restore_backup_title),
         text = stringResource(R.string.backup_dialog_restore_backup_message),
         onDismiss = onCancelBackupRestore,
@@ -69,18 +71,20 @@ fun PickRestoreFileDialog(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun EnterRestorePasswordDialog(
     isWrongPassword: Boolean,
-    onRestoreBackupFile: (String) -> Unit,
+    backupPasswordTextState: TextFieldState,
+    onRestoreBackupFile: () -> Unit,
     onAcknowledgeWrongPassword: () -> Unit,
-    onCancelBackupRestore: () -> Unit
+    onCancelBackupRestore: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     var restorePassword by remember { mutableStateOf(TextFieldValue((""))) }
 
     if (!isWrongPassword) {
         WireDialog(
+            modifier = modifier,
             title = stringResource(R.string.backup_label_enter_password),
             text = stringResource(R.string.backup_dialog_restore_backup_password_message),
             onDismiss = onCancelBackupRestore,
@@ -94,20 +98,20 @@ fun EnterRestorePasswordDialog(
                 state = WireButtonState.Default
             ),
             optionButton1Properties = WireDialogButtonProperties(
-                onClick = { onRestoreBackupFile(restorePassword.text) },
+                onClick = onRestoreBackupFile,
                 text = stringResource(id = R.string.label_continue),
                 type = WireDialogButtonType.Primary,
-                state = if (restorePassword.text.isEmpty()) WireButtonState.Disabled else WireButtonState.Default
+                state = if (backupPasswordTextState.text.isEmpty()) WireButtonState.Disabled else WireButtonState.Default
             )
         ) {
             WirePasswordTextField(
-                value = restorePassword,
-                onValueChange = { restorePassword = it },
-                autofill = false
+                textState = backupPasswordTextState,
+                autoFill = false
             )
         }
     } else {
         WireDialog(
+            modifier = modifier,
             title = stringResource(R.string.backup_label_wrong_password),
             text = stringResource(R.string.backup_label_verify_input),
             onDismiss = onCancelBackupRestore,
@@ -125,10 +129,12 @@ fun RestoreProgressDialog(
     isRestoreCompleted: Boolean,
     restoreProgress: Float,
     onOpenConversation: () -> Unit,
-    onCancelBackupRestore: () -> Unit
+    onCancelBackupRestore: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val progress by animateFloatAsState(targetValue = restoreProgress)
     WireDialog(
+        modifier = modifier,
         title = stringResource(R.string.backup_dialog_restoring_backup_title),
         onDismiss = {
             // User is not able to dismiss the dialog

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedDialog.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.window.DialogProperties
 import com.wire.android.R
 import com.wire.android.ui.common.WireDialog

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedDialog.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -41,6 +43,7 @@ import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.button.WireButtonState
+import com.wire.android.ui.common.textfield.DefaultPassword
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.legalhold.dialog.common.LearnMoreAboutLegalHoldButton
@@ -54,12 +57,14 @@ import com.wire.kalium.logic.data.user.UserId
 @Composable
 fun LegalHoldRequestedDialog(
     state: LegalHoldRequestedState.Visible,
-    passwordChanged: (TextFieldValue) -> Unit,
+    passwordTextState: TextFieldState,
     notNowClicked: () -> Unit,
     acceptClicked: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     var keyboardController: SoftwareKeyboardController? = null
     WireDialog(
+        modifier = modifier,
         title = stringResource(R.string.legal_hold_requested_dialog_title),
         properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false, usePlatformDefaultWidth = false),
         onDismiss = { keyboardController?.hide() },
@@ -111,8 +116,7 @@ fun LegalHoldRequestedDialog(
                     keyboardController = LocalSoftwareKeyboardController.current
                     val focusRequester = remember { FocusRequester() }
                     WirePasswordTextField(
-                        value = state.password,
-                        onValueChange = passwordChanged,
+                        textState = passwordTextState,
                         state = when {
                             state.error is LegalHoldRequestedError.InvalidCredentialsError ->
                                 WireTextFieldState.Error(stringResource(id = R.string.remove_device_invalid_password))
@@ -120,13 +124,13 @@ fun LegalHoldRequestedDialog(
                             state.loading -> WireTextFieldState.Disabled
                             else -> WireTextFieldState.Default
                         },
-                        imeAction = ImeAction.Done,
-                        onImeAction = { keyboardController?.hide() },
+                        keyboardOptions = KeyboardOptions.DefaultPassword.copy(imeAction = ImeAction.Done),
+                        onKeyboardAction = { keyboardController?.hide() },
                         modifier = Modifier
                             .focusRequester(focusRequester)
                             .padding(bottom = MaterialTheme.wireDimensions.spacing8x)
                             .testTag("remove device password field"),
-                        autofill = true
+                        autoFill = true
                     )
                 }
             }
@@ -139,11 +143,14 @@ fun LegalHoldRequestedDialog(
 fun PreviewLegalHoldRequestedDialogWithPassword() {
     WireTheme {
         LegalHoldRequestedDialog(
-            LegalHoldRequestedState.Visible(
+            state = LegalHoldRequestedState.Visible(
                 legalHoldDeviceFingerprint = "0123456789ABCDEF",
                 requiresPassword = true,
                 userId = UserId("", ""),
-            ), {}, {}, {}
+            ),
+            passwordTextState = TextFieldState(),
+            notNowClicked = {},
+            acceptClicked = {},
         )
     }
 }
@@ -153,11 +160,14 @@ fun PreviewLegalHoldRequestedDialogWithPassword() {
 fun PreviewLegalHoldRequestedDialogWithoutPassword() {
     WireTheme {
         LegalHoldRequestedDialog(
-            LegalHoldRequestedState.Visible(
+            state = LegalHoldRequestedState.Visible(
                 legalHoldDeviceFingerprint = "0123456789ABCDEF",
                 requiresPassword = false,
                 userId = UserId("", ""),
-            ), {}, {}, {}
+            ),
+            passwordTextState = TextFieldState(),
+            notNowClicked = {},
+            acceptClicked = {},
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedState.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.android.ui.legalhold.dialog.requested
 
-import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.user.UserId
 
@@ -25,7 +24,6 @@ sealed class LegalHoldRequestedState {
     data object Hidden : LegalHoldRequestedState()
     data class Visible(
         val legalHoldDeviceFingerprint: String = "",
-        val password: TextFieldValue = TextFieldValue(""),
         val requiresPassword: Boolean = false,
         val loading: Boolean = false,
         val acceptEnabled: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModel.kt
@@ -17,14 +17,16 @@
  */
 package com.wire.android.ui.legalhold.dialog.requested
 
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.UserSessionScope
@@ -37,6 +39,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.mapLatest
@@ -50,8 +53,19 @@ class LegalHoldRequestedViewModel @Inject constructor(
     @KaliumCoreLogic private val coreLogic: CoreLogic,
 ) : ViewModel() {
 
+    val passwordTextState: TextFieldState = TextFieldState()
     var state: LegalHoldRequestedState by mutableStateOf(LegalHoldRequestedState.Hidden)
         private set
+
+    init {
+        viewModelScope.launch {
+            passwordTextState.textAsFlow().distinctUntilChanged().collectLatest {
+                state.ifVisible {
+                    state = it.copy(acceptEnabled = !it.requiresPassword || validatePassword(it.toString()).isValid)
+                }
+            }
+        }
+    }
 
     private val legalHoldRequestDataStateFlow = currentSessionFlow(noSession = LegalHoldRequestData.None) { userId ->
         observeLegalHoldRequest()
@@ -96,6 +110,7 @@ class LegalHoldRequestedViewModel @Inject constructor(
             legalHoldRequestDataStateFlow.collectLatest { legalHoldRequestData ->
                 state = when (legalHoldRequestData) {
                     is LegalHoldRequestData.Pending -> {
+                        passwordTextState.clearText()
                         LegalHoldRequestedState.Visible(
                             requiresPassword = legalHoldRequestData.isPasswordRequired,
                             acceptEnabled = !legalHoldRequestData.isPasswordRequired,
@@ -114,18 +129,13 @@ class LegalHoldRequestedViewModel @Inject constructor(
         if (this is LegalHoldRequestedState.Visible) action(this)
     }
 
-    fun passwordChanged(password: TextFieldValue) {
-        state.ifVisible {
-            state = it.copy(password = password, acceptEnabled = !it.requiresPassword || validatePassword(password.text).isValid)
-        }
-    }
-
     fun notNowClicked() {
         state = LegalHoldRequestedState.Hidden
     }
 
     fun show() {
         (legalHoldRequestDataStateFlow.value as? LegalHoldRequestData.Pending)?.let {
+            passwordTextState.clearText()
             state = LegalHoldRequestedState.Visible(
                 requiresPassword = it.isPasswordRequired,
                 acceptEnabled = !it.isPasswordRequired,
@@ -139,10 +149,10 @@ class LegalHoldRequestedViewModel @Inject constructor(
         state.ifVisible {
             state = it.copy(acceptEnabled = false, loading = true)
             // the accept button is enabled if the password is valid, this check is for safety only
-            if (it.requiresPassword && validatePassword(it.password.text).isValid.not()) {
+            if (it.requiresPassword && validatePassword(passwordTextState.text.toString()).isValid.not()) {
                 state = it.copy(loading = false, error = LegalHoldRequestedError.InvalidCredentialsError)
             } else {
-                val password = if (it.requiresPassword) it.password.text else null
+                val password = if (it.requiresPassword) passwordTextState.text.toString() else null
                 viewModelScope.launch {
                     coreLogic.sessionScope(it.userId) {
                         approveLegalHoldRequest(password).let { approveLegalHoldResult ->

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -110,9 +110,9 @@ import com.wire.kalium.logic.data.user.UserId
 @Composable
 fun SelfUserProfileScreen(
     navigator: Navigator,
+    avatarPickerResultRecipient: ResultRecipient<AvatarPickerScreenDestination, String?>,
     viewModelSelf: SelfUserProfileViewModel = hiltViewModel(),
-    legalHoldRequestedViewModel: LegalHoldRequestedViewModel = hiltViewModel(),
-    avatarPickerResultRecipient: ResultRecipient<AvatarPickerScreenDestination, String?>
+    legalHoldRequestedViewModel: LegalHoldRequestedViewModel = hiltViewModel()
 ) {
     val legalHoldSubjectDialogState = rememberVisibilityState<Unit>()
 
@@ -153,7 +153,7 @@ fun SelfUserProfileScreen(
     if (legalHoldRequestedViewModel.state is LegalHoldRequestedState.Visible) {
         LegalHoldRequestedDialog(
             state = legalHoldRequestedViewModel.state as LegalHoldRequestedState.Visible,
-            passwordChanged = legalHoldRequestedViewModel::passwordChanged,
+            passwordTextState = legalHoldRequestedViewModel.passwordTextState,
             notNowClicked = legalHoldRequestedViewModel::notNowClicked,
             acceptClicked = legalHoldRequestedViewModel::acceptClicked,
         )

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/create/username/CreateAccountUsernameViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/create/username/CreateAccountUsernameViewModelTest.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.ui.authentication.create.username
 
+import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.SnapshotExtension
@@ -37,6 +38,7 @@ import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
@@ -161,6 +163,26 @@ class CreateAccountUsernameViewModelTest {
                 HandleUpdateErrorState.DialogError.GenericError::class
         createAccountUsernameViewModel.onErrorDismiss()
         createAccountUsernameViewModel.state.error shouldBe HandleUpdateErrorState.None
+    }
+
+    @Test
+    fun `given account name, when creating group, then do not show NameEmptyError until name is entered and cleared`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withValidateHandleResult(ValidateUserHandleResult.Invalid.TooShort(String.EMPTY), String.EMPTY)
+            .withValidateHandleResult(ValidateUserHandleResult.Valid("name"), "name")
+            .withSetUserHandle(SetUserHandleResult.Failure.HandleExists)
+            .arrange()
+        viewModel.textState.setTextAndPlaceCursorAtEnd(String.EMPTY)
+        advanceUntilIdle()
+        assertEquals(HandleUpdateErrorState.None, viewModel.state.error)
+
+        viewModel.textState.setTextAndPlaceCursorAtEnd("name")
+        advanceUntilIdle()
+        assertEquals(HandleUpdateErrorState.None, viewModel.state.error)
+
+        viewModel.textState.clearText()
+        advanceUntilIdle()
+        assertEquals(HandleUpdateErrorState.TextFieldError.UsernameInvalidError, viewModel.state.error)
     }
 
     private class Arrangement {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/CreatePasswordGuestLinkViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/CreatePasswordGuestLinkViewModelTest.kt
@@ -93,6 +93,7 @@ class CreatePasswordGuestLinkViewModelTest {
     @Test
     fun `given password confirm emitted new value, when the new value is not different, then validate is not called`() {
         val (arrangement, viewModel) = Arrangement()
+            .withPasswordValidation(true)
             .arrange()
         viewModel.confirmPasswordTextState.setTextAndPlaceCursorAtEnd("password")
         arrangement.clearValidatePasswordCallsCount()
@@ -150,9 +151,8 @@ class CreatePasswordGuestLinkViewModelTest {
     @Test
     fun `given onGenerateLink called, when link is generated, then isLinkCreationSuccessful is marked as true`() {
         val (_, viewModel) = Arrangement()
-            .withGenerateGuestLink(
-                GenerateGuestRoomLinkResult.Success
-            )
+            .withPasswordValidation(true)
+            .withGenerateGuestLink(GenerateGuestRoomLinkResult.Success)
             .arrange()
 
         viewModel.passwordTextState.setTextAndPlaceCursorAtEnd("password")
@@ -168,9 +168,8 @@ class CreatePasswordGuestLinkViewModelTest {
     fun `given onGenerateLink called, when link is not generated, then isLinkCreationSuccessful is marked as false`() {
         val expectedError = NetworkFailure.NoNetworkConnection(null)
         val (_, viewModel) = Arrangement()
-            .withGenerateGuestLink(
-                GenerateGuestRoomLinkResult.Failure(expectedError)
-            )
+            .withPasswordValidation(true)
+            .withGenerateGuestLink(GenerateGuestRoomLinkResult.Failure(expectedError))
             .arrange()
 
         viewModel.passwordTextState.setTextAndPlaceCursorAtEnd("password")

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
@@ -58,12 +58,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(CoroutineTestExtension::class)
 @ExtendWith(NavigationTestExtension::class)
 class EditGuestAccessViewModelTest {
+    private val dispatcher = TestDispatcherProvider()
 
     @Test
     fun `given updateConversationAccessRole use case runs successfully, when trying to enable guest access, then enable guest access`() =
-        runTest {
+        runTest(dispatcher.default()) {
             // given
-            val (arrangement, editGuestAccessViewModel) = Arrangement()
+            val (arrangement, editGuestAccessViewModel) = Arrangement(dispatcher)
                 .withUpdateConversationAccessRoleResult(UpdateConversationAccessRoleUseCase.Result.Success)
                 .arrange()
             advanceUntilIdle()
@@ -78,9 +79,9 @@ class EditGuestAccessViewModelTest {
 
     @Test
     fun `given a failure when running updateConversationAccessRole, when trying to enable guest access, then do not enable guest access`() =
-        runTest {
+        runTest(dispatcher.default()) {
             // given
-            val (arrangement, editGuestAccessViewModel) = Arrangement()
+            val (arrangement, editGuestAccessViewModel) = Arrangement(dispatcher)
                 .withUpdateConversationAccessRoleResult(
                     UpdateConversationAccessRoleUseCase.Result.Failure(CoreFailure.MissingClientRegistration)
                 ).arrange()
@@ -96,9 +97,9 @@ class EditGuestAccessViewModelTest {
 
     @Test
     fun `given guest access is activated, when trying to disable guest access, then display dialog before disabling guest access`() =
-        runTest {
+        runTest(dispatcher.default()) {
             // given
-            val (arrangement, editGuestAccessViewModel) = Arrangement()
+            val (arrangement, editGuestAccessViewModel) = Arrangement(dispatcher)
                 .withUpdateConversationAccessRoleResult(UpdateConversationAccessRoleUseCase.Result.Success)
                 .arrange()
             advanceUntilIdle()
@@ -112,9 +113,9 @@ class EditGuestAccessViewModelTest {
         }
 
     @Test
-    fun `given useCase runs with success, when_generating guest link, then invoke it once`() = runTest {
+    fun `given useCase runs with success, when_generating guest link, then invoke it once`() = runTest(dispatcher.default()) {
         // given
-        val (arrangement, editGuestAccessViewModel) = Arrangement()
+        val (arrangement, editGuestAccessViewModel) = Arrangement(dispatcher)
             .withGenerateGuestRoomResult(GenerateGuestRoomLinkResult.Success)
             .arrange()
         advanceUntilIdle()
@@ -128,9 +129,9 @@ class EditGuestAccessViewModelTest {
     }
 
     @Test
-    fun `given useCase runs with failure, when generating guest link, then show dialog error`() = runTest {
+    fun `given useCase runs with failure, when generating guest link, then show dialog error`() = runTest(dispatcher.default()) {
         // given
-        val (arrangement, editGuestAccessViewModel) = Arrangement()
+        val (arrangement, editGuestAccessViewModel) = Arrangement(dispatcher)
             .withGenerateGuestRoomResult(
                 GenerateGuestRoomLinkResult.Failure(NetworkFailure.NoNetworkConnection(RuntimeException("no network")))
             ).arrange()
@@ -145,9 +146,9 @@ class EditGuestAccessViewModelTest {
     }
 
     @Test
-    fun `given useCase runs with success, when revoking guest link, then invoke it once`() = runTest {
+    fun `given useCase runs with success, when revoking guest link, then invoke it once`() = runTest(dispatcher.default()) {
         // given
-        val (arrangement, editGuestAccessViewModel) = Arrangement()
+        val (arrangement, editGuestAccessViewModel) = Arrangement(dispatcher)
             .withRevokeGuestRoomLinkResult(RevokeGuestRoomLinkResult.Success)
             .arrange()
         advanceUntilIdle()
@@ -161,9 +162,9 @@ class EditGuestAccessViewModelTest {
     }
 
     @Test
-    fun `given useCase runs with failure when revoking guest link then show dialog error`() = runTest {
+    fun `given useCase runs with failure when revoking guest link then show dialog error`() = runTest(dispatcher.default()) {
         // given
-        val (arrangement, editGuestAccessViewModel) = Arrangement()
+        val (arrangement, editGuestAccessViewModel) = Arrangement(dispatcher)
             .withRevokeGuestRoomLinkResult(RevokeGuestRoomLinkResult.Failure(CoreFailure.MissingClientRegistration))
             .arrange()
         advanceUntilIdle()
@@ -179,9 +180,9 @@ class EditGuestAccessViewModelTest {
 
     @Test
     fun `given updateConversationAccessRole use case runs successfully, when trying to disable guest access, then disable guest access`() =
-        runTest {
+        runTest(dispatcher.default()) {
             // given
-            val (arrangement, editGuestAccessViewModel) = Arrangement()
+            val (arrangement, editGuestAccessViewModel) = Arrangement(dispatcher)
                 .withUpdateConversationAccessRoleResult(UpdateConversationAccessRoleUseCase.Result.Success)
                 .arrange()
             advanceUntilIdle()
@@ -196,9 +197,9 @@ class EditGuestAccessViewModelTest {
 
     @Test
     fun `given a failure running updateConversationAccessRole, when trying to disable guest access, then do not disable guest access`() =
-        runTest {
+        runTest(dispatcher.default()) {
             // given
-            val (arrangement, editGuestAccessViewModel) = Arrangement()
+            val (arrangement, editGuestAccessViewModel) = Arrangement(dispatcher)
                 .withUpdateConversationAccessRoleResult(
                     UpdateConversationAccessRoleUseCase.Result.Failure(CoreFailure.MissingClientRegistration)
                 )
@@ -213,7 +214,7 @@ class EditGuestAccessViewModelTest {
             assertEquals(true, editGuestAccessViewModel.editGuestAccessState.isGuestAccessAllowed)
         }
 
-    private class Arrangement {
+    private class Arrangement(dispatcherProvider: TestDispatcherProvider) {
         @MockK
         lateinit var savedStateHandle: SavedStateHandle
 
@@ -258,7 +259,7 @@ class EditGuestAccessViewModelTest {
                 revokeGuestRoomLink = revokeGuestRoomLink,
                 observeGuestRoomLinkFeatureFlag = observeGuestRoomLinkFeatureFlag,
                 canCreatePasswordProtectedLinks = canCreatePasswordProtectedLinks,
-                dispatcher = TestDispatcherProvider(),
+                dispatcher = dispatcherProvider,
                 syncConversationCode = syncConversationCodeUseCase
             )
         }

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelperTest.kt
@@ -34,10 +34,10 @@ import org.robolectric.annotation.Config
 @Config(
     sdk = [Build.VERSION_CODES.TIRAMISU],
     /*
-    Run tests in isolation, use basic Application class instead of initializing WireApplication.
-    It won't work with WireApplication because of Datadog - for each test new WireApplication instance is created but Datadog uses
-    singleton and initializes itself only once for the first instance of WireApplication which then crashes for other instances.
-    */
+     * Run tests in isolation, use basic Application class instead of initializing WireApplication.
+     * It won't work with WireApplication because of Datadog - for each test new WireApplication instance is created but Datadog uses
+     * singleton and initializes itself only once for the first instance of WireApplication which then crashes for other instances.
+     */
     application = Application::class,
 )
 class LocationPickerHelperTest {

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelperTest.kt
@@ -31,7 +31,15 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+@Config(
+    sdk = [Build.VERSION_CODES.TIRAMISU],
+    /*
+    Run tests in isolation, use basic Application class instead of initializing WireApplication.
+    It won't work with WireApplication because of Datadog - for each test new WireApplication instance is created but Datadog uses
+    singleton and initializes itself only once for the first instance of WireApplication which then crashes for other instances.
+    */
+    application = Application::class,
+)
 class LocationPickerHelperTest {
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -105,7 +105,7 @@ class NewConversationViewModelTest {
 
         coVerify {
             arrangement.createGroupConversation(
-                viewModel.newGroupState.groupName.text,
+                viewModel.newGroupNameTextState.text.toString(),
                 viewModel.newGroupState.selectedUsers.map { contact -> UserId(contact.id, contact.domain) },
                 ConversationOptions(
                     Conversation.defaultGroupAccess,
@@ -134,7 +134,7 @@ class NewConversationViewModelTest {
 
             coVerify {
                 arrangement.createGroupConversation(
-                    viewModel.newGroupState.groupName.text,
+                    viewModel.newGroupNameTextState.text.toString(),
                     viewModel.newGroupState.selectedUsers.map { contact -> UserId(contact.id, contact.domain) },
                     ConversationOptions(
                         setOf(Conversation.Access.INVITE, Conversation.Access.CODE),

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -20,8 +20,13 @@
 
 package com.wire.android.ui.home.newconversation
 
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.SnapshotExtension
+import com.wire.android.ui.common.groupname.GroupMetadataState
 import com.wire.android.ui.home.newconversation.common.CreateGroupState
+import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.user.SupportedProtocol
@@ -38,7 +43,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(CoroutineTestExtension::class)
+@ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class)
 class NewConversationViewModelTest {
 
     @Test
@@ -190,5 +195,23 @@ class NewConversationViewModelTest {
         val result = viewModel.newGroupState.isGroupCreatingAllowed
         // then
         assertEquals(true, result)
+    }
+
+    @Test
+    fun `given group name, when creating group, then do not show NameEmptyError until name is entered and cleared`() = runTest {
+        val (_, viewModel) = NewConversationViewModelArrangement()
+            .withGetSelfUser(isTeamMember = true)
+            .arrange()
+        viewModel.newGroupNameTextState.setTextAndPlaceCursorAtEnd(String.EMPTY)
+        advanceUntilIdle()
+        assertEquals(GroupMetadataState.NewGroupError.None, viewModel.newGroupState.error)
+
+        viewModel.newGroupNameTextState.setTextAndPlaceCursorAtEnd("name")
+        advanceUntilIdle()
+        assertEquals(GroupMetadataState.NewGroupError.None, viewModel.newGroupState.error)
+
+        viewModel.newGroupNameTextState.clearText()
+        advanceUntilIdle()
+        assertEquals(GroupMetadataState.NewGroupError.TextFieldError.GroupNameEmptyError, viewModel.newGroupState.error)
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/home/BackupAndRestoreViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/home/BackupAndRestoreViewModelTest.kt
@@ -19,8 +19,9 @@
 package com.wire.android.ui.home.settings.home
 
 import android.net.Uri
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.core.net.toUri
+import com.wire.android.config.SnapshotExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.framework.FakeKaliumFileSystem
@@ -71,8 +72,10 @@ import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(SnapshotExtension::class)
 class BackupAndRestoreViewModelTest {
 
     private val dispatcher = TestDispatcherProvider()
@@ -92,11 +95,13 @@ class BackupAndRestoreViewModelTest {
         // Given
         val emptyPassword = ""
         val (arrangement, backupAndRestoreViewModel) = Arrangement()
+            .withValidPassword()
             .withSuccessfulCreation(emptyPassword)
             .arrange()
+        backupAndRestoreViewModel.createBackupPasswordState.setTextAndPlaceCursorAtEnd(emptyPassword)
 
         // When
-        backupAndRestoreViewModel.createBackup(emptyPassword)
+        backupAndRestoreViewModel.createBackup()
         advanceUntilIdle()
 
         // Then
@@ -110,11 +115,13 @@ class BackupAndRestoreViewModelTest {
         // Given
         val password = "mayTh3ForceBeWIthYou"
         val (arrangement, backupAndRestoreViewModel) = Arrangement()
+            .withValidPassword()
             .withSuccessfulCreation(password)
             .arrange()
+        backupAndRestoreViewModel.createBackupPasswordState.setTextAndPlaceCursorAtEnd(password)
 
         // When
-        backupAndRestoreViewModel.createBackup(password)
+        backupAndRestoreViewModel.createBackup()
         advanceUntilIdle()
 
         // Then
@@ -132,7 +139,7 @@ class BackupAndRestoreViewModelTest {
             .arrange()
 
         // When
-        backupAndRestoreViewModel.validateBackupCreationPassword(TextFieldValue(password))
+        backupAndRestoreViewModel.validateBackupCreationPassword(password)
         advanceUntilIdle()
 
         // Then
@@ -149,7 +156,7 @@ class BackupAndRestoreViewModelTest {
             .arrange()
 
         // When
-        backupAndRestoreViewModel.validateBackupCreationPassword(TextFieldValue(password))
+        backupAndRestoreViewModel.validateBackupCreationPassword(password)
         advanceUntilIdle()
 
         // Then
@@ -165,7 +172,7 @@ class BackupAndRestoreViewModelTest {
             .arrange()
 
         // When
-        backupAndRestoreViewModel.validateBackupCreationPassword(TextFieldValue(password))
+        backupAndRestoreViewModel.validateBackupCreationPassword(password)
         advanceUntilIdle()
 
         // Then
@@ -177,11 +184,13 @@ class BackupAndRestoreViewModelTest {
         // Given
         val password = "mayTh3ForceBeWIthYou"
         val (arrangement, backupAndRestoreViewModel) = Arrangement()
+            .withValidPassword()
             .withFailedCreation(password)
             .arrange()
+        backupAndRestoreViewModel.createBackupPasswordState.setTextAndPlaceCursorAtEnd(password)
 
         // When
-        backupAndRestoreViewModel.createBackup(password)
+        backupAndRestoreViewModel.createBackup()
         advanceUntilIdle()
 
         // Then
@@ -372,9 +381,10 @@ class BackupAndRestoreViewModelTest {
             .withSuccessfulBackupRestore()
             .withRequestedPasswordDialog()
             .arrange()
+        backupAndRestoreViewModel.restoreBackupPasswordState.setTextAndPlaceCursorAtEnd(password)
 
         // When
-        backupAndRestoreViewModel.restorePasswordProtectedBackup(password)
+        backupAndRestoreViewModel.restorePasswordProtectedBackup()
         advanceUntilIdle()
 
         // Then
@@ -394,9 +404,10 @@ class BackupAndRestoreViewModelTest {
             .withFailedDBImport(Failure(InvalidPassword))
             .withRequestedPasswordDialog()
             .arrange()
+        backupAndRestoreViewModel.restoreBackupPasswordState.setTextAndPlaceCursorAtEnd(password)
 
         // When
-        backupAndRestoreViewModel.restorePasswordProtectedBackup(password)
+        backupAndRestoreViewModel.restorePasswordProtectedBackup()
         advanceUntilIdle()
 
         // Then
@@ -417,9 +428,10 @@ class BackupAndRestoreViewModelTest {
                 .withFailedDBImport(Failure(InvalidUserId))
                 .withRequestedPasswordDialog()
                 .arrange()
+            backupAndRestoreViewModel.restoreBackupPasswordState.setTextAndPlaceCursorAtEnd(password)
 
             // When
-            backupAndRestoreViewModel.restorePasswordProtectedBackup(password)
+            backupAndRestoreViewModel.restorePasswordProtectedBackup()
             advanceUntilIdle()
 
             // Then
@@ -439,9 +451,10 @@ class BackupAndRestoreViewModelTest {
             .withFailedDBImport(Failure(IncompatibleBackup("old format backup")))
             .withRequestedPasswordDialog()
             .arrange()
+        backupAndRestoreViewModel.restoreBackupPasswordState.setTextAndPlaceCursorAtEnd(password)
 
         // When
-        backupAndRestoreViewModel.restorePasswordProtectedBackup(password)
+        backupAndRestoreViewModel.restorePasswordProtectedBackup()
         advanceUntilIdle()
 
         // Then
@@ -462,9 +475,10 @@ class BackupAndRestoreViewModelTest {
             .withRequestedPasswordDialog()
             .withValidPassword()
             .arrange()
+        backupAndRestoreViewModel.restoreBackupPasswordState.setTextAndPlaceCursorAtEnd(password)
 
         // When
-        backupAndRestoreViewModel.restorePasswordProtectedBackup(password)
+        backupAndRestoreViewModel.restorePasswordProtectedBackup()
         advanceUntilIdle()
 
         // Then

--- a/app/src/test/kotlin/com/wire/android/ui/joinDeepLink/JoinConversationViaCodeViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/joinDeepLink/JoinConversationViaCodeViewModelTest.kt
@@ -17,8 +17,9 @@
  */
 package com.wire.android.ui.joinDeepLink
 
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.SnapshotExtension
 import com.wire.android.ui.joinConversation.JoinConversationViaCodeViewModel
 import com.wire.android.ui.joinConversation.JoinViaDeepLinkDialogState
 import com.wire.kalium.logic.NetworkFailure
@@ -35,8 +36,8 @@ import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(CoroutineTestExtension::class)
-class JoinViaCodeViewModelTest {
+@ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class)
+class JoinConversationViaCodeViewModelTest {
 
     @Test
     fun `given valid code, when joining conversion success, then stat is updated`() = runTest {
@@ -159,7 +160,7 @@ class JoinViaCodeViewModelTest {
 
         viewModel.state = JoinViaDeepLinkDialogState.WrongPassword
 
-        viewModel.onPasswordUpdated(TextFieldValue("password"))
+        viewModel.passwordTextState.setTextAndPlaceCursorAtEnd("password123")
 
         viewModel.state `should be equal to` JoinViaDeepLinkDialogState.Idle
     }
@@ -187,10 +188,10 @@ class JoinViaCodeViewModelTest {
         }
 
         fun withPassword(password: String): Arrangement = apply {
-            viewModel.onPasswordUpdated(TextFieldValue(password))
+            viewModel.passwordTextState.setTextAndPlaceCursorAtEnd(password)
         }
 
-        private val viewModel: JoinConversationViaCodeViewModel = JoinConversationViaCodeViewModel(joinViaCode)
+        private val viewModel: JoinConversationViaCodeViewModel by lazy { JoinConversationViaCodeViewModel(joinViaCode) }
 
         fun arrange() = Pair(this, viewModel)
     }

--- a/app/src/test/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModelTest.kt
@@ -17,8 +17,9 @@
  */
 package com.wire.android.ui.legalhold.dialog.requested
 
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.SnapshotExtension
 import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedViewModelTest.Arrangement.Companion.UNKNOWN_ERROR
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.CoreLogic
@@ -48,7 +49,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(CoroutineTestExtension::class)
+@ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class)
 class LegalHoldRequestedViewModelTest {
 
     @Test
@@ -154,7 +155,7 @@ class LegalHoldRequestedViewModelTest {
             .withValidatePasswordResult(ValidatePasswordResult.Invalid())
             .arrange()
         advanceUntilIdle()
-        viewModel.passwordChanged(TextFieldValue("password"))
+        viewModel.passwordTextState.setTextAndPlaceCursorAtEnd("password")
         viewModel.state.assertStateVisible { it.acceptEnabled shouldBeEqualTo false }
     }
 
@@ -164,7 +165,7 @@ class LegalHoldRequestedViewModelTest {
             .withValidatePasswordResult(ValidatePasswordResult.Valid)
             .arrange()
         advanceUntilIdle()
-        viewModel.passwordChanged(TextFieldValue("password"))
+        viewModel.passwordTextState.setTextAndPlaceCursorAtEnd("password")
         viewModel.state.assertStateVisible { it.acceptEnabled shouldBeEqualTo true }
     }
 
@@ -258,7 +259,7 @@ class LegalHoldRequestedViewModelTest {
             .withApproveLegalHoldRequestResult(ApproveLegalHoldRequestUseCase.Result.Success)
             .arrange()
         val password = "invalidpassword"
-        viewModel.passwordChanged(TextFieldValue(password))
+        viewModel.passwordTextState.setTextAndPlaceCursorAtEnd(password)
         advanceUntilIdle()
         viewModel.acceptClicked()
         verify { arrangement.validatePassword(password) }
@@ -272,7 +273,7 @@ class LegalHoldRequestedViewModelTest {
             .withApproveLegalHoldRequestResult(ApproveLegalHoldRequestUseCase.Result.Success)
             .arrange()
         val password = "invalidpassword"
-        viewModel.passwordChanged(TextFieldValue(password))
+        viewModel.passwordTextState.setTextAndPlaceCursorAtEnd(password)
         advanceUntilIdle()
         viewModel.acceptClicked()
         coVerify { arrangement.userSessionScope.approveLegalHoldRequest(password) wasNot Called }
@@ -285,7 +286,7 @@ class LegalHoldRequestedViewModelTest {
             .withApproveLegalHoldRequestResult(ApproveLegalHoldRequestUseCase.Result.Success)
             .arrange()
         val password = "ValidPassword123!"
-        viewModel.passwordChanged(TextFieldValue(password))
+        viewModel.passwordTextState.setTextAndPlaceCursorAtEnd(password)
         advanceUntilIdle()
         viewModel.acceptClicked()
         coVerify { arrangement.userSessionScope.approveLegalHoldRequest(password) }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8779" title="WPB-8779" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8779</a>  Introduce BasicTextField2
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Android Compose has new v2 version of text field inputs, and with that, they are going away from the previous approach with `TextFieldValue` and `onValueChanged` and replacing it with `TextFieldState`.
We already updated text fields to v2 but still are using "hybrid" solution which synchronises between `TextFieldValue/onValueChanged` and `TextFieldState`.

In this PR, following screens, their ViewModels logic and tests are updated to use `TextFieldState`:
- CreateBackupDialogs
- RestoreBackupDialogs
- CreatePasswordProtectedGuestLinkScreen
- LegalHoldRequestedDialog
- JoinConversationViaDeepLinkDialog
- GroupConversationNameComponent

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Use text fields from any of listed screens.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
