### PR TITLE
fix: swipe to reply not working on first try

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
@@ -301,34 +301,8 @@ private fun SwipableToReplyBox(
     var didVibrateOnCurrentDrag by remember { mutableStateOf(false) }
 
     // Finish the animation in the first 25% of the drag
-    val progressUntilAnimationCompletion = 0.33f
+    val progressUntilAnimationCompletion = 0.25f
     val dragWidth = screenWidth * progressUntilAnimationCompletion
-    val dragState = remember {
-        AnchoredDraggableState(
-            initialValue = SwipeAnchor.CENTERED,
-            positionalThreshold = { dragWidth },
-            velocityThreshold = { screenWidth },
-            snapAnimationSpec = tween(),
-            decayAnimationSpec = splineBasedDecay(density),
-            confirmValueChange = { changedValue ->
-                if (changedValue == SwipeAnchor.START_TO_END) {
-                    // Attempt to finish dismiss, notify reply intention
-                    onSwipedToReply()
-                }
-                if (changedValue == SwipeAnchor.CENTERED) {
-                    // Reset the haptic feedback when drag is stopped
-                    didVibrateOnCurrentDrag = false
-                }
-                // Reject state change, only allow returning back to rest position
-                changedValue == SwipeAnchor.CENTERED
-            },
-            anchors = DraggableAnchors {
-                SwipeAnchor.CENTERED at 0f
-                SwipeAnchor.START_TO_END at screenWidth
-            }
-        )
-    }
-    val primaryColor = colorsScheme().primary
 
     val currentViewConfiguration = LocalViewConfiguration.current
     val scopedViewConfiguration = object : ViewConfiguration by currentViewConfiguration {
@@ -337,6 +311,33 @@ private fun SwipableToReplyBox(
             get() = currentViewConfiguration.touchSlop * 3f
     }
     CompositionLocalProvider(LocalViewConfiguration provides scopedViewConfiguration) {
+        val dragState = remember {
+            AnchoredDraggableState(
+                initialValue = SwipeAnchor.CENTERED,
+                positionalThreshold = { dragWidth },
+                velocityThreshold = { screenWidth },
+                snapAnimationSpec = tween(),
+                decayAnimationSpec = splineBasedDecay(density),
+                confirmValueChange = { changedValue ->
+                    if (changedValue == SwipeAnchor.START_TO_END) {
+                        // Attempt to finish dismiss, notify reply intention
+                        onSwipedToReply()
+                    }
+                    if (changedValue == SwipeAnchor.CENTERED) {
+                        // Reset the haptic feedback when drag is stopped
+                        didVibrateOnCurrentDrag = false
+                    }
+                    // Reject state change, only allow returning back to rest position
+                    changedValue == SwipeAnchor.CENTERED
+                },
+                anchors = DraggableAnchors {
+                    SwipeAnchor.CENTERED at 0f
+                    SwipeAnchor.START_TO_END at screenWidth
+                }
+            )
+        }
+        val primaryColor = colorsScheme().primary
+
         Box(
             modifier = modifier.fillMaxSize(),
         ) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

As noticed by some, the `swipeToReply` doesn't work properly on first time.

### Causes

1. It was working fine when using a `1.6.x` stable version of Compose Foundation.
2. It broke when moving to an early `1.7.0-alpha`  version.
3. It seemed "fixed" after updating to later `1.7.0-beta`version.

But, it seems that it has a breaking change now that I'm not sure if is intended or not, so I opened an [issue on Google's Issue Tracker](https://issuetracker.google.com/u/1/issues/343827265?pli=1).

We override the local touchSlop to make easier to scroll through the messages without activating the swipe action.

But with these new versions of Foundation, when overriding the the `touchSlop` locally using a `CompositionLocalProvider`, we need to make sure that **both** the `AnchoredDraggableState` and the `anchoredDraggable` modifier are used within the same local composition provider.

### Solutions

Just move the `AnchoredDraggableState` initialisation inside the `CompositionLocalProvider`.

ALSO, a slight improvement: reduce a bit the drag required to reply. When developing it I was a bit unsure if 25% or 33% of the screen was best initially, but 33% is a bit too much compared to the experience in other messengers.

### Testing

Manually tested

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
