### PR TITLE
fix: disable message options for gallery asset [WPB-9047]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -125,7 +125,7 @@ import com.wire.android.ui.home.conversations.call.ConversationCallViewState
 import com.wire.android.ui.home.conversations.composer.MessageComposerViewModel
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
 import com.wire.android.ui.home.conversations.details.GroupConversationDetailsNavBackArgs
-import com.wire.android.ui.home.conversations.edit.EditMessageMenuItems
+import com.wire.android.ui.home.conversations.edit.editMessageMenuItems
 import com.wire.android.ui.home.conversations.info.ConversationDetailsData
 import com.wire.android.ui.home.conversations.info.ConversationInfoViewModel
 import com.wire.android.ui.home.conversations.info.ConversationInfoViewState
@@ -399,7 +399,8 @@ fun ConversationScreen(
                             conversationId = conversationId,
                             messageId = message.header.messageId,
                             isSelfAsset = isSelfMessage,
-                            isEphemeral = message.header.messageStatus.expirationStatus is ExpirationStatus.Expirable
+                            isEphemeral = message.header.messageStatus.expirationStatus is ExpirationStatus.Expirable,
+                            messageOptionsEnabled = true
                         )
                     )
                 )
@@ -751,8 +752,9 @@ private fun ConversationScreen(
 
     val menuItems = when (val menuType = conversationScreenState.bottomSheetMenuType) {
         is ConversationScreenState.BottomSheetMenuType.Edit -> {
-            EditMessageMenuItems(
+            editMessageMenuItems(
                 message = menuType.selectedMessage,
+                messageOptionsEnabled = true,
                 hideEditMessageMenu = conversationScreenState::hideContextMenu,
                 onCopyClick = conversationScreenState::copyMessage,
                 onDeleteClick = onDeleteMessage,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/AssetEditMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/AssetEditMenuItems.kt
@@ -26,26 +26,47 @@ import com.wire.android.ui.edit.ReactionOption
 import com.wire.android.ui.edit.ReplyMessageOption
 
 @Composable
-fun AssetEditMenuItems(
+fun assetEditMenuItems(
     isEphemeral: Boolean,
-    isUploading: Boolean = false,
+    messageOptionsEnabled: Boolean,
     onDeleteClick: () -> Unit,
     onDetailsClick: () -> Unit,
     onShareAsset: () -> Unit,
     onDownloadAsset: () -> Unit,
     onReplyClick: () -> Unit,
     onReactionClick: (String) -> Unit,
+    isUploading: Boolean = false,
     onOpenAsset: (() -> Unit)? = null
 ): List<@Composable () -> Unit> {
     return buildList {
-        if (!isUploading) {
-            if (!isEphemeral) add { ReactionOption(onReactionClick) }
-            add { MessageDetailsMenuOption(onDetailsClick) }
-            if (!isEphemeral) add { ReplyMessageOption(onReplyClick) }
-            add { DownloadAssetExternallyOption(onDownloadAsset) }
-            if (!isEphemeral) add { ShareAssetMenuOption(onShareAsset) }
-            if (onOpenAsset != null && !isEphemeral) add { OpenAssetExternallyOption(onOpenAsset) }
+        when {
+            isUploading -> {
+                add { DeleteItemMenuOption(onDeleteClick) }
+            }
+
+            isEphemeral -> {
+                if (messageOptionsEnabled) {
+                    add { MessageDetailsMenuOption(onDetailsClick) }
+                }
+                add { DownloadAssetExternallyOption(onDownloadAsset) }
+                add { DeleteItemMenuOption(onDeleteClick) }
+            }
+
+            !messageOptionsEnabled -> {
+                add { DownloadAssetExternallyOption(onDownloadAsset) }
+                add { ShareAssetMenuOption(onShareAsset) }
+                add { DeleteItemMenuOption(onDeleteClick) }
+            }
+
+            else -> {
+                add { ReactionOption(onReactionClick) }
+                add { MessageDetailsMenuOption(onDetailsClick) }
+                add { ReplyMessageOption(onReplyClick) }
+                add { DownloadAssetExternallyOption(onDownloadAsset) }
+                add { ShareAssetMenuOption(onShareAsset) }
+                if (onOpenAsset != null) add { OpenAssetExternallyOption(onOpenAsset) }
+                add { DeleteItemMenuOption(onDeleteClick) }
+            }
         }
-        add { DeleteItemMenuOption(onDeleteClick) }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/EditMessageMenuItems.kt
@@ -33,8 +33,9 @@ import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.message.mention.MessageMention
 
 @Composable
-fun EditMessageMenuItems(
+fun editMessageMenuItems(
     message: UIMessage.Regular,
+    messageOptionsEnabled: Boolean,
     hideEditMessageMenu: (OnComplete) -> Unit,
     onCopyClick: (String) -> Unit,
     onDeleteClick: (messageId: String, Boolean) -> Unit,
@@ -117,7 +118,8 @@ fun EditMessageMenuItems(
     }
 
     return if (message.isAssetMessage) {
-        AssetEditMenuItems(
+        assetEditMenuItems(
+            messageOptionsEnabled = messageOptionsEnabled,
             isEphemeral = message.header.messageStatus.expirationStatus is ExpirationStatus.Expirable,
             isUploading = message.isPending,
             onDeleteClick = onDeleteItemClick,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
@@ -98,7 +98,8 @@ fun ConversationMediaScreen(
                         conversationId = conversationId,
                         messageId = messageId,
                         isSelfAsset = isSelfAsset,
-                        isEphemeral = false
+                        isEphemeral = false,
+                        messageOptionsEnabled = false
                     )
                 )
             )
@@ -135,10 +136,10 @@ fun ConversationMediaScreen(
 @Composable
 private fun Content(
     state: ConversationAssetMessagesViewState,
-    onNavigationPressed: () -> Unit = {},
     onImageFullScreenMode: (conversationId: ConversationId, messageId: String, isSelfAsset: Boolean) -> Unit,
-    audioMessagesState: PersistentMap<String, AudioState> = persistentMapOf(),
     onAudioItemClicked: (String) -> Unit,
+    onNavigationPressed: () -> Unit = {},
+    audioMessagesState: PersistentMap<String, AudioState> = persistentMapOf(),
     onAssetItemClicked: (String) -> Unit
 ) {
     val scope = rememberCoroutineScope()
@@ -211,7 +212,7 @@ enum class ConversationMediaScreenTabItem(@StringRes val titleResId: Int) : TabI
 
 @PreviewMultipleThemes
 @Composable
-fun previewConversationMediaScreenEmptyContent() {
+fun PreviewConversationMediaScreenEmptyContent() {
     WireTheme {
         Content(
             state = ConversationAssetMessagesViewState(),

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryNavArgs.kt
@@ -25,7 +25,8 @@ data class MediaGalleryNavArgs(
     val conversationId: ConversationId,
     val messageId: String,
     val isSelfAsset: Boolean,
-    val isEphemeral: Boolean
+    val isEphemeral: Boolean,
+    val messageOptionsEnabled: Boolean
 )
 
 @Parcelize

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -46,7 +46,7 @@ import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.home.conversations.MediaGallerySnackbarMessages
 import com.wire.android.ui.home.conversations.PermissionPermanentlyDeniedDialogState
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
-import com.wire.android.ui.home.conversations.edit.AssetEditMenuItems
+import com.wire.android.ui.home.conversations.edit.assetEditMenuItems
 import com.wire.android.util.permission.rememberWriteStorageRequestFlow
 import com.wire.android.util.ui.openDownloadFolder
 
@@ -58,8 +58,9 @@ import com.wire.android.util.ui.openDownloadFolder
 @Composable
 fun MediaGalleryScreen(
     navigator: Navigator,
-    mediaGalleryViewModel: MediaGalleryViewModel = hiltViewModel(),
-    resultNavigator: ResultBackNavigator<MediaGalleryNavBackArgs>
+    resultNavigator: ResultBackNavigator<MediaGalleryNavBackArgs>,
+    modifier: Modifier = Modifier,
+    mediaGalleryViewModel: MediaGalleryViewModel = hiltViewModel()
 ) {
     val permissionPermanentlyDeniedDialogState =
         rememberVisibilityState<PermissionPermanentlyDeniedDialogState>()
@@ -91,6 +92,7 @@ fun MediaGalleryScreen(
 
     with(viewModelState) {
         WireScaffold(
+            modifier = modifier,
             topBar = {
                 MediaGalleryScreenTopAppBar(
                     title = screenTitle
@@ -108,7 +110,8 @@ fun MediaGalleryScreen(
         MenuModalSheetLayout(
             sheetState = mediaGalleryScreenState.modalBottomSheetState,
             coroutineScope = scope,
-            menuItems = AssetEditMenuItems(
+            menuItems = assetEditMenuItems(
+                messageOptionsEnabled = viewModelState.messageBottomSheetOptionsEnabled,
                 isEphemeral = viewModelState.isEphemeral,
                 onDeleteClick = {
                     mediaGalleryScreenState.showContextualMenu(false)
@@ -158,7 +161,12 @@ fun MediaGalleryScreen(
 }
 
 @Composable
-fun MediaGalleryContent(navigator: Navigator, viewModel: MediaGalleryViewModel, mediaGalleryScreenState: MediaGalleryScreenState) {
+fun MediaGalleryContent(
+    navigator: Navigator,
+    viewModel: MediaGalleryViewModel,
+    mediaGalleryScreenState: MediaGalleryScreenState,
+    modifier: Modifier = Modifier
+) {
     val context = LocalContext.current
     val uiState = viewModel.mediaGalleryViewState
     suspend fun showSnackbarMessage(message: String, actionLabel: String?, messageCode: MediaGallerySnackbarMessages) {
@@ -180,7 +188,7 @@ fun MediaGalleryContent(navigator: Navigator, viewModel: MediaGalleryViewModel, 
     }
 
     Box(
-        Modifier
+        modifier
             .fillMaxWidth()
             .fillMaxHeight()
             .background(colorsScheme().surface)

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
@@ -76,7 +76,12 @@ class MediaGalleryViewModel @Inject constructor(
 
     private val messageId = imageAsset.messageId
     private val conversationId = imageAsset.conversationId
-    var mediaGalleryViewState by mutableStateOf(MediaGalleryViewState(isEphemeral = imageAsset.isEphemeral))
+    var mediaGalleryViewState by mutableStateOf(
+        MediaGalleryViewState(
+            isEphemeral = imageAsset.isEphemeral,
+            messageBottomSheetOptionsEnabled = mediaGalleryNavArgs.messageOptionsEnabled
+        )
+    )
         private set
 
     val deleteMessageHelper = DeleteMessageDialogHelper(

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewState.kt
@@ -27,5 +27,6 @@ data class MediaGalleryViewState(
     val deleteMessageDialogsState: DeleteMessageDialogsState = DeleteMessageDialogsState.States(
         forYourself = DeleteMessageDialogActiveState.Hidden,
         forEveryone = DeleteMessageDialogActiveState.Hidden
-    )
+    ),
+    val messageBottomSheetOptionsEnabled: Boolean
 )

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -217,7 +217,8 @@ class MediaGalleryViewModelTest {
                 conversationId = dummyConversationId,
                 messageId = dummyPrivateAsset,
                 isSelfAsset = true,
-                isEphemeral = false
+                isEphemeral = false,
+                messageOptionsEnabled = true
             )
 
             coEvery { deleteMessage(any(), any(), any()) } returns Either.Right(Unit)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9047" title="WPB-9047" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9047</a>  [Android] Remove some menu options from images in media gallery
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In conversation media gallery when opening full screen asset there was options for message.

### Solutions

Remove message options and leave only asset options.

The menu should open and I should only see three options
- Download
- Share
- Delete

Removed the other options, these are
- Reactions
- Message details
- Reply