### PR TITLE
fix: more issues with sharing media [WPB-9550]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -184,13 +184,17 @@ class WireActivity : AppCompatActivity() {
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
+        setIntent(intent)
         if (isNavigationCollecting) {
-            // when true then navigationCommands is subscribed and can handle navigation commands
+            /*
+             * - When true then navigationCommands is subscribed and can handle navigation commands right away.
+             * - When false then navigationCommands needs to be subscribed again to be able to receive and handle navigation commands.
+             *
+             * Activity intent is updated anyway using setIntent(intent) so that we always keep the latest intent received, so when
+             * isNavigationCollecting is false then we handle it after navigationCommands is subscribed again and onComplete called again.
+             * We make sure to handle particular intent only once thanks to the flag HANDLED_DEEPLINK_FLAG put into the handled intent.
+            */
             handleDeepLink(intent)
-        } else {
-            // when false then navigationCommands needs to be subscribed again to be able to receive and handle navigation commands
-            // Activity intent is updated to handle deep link after navigationCommands is subscribed again and onComplete called again
-            setIntent(intent)
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -193,7 +193,7 @@ class WireActivity : AppCompatActivity() {
              * Activity intent is updated anyway using setIntent(intent) so that we always keep the latest intent received, so when
              * isNavigationCollecting is false then we handle it after navigationCommands is subscribed again and onComplete called again.
              * We make sure to handle particular intent only once thanks to the flag HANDLED_DEEPLINK_FLAG put into the handled intent.
-            */
+             */
             handleDeepLink(intent)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -168,7 +168,7 @@ private fun ImportMediaAuthenticatedContent(
                                             pendingBundles = ArrayList(it)
                                         )
                                     ),
-                                    BackStackMode.UPDATE_EXISTED
+                                    BackStackMode.REMOVE_CURRENT_AND_REPLACE
                                 ),
                             )
                         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9550" title="WPB-9550" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9550</a>  [Android] Can not share files anymore from gallery / files
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

After these fixes: https://github.com/wireapp/wire-android/pull/3077
now the import media screen appears but the preview at the top of the screen does not load the image when the app was already open before the sharing (so that `onNewIntent` is called) and the message is not being sent when clicked, but the navigation to conversation screen works.
It was an oversight and apparently storing the intent (`setIntent(intent)`) was required in this case to get it and handle on `ImportMediaScreen`.
Now, it's restored and the intent is actually stored in all cases so that we always keep the latest intent.
Also, navigation flag is changed to remove the ImportMediaScreen from back stack after the image is sent, it's not needed anymore and the app shouldn't go back to this screen when user navigates back.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
