### PR TITLE
fix: remove brackets from build file name

### DIFF
--- a/build-logic/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -38,8 +38,8 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 applicationId = AndroidApp.id
                 defaultConfig.targetSdk = AndroidSdk.target
                 versionCode = AndroidApp.versionCode
-                versionName = "${AndroidApp.versionName}($versionCode)"
-                setProperty("archivesBaseName", "$applicationId-v$versionName($versionCode)")
+                versionName = "${AndroidApp.versionName}-$versionCode"
+                setProperty("archivesBaseName", "$applicationId-v$versionName")
             }
 
             configureCompose(this)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Android Studio fails to install the app on older Android versions because of the error:
>The application could not be installed. Installation failed due to: 'Error code: 'UNKNOWN', message='Unknown failure: '/system/bin/sh: syntax error: unexpected '('''' List of apks: [0] '/Users/Michal/Projects/github/wire/reloaded-apk-filename-android9-issue/app/build/intermediates/apk/beta/debug/com.wire.android-v4.8.0(9879175)(9879175)-beta-debug.apk'

Apparently it has a problem with brackets in build file name, so the solution is to replace brackets with something else.
After syncing with QA to make sure it won't affect automation, scripts were updated to be more reactive and to allow different build file names.

Previously the app build file looked like this: `com.wire.android-v4.8.0(9879175)(9879175)-beta-debug.apk`
Now it looks like this: `com.wire.android-v4.8.0-9879175-beta-debug.apk`

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
