### PR TITLE
fix: change display name state [WPB-9653]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameViewModel.kt
@@ -69,7 +69,7 @@ class ChangeDisplayNameViewModel @Inject constructor(
     ) {
         displayNameState = displayNameState.copy(loading = true)
         viewModelScope.launch {
-            updateDisplayName(textState.toString().trim())
+            updateDisplayName(textState.text.toString().trim())
                 .also { displayNameState = displayNameState.copy(loading = false) }
                 .let {
                     when (it) {

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameViewModelTest.kt
@@ -30,7 +30,6 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
-import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameViewModelTest.kt
@@ -28,9 +28,12 @@ import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.UpdateDisplayNameUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -118,6 +121,21 @@ class ChangeDisplayNameViewModelTest {
 
         assertEquals(DisplayNameState.NameError.None, viewModel.displayNameState.error)
         assertEquals(true, viewModel.displayNameState.saveEnabled)
+    }
+
+    @Test
+    fun `given valid name, when updating, then should take only text value not the whole state toString`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .withUserSaveNameResult(DisplayNameUpdateResult.Success)
+            .arrange()
+
+        val newValue = "valid new name"
+        viewModel.textState.setTextAndPlaceCursorAtEnd(newValue)
+        advanceUntilIdle()
+
+        viewModel.saveDisplayName(onFailure = {}, onSuccess = {})
+
+        coVerify(exactly = 1) { arrangement.updateDisplayNameUseCase(newValue) }
     }
 
     private class Arrangement {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9653" title="WPB-9653" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9653</a>  [Android] Username can not be updated because of convertion to string
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the user decides to update a display name, the whole state of text input is converted into text and sent as a display name.

### Solutions

Take only `.text` part of the `TextFieldState`.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Update a display name.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
