### PR TITLE
fix: change default lineLimits for text fields to be single-line

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -75,7 +75,7 @@ internal fun WireTextField(
     trailingIcon: @Composable (() -> Unit)? = null,
     state: WireTextFieldState = WireTextFieldState.Default,
     autoFillType: WireAutoFillType = WireAutoFillType.None,
-    lineLimits: TextFieldLineLimits = TextFieldLineLimits.Default,
+    lineLimits: TextFieldLineLimits = TextFieldLineLimits.SingleLine,
     inputTransformation: InputTransformation = InputTransformation.maxLength(8000),
     outputTransformation: OutputTransformation? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.DefaultText,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

For new text fields v2 by default `TextFieldLineLimits.Default` is `Multiline`, in most cases it shouldn't be a problem because we have keyboard action `DONE` by default so there shouldn't be a "new line" button at all, but in case someone uses custom keyboard or external one, it could be possible to enter a new line in text field which shouldn't allow to do that.

### Solutions

Change the default value of `lineLimits` for our text fields to be `SingleLine` so that we need to intentionally set it to `Multiline` when needed.

### Testing

#### How to Test

Attach external keyboard or use Android Studio mirroring to use keyboard from your computer, open for instance login screen and press "enter" to try to insert new line.

### Attachments (Optional)

In both videos user presses "enter" key on external keyboard, on second one it actually moves the focus to the next input instead of creating a new line so it works properly like the action button.

| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/wireapp/wire-android/assets/30429749/74cdfbdb-6526-42f0-8430-ac1b789f5fa9"/> | <video width="400" src="https://github.com/wireapp/wire-android/assets/30429749/2fa50527-1be9-46a6-be42-ec36cc706096"/> |
----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
