### PR TITLE
fix: inject usecases lazily in WireActivityViewModel (WPB-6874)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -202,8 +202,11 @@ class WireActivityViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.get().io()) {
             currentScreenManager.get().observeCurrentScreen(this)
                 .flatMapLatest {
-                    if (it.isGlobalDialogAllowed()) observeNewClients.get().invoke()
-                    else flowOf(NewClientResult.Empty)
+                    if (it.isGlobalDialogAllowed()) {
+                        observeNewClients.get().invoke()
+                    } else {
+                        flowOf(NewClientResult.Empty)
+                    }
                 }
                 .collect {
                     val newClientDialog = NewClientsData.fromUseCaseResul(it)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -76,6 +76,7 @@ import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import dagger.Lazy
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -99,32 +100,32 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class WireActivityViewModel @Inject constructor(
-    @KaliumCoreLogic private val coreLogic: CoreLogic,
-    private val dispatchers: DispatcherProvider,
-    private val currentSessionFlow: CurrentSessionFlowUseCase,
-    private val doesValidSessionExist: DoesValidSessionExistUseCase,
-    private val getServerConfigUseCase: GetServerConfigUseCase,
-    private val deepLinkProcessor: DeepLinkProcessor,
-    private val authServerConfigProvider: AuthServerConfigProvider,
-    private val getSessions: GetSessionsUseCase,
-    private val accountSwitch: AccountSwitchUseCase,
-    private val migrationManager: MigrationManager,
-    private val servicesManager: ServicesManager,
+    @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>,
+    private val dispatchers: Lazy<DispatcherProvider>,
+    private val currentSessionFlow: Lazy<CurrentSessionFlowUseCase>,
+    private val doesValidSessionExist: Lazy<DoesValidSessionExistUseCase>,
+    private val getServerConfigUseCase: Lazy<GetServerConfigUseCase>,
+    private val deepLinkProcessor: Lazy<DeepLinkProcessor>,
+    private val authServerConfigProvider: Lazy<AuthServerConfigProvider>,
+    private val getSessions: Lazy<GetSessionsUseCase>,
+    private val accountSwitch: Lazy<AccountSwitchUseCase>,
+    private val migrationManager: Lazy<MigrationManager>,
+    private val servicesManager: Lazy<ServicesManager>,
     private val observeSyncStateUseCaseProviderFactory: ObserveSyncStateUseCaseProvider.Factory,
-    private val observeIfAppUpdateRequired: ObserveIfAppUpdateRequiredUseCase,
-    private val observeNewClients: ObserveNewClientsUseCase,
-    private val clearNewClientsForUser: ClearNewClientsForUserUseCase,
-    private val currentScreenManager: CurrentScreenManager,
+    private val observeIfAppUpdateRequired: Lazy<ObserveIfAppUpdateRequiredUseCase>,
+    private val observeNewClients: Lazy<ObserveNewClientsUseCase>,
+    private val clearNewClientsForUser: Lazy<ClearNewClientsForUserUseCase>,
+    private val currentScreenManager: Lazy<CurrentScreenManager>,
     private val observeScreenshotCensoringConfigUseCaseProviderFactory: ObserveScreenshotCensoringConfigUseCaseProvider.Factory,
-    private val globalDataStore: GlobalDataStore,
+    private val globalDataStore: Lazy<GlobalDataStore>,
     private val observeIfE2EIRequiredDuringLoginUseCaseProviderFactory: ObserveIfE2EIRequiredDuringLoginUseCaseProvider.Factory,
-    private val workManager: WorkManager
+    private val workManager: Lazy<WorkManager>
 ) : ViewModel() {
 
     var globalAppState: GlobalAppState by mutableStateOf(GlobalAppState())
         private set
 
-    private val observeUserId = currentSessionFlow()
+    private val observeUserId = currentSessionFlow.get().invoke()
         .distinctUntilChanged()
         .onEach {
             if (it is CurrentSessionResult.Success) {
@@ -145,7 +146,7 @@ class WireActivityViewModel @Inject constructor(
             }
         }
         .distinctUntilChanged()
-        .flowOn(dispatchers.io())
+        .flowOn(dispatchers.get().io())
         .shareIn(viewModelScope, SharingStarted.WhileSubscribed(), 1)
 
     private val _observeSyncFlowState: MutableStateFlow<SyncState?> = MutableStateFlow(null)
@@ -167,8 +168,8 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun observeAppThemeState() {
-        viewModelScope.launch(dispatchers.io()) {
-            globalDataStore.selectedThemeOptionFlow()
+        viewModelScope.launch(dispatchers.get().io()) {
+            globalDataStore.get().selectedThemeOptionFlow()
                 .distinctUntilChanged()
                 .collect {
                     globalAppState = globalAppState.copy(themeOption = it)
@@ -177,7 +178,7 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun observeSyncState() {
-        viewModelScope.launch(dispatchers.io()) {
+        viewModelScope.launch(dispatchers.get().io()) {
             observeUserId
                 .flatMapLatest {
                     it?.let { observeSyncStateUseCaseProviderFactory.create(it).observeSyncState() } ?: flowOf(null)
@@ -189,7 +190,7 @@ class WireActivityViewModel @Inject constructor(
 
     private fun observeUpdateAppState() {
         viewModelScope.launch {
-            observeIfAppUpdateRequired(BuildConfig.VERSION_CODE)
+            observeIfAppUpdateRequired.get().invoke(BuildConfig.VERSION_CODE)
                 .distinctUntilChanged()
                 .collect {
                     globalAppState = globalAppState.copy(updateAppDialog = it)
@@ -198,10 +199,10 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun observeNewClientState() {
-        viewModelScope.launch(dispatchers.io()) {
-            currentScreenManager.observeCurrentScreen(this)
+        viewModelScope.launch(dispatchers.get().io()) {
+            currentScreenManager.get().observeCurrentScreen(this)
                 .flatMapLatest {
-                    if (it.isGlobalDialogAllowed()) observeNewClients()
+                    if (it.isGlobalDialogAllowed()) observeNewClients.get().invoke()
                     else flowOf(NewClientResult.Empty)
                 }
                 .collect {
@@ -212,7 +213,7 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun observeScreenshotCensoringConfigState() {
-        viewModelScope.launch(dispatchers.io()) {
+        viewModelScope.launch(dispatchers.get().io()) {
             observeUserId
                 .flatMapLatest {
                     it?.let {
@@ -227,7 +228,7 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private suspend fun handleInvalidSession(logoutReason: LogoutReason) {
-        withContext(dispatchers.main()) {
+        withContext(dispatchers.get().main()) {
             when (logoutReason) {
                 LogoutReason.SELF_SOFT_LOGOUT, LogoutReason.SELF_HARD_LOGOUT -> {
                     // Self logout is handled from the Self user profile screen directly
@@ -244,7 +245,6 @@ class WireActivityViewModel @Inject constructor(
             }
         }
     }
-
     val initialAppState: InitialAppState
         get() = when {
             shouldMigrate() -> InitialAppState.NOT_MIGRATED
@@ -259,11 +259,11 @@ class WireActivityViewModel @Inject constructor(
 
     @VisibleForTesting
     internal suspend fun canLoginThroughDeepLinks() = viewModelScope.async {
-        coreLogic.getGlobalScope().session.currentSession().takeIf {
+        coreLogic.get().getGlobalScope().session.currentSession().takeIf {
             it is CurrentSessionResult.Success
         }?.let {
             val currentUserId = (it as CurrentSessionResult.Success).accountInfo.userId
-            coreLogic.getSessionScope(currentUserId).calls.establishedCall().first().isEmpty()
+            coreLogic.get().getSessionScope(currentUserId).calls.establishedCall().first().isEmpty()
         } ?: true
     }
 
@@ -281,7 +281,7 @@ class WireActivityViewModel @Inject constructor(
             return
         }
         viewModelScope.launch {
-            val result = intent?.data?.let { deepLinkProcessor(it) }
+            val result = intent?.data?.let { deepLinkProcessor.get().invoke(it) }
             when {
                 result is DeepLinkResult.SSOLogin -> {
                     if (canLoginThroughDeepLinks().await()) {
@@ -320,7 +320,7 @@ class WireActivityViewModel @Inject constructor(
     fun customBackendDialogProceedButtonClicked(onProceed: () -> Unit) {
         if (globalAppState.customBackendDialog != null) {
             viewModelScope.launch {
-                authServerConfigProvider.updateAuthServer(globalAppState.customBackendDialog!!.serverLinks)
+                authServerConfigProvider.get().updateAuthServer(globalAppState.customBackendDialog!!.serverLinks)
                 dismissCustomBackendDialog()
                 if (checkNumberOfSessions() >= BuildConfig.MAX_ACCOUNTS) {
                     globalAppState = globalAppState.copy(maxAccountDialog = true)
@@ -337,16 +337,16 @@ class WireActivityViewModel @Inject constructor(
         switchAccountActions: SwitchAccountActions
     ) {
         viewModelScope.launch {
-            coreLogic.getGlobalScope().session.currentSession().takeIf {
+            coreLogic.get().getGlobalScope().session.currentSession().takeIf {
                 it is CurrentSessionResult.Success
             }?.let {
                 val currentUserId = (it as CurrentSessionResult.Success).accountInfo.userId
-                coreLogic.getSessionScope(currentUserId).logout(LogoutReason.SELF_HARD_LOGOUT)
+                coreLogic.get().getSessionScope(currentUserId).logout(LogoutReason.SELF_HARD_LOGOUT)
                 clearUserData(currentUserId)
             }
-            accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount).also {
+            accountSwitch.get().invoke(SwitchAccountParam.TryToSwitchToNextAccount).also {
                 if (it == SwitchAccountResult.NoOtherAccountToSwitch) {
-                    globalDataStore.clearAppLockPasscode()
+                    globalDataStore.get().clearAppLockPasscode()
                 }
             }.callAction(switchAccountActions)
         }
@@ -355,9 +355,9 @@ class WireActivityViewModel @Inject constructor(
     fun dismissNewClientsDialog(userId: UserId) {
         globalAppState = globalAppState.copy(newClientDialog = null)
         viewModelScope.launch {
-            doesValidSessionExist(userId).let {
+            doesValidSessionExist.get().invoke(userId).let {
                 if (it is DoesValidSessionExistResult.Success && it.doesValidSessionExist) {
-                    clearNewClientsForUser(userId)
+                    clearNewClientsForUser.get().invoke(userId)
                 }
             }
         }
@@ -365,7 +365,7 @@ class WireActivityViewModel @Inject constructor(
 
     fun switchAccount(userId: UserId, actions: SwitchAccountActions, onComplete: () -> Unit) {
         viewModelScope.launch {
-            accountSwitch(SwitchAccountParam.SwitchToAccount(userId))
+            accountSwitch.get().invoke(SwitchAccountParam.SwitchToAccount(userId))
                 .callAction(actions)
             onComplete()
         }
@@ -374,13 +374,13 @@ class WireActivityViewModel @Inject constructor(
     fun tryToSwitchAccount(actions: SwitchAccountActions) {
         viewModelScope.launch {
             globalAppState = globalAppState.copy(blockUserUI = null)
-            accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount)
+            accountSwitch.get().invoke(SwitchAccountParam.TryToSwitchToNextAccount)
                 .callAction(actions)
         }
     }
 
     private suspend fun checkNumberOfSessions(): Int {
-        getSessions().let {
+        getSessions.get().invoke().let {
             return when (it) {
                 is GetAllSessionsResult.Success -> {
                     it.sessions.filterIsInstance<AccountInfo.Valid>().size
@@ -392,7 +392,7 @@ class WireActivityViewModel @Inject constructor(
         }
     }
 
-    private suspend fun loadServerConfig(url: String): ServerConfig.Links? = when (val result = getServerConfigUseCase(url)) {
+    private suspend fun loadServerConfig(url: String): ServerConfig.Links? = when (val result = getServerConfigUseCase.get().invoke(url)) {
         is GetServerConfigResult.Success -> result.serverConfigLinks
         // TODO: show error message on failure
         is GetServerConfigResult.Failure.Generic -> {
@@ -416,11 +416,11 @@ class WireActivityViewModel @Inject constructor(
         key: String,
         domain: String?,
         onSuccess: (ConversationId) -> Unit
-    ) = when (val currentSession = coreLogic.getGlobalScope().session.currentSession()) {
+    ) = when (val currentSession = coreLogic.get().getGlobalScope().session.currentSession()) {
         is CurrentSessionResult.Failure.Generic -> null
         CurrentSessionResult.Failure.SessionNotFound -> null
         is CurrentSessionResult.Success -> {
-            coreLogic.sessionScope(currentSession.accountInfo.userId) {
+            coreLogic.get().sessionScope(currentSession.accountInfo.userId) {
                 when (val result = conversations.checkIConversationInviteCode(code, key, domain)) {
                     is CheckConversationInviteCodeUseCase.Result.Success -> {
                         if (result.isSelfMember) {
@@ -460,7 +460,7 @@ class WireActivityViewModel @Inject constructor(
 
     private fun hasValidCurrentSession(): Boolean = runBlocking {
         // TODO: the usage of currentSessionFlow is a temporary solution, it should be replaced with a proper solution
-        currentSessionFlow().first().let {
+        currentSessionFlow.get().invoke().first().let {
             when (it) {
                 is CurrentSessionResult.Failure.Generic -> false
                 CurrentSessionResult.Failure.SessionNotFound -> false
@@ -470,7 +470,7 @@ class WireActivityViewModel @Inject constructor(
     }
 
     fun shouldMigrate(): Boolean = runBlocking {
-        migrationManager.shouldMigrate()
+        migrationManager.get().shouldMigrate()
     }
 
     fun dismissMaxAccountDialog() {
@@ -479,7 +479,7 @@ class WireActivityViewModel @Inject constructor(
 
     fun observePersistentConnectionStatus() {
         viewModelScope.launch {
-            coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus().let { result ->
+            coreLogic.get().getGlobalScope().observePersistentWebSocketConnectionStatus().let { result ->
                 when (result) {
                     is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> {
                         appLogger.e("Failure while fetching persistent web socket status flow from wire activity")
@@ -489,13 +489,13 @@ class WireActivityViewModel @Inject constructor(
                         result.persistentWebSocketStatusListFlow.collect { statuses ->
 
                             if (statuses.any { it.isPersistentWebSocketEnabled }) {
-                                if (!servicesManager.isPersistentWebSocketServiceRunning()) {
-                                    servicesManager.startPersistentWebSocketService()
-                                    workManager.enqueuePeriodicPersistentWebsocketCheckWorker()
+                                if (!servicesManager.get().isPersistentWebSocketServiceRunning()) {
+                                    servicesManager.get().startPersistentWebSocketService()
+                                    workManager.get().enqueuePeriodicPersistentWebsocketCheckWorker()
                                 }
                             } else {
-                                servicesManager.stopPersistentWebSocketService()
-                                workManager.cancelPeriodicPersistentWebsocketCheckWorker()
+                                servicesManager.get().stopPersistentWebSocketService()
+                                workManager.get().cancelPeriodicPersistentWebsocketCheckWorker()
                             }
                         }
                     }

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -741,26 +741,26 @@ class WireActivityViewModelTest {
 
         private val viewModel by lazy {
             WireActivityViewModel(
-                coreLogic = coreLogic,
-                dispatchers = TestDispatcherProvider(),
-                currentSessionFlow = currentSessionFlow,
-                doesValidSessionExist = doesValidSessionExist,
-                getServerConfigUseCase = getServerConfigUseCase,
-                deepLinkProcessor = deepLinkProcessor,
-                authServerConfigProvider = authServerConfigProvider,
-                getSessions = getSessionsUseCase,
-                accountSwitch = switchAccount,
-                migrationManager = migrationManager,
-                servicesManager = servicesManager,
+                coreLogic = { coreLogic },
+                dispatchers = { TestDispatcherProvider() },
+                currentSessionFlow = { currentSessionFlow },
+                doesValidSessionExist = { doesValidSessionExist },
+                getServerConfigUseCase = { getServerConfigUseCase },
+                deepLinkProcessor = { deepLinkProcessor },
+                authServerConfigProvider = { authServerConfigProvider },
+                getSessions = { getSessionsUseCase },
+                accountSwitch = { switchAccount },
+                migrationManager = { migrationManager },
+                servicesManager = { servicesManager },
                 observeSyncStateUseCaseProviderFactory = observeSyncStateUseCaseProviderFactory,
-                observeIfAppUpdateRequired = observeIfAppUpdateRequired,
-                observeNewClients = observeNewClients,
-                clearNewClientsForUser = clearNewClientsForUser,
-                currentScreenManager = currentScreenManager,
+                observeIfAppUpdateRequired = { observeIfAppUpdateRequired },
+                observeNewClients = { observeNewClients },
+                clearNewClientsForUser = { clearNewClientsForUser },
+                currentScreenManager = { currentScreenManager },
                 observeScreenshotCensoringConfigUseCaseProviderFactory = observeScreenshotCensoringConfigUseCaseProviderFactory,
-                globalDataStore = globalDataStore,
+                globalDataStore = { globalDataStore },
                 observeIfE2EIRequiredDuringLoginUseCaseProviderFactory = observeIfE2EIRequiredDuringLoginUseCaseProviderFactory,
-                workManager = workManager
+                workManager = { workManager }
             )
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6874" title="WPB-6874" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6874</a>  [Android] ANR in WireActivityViewModel.hasValidCurrentSession
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently all usecases (with their dependencies: repository, db...) are being created and injected at launch time even they are not used immediately.

More details here:
https://wearezeta.atlassian.net/browse/WPB-9678

### Solutions

Dagger has `Lazy` modifier which will inject the item when it's needed.
 
Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
