### PR TITLE
fix: run WireViewModel usecases on worker thread (WPB-6874)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -166,7 +166,7 @@ class WireActivity : AppCompatActivity() {
             legalHoldRequestedViewModel.observeLegalHoldRequest()
 
             appLogger.i("$TAG start destination")
-            val startDestination = when (viewModel.initialAppState) {
+            val startDestination = when (viewModel.initialAppState()) {
                 InitialAppState.NOT_MIGRATED -> MigrationScreenDestination
                 InitialAppState.NOT_LOGGED_IN -> WelcomeScreenDestination
                 InitialAppState.ENROLL_E2EI -> E2EIEnrollmentScreenDestination

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -162,6 +162,7 @@ class WireActivityViewModel @Inject constructor(
         observeAppThemeState()
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun shouldEnrollToE2ei() = viewModelScope.async(dispatchers.io()) {
         try {
             val userId = userIdDeferred.await()
@@ -187,6 +188,7 @@ class WireActivityViewModel @Inject constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun observeSyncState() {
         viewModelScope.launch(dispatchers.io()) {
             try {
@@ -198,7 +200,7 @@ class WireActivityViewModel @Inject constructor(
                         .distinctUntilChanged()
                         .collect { _observeSyncFlowState.emit(it) }
                 }
-            } catch (e: Exception) {
+            } catch (e: NullPointerException) {
                 appLogger.e("Error while observing sync state: $e")
             }
         }
@@ -231,6 +233,7 @@ class WireActivityViewModel @Inject constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun observeScreenshotCensoringConfigState() {
         viewModelScope.launch(dispatchers.io()) {
             try {
@@ -247,7 +250,7 @@ class WireActivityViewModel @Inject constructor(
                         screenshotCensoringEnabled = false
                     )
                 }
-            } catch (e: NullPointerException) {
+            } catch (exception: NullPointerException) {
                 globalAppState = globalAppState.copy(
                     screenshotCensoringEnabled = false
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -202,8 +202,11 @@ class WireActivityViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.get().io()) {
             currentScreenManager.get().observeCurrentScreen(this)
                 .flatMapLatest {
-                    if (it.isGlobalDialogAllowed()) observeNewClients.get().invoke()
-                    else flowOf(NewClientResult.Empty)
+                    if (it.isGlobalDialogAllowed()) {
+                        observeNewClients.get().invoke()
+                    } else {
+                        flowOf(NewClientResult.Empty)
+                    }
                 }
                 .collect {
                     val newClientDialog = NewClientsData.fromUseCaseResul(it)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -78,6 +78,7 @@ import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSo
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import dagger.Lazy
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -92,7 +93,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -101,7 +101,7 @@ import javax.inject.Inject
 @HiltViewModel
 class WireActivityViewModel @Inject constructor(
     @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>,
-    private val dispatchers: Lazy<DispatcherProvider>,
+    private val dispatchers: DispatcherProvider,
     private val currentSessionFlow: Lazy<CurrentSessionFlowUseCase>,
     private val doesValidSessionExist: Lazy<DoesValidSessionExistUseCase>,
     private val getServerConfigUseCase: Lazy<GetServerConfigUseCase>,
@@ -125,39 +125,34 @@ class WireActivityViewModel @Inject constructor(
     var globalAppState: GlobalAppState by mutableStateOf(GlobalAppState())
         private set
 
-    private val observeUserId = currentSessionFlow.get().invoke()
-        .distinctUntilChanged()
-        .onEach {
-            if (it is CurrentSessionResult.Success) {
-                if (it.accountInfo.isValid().not()) {
-                    handleInvalidSession((it.accountInfo as AccountInfo.Invalid).logoutReason)
-                }
-            }
-        }
-        .map { result ->
-            if (result is CurrentSessionResult.Success) {
-                if (result.accountInfo.isValid()) {
-                    result.accountInfo.userId
-                } else {
-                    null
-                }
-            } else {
-                null
-            }
-        }
-        .distinctUntilChanged()
-        .flowOn(dispatchers.get().io())
-        .shareIn(viewModelScope, SharingStarted.WhileSubscribed(), 1)
-
     private val _observeSyncFlowState: MutableStateFlow<SyncState?> = MutableStateFlow(null)
     val observeSyncFlowState: StateFlow<SyncState?> = _observeSyncFlowState
 
-    private val observeE2EIState = observeUserId
-        .flatMapLatest {
-            it?.let { observeIfE2EIRequiredDuringLoginUseCaseProviderFactory.create(it).observeIfE2EIIsRequiredDuringLogin() }
-                ?: flowOf(null)
-        }
-        .distinctUntilChanged()
+    private val userIdDeferred: Deferred<UserId?> = viewModelScope.async(dispatchers.io()) {
+        currentSessionFlow.get().invoke()
+            .distinctUntilChanged()
+            .onEach {
+                if (it is CurrentSessionResult.Success) {
+                    if (it.accountInfo.isValid().not()) {
+                        handleInvalidSession((it.accountInfo as AccountInfo.Invalid).logoutReason)
+                    }
+                }
+            }
+            .map { result ->
+                if (result is CurrentSessionResult.Success) {
+                    if (result.accountInfo.isValid()) {
+                        result.accountInfo.userId
+                    } else {
+                        null
+                    }
+                } else {
+                    null
+                }
+            }
+            .distinctUntilChanged()
+            .flowOn(dispatchers.io())
+            .shareIn(viewModelScope, SharingStarted.WhileSubscribed(), 1).first()
+    }
 
     init {
         observeSyncState()
@@ -167,8 +162,23 @@ class WireActivityViewModel @Inject constructor(
         observeAppThemeState()
     }
 
+    private fun shouldEnrollToE2ei() = viewModelScope.async(dispatchers.io()) {
+        try {
+            val userId = userIdDeferred.await()
+            if (userId != null) {
+                observeIfE2EIRequiredDuringLoginUseCaseProviderFactory.create(userId)
+                    .observeIfE2EIIsRequiredDuringLogin().first() ?: false
+            } else {
+                false
+            }
+        } catch (e: NullPointerException) {
+            appLogger.e("Error while observing E2EI state: $e")
+            false
+        }
+    }
+
     private fun observeAppThemeState() {
-        viewModelScope.launch(dispatchers.get().io()) {
+        viewModelScope.launch(dispatchers.io()) {
             globalDataStore.get().selectedThemeOptionFlow()
                 .distinctUntilChanged()
                 .collect {
@@ -178,18 +188,24 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun observeSyncState() {
-        viewModelScope.launch(dispatchers.get().io()) {
-            observeUserId
-                .flatMapLatest {
-                    it?.let { observeSyncStateUseCaseProviderFactory.create(it).observeSyncState() } ?: flowOf(null)
+        viewModelScope.launch(dispatchers.io()) {
+            try {
+                val userId = userIdDeferred.await()
+                if (userId != null) {
+                    observeSyncStateUseCaseProviderFactory.create(userId).observeSyncState()
+                } else {
+                    flowOf(null)
+                        .distinctUntilChanged()
+                        .collect { _observeSyncFlowState.emit(it) }
                 }
-                .distinctUntilChanged()
-                .collect { _observeSyncFlowState.emit(it) }
+            } catch (e: Exception) {
+                appLogger.e("Error while observing sync state: $e")
+            }
         }
     }
 
     private fun observeUpdateAppState() {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatchers.io()) {
             observeIfAppUpdateRequired.get().invoke(BuildConfig.VERSION_CODE)
                 .distinctUntilChanged()
                 .collect {
@@ -199,7 +215,7 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun observeNewClientState() {
-        viewModelScope.launch(dispatchers.get().io()) {
+        viewModelScope.launch(dispatchers.io()) {
             currentScreenManager.get().observeCurrentScreen(this)
                 .flatMapLatest {
                     if (it.isGlobalDialogAllowed()) {
@@ -216,47 +232,68 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun observeScreenshotCensoringConfigState() {
-        viewModelScope.launch(dispatchers.get().io()) {
-            observeUserId
-                .flatMapLatest {
-                    it?.let {
-                        observeScreenshotCensoringConfigUseCaseProviderFactory.create(it).observeScreenshotCensoringConfig()
-                    } ?: flowOf(ObserveScreenshotCensoringConfigResult.Disabled)
-                }.collect {
+        viewModelScope.launch(dispatchers.io()) {
+            try {
+                val userId = userIdDeferred.await()
+                if (userId != null) {
+                    observeScreenshotCensoringConfigUseCaseProviderFactory.create(userId)
+                        .observeScreenshotCensoringConfig().collect { result ->
+                            globalAppState = globalAppState.copy(
+                                screenshotCensoringEnabled = result is ObserveScreenshotCensoringConfigResult.Enabled
+                            )
+                        }
+                } else {
                     globalAppState = globalAppState.copy(
-                        screenshotCensoringEnabled = it is ObserveScreenshotCensoringConfigResult.Enabled
+                        screenshotCensoringEnabled = false
                     )
                 }
+            } catch (e: NullPointerException) {
+                globalAppState = globalAppState.copy(
+                    screenshotCensoringEnabled = false
+                )
+            }
+        }
+    }
+
+    suspend fun initialAppState(): InitialAppState {
+        val shouldMigrate = viewModelScope.async(dispatchers.io()) {
+            shouldMigrate()
+        }
+        val shouldLogin = viewModelScope.async(dispatchers.io()) {
+            shouldLogIn()
+        }
+        val shouldEnrollToE2ei = shouldEnrollToE2ei().await()
+        return when {
+            shouldMigrate.await() -> InitialAppState.NOT_MIGRATED
+            shouldLogin.await() -> InitialAppState.NOT_LOGGED_IN
+            shouldEnrollToE2ei -> InitialAppState.ENROLL_E2EI
+            else -> InitialAppState.LOGGED_IN
         }
     }
 
     private suspend fun handleInvalidSession(logoutReason: LogoutReason) {
-        withContext(dispatchers.get().main()) {
+        withContext(dispatchers.main()) {
             when (logoutReason) {
                 LogoutReason.SELF_SOFT_LOGOUT, LogoutReason.SELF_HARD_LOGOUT -> {
                     // Self logout is handled from the Self user profile screen directly
                 }
 
                 LogoutReason.REMOVED_CLIENT ->
-                    globalAppState = globalAppState.copy(blockUserUI = CurrentSessionErrorState.RemovedClient)
+                    globalAppState =
+                        globalAppState.copy(blockUserUI = CurrentSessionErrorState.RemovedClient)
 
                 LogoutReason.DELETED_ACCOUNT ->
-                    globalAppState = globalAppState.copy(blockUserUI = CurrentSessionErrorState.DeletedAccount)
+                    globalAppState =
+                        globalAppState.copy(blockUserUI = CurrentSessionErrorState.DeletedAccount)
 
                 LogoutReason.SESSION_EXPIRED ->
-                    globalAppState = globalAppState.copy(blockUserUI = CurrentSessionErrorState.SessionExpired)
+                    globalAppState =
+                        globalAppState.copy(blockUserUI = CurrentSessionErrorState.SessionExpired)
             }
         }
     }
-    val initialAppState: InitialAppState
-        get() = when {
-            shouldMigrate() -> InitialAppState.NOT_MIGRATED
-            shouldLogIn() -> InitialAppState.NOT_LOGGED_IN
-            blockedByE2EI() -> InitialAppState.ENROLL_E2EI
-            else -> InitialAppState.LOGGED_IN
-        }
 
-    fun isSharingIntent(intent: Intent?): Boolean {
+    private fun isSharingIntent(intent: Intent?): Boolean {
         return intent?.action == Intent.ACTION_SEND || intent?.action == Intent.ACTION_SEND_MULTIPLE
     }
 
@@ -278,12 +315,12 @@ class WireActivityViewModel @Inject constructor(
         onResult: (DeepLinkResult) -> Unit,
         onCannotLoginDuringACall: () -> Unit
     ) {
-        if (shouldMigrate()) {
-            // means User is Logged in, but didn't finish the migration yet.
-            // so we need to finish migration first.
-            return
-        }
-        viewModelScope.launch {
+        viewModelScope.launch(dispatchers.io()) {
+            if (shouldMigrate()) {
+                // means User is Logged in, but didn't finish the migration yet.
+                // so we need to finish migration first.
+                return@launch
+            }
             val result = intent?.data?.let { deepLinkProcessor.get().invoke(it) }
             when {
                 result is DeepLinkResult.SSOLogin -> {
@@ -293,6 +330,7 @@ class WireActivityViewModel @Inject constructor(
                         onCannotLoginDuringACall()
                     }
                 }
+
                 result is DeepLinkResult.MigrationLogin -> onResult(result)
                 result is DeepLinkResult.CustomServerConfig -> {
                     if (canLoginThroughDeepLinks().await()) {
@@ -301,6 +339,7 @@ class WireActivityViewModel @Inject constructor(
                         onCannotLoginDuringACall()
                     }
                 }
+
                 isSharingIntent(intent) -> onIsSharingIntent()
                 shouldLogIn() -> {
                     // to handle the deepLinks above user needs to be Logged in
@@ -308,7 +347,12 @@ class WireActivityViewModel @Inject constructor(
                 }
 
                 result is DeepLinkResult.JoinConversation ->
-                    onConversationInviteDeepLink(result.code, result.key, result.domain, onOpenConversation)
+                    onConversationInviteDeepLink(
+                        result.code,
+                        result.key,
+                        result.domain,
+                        onOpenConversation
+                    )
 
                 result != null -> onResult(result)
                 result is DeepLinkResult.Unknown -> appLogger.e("unknown deeplink result $result")
@@ -323,7 +367,8 @@ class WireActivityViewModel @Inject constructor(
     fun customBackendDialogProceedButtonClicked(onProceed: () -> Unit) {
         if (globalAppState.customBackendDialog != null) {
             viewModelScope.launch {
-                authServerConfigProvider.get().updateAuthServer(globalAppState.customBackendDialog!!.serverLinks)
+                authServerConfigProvider.get()
+                    .updateAuthServer(globalAppState.customBackendDialog!!.serverLinks)
                 dismissCustomBackendDialog()
                 if (checkNumberOfSessions() >= BuildConfig.MAX_ACCOUNTS) {
                     globalAppState = globalAppState.copy(maxAccountDialog = true)
@@ -395,14 +440,15 @@ class WireActivityViewModel @Inject constructor(
         }
     }
 
-    private suspend fun loadServerConfig(url: String): ServerConfig.Links? = when (val result = getServerConfigUseCase.get().invoke(url)) {
-        is GetServerConfigResult.Success -> result.serverConfigLinks
-        // TODO: show error message on failure
-        is GetServerConfigResult.Failure.Generic -> {
-            appLogger.e("something went wrong during handling the custom server deep link: ${result.genericFailure}")
-            null
+    private suspend fun loadServerConfig(url: String): ServerConfig.Links? =
+        when (val result = getServerConfigUseCase.get().invoke(url)) {
+            is GetServerConfigResult.Success -> result.serverConfigLinks
+            // TODO: show error message on failure
+            is GetServerConfigResult.Failure.Generic -> {
+                appLogger.e("something went wrong during handling the custom server deep link: ${result.genericFailure}")
+                null
+            }
         }
-    }
 
     private suspend fun onCustomServerConfig(result: DeepLinkResult.CustomServerConfig) {
         loadServerConfig(result.url)?.let { serverLinks ->
@@ -445,7 +491,9 @@ class WireActivityViewModel @Inject constructor(
                     }
 
                     is CheckConversationInviteCodeUseCase.Result.Failure -> globalAppState =
-                        globalAppState.copy(conversationJoinedDialog = JoinConversationViaCodeState.Error(result))
+                        globalAppState.copy(
+                            conversationJoinedDialog = JoinConversationViaCodeState.Error(result)
+                        )
                 }
             }
         }
@@ -455,26 +503,21 @@ class WireActivityViewModel @Inject constructor(
         globalAppState = globalAppState.copy(conversationJoinedDialog = null)
     }
 
-    fun shouldLogIn(): Boolean = !hasValidCurrentSession()
+    private suspend fun shouldLogIn(): Boolean = !hasValidCurrentSession().await()
 
-    private fun blockedByE2EI(): Boolean = runBlocking {
-        observeE2EIState.first() ?: false
-    }
-
-    private fun hasValidCurrentSession(): Boolean = runBlocking {
-        // TODO: the usage of currentSessionFlow is a temporary solution, it should be replaced with a proper solution
-        currentSessionFlow.get().invoke().first().let {
-            when (it) {
-                is CurrentSessionResult.Failure.Generic -> false
-                CurrentSessionResult.Failure.SessionNotFound -> false
-                is CurrentSessionResult.Success -> true
+    private fun hasValidCurrentSession(): Deferred<Boolean> =
+        viewModelScope.async(dispatchers.io()) {
+            // TODO: the usage of currentSessionFlow is a temporary solution, it should be replaced with a proper solution
+            currentSessionFlow.get().invoke().first().let {
+                when (it) {
+                    is CurrentSessionResult.Failure.Generic -> false
+                    CurrentSessionResult.Failure.SessionNotFound -> false
+                    is CurrentSessionResult.Success -> true
+                }
             }
         }
-    }
 
-    fun shouldMigrate(): Boolean = runBlocking {
-        migrationManager.get().shouldMigrate()
-    }
+    private suspend fun shouldMigrate(): Boolean = migrationManager.get().shouldMigrate()
 
     fun dismissMaxAccountDialog() {
         globalAppState = globalAppState.copy(maxAccountDialog = false)
@@ -482,28 +525,32 @@ class WireActivityViewModel @Inject constructor(
 
     fun observePersistentConnectionStatus() {
         viewModelScope.launch {
-            coreLogic.get().getGlobalScope().observePersistentWebSocketConnectionStatus().let { result ->
-                when (result) {
-                    is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> {
-                        appLogger.e("Failure while fetching persistent web socket status flow from wire activity")
-                    }
+            coreLogic.get().getGlobalScope().observePersistentWebSocketConnectionStatus()
+                .let { result ->
+                    when (result) {
+                        is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> {
+                            appLogger.e("Failure while fetching persistent web socket status flow from wire activity")
+                        }
 
-                    is ObservePersistentWebSocketConnectionStatusUseCase.Result.Success -> {
-                        result.persistentWebSocketStatusListFlow.collect { statuses ->
+                        is ObservePersistentWebSocketConnectionStatusUseCase.Result.Success -> {
+                            result.persistentWebSocketStatusListFlow.collect { statuses ->
 
-                            if (statuses.any { it.isPersistentWebSocketEnabled }) {
-                                if (!servicesManager.get().isPersistentWebSocketServiceRunning()) {
-                                    servicesManager.get().startPersistentWebSocketService()
-                                    workManager.get().enqueuePeriodicPersistentWebsocketCheckWorker()
+                                if (statuses.any { it.isPersistentWebSocketEnabled }) {
+                                    if (!servicesManager.get()
+                                            .isPersistentWebSocketServiceRunning()
+                                    ) {
+                                        servicesManager.get().startPersistentWebSocketService()
+                                        workManager.get()
+                                            .enqueuePeriodicPersistentWebsocketCheckWorker()
+                                    }
+                                } else {
+                                    servicesManager.get().stopPersistentWebSocketService()
+                                    workManager.get().cancelPeriodicPersistentWebsocketCheckWorker()
                                 }
-                            } else {
-                                servicesManager.get().stopPersistentWebSocketService()
-                                workManager.get().cancelPeriodicPersistentWebsocketCheckWorker()
                             }
                         }
                     }
                 }
-            }
         }
     }
 
@@ -565,7 +612,10 @@ sealed class NewClientsData(open val clientsInfo: List<NewClientInfo>, open val 
 data class NewClientInfo(val date: String, val deviceInfo: UIText) {
     companion object {
         fun fromClient(client: Client): NewClientInfo =
-            NewClientInfo(client.registrationTime?.toIsoDateTimeString() ?: "", client.displayName())
+            NewClientInfo(
+                client.registrationTime?.toIsoDateTimeString() ?: "",
+                client.displayName()
+            )
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -76,6 +76,7 @@ import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import dagger.Lazy
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -99,32 +100,32 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class WireActivityViewModel @Inject constructor(
-    @KaliumCoreLogic private val coreLogic: CoreLogic,
-    private val dispatchers: DispatcherProvider,
-    private val currentSessionFlow: CurrentSessionFlowUseCase,
-    private val doesValidSessionExist: DoesValidSessionExistUseCase,
-    private val getServerConfigUseCase: GetServerConfigUseCase,
-    private val deepLinkProcessor: DeepLinkProcessor,
-    private val authServerConfigProvider: AuthServerConfigProvider,
-    private val getSessions: GetSessionsUseCase,
-    private val accountSwitch: AccountSwitchUseCase,
-    private val migrationManager: MigrationManager,
-    private val servicesManager: ServicesManager,
+    @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>,
+    private val dispatchers: Lazy<DispatcherProvider>,
+    private val currentSessionFlow: Lazy<CurrentSessionFlowUseCase>,
+    private val doesValidSessionExist: Lazy<DoesValidSessionExistUseCase>,
+    private val getServerConfigUseCase: Lazy<GetServerConfigUseCase>,
+    private val deepLinkProcessor: Lazy<DeepLinkProcessor>,
+    private val authServerConfigProvider: Lazy<AuthServerConfigProvider>,
+    private val getSessions: Lazy<GetSessionsUseCase>,
+    private val accountSwitch: Lazy<AccountSwitchUseCase>,
+    private val migrationManager: Lazy<MigrationManager>,
+    private val servicesManager: Lazy<ServicesManager>,
     private val observeSyncStateUseCaseProviderFactory: ObserveSyncStateUseCaseProvider.Factory,
-    private val observeIfAppUpdateRequired: ObserveIfAppUpdateRequiredUseCase,
-    private val observeNewClients: ObserveNewClientsUseCase,
-    private val clearNewClientsForUser: ClearNewClientsForUserUseCase,
-    private val currentScreenManager: CurrentScreenManager,
+    private val observeIfAppUpdateRequired: Lazy<ObserveIfAppUpdateRequiredUseCase>,
+    private val observeNewClients: Lazy<ObserveNewClientsUseCase>,
+    private val clearNewClientsForUser: Lazy<ClearNewClientsForUserUseCase>,
+    private val currentScreenManager: Lazy<CurrentScreenManager>,
     private val observeScreenshotCensoringConfigUseCaseProviderFactory: ObserveScreenshotCensoringConfigUseCaseProvider.Factory,
-    private val globalDataStore: GlobalDataStore,
+    private val globalDataStore: Lazy<GlobalDataStore>,
     private val observeIfE2EIRequiredDuringLoginUseCaseProviderFactory: ObserveIfE2EIRequiredDuringLoginUseCaseProvider.Factory,
-    private val workManager: WorkManager
+    private val workManager: Lazy<WorkManager>
 ) : ViewModel() {
 
     var globalAppState: GlobalAppState by mutableStateOf(GlobalAppState())
         private set
 
-    private val observeUserId = currentSessionFlow()
+    private val observeUserId = currentSessionFlow.get().invoke()
         .distinctUntilChanged()
         .onEach {
             if (it is CurrentSessionResult.Success) {
@@ -145,7 +146,7 @@ class WireActivityViewModel @Inject constructor(
             }
         }
         .distinctUntilChanged()
-        .flowOn(dispatchers.io())
+        .flowOn(dispatchers.get().io())
         .shareIn(viewModelScope, SharingStarted.WhileSubscribed(), 1)
 
     private val _observeSyncFlowState: MutableStateFlow<SyncState?> = MutableStateFlow(null)
@@ -167,8 +168,8 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun observeAppThemeState() {
-        viewModelScope.launch(dispatchers.io()) {
-            globalDataStore.selectedThemeOptionFlow()
+        viewModelScope.launch(dispatchers.get().io()) {
+            globalDataStore.get().selectedThemeOptionFlow()
                 .distinctUntilChanged()
                 .collect {
                     globalAppState = globalAppState.copy(themeOption = it)
@@ -177,7 +178,7 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun observeSyncState() {
-        viewModelScope.launch(dispatchers.io()) {
+        viewModelScope.launch(dispatchers.get().io()) {
             observeUserId
                 .flatMapLatest {
                     it?.let { observeSyncStateUseCaseProviderFactory.create(it).observeSyncState() } ?: flowOf(null)
@@ -189,7 +190,7 @@ class WireActivityViewModel @Inject constructor(
 
     private fun observeUpdateAppState() {
         viewModelScope.launch {
-            observeIfAppUpdateRequired(BuildConfig.VERSION_CODE)
+            observeIfAppUpdateRequired.get().invoke(BuildConfig.VERSION_CODE)
                 .distinctUntilChanged()
                 .collect {
                     globalAppState = globalAppState.copy(updateAppDialog = it)
@@ -198,10 +199,10 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun observeNewClientState() {
-        viewModelScope.launch(dispatchers.io()) {
-            currentScreenManager.observeCurrentScreen(this)
+        viewModelScope.launch(dispatchers.get().io()) {
+            currentScreenManager.get().observeCurrentScreen(this)
                 .flatMapLatest {
-                    if (it.isGlobalDialogAllowed()) observeNewClients()
+                    if (it.isGlobalDialogAllowed()) observeNewClients.get().invoke()
                     else flowOf(NewClientResult.Empty)
                 }
                 .collect {
@@ -212,7 +213,7 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun observeScreenshotCensoringConfigState() {
-        viewModelScope.launch(dispatchers.io()) {
+        viewModelScope.launch(dispatchers.get().io()) {
             observeUserId
                 .flatMapLatest {
                     it?.let {
@@ -227,7 +228,7 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private suspend fun handleInvalidSession(logoutReason: LogoutReason) {
-        withContext(dispatchers.main()) {
+        withContext(dispatchers.get().main()) {
             when (logoutReason) {
                 LogoutReason.SELF_SOFT_LOGOUT, LogoutReason.SELF_HARD_LOGOUT -> {
                     // Self logout is handled from the Self user profile screen directly
@@ -244,7 +245,6 @@ class WireActivityViewModel @Inject constructor(
             }
         }
     }
-
     val initialAppState: InitialAppState
         get() = when {
             shouldMigrate() -> InitialAppState.NOT_MIGRATED
@@ -259,11 +259,11 @@ class WireActivityViewModel @Inject constructor(
 
     @VisibleForTesting
     internal suspend fun canLoginThroughDeepLinks() = viewModelScope.async {
-        coreLogic.getGlobalScope().session.currentSession().takeIf {
+        coreLogic.get().getGlobalScope().session.currentSession().takeIf {
             it is CurrentSessionResult.Success
         }?.let {
             val currentUserId = (it as CurrentSessionResult.Success).accountInfo.userId
-            coreLogic.getSessionScope(currentUserId).calls.establishedCall().first().isEmpty()
+            coreLogic.get().getSessionScope(currentUserId).calls.establishedCall().first().isEmpty()
         } ?: true
     }
 
@@ -281,7 +281,7 @@ class WireActivityViewModel @Inject constructor(
             return
         }
         viewModelScope.launch {
-            val result = intent?.data?.let { deepLinkProcessor(it) }
+            val result = intent?.data?.let { deepLinkProcessor.get().invoke(it) }
             when {
                 result is DeepLinkResult.SSOLogin -> {
                     if (canLoginThroughDeepLinks().await()) {
@@ -320,7 +320,7 @@ class WireActivityViewModel @Inject constructor(
     fun customBackendDialogProceedButtonClicked(onProceed: () -> Unit) {
         if (globalAppState.customBackendDialog != null) {
             viewModelScope.launch {
-                authServerConfigProvider.updateAuthServer(globalAppState.customBackendDialog!!.serverLinks)
+                authServerConfigProvider.get().updateAuthServer(globalAppState.customBackendDialog!!.serverLinks)
                 dismissCustomBackendDialog()
                 if (checkNumberOfSessions() >= BuildConfig.MAX_ACCOUNTS) {
                     globalAppState = globalAppState.copy(maxAccountDialog = true)
@@ -337,16 +337,16 @@ class WireActivityViewModel @Inject constructor(
         switchAccountActions: SwitchAccountActions
     ) {
         viewModelScope.launch {
-            coreLogic.getGlobalScope().session.currentSession().takeIf {
+            coreLogic.get().getGlobalScope().session.currentSession().takeIf {
                 it is CurrentSessionResult.Success
             }?.let {
                 val currentUserId = (it as CurrentSessionResult.Success).accountInfo.userId
-                coreLogic.getSessionScope(currentUserId).logout(LogoutReason.SELF_HARD_LOGOUT)
+                coreLogic.get().getSessionScope(currentUserId).logout(LogoutReason.SELF_HARD_LOGOUT)
                 clearUserData(currentUserId)
             }
-            accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount).also {
+            accountSwitch.get().invoke(SwitchAccountParam.TryToSwitchToNextAccount).also {
                 if (it == SwitchAccountResult.NoOtherAccountToSwitch) {
-                    globalDataStore.clearAppLockPasscode()
+                    globalDataStore.get().clearAppLockPasscode()
                 }
             }.callAction(switchAccountActions)
         }
@@ -355,9 +355,9 @@ class WireActivityViewModel @Inject constructor(
     fun dismissNewClientsDialog(userId: UserId) {
         globalAppState = globalAppState.copy(newClientDialog = null)
         viewModelScope.launch {
-            doesValidSessionExist(userId).let {
+            doesValidSessionExist.get().invoke(userId).let {
                 if (it is DoesValidSessionExistResult.Success && it.doesValidSessionExist) {
-                    clearNewClientsForUser(userId)
+                    clearNewClientsForUser.get().invoke(userId)
                 }
             }
         }
@@ -365,7 +365,7 @@ class WireActivityViewModel @Inject constructor(
 
     fun switchAccount(userId: UserId, actions: SwitchAccountActions, onComplete: () -> Unit) {
         viewModelScope.launch {
-            accountSwitch(SwitchAccountParam.SwitchToAccount(userId))
+            accountSwitch.get().invoke(SwitchAccountParam.SwitchToAccount(userId))
                 .callAction(actions)
             onComplete()
         }
@@ -374,13 +374,13 @@ class WireActivityViewModel @Inject constructor(
     fun tryToSwitchAccount(actions: SwitchAccountActions) {
         viewModelScope.launch {
             globalAppState = globalAppState.copy(blockUserUI = null)
-            accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount)
+            accountSwitch.get().invoke(SwitchAccountParam.TryToSwitchToNextAccount)
                 .callAction(actions)
         }
     }
 
     private suspend fun checkNumberOfSessions(): Int {
-        getSessions().let {
+        getSessions.get().invoke().let {
             return when (it) {
                 is GetAllSessionsResult.Success -> {
                     it.sessions.filterIsInstance<AccountInfo.Valid>().size
@@ -392,7 +392,7 @@ class WireActivityViewModel @Inject constructor(
         }
     }
 
-    private suspend fun loadServerConfig(url: String): ServerConfig.Links? = when (val result = getServerConfigUseCase(url)) {
+    private suspend fun loadServerConfig(url: String): ServerConfig.Links? = when (val result = getServerConfigUseCase.get().invoke(url)) {
         is GetServerConfigResult.Success -> result.serverConfigLinks
         // TODO: show error message on failure
         is GetServerConfigResult.Failure.Generic -> {
@@ -416,11 +416,11 @@ class WireActivityViewModel @Inject constructor(
         key: String,
         domain: String?,
         onSuccess: (ConversationId) -> Unit
-    ) = when (val currentSession = coreLogic.getGlobalScope().session.currentSession()) {
+    ) = when (val currentSession = coreLogic.get().getGlobalScope().session.currentSession()) {
         is CurrentSessionResult.Failure.Generic -> null
         CurrentSessionResult.Failure.SessionNotFound -> null
         is CurrentSessionResult.Success -> {
-            coreLogic.sessionScope(currentSession.accountInfo.userId) {
+            coreLogic.get().sessionScope(currentSession.accountInfo.userId) {
                 when (val result = conversations.checkIConversationInviteCode(code, key, domain)) {
                     is CheckConversationInviteCodeUseCase.Result.Success -> {
                         if (result.isSelfMember) {
@@ -460,7 +460,7 @@ class WireActivityViewModel @Inject constructor(
 
     private fun hasValidCurrentSession(): Boolean = runBlocking {
         // TODO: the usage of currentSessionFlow is a temporary solution, it should be replaced with a proper solution
-        currentSessionFlow().first().let {
+        currentSessionFlow.get().invoke().first().let {
             when (it) {
                 is CurrentSessionResult.Failure.Generic -> false
                 CurrentSessionResult.Failure.SessionNotFound -> false
@@ -470,7 +470,7 @@ class WireActivityViewModel @Inject constructor(
     }
 
     fun shouldMigrate(): Boolean = runBlocking {
-        migrationManager.shouldMigrate()
+        migrationManager.get().shouldMigrate()
     }
 
     fun dismissMaxAccountDialog() {
@@ -479,7 +479,7 @@ class WireActivityViewModel @Inject constructor(
 
     fun observePersistentConnectionStatus() {
         viewModelScope.launch {
-            coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus().let { result ->
+            coreLogic.get().getGlobalScope().observePersistentWebSocketConnectionStatus().let { result ->
                 when (result) {
                     is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> {
                         appLogger.e("Failure while fetching persistent web socket status flow from wire activity")
@@ -489,13 +489,13 @@ class WireActivityViewModel @Inject constructor(
                         result.persistentWebSocketStatusListFlow.collect { statuses ->
 
                             if (statuses.any { it.isPersistentWebSocketEnabled }) {
-                                if (!servicesManager.isPersistentWebSocketServiceRunning()) {
-                                    servicesManager.startPersistentWebSocketService()
-                                    workManager.enqueuePeriodicPersistentWebsocketCheckWorker()
+                                if (!servicesManager.get().isPersistentWebSocketServiceRunning()) {
+                                    servicesManager.get().startPersistentWebSocketService()
+                                    workManager.get().enqueuePeriodicPersistentWebsocketCheckWorker()
                                 }
                             } else {
-                                servicesManager.stopPersistentWebSocketService()
-                                workManager.cancelPeriodicPersistentWebsocketCheckWorker()
+                                servicesManager.get().stopPersistentWebSocketService()
+                                workManager.get().cancelPeriodicPersistentWebsocketCheckWorker()
                             }
                         }
                     }

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -104,7 +104,7 @@ class WireActivityViewModelTest {
 
         viewModel.handleDeepLink(null, {}, {}, {}, {})
 
-        assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState)
+        assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
     }
 
     @Test
@@ -115,7 +115,7 @@ class WireActivityViewModelTest {
 
         viewModel.handleDeepLink(null, {}, {}, {}, {})
 
-        assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState)
+        assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
     }
 
     @Test
@@ -144,7 +144,7 @@ class WireActivityViewModelTest {
 
             viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
 
-            assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState)
+            assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
             assertEquals(newServerConfig(1).links, viewModel.globalAppState.customBackendDialog!!.serverLinks)
         }
@@ -160,7 +160,7 @@ class WireActivityViewModelTest {
 
             viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
 
-            assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState)
+            assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
             assertEquals(newServerConfig(1).links, viewModel.globalAppState.customBackendDialog!!.serverLinks)
         }
@@ -191,7 +191,7 @@ class WireActivityViewModelTest {
 
             viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
 
-            assertEquals(InitialAppState.NOT_MIGRATED, viewModel.initialAppState)
+            assertEquals(InitialAppState.NOT_MIGRATED, viewModel.initialAppState())
             verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
             assertEquals(null, viewModel.globalAppState.customBackendDialog)
         }
@@ -207,7 +207,7 @@ class WireActivityViewModelTest {
 
         viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
 
-        assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState)
+        assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
         verify(exactly = 1) { arrangement.onDeepLinkResult(ssoLogin) }
     }
 
@@ -236,7 +236,7 @@ class WireActivityViewModelTest {
 
         viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
 
-        assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState)
+        assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
         verify(exactly = 1) { arrangement.onDeepLinkResult(ssoLogin) }
     }
 
@@ -251,7 +251,7 @@ class WireActivityViewModelTest {
 
             viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
 
-            assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState)
+            assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
         }
 
@@ -266,7 +266,7 @@ class WireActivityViewModelTest {
 
             viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
 
-            assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState)
+            assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
         }
 
@@ -281,7 +281,7 @@ class WireActivityViewModelTest {
 
             viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
 
-            assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState)
+            assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
         }
 
@@ -295,7 +295,7 @@ class WireActivityViewModelTest {
 
         viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
 
-        assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState)
+        assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
         verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
     }
 
@@ -311,7 +311,7 @@ class WireActivityViewModelTest {
 
             viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
 
-            assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState)
+            assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
         }
 
@@ -325,7 +325,7 @@ class WireActivityViewModelTest {
 
         viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
 
-        assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState)
+        assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
         verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
     }
 
@@ -742,7 +742,7 @@ class WireActivityViewModelTest {
         private val viewModel by lazy {
             WireActivityViewModel(
                 coreLogic = { coreLogic },
-                dispatchers = { TestDispatcherProvider() },
+                dispatchers = TestDispatcherProvider(),
                 currentSessionFlow = { currentSessionFlow },
                 doesValidSessionExist = { doesValidSessionExist },
                 getServerConfigUseCase = { getServerConfigUseCase },

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -741,26 +741,26 @@ class WireActivityViewModelTest {
 
         private val viewModel by lazy {
             WireActivityViewModel(
-                coreLogic = coreLogic,
-                dispatchers = TestDispatcherProvider(),
-                currentSessionFlow = currentSessionFlow,
-                doesValidSessionExist = doesValidSessionExist,
-                getServerConfigUseCase = getServerConfigUseCase,
-                deepLinkProcessor = deepLinkProcessor,
-                authServerConfigProvider = authServerConfigProvider,
-                getSessions = getSessionsUseCase,
-                accountSwitch = switchAccount,
-                migrationManager = migrationManager,
-                servicesManager = servicesManager,
+                coreLogic = { coreLogic },
+                dispatchers = { TestDispatcherProvider() },
+                currentSessionFlow = { currentSessionFlow },
+                doesValidSessionExist = { doesValidSessionExist },
+                getServerConfigUseCase = { getServerConfigUseCase },
+                deepLinkProcessor = { deepLinkProcessor },
+                authServerConfigProvider = { authServerConfigProvider },
+                getSessions = { getSessionsUseCase },
+                accountSwitch = { switchAccount },
+                migrationManager = { migrationManager },
+                servicesManager = { servicesManager },
                 observeSyncStateUseCaseProviderFactory = observeSyncStateUseCaseProviderFactory,
-                observeIfAppUpdateRequired = observeIfAppUpdateRequired,
-                observeNewClients = observeNewClients,
-                clearNewClientsForUser = clearNewClientsForUser,
-                currentScreenManager = currentScreenManager,
+                observeIfAppUpdateRequired = { observeIfAppUpdateRequired },
+                observeNewClients = { observeNewClients },
+                clearNewClientsForUser = { clearNewClientsForUser },
+                currentScreenManager = { currentScreenManager },
                 observeScreenshotCensoringConfigUseCaseProviderFactory = observeScreenshotCensoringConfigUseCaseProviderFactory,
-                globalDataStore = globalDataStore,
+                globalDataStore = { globalDataStore },
                 observeIfE2EIRequiredDuringLoginUseCaseProviderFactory = observeIfE2EIRequiredDuringLoginUseCaseProviderFactory,
-                workManager = workManager
+                workManager = { workManager }
             )
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6874" title="WPB-6874" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6874</a>  [Android] ANR in WireActivityViewModel.hasValidCurrentSession
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After making use cases being injected lazily in https://github.com/wireapp/wire-android/pull/3096 which helped reducing disk violations, we need to make sure that those use cases are created on background thread

### Solutions

- Changed the way we get current userId to be deferred
- Changed the way to select which screen to show by making running multiple coroutines in parallel

This PR cleans all remaining disk violation that we have on app startup

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
