### PR TITLE
chore(mls): unify MLS client identity models (WPB-9774)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.feature.conversation.GetAllContactsNotInConversatio
 import com.wire.kalium.logic.feature.e2ei.CertificateRevocationListCheckWorker
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMLSClientIdentityUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMembersE2EICertificateStatusesUseCase
-import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.IsOtherUserE2EIVerifiedUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
 import com.wire.kalium.logic.feature.featureConfig.FeatureFlagsSyncWorker
@@ -217,7 +217,7 @@ class UserModule {
 
     @ViewModelScoped
     @Provides
-    fun provideGetUserE2eiCertificateStatusUseCase(userScope: UserScope): GetUserE2eiCertificateStatusUseCase =
+    fun provideGetUserE2eiCertificateStatusUseCase(userScope: UserScope): IsOtherUserE2EIVerifiedUseCase =
         userScope.getUserE2eiCertificateStatus
 
     @ViewModelScoped

--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.feature.asset.GetAvatarAssetUseCase
 import com.wire.kalium.logic.feature.client.FinalizeMLSClientAfterE2EIEnrollment
 import com.wire.kalium.logic.feature.conversation.GetAllContactsNotInConversationUseCase
 import com.wire.kalium.logic.feature.e2ei.CertificateRevocationListCheckWorker
-import com.wire.kalium.logic.feature.e2ei.usecase.GetE2eiCertificateUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.GetMLSClientIdentityUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMembersE2EICertificateStatusesUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
@@ -212,7 +212,7 @@ class UserModule {
 
     @ViewModelScoped
     @Provides
-    fun provideGetE2EICertificateUseCase(userScope: UserScope): GetE2eiCertificateUseCase =
+    fun provideGetE2EICertificateUseCase(userScope: UserScope): GetMLSClientIdentityUseCase =
         userScope.getE2EICertificate
 
     @ViewModelScoped

--- a/app/src/main/kotlin/com/wire/android/mapper/UIParticipantMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/UIParticipantMapper.kt
@@ -29,14 +29,13 @@ import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.type.UserType
-import com.wire.kalium.logic.feature.e2ei.CertificateStatus
 import javax.inject.Inject
 
 class UIParticipantMapper @Inject constructor(
     private val userTypeMapper: UserTypeMapper,
     private val wireSessionImageLoader: WireSessionImageLoader
 ) {
-    fun toUIParticipant(user: User, mlsCertificateStatus: CertificateStatus? = null): UIParticipant = with(user) {
+    fun toUIParticipant(user: User, isMLSVerified: Boolean = false): UIParticipant = with(user) {
         val (userType, connectionState, unavailable) = when (this) {
             is OtherUser -> Triple(this.userType, this.connectionStatus, this.isUnavailableUser)
             // TODO(refactor): does self user need a type ? to false
@@ -56,7 +55,7 @@ class UIParticipantMapper @Inject constructor(
             botService = (user as? OtherUser)?.botService,
             isDefederated = (user is OtherUser && user.defederated),
             isProteusVerified = (user is OtherUser && user.isProteusVerified),
-            isMLSVerified = mlsCertificateStatus == CertificateStatus.VALID,
+            isMLSVerified = isMLSVerified,
             supportedProtocolList = supportedProtocols.orEmpty().toList()
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
@@ -183,7 +183,7 @@ private fun DeviceItemTexts(
         )
         if (shouldShowVerifyLabel) {
             if (shouldShowE2EIInfo) {
-                MLSVerificationIcon(device.e2eiCertificate?.status)
+                MLSVerificationIcon(device.mlsClientIdentity?.e2eiStatus)
             }
             Spacer(modifier = Modifier.width(MaterialTheme.wireDimensions.spacing8x))
             if (device.isVerifiedProteus && !isCurrentClient) ProteusVerifiedIcon(
@@ -205,7 +205,7 @@ private fun DeviceItemTexts(
 
     Spacer(modifier = Modifier.height(MaterialTheme.wireDimensions.removeDeviceItemTitleVerticalPadding))
 
-    device.e2eiCertificate?.let { certificate ->
+    device.mlsClientIdentity?.let { identity ->
         Text(
             style = MaterialTheme.wireTypography.subline01,
             color = MaterialTheme.wireColorScheme.labelText,
@@ -213,7 +213,7 @@ private fun DeviceItemTexts(
             overflow = TextOverflow.Ellipsis,
             text = stringResource(
                 R.string.remove_device_mls_thumbprint_label,
-                certificate.thumbprint.formatAsFingerPrint()
+                identity.thumbprint.formatAsFingerPrint()
             ),
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/model/Device.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/model/Device.kt
@@ -26,7 +26,7 @@ import com.wire.android.R
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.conversation.ClientId
-import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
+import com.wire.kalium.logic.feature.e2ei.MLSClientIdentity
 import com.wire.kalium.logic.util.inWholeWeeks
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.datetime.Clock
@@ -38,16 +38,16 @@ data class Device(
     val lastActiveInWholeWeeks: Int? = null,
     val isValid: Boolean = true,
     val isVerifiedProteus: Boolean = false,
-    val e2eiCertificate: E2eiCertificate? = null
+    val mlsClientIdentity: MLSClientIdentity? = null
 ) {
-    constructor(client: Client, e2eiCertificate: E2eiCertificate? = null) : this(
+    constructor(client: Client, mlsClientIdentity: MLSClientIdentity? = null) : this(
         name = client.displayName(),
         clientId = client.id,
         registrationTime = client.registrationTime?.toIsoDateTimeString(),
         lastActiveInWholeWeeks = client.lastActiveInWholeWeeks(),
         isValid = client.isValid,
         isVerifiedProteus = client.isVerified,
-        e2eiCertificate = e2eiCertificate
+        mlsClientIdentity = mlsClientIdentity
     )
 
     fun updateFromClient(client: Client): Device = copy(
@@ -57,11 +57,11 @@ data class Device(
         lastActiveInWholeWeeks = client.lastActiveInWholeWeeks(),
         isValid = client.isValid,
         isVerifiedProteus = client.isVerified,
-        e2eiCertificate = null,
+        mlsClientIdentity = null,
     )
 
-    fun updateE2EICertificate(e2eiCertificate: E2eiCertificate): Device = copy(
-        e2eiCertificate = e2eiCertificate
+    fun updateE2EICertificate(mlsClientIdentity: MLSClientIdentity): Device = copy(
+        mlsClientIdentity = mlsClientIdentity
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/VerifiedIcons.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/VerifiedIcons.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.feature.e2ei.CertificateStatus
+import com.wire.kalium.logic.feature.e2ei.MLSClientE2EIStatus
 
 @Composable
 fun RowScope.ConversationVerificationIcons(
@@ -68,23 +68,26 @@ fun RowScope.ConversationVerificationIcons(
 }
 
 @Composable
-fun RowScope.MLSVerificationIcon(mlsVerificationStatus: CertificateStatus?) {
+fun RowScope.MLSVerificationIcon(mlsVerificationStatus: MLSClientE2EIStatus?) {
     val mlsIconModifier = Modifier
         .wrapContentWidth()
         .align(Alignment.CenterVertically)
 
     when (mlsVerificationStatus) {
-        CertificateStatus.VALID -> MLSVerifiedIcon(
+        MLSClientE2EIStatus.VALID -> MLSVerifiedIcon(
             contentDescriptionId = R.string.e2ei_certificat_status_valid,
             modifier = mlsIconModifier
         )
 
-        CertificateStatus.REVOKED -> MLSRevokedIcon(modifier = mlsIconModifier)
+        MLSClientE2EIStatus.REVOKED -> MLSRevokedIcon(modifier = mlsIconModifier)
 
-        CertificateStatus.EXPIRED -> MLSNotVerifiedIcon(
+        MLSClientE2EIStatus.EXPIRED
+        -> MLSNotVerifiedIcon(
             contentDescriptionId = R.string.e2ei_certificat_status_expired,
             modifier = mlsIconModifier
         )
+
+        MLSClientE2EIStatus.NOT_ACTIVATED -> MLSNotVerifiedIcon(modifier = mlsIconModifier)
 
         null -> MLSNotVerifiedIcon(modifier = mlsIconModifier)
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
@@ -30,7 +30,6 @@ import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
-import com.wire.kalium.logic.feature.e2ei.CertificateStatus
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMembersE2EICertificateStatusesUseCase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.drop
@@ -55,7 +54,7 @@ class ObserveParticipantsForConversationUseCase @Inject constructor(
                 }
             }
             .scan(
-                ConversationParticipantsData() to emptyMap<UserId, CertificateStatus?>()
+                ConversationParticipantsData() to emptyMap<UserId, Boolean>()
             ) { (_, previousMlsVerificationMap), sortedMemberList ->
                 val allAdminsWithoutServices = sortedMemberList.getOrDefault(true, listOf())
                 val visibleAdminsWithoutServices = allAdminsWithoutServices.limit(limit)
@@ -74,9 +73,9 @@ class ObserveParticipantsForConversationUseCase @Inject constructor(
 
                 ConversationParticipantsData(
                     admins = visibleAdminsWithoutServices
-                        .map { uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.user.id]) },
+                        .map { uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.user.id].let { false }) },
                     participants = visibleParticipants
-                        .map { uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.user.id]) },
+                        .map { uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.user.id].let { false }) },
                     allAdminsCount = allAdminsWithoutServices.size,
                     allParticipantsCount = allParticipants.size,
                     isSelfAnAdmin = allAdminsWithoutServices.any { it.user is SelfUser }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -51,7 +51,6 @@ import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.BuildConfig
 import com.wire.android.R
-import com.wire.android.appLogger
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.authentication.devices.model.Device
@@ -92,6 +91,9 @@ import com.wire.android.util.extension.formatAsString
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.QualifiedClientID
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.e2ei.Handle
 import com.wire.kalium.logic.feature.e2ei.MLSClientE2EIStatus
 import com.wire.kalium.logic.feature.e2ei.MLSClientIdentity
 import com.wire.kalium.logic.feature.e2ei.MLSCredentialsType
@@ -192,8 +194,6 @@ fun DeviceDetailsContent(
                 .padding(internalPadding)
                 .background(MaterialTheme.wireColorScheme.surface)
         ) {
-
-            appLogger.e("device info:"+state.device.toString())
             state.device.mlsClientIdentity?.let { identity ->
                 item {
                     DeviceMLSSignatureItem(identity.thumbprint, screenState::copyMessage)
@@ -578,10 +578,12 @@ fun PreviewDeviceDetailsScreen() {
                 name = UIText.DynamicString("My Device"),
                 registrationTime = "2022-03-24T18:02:30.360Z",
                 mlsClientIdentity = MLSClientIdentity(
+                    clientId = QualifiedClientID(ClientId(""), UserId("", "")),
                     e2eiStatus = MLSClientE2EIStatus.VALID,
                     thumbprint = "thumbprint",
                     credentialType = MLSCredentialsType.X509,
                     x509Identity = X509Identity(
+                        handle = Handle("", "", ""),
                         displayName = "",
                         domain = "",
                         certificate = "",

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -584,7 +584,7 @@ fun PreviewDeviceDetailsScreen() {
                     x509Identity = X509Identity(
                         displayName = "",
                         domain = "",
-                        certificateDetail = "",
+                        certificate = "",
                         serialNumber = "e5:d5:e6:75:7e:04:86:07:14:3c:a0:ed:9a:8d:e4:fd",
                         notBefore = Instant.DISTANT_PAST,
                         notAfter = Instant.DISTANT_FUTURE

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
@@ -221,7 +221,7 @@ fun PreviewEndToEndIdentityCertificateItem() {
             x509Identity = X509Identity(
                 displayName = "",
                 domain = "",
-                certificateDetail = "",
+                certificate = "",
                 serialNumber = "e5:d5:e6:75:7e:04:86:07:14:3c:a0:ed:9a:8d:e4:fd",
                 notBefore = Instant.DISTANT_PAST,
                 notAfter = Instant.DISTANT_FUTURE
@@ -246,7 +246,7 @@ fun PreviewEndToEndIdentityCertificateSelfItem() {
             x509Identity = X509Identity(
                 displayName = "",
                 domain = "",
-                certificateDetail = "",
+                certificate = "",
                 serialNumber = "e5:d5:e6:75:7e:04:86:07:14:3c:a0:ed:9a:8d:e4:fd",
                 notBefore = Instant.DISTANT_PAST,
                 notAfter = Instant.DISTANT_FUTURE

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
@@ -40,6 +40,10 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.QualifiedClientID
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.e2ei.Handle
 import com.wire.kalium.logic.feature.e2ei.MLSClientE2EIStatus
 import com.wire.kalium.logic.feature.e2ei.MLSClientIdentity
 import com.wire.kalium.logic.feature.e2ei.MLSCredentialsType
@@ -121,7 +125,7 @@ fun EndToEndIdentityCertificateItem(
                             )
                         }
                     }
-                    MLSClientE2EIStatus.NOT_ACTIVATED->{
+                    MLSClientE2EIStatus.NOT_ACTIVATED -> {
                         E2EIStatusRow(
                             label = stringResource(id = R.string.e2ei_certificat_status_not_activated),
                             labelColor = colorsScheme().error,
@@ -215,10 +219,12 @@ fun PreviewEndToEndIdentityCertificateItem() {
         isE2eiCertificateActivated = true,
         isCurrentDevice = false,
         mlsClientIdentity = MLSClientIdentity(
+            clientId = QualifiedClientID(ClientId(""), UserId("", "")),
             e2eiStatus = MLSClientE2EIStatus.VALID,
             thumbprint = "thumbprint",
             credentialType = MLSCredentialsType.X509,
             x509Identity = X509Identity(
+                handle = Handle("", "", ""),
                 displayName = "",
                 domain = "",
                 certificate = "",
@@ -240,10 +246,12 @@ fun PreviewEndToEndIdentityCertificateSelfItem() {
         isE2eiCertificateActivated = true,
         isCurrentDevice = true,
         mlsClientIdentity = MLSClientIdentity(
+            clientId = QualifiedClientID(ClientId(""), UserId("", "")),
             e2eiStatus = MLSClientE2EIStatus.VALID,
             thumbprint = "thumbprint",
             credentialType = MLSCredentialsType.X509,
             x509Identity = X509Identity(
+                handle = Handle("", "", ""),
                 displayName = "",
                 domain = "",
                 certificate = "",

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
@@ -218,21 +218,7 @@ fun PreviewEndToEndIdentityCertificateItem() {
     EndToEndIdentityCertificateItem(
         isE2eiCertificateActivated = true,
         isCurrentDevice = false,
-        mlsClientIdentity = MLSClientIdentity(
-            clientId = QualifiedClientID(ClientId(""), UserId("", "")),
-            e2eiStatus = MLSClientE2EIStatus.VALID,
-            thumbprint = "thumbprint",
-            credentialType = MLSCredentialsType.X509,
-            x509Identity = X509Identity(
-                handle = Handle("", "", ""),
-                displayName = "",
-                domain = "",
-                certificate = "",
-                serialNumber = "e5:d5:e6:75:7e:04:86:07:14:3c:a0:ed:9a:8d:e4:fd",
-                notBefore = Instant.DISTANT_PAST,
-                notAfter = Instant.DISTANT_FUTURE
-            )
-        ),
+        mlsClientIdentity = DUMMY_MLSClientIdentity,
         isLoadingCertificate = false,
         enrollE2eiCertificate = {},
         showCertificate = {}
@@ -245,23 +231,25 @@ fun PreviewEndToEndIdentityCertificateSelfItem() {
     EndToEndIdentityCertificateItem(
         isE2eiCertificateActivated = true,
         isCurrentDevice = true,
-        mlsClientIdentity = MLSClientIdentity(
-            clientId = QualifiedClientID(ClientId(""), UserId("", "")),
-            e2eiStatus = MLSClientE2EIStatus.VALID,
-            thumbprint = "thumbprint",
-            credentialType = MLSCredentialsType.X509,
-            x509Identity = X509Identity(
-                handle = Handle("", "", ""),
-                displayName = "",
-                domain = "",
-                certificate = "",
-                serialNumber = "e5:d5:e6:75:7e:04:86:07:14:3c:a0:ed:9a:8d:e4:fd",
-                notBefore = Instant.DISTANT_PAST,
-                notAfter = Instant.DISTANT_FUTURE
-            )
-        ),
+        mlsClientIdentity = DUMMY_MLSClientIdentity,
         isLoadingCertificate = false,
         enrollE2eiCertificate = {},
         showCertificate = {}
     )
 }
+
+var DUMMY_MLSClientIdentity = MLSClientIdentity(
+    clientId = QualifiedClientID(ClientId(""), UserId("", "")),
+    e2eiStatus = MLSClientE2EIStatus.VALID,
+    thumbprint = "thumbprint",
+    credentialType = MLSCredentialsType.X509,
+    x509Identity = X509Identity(
+        handle = Handle("", "", ""),
+        displayName = "",
+        domain = "",
+        certificate = "",
+        serialNumber = "e5:d5:e6:75:7e:04:86:07:14:3c:a0:ed:9a:8d:e4:fd",
+        notBefore = Instant.DISTANT_PAST,
+        notAfter = Instant.DISTANT_FUTURE
+    )
+)

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
@@ -218,7 +218,7 @@ fun PreviewEndToEndIdentityCertificateItem() {
     EndToEndIdentityCertificateItem(
         isE2eiCertificateActivated = true,
         isCurrentDevice = false,
-        mlsClientIdentity = DUMMY_MLSClientIdentity,
+        mlsClientIdentity = previewMLSClientIdentity(),
         isLoadingCertificate = false,
         enrollE2eiCertificate = {},
         showCertificate = {}
@@ -231,14 +231,14 @@ fun PreviewEndToEndIdentityCertificateSelfItem() {
     EndToEndIdentityCertificateItem(
         isE2eiCertificateActivated = true,
         isCurrentDevice = true,
-        mlsClientIdentity = DUMMY_MLSClientIdentity,
+        mlsClientIdentity = previewMLSClientIdentity(),
         isLoadingCertificate = false,
         enrollE2eiCertificate = {},
         showCertificate = {}
     )
 }
 
-var DUMMY_MLSClientIdentity = MLSClientIdentity(
+internal fun previewMLSClientIdentity() = MLSClientIdentity(
     clientId = QualifiedClientID(ClientId(""), UserId("", "")),
     e2eiStatus = MLSClientE2EIStatus.VALID,
     thumbprint = "thumbprint",

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsBottomSheet.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsBottomSheet.kt
@@ -38,7 +38,7 @@ fun E2eiCertificateDetailsBottomSheet(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val onSaveFileWriteStorageRequest = rememberWriteStorageRequestFlow(
-        onGranted = onDownload ,
+        onGranted = onDownload,
         onDenied = { }
     )
     WireModalSheetLayout(sheetState = sheetState, coroutineScope = coroutineScope) {

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsBottomSheet.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsBottomSheet.kt
@@ -28,6 +28,7 @@ import com.wire.android.ui.common.bottomsheet.MenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
+import com.wire.android.util.permission.rememberWriteStorageRequestFlow
 
 @Composable
 fun E2eiCertificateDetailsBottomSheet(
@@ -36,7 +37,10 @@ fun E2eiCertificateDetailsBottomSheet(
     onDownload: () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
-
+    val onSaveFileWriteStorageRequest = rememberWriteStorageRequestFlow(
+        onGranted = onDownload ,
+        onDenied = { }
+    )
     WireModalSheetLayout(sheetState = sheetState, coroutineScope = coroutineScope) {
         MenuModalSheetContent(
             header = MenuModalSheetHeader.Gone,
@@ -53,7 +57,7 @@ fun E2eiCertificateDetailsBottomSheet(
                     CreateCertificateSheetItem(
                         title = stringResource(R.string.e2ei_certificate_details_download),
                         icon = R.drawable.ic_download,
-                        onClicked = onDownload,
+                        onClicked = onSaveFileWriteStorageRequest::launch,
                         enabled = true
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreenNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreenNavArgs.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.android.ui.settings.devices.e2ei
 
-import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
+import com.wire.kalium.logic.feature.e2ei.MLSClientIdentity
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -26,7 +26,7 @@ data class E2eiCertificateDetailsScreenNavArgs(val certificateDetails: E2EICerti
 @Serializable
 sealed class E2EICertificateDetails {
     @Serializable
-    data class AfterLoginCertificateDetails(@SerialName("certificate") val certificate: E2eiCertificate) : E2EICertificateDetails()
+    data class AfterLoginCertificateDetails(@SerialName("certificate") val mlsClientIdentity: MLSClientIdentity) : E2EICertificateDetails()
     @Serializable
     data class DuringLoginCertificateDetails(@SerialName("certificate") val certificate: String) : E2EICertificateDetails()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
@@ -63,7 +63,7 @@ class E2eiCertificateDetailsViewModel @Inject constructor(
                 navArgs.certificateDetails.certificate
 
             is E2EICertificateDetails.AfterLoginCertificateDetails ->
-                navArgs.certificateDetails.mlsClientIdentity.x509Identity!!.certificateDetail
+                navArgs.certificateDetails.mlsClientIdentity.x509Identity!!.certificate
         }
 
     fun userHandle() =
@@ -72,7 +72,7 @@ class E2eiCertificateDetailsViewModel @Inject constructor(
                 selfUserHandle
 
             is E2EICertificateDetails.AfterLoginCertificateDetails ->
-                navArgs.certificateDetails.mlsClientIdentity.x509Identity!!.certificateDetail
+                navArgs.certificateDetails.mlsClientIdentity.x509Identity!!.certificate
         }
 
     fun getCertificateName(): String {

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
@@ -63,7 +63,7 @@ class E2eiCertificateDetailsViewModel @Inject constructor(
                 navArgs.certificateDetails.certificate
 
             is E2EICertificateDetails.AfterLoginCertificateDetails ->
-                navArgs.certificateDetails.certificate.certificateDetail
+                navArgs.certificateDetails.mlsClientIdentity.x509Identity!!.certificateDetail
         }
 
     fun userHandle() =
@@ -72,7 +72,7 @@ class E2eiCertificateDetailsViewModel @Inject constructor(
                 selfUserHandle
 
             is E2EICertificateDetails.AfterLoginCertificateDetails ->
-                navArgs.certificateDetails.certificate.userHandle
+                navArgs.certificateDetails.mlsClientIdentity.x509Identity!!.certificateDetail
         }
 
     fun getCertificateName(): String {

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
@@ -63,7 +63,7 @@ class E2eiCertificateDetailsViewModel @Inject constructor(
                 navArgs.certificateDetails.certificate
 
             is E2EICertificateDetails.AfterLoginCertificateDetails ->
-                navArgs.certificateDetails.mlsClientIdentity.x509Identity!!.certificate
+                navArgs.certificateDetails.mlsClientIdentity.x509Identity?.certificate ?: ""
         }
 
     fun userHandle() =
@@ -72,7 +72,7 @@ class E2eiCertificateDetailsViewModel @Inject constructor(
                 selfUserHandle
 
             is E2EICertificateDetails.AfterLoginCertificateDetails ->
-                navArgs.certificateDetails.mlsClientIdentity.x509Identity!!.certificate
+                navArgs.certificateDetails.mlsClientIdentity.x509Identity?.handle?.handle ?: ""
         }
 
     fun getCertificateName(): String {

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/DeviceDetailsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/DeviceDetailsState.kt
@@ -20,7 +20,7 @@ package com.wire.android.ui.settings.devices.model
 import com.wire.android.ui.authentication.devices.model.Device
 import com.wire.android.ui.authentication.devices.remove.RemoveDeviceDialogState
 import com.wire.android.ui.authentication.devices.remove.RemoveDeviceError
-import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
+import com.wire.kalium.logic.feature.e2ei.MLSClientIdentity
 
 data class DeviceDetailsState(
     val device: Device = Device(),
@@ -31,7 +31,7 @@ data class DeviceDetailsState(
     val isSelfClient: Boolean = false,
     val userName: String? = null,
     val isE2eiCertificateActivated: Boolean = false,
-    val e2eiCertificate: E2eiCertificate? = null,
+    val mlsClientIdentity: MLSClientIdentity? = null,
     val canBeRemoved: Boolean = false,
     val isLoadingCertificate: Boolean = false,
     val isE2EICertificateEnrollSuccess: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
@@ -123,7 +123,7 @@ private fun OtherUserDevicesContent(
                     onClickAction = onDeviceClick,
                     icon = Icons.Filled.ChevronRight.Icon(),
                     shouldShowVerifyLabel = true,
-                    shouldShowE2EIInfo = item.e2eiCertificate != null
+                    shouldShowE2EIInfo = item.mlsClientIdentity != null
                 )
                 if (index < otherUserDevices.lastIndex) WireDivider()
             }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -69,8 +69,6 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationArchivedStat
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
-import com.wire.kalium.logic.feature.e2ei.CertificateStatus
-import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusResult
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
@@ -147,9 +145,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
 
     private fun getMLSVerificationStatus() {
         viewModelScope.launch {
-            val isMLSVerified = getUserE2eiCertificateStatus(userId).let {
-                it is GetUserE2eiCertificateStatusResult.Success && it.status == CertificateStatus.VALID
-            }
+            val isMLSVerified = getUserE2eiCertificateStatus(userId)
             state = state.copy(isMLSVerified = isMLSVerified)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -69,7 +69,7 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationArchivedStat
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
-import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.IsOtherUserE2EIVerifiedUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
@@ -104,7 +104,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     private val fetchUsersClients: FetchUsersClientsFromRemoteUseCase,
     private val clearConversationContentUseCase: ClearConversationContentUseCase,
     private val updateConversationArchivedStatus: UpdateConversationArchivedStatusUseCase,
-    private val getUserE2eiCertificateStatus: GetUserE2eiCertificateStatusUseCase,
+    private val getUserE2eiCertificateStatus: IsOtherUserE2EIVerifiedUseCase,
     private val getUserE2eiCertificates: GetUserE2eiCertificatesUseCase,
     private val isOneToOneConversationCreated: IsOneToOneConversationCreatedUseCase,
     savedStateHandle: SavedStateHandle

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
@@ -206,7 +206,7 @@ internal class ObserveParticipantsForConversationUseCaseArrangement {
         MockKAnnotations.init(this, relaxUnitFun = true)
         // Default empty values
         coEvery { observeConversationMembersUseCase(any()) } returns flowOf()
-        coEvery { getMembersE2EICertificateStatuses(any(), any()) } answers { secondArg<List<UserId>>().associateWith { null } }
+        coEvery { getMembersE2EICertificateStatuses(any(), any()) } answers { secondArg<List<UserId>>().associateWith { false } }
     }
 
     suspend fun withConversationParticipantsUpdate(members: List<MemberDetails>): ObserveParticipantsForConversationUseCaseArrangement {

--- a/app/src/test/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModelTest.kt
@@ -39,8 +39,7 @@ import com.wire.kalium.logic.feature.client.Result
 import com.wire.kalium.logic.feature.client.UpdateClientVerificationStatusUseCase
 import com.wire.kalium.logic.feature.e2ei.CertificateStatus
 import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
-import com.wire.kalium.logic.feature.e2ei.usecase.GetE2EICertificateUseCaseResult
-import com.wire.kalium.logic.feature.e2ei.usecase.GetE2eiCertificateUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.GetMLSClientIdentityUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
@@ -332,7 +331,7 @@ class DeviceDetailsViewModelTest {
         lateinit var observeUserInfo: ObserveUserInfoUseCase
 
         @MockK
-        lateinit var getE2eiCertificate: GetE2eiCertificateUseCase
+        lateinit var getE2eiCertificate: GetMLSClientIdentityUseCase
 
         @MockK(relaxed = true)
         lateinit var onSuccess: () -> Unit

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -45,8 +45,7 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleRe
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
 import com.wire.kalium.logic.feature.e2ei.CertificateStatus
-import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusResult
-import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.IsOtherUserE2EIVerifiedUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
@@ -108,7 +107,7 @@ internal class OtherUserProfileViewModelArrangement {
     lateinit var updateConversationArchivedStatus: UpdateConversationArchivedStatusUseCase
 
     @MockK
-    lateinit var getUserE2eiCertificateStatus: GetUserE2eiCertificateStatusUseCase
+    lateinit var getUserE2eiCertificateStatus: IsOtherUserE2EIVerifiedUseCase
 
     @MockK
     lateinit var getUserE2eiCertificates: GetUserE2eiCertificatesUseCase
@@ -164,7 +163,7 @@ internal class OtherUserProfileViewModelArrangement {
         coEvery { getOneToOneConversation(USER_ID) } returns flowOf(
             GetOneToOneConversationUseCase.Result.Success(OtherUserProfileScreenViewModelTest.CONVERSATION)
         )
-        coEvery { getUserE2eiCertificateStatus.invoke(any()) } returns GetUserE2eiCertificateStatusResult.Success(CertificateStatus.VALID)
+        coEvery { getUserE2eiCertificateStatus.invoke(any()) } returns true
         coEvery { getUserE2eiCertificates.invoke(any()) } returns mapOf()
         coEvery { isOneToOneConversationCreated.invoke(any()) } returns true
     }

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -44,7 +44,6 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationArchivedStat
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
-import com.wire.kalium.logic.feature.e2ei.CertificateStatus
 import com.wire.kalium.logic.feature.e2ei.usecase.IsOtherUserE2EIVerifiedUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9774" title="WPB-9774" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9774</a>  Refactoring MLS Client Identity models
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
To fetch the MLSClientIdentity from CC we were mapping them in different models, due to different changes we needed more data to be exposed, we needed them to be unified and map all the available data from CC.

### Issues

Hard to maintain different models
Due to maturity of CC now we have a rich and solid model we can map full object in Kalium and Android App.

Needs releases with:

- [x] GitHub link to other pull request https://github.com/wireapp/kalium/pull/2818

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test
We need to test all E2EI features on this PR
----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
