### PR TITLE
ci: add DataDog tokens to GitHub workflows [WPB-9788]

### DIFF
--- a/.github/workflows/build-beta-app.yml
+++ b/.github/workflows/build-beta-app.yml
@@ -54,6 +54,8 @@ jobs:
         run:
           ./gradlew app:assembleBetaRelease
         env:
+          DATADOG_APP_ID: ${{ secrets.DATADOG_APP_ID }}
+          DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           KEYSTORE_FILE_PATH_DEBUG: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_COMPAT: ${{ vars.KEYSTORE_FILE_PATH }}
@@ -66,6 +68,8 @@ jobs:
         run:
           ./gradlew app:bundleBetaRelease
         env:
+          DATADOG_APP_ID: ${{ secrets.DATADOG_APP_ID }}
+          DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           KEYSTORE_FILE_PATH_DEBUG: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_COMPAT: ${{ vars.KEYSTORE_FILE_PATH }}

--- a/.github/workflows/build-develop-app.yml
+++ b/.github/workflows/build-develop-app.yml
@@ -45,6 +45,8 @@ jobs:
         run:
           ./gradlew app:assembleDevDebug
         env:
+          DATADOG_APP_ID: ${{ secrets.DATADOG_APP_ID }}
+          DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           KEYSTORE_FILE_PATH_DEBUG: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_COMPAT: ${{ vars.KEYSTORE_FILE_PATH }}
@@ -63,6 +65,8 @@ jobs:
         run:
           ./gradlew app:assembleStagingRelease
         env:
+          DATADOG_APP_ID: ${{ secrets.DATADOG_APP_ID }}
+          DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           KEYSTORE_FILE_PATH_DEBUG: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_COMPAT: ${{ vars.KEYSTORE_FILE_PATH }}

--- a/.github/workflows/build-rc-app.yml
+++ b/.github/workflows/build-rc-app.yml
@@ -50,6 +50,8 @@ jobs:
         run:
           ./gradlew app:assembleInternalCompat
         env:
+          DATADOG_APP_ID: ${{ secrets.DATADOG_APP_ID }}
+          DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           KEYSTORE_FILE_PATH_DEBUG: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_COMPAT: ${{ vars.KEYSTORE_FILE_PATH }}
@@ -62,6 +64,8 @@ jobs:
         run:
           ./gradlew app:bundleInternalCompat
         env:
+          DATADOG_APP_ID: ${{ secrets.DATADOG_APP_ID }}
+          DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           KEYSTORE_FILE_PATH_DEBUG: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_COMPAT: ${{ vars.KEYSTORE_FILE_PATH }}
@@ -75,6 +79,8 @@ jobs:
         run:
           ./gradlew app:assembleStagingCompat
         env:
+          DATADOG_APP_ID: ${{ secrets.DATADOG_APP_ID }}
+          DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           KEYSTORE_FILE_PATH_DEBUG: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_COMPAT: ${{ vars.KEYSTORE_FILE_PATH }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,12 +62,12 @@ private fun getFlavorsSettings(): NormalizedFlavorSettings =
 android {
     defaultConfig {
         val datadogApiKeyKey = "DATADOG_CLIENT_TOKEN"
-        val apiKey: String? = System.getenv(datadogApiKeyKey) ?: project.getLocalProperty(datadogApiKeyKey, null)
-        buildConfigField("String", "DATADOG_CLIENT_TOKEN", apiKey?.let { "\"$it\"" } ?: "null")
+        val datadogApiKey: String? = System.getenv(datadogApiKeyKey) ?: project.getLocalProperty(datadogApiKeyKey, null)
+        buildConfigField("String", datadogApiKeyKey, datadogApiKey?.let { "\"$it\"" } ?: "null")
 
-        val datadogAppId = "DATADOG_APP_ID"
-        val appId: String? = System.getenv(datadogAppId) ?: project.getLocalProperty(datadogAppId, null)
-        buildConfigField("String", datadogAppId, appId?.let { "\"$it\"" } ?: "null")
+        val datadogAppIdKey = "DATADOG_APP_ID"
+        val appId: String? = System.getenv(datadogAppIdKey) ?: project.getLocalProperty(datadogAppIdKey, null)
+        buildConfigField("String", datadogAppIdKey, appId?.let { "\"$it\"" } ?: "null")
     }
     // Most of the configuration is done in the build-logic
     // through the Wire Application convention plugin


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9788" title="WPB-9788" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9788</a>  [Android] Add event processing performance logs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We have no Datadog in our private builds to gather metrics.

### Solutions

Add the missing Datadog keys to all GH Workflows (except Prod builds).

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
