### PR TITLE
fix: handle NoCommonProtocol error while starting conversation

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import com.wire.android.R
 import com.wire.android.di.hiltViewModelScoped
 import com.wire.android.model.ClickBlockParams
@@ -51,6 +52,7 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.stringWithStyledArgs
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
@@ -98,7 +100,7 @@ fun ConnectionActionButton(
             loading = viewModel.actionableState().isPerformingAction,
             onClick = {
                 viewModel.onOpenConversation(onOpenConversation) {
-                    unableStartConversationDialogState.show(UnableStartConversationDialogState(fullName))
+                    unableStartConversationDialogState.show(UnableStartConversationDialogState(fullName, it))
                 }
             },
         )
@@ -189,16 +191,60 @@ fun ConnectionActionButton(
 @Composable
 fun UnableStartConversationDialogContent(dialogState: VisibilityState<UnableStartConversationDialogState>) {
     VisibilityState(dialogState) { state ->
+        val title: String
+        val text: AnnotatedString
+
+        when (state.error) {
+            is CoreFailure.MissingKeyPackages -> {
+                title = stringResource(id = R.string.missing_keypackage_dialog_title)
+                text = LocalContext.current.resources.stringWithStyledArgs(
+                    R.string.missing_keypackage_dialog_body,
+                    MaterialTheme.wireTypography.body01,
+                    MaterialTheme.wireTypography.body02,
+                    colorsScheme().onBackground,
+                    colorsScheme().onBackground,
+                    state.userName
+                )
+            }
+
+            is CoreFailure.NoCommonProtocolFound.SelfNeedToUpdate -> {
+                title = stringResource(id = R.string.missing_keypackage_dialog_title)
+                text = LocalContext.current.resources.stringWithStyledArgs(
+                    R.string.no_common_protocol_dialog_body_self_need_update,
+                    MaterialTheme.wireTypography.body01,
+                    MaterialTheme.wireTypography.body02,
+                    colorsScheme().onBackground,
+                    colorsScheme().onBackground,
+                    state.userName
+                )
+            }
+
+            is CoreFailure.NoCommonProtocolFound.OtherNeedToUpdate -> {
+                title = stringResource(id = R.string.missing_keypackage_dialog_title)
+                text = LocalContext.current.resources.stringWithStyledArgs(
+                    R.string.no_common_protocol_dialog_body_other_need_update,
+                    MaterialTheme.wireTypography.body01,
+                    MaterialTheme.wireTypography.body02,
+                    colorsScheme().onBackground,
+                    colorsScheme().onBackground,
+                    state.userName
+                )
+            }
+
+            else -> {
+                title = stringResource(id = R.string.error_unknown_title)
+                text = LocalContext.current.resources.stringWithStyledArgs(
+                    R.string.error_unknown_message,
+                    MaterialTheme.wireTypography.body01,
+                    MaterialTheme.wireTypography.body02,
+                    colorsScheme().onBackground,
+                    colorsScheme().onBackground
+                )
+            }
+        }
         WireDialog(
-            title = stringResource(id = R.string.missing_keypackage_dialog_title),
-            text = LocalContext.current.resources.stringWithStyledArgs(
-                R.string.missing_keypackage_dialog_body,
-                MaterialTheme.wireTypography.body01,
-                MaterialTheme.wireTypography.body02,
-                colorsScheme().onBackground,
-                colorsScheme().onBackground,
-                state.userName
-            ),
+            title = title,
+            text = text,
             onDismiss = dialogState::dismiss,
             optionButton1Properties = WireDialogButtonProperties(
                 onClick = dialogState::dismiss,
@@ -209,7 +255,7 @@ fun UnableStartConversationDialogContent(dialogState: VisibilityState<UnableStar
     }
 }
 
-data class UnableStartConversationDialogState(val userName: String)
+data class UnableStartConversationDialogState(val userName: String, val error: CoreFailure)
 
 @Composable
 @PreviewMultipleThemes

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -875,6 +875,10 @@
     <!-- Missing keyPackages dialog -->
     <string name="missing_keypackage_dialog_title">Unable to start conversation</string>
     <string name="missing_keypackage_dialog_body">You can’t start the conversation with %1$s right now. %1$s needs to open Wire or log in again first. Please try again later.</string>
+    <!-- No Common protocol dialog -->
+    <string name="no_common_protocol_dialog_title">Unable to start conversation</string>
+    <string name="no_common_protocol_dialog_body_self_need_update">You can’t communicate with %1$s, as your device doesn’t support the suitable protocol. Download the latest MLS Wire version, to call, and send messages and files.</string>
+    <string name="no_common_protocol_dialog_body_other_need_update">You can’t communicate with %1$s, as you two use different protocols. When %1$s gets an update, you can call and send messages and files.</string>
     <!-- Gallery -->
     <string name="media_gallery_default_title_name">Media Gallery</string>
     <string name="media_gallery_on_image_downloaded">Saved to Downloads folder</string>


### PR DESCRIPTION
# What's new in this PR?

### Issues

When user is trying to start 1o1 conversation with user that has no common protocol with, the error is no displayed anyhow.

### Causes (Optional)

Error handling in creating conversation was implemented only for NoKeypackages error. 

### Solutions

Add handling for all errors (specific texts for `NoKeypackages` and `NoCommonProtocol` errors and some default text for other errors.)

### Attachments (Optional)

<img width="264" alt="Screenshot 2024-06-24 at 12 20 43" src="https://github.com/wireapp/wire-android/assets/6539347/e005843d-b06a-4118-9177-120a0c6afc8c">

