### PR TITLE
fix: camera on/off button when in fullscreen [WPB-9815]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -81,6 +81,7 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
+import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import java.util.Locale
@@ -122,19 +123,23 @@ fun OngoingCallScreen(
             hangUpCall = { sharedCallingViewModel.hangUpCall(navigator::navigateBack) },
             toggleVideo = sharedCallingViewModel::toggleVideo,
             flipCamera = sharedCallingViewModel::flipCamera,
-            setVideoPreview = {
-                sharedCallingViewModel.setVideoPreview(it)
-                ongoingCallViewModel.startSendingVideoFeed()
-            },
-            clearVideoPreview = {
-                sharedCallingViewModel.clearVideoPreview()
-                ongoingCallViewModel.stopSendingVideoFeed()
-            },
+            setVideoPreview = sharedCallingViewModel::setVideoPreview,
+            clearVideoPreview = sharedCallingViewModel::clearVideoPreview,
             navigateBack = navigator::navigateBack,
             requestVideoStreams = ongoingCallViewModel::requestVideoStreams,
             hideDoubleTapToast = ongoingCallViewModel::hideDoubleTapToast
         )
         BackHandler(enabled = isCameraOn, navigator::navigateBack)
+    }
+
+    // Start/stop sending video feed based on the camera state when the call is established.
+    LaunchedEffect(sharedCallingViewModel.callState.callStatus, sharedCallingViewModel.callState.isCameraOn) {
+        if (sharedCallingViewModel.callState.callStatus == CallStatus.ESTABLISHED) {
+            when (sharedCallingViewModel.callState.isCameraOn) {
+                true -> ongoingCallViewModel.startSendingVideoFeed()
+                false -> ongoingCallViewModel.stopSendingVideoFeed()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9815" title="WPB-9815" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9815</a>  [Android] app continues to stream video even if video is turned off
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a user double taps to expand (open in fullscreen) any participant's video, the button to toggle camera is not doing anything so if the user has camera enabled, then opens fullscreen and clicks on a camera button to turn it off, the button indicates that the camera is now off for the user but the app continues streaming video to other participants.

### Causes (Optional)

Calls to start or stop sending video feed were associated with setting or clearing self video preview but only for the participants grid, not the fullscreen mode.

### Solutions

Make start or stop sending video actions to be associated with `isCameraOn` state changes, independently from setting or clearing the video preview view - the user may not have the preview view present (because other participant's video is expanded to fullscreen) but still stream the video and be able to change camera state by clicking on a button.

### Testing

#### How to Test

- Start a video call.
- Turn on your camera.
- Double tap on your video to expand it.
- Turn off your camera.

Expected Result: The camera should turn off for both the user and other participants, stopping the video stream.
Actual Result: For the user, the video appears to be off, but other participants can still see the video stream.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
