### PR TITLE
fix: wrong caller name in outgoing call (WPB-9758)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
@@ -139,7 +139,7 @@ private fun ConnectivityStatusBar(
                     IncomingCallContent(callerName = connectivityInfo.callerName)
 
                 is ConnectivityUIState.OutgoingCall ->
-                    OutgoingCallContent(callerName = connectivityInfo.callerName)
+                    OutgoingCallContent(conversationName = connectivityInfo.conversationName)
 
                 ConnectivityUIState.Connecting ->
                     StatusLabel(
@@ -183,11 +183,11 @@ private fun IncomingCallContent(callerName: String?) {
 }
 
 @Composable
-private fun OutgoingCallContent(callerName: String?) {
+private fun OutgoingCallContent(conversationName: String?) {
     Row {
         StatusLabelWithValue(
             stringResource = R.string.connectivity_status_bar_return_to_outgoing_call,
-            callerName = callerName,
+            callerName = conversationName,
             color = MaterialTheme.wireColorScheme.onPositive
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
@@ -133,7 +133,7 @@ class CommonTopAppBarViewModel @Inject constructor(
             return if (activeCall.status == CallStatus.INCOMING) {
                 ConnectivityUIState.IncomingCall(activeCall.conversationId, activeCall.callerName)
             } else if (activeCall.status == CallStatus.STARTED) {
-                ConnectivityUIState.OutgoingCall(activeCall.conversationId, activeCall.callerName)
+                ConnectivityUIState.OutgoingCall(activeCall.conversationId, activeCall.conversationName)
             } else {
                 ConnectivityUIState.EstablishedCall(activeCall.conversationId, activeCall.isMuted)
             }

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/ConnectivityUIState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/ConnectivityUIState.kt
@@ -41,6 +41,6 @@ sealed interface ConnectivityUIState {
 
     data class OutgoingCall(
         val conversationId: ConversationId,
-        val callerName: String?
+        val conversationName: String?
     ) : ConnectivityUIState
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9758" title="WPB-9758" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9758</a>  [Android] While making a call, it shows caller's name as callee
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Wrong display of caller name in top bar when its an outgoing call

### Causes (Optional)

We were using the caller name and not the other_user/conversation name

### Solutions

Change displayed name to conversation name, as in:
```
Outgoing call ->
   - group call -> conversation name
   - 1:1 call -> other user name
Incoming call ->
   - group/1:1 call - >other user name
```

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Open App
- Make 1:1 call
- minimize outgoing call
-  -> confirm other user name is shown on top bar
<hr>

- Open App
- Make group call
- minimize outgoing call
-  -> confirm conversation name is shown on top bar

### Attachments (Optional)
| 1:1 Call | Group Call |
| ----------- | ------------ |
| <img src="https://github.com/wireapp/wire-android/assets/5890660/cf0e8539-88bc-4b05-a843-7fbac75cbd8f" width="200" height="400" alt="1:1 call display on top app bar" />  | <img src="https://github.com/wireapp/wire-android/assets/5890660/c09a6c80-f2c9-454b-af9f-27b2e611d4df" width="200" height="400" alt="group call display on top app bar" />  |