### PR TITLE
fix: crash when loading what's new section [WPB-9810]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewItem.kt
@@ -158,4 +158,3 @@ fun previewFileRestrictionDialogPlaceholder() {
         )
     }
 }
-

--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewItem.kt
@@ -52,7 +52,7 @@ fun WhatsNewItem(
     text: String? = null,
     @DrawableRes trailingIcon: Int? = null,
     onRowPressed: Clickable = Clickable(false),
-    placeholder: Boolean = false,
+    isLoading: Boolean = false,
 ) {
     RowItemTemplate(
         title = {
@@ -63,7 +63,7 @@ fun WhatsNewItem(
                     text = title,
                     modifier = Modifier
                         .padding(start = dimensions().spacing8x)
-                        .shimmerPlaceholder(visible = placeholder)
+                        .shimmerPlaceholder(visible = isLoading)
                 )
             }
         },
@@ -75,7 +75,7 @@ fun WhatsNewItem(
                     text = text,
                     modifier = Modifier
                         .padding(start = dimensions().spacing8x, top = dimensions().spacing8x)
-                        .shimmerPlaceholder(visible = placeholder)
+                        .shimmerPlaceholder(visible = isLoading)
                 )
             }
         },
@@ -88,7 +88,7 @@ fun WhatsNewItem(
                     modifier = Modifier
                         .defaultMinSize(dimensions().wireIconButtonSize)
                         .padding(end = dimensions().spacing8x)
-                        .shimmerPlaceholder(visible = placeholder)
+                        .shimmerPlaceholder(visible = isLoading)
                 )
             } ?: Icons.Filled.ChevronRight
         },
@@ -136,7 +136,7 @@ sealed class WhatsNewItem(
 
 @PreviewMultipleThemes
 @Composable
-fun previewFileRestrictionDialog() {
+fun PreviewFileRestrictionDialog() {
     WireTheme {
         WhatsNewItem(
             title = "What's new item",
@@ -148,13 +148,13 @@ fun previewFileRestrictionDialog() {
 
 @PreviewMultipleThemes
 @Composable
-fun previewFileRestrictionDialogPlaceholder() {
+fun PreviewFileRestrictionDialogLoading() {
     WireTheme {
         WhatsNewItem(
             title = "What's new item",
             text = "This is the text of the item",
             trailingIcon = R.drawable.ic_arrow_right,
-            placeholder = true,
+            isLoading = true,
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewItem.kt
@@ -38,6 +38,7 @@ import com.wire.android.navigation.ExternalUriDirection
 import com.wire.android.navigation.WelcomeToNewAndroidAppDestination
 import com.wire.android.ui.common.RowItemTemplate
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.shimmerPlaceholder
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
@@ -51,6 +52,7 @@ fun WhatsNewItem(
     text: String? = null,
     @DrawableRes trailingIcon: Int? = null,
     onRowPressed: Clickable = Clickable(false),
+    placeholder: Boolean = false,
 ) {
     RowItemTemplate(
         title = {
@@ -59,7 +61,9 @@ fun WhatsNewItem(
                     style = if (boldTitle) MaterialTheme.wireTypography.body02 else MaterialTheme.wireTypography.body01,
                     color = MaterialTheme.wireColorScheme.onBackground,
                     text = title,
-                    modifier = Modifier.padding(start = dimensions().spacing8x)
+                    modifier = Modifier
+                        .padding(start = dimensions().spacing8x)
+                        .shimmerPlaceholder(visible = placeholder)
                 )
             }
         },
@@ -69,7 +73,9 @@ fun WhatsNewItem(
                     style = MaterialTheme.wireTypography.label04,
                     color = MaterialTheme.wireColorScheme.secondaryText,
                     text = text,
-                    modifier = Modifier.padding(start = dimensions().spacing8x, top = dimensions().spacing8x)
+                    modifier = Modifier
+                        .padding(start = dimensions().spacing8x, top = dimensions().spacing8x)
+                        .shimmerPlaceholder(visible = placeholder)
                 )
             }
         },
@@ -82,6 +88,7 @@ fun WhatsNewItem(
                     modifier = Modifier
                         .defaultMinSize(dimensions().wireIconButtonSize)
                         .padding(end = dimensions().spacing8x)
+                        .shimmerPlaceholder(visible = placeholder)
                 )
             } ?: Icons.Filled.ChevronRight
         },
@@ -138,3 +145,17 @@ fun previewFileRestrictionDialog() {
         )
     }
 }
+
+@PreviewMultipleThemes
+@Composable
+fun previewFileRestrictionDialogPlaceholder() {
+    WireTheme {
+        WhatsNewItem(
+            title = "What's new item",
+            text = "This is the text of the item",
+            trailingIcon = R.drawable.ic_arrow_right,
+            placeholder = true,
+        )
+    }
+}
+

--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewScreen.kt
@@ -77,26 +77,42 @@ fun WhatsNewScreenContent(
             items = buildList {
                 add(WhatsNewItem.WelcomeToNewAndroidApp)
             },
-            onItemClicked = onItemClicked
+            onItemClicked = onItemClicked,
+            placeholder = false,
         )
 
         folderWithElements(
             header = context.getString(R.string.whats_new_release_notes_group_title),
             items = buildList {
-                state.releaseNotesItems.forEach {
-                    add(
-                        WhatsNewItem.AndroidReleaseNotes(
-                            id = it.id,
-                            title = UIText.DynamicString(it.title),
-                            boldTitle = true,
-                            text = UIText.DynamicString(it.publishDate),
-                            url = it.link,
+                if (state.isLoading) {
+                    for (i in 0..3) {
+                        add(
+                            WhatsNewItem.AndroidReleaseNotes(
+                                id = "placeholder_$i",
+                                title = UIText.DynamicString("Android X.X.X"), // this text won't be displayed
+                                boldTitle = true,
+                                text = UIText.DynamicString("01 Jan 2024"), // this text won't be displayed
+                                url = "",
+                            )
                         )
-                    )
+                    }
+                } else {
+                    state.releaseNotesItems.forEach {
+                        add(
+                            WhatsNewItem.AndroidReleaseNotes(
+                                id = it.id,
+                                title = UIText.DynamicString(it.title),
+                                boldTitle = true,
+                                text = UIText.DynamicString(it.publishDate),
+                                url = it.link,
+                            )
+                        )
+                    }
                 }
                 add(WhatsNewItem.AllAndroidReleaseNotes)
             },
-            onItemClicked = onItemClicked
+            onItemClicked = onItemClicked,
+            placeholder = state.isLoading,
         )
     }
 }
@@ -104,7 +120,8 @@ fun WhatsNewScreenContent(
 private fun LazyListScope.folderWithElements(
     header: String? = null,
     items: List<WhatsNewItem>,
-    onItemClicked: (WhatsNewItem) -> Unit
+    onItemClicked: (WhatsNewItem) -> Unit,
+    placeholder: Boolean,
 ) {
     folderWithElements(
         header = header?.uppercase(),
@@ -114,8 +131,9 @@ private fun LazyListScope.folderWithElements(
             title = item.title.asString(),
             boldTitle = item.boldTitle,
             text = item.text?.asString(),
-            onRowPressed = remember { Clickable(enabled = true) { onItemClicked(item) } },
+            onRowPressed = remember { Clickable(enabled = !placeholder) { onItemClicked(item) } },
             trailingIcon = R.drawable.ic_arrow_right,
+            placeholder = placeholder,
         )
     }
 }
@@ -123,5 +141,11 @@ private fun LazyListScope.folderWithElements(
 @Preview(showBackground = false)
 @Composable
 fun PreviewWhatsNewScreen() {
-    WhatsNewScreenContent(WhatsNewState()) {}
+    WhatsNewScreenContent(WhatsNewState(isLoading = false)) {}
+}
+
+@Preview(showBackground = false)
+@Composable
+fun PreviewWhatsNewScreenLoading() {
+    WhatsNewScreenContent(WhatsNewState(isLoading = true)) {}
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewScreen.kt
@@ -78,7 +78,7 @@ fun WhatsNewScreenContent(
                 add(WhatsNewItem.WelcomeToNewAndroidApp)
             },
             onItemClicked = onItemClicked,
-            placeholder = false,
+            isLoading = false,
         )
 
         folderWithElements(
@@ -112,7 +112,7 @@ fun WhatsNewScreenContent(
                 add(WhatsNewItem.AllAndroidReleaseNotes)
             },
             onItemClicked = onItemClicked,
-            placeholder = state.isLoading,
+            isLoading = state.isLoading,
         )
     }
 }
@@ -121,7 +121,7 @@ private fun LazyListScope.folderWithElements(
     header: String? = null,
     items: List<WhatsNewItem>,
     onItemClicked: (WhatsNewItem) -> Unit,
-    placeholder: Boolean,
+    isLoading: Boolean,
 ) {
     folderWithElements(
         header = header?.uppercase(),
@@ -131,9 +131,9 @@ private fun LazyListScope.folderWithElements(
             title = item.title.asString(),
             boldTitle = item.boldTitle,
             text = item.text?.asString(),
-            onRowPressed = remember { Clickable(enabled = !placeholder) { onItemClicked(item) } },
+            onRowPressed = remember { Clickable(enabled = !isLoading) { onItemClicked(item) } },
             trailingIcon = R.drawable.ic_arrow_right,
-            placeholder = placeholder,
+            isLoading = isLoading,
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewState.kt
@@ -18,6 +18,7 @@
 package com.wire.android.ui.home.whatsnew
 
 data class WhatsNewState(
+    val isLoading: Boolean = false,
     val releaseNotesItems: List<ReleaseNotesItem> = emptyList()
 )
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewViewModel.kt
@@ -18,7 +18,6 @@
 package com.wire.android.ui.home.whatsnew
 
 import android.content.Context
-import android.icu.text.SimpleDateFormat
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -26,10 +25,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.prof18.rssparser.RssParser
 import com.wire.android.R
-import com.wire.android.util.sha256
 import com.wire.android.util.toMediumOnlyDateTime
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
 import java.util.Locale
 import javax.inject.Inject
 
@@ -51,10 +50,10 @@ class WhatsNewViewModel @Inject constructor(context: Context) : ViewModel() {
                         releaseNotesItems = it.items
                             .map { item ->
                                 ReleaseNotesItem(
-                                    id = item.guid.orEmpty().sha256(),
+                                    id = item.guid.orEmpty(),
                                     title = item.title.orEmpty(),
                                     link = item.link.orEmpty(),
-                                    publishDate = item.pubDate?.let { publishDateFormat.parse(it).toMediumOnlyDateTime() }.orEmpty(),
+                                    publishDate = item.pubDate?.let { publishDateFormat.parse(it)?.toMediumOnlyDateTime() }.orEmpty(),
                                 )
                             }
                             .filter {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,6 +184,7 @@
     <string name="url_federation_support" translatable="false">https://support.wire.com/hc/categories/4719917054365-Federation</string>
     <string name="url_create_account_learn_more" translatable="false">https://support.wire.com/hc/articles/115004082129</string>
     <string name="url_android_release_notes" translatable="false">https://medium.com/wire-news/android-updates/home</string>
+    <string name="url_android_release_notes_feed" translatable="false">https://medium.com/feed/wire-news/tagged/android</string>
     <string name="url_maps_location_coordinates_fallback" translatable="false">http://maps.google.com/maps?z=%1d&amp;q=loc:%2f+%2f</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewViewModelTest.kt
@@ -73,7 +73,7 @@ class WhatsNewViewModelTest {
         }
     }
 
-    inner class Arrangement() {
+    inner class Arrangement {
 
         @MockK
         lateinit var context: Context

--- a/app/src/test/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewViewModelTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.whatsnew
+
+import android.content.Context
+import com.prof18.rssparser.RssParser
+import com.prof18.rssparser.model.RssChannel
+import com.prof18.rssparser.model.RssItem
+import com.wire.android.R
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.util.toMediumOnlyDateTime
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkStatic
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.text.SimpleDateFormat
+import java.util.Date
+
+@ExtendWith(CoroutineTestExtension::class)
+class WhatsNewViewModelTest {
+
+    @Test
+    fun `given url is not blank, when fetching release notes, then execute getRssChannel`() = runTest {
+        val url = "url"
+        val (arrangement, viewModel) = Arrangement()
+            .withFeedResult(testRssChannel)
+            .withFeedUrl(url)
+            .arrange()
+
+        advanceUntilIdle()
+
+        assertEquals(testReleaseNotes, viewModel.state.releaseNotesItems)
+        assertEquals(false, viewModel.state.isLoading)
+        coVerify(exactly = 1) {
+            arrangement.rssParser.getRssChannel(url)
+        }
+    }
+
+    @Test
+    fun `given url is blank, when fetching release notes, then do not execute getRssChannel`() = runTest {
+        val url = ""
+        val (arrangement, viewModel) = Arrangement()
+            .withFeedUrl(url)
+            .arrange()
+
+        advanceUntilIdle()
+
+        assertEquals(emptyList(), viewModel.state.releaseNotesItems)
+        assertEquals(false, viewModel.state.isLoading)
+        coVerify(exactly = 0) {
+            arrangement.rssParser.getRssChannel(url)
+        }
+    }
+
+    inner class Arrangement() {
+
+        @MockK
+        lateinit var context: Context
+
+        @MockK
+        lateinit var rssParser: RssParser
+
+        val viewModel by lazy {
+            WhatsNewViewModel(context)
+        }
+
+        fun withFeedUrl(feedUrl: String) = apply {
+            coEvery { context.resources.getString(R.string.url_android_release_notes_feed) } returns feedUrl
+        }
+
+        fun withFeedResult(rssChannel: RssChannel) = apply {
+            coEvery { rssParser.getRssChannel(any()) } returns rssChannel
+        }
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+            mockkStatic(::RssParser)
+            coEvery { RssParser() } returns rssParser
+            mockkStatic(Date::toMediumOnlyDateTime)
+            coEvery { any<Date>().toMediumOnlyDateTime() } answers {
+                SimpleDateFormat("dd MMM yyyy").format(firstArg())
+            }
+        }
+
+        fun arrange() = this to viewModel
+    }
+
+    private val testRssItem = RssItem(
+        guid = "guid",
+        title = "itemTitle",
+        author = "author",
+        link = "link",
+        pubDate = "Mon, 01 Jan 2024 00:00:00",
+        description = null,
+        content = null,
+        image = null,
+        audio = null,
+        video = null,
+        sourceName = null,
+        sourceUrl = null,
+        categories = emptyList(),
+        itunesItemData = null,
+        commentsUrl = null,
+    )
+    private val testRssChannel: RssChannel = RssChannel(
+        title = "title",
+        items = listOf(testRssItem),
+        link = null,
+        description = null,
+        image = null,
+        lastBuildDate = null,
+        updatePeriod = null,
+        itunesChannelData = null,
+    )
+    private val testReleaseNoteItem = ReleaseNotesItem(
+        id = "guid",
+        title = "itemTitle",
+        link = "link",
+        publishDate = "01 Jan 2024",
+    )
+    private val testReleaseNotes: List<ReleaseNotesItem> = listOf(testReleaseNoteItem)
+}

--- a/default.json
+++ b/default.json
@@ -119,7 +119,6 @@
         ]
     },
     "is_password_protected_guest_link_enabled": false,
-    "url_rss_release_notes": "https://medium.com/feed/wire-news/tagged/android",
     "team_app_lock": false,
     "team_app_lock_timeout": 60,
     "max_remote_search_result_count": 30,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9810" title="WPB-9810" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9810</a>  [Android] Crash when pressing on the what's new section
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On Bund build Column 3, The Android app crashes when the user presses on the "What's New" section in version 4.6.3.

### Causes (Optional)

Probably because `url_rss_release_notes` is not present in bund build config.

### Solutions

Move this url to string resources so that it's always available, all builds have the same release notes for its versions.
Add loading state for the "what's new" screen.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Open drawer menu and select "what's new".

### Attachments (Optional)

https://github.com/wireapp/wire-android/assets/30429749/cec1b754-03a4-45b6-8572-7e55e29e7f0c

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
