### PR TITLE
ci: s3 path for artifacts adjustment (WPB-8730)

### DIFF
--- a/.github/actions/deploy-to-s3/action.yml
+++ b/.github/actions/deploy-to-s3/action.yml
@@ -46,7 +46,7 @@ runs:
         public: true
     - name: Upload to S3 from branch
       if: github.event.pull_request.number == ''
-      id: upload
+      id: upload-from-branch
       uses: hkusu/s3-upload-action@v2.1.0
       env:
         APK_FULL_PATH: ${{ steps.path.outputs.apk_full_path }}

--- a/.github/actions/deploy-to-s3/action.yml
+++ b/.github/actions/deploy-to-s3/action.yml
@@ -33,30 +33,26 @@ runs:
       if: github.event.pull_request.number != ''
       id: upload
       uses: hkusu/s3-upload-action@v2.1.0
-      env:
-        APK_FULL_PATH: ${{ steps.path.outputs.apk_full_path }}
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: 'us-west-1'
         aws-bucket: ${{ inputs.aws-bucket }}
         destination-dir: "megazord/android/reloaded/${{ inputs.build-flavour }}/${{ inputs.build-variant }}/PR-${{ github.event.pull_request.number }}/"
-        file-path: $APK_FULL_PATH
+        file-path: ${{ steps.path.outputs.apk_full_path }}
         output-file-url: 'true'
         public: true
     - name: Upload to S3 from branch
       if: github.event.pull_request.number == ''
       id: upload-from-branch
       uses: hkusu/s3-upload-action@v2.1.0
-      env:
-        APK_FULL_PATH: ${{ steps.path.outputs.apk_full_path }}
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: 'us-west-1'
         aws-bucket: ${{ inputs.aws-bucket }}
         destination-dir: "megazord/android/reloaded/${{ inputs.build-flavour }}/${{ inputs.build-variant }}/"
-        file-path: $APK_FULL_PATH
+        file-path: ${{ steps.path.outputs.apk_full_path }}
         output-file-url: 'true'
         public: true
     - name: Show URL

--- a/.github/actions/deploy-to-s3/action.yml
+++ b/.github/actions/deploy-to-s3/action.yml
@@ -25,6 +25,7 @@ runs:
     - name: Copy build to tmp file
       shell: bash
       run:
+        echo "$(set -- app/build/outputs/apk/${{ inputs.build-flavour }}/${{ inputs.build-variant }}/com.wire.*.apk; echo "$1")
         cp app/build/outputs/apk/${{ inputs.build-flavour }}/${{ inputs.build-variant }}/com.wire.*.apk wire-android-${{ inputs.build-flavour }}-${{ inputs.build-variant }}-pr-${{ github.event.pull_request.number }}.apk
     - name: Upload to S3
       id: upload

--- a/.github/actions/deploy-to-s3/action.yml
+++ b/.github/actions/deploy-to-s3/action.yml
@@ -25,8 +25,8 @@ runs:
     - name: Set APK full path
       id: path
       shell: bash
-      run:
-        APK_FULL_PATH_REF="$(set -- app/build/outputs/apk/${{ inputs.build-flavour }}/${{ inputs.build-variant }}/com.wire.*.apk; echo "$1")"
+      run: |
+        APK_FULL_PATH_REF="$(set -- app/build/outputs/apk/${{ inputs.build-flavour }}/${{ inputs.build-variant }}/com.wire.*.apk; echo $1)"
         echo "apk_full_path=$APK_FULL_PATH_REF" >> $GITHUB_OUTPUT
         unset APK_FULL_PATH_REF
     - name: Upload to S3 from PR

--- a/.github/actions/deploy-to-s3/action.yml
+++ b/.github/actions/deploy-to-s3/action.yml
@@ -22,21 +22,41 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Copy build to tmp file
+    - name: Set APK full path
+      id: path
       shell: bash
       run:
-        echo "$(set -- app/build/outputs/apk/${{ inputs.build-flavour }}/${{ inputs.build-variant }}/com.wire.*.apk; echo "$1")
-        cp app/build/outputs/apk/${{ inputs.build-flavour }}/${{ inputs.build-variant }}/com.wire.*.apk wire-android-${{ inputs.build-flavour }}-${{ inputs.build-variant }}-pr-${{ github.event.pull_request.number }}.apk
-    - name: Upload to S3
+        APK_FULL_PATH_REF="$(set -- app/build/outputs/apk/${{ inputs.build-flavour }}/${{ inputs.build-variant }}/com.wire.*.apk; echo "$1")"
+        echo "apk_full_path=$APK_FULL_PATH_REF" >> $GITHUB_OUTPUT
+        unset APK_FULL_PATH_REF
+    - name: Upload to S3 from PR
+      if: github.event.pull_request.number != ''
       id: upload
       uses: hkusu/s3-upload-action@v2.1.0
+      env:
+        APK_FULL_PATH: ${{ steps.path.outputs.apk_full_path }}
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: 'us-west-1'
+        aws-bucket: ${{ inputs.aws-bucket }}
+        destination-dir: "megazord/android/reloaded/${{ inputs.build-flavour }}/${{ inputs.build-variant }}/PR-${{ github.event.pull_request.number }}/"
+        file-path: $APK_FULL_PATH
+        output-file-url: 'true'
+        public: true
+    - name: Upload to S3 from branch
+      if: github.event.pull_request.number == ''
+      id: upload
+      uses: hkusu/s3-upload-action@v2.1.0
+      env:
+        APK_FULL_PATH: ${{ steps.path.outputs.apk_full_path }}
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: 'us-west-1'
         aws-bucket: ${{ inputs.aws-bucket }}
         destination-dir: "megazord/android/reloaded/${{ inputs.build-flavour }}/${{ inputs.build-variant }}/"
-        file-path: './wire-android-${{ inputs.build-flavour }}-${{ inputs.build-variant }}-pr-${{ github.event.pull_request.number }}.apk'
+        file-path: $APK_FULL_PATH
         output-file-url: 'true'
         public: true
     - name: Show URL


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8730" title="WPB-8730" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8730</a>  [Android] Upload builds to AWS S3
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some of the destinations paths when we build the apps, needs to be adjusted so QA can find it easily for their automation scripts. Specially the ones for branches (non PR) also needs to maintain the name.

### Solutions

Use a different destination for the apk when uploading to s3
- For Branches, stays under buildFlavor/buildType
- For PRs, they are added to a specific folder PR-{{NUMBER}}

In this way we keep retrocompatibility with what we had before in Jenkins.

#### How to Test

Look for the paths under this PR.
https://github.com/wireapp/wire-android/pull/3131#issuecomment-2194090317

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
