### PR TITLE
fix: handle NoCommonProtocol error while starting conversation cherry-pick 

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -899,6 +899,10 @@
     <!-- Missing keyPackages dialog -->
     <string name="missing_keypackage_dialog_title">Unable to start conversation</string>
     <string name="missing_keypackage_dialog_body">You can’t start the conversation with %1$s right now. %1$s needs to open Wire or log in again first. Please try again later.</string>
+    <!-- No Common protocol dialog -->
+    <string name="no_common_protocol_dialog_title">Unable to start conversation</string>
+    <string name="no_common_protocol_dialog_body_self_need_update">You can’t communicate with %1$s, as your device doesn’t support the suitable protocol. Download the latest MLS Wire version, to call, and send messages and files.</string>
+    <string name="no_common_protocol_dialog_body_other_need_update">You can’t communicate with %1$s, as you two use different protocols. When %1$s gets an update, you can call and send messages and files.</string>
     <!-- Gallery -->
     <string name="media_gallery_default_title_name">Media Gallery</string>
     <string name="media_gallery_on_image_downloaded">Saved to Downloads folder</string>

--- a/app/src/test/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModelTest.kt
@@ -267,14 +267,14 @@ class ConnectionActionButtonViewModelTest {
                 .arrange()
 
             // when
-            viewModel.onOpenConversation(arrangement.onOpenConversation, arrangement.onMissingKeyPackages)
+            viewModel.onOpenConversation(arrangement.onOpenConversation, arrangement.onStartConversationError)
 
             // then
             coVerify {
                 arrangement.getOrCreateOneToOneConversation(TestUser.USER_ID)
             }
             verify { arrangement.onOpenConversation(any()) }
-            verify { arrangement.onMissingKeyPackages wasNot Called }
+            verify { arrangement.onStartConversationError wasNot Called }
         }
 
     @Test
@@ -286,33 +286,34 @@ class ConnectionActionButtonViewModelTest {
                 .arrange()
 
             // when
-            viewModel.onOpenConversation(arrangement.onOpenConversation, arrangement.onMissingKeyPackages)
+            viewModel.onOpenConversation(arrangement.onOpenConversation, arrangement.onStartConversationError)
 
             // then
             coVerify {
                 arrangement.getOrCreateOneToOneConversation(TestUser.USER_ID)
             }
             verify { arrangement.onOpenConversation wasNot Called }
-            verify { arrangement.onMissingKeyPackages wasNot Called }
+            verify { arrangement.onStartConversationError(eq(failure)) }
         }
 
     @Test
     fun `given a conversationId, when trying to open the conversation and fails with MissingKeyPackages, then call MissingKeyPackage()`() =
         runTest {
             // given
+            val errorResult = CoreFailure.MissingKeyPackages(setOf())
             val (arrangement, viewModel) = ConnectionActionButtonHiltArrangement()
-                .withGetOneToOneConversation(CreateConversationResult.Failure(CoreFailure.MissingKeyPackages(setOf())))
+                .withGetOneToOneConversation(CreateConversationResult.Failure(errorResult))
                 .arrange()
 
             // when
-            viewModel.onOpenConversation(arrangement.onOpenConversation, arrangement.onMissingKeyPackages)
+            viewModel.onOpenConversation(arrangement.onOpenConversation, arrangement.onStartConversationError)
 
             // then
             coVerify {
                 arrangement.getOrCreateOneToOneConversation(TestUser.USER_ID)
             }
             verify { arrangement.onOpenConversation wasNot Called }
-            verify { arrangement.onMissingKeyPackages() }
+            verify { arrangement.onStartConversationError(eq(errorResult)) }
         }
 
     companion object {
@@ -356,7 +357,7 @@ internal class ConnectionActionButtonHiltArrangement {
     lateinit var onOpenConversation: (conversationId: ConversationId) -> Unit
 
     @MockK(relaxed = true)
-    lateinit var onMissingKeyPackages: () -> Unit
+    lateinit var onStartConversationError: (CoreFailure) -> Unit
 
     private val viewModel by lazy {
         ConnectionActionButtonViewModelImpl(


### PR DESCRIPTION
For some reason auto-cherry-pick didn't work, so i raised it by myself 
cherry-pick of https://github.com/wireapp/wire-android/pull/3120

# What's new in this PR?

### Issues

When user is trying to start 1o1 conversation with user that has no common protocol with, the error is no displayed anyhow.

### Causes (Optional)

Error handling in creating conversation was implemented only for NoKeypackages error. 

### Solutions

Add handling for all errors (specific texts for `NoKeypackages` and `NoCommonProtocol` errors and some default text for other errors.)

### Attachments (Optional)

<img width="264" alt="Screenshot 2024-06-24 at 12 20 43" src="https://github.com/wireapp/wire-android/assets/6539347/e005843d-b06a-4118-9177-120a0c6afc8c">

