### PR TITLE
chore: update compose libs to get rid of rendering crashes [WPB-9666]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -182,7 +182,7 @@ class WireActivity : AppCompatActivity() {
         }
     }
 
-    override fun onNewIntent(intent: Intent?) {
+    override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
         if (isNavigationCollecting) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,10 +45,10 @@ androidx-startup = "1.1.1"
 androidx-compose-runtime = "1.6.7"
 
 # Compose
-composeBom = "2024.05.00"
-compose-foundation = "1.7.0-beta02" # remove when composeBom contains new stable version of BasicTextField2
-compose-material-android = "1.7.0-beta02" # remove when composeBom contains new stable version of BasicTextField2
-compose-activity = "1.8.2"
+composeBom = "2024.06.00"
+compose-foundation = "1.7.0-beta04" # remove when composeBom contains new stable version of BasicTextField2
+compose-material-android = "1.7.0-beta04" # remove when composeBom contains new stable version of BasicTextField2
+compose-activity = "1.9.0"
 compose-compiler = "1.5.11"
 compose-constraint = "1.0.1"
 compose-navigation = "2.7.7" # adjusted to work with compose-destinations "1.9.54"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9666" title="WPB-9666" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9666</a>  [Android] Crash on opening the app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

With compose v1.7 they introduced some issues related to rendering images which can crash when launching the app.

### Solutions

Update compose libraries, in `beta03` they introduced exact fix for crashes our app experience:

![image](https://github.com/wireapp/wire-android/assets/30429749/dfd9ea51-08c1-4d91-8e45-e15f73ecc6cf)

In `beta04` they additionally fixed some other issues so we could also benefit from it:

<img width="867" alt="image" src="https://github.com/wireapp/wire-android/assets/30429749/55c77692-71c4-4940-b81a-3aebc7954365">

Also updated other compose-related libs to newest versions.
Let's hope stable v1.7 comes soon!

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
