### PR TITLE
fix: cherrypick terms of use copy (WPB-8846)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
@@ -64,7 +64,7 @@ object PrivacyPolicyScreenDestination : ExternalUriStringResDirection {
 
 object TermsOfUseScreenDestination : ExternalUriStringResDirection {
     override val uriStringRes: Int
-        get() = R.string.url_terms_of_use
+        get() = R.string.url_terms_of_use_legal
 }
 
 object GiveFeedbackDestination : IntentDirection {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -909,7 +909,7 @@
     <string name="settings_your_account_label">Kontodetails</string>
     <string name="settings_app_settings_label">App-Einstellungen</string>
     <string name="settings_privacy_policy_label">Datenschutzerklärung</string>
-    <string name="settings_terms_of_use_label">Nutzungsbedingungen</string>
+    <string name="settings_terms_of_use_label">Datenschutz und AGB</string>
     <string name="settings_network_settings_label">Netzwerkeinstellungen</string>
     <string name="settings_manage_devices_label">Geräte verwalten</string>
     <string name="settings_keep_connection_to_websocket">Verbindung zu Websocket behalten</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,7 +187,7 @@
     <string name="url_android_release_notes_feed" translatable="false">https://medium.com/feed/wire-news/tagged/android</string>
     <string name="url_maps_location_coordinates_fallback" translatable="false">http://maps.google.com/maps?z=%1d&amp;q=loc:%2f+%2f</string>
     <string name="url_privacy_policy" translatable="false">https://wire.com/privacy-policy#:~:text=We%20process%20individual%20data%20about,%C2%A7%201%20a)%20GDPR).</string>
-    <string name="url_terms_of_use_legal" translatable="false">https://wire.com/legal#:~:text=Wire%20is%20used%20for%20private,disable%20your%20access%20to%20Wire.</string>
+    <string name="url_terms_of_use_legal" translatable="false">https://wire.com/legal</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="archive_screen_title">Archive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,7 +187,7 @@
     <string name="url_android_release_notes_feed" translatable="false">https://medium.com/feed/wire-news/tagged/android</string>
     <string name="url_maps_location_coordinates_fallback" translatable="false">http://maps.google.com/maps?z=%1d&amp;q=loc:%2f+%2f</string>
     <string name="url_privacy_policy" translatable="false">https://wire.com/privacy-policy#:~:text=We%20process%20individual%20data%20about,%C2%A7%201%20a)%20GDPR).</string>
-    <string name="url_terms_of_use" translatable="false">https://wire.com/legal#:~:text=Wire%20is%20used%20for%20private,disable%20your%20access%20to%20Wire.</string>
+    <string name="url_terms_of_use_legal" translatable="false">https://wire.com/legal#:~:text=Wire%20is%20used%20for%20private,disable%20your%20access%20to%20Wire.</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="archive_screen_title">Archive</string>
@@ -200,7 +200,7 @@
     <string name="report_bug_screen_title">Report Bug</string>
     <string name="about_app_screen_title">About This App</string>
     <string name="settings_privacy_policy_label">Privacy Policy</string>
-    <string name="settings_terms_of_use_label">Terms of Use</string>
+    <string name="settings_terms_of_use_label">Legal</string>
     <string name="label_copyright">Copyright</string>
     <string translatable="false" name="label_copyright_value">© Wire Swiss GmbH</string>
     <string name="debug_settings_screen_title">Debug Settings</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8846" title="WPB-8846" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8846</a>  [Android] Add privacy policy and terms of use section to Android  
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Cherry-pick Fix copy for terms of use.
https://github.com/wireapp/wire-android/pull/3030/commits/9f11faa5efcce5e7e46fc1b1e7ced6978c31c477

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
