### PR TITLE
fix: self deleting option refreshing [WPB-9419]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -138,7 +138,7 @@ import com.wire.android.ui.home.conversations.migration.ConversationMigrationVie
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
-import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMenuItems
+import com.wire.android.ui.home.conversations.selfdeletion.selfDeletionMenuItems
 import com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
 import com.wire.android.ui.home.gallery.MediaGalleryActionType
 import com.wire.android.ui.home.gallery.MediaGalleryNavBackArgs
@@ -777,9 +777,9 @@ private fun ConversationScreen(
         }
 
         is ConversationScreenState.BottomSheetMenuType.SelfDeletion -> {
-            SelfDeletionMenuItems(
+            selfDeletionMenuItems(
                 hideEditMessageMenu = conversationScreenState::hideContextMenu,
-                currentlySelected = messageComposerViewState.selfDeletionTimer.duration.toSelfDeletionDuration(),
+                currentlySelected = menuType.currentlySelected.duration.toSelfDeletionDuration(),
                 onSelfDeletionDurationChanged = { newTimer ->
                     onNewSelfDeletingMessagesStatus(SelfDeletionTimer.Enabled(newTimer.value))
                 }
@@ -846,7 +846,7 @@ private fun ConversationScreen(
                     onSelfDeletingMessageRead = onSelfDeletingMessageRead,
                     onFailedMessageCancelClicked = remember { { onDeleteMessage(it, false) } },
                     onFailedMessageRetryClicked = onFailedMessageRetryClicked,
-                    onChangeSelfDeletionClicked = { conversationScreenState.showSelfDeletionContextMenu() },
+                    onChangeSelfDeletionClicked = conversationScreenState::showSelfDeletionContextMenu,
                     onClearMentionSearchResult = onClearMentionSearchResult,
                     onCaptureVideoPermissionPermanentlyDenied = onPermissionPermanentlyDenied,
                     tempWritableImageUri = tempWritableImageUri,
@@ -894,7 +894,7 @@ private fun ConversationScreenContent(
     conversationDetailsData: ConversationDetailsData,
     onFailedMessageRetryClicked: (String, ConversationId) -> Unit,
     onFailedMessageCancelClicked: (String) -> Unit,
-    onChangeSelfDeletionClicked: () -> Unit,
+    onChangeSelfDeletionClicked: (SelfDeletionTimer) -> Unit,
     onClearMentionSearchResult: () -> Unit,
     onCaptureVideoPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit,
     tempWritableImageUri: Uri?,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreenState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreenState.kt
@@ -36,6 +36,7 @@ import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -91,16 +92,16 @@ class ConversationScreenState(
         }
     }
 
-    fun showSelfDeletionContextMenu() {
-        bottomSheetMenuType = BottomSheetMenuType.SelfDeletion
+    fun showSelfDeletionContextMenu(currentlySelected: SelfDeletionTimer) {
+        bottomSheetMenuType = BottomSheetMenuType.SelfDeletion(currentlySelected)
         coroutineScope.launch { modalBottomSheetState.show() }
     }
 
     sealed class BottomSheetMenuType {
         class Edit(val selectedMessage: UIMessage.Regular) : BottomSheetMenuType()
 
-        object SelfDeletion : BottomSheetMenuType()
+        class SelfDeletion(val currentlySelected: SelfDeletionTimer) : BottomSheetMenuType()
 
-        object None : BottomSheetMenuType()
+        data object None : BottomSheetMenuType()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewState.kt
@@ -24,16 +24,13 @@ import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.MessageId
-import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
-import kotlin.time.Duration.Companion.ZERO
 
 data class MessageComposerViewState(
     val isFileSharingEnabled: Boolean = true,
     val interactionAvailability: InteractionAvailability = InteractionAvailability.ENABLED,
     val mentionSearchResult: List<Contact> = listOf(),
-    val mentionSearchQuery: String = String.EMPTY,
-    val selfDeletionTimer: SelfDeletionTimer = SelfDeletionTimer.Enabled(ZERO)
+    val mentionSearchQuery: String = String.EMPTY
 )
 
 sealed class AssetTooLargeDialogState {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModel.kt
@@ -50,7 +50,6 @@ import com.wire.kalium.logic.feature.conversation.SendTypingEventUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
 import com.wire.kalium.logic.feature.message.draft.SaveMessageDraftUseCase
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
-import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
@@ -75,7 +74,6 @@ class MessageComposerViewModel @Inject constructor(
     private val contactMapper: ContactMapper,
     private val membersToMention: MembersToMentionUseCase,
     private val enqueueMessageSelfDeletion: EnqueueMessageSelfDeletionUseCase,
-    private val observeSelfDeletingMessages: ObserveSelfDeletionTimerSettingsForConversationUseCase,
     private val persistNewSelfDeletingStatus: PersistNewSelfDeletionTimerUseCase,
     private val sendTypingEvent: SendTypingEventUseCase,
     private val saveMessageDraft: SaveMessageDraftUseCase,
@@ -108,7 +106,6 @@ class MessageComposerViewModel @Inject constructor(
         initTempWritableVideoUri()
         initTempWritableImageUri()
         observeIsTypingAvailable()
-        observeSelfDeletingMessagesStatus()
         setFileSharingStatus()
     }
 
@@ -145,16 +142,6 @@ class MessageComposerViewModel @Inject constructor(
             .collectLatest {
                 messageComposerViewState.value = messageComposerViewState.value.copy(interactionAvailability = it)
             }
-    }
-
-    private fun observeSelfDeletingMessagesStatus() = viewModelScope.launch {
-        observeSelfDeletingMessages(
-            conversationId,
-            considerSelfUserSettings = true
-        ).collect { selfDeletingStatus ->
-            messageComposerViewState.value =
-                messageComposerViewState.value.copy(selfDeletionTimer = selfDeletingStatus)
-        }
     }
 
     fun searchMembersToMention(searchQuery: String) {
@@ -205,8 +192,6 @@ class MessageComposerViewModel @Inject constructor(
 
     fun updateSelfDeletingMessages(newSelfDeletionTimer: SelfDeletionTimer) =
         viewModelScope.launch {
-            messageComposerViewState.value =
-                messageComposerViewState.value.copy(selfDeletionTimer = newSelfDeletionTimer)
             persistNewSelfDeletingStatus(conversationId, newSelfDeletionTimer)
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/selfdeletion/SelfDeletionMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/selfdeletion/SelfDeletionMenuItems.kt
@@ -27,7 +27,7 @@ import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
 import com.wire.android.ui.theme.wireTypography
 
 @Composable
-fun SelfDeletionMenuItems(
+fun selfDeletionMenuItems(
     currentlySelected: SelfDeletionDuration,
     hideEditMessageMenu: (OnComplete) -> Unit,
     onSelfDeletionDurationChanged: (SelfDeletionDuration) -> Unit,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AdditionalOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AdditionalOptions.kt
@@ -38,34 +38,34 @@ import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSubMenuSta
 import com.wire.android.ui.home.messagecomposer.state.RichTextMarkdown
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.permission.PermissionDenialType
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
 
 @Composable
 fun AdditionalOptionsMenu(
+    conversationId: ConversationId,
     additionalOptionsState: AdditionalOptionMenuState,
     selectedOption: AdditionalOptionSelectItem,
-    isSelfDeletingSettingEnabled: Boolean,
-    isSelfDeletingActive: Boolean,
     isEditing: Boolean,
     isMentionActive: Boolean,
-    onOnSelfDeletingOptionClicked: (() -> Unit)? = null,
     onAdditionalOptionsMenuClicked: () -> Unit,
     onMentionButtonClicked: (() -> Unit),
-    onGifOptionClicked: (() -> Unit)? = null,
     onPingOptionClicked: () -> Unit,
     onRichEditingButtonClicked: () -> Unit,
     onCloseRichEditingButtonClicked: () -> Unit,
     onRichOptionButtonClicked: (RichTextMarkdown) -> Unit,
     onDrawingModeClicked: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onOnSelfDeletingOptionClicked: ((SelfDeletionTimer) -> Unit)? = null,
+    onGifOptionClicked: (() -> Unit)? = null
 ) {
     Box(modifier.background(colorsScheme().messageComposerBackgroundColor)) {
         when (additionalOptionsState) {
             AdditionalOptionMenuState.AttachmentAndAdditionalOptionsMenu -> {
                 AttachmentAndAdditionalOptionsMenuItems(
+                    conversationId = conversationId,
                     selectedOption = selectedOption,
                     isEditing = isEditing,
-                    isSelfDeletingSettingEnabled = isSelfDeletingSettingEnabled,
-                    isSelfDeletingActive = isSelfDeletingActive,
                     isMentionActive = isMentionActive,
                     onMentionButtonClicked = onMentionButtonClicked,
                     onAdditionalOptionsMenuClicked = onAdditionalOptionsMenuClicked,
@@ -105,7 +105,7 @@ fun AdditionalOptionSubMenu(
     onLocationPicked: (GeoLocatedAddress) -> Unit,
     tempWritableImageUri: Uri?,
     tempWritableVideoUri: Uri?,
-    modifier: Modifier
+    modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier) {
         AttachmentOptionsComponent(
@@ -146,23 +146,23 @@ fun AdditionalOptionSubMenu(
 
 @Composable
 fun AttachmentAndAdditionalOptionsMenuItems(
+    conversationId: ConversationId,
     isEditing: Boolean,
     selectedOption: AdditionalOptionSelectItem,
     isMentionActive: Boolean,
     onMentionButtonClicked: () -> Unit,
+    onSelfDeletionOptionButtonClicked: (SelfDeletionTimer) -> Unit,
+    modifier: Modifier = Modifier,
     onAdditionalOptionsMenuClicked: () -> Unit = {},
     onPingClicked: () -> Unit = {},
-    onSelfDeletionOptionButtonClicked: () -> Unit,
-    isSelfDeletingSettingEnabled: Boolean,
-    isSelfDeletingActive: Boolean,
     onGifButtonClicked: () -> Unit = {},
     onRichEditingButtonClicked: () -> Unit = {},
-    onDrawingModeClicked: () -> Unit = {},
-    modifier: Modifier = Modifier
+    onDrawingModeClicked: () -> Unit = {}
 ) {
     Column(modifier.wrapContentSize()) {
         HorizontalDivider(color = MaterialTheme.wireColorScheme.outline)
         MessageComposeActions(
+            conversationId = conversationId,
             isEditing = isEditing,
             selectedOption = selectedOption,
             isMentionActive = isMentionActive,
@@ -170,8 +170,6 @@ fun AttachmentAndAdditionalOptionsMenuItems(
             onAdditionalOptionButtonClicked = onAdditionalOptionsMenuClicked,
             onPingButtonClicked = onPingClicked,
             onSelfDeletionOptionButtonClicked = onSelfDeletionOptionButtonClicked,
-            isSelfDeletingSettingEnabled = isSelfDeletingSettingEnabled,
-            isSelfDeletingActive = isSelfDeletingActive,
             onGifButtonClicked = onGifButtonClicked,
             onRichEditingButtonClicked = onRichEditingButtonClicked,
             onDrawingModeClicked = onDrawingModeClicked

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AttachmentOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/AttachmentOptions.kt
@@ -68,7 +68,8 @@ fun AttachmentOptionsComponent(
     tempWritableVideoUri: Uri?,
     isFileSharingEnabled: Boolean,
     onLocationPickerClicked: () -> Unit,
-    onCaptureVideoPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit
+    onCaptureVideoPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val density = LocalDensity.current
     val textMeasurer = rememberTextMeasurer()
@@ -105,7 +106,7 @@ fun AttachmentOptionsComponent(
         }
         .maxBy { it }
 
-    BoxWithConstraints(Modifier.fillMaxSize()) {
+    BoxWithConstraints(modifier.fillMaxSize()) {
         val fullWidth: Dp = with(density) { constraints.maxWidth.toDp() }
         val minPadding: Dp = dimensions().spacing2x
         val minColumnWidth: Dp = with(density) { maxTextWidth.toDp() + dimensions().spacing28x }
@@ -156,7 +157,7 @@ private fun calculateGridParams(
 }
 
 @Composable
-fun FileBrowserFlow(
+fun fileBrowserFlow(
     onFilePicked: (Uri) -> Unit,
     onPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit
 ): UseStorageRequestFlow<Uri?> {
@@ -171,7 +172,7 @@ fun FileBrowserFlow(
 }
 
 @Composable
-fun MultipleFileBrowserFlow(
+fun multipleFileBrowserFlow(
     onFilesPicked: (List<Uri>) -> Unit,
     onPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit
 ): UseStorageRequestFlow<List<Uri>> {
@@ -188,7 +189,7 @@ fun MultipleFileBrowserFlow(
 }
 
 @Composable
-private fun MultipleGalleryFlow(
+private fun multipleGalleryFlow(
     onImagesPicked: (List<Uri>) -> Unit,
     onPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit
 ): UseStorageRequestFlow<List<Uri>> {
@@ -205,7 +206,7 @@ private fun MultipleGalleryFlow(
 }
 
 @Composable
-private fun TakePictureFlow(
+private fun takePictureFlow(
     tempWritableVideoUri: Uri?,
     onPictureTaken: (Uri) -> Unit,
     onPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit
@@ -253,15 +254,15 @@ private fun buildAttachmentOptionItems(
     onLocationPickerClicked: () -> Unit,
     onPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit
 ): List<AttachmentOptionItem> {
-    val fileFlow = MultipleFileBrowserFlow(
+    val fileFlow = multipleFileBrowserFlow(
         remember { { onImagesPicked(it) } },
         onPermissionPermanentlyDenied
     )
-    val galleryFlow = MultipleGalleryFlow(
+    val galleryFlow = multipleGalleryFlow(
         remember { { onImagesPicked(it) } },
         onPermissionPermanentlyDenied
     )
-    val cameraFlow = TakePictureFlow(
+    val cameraFlow = takePictureFlow(
         tempWritableImageUri,
         remember { { onFilePicked(UriAsset(it, false)) } },
         onPermissionPermanentlyDenied

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -61,7 +61,7 @@ import com.wire.android.ui.home.messagecomposer.state.MessageComposerStateHolder
 import com.wire.android.util.CurrentConversationDetailsCache
 import com.wire.android.util.permission.PermissionDenialType
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.util.isPositiveNotNull
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
 
 @OptIn(ExperimentalLayoutApi::class)
 @Suppress("ComplexMethod")
@@ -70,7 +70,7 @@ fun EnabledMessageComposer(
     conversationId: ConversationId,
     messageComposerStateHolder: MessageComposerStateHolder,
     messageListContent: @Composable () -> Unit,
-    onChangeSelfDeletionClicked: () -> Unit,
+    onChangeSelfDeletionClicked: (currentlySelected: SelfDeletionTimer) -> Unit,
     onSendButtonClicked: () -> Unit,
     onImagesPicked: (List<Uri>) -> Unit,
     onAttachmentPicked: (UriAsset) -> Unit,
@@ -221,16 +221,15 @@ fun EnabledMessageComposer(
                     if (inputStateHolder.optionsVisible) {
                         if (additionalOptionStateHolder.additionalOptionsSubMenuState != AdditionalOptionSubMenuState.RecordAudio) {
                             AdditionalOptionsMenu(
+                                conversationId = conversationId,
                                 additionalOptionsState = additionalOptionStateHolder.additionalOptionState,
                                 selectedOption = additionalOptionStateHolder.selectedOption,
                                 isEditing = messageCompositionInputStateHolder.inputType is InputType.Editing,
-                                isSelfDeletingSettingEnabled = isSelfDeletingSettingEnabled,
-                                isSelfDeletingActive = messageComposerViewState.value.selfDeletionTimer.duration.isPositiveNotNull(),
                                 isMentionActive = messageComposerViewState.value.mentionSearchResult.isNotEmpty(),
                                 onMentionButtonClicked = messageCompositionHolder::startMention,
                                 onOnSelfDeletingOptionClicked = {
                                     additionalOptionStateHolder.toSelfDeletingOptionsMenu()
-                                    onChangeSelfDeletionClicked()
+                                    onChangeSelfDeletionClicked(it)
                                 },
                                 onRichOptionButtonClicked = messageCompositionHolder::addOrRemoveMessageMarkdown,
                                 onPingOptionClicked = onPingOptionClicked,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActions.kt
@@ -51,44 +51,33 @@ import kotlin.time.Duration.Companion.minutes
 
 @Composable
 fun MessageSendActions(
-    sendButtonEnabled: Boolean,
-    onSendButtonClicked: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    SendButton(
-        isEnabled = sendButtonEnabled,
-        onSendButtonClicked = onSendButtonClicked,
-        modifier = modifier,
-    )
-}
-
-@Composable
-fun SelfDeletingActions(
     selfDeletionTimer: SelfDeletionTimer,
     sendButtonEnabled: Boolean,
     onSendButtonClicked: () -> Unit,
-    onChangeSelfDeletionClicked: () -> Unit,
+    onChangeSelfDeletionClicked: (currentlySelected: SelfDeletionTimer) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier,
     ) {
-        WireTertiaryButton(
-            minSize = MaterialTheme.wireDimensions.buttonCircleMinSize,
-            minClickableSize = MaterialTheme.wireDimensions.buttonCircleMinSize,
-            shape = CircleShape,
-            contentPadding = PaddingValues(horizontal = dimensions().spacing4x, vertical = dimensions().spacing8x),
-            onClick = onChangeSelfDeletionClicked,
-            text = selfDeletionTimer.duration.toSelfDeletionDuration().shortLabel.asString(),
-            textStyle = typography().label02,
-            fillMaxWidth = false,
-            state = if (!selfDeletionTimer.isEnforced) WireButtonState.Default else WireButtonState.Disabled,
-            colors = wireTertiaryButtonColors().copy(onEnabled = colorsScheme().primary, onDisabled = colorsScheme().primary),
-        )
+        if (selfDeletionTimer.duration != null) {
+            WireTertiaryButton(
+                minSize = MaterialTheme.wireDimensions.buttonCircleMinSize,
+                minClickableSize = MaterialTheme.wireDimensions.buttonCircleMinSize,
+                shape = CircleShape,
+                contentPadding = PaddingValues(horizontal = dimensions().spacing4x, vertical = dimensions().spacing8x),
+                onClick = { onChangeSelfDeletionClicked(selfDeletionTimer) },
+                text = selfDeletionTimer.duration.toSelfDeletionDuration().shortLabel.asString(),
+                textStyle = typography().label02,
+                fillMaxWidth = false,
+                state = if (!selfDeletionTimer.isEnforced) WireButtonState.Default else WireButtonState.Disabled,
+                colors = wireTertiaryButtonColors().copy(onEnabled = colorsScheme().primary, onDisabled = colorsScheme().primary),
+            )
+        }
         WirePrimaryIconButton(
             onButtonClicked = onSendButtonClicked,
-            iconResource = R.drawable.ic_timer,
+            iconResource = if (selfDeletionTimer.duration != null) R.drawable.ic_timer else R.drawable.ic_send,
             contentDescription = R.string.content_description_send_button,
             state = if (sendButtonEnabled) WireButtonState.Default else WireButtonState.Disabled,
             shape = RoundedCornerShape(dimensions().spacing20x),
@@ -145,26 +134,6 @@ fun MessageEditActions(
     }
 }
 
-@Composable
-private fun SendButton(
-    isEnabled: Boolean,
-    modifier: Modifier = Modifier,
-    onSendButtonClicked: () -> Unit
-) {
-    WirePrimaryIconButton(
-        modifier = modifier,
-        onButtonClicked = onSendButtonClicked,
-        iconResource = R.drawable.ic_send,
-        contentDescription = R.string.content_description_send_button,
-        state = if (isEnabled) WireButtonState.Default else WireButtonState.Disabled,
-        shape = RoundedCornerShape(dimensions().spacing20x),
-        colors = wireSendPrimaryButtonColors(),
-        clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = false),
-        minSize = MaterialTheme.wireDimensions.buttonCircleMinSize,
-        minClickableSize = MaterialTheme.wireDimensions.buttonMinClickableSize,
-    )
-}
-
 @PreviewMultipleThemes
 @Composable
 fun PreviewMessageEditActionsEnabled() = WireTheme {
@@ -180,23 +149,23 @@ fun PreviewMessageEditActionsDisabled() = WireTheme {
 @PreviewMultipleThemes
 @Composable
 fun PreviewMessageSelfDeletingActionsEnabled() = WireTheme {
-    SelfDeletingActions(SelfDeletionTimer.Enabled(1.minutes), true, {}, {}, Modifier)
+    MessageSendActions(SelfDeletionTimer.Enabled(1.minutes), true, {}, {}, Modifier)
 }
 
 @PreviewMultipleThemes
 @Composable
 fun PreviewMessageSelfDeletingActionsDisabled() = WireTheme {
-    SelfDeletingActions(SelfDeletionTimer.Enabled(1.minutes), false, {}, {}, Modifier)
+    MessageSendActions(SelfDeletionTimer.Enabled(1.minutes), false, {}, {}, Modifier)
 }
 
 @PreviewMultipleThemes
 @Composable
 fun PreviewMessageSendActionsEnabled() = WireTheme {
-    MessageSendActions(true, {})
+    MessageSendActions(SelfDeletionTimer.Disabled, true, {}, {})
 }
 
 @PreviewMultipleThemes
 @Composable
 fun PreviewMessageSendActionsDisabled() = WireTheme {
-    MessageSendActions(false, {})
+    MessageSendActions(SelfDeletionTimer.Disabled, false, {}, {})
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposeActions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposeActions.kt
@@ -31,27 +31,33 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
+import com.wire.android.di.hiltViewModelScoped
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionArgs
+import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModel
+import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModelImpl
 import com.wire.android.ui.home.messagecomposer.attachments.AdditionalOptionButton
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSelectItem
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
+import com.wire.kalium.logic.util.isPositiveNotNull
 
 @Composable
 fun MessageComposeActions(
+    conversationId: ConversationId,
     isEditing: Boolean,
     selectedOption: AdditionalOptionSelectItem,
-    isMentionActive: Boolean = true,
-    isSelfDeletingSettingEnabled: Boolean = true,
-    isSelfDeletingActive: Boolean = false,
     onMentionButtonClicked: () -> Unit,
     onAdditionalOptionButtonClicked: () -> Unit,
     onPingButtonClicked: () -> Unit,
-    onSelfDeletionOptionButtonClicked: () -> Unit,
+    onSelfDeletionOptionButtonClicked: (SelfDeletionTimer) -> Unit,
     onGifButtonClicked: () -> Unit,
     onRichEditingButtonClicked: () -> Unit,
+    isMentionActive: Boolean = true,
     onDrawingModeClicked: () -> Unit
 ) {
     if (isEditing) {
@@ -63,13 +69,12 @@ fun MessageComposeActions(
         )
     } else {
         ComposingActions(
+            conversationId,
             selectedOption,
             isMentionActive,
             onAdditionalOptionButtonClicked,
             onRichEditingButtonClicked,
             onGifButtonClicked,
-            isSelfDeletingSettingEnabled,
-            isSelfDeletingActive,
             onSelfDeletionOptionButtonClicked,
             onPingButtonClicked,
             onMentionButtonClicked,
@@ -80,14 +85,13 @@ fun MessageComposeActions(
 
 @Composable
 private fun ComposingActions(
+    conversationId: ConversationId,
     selectedOption: AdditionalOptionSelectItem,
     isMentionActive: Boolean,
     onAdditionalOptionButtonClicked: () -> Unit,
     onRichEditingButtonClicked: () -> Unit,
     onGifButtonClicked: () -> Unit,
-    isSelfDeletingSettingEnabled: Boolean,
-    isSelfDeletingActive: Boolean,
-    onSelfDeletionOptionButtonClicked: () -> Unit,
+    onSelfDeletionOptionButtonClicked: (SelfDeletionTimer) -> Unit,
     onPingButtonClicked: () -> Unit,
     onMentionButtonClicked: () -> Unit,
     onDrawingModeClicked: () -> Unit
@@ -118,8 +122,8 @@ private fun ComposingActions(
             }
             if (EmojiIcon) AddEmojiAction({})
             if (GifIcon) AddGifAction(onGifButtonClicked)
-            if (isSelfDeletingSettingEnabled) SelfDeletingMessageAction(
-                isSelected = isSelfDeletingActive,
+            SelfDeletingMessageAction(
+                conversationId = conversationId,
                 onButtonClicked = onSelfDeletionOptionButtonClicked
             )
             if (PingIcon) PingAction(onPingButtonClicked)
@@ -136,12 +140,13 @@ fun EditingActions(
     selectedOption: AdditionalOptionSelectItem,
     isMentionActive: Boolean,
     onRichEditingButtonClicked: () -> Unit,
-    onMentionButtonClicked: () -> Unit
+    onMentionButtonClicked: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceEvenly,
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .height(dimensions().spacing56x)
     ) {
@@ -233,16 +238,46 @@ private fun PingAction(onButtonClicked: () -> Unit) {
 }
 
 @Composable
-fun SelfDeletingMessageAction(isSelected: Boolean, onButtonClicked: () -> Unit) {
-    WireSecondaryIconButton(
-        onButtonClicked = {
-            onButtonClicked()
-        },
-        clickBlockParams = ClickBlockParams(blockWhenSyncing = false, blockWhenConnecting = false),
-        iconResource = R.drawable.ic_timer,
-        contentDescription = R.string.content_description_self_deleting_message_timer,
-        state = if (isSelected) WireButtonState.Selected else WireButtonState.Default
-    )
+fun SelfDeletingMessageAction(
+    conversationId: ConversationId,
+    onButtonClicked: (SelfDeletionTimer) -> Unit,
+    viewModel: SelfDeletingMessageActionViewModel =
+        hiltViewModelScoped<SelfDeletingMessageActionViewModelImpl, SelfDeletingMessageActionViewModel, SelfDeletingMessageActionArgs>(
+            SelfDeletingMessageActionArgs(conversationId = conversationId)
+        ),
+) {
+    when (val state = viewModel.state()) {
+        SelfDeletionTimer.Disabled -> {}
+        is SelfDeletionTimer.Enabled -> WireSecondaryIconButton(
+            onButtonClicked = {
+                onButtonClicked(state)
+            },
+            clickBlockParams = ClickBlockParams(blockWhenSyncing = false, blockWhenConnecting = false),
+            iconResource = R.drawable.ic_timer,
+            contentDescription = R.string.content_description_self_deleting_message_timer,
+            state = if (state.duration.isPositiveNotNull()) WireButtonState.Selected else WireButtonState.Default
+        )
+
+        is SelfDeletionTimer.Enforced.ByGroup -> WireSecondaryIconButton(
+            onButtonClicked = {
+                onButtonClicked(state)
+            },
+            clickBlockParams = ClickBlockParams(blockWhenSyncing = false, blockWhenConnecting = false),
+            iconResource = R.drawable.ic_timer,
+            contentDescription = R.string.content_description_self_deleting_message_timer,
+            state = WireButtonState.Disabled
+        )
+
+        is SelfDeletionTimer.Enforced.ByTeam -> WireSecondaryIconButton(
+            onButtonClicked = {
+                onButtonClicked(state)
+            },
+            clickBlockParams = ClickBlockParams(blockWhenSyncing = false, blockWhenConnecting = false),
+            iconResource = R.drawable.ic_timer,
+            contentDescription = R.string.content_description_self_deleting_message_timer,
+            state = WireButtonState.Disabled
+        )
+    }
 }
 
 @Preview

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -72,7 +72,6 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
 import kotlin.math.roundToInt
-import kotlin.time.Duration
 
 @Composable
 fun MessageComposer(
@@ -80,7 +79,7 @@ fun MessageComposer(
     messageComposerStateHolder: MessageComposerStateHolder,
     messageListContent: @Composable () -> Unit,
     onSendMessageBundle: (MessageBundle) -> Unit,
-    onChangeSelfDeletionClicked: () -> Unit,
+    onChangeSelfDeletionClicked: (currentlySelected: SelfDeletionTimer) -> Unit,
     onClearMentionSearchResult: () -> Unit,
     onCaptureVideoPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit,
     tempWritableVideoUri: Uri?,
@@ -255,7 +254,6 @@ private fun BaseComposerPreview(
     }
     val messageTextState = rememberTextFieldState()
     val messageComposition = remember { mutableStateOf(MessageComposition(ConversationId("value", "domain"))) }
-    val selfDeletionTimer = remember { mutableStateOf(SelfDeletionTimer.Enabled(Duration.ZERO)) }
 
     MessageComposer(
         conversationId = ConversationId("value", "domain"),
@@ -263,7 +261,6 @@ private fun BaseComposerPreview(
             messageComposerViewState = messageComposerViewState,
             messageCompositionInputStateHolder = MessageCompositionInputStateHolder(
                 messageTextState = messageTextState,
-                selfDeletionTimer = selfDeletionTimer
             ),
             messageCompositionHolder = MessageCompositionHolder(
                 messageComposition = messageComposition,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -208,7 +208,7 @@ private fun InputContent(
         MessageComposerTextInput(
             isTextExpanded = isTextExpanded,
             inputFocused = inputFocused,
-            colors = inputType.inputTextColor(isPrimaryColor = viewModel.state().duration != null),
+            colors = inputType.inputTextColor(isSelfDeleting = viewModel.state().duration != null),
             messageTextState = messageTextState,
             placeHolderText = viewModel.state().duration?.let { stringResource(id = R.string.self_deleting_message_label) }
                 ?: inputType.labelText(),

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.nativeKeyCode
 import androidx.compose.ui.input.key.onPreInterceptKeyBeforeSoftKeyboard
@@ -71,7 +70,6 @@ import com.wire.android.ui.common.textfield.DefaultText
 import com.wire.android.ui.common.textfield.WireTextField
 import com.wire.android.ui.common.textfield.WireTextFieldColors
 import com.wire.android.ui.common.textfield.WireTextFieldState
-import com.wire.android.ui.common.textfield.wireTextFieldColors
 import com.wire.android.ui.home.conversations.UsersTypingIndicatorForConversation
 import com.wire.android.ui.home.conversations.messages.QuotedMessagePreview
 import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionArgs
@@ -210,14 +208,7 @@ private fun InputContent(
         MessageComposerTextInput(
             isTextExpanded = isTextExpanded,
             inputFocused = inputFocused,
-            colors = viewModel.state().duration?.let {
-                wireTextFieldColors(
-                    backgroundColor = Color.Transparent,
-                    borderColor = Color.Transparent,
-                    focusColor = Color.Transparent,
-                    placeholderColor = colorsScheme().primary
-                )
-            } ?: inputType.inputTextColor(),
+            colors = inputType.inputTextColor(isPrimaryColor = viewModel.state().duration != null),
             messageTextState = messageTextState,
             placeHolderText = viewModel.state().duration?.let { stringResource(id = R.string.self_deleting_message_label) }
                 ?: inputType.labelText(),

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/actions/SelfDeletingMessageActionArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/actions/SelfDeletingMessageActionArgs.kt
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.messagecomposer.actions
+
+import com.wire.android.di.ScopedArgs
+import com.wire.kalium.logic.data.id.ConversationId
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SelfDeletingMessageActionArgs(
+    val conversationId: ConversationId,
+) : ScopedArgs {
+    override val key = "$ARGS_KEY:$conversationId"
+
+    companion object {
+        const val ARGS_KEY = "SelfDeletingMessageActionArgsKey"
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/actions/SelfDeletingMessageActionViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/actions/SelfDeletingMessageActionViewModel.kt
@@ -1,0 +1,74 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.messagecomposer.actions
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.di.ViewModelScopedPreview
+import com.wire.android.di.scopedArgs
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
+import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@ViewModelScopedPreview
+interface SelfDeletingMessageActionViewModel {
+    fun state(): SelfDeletionTimer = SelfDeletionTimer.Disabled
+}
+
+@Suppress("LongParameterList", "TooManyFunctions")
+@HiltViewModel
+class SelfDeletingMessageActionViewModelImpl @Inject constructor(
+    private val dispatchers: DispatcherProvider,
+    private val observeSelfDeletingMessages: ObserveSelfDeletionTimerSettingsForConversationUseCase,
+    savedStateHandle: SavedStateHandle
+) : SelfDeletingMessageActionViewModel, ViewModel() {
+
+    private val args: SelfDeletingMessageActionArgs = savedStateHandle.scopedArgs()
+    private val conversationId: QualifiedID = args.conversationId
+
+    var state: SelfDeletionTimer by mutableStateOf(SelfDeletionTimer.Disabled)
+
+    override fun state(): SelfDeletionTimer = state
+
+    init {
+        observeSelfDeletingMessagesStatus()
+    }
+
+    private fun observeSelfDeletingMessagesStatus() {
+        viewModelScope.launch(dispatchers.io()) {
+            observeSelfDeletingMessages(conversationId, considerSelfUserSettings = true)
+                .flowOn(dispatchers.io())
+                .collectLatest { selfDeletingStatus ->
+                    withContext(dispatchers.main()) {
+                        state = selfDeletingStatus
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -33,7 +32,6 @@ import com.wire.android.ui.home.conversations.MessageComposerViewState
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
 import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.data.message.draft.MessageDraft
 import com.wire.kalium.logic.data.message.mention.MessageMention
 
@@ -74,24 +72,14 @@ fun rememberMessageComposerStateHolder(
         messageCompositionHolder.handleMessageTextUpdates()
     }
 
-    // we derive the selfDeletionTimer from the messageCompositionHolder as a state in order to "observe" the changes to it
-    // which are made "externally" and not inside the MessageComposer.
-    val selfDeletionTimer = remember {
-        derivedStateOf {
-            messageComposerViewState.value.selfDeletionTimer
-        }
-    }
-
     val messageCompositionInputStateHolder = rememberSaveable(
         saver = MessageCompositionInputStateHolder.saver(
             messageTextState = messageTextState,
-            selfDeletionTimer = selfDeletionTimer,
             density = density
         )
     ) {
         MessageCompositionInputStateHolder(
             messageTextState = messageTextState,
-            selfDeletionTimer = selfDeletionTimer
         )
     }
 
@@ -124,9 +112,6 @@ class MessageComposerStateHolder(
     val modalBottomSheetState: WireModalSheetState
 ) {
     val messageComposition = messageCompositionHolder.messageComposition
-
-    val isSelfDeletingSettingEnabled = messageComposerViewState.value.selfDeletionTimer !is SelfDeletionTimer.Disabled &&
-            messageComposerViewState.value.selfDeletionTimer !is SelfDeletionTimer.Enforced
 
     fun toEdit(messageId: String, editMessageText: String, mentions: List<MessageMention>) {
         messageCompositionHolder.setEditText(messageId, editMessageText, mentions)

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
@@ -239,11 +239,15 @@ private sealed class CompositionState {
 
 sealed class InputType {
     @Composable
-    open fun inputTextColor(): WireTextFieldColors = wireTextFieldColors(
+    open fun inputTextColor(isPrimaryColor: Boolean = false): WireTextFieldColors = wireTextFieldColors(
         backgroundColor = Color.Transparent,
         borderColor = Color.Transparent,
         focusColor = Color.Transparent,
-        placeholderColor = colorsScheme().secondaryText
+        placeholderColor = if (isPrimaryColor) {
+            colorsScheme().primary
+        } else {
+            colorsScheme().secondaryText
+        }
     )
 
     @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
@@ -239,11 +239,11 @@ private sealed class CompositionState {
 
 sealed class InputType {
     @Composable
-    open fun inputTextColor(isPrimaryColor: Boolean = false): WireTextFieldColors = wireTextFieldColors(
+    open fun inputTextColor(isSelfDeleting: Boolean): WireTextFieldColors = wireTextFieldColors(
         backgroundColor = Color.Transparent,
         borderColor = Color.Transparent,
         focusColor = Color.Transparent,
-        placeholderColor = if (isPrimaryColor) {
+        placeholderColor = if (isSelfDeleting) {
             colorsScheme().primary
         } else {
             colorsScheme().secondaryText

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
@@ -21,7 +21,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -38,14 +37,9 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.textfield.WireTextFieldColors
 import com.wire.android.ui.common.textfield.wireTextFieldColors
 import com.wire.android.util.ui.KeyboardHeight
-import com.wire.kalium.logic.data.message.SelfDeletionTimer
-import com.wire.kalium.logic.util.isPositiveNotNull
 
 @Stable
-class MessageCompositionInputStateHolder(
-    val messageTextState: TextFieldState,
-    selfDeletionTimer: State<SelfDeletionTimer>
-) {
+class MessageCompositionInputStateHolder(val messageTextState: TextFieldState) {
     var inputFocused: Boolean by mutableStateOf(false)
         private set
 
@@ -75,12 +69,9 @@ class MessageCompositionInputStateHolder(
     val inputType: InputType by derivedStateOf {
         when (val state = compositionState) {
             is CompositionState.Composing -> InputType.Composing(
-                isSendButtonEnabled = messageTextState.text.isNotEmpty(),
-                messageType = when {
-                    selfDeletionTimer.value.duration.isPositiveNotNull() -> MessageType.SelfDeleting(selfDeletionTimer.value)
-                    else -> MessageType.Normal
-                }
+                isSendButtonEnabled = messageTextState.text.isNotEmpty()
             )
+
             is CompositionState.Editing -> InputType.Editing(
                 isEditButtonEnabled = messageTextState.text.toString() != state.originalMessageText
             )
@@ -207,7 +198,6 @@ class MessageCompositionInputStateHolder(
 
         fun saver(
             messageTextState: TextFieldState,
-            selfDeletionTimer: State<SelfDeletionTimer>,
             density: Density
         ): Saver<MessageCompositionInputStateHolder, *> = Saver(
             save = {
@@ -227,7 +217,6 @@ class MessageCompositionInputStateHolder(
                 with(density) {
                     MessageCompositionInputStateHolder(
                         messageTextState = messageTextState,
-                        selfDeletionTimer = selfDeletionTimer
                     ).apply {
                         inputFocused = savedState[0] as Boolean
                         keyboardHeight = (savedState[1] as Float).toDp()
@@ -263,24 +252,11 @@ sealed class InputType {
     @Composable
     open fun labelText(): String = stringResource(R.string.label_type_a_message)
 
-    data class Composing(val isSendButtonEnabled: Boolean, val messageType: MessageType) : InputType() {
-
-        @Composable
-        override fun labelText(): String = if (messageType is MessageType.SelfDeleting) {
-            stringResource(id = R.string.self_deleting_message_label)
-        } else {
-            super.labelText()
-        }
-    }
+    data class Composing(val isSendButtonEnabled: Boolean) : InputType()
 
     class Editing(val isEditButtonEnabled: Boolean) : InputType() {
 
         @Composable
         override fun backgroundColor(): Color = colorsScheme().messageComposerEditBackgroundColor
     }
-}
-
-sealed class MessageType {
-    data object Normal : MessageType()
-    data class SelfDeleting(val selfDeletionTimer: SelfDeletionTimer) : MessageType()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
@@ -40,7 +40,7 @@ import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.wireDialogPropertiesBuilder
-import com.wire.android.ui.home.messagecomposer.FileBrowserFlow
+import com.wire.android.ui.home.messagecomposer.fileBrowserFlow
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.permission.PermissionDenialType
 import kotlin.math.roundToInt
@@ -52,7 +52,7 @@ fun PickRestoreFileDialog(
     onPermissionPermanentlyDenied: (type: PermissionDenialType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val fileFlow = FileBrowserFlow(onChooseBackupFile, onPermissionPermanentlyDenied)
+    val fileFlow = fileBrowserFlow(onChooseBackupFile, onPermissionPermanentlyDenied)
 
     WireDialog(
         modifier = modifier,

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -80,7 +80,7 @@ import com.wire.android.ui.home.conversations.media.CheckAssetRestrictionsViewMo
 import com.wire.android.ui.home.conversations.media.preview.AssetTilePreview
 import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
-import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMenuItems
+import com.wire.android.ui.home.conversations.selfdeletion.selfDeletionMenuItems
 import com.wire.android.ui.home.conversationslist.common.ConversationList
 import com.wire.android.ui.home.conversationslist.model.ConversationFolder
 import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
@@ -280,7 +280,7 @@ fun ImportMediaRegularContent(
             }
         )
         MenuModalSheetLayout(
-            menuItems = SelfDeletionMenuItems(
+            menuItems = selfDeletionMenuItems(
                 currentlySelected = importMediaAuthenticatedState.selfDeletingTimer.duration.toSelfDeletionDuration(),
                 hideEditMessageMenu = importMediaScreenState::hideBottomSheetMenu,
                 onSelfDeletionDurationChanged = onNewSelfDeletionTimerPicked,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelTest.kt
@@ -22,7 +22,6 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.data.message.draft.MessageDraft
 import com.wire.kalium.logic.feature.conversation.InteractionAvailability
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
@@ -32,66 +31,14 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
-import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
 @ExtendWith(NavigationTestExtension::class)
 @Suppress("LargeClass")
 class MessageComposerViewModelTest {
-
-    @Test
-    fun `given that a user updates the self-deleting message timer, when invoked, then the timer gets successfully updated`() =
-        runTest {
-            // Given
-            val expectedDuration = 1.toDuration(DurationUnit.HOURS)
-            val expectedTimer = SelfDeletionTimer.Enabled(expectedDuration)
-            val (arrangement, viewModel) = MessageComposerViewModelArrangement()
-                .withSuccessfulViewModelInit()
-                .withPersistSelfDeletionStatus()
-                .arrange()
-
-            // When
-            viewModel.updateSelfDeletingMessages(expectedTimer)
-
-            // Then
-            coVerify(exactly = 1) {
-                arrangement.persistSelfDeletionStatus.invoke(
-                    arrangement.conversationId,
-                    expectedTimer
-                )
-            }
-            assertInstanceOf(SelfDeletionTimer.Enabled::class.java, viewModel.messageComposerViewState.value.selfDeletionTimer)
-            assertEquals(expectedDuration, viewModel.messageComposerViewState.value.selfDeletionTimer.duration)
-        }
-
-    @Test
-    fun `given a valid observed enforced self-deleting message timer, when invoked, then the timer gets successfully updated`() =
-        runTest {
-            // Given
-            val expectedDuration = 1.toDuration(DurationUnit.DAYS)
-            val expectedTimer = SelfDeletionTimer.Enabled(expectedDuration)
-            val (arrangement, viewModel) = MessageComposerViewModelArrangement()
-                .withSuccessfulViewModelInit()
-                .withObserveSelfDeletingStatus(expectedTimer)
-                .arrange()
-
-            // When
-
-            // Then
-            coVerify(exactly = 1) {
-                arrangement.observeConversationSelfDeletionStatus.invoke(
-                    arrangement.conversationId,
-                    true
-                )
-            }
-            assertInstanceOf(SelfDeletionTimer.Enabled::class.java, viewModel.messageComposerViewState.value.selfDeletionTimer)
-            assertEquals(expectedDuration, viewModel.messageComposerViewState.value.selfDeletionTimer.duration)
-        }
 
     @Test
     fun `given that user types a text message, when invoked typing invoked, then send typing event is called`() = runTest {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/actions/SelfDeletingMessageActionViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/actions/SelfDeletingMessageActionViewModelTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.composer.actions
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.config.ScopedArgsTestExtension
+import com.wire.android.config.TestDispatcherProvider
+import com.wire.android.config.mockUri
+import com.wire.android.di.scopedArgs
+import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionArgs
+import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModelImpl
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
+import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+@ExtendWith(ScopedArgsTestExtension::class)
+class SelfDeletingMessageActionViewModelTest {
+
+    @Test
+    fun `given self-deleting message timer, when observing, then the timer gets successfully updated`() =
+        runTest {
+            // Given
+            val expectedDuration = 1.toDuration(DurationUnit.HOURS)
+            val expectedTimer = SelfDeletionTimer.Enabled(expectedDuration)
+            val (arrangement, viewModel) = Arrangement()
+                .withObserveSelfDeletingStatus(expectedTimer)
+                .arrange()
+
+            // When
+
+            // Then
+            Assertions.assertInstanceOf(SelfDeletionTimer.Enabled::class.java, viewModel.state)
+            assertEquals(expectedDuration, viewModel.state.duration)
+        }
+
+    @Test
+    fun `given a valid observed enforced self-deleting message timer, when observing, then the timer gets successfully updated`() =
+        runTest {
+            // Given
+            val expectedDuration = 1.toDuration(DurationUnit.DAYS)
+            val expectedTimer = SelfDeletionTimer.Enforced.ByTeam(expectedDuration)
+            val (arrangement, viewModel) = Arrangement()
+                .withObserveSelfDeletingStatus(expectedTimer)
+                .arrange()
+
+            // When
+
+            // Then
+            coVerify(exactly = 1) {
+                arrangement.observeConversationSelfDeletionStatus.invoke(
+                    arrangement.conversationId,
+                    true
+                )
+            }
+            Assertions.assertInstanceOf(SelfDeletionTimer.Enforced.ByTeam::class.java, viewModel.state)
+            assertEquals(expectedDuration, viewModel.state.duration)
+        }
+
+    private class Arrangement {
+
+        val conversationId: ConversationId = ConversationId("some-dummy-value", "some.dummy.domain")
+
+        init {
+            // Tests setup
+            MockKAnnotations.init(this, relaxUnitFun = true)
+            mockUri()
+            every { savedStateHandle.scopedArgs<SelfDeletingMessageActionArgs>() } returns SelfDeletingMessageActionArgs(
+                conversationId = conversationId
+            )
+        }
+
+        @MockK
+        private lateinit var savedStateHandle: SavedStateHandle
+
+        @MockK
+        lateinit var observeConversationSelfDeletionStatus: ObserveSelfDeletionTimerSettingsForConversationUseCase
+
+        private val viewModel by lazy {
+            SelfDeletingMessageActionViewModelImpl(
+                savedStateHandle = savedStateHandle,
+                dispatchers = TestDispatcherProvider(),
+                observeSelfDeletingMessages = observeConversationSelfDeletionStatus,
+            )
+        }
+
+        fun withObserveSelfDeletingStatus(expectedSelfDeletionTimer: SelfDeletionTimer) = apply {
+            coEvery { observeConversationSelfDeletionStatus(conversationId, true) } returns flowOf(expectedSelfDeletionTimer)
+        }
+
+        fun arrange() = this to viewModel
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerStateHolderTest.kt
@@ -38,9 +38,7 @@ import com.wire.android.ui.home.messagecomposer.state.InputType
 import com.wire.android.ui.home.messagecomposer.state.MessageComposerStateHolder
 import com.wire.android.ui.home.messagecomposer.state.MessageCompositionHolder
 import com.wire.android.ui.home.messagecomposer.state.MessageCompositionInputStateHolder
-import com.wire.android.ui.home.messagecomposer.state.MessageType
 import com.wire.android.util.EMPTY
-import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -73,10 +71,7 @@ class MessageComposerStateHolderTest {
         messageComposerViewState = mutableStateOf(MessageComposerViewState())
         messageComposition = mutableStateOf(MessageComposition(TestConversation.ID))
         messageTextState = TextFieldState()
-        messageCompositionInputStateHolder = MessageCompositionInputStateHolder(
-            messageTextState = messageTextState,
-            selfDeletionTimer = mutableStateOf(SelfDeletionTimer.Disabled)
-        )
+        messageCompositionInputStateHolder = MessageCompositionInputStateHolder(messageTextState = messageTextState)
         messageCompositionHolder = MessageCompositionHolder(
             messageComposition = messageComposition,
             messageTextState = messageTextState,
@@ -147,9 +142,7 @@ class MessageComposerStateHolderTest {
 
             // then
             assertEquals(String.EMPTY, messageCompositionHolder.messageTextState.text.toString())
-            assertInstanceOf(InputType.Composing::class.java, messageCompositionInputStateHolder.inputType).also {
-                assertInstanceOf(MessageType.Normal::class.java, it.messageType)
-            }
+            assertInstanceOf(InputType.Composing::class.java, messageCompositionInputStateHolder.inputType)
         }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
@@ -18,11 +18,9 @@
 package com.wire.android.ui.home.messagecomposer.state
 
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.unit.dp
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.SnapshotExtension
-import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
@@ -41,10 +39,7 @@ class MessageCompositionInputStateHolderTest {
     @BeforeEach
     fun before() {
         messageTextState = TextFieldState()
-        state = MessageCompositionInputStateHolder(
-            messageTextState = messageTextState,
-            selfDeletionTimer = mutableStateOf(SelfDeletionTimer.Disabled)
-        )
+        state = MessageCompositionInputStateHolder(messageTextState = messageTextState)
     }
 
     @Test

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/button/WireSecondaryIconButton.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/button/WireSecondaryIconButton.kt
@@ -42,9 +42,10 @@ import com.wire.android.ui.theme.wireDimensions
 @Composable
 fun WireSecondaryIconButton(
     onButtonClicked: () -> Unit,
-    loading: Boolean = false,
     @DrawableRes iconResource: Int,
     @StringRes contentDescription: Int,
+    modifier: Modifier = Modifier,
+    loading: Boolean = false,
     shape: Shape = RoundedCornerShape(MaterialTheme.wireDimensions.buttonCornerSize),
     minSize: DpSize = MaterialTheme.wireDimensions.buttonSmallMinSize,
     minClickableSize: DpSize = MaterialTheme.wireDimensions.buttonMinClickableSize,
@@ -52,7 +53,6 @@ fun WireSecondaryIconButton(
     state: WireButtonState = WireButtonState.Default,
     colors: WireButtonColors = wireSecondaryButtonColors(),
     clickBlockParams: ClickBlockParams = ClickBlockParams(),
-    modifier: Modifier = Modifier,
     fillMaxWidth: Boolean = false
 ) {
     WireSecondaryButton(
@@ -81,13 +81,23 @@ fun WireSecondaryIconButton(
 @Preview
 @Composable
 fun PreviewWireSecondaryIconButton() {
-    WireSecondaryIconButton({}, false, com.google.android.material.R.drawable.m3_password_eye, 0)
+    WireSecondaryIconButton(
+        {},
+        loading = false,
+        iconResource = com.google.android.material.R.drawable.m3_password_eye,
+        contentDescription = 0
+    )
 }
 
 @Preview
 @Composable
 fun PreviewWireSecondaryIconButtonLoading() {
-    WireSecondaryIconButton({}, true, com.google.android.material.R.drawable.m3_password_eye, 0)
+    WireSecondaryIconButton(
+        {},
+        loading = true,
+        iconResource = com.google.android.material.R.drawable.m3_password_eye,
+        contentDescription = 0
+    )
 }
 
 @Preview
@@ -95,11 +105,11 @@ fun PreviewWireSecondaryIconButtonLoading() {
 fun PreviewWireSecondaryIconButtonRound() {
     WireSecondaryIconButton(
         {},
-        false,
-        com.google.android.material.R.drawable.m3_password_eye,
-        0,
-        CircleShape,
-        DpSize(40.dp, 40.dp),
-        DpSize(48.dp, 48.dp)
+        loading = false,
+        iconResource = com.google.android.material.R.drawable.m3_password_eye,
+        contentDescription = 0,
+        shape = CircleShape,
+        minSize = DpSize(40.dp, 40.dp),
+        minClickableSize = DpSize(48.dp, 48.dp)
     )
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9419" title="WPB-9419" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9419</a>  [Android] Self deleting messages button is disappearing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Using MessageComposerViewState for self deleting option causes unexpected behavior of self deleting button.

### Causes (Optional)

Self deleting option after reopening conversation screen was clickable even if it was forced by group options

### Solutions

- use small view model for managing self deleting option state which also simplifies managing it
- show self deleting option as visible but not clickable when it's enforced either by group or team
- fixed input text field color when self deleting option is enabled


### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 

https://github.com/wireapp/wire-android/assets/13151239/ab3245a6-7bb8-4157-bb85-8a70c25283b1
