### PR TITLE
feat: Remove Reply option for notifications in degraded conversation [WPB-7425]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -202,8 +202,9 @@ class MessageNotificationManager
 
                             is NotificationMessage.Comment -> {
                                 val isAppLocked = lockCodeTimeManager.isAppLocked()
+                                if (conversation.isReplyAllowed)
+                                    addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
-                                addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
                             }
 
                             is NotificationMessage.Knock -> {
@@ -213,14 +214,16 @@ class MessageNotificationManager
 
                             is NotificationMessage.Text -> {
                                 val isAppLocked = lockCodeTimeManager.isAppLocked()
+                                if (conversation.isReplyAllowed)
+                                    addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
-                                addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
                             }
 
                             is NotificationMessage.ObfuscatedMessage -> {
                                 val isAppLocked = lockCodeTimeManager.isAppLocked()
+                                if (conversation.isReplyAllowed)
+                                    addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
-                                addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
                             }
 
                             is NotificationMessage.ObfuscatedKnock -> {
@@ -230,8 +233,9 @@ class MessageNotificationManager
 
                             null -> {
                                 val isAppLocked = lockCodeTimeManager.isAppLocked()
+                                if (conversation.isReplyAllowed)
+                                    addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
-                                addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -173,7 +173,7 @@ class MessageNotificationManager
      * @return [Notification] for the conversation with all the messages in it (including previous messages as well)
      * OR null if there is no new messages in conversation and no need to update the existed notification.
      */
-    @Suppress("ComplexMethod", "NestedBlockDepth")
+    @Suppress("LongMethod", "ComplexMethod", "NestedBlockDepth")
     private fun getConversationNotification(
         conversation: NotificationConversation,
         userId: QualifiedID,

--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -173,6 +173,7 @@ class MessageNotificationManager
      * @return [Notification] for the conversation with all the messages in it (including previous messages as well)
      * OR null if there is no new messages in conversation and no need to update the existed notification.
      */
+    @Suppress("ComplexMethod", "NestedBlockDepth")
     private fun getConversationNotification(
         conversation: NotificationConversation,
         userId: QualifiedID,
@@ -201,9 +202,10 @@ class MessageNotificationManager
                             }
 
                             is NotificationMessage.Comment -> {
-                                val isAppLocked = lockCodeTimeManager.isAppLocked()
-                                if (conversation.isReplyAllowed)
+                                if (conversation.isReplyAllowed) {
+                                    val isAppLocked = lockCodeTimeManager.isAppLocked()
                                     addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
+                                }
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
                             }
 
@@ -213,16 +215,18 @@ class MessageNotificationManager
                             }
 
                             is NotificationMessage.Text -> {
-                                val isAppLocked = lockCodeTimeManager.isAppLocked()
-                                if (conversation.isReplyAllowed)
+                                if (conversation.isReplyAllowed) {
+                                    val isAppLocked = lockCodeTimeManager.isAppLocked()
                                     addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
+                                }
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
                             }
 
                             is NotificationMessage.ObfuscatedMessage -> {
-                                val isAppLocked = lockCodeTimeManager.isAppLocked()
-                                if (conversation.isReplyAllowed)
+                                if (conversation.isReplyAllowed) {
+                                    val isAppLocked = lockCodeTimeManager.isAppLocked()
                                     addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
+                                }
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
                             }
 
@@ -232,9 +236,10 @@ class MessageNotificationManager
                             }
 
                             null -> {
-                                val isAppLocked = lockCodeTimeManager.isAppLocked()
-                                if (conversation.isReplyAllowed)
+                                if (conversation.isReplyAllowed) {
+                                    val isAppLocked = lockCodeTimeManager.isAppLocked()
                                     addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
+                                }
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
                             }
                         }

--- a/app/src/main/kotlin/com/wire/android/notification/Models.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/Models.kt
@@ -30,7 +30,8 @@ data class NotificationConversation(
     val image: ByteArray?,
     val messages: List<NotificationMessage>,
     val isOneToOneConversation: Boolean,
-    val lastMessageTime: Long
+    val lastMessageTime: Long,
+    val isReplyAllowed: Boolean
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -153,7 +154,8 @@ fun LocalNotification.Conversation.intoNotificationConversation(): NotificationC
         image = null, // TODO
         messages = notificationMessages,
         isOneToOneConversation = isOneToOneConversation,
-        lastMessageTime = lastMessageTime
+        lastMessageTime = lastMessageTime,
+        isReplyAllowed = isReplyAllowed
     )
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7425" title="WPB-7425" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7425</a>  [Android] Replying from notification to degraded conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

Notification for the conversations that has degraded verifications status should not have "Reply" option.

### Causes (Optional)

Wasn't implemented.

### Solutions

Use update kalium version that has `isReplyAllowed` field in `LocalNotification.Conversation` and according to that flag add or remove such an option in notifications.

### Dependencies (Optional)

waiting kalium update to me merged (https://github.com/wireapp/kalium/pull/2867)
