### PR TITLE
fix: unfocus message composer when keyboard hides [WPB-9722]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -95,7 +95,7 @@ fun EnabledMessageComposer(
         val inputStateHolder = messageCompositionInputStateHolder
 
         LaunchedEffect(isImeVisible) {
-            if(!isImeVisible) {
+            if (!isImeVisible) {
                 inputStateHolder.clearFocus()
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -94,6 +94,12 @@ fun EnabledMessageComposer(
     with(messageComposerStateHolder) {
         val inputStateHolder = messageCompositionInputStateHolder
 
+        LaunchedEffect(isImeVisible) {
+            if(!isImeVisible) {
+                inputStateHolder.clearFocus()
+            }
+        }
+
         LaunchedEffect(offsetY) {
             with(density) {
                 inputStateHolder.handleImeOffsetChange(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -315,7 +315,7 @@ private fun MessageComposerTextInput(
             .focusRequester(focusRequester)
             .onFocusChanged { focusState ->
                 if (focusState.isFocused) {
-                    onFocusChanged(focusState.isFocused)
+                    onFocusChanged(true)
                 }
             }
             .onPreInterceptKeyBeforeSoftKeyboard { event ->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9722" title="WPB-9722" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9722</a>  [Android] Keyboard open unexpectedly in a conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Keyboard open unexpectedly in a conversation after closing notification drawer


### Solutions

Unfocus message compose input when keyboard hides

### Attachments (Optional)


https://github.com/wireapp/wire-android/assets/13151239/00b4b3af-cb54-44c7-b597-9d05793af4eb

