### PR TITLE
fix: Better error messages on github action or smoke run failures (WPB-9676)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,15 +98,14 @@ pipeline {
                         error("Could not find any apk at provided location!")
                     } else {
                         def lastModifiedFileName = files[-1].name
-                        def childJob = build job: 'android_reloaded_smoke', parameters: [string(name: 'AppBuildNumber', value: "artifacts/megazord/android/reloaded/staging/compat/$BRANCH_NAME/${lastModifiedFileName}"), string(name: 'TAGS', value: '@smoke'), string(name: 'Branch', value: 'main')]
-                        env.CHILD_JOB_URL = childJob.getAbsoluteUrl()
+                        build job: 'android_reloaded_smoke', parameters: [string(name: 'AppBuildNumber', value: "artifacts/megazord/android/reloaded/staging/compat/$BRANCH_NAME/${lastModifiedFileName}"), string(name: 'TAGS', value: '@smoke'), string(name: 'Branch', value: 'main')]
                     }
                 }
             }
             post {
                 unsuccessful {
                     script {
-                        wireSend(secret: env.WIRE_BOT_SECRET, message: "❌ **$BRANCH_NAME**\n[$CHANGE_TITLE](${CHANGE_URL})\nQA-Jenkins - Smoke Tests failed! [Details](" + env.CHILD_JOB_URL + ")")
+                        wireSend(secret: env.WIRE_BOT_SECRET, message: "❌ **$BRANCH_NAME**\n[$CHANGE_TITLE](${CHANGE_URL})\nQA-Jenkins - Smoke tests failed (see above report)")
                     }
                 }
             }
@@ -118,7 +117,7 @@ pipeline {
         success {
             script {
                 if (env.BRANCH_NAME ==~ /PR-[0-9]+/) {
-                    wireSend(secret: env.WIRE_BOT_SECRET, message: "✅ **$BRANCH_NAME**\n[$CHANGE_TITLE](${CHANGE_URL})\nQA-Jenkins - Smoke Tests [Details](${BUILD_URL})")
+                    wireSend(secret: env.WIRE_BOT_SECRET, message: "✅ **$BRANCH_NAME**\n[$CHANGE_TITLE](${CHANGE_URL})\nQA-Jenkins - Smoke tests successful (see above report)")
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,13 +57,14 @@ pipeline {
                            for (run in runs) {
                                if (run['head_sha'] == commit_hash) {
                                    echo("conclusion: " + run['conclusion'])
+                                   env.GITHUB_ACTION_URL = run['url'].replace('api.github.com/repos', 'github.com/')
                                    // conclusion can be: success, failure, neutral, cancelled, skipped, timed_out, or action_required
                                    if (run['conclusion'] == 'success') {
                                        return true
                                    } else if (run['conclusion'] == 'failure') {
-                                       error("❌ **Build failed for branch '${GIT_BRANCH_WEBAPP}'** See [Github Actions](" + run['url'] + ")")
+                                       error("❌ **Build failed for branch '${BRANCH_NAME}'** See Github Actions: " + env.GITHUB_ACTION_URL)
                                    } else if (run['conclusion'] == 'cancelled') {
-                                       error("⚠️ **Build aborted for branch '${GIT_BRANCH_WEBAPP}'** See [Github Actions](" + run['url'] + ")")
+                                       error("⚠️ **Build aborted for branch '${BRANCH_NAME}'** See Github Actions: " + env.GITHUB_ACTION_URL)
                                    }
                                }
                            }
@@ -71,6 +72,13 @@ pipeline {
                            return false;
                        }
                    }
+                }
+            }
+            post {
+                unsuccessful {
+                    script {
+                        wireSend(secret: env.WIRE_BOT_SECRET, message: "❌ **$BRANCH_NAME**\n[$CHANGE_TITLE](${CHANGE_URL})\nBuild aborted or failed! See [Github Actions](" + env.GITHUB_ACTION_URL + ")")
+                    }
                 }
             }
         }
@@ -90,7 +98,15 @@ pipeline {
                         error("Could not find any apk at provided location!")
                     } else {
                         def lastModifiedFileName = files[-1].name
-                        build job: 'android_reloaded_smoke', parameters: [string(name: 'AppBuildNumber', value: "artifacts/megazord/android/reloaded/staging/compat/$BRANCH_NAME/${lastModifiedFileName}"), string(name: 'TAGS', value: '@smoke'), string(name: 'Branch', value: 'main')]
+                        def childJob = build job: 'android_reloaded_smoke', parameters: [string(name: 'AppBuildNumber', value: "artifacts/megazord/android/reloaded/staging/compat/$BRANCH_NAME/${lastModifiedFileName}"), string(name: 'TAGS', value: '@smoke'), string(name: 'Branch', value: 'main')]
+                        env.CHILD_JOB_URL = childJob.getAbsoluteUrl()
+                    }
+                }
+            }
+            post {
+                unsuccessful {
+                    script {
+                        wireSend(secret: env.WIRE_BOT_SECRET, message: "❌ **$BRANCH_NAME**\n[$CHANGE_TITLE](${CHANGE_URL})\nQA-Jenkins - Smoke Tests failed! [Details](" + env.CHILD_JOB_URL + ")")
                     }
                 }
             }
@@ -103,14 +119,6 @@ pipeline {
             script {
                 if (env.BRANCH_NAME ==~ /PR-[0-9]+/) {
                     wireSend(secret: env.WIRE_BOT_SECRET, message: "✅ **$BRANCH_NAME**\n[$CHANGE_TITLE](${CHANGE_URL})\nQA-Jenkins - Smoke Tests [Details](${BUILD_URL})")
-                }
-            }
-        }
-
-        unsuccessful {
-            script {
-                if (env.BRANCH_NAME ==~ /PR-[0-9]+/) {
-                    wireSend(secret: env.WIRE_BOT_SECRET, message: "❌ **$BRANCH_NAME**\n[$CHANGE_TITLE](${CHANGE_URL})\nQA-Jenkins - Smoke Tests failed! [Details](${BUILD_URL})")
                 }
             }
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9676" title="WPB-9676" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9676</a>  Enable running end to end automation on Android PR
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The smoke test trigger script threw confusing error messages when a github action was aborted or failed (in case of unit test failures or similar).

### Solutions

The change returns a better error message if a github action failed or was aborted. Additionally it adds the URL of the smoke test job to the chat message in case of smoke failures.