### PR TITLE
fix: anonymous analytics manager initialisation [WPB-10063]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -48,6 +48,7 @@ import dagger.Lazy
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -198,6 +199,7 @@ class WireApplication : BaseApp() {
                     flowOf(false)
                 }
             }
+            .distinctUntilChanged()
 
         AnonymousAnalyticsManagerImpl.init(
             context = this,

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -140,6 +140,7 @@ class WireApplication : BaseApp() {
         }
     }
 
+    @Suppress("EmptyFunctionBlock")
     private fun startActivityLifecycleCallback() {
         registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
             override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -41,12 +41,10 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -60,8 +58,6 @@ import com.wire.android.config.CustomUiConfigurationProvider
 import com.wire.android.config.LocalCustomUiConfigurationProvider
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.feature.NavigationSwitchAccountActions
-import com.wire.android.feature.analytics.globalAnalyticsManager
-import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.LocalNavigator
 import com.wire.android.navigation.NavigationCommand
@@ -295,25 +291,6 @@ class WireActivity : AppCompatActivity() {
             onDispose {
                 navController.removeOnDestinationChangedListener(updateScreenSettingsListener)
                 navController.removeOnDestinationChangedListener(currentScreenManager)
-            }
-        }
-
-        val lifecycleOwner = LocalLifecycleOwner.current
-        val activity = LocalContext.current as Activity
-        DisposableEffect(lifecycleOwner) {
-            val observer = LifecycleEventObserver { _, event ->
-                if (event == Lifecycle.Event.ON_START) {
-                    globalAnalyticsManager.onStart(activity = activity)
-                    globalAnalyticsManager.sendEvent(AnalyticsEvent.AppOpen())
-                }
-                if (event == Lifecycle.Event.ON_STOP) {
-                    globalAnalyticsManager.onStop()
-                }
-            }
-            lifecycleOwner.lifecycle.addObserver(observer)
-
-            onDispose {
-                lifecycleOwner.lifecycle.removeObserver(observer)
             }
         }
     }

--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerImpl.kt
@@ -34,6 +34,10 @@ object AnonymousAnalyticsManagerImpl : AnonymousAnalyticsManager {
     private var anonymousAnalyticsRecorder: AnonymousAnalyticsRecorder? = null
     private val startedActivities = mutableSetOf<Activity>()
 
+    init {
+        globalAnalyticsManager = this
+    }
+
     override fun init(
         context: Context,
         analyticsSettings: AnalyticsSettings,
@@ -42,7 +46,6 @@ object AnonymousAnalyticsManagerImpl : AnonymousAnalyticsManager {
         dispatcher: CoroutineDispatcher
     ) {
         this.anonymousAnalyticsRecorder = anonymousAnalyticsRecorder
-        globalAnalyticsManager = this
 
         CoroutineScope(dispatcher).launch {
             isEnabledFlow

--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerImpl.kt
@@ -53,10 +53,12 @@ object AnonymousAnalyticsManagerImpl : AnonymousAnalyticsManager {
                                 context = context,
                                 analyticsSettings = analyticsSettings,
                             )
+                            // start recording for all Activities started before the feature was enabled
                             startedActivities.forEach { activity ->
                                 anonymousAnalyticsRecorder.onStart(activity = activity)
                             }
                         } else {
+                            // immediately disable event tracking
                             anonymousAnalyticsRecorder.halt()
                         }
                         isAnonymousUsageDataEnabled = enabled

--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerImpl.kt
@@ -25,52 +25,66 @@ import com.wire.android.feature.analytics.model.AnalyticsSettings
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 object AnonymousAnalyticsManagerImpl : AnonymousAnalyticsManager {
     private const val TAG = "AnonymousAnalyticsManagerImpl"
     private var isAnonymousUsageDataEnabled = false
     private var anonymousAnalyticsRecorder: AnonymousAnalyticsRecorder? = null
+    private val startedActivities = mutableSetOf<Activity>()
 
     override fun init(
         context: Context,
         analyticsSettings: AnalyticsSettings,
-        isEnabledFlowProvider: suspend () -> Flow<Boolean>,
+        isEnabledFlow: Flow<Boolean>,
         anonymousAnalyticsRecorder: AnonymousAnalyticsRecorder,
         dispatcher: CoroutineDispatcher
     ) {
         this.anonymousAnalyticsRecorder = anonymousAnalyticsRecorder
+        globalAnalyticsManager = this
 
         CoroutineScope(dispatcher).launch {
-            isEnabledFlowProvider().collect { enabled ->
-                isAnonymousUsageDataEnabled = enabled
-                if (enabled) {
-                    anonymousAnalyticsRecorder.configure(
-                        context = context,
-                        analyticsSettings = analyticsSettings,
-                    )
+            isEnabledFlow
+                .collectLatest { enabled ->
+                    synchronized(this@AnonymousAnalyticsManagerImpl) {
+                        if (enabled) {
+                            anonymousAnalyticsRecorder.configure(
+                                context = context,
+                                analyticsSettings = analyticsSettings,
+                            )
+                            startedActivities.forEach { activity ->
+                                anonymousAnalyticsRecorder.onStart(activity = activity)
+                            }
+                        } else {
+                            anonymousAnalyticsRecorder.halt()
+                        }
+                        isAnonymousUsageDataEnabled = enabled
+                    }
                 }
-            }
         }
-        globalAnalyticsManager = this
     }
 
-    override fun onStart(activity: Activity) {
-        if (!isAnonymousUsageDataEnabled) return
+    override fun onStart(activity: Activity) = synchronized(this@AnonymousAnalyticsManagerImpl) {
+        startedActivities.add(activity)
+
+        if (!isAnonymousUsageDataEnabled) return@synchronized
 
         anonymousAnalyticsRecorder?.onStart(activity = activity)
             ?: Log.w(TAG, "Calling onStart with a null recorder.")
     }
 
-    override fun onStop() {
-        if (!isAnonymousUsageDataEnabled) return
+    override fun onStop(activity: Activity) = synchronized(this@AnonymousAnalyticsManagerImpl) {
+        startedActivities.remove(activity)
+
+        if (!isAnonymousUsageDataEnabled) return@synchronized
 
         anonymousAnalyticsRecorder?.onStop()
             ?: Log.w(TAG, "Calling onStop with a null recorder.")
     }
 
-    override fun sendEvent(event: AnalyticsEvent) {
-        if (!isAnonymousUsageDataEnabled) return
+    override fun sendEvent(event: AnalyticsEvent) = synchronized(this@AnonymousAnalyticsManagerImpl) {
+        if (!isAnonymousUsageDataEnabled) return@synchronized
 
         anonymousAnalyticsRecorder?.sendEvent(event = event)
             ?: Log.w(TAG, "Calling sendEvent with key : ${event.key} with a null recorder.")

--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
@@ -65,4 +65,8 @@ class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
     override fun sendEvent(event: AnalyticsEvent) {
         Countly.sharedInstance().events().recordEvent(event.key, event.toSegmentation())
     }
+
+    override fun halt() {
+        Countly.sharedInstance().halt()
+    }
 }

--- a/core/analytics-enabled/src/test/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerTest.kt
+++ b/core/analytics-enabled/src/test/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerTest.kt
@@ -49,7 +49,7 @@ class AnonymousAnalyticsManagerTest {
         manager.init(
             context = arrangement.context,
             analyticsSettings = Arrangement.analyticsSettings,
-            isEnabledFlowProvider = arrangement.isEnabledFlowProvider::consumeAsFlow,
+            isEnabledFlow = arrangement.isEnabledFlow.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             dispatcher = dispatcher
         )
@@ -82,7 +82,7 @@ class AnonymousAnalyticsManagerTest {
         manager.init(
             context = arrangement.context,
             analyticsSettings = Arrangement.analyticsSettings,
-            isEnabledFlowProvider = arrangement.isEnabledFlowProvider::consumeAsFlow,
+            isEnabledFlow = arrangement.isEnabledFlow.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             dispatcher = dispatcher
         )
@@ -114,7 +114,7 @@ class AnonymousAnalyticsManagerTest {
         manager.init(
             context = arrangement.context,
             analyticsSettings = Arrangement.analyticsSettings,
-            isEnabledFlowProvider = arrangement.isEnabledFlowProvider::consumeAsFlow,
+            isEnabledFlow = arrangement.isEnabledFlow.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             dispatcher = dispatcher
         )
@@ -161,11 +161,67 @@ class AnonymousAnalyticsManagerTest {
         arrangement.toggleIsEnabledFlow(false)
         advanceUntilIdle()
 
-        manager.onStop()
+        manager.onStop(activity = mockk<Activity>())
 
         // then
         verify(exactly = 0) {
             arrangement.anonymousAnalyticsRecorder.onStop()
+        }
+    }
+
+    @Test
+    fun givenIsEnabledFlowIsFalseAndOneActivityStarted_whenTogglingEnabledToTrue_thenCallStartAfterToggled() = runTest(dispatcher) {
+        // given
+        val (arrangement, manager) = Arrangement()
+            .withAnonymousAnalyticsRecorderConfigure()
+            .toggleIsEnabledFlow(false)
+            .arrange()
+        val activity: Activity = mockk()
+        manager.onStart(activity)
+        manager.init(
+            context = arrangement.context,
+            analyticsSettings = Arrangement.analyticsSettings,
+            isEnabledFlow = arrangement.isEnabledFlow.consumeAsFlow(),
+            anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
+            dispatcher = dispatcher
+        )
+        advanceUntilIdle()
+        verify(exactly = 0) {
+            arrangement.anonymousAnalyticsRecorder.onStart(activity)
+        }
+
+        // when
+        arrangement.toggleIsEnabledFlow(true)
+        advanceUntilIdle()
+
+        // then
+        verify(exactly = 1) {
+            arrangement.anonymousAnalyticsRecorder.onStart(activity)
+        }
+    }
+
+    @Test
+    fun givenManagerInitialized_whenTogglingEnabledToFalse_thenHaltIsCalled() = runTest(dispatcher) {
+        // given
+        val (arrangement, manager) = Arrangement()
+            .withAnonymousAnalyticsRecorderConfigure()
+            .arrange()
+        manager.init(
+            context = arrangement.context,
+            analyticsSettings = Arrangement.analyticsSettings,
+            isEnabledFlow = arrangement.isEnabledFlow.consumeAsFlow(),
+            anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
+            dispatcher = dispatcher
+        )
+        advanceUntilIdle()
+
+        // when
+        arrangement.toggleIsEnabledFlow(false)
+        advanceUntilIdle()
+
+        // then
+        verify(exactly = 1) {
+            arrangement.anonymousAnalyticsRecorder.halt()
         }
     }
 
@@ -176,7 +232,7 @@ class AnonymousAnalyticsManagerTest {
         @MockK
         lateinit var anonymousAnalyticsRecorder: AnonymousAnalyticsRecorder
 
-        val isEnabledFlowProvider = Channel<Boolean>(capacity = Channel.UNLIMITED)
+        val isEnabledFlow = Channel<Boolean>(capacity = Channel.UNLIMITED)
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
@@ -193,7 +249,7 @@ class AnonymousAnalyticsManagerTest {
         }
 
         suspend fun toggleIsEnabledFlow(enabled: Boolean) = apply {
-            isEnabledFlowProvider.send(enabled)
+            isEnabledFlow.send(enabled)
         }
 
         companion object {

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManager.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManager.kt
@@ -31,7 +31,7 @@ interface AnonymousAnalyticsManager {
     fun init(
         context: Context,
         analyticsSettings: AnalyticsSettings,
-        isEnabledFlowProvider: suspend () -> Flow<Boolean>,
+        isEnabledFlow: Flow<Boolean>,
         anonymousAnalyticsRecorder: AnonymousAnalyticsRecorder,
         dispatcher: CoroutineDispatcher
     )
@@ -40,5 +40,5 @@ interface AnonymousAnalyticsManager {
 
     fun onStart(activity: Activity)
 
-    fun onStop()
+    fun onStop(activity: Activity)
 }

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerStub.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerStub.kt
@@ -29,7 +29,7 @@ open class AnonymousAnalyticsManagerStub : AnonymousAnalyticsManager {
     override fun init(
         context: Context,
         analyticsSettings: AnalyticsSettings,
-        isEnabledFlowProvider: suspend () -> Flow<Boolean>,
+        isEnabledFlow: Flow<Boolean>,
         anonymousAnalyticsRecorder: AnonymousAnalyticsRecorder,
         dispatcher: CoroutineDispatcher
     ) = Unit
@@ -38,5 +38,5 @@ open class AnonymousAnalyticsManagerStub : AnonymousAnalyticsManager {
 
     override fun onStart(activity: Activity) = Unit
 
-    override fun onStop() = Unit
+    override fun onStop(activity: Activity) = Unit
 }

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorder.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorder.kt
@@ -33,4 +33,6 @@ interface AnonymousAnalyticsRecorder {
     fun onStop()
 
     fun sendEvent(event: AnalyticsEvent)
+
+    fun halt()
 }

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderStub.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderStub.kt
@@ -30,4 +30,6 @@ open class AnonymousAnalyticsRecorderStub : AnonymousAnalyticsRecorder {
     override fun onStop() = Unit
 
     override fun sendEvent(event: AnalyticsEvent) = Unit
+
+    override fun halt() = Unit
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10063" title="WPB-10063" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10063</a>  [Andoid] initializeApplicationLoggingFrameworks is stalling on app start
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- `AnonymousAnalyticsManager.init` was blocking other app start actions
- `onStart`/`onStop` was being called only for `WireActivity`
- manager was not being halted properly after setting anonymous analytics option to `false`
- possible race condition because of setting and checking `isAnonymousUsageDataEnabled` on different threads

### Solutions

- blocking other actions is fixed already by this workaround: 
https://github.com/wireapp/wire-android/pull/3173 
but in this PR there are also some further improvements:
  - merge Flow of current session and enabled option into single one
  - pass it as a Flow instead of lambda "Flow provider" and observe this flow only inside `init` in a dedicated coroutine
  - thanks to that `initializeAnonymousAnalytics` can't be suspended so remove `suspend` from it and no need to launch new coroutine to call it
- move calling `onStart` and `onStop` to `WireApplication` using `ActivityLifecycleCallbacks` so that it's called for all Activities and there's no need to put that logic into all Activities manually
- call `halt` when enabled option is set to false so that the event tracking is immediately disabled
- make functions `synchronized` to prevent any possible race condition

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
