### PR TITLE
fix: Make smoke tests not report if github actions are aborted (WPB-9676)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,6 +65,7 @@ pipeline {
                                    } else if (run['conclusion'] == 'failure') {
                                        error("❌ **Build failed for branch '${BRANCH_NAME}'** See Github Actions: " + env.GITHUB_ACTION_URL)
                                    } else if (run['conclusion'] == 'cancelled') {
+                                       // mark step as aborted
                                        currentBuild.result = 'ABORTED'
                                        error("⚠️ **Build aborted for branch '${BRANCH_NAME}'** See Github Actions: " + env.GITHUB_ACTION_URL)
                                    }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9676" title="WPB-9676" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9676</a>  Enable running end to end automation on Android PR
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR changes the behaviour of the smoke test script to fail silently if github actions are aborted automatically (usually through a new commit or merge).