### PR TITLE
feat: Remove Reply option for notifications in degraded conversation [WPB-7425] 🍒

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -185,6 +185,7 @@ class MessageNotificationManager
      * @return [Notification] for the conversation with all the messages in it (including previous messages as well)
      * OR null if there is no new messages in conversation and no need to update the existed notification.
      */
+    @Suppress("LongMethod", "ComplexMethod", "NestedBlockDepth")
     private fun getConversationNotification(
         conversation: NotificationConversation,
         userId: QualifiedID,
@@ -213,9 +214,11 @@ class MessageNotificationManager
                             }
 
                             is NotificationMessage.Comment -> {
-                                val isAppLocked = lockCodeTimeManager.isAppLocked()
+                                if (conversation.isReplyAllowed) {
+                                    val isAppLocked = lockCodeTimeManager.isAppLocked()
+                                    addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
+                                }
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
-                                addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
                             }
 
                             is NotificationMessage.Knock -> {
@@ -224,15 +227,19 @@ class MessageNotificationManager
                             }
 
                             is NotificationMessage.Text -> {
-                                val isAppLocked = lockCodeTimeManager.isAppLocked()
+                                if (conversation.isReplyAllowed) {
+                                    val isAppLocked = lockCodeTimeManager.isAppLocked()
+                                    addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
+                                }
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
-                                addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
                             }
 
                             is NotificationMessage.ObfuscatedMessage -> {
-                                val isAppLocked = lockCodeTimeManager.isAppLocked()
+                                if (conversation.isReplyAllowed) {
+                                    val isAppLocked = lockCodeTimeManager.isAppLocked()
+                                    addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
+                                }
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
-                                addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
                             }
 
                             is NotificationMessage.ObfuscatedKnock -> {
@@ -241,9 +248,11 @@ class MessageNotificationManager
                             }
 
                             null -> {
-                                val isAppLocked = lockCodeTimeManager.isAppLocked()
+                                if (conversation.isReplyAllowed) {
+                                    val isAppLocked = lockCodeTimeManager.isAppLocked()
+                                    addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
+                                }
                                 setContentIntent(messagePendingIntent(context, conversation.id, userIdString))
-                                addAction(getActionReply(context, conversation.id, userIdString, isAppLocked))
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/wire/android/notification/Models.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/Models.kt
@@ -29,7 +29,8 @@ data class NotificationConversation(
     val name: String?,
     val messages: List<NotificationMessage>,
     val isOneToOneConversation: Boolean,
-    val lastMessageTime: Long
+    val lastMessageTime: Long,
+    val isReplyAllowed: Boolean,
 )
 
 sealed class NotificationMessage(open val messageId: String, open val author: NotificationMessageAuthor?, open val time: Long) {
@@ -99,7 +100,8 @@ fun LocalNotification.Conversation.intoNotificationConversation(): NotificationC
         name = conversationName,
         messages = notificationMessages,
         isOneToOneConversation = isOneToOneConversation,
-        lastMessageTime = lastMessageTime
+        lastMessageTime = lastMessageTime,
+        isReplyAllowed = isReplyAllowed,
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -17,11 +17,9 @@
  */
 package com.wire.android.ui.sharing
 
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Parcelable
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -68,7 +66,6 @@ import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTim
 import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
@@ -92,7 +89,6 @@ import javax.inject.Inject
 @OptIn(FlowPreview::class)
 @Suppress("LongParameterList", "TooManyFunctions")
 class ImportMediaAuthenticatedViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val getSelf: GetSelfUserUseCase,
     private val userTypeMapper: UserTypeMapper,
     private val observeConversationListDetails: ObserveConversationListDetailsUseCase,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7425" title="WPB-7425" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7425</a>  [Android] Replying from notification to degraded conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Manual Cherry-pick of https://github.com/wireapp/wire-android/pull/3166

lets wait for disabling reply in notification for LegalHold case be merge into kalium RC too, so that feature would be full
( https://github.com/wireapp/kalium/pull/2874)