### PR TITLE
fix: avs and cc versions in new section about this app (WPB-5935)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
@@ -67,6 +67,11 @@ object TermsOfUseScreenDestination : ExternalUriStringResDirection {
         get() = R.string.url_terms_of_use_legal
 }
 
+object WireWebsiteScreenDestination : ExternalUriStringResDirection {
+    override val uriStringRes: Int
+        get() = R.string.url_wire_website
+}
+
 object GiveFeedbackDestination : IntentDirection {
     override fun intent(context: Context): Intent {
         val intent = Intent(Intent.ACTION_SEND)

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.wire.android.BuildConfig
@@ -51,7 +50,6 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.e2ei.usecase.E2EIEnrollmentResult
 import com.wire.kalium.logic.functional.Either
 import kotlinx.collections.immutable.ImmutableMap
-import kotlinx.collections.immutable.persistentMapOf
 
 @Composable
 fun DebugDataOptions(
@@ -76,7 +74,6 @@ fun DebugDataOptions(
         handleE2EIEnrollmentResult = viewModel::handleE2EIEnrollmentResult,
         dismissCertificateDialog = viewModel::dismissCertificateDialog,
         checkCrlRevocationList = viewModel::checkCrlRevocationList,
-        dependenciesMap = viewModel.state().dependencies
     )
 }
 
@@ -96,7 +93,6 @@ fun DebugDataOptionsContent(
     handleE2EIEnrollmentResult: (Either<CoreFailure, E2EIEnrollmentResult>) -> Unit,
     dismissCertificateDialog: () -> Unit,
     checkCrlRevocationList: () -> Unit,
-    dependenciesMap: ImmutableMap<String, String?>
 ) {
     Column {
 
@@ -131,7 +127,6 @@ fun DebugDataOptionsContent(
                 onClick = { onCopyText(state.commitish) }
             )
         )
-        DependenciesItem(dependenciesMap)
         if (BuildConfig.PRIVATE_BUILD) {
 
             SettingsItem(
@@ -427,29 +422,6 @@ private fun DebugToolsOptions(
     }
 }
 
-/**
- * Compose function that will display the list of dependencies
- * @param dependencies an Immutable map of a dependency name to its version number
- */
-@Composable
-fun DependenciesItem(dependencies: ImmutableMap<String, String?>) {
-    val title = stringResource(id = R.string.item_dependencies_title)
-    val text = remember {
-        prettyPrintMap(dependencies, title)
-    }
-    RowItemTemplate(
-        modifier = Modifier.wrapContentWidth(),
-        title = {
-            Text(
-                style = MaterialTheme.wireTypography.body01,
-                color = MaterialTheme.wireColorScheme.onBackground,
-                text = text,
-                modifier = Modifier.padding(start = dimensions().spacing8x)
-            )
-        }
-    )
-}
-
 @Composable
 private fun DisableEventProcessingSwitch(
     isEnabled: Boolean = false,
@@ -514,6 +486,5 @@ fun PreviewOtherDebugOptions() {
         handleE2EIEnrollmentResult = {},
         dismissCertificateDialog = {},
         checkCrlRevocationList = {},
-        dependenciesMap = persistentMapOf()
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.wire.android.BuildConfig
@@ -49,7 +48,6 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.e2ei.usecase.E2EIEnrollmentResult
 import com.wire.kalium.logic.functional.Either
-import kotlinx.collections.immutable.ImmutableMap
 
 @Composable
 fun DebugDataOptions(
@@ -450,15 +448,6 @@ private fun DisableEventProcessingSwitch(
         }
     )
 }
-
-@Stable
-private fun prettyPrintMap(map: ImmutableMap<String, String?>, title: String): String = StringBuilder().apply {
-    append("$title\n")
-    map.forEach { (key, value) ->
-        append("$key: $value\n")
-    }
-}.toString()
-
 //endregion
 
 @PreviewMultipleThemes

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsState.kt
@@ -17,9 +17,6 @@
  */
 package com.wire.android.ui.debug
 
-import kotlinx.collections.immutable.ImmutableMap
-import kotlinx.collections.immutable.persistentMapOf
-
 data class DebugDataOptionsState(
     val isEncryptedProteusStorageEnabled: Boolean = false,
     val isEventProcessingDisabled: Boolean = false,
@@ -32,5 +29,4 @@ data class DebugDataOptionsState(
     val certificate: String = "null",
     val showCertificate: Boolean = false,
     val startGettingE2EICertificate: Boolean = false,
-    val dependencies: ImmutableMap<String, String?> = persistentMapOf()
 )

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsViewModel.kt
@@ -28,7 +28,6 @@ import com.wire.android.di.CurrentAccount
 import com.wire.android.di.ScopedArgs
 import com.wire.android.di.ViewModelScopedPreview
 import com.wire.android.migration.failure.UserMigrationStatus
-import com.wire.android.util.getDependenciesVersion
 import com.wire.android.util.getDeviceIdString
 import com.wire.android.util.getGitBuildId
 import com.wire.kalium.logic.CoreFailure
@@ -44,7 +43,6 @@ import com.wire.kalium.logic.sync.periodic.UpdateApiVersionsScheduler
 import com.wire.kalium.logic.sync.slow.RestartSlowSyncProcessForRecoveryUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
@@ -87,16 +85,6 @@ class DebugDataOptionsViewModelImpl
         observeMlsMetadata()
         checkIfCanTriggerManualMigration()
         setGitHashAndDeviceId()
-        checkDependenciesVersion()
-    }
-
-    private fun checkDependenciesVersion() {
-        viewModelScope.launch {
-            val dependencies = context.getDependenciesVersion().toImmutableMap()
-            state = state.copy(
-                dependencies = dependencies
-            )
-        }
     }
 
     private fun setGitHashAndDeviceId() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
@@ -37,6 +37,7 @@ import com.wire.android.navigation.PrivacyPolicyScreenDestination
 import com.wire.android.navigation.ReportBugDestination
 import com.wire.android.navigation.SupportScreenDestination
 import com.wire.android.navigation.TermsOfUseScreenDestination
+import com.wire.android.navigation.WireWebsiteScreenDestination
 import com.wire.android.ui.common.RowItemTemplate
 import com.wire.android.ui.common.clickable
 import com.wire.android.ui.common.dimensions
@@ -45,6 +46,7 @@ import com.wire.android.ui.destinations.AppSettingsScreenDestination
 import com.wire.android.ui.destinations.AppearanceScreenDestination
 import com.wire.android.ui.destinations.BackupAndRestoreScreenDestination
 import com.wire.android.ui.destinations.DebugScreenDestination
+import com.wire.android.ui.destinations.DependenciesScreenDestination
 import com.wire.android.ui.destinations.LicensesScreenDestination
 import com.wire.android.ui.destinations.MyAccountScreenDestination
 import com.wire.android.ui.destinations.NetworkSettingsScreenDestination
@@ -156,6 +158,12 @@ sealed class SettingsItem(open val id: String, open val title: UIText) {
         direction = TermsOfUseScreenDestination
     )
 
+    data object WireWebsite : DirectionItem(
+        id = "terms_of_use",
+        title = UIText.StringResource(R.string.settings_wire_website_label),
+        direction = WireWebsiteScreenDestination
+    )
+
     data object PrivacyPolicy : DirectionItem(
         id = "privacy_policy",
         title = UIText.StringResource(R.string.settings_privacy_policy_label),
@@ -166,6 +174,12 @@ sealed class SettingsItem(open val id: String, open val title: UIText) {
         id = "other_licenses",
         title = UIText.StringResource(R.string.settings_licenses_settings_label),
         direction = LicensesScreenDestination
+    )
+
+    data object Dependencies : DirectionItem(
+        id = "other_licenses",
+        title = UIText.StringResource(R.string.settings_dependencies_label),
+        direction = DependenciesScreenDestination
     )
 
     data object BackupAndRestore : DirectionItem(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/about/dependencies/DependenciesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/about/dependencies/DependenciesScreen.kt
@@ -1,0 +1,110 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.settings.about.dependencies
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.annotation.RootNavGraph
+import com.wire.android.R
+import com.wire.android.navigation.Navigator
+import com.wire.android.ui.common.RowItemTemplate
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.scaffold.WireScaffold
+import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.immutableMapOf
+
+@Composable
+@Destination
+@RootNavGraph
+fun DependenciesScreen(
+    navigator: Navigator,
+    viewModel: DependenciesViewModel = hiltViewModel()
+) {
+    WireScaffold(topBar = {
+        WireCenterAlignedTopAppBar(
+            onNavigationPressed = navigator::navigateBack,
+            elevation = 0.dp,
+            title = stringResource(id = R.string.settings_dependencies_label)
+        )
+    }) { internalPadding ->
+        DependenciesContent(
+            internalPadding = internalPadding,
+            dependencies = viewModel.state.dependencies
+        )
+    }
+}
+
+@Composable
+private fun DependenciesContent(
+    internalPadding: PaddingValues,
+    dependencies: ImmutableMap<String, String?>,
+) {
+    val lazyListState = rememberLazyListState()
+    LazyColumn(
+        Modifier.fillMaxSize(),
+        state = lazyListState,
+        contentPadding = internalPadding
+    ) {
+        dependencies.entries.forEach {
+            item {
+                DependenciesItem(dependencyName = it.key, dependencyVersion = it.value.orEmpty())
+            }
+        }
+    }
+}
+
+@Composable
+private fun DependenciesItem(
+    dependencyName: String,
+    dependencyVersion: String
+) {
+    RowItemTemplate(
+        modifier = Modifier.wrapContentWidth(),
+        title = {
+            Text(
+                style = MaterialTheme.wireTypography.body01,
+                color = MaterialTheme.wireColorScheme.onBackground,
+                text = "${dependencyName.uppercase()}: $dependencyVersion",
+            )
+        }
+    )
+}
+
+@Composable
+@PreviewMultipleThemes
+fun DependenciesContentPreview() {
+    DependenciesContent(
+        internalPadding = PaddingValues(dimensions().spacing8x),
+        dependencies = immutableMapOf("avs" to "4.10.1", "cc" to "0.0.1")
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/about/dependencies/DependenciesState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/about/dependencies/DependenciesState.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.settings.about.dependencies
+
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentMapOf
+
+data class DependenciesState(
+    val dependencies: ImmutableMap<String, String?> = persistentMapOf()
+)

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/about/dependencies/DependenciesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/about/dependencies/DependenciesViewModel.kt
@@ -1,0 +1,51 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.settings.about.dependencies
+
+import android.content.Context
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.util.getDependenciesVersion
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.collections.immutable.toImmutableMap
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class DependenciesViewModel @Inject constructor(
+    @ApplicationContext val context: Context
+) : ViewModel() {
+
+    var state: DependenciesState by mutableStateOf(DependenciesState())
+        private set
+
+    init {
+        checkDependenciesVersion()
+    }
+
+    private fun checkDependenciesVersion() {
+        viewModelScope.launch {
+            val dependencies = context.getDependenciesVersion().toImmutableMap()
+            state = state.copy(dependencies = dependencies)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppScreen.kt
@@ -97,6 +97,16 @@ private fun AboutThisAppContent(
                 .padding(internalPadding)
         ) {
             SettingsItem(
+                text = stringResource(id = R.string.settings_wire_website_label),
+                trailingIcon = R.drawable.ic_arrow_right,
+                onRowPressed = Clickable(
+                    enabled = true,
+                    onClick = {
+                        onItemClicked(SettingsItem.WireWebsite)
+                    }
+                )
+            )
+            SettingsItem(
                 text = stringResource(id = R.string.settings_terms_of_use_label),
                 trailingIcon = R.drawable.ic_arrow_right,
                 onRowPressed = Clickable(
@@ -123,6 +133,16 @@ private fun AboutThisAppContent(
                     enabled = true,
                     onClick = {
                         onItemClicked(SettingsItem.Licenses)
+                    }
+                )
+            )
+            SettingsItem(
+                text = stringResource(id = R.string.settings_dependencies_label),
+                trailingIcon = R.drawable.ic_arrow_right,
+                onRowPressed = Clickable(
+                    enabled = true,
+                    onClick = {
+                        onItemClicked(SettingsItem.Dependencies)
                     }
                 )
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
     <string name="url_android_release_notes_feed" translatable="false">https://medium.com/feed/wire-news/tagged/android</string>
     <string name="url_maps_location_coordinates_fallback" translatable="false">http://maps.google.com/maps?z=%1d&amp;q=loc:%2f+%2f</string>
     <!-- Wire Urls - Non translatable -->
+    <string name="url_wire_website" translatable="false">https://www.wire.com</string>
     <string name="url_support" translatable="false">https://support.wire.com</string>
     <string name="url_terms_of_use_legal" translatable="false">https://wire.com/legal</string>
     <string name="url_privacy_policy" translatable="false">https://wire.com/privacy-policy#:~:text=We%20process%20individual%20data%20about,%C2%A7%201%20a)%20GDPR).</string>
@@ -211,6 +212,7 @@
     <string name="about_app_screen_title">About This App</string>
     <string name="settings_privacy_policy_label">Privacy Policy</string>
     <string name="settings_terms_of_use_label">Legal</string>
+    <string name="settings_wire_website_label">Wire Website</string>
     <string name="label_copyright">Copyright</string>
     <string translatable="false" name="label_copyright_value">© Wire Swiss GmbH</string>
     <string name="debug_settings_screen_title">Debug Settings</string>
@@ -1302,6 +1304,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="notification_obfuscated_message_title">Someone</string>
     <string name="notification_obfuscated_message_content">Sent a self-deleting message</string>
     <string name="settings_licenses_settings_label">License Information</string>
+    <string name="settings_dependencies_label">Dependencies</string>
     <string name="settings_myaccount_logout">Delete Account</string>
     <string name="app_not_found_for_action">No Application has been found to do Action</string>
     <string name="delete_acount_dialog_title">Delete Account</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5935" title="WPB-5935" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-5935</a>  [Android] AVS version should be shown in the UI for better transparency
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to provide versions of AVS and CC in the app.

### Causes (Optional)

New design specs

### Solutions

- Implement accordingly to new specs from Figma
- Add new section "wire website"

### Attachments (Optional)

<img src="https://github.com/user-attachments/assets/b93005dd-18fd-4925-a835-a38fa943cd84" width="300"/>

<img src="https://github.com/user-attachments/assets/84f63db5-bd51-47e7-9e01-8c8e9194ddce" width="300"/>


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
