### PR TITLE
fix: flickering call other participants video (WPB-9617)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
@@ -174,7 +175,7 @@ class SharedCallingViewModel @AssistedInject constructor(
     }
 
     private suspend fun observeParticipants(sharedFlow: SharedFlow<Call?>) {
-        sharedFlow.collect { call ->
+        sharedFlow.distinctUntilChanged().collectLatest { call ->
             call?.let {
                 callState = callState.copy(
                     isMuted = it.isMuted,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,8 +46,8 @@ androidx-compose-runtime = "1.6.7"
 
 # Compose
 composeBom = "2024.06.00"
-compose-foundation = "1.7.0-beta04" # remove when composeBom contains new stable version of BasicTextField2
-compose-material-android = "1.7.0-beta04" # remove when composeBom contains new stable version of BasicTextField2
+compose-foundation = "1.7.0-beta05" # remove when composeBom contains new stable version of BasicTextField2
+compose-material-android = "1.7.0-beta05" # remove when composeBom contains new stable version of BasicTextField2
 compose-activity = "1.9.0"
 compose-compiler = "1.5.11"
 compose-constraint = "1.0.1"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

TL;DR; This PR https://github.com/wireapp/wire-android/pull/3034 upgraded the compose libraries to beta01. That had an unintended side effect with `AndroidView` component that we use for rendering other participants video streams.


#### A long story of debugging and side effects.
After checking recompositions and validating that these were skipped, as well, validating the code visually. I checked for the latest working version, this being initially (4.6.4) previous prod.

The candidates that could have introduced the bug were:
- https://github.com/wireapp/wire-android/pull/2882
- https://github.com/wireapp/wire-android/pull/2988

And no clue after those were ok, so checking with @ohassine the idea came to validate for dependencies changes. We stumbled upon the PR with the regression, this by validating installing and updating old Apks.

- https://github.com/wireapp/wire-android/pull/3034

The issue was no present in `1.7.0-alpha05` but it is from `1.7.0-beta01` to `1.7.0-beta04`.
The fix is present in the latest version `1.7.0-beta05` https://developer.android.com/jetpack/androidx/releases/compose-ui#1.7.0-beta05

### Causes (Optional)

Regression in the compose dependency.

### Solutions

Bump to the newest version, and also avoid unnecessary collection of the flow emissions for call state (not related, but efficient improvement)

### Testing

Tested manually after version bump.

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
