### PR TITLE
fix: "All Android Release Notes" item is not clickable - 🍒 v4.7 [WPB-10125]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/RowItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/RowItem.kt
@@ -32,7 +32,6 @@ import com.wire.android.ui.common.SurfaceBackgroundWrapper
 import com.wire.android.ui.common.clickable
 import com.wire.android.ui.theme.wireDimensions
 
-// TODO: added onRowClick only for UI-Design purpose
 @Composable
 fun RowItem(
     clickable: Clickable,
@@ -45,10 +44,13 @@ fun RowItem(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier
-                .defaultMinSize(minHeight = MaterialTheme.wireDimensions.conversationItemRowHeight)
-                .fillMaxWidth()
+            modifier = Modifier
                 .clickable(clickable)
+                .then(
+                    modifier
+                        .defaultMinSize(minHeight = MaterialTheme.wireDimensions.conversationItemRowHeight)
+                        .fillMaxWidth()
+                )
         ) {
             content()
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewItem.kt
@@ -47,6 +47,7 @@ import com.wire.android.util.ui.UIText
 
 @Composable
 fun WhatsNewItem(
+    modifier: Modifier = Modifier,
     title: String? = null,
     boldTitle: Boolean = false,
     text: String? = null,
@@ -93,7 +94,7 @@ fun WhatsNewItem(
             } ?: Icons.Filled.ChevronRight
         },
         clickable = onRowPressed,
-        modifier = Modifier.padding(vertical = dimensions().spacing4x)
+        modifier = modifier.padding(vertical = dimensions().spacing4x)
     )
 }
 
@@ -110,8 +111,10 @@ sealed class WhatsNewItem(
         direction = WelcomeToNewAndroidAppDestination
     )
 
-    data object AllAndroidReleaseNotes : WhatsNewItem(
-        id = "android_release_notes",
+    data class AllAndroidReleaseNotes(
+        override val id: String = "android_release_notes"
+    ) : WhatsNewItem(
+        id = id,
         title = UIText.StringResource(R.string.whats_new_android_release_notes_label),
         direction = AndroidReleaseNotesDestination
     )
@@ -119,8 +122,8 @@ sealed class WhatsNewItem(
     data class AndroidReleaseNotes(
         override val id: String,
         override val title: UIText,
-        override val boldTitle: Boolean,
-        override val text: UIText?,
+        override val boldTitle: Boolean = false,
+        override val text: UIText? = null,
         val url: String
     ) : WhatsNewItem(
         id = id,
@@ -141,7 +144,9 @@ fun PreviewFileRestrictionDialog() {
         WhatsNewItem(
             title = "What's new item",
             text = "This is the text of the item",
-            trailingIcon = R.drawable.ic_arrow_right
+            trailingIcon = R.drawable.ic_arrow_right,
+            isLoading = false,
+            onRowPressed = Clickable(enabled = true) {}
         )
     }
 }
@@ -155,6 +160,7 @@ fun PreviewFileRestrictionDialogLoading() {
             text = "This is the text of the item",
             trailingIcon = R.drawable.ic_arrow_right,
             isLoading = true,
+            onRowPressed = Clickable(enabled = false) {}
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewScreen.kt
@@ -65,13 +65,14 @@ fun WhatsNewScreen(
 @Composable
 fun WhatsNewScreenContent(
     state: WhatsNewState,
-    lazyListState: LazyListState = rememberLazyListState(),
-    onItemClicked: (WhatsNewItem) -> Unit
+    onItemClicked: (WhatsNewItem) -> Unit,
+    modifier: Modifier = Modifier,
+    lazyListState: LazyListState = rememberLazyListState()
 ) {
     val context = LocalContext.current
     LazyColumn(
         state = lazyListState,
-        modifier = Modifier.fillMaxSize()
+        modifier = modifier.fillMaxSize()
     ) {
         folderWithElements(
             items = buildList {
@@ -85,6 +86,7 @@ fun WhatsNewScreenContent(
             header = context.getString(R.string.whats_new_release_notes_group_title),
             items = buildList {
                 if (state.isLoading) {
+                    // placeholders with shimmer effect
                     for (i in 0..3) {
                         add(
                             WhatsNewItem.AndroidReleaseNotes(
@@ -96,6 +98,7 @@ fun WhatsNewScreenContent(
                             )
                         )
                     }
+                    add(WhatsNewItem.AllAndroidReleaseNotes(id = "placeholder_all"))
                 } else {
                     state.releaseNotesItems.forEach {
                         add(
@@ -108,8 +111,8 @@ fun WhatsNewScreenContent(
                             )
                         )
                     }
+                    add(WhatsNewItem.AllAndroidReleaseNotes())
                 }
-                add(WhatsNewItem.AllAndroidReleaseNotes)
             },
             onItemClicked = onItemClicked,
             isLoading = state.isLoading,
@@ -131,7 +134,7 @@ private fun LazyListScope.folderWithElements(
             title = item.title.asString(),
             boldTitle = item.boldTitle,
             text = item.text?.asString(),
-            onRowPressed = remember { Clickable(enabled = !isLoading) { onItemClicked(item) } },
+            onRowPressed = remember(isLoading) { Clickable(enabled = !isLoading) { onItemClicked(item) } },
             trailingIcon = R.drawable.ic_arrow_right,
             isLoading = isLoading,
         )
@@ -141,11 +144,24 @@ private fun LazyListScope.folderWithElements(
 @Preview(showBackground = false)
 @Composable
 fun PreviewWhatsNewScreen() {
-    WhatsNewScreenContent(WhatsNewState(isLoading = false)) {}
+    WhatsNewScreenContent(
+        state = WhatsNewState(
+            isLoading = false,
+            releaseNotesItems = buildList {
+                for (i in 0..3) {
+                    add(ReleaseNotesItem(i.toString(), "Title $i", "https://www.example.com", "01 Jan 2024"))
+                }
+            }
+        ),
+        onItemClicked = {}
+    )
 }
 
 @Preview(showBackground = false)
 @Composable
 fun PreviewWhatsNewScreenLoading() {
-    WhatsNewScreenContent(WhatsNewState(isLoading = true)) {}
+    WhatsNewScreenContent(
+        state = WhatsNewState(isLoading = true),
+        onItemClicked = {}
+    )
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10125" title="WPB-10125" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10125</a>  [Android] "All Android Release notes" under Android Release notes not clickable on graphene
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Manual cherry-pick for v4.7 of this one: https://github.com/wireapp/wire-android/pull/3187

### Issues

"All Android Release Notes" item on "What's new" screen is not clickable.

### Solutions

Added key to `remember` to update `Clickable` to be enabled for items after loading. 
Added this "All Android Release Notes" item with different id for the placeholder so that it doesn't jump to the bottom after loading is finished. 
Handled errors when fetching or parsing RSS feed simply by returning empty release notes list.
Fixed clickable area for `RowItem` so that even if any padding is applied, the click indication will always be shown for the whole row.
Also, fixed `DependenciesScreen` to be annotated with new `@WireDestination` instead of `@Destination`.

### Testing

#### How to Test

Open "What's new" section and try to click on "All Android Release Notes".

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
