### PR TITLE
fix: user logged out listener [WPB-10114]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -84,7 +84,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -204,7 +203,7 @@ class WireActivityViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             currentSessionFlow.get().invoke()
                 .distinctUntilChanged()
-                .collectLatest {
+                .collect {
                     if (it is CurrentSessionResult.Success) {
                         if (it.accountInfo.isValid().not()) {
                             handleInvalidSession((it.accountInfo as AccountInfo.Invalid).logoutReason)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -84,13 +84,13 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -131,13 +131,6 @@ class WireActivityViewModel @Inject constructor(
     private val userIdDeferred: Deferred<UserId?> = viewModelScope.async(dispatchers.io()) {
         currentSessionFlow.get().invoke()
             .distinctUntilChanged()
-            .onEach {
-                if (it is CurrentSessionResult.Success) {
-                    if (it.accountInfo.isValid().not()) {
-                        handleInvalidSession((it.accountInfo as AccountInfo.Invalid).logoutReason)
-                    }
-                }
-            }
             .map { result ->
                 if (result is CurrentSessionResult.Success) {
                     if (result.accountInfo.isValid()) {
@@ -160,6 +153,7 @@ class WireActivityViewModel @Inject constructor(
         observeNewClientState()
         observeScreenshotCensoringConfigState()
         observeAppThemeState()
+        observeLogoutState()
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -203,6 +197,20 @@ class WireActivityViewModel @Inject constructor(
             } catch (e: NullPointerException) {
                 appLogger.e("Error while observing sync state: $e")
             }
+        }
+    }
+
+    private fun observeLogoutState() {
+        viewModelScope.launch(dispatchers.io()) {
+            currentSessionFlow.get().invoke()
+                .distinctUntilChanged()
+                .collectLatest {
+                    if (it is CurrentSessionResult.Success) {
+                        if (it.accountInfo.isValid().not()) {
+                            handleInvalidSession((it.accountInfo as AccountInfo.Invalid).logoutReason)
+                        }
+                    }
+                }
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10114" title="WPB-10114" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10114</a>  [Android] Alerts for forcing user to log out are not displayed anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Listener responsible for observing logout state is triggered only once

### Causes (Optional)

When current user device get's removed from another client it doesn't show proper dialog and user is stuck on connecting

### Solutions

Instead of updating logout state dialog by side effect, move it to separate observer to listen only this change without taking only first event (`.first()`) 
