### PR TITLE
fix: multiline topbar title not centered [WPB-9608]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/WireCenterAlignedTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/WireCenterAlignedTopAppBar.kt
@@ -121,6 +121,7 @@ fun WireTopAppBarTitle(
     maxLines: Int = 2
 ) {
     // There's an ongoing issue about multiline text taking all width available instead of wrapping visible text.
+    // https://issuetracker.google.com/issues/206039942
     // It's very noticeable on TopAppBar because due to that issue, the title is not centered, even if there are large enough empty spaces
     // on both sides and all lines of text are actually shorter and could fit at the center.
     // This workaround is based on this: https://stackoverflow.com/a/69947555, but instead of using SubcomposeLayout, we just measure text.

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/WireCenterAlignedTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/WireCenterAlignedTopAppBar.kt
@@ -18,10 +18,13 @@
 
 package com.wire.android.ui.common.topappbar
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -30,16 +33,25 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.PreviewMultipleThemes
+import kotlin.math.ceil
 
 @Composable
 fun WireCenterAlignedTopAppBar(
     title: String,
+    modifier: Modifier = Modifier,
     titleStyle: TextStyle = MaterialTheme.wireTypography.title01,
     maxLines: Int = 2,
     subtitleContent: @Composable ColumnScope.() -> Unit = {},
@@ -47,7 +59,6 @@ fun WireCenterAlignedTopAppBar(
     navigationIconType: NavigationIconType? = NavigationIconType.Back,
     elevation: Dp = MaterialTheme.wireDimensions.topBarShadowElevation,
     actions: @Composable RowScope.() -> Unit = {},
-    modifier: Modifier = Modifier,
     bottomContent: @Composable ColumnScope.() -> Unit = {}
 ) {
     WireCenterAlignedTopAppBar(
@@ -72,12 +83,12 @@ fun WireCenterAlignedTopAppBar(
 @Composable
 fun WireCenterAlignedTopAppBar(
     titleContent: @Composable ColumnScope.() -> Unit,
+    modifier: Modifier = Modifier,
     subtitleContent: @Composable ColumnScope.() -> Unit = {},
     onNavigationPressed: () -> Unit = {},
     navigationIconType: NavigationIconType? = NavigationIconType.Back,
     elevation: Dp = MaterialTheme.wireDimensions.topBarShadowElevation,
     actions: @Composable RowScope.() -> Unit = {},
-    modifier: Modifier = Modifier,
     bottomContent: @Composable ColumnScope.() -> Unit = {}
 ) {
     Surface(
@@ -106,16 +117,75 @@ fun WireCenterAlignedTopAppBar(
 fun WireTopAppBarTitle(
     title: String,
     style: TextStyle,
+    modifier: Modifier = Modifier,
     maxLines: Int = 2
 ) {
-    Text(
-        modifier = Modifier.padding(
-            start = dimensions().spacing6x,
-            end = dimensions().spacing6x
-        ),
-        text = title,
-        style = style,
-        maxLines = maxLines,
-        overflow = TextOverflow.Ellipsis
-    )
+    // There's an ongoing issue about multiline text taking all width available instead of wrapping visible text.
+    // It's very noticeable on TopAppBar because due to that issue, the title is not centered, even if there are large enough empty spaces
+    // on both sides and all lines of text are actually shorter and could fit at the center.
+    // This workaround is based on this: https://stackoverflow.com/a/69947555, but instead of using SubcomposeLayout, we just measure text.
+    BoxWithConstraints(
+        modifier = modifier
+    ) {
+        val textMeasurer = rememberTextMeasurer()
+        val textLayoutResult: TextLayoutResult = textMeasurer.measure(
+            text = title,
+            style = style,
+            maxLines = maxLines,
+            overflow = TextOverflow.Ellipsis,
+            constraints = Constraints(
+                minWidth = 0,
+                minHeight = 0,
+                maxWidth = constraints.maxWidth,
+                maxHeight = constraints.maxHeight
+            )
+        )
+        val width = with(LocalDensity.current) {
+            (0 until textLayoutResult.lineCount).maxOf { line ->
+                ceil(textLayoutResult.getLineRight(line) - textLayoutResult.getLineLeft(line)).toInt()
+            }.toDp()
+        }
+        Text(
+            modifier = Modifier
+                .padding(horizontal = dimensions().spacing6x)
+                .width(width),
+            text = title,
+            style = style,
+            maxLines = maxLines,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewWireCenterAlignedTopAppBarWithDefaultTitle() = WireTheme {
+    Box(modifier = Modifier.width(400.dp)) {
+        WireCenterAlignedTopAppBar(
+            title = "This is title",
+            titleStyle = MaterialTheme.wireTypography.title01
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewWireCenterAlignedTopAppBarWithDefaultTwoLinesTitle() = WireTheme {
+    Box(modifier = Modifier.width(400.dp)) {
+        WireCenterAlignedTopAppBar(
+            title = "This is title is very long this_is_a_very_long_word",
+            titleStyle = MaterialTheme.wireTypography.title01
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewWireCenterAlignedTopAppBarWithDefaultTwoLinesTooLongTitle() = WireTheme {
+    Box(modifier = Modifier.width(400.dp)) {
+        WireCenterAlignedTopAppBar(
+            title = "This is title is even longer than previous one this_is_a_very_long_word",
+            titleStyle = MaterialTheme.wireTypography.title01
+        )
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9608" title="WPB-9608" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9608</a>  [Android] Heading of own devices not centralised anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Top bar title is not centered when it has two lines of text.

### Causes (Optional)

There's an ongoing issue about multiline text taking all width available instead of wrapping visible text.
https://issuetracker.google.com/issues/206039942

### Solutions

This workaround is based on this: https://stackoverflow.com/a/69947555, but instead of using `SubcomposeLayout`, we just first measure the text, check the length of each line of text, choose the longest and set it as the width of the `Text` composable.

### Testing

#### How to Test

Open the screen where title takes more than one line of text, usually device details where device name is long enough to take two lines.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <img width="400" alt="title_before" src="https://github.com/user-attachments/assets/ac3a4ed5-7ba0-48da-b932-516a185e7234"> | <img width="400" alt="title_after" src="https://github.com/user-attachments/assets/66c15d59-7be8-48b4-8ce9-18c3db015a97"> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
