### PR TITLE
refactor: use proper ids for notifications ids (improvement) (WPB-9965)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationManager.kt
@@ -40,6 +40,7 @@ import com.wire.android.migration.feature.MigrateServerConfigUseCase
 import com.wire.android.migration.feature.MigrateUsersUseCase
 import com.wire.android.migration.util.ScalaDBNameProvider
 import com.wire.android.notification.NotificationConstants
+import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.openAppPendingIntent
 import com.wire.android.notification.openMigrationLoginPendingIntent
 import com.wire.android.util.EMPTY
@@ -95,6 +96,7 @@ class MigrationManager @Inject constructor(
             .getDatabasePath(ScalaDBNameProvider.globalDB())
             .let { it.isFile && it.exists() }
     }
+
     suspend fun shouldMigrate(): Boolean = when {
         // already migrated
         globalDataStore.isMigrationCompleted() -> false
@@ -316,7 +318,7 @@ class MigrationManager @Inject constructor(
             .setPriority(NotificationCompat.PRIORITY_MAX)
             .setContentIntent(pendingIntent)
             .build()
-        notificationManager.notify(NotificationConstants.MIGRATION_ERROR_NOTIFICATION_ID, notification)
+        notificationManager.notify(NotificationIds.MIGRATION_ERROR_NOTIFICATION_ID.ordinal, notification)
     }
 
     private fun showAccountAnyNotification() {
@@ -338,7 +340,7 @@ class MigrationManager @Inject constructor(
     }
 
     fun dismissMigrationFailureNotification() {
-        notificationManager.cancel(NotificationConstants.MIGRATION_ERROR_NOTIFICATION_ID)
+        notificationManager.cancel(NotificationIds.MIGRATION_ERROR_NOTIFICATION_ID.ordinal)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
@@ -146,12 +146,12 @@ class CallNotificationManager @Inject constructor(
         // cancelling vibration as probably when we were cancelling, the vibration object was still being created and started and thus
         // never stopped.
         TimeUnit.MILLISECONDS.sleep(CANCEL_CALL_NOTIFICATION_DELAY)
-        notificationManager.cancel(NotificationConstants.CALL_INCOMING_NOTIFICATION_ID)
+        notificationManager.cancel(NotificationIds.CALL_INCOMING_NOTIFICATION_ID.ordinal)
     }
 
     private fun hideOutgoingCallNotification() {
         appLogger.i("$TAG: hiding outgoing call")
-        notificationManager.cancel(NotificationConstants.CALL_OUTGOING_NOTIFICATION_ID)
+        notificationManager.cancel(NotificationIds.CALL_OUTGOING_NOTIFICATION_ID.ordinal)
     }
 
     @SuppressLint("MissingPermission")
@@ -160,7 +160,7 @@ class CallNotificationManager @Inject constructor(
         appLogger.i("$TAG: showing incoming call notification for user ${data.userId.toLogString()}")
         val notification = builder.getIncomingCallNotification(data)
         notificationManager.notify(
-            NotificationConstants.CALL_INCOMING_NOTIFICATION_ID,
+            NotificationIds.CALL_INCOMING_NOTIFICATION_ID.ordinal,
             notification
         )
     }
@@ -171,7 +171,7 @@ class CallNotificationManager @Inject constructor(
         appLogger.i("$TAG: showing outgoing call notification for user ${data.userId.toLogString()}")
         val notification = builder.getOutgoingCallNotification(data)
         notificationManager.notify(
-            NotificationConstants.CALL_OUTGOING_NOTIFICATION_ID,
+            NotificationIds.CALL_OUTGOING_NOTIFICATION_ID.ordinal,
             notification
         )
     }
@@ -186,7 +186,7 @@ class CallNotificationManager @Inject constructor(
         internal const val DEBOUNCE_TIME = 200L
 
         fun hideIncomingCallNotification(context: Context) {
-            NotificationManagerCompat.from(context).cancel(NotificationConstants.CALL_INCOMING_NOTIFICATION_ID)
+            NotificationManagerCompat.from(context).cancel(NotificationIds.CALL_INCOMING_NOTIFICATION_ID.ordinal)
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationConstants.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationConstants.kt
@@ -49,16 +49,6 @@ object NotificationConstants {
 
     private const val CHANNEL_GROUP_ID_PREFIX = "com.wire.notification_channel_group"
 
-    // Notification IDs (has to be unique!)
-    val CALL_INCOMING_NOTIFICATION_ID = "wire_incoming_call_notification".hashCode()
-    val CALL_OUTGOING_NOTIFICATION_ID = "wire_outgoing_call_notification".hashCode()
-    val CALL_ONGOING_NOTIFICATION_ID = "wire_ongoing_call_notification".hashCode()
-    val PERSISTENT_NOTIFICATION_ID = "wire_persistent_web_socket_notification".hashCode()
-    val MESSAGE_SYNC_NOTIFICATION_ID = "wire_notification_fetch_notification".hashCode()
-    val MIGRATION_NOTIFICATION_ID = "wire_migration_notification".hashCode()
-    val SINGLE_USER_MIGRATION_NOTIFICATION_ID = "wire_single_user_migration_notification".hashCode()
-    val MIGRATION_ERROR_NOTIFICATION_ID = "wire_migration_error_notification".hashCode()
-
     // MessagesSummaryNotification ID depends on User, use fun getMessagesSummaryId(userId: UserId) to get it
     private const val MESSAGE_SUMMARY_ID_STRING = "wire_messages_summary_notification"
 
@@ -78,4 +68,16 @@ object NotificationConstants {
      * one of [NotificationConstants.INCOMING_CALL_CHANNEL_ID], [NotificationConstants.MESSAGE_CHANNEL_ID].
      */
     private fun getChanelIdForUser(userId: UserId, channelIdPrefix: String): String = "$channelIdPrefix.$userId"
+}
+
+// Notification IDs (has to be unique!)
+enum class NotificationIds {
+    CALL_INCOMING_NOTIFICATION_ID,
+    CALL_OUTGOING_NOTIFICATION_ID,
+    CALL_ONGOING_NOTIFICATION_ID,
+    PERSISTENT_NOTIFICATION_ID,
+    MESSAGE_SYNC_NOTIFICATION_ID,
+    MIGRATION_NOTIFICATION_ID,
+    SINGLE_USER_MIGRATION_NOTIFICATION_ID,
+    MIGRATION_ERROR_NOTIFICATION_ID
 }

--- a/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/OngoingCallService.kt
@@ -30,7 +30,7 @@ import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.NoSession
 import com.wire.android.notification.CallNotificationData
 import com.wire.android.notification.CallNotificationManager
-import com.wire.android.notification.NotificationConstants.CALL_ONGOING_NOTIFICATION_ID
+import com.wire.android.notification.NotificationIds
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
@@ -138,7 +138,7 @@ class OngoingCallService : Service() {
         val notification: Notification = callNotificationManager.builder.getOngoingCallNotification(data)
         ServiceCompat.startForeground(
             this,
-            CALL_ONGOING_NOTIFICATION_ID,
+            NotificationIds.CALL_ONGOING_NOTIFICATION_ID.ordinal,
             notification,
             ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
         )
@@ -152,7 +152,7 @@ class OngoingCallService : Service() {
             callNotificationManager.builder.getOngoingCallPlaceholderNotification()
         ServiceCompat.startForeground(
             this,
-            CALL_ONGOING_NOTIFICATION_ID,
+            NotificationIds.CALL_ONGOING_NOTIFICATION_ID.ordinal,
             notification,
             ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
         )

--- a/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
@@ -31,9 +31,9 @@ import com.wire.android.appLogger
 import com.wire.android.di.CurrentSessionFlowService
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.notification.NotificationChannelsManager
-import com.wire.android.notification.NotificationConstants.PERSISTENT_NOTIFICATION_ID
 import com.wire.android.notification.NotificationConstants.WEB_SOCKET_CHANNEL_ID
 import com.wire.android.notification.NotificationConstants.WEB_SOCKET_CHANNEL_NAME
+import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.WireNotificationManager
 import com.wire.android.notification.openAppPendingIntent
 import com.wire.android.util.dispatchers.DispatcherProvider
@@ -129,7 +129,12 @@ class PersistentWebSocketService : Service() {
             .setOngoing(true)
             .build()
 
-        ServiceCompat.startForeground(this, PERSISTENT_NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
+        ServiceCompat.startForeground(
+            this,
+            NotificationIds.PERSISTENT_NOTIFICATION_ID.ordinal,
+            notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+        )
     }
 
     override fun onDestroy() {

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/MigrationWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/MigrationWorker.kt
@@ -43,6 +43,7 @@ import com.wire.android.migration.getMigrationProgress
 import com.wire.android.migration.toData
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants
+import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.openAppPendingIntent
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -92,7 +93,7 @@ class MigrationWorker
             .setContentIntent(openAppPendingIntent(applicationContext))
             .build()
 
-        return ForegroundInfo(NotificationConstants.MIGRATION_NOTIFICATION_ID, notification)
+        return ForegroundInfo(NotificationIds.MIGRATION_NOTIFICATION_ID.ordinal, notification)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
@@ -27,6 +27,7 @@ import androidx.work.WorkerParameters
 import com.wire.android.R
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants
+import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.WireNotificationManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -69,6 +70,6 @@ class NotificationFetchWorker
             .setPriority(NotificationCompat.PRIORITY_MIN)
             .build()
 
-        return ForegroundInfo(NotificationConstants.MESSAGE_SYNC_NOTIFICATION_ID, notification)
+        return ForegroundInfo(NotificationIds.MESSAGE_SYNC_NOTIFICATION_ID.ordinal, notification)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/SingleUserMigrationWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/SingleUserMigrationWorker.kt
@@ -41,6 +41,7 @@ import com.wire.android.migration.getMigrationProgress
 import com.wire.android.migration.toData
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants
+import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.openAppPendingIntent
 import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
 import com.wire.kalium.logic.data.user.UserId
@@ -93,7 +94,7 @@ class SingleUserMigrationWorker @AssistedInject constructor(
             .setContentIntent(openAppPendingIntent(applicationContext))
             .build()
 
-        return ForegroundInfo(NotificationConstants.SINGLE_USER_MIGRATION_NOTIFICATION_ID, notification)
+        return ForegroundInfo(NotificationIds.SINGLE_USER_MIGRATION_NOTIFICATION_ID.ordinal, notification)
     }
 
     companion object {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9965" title="WPB-9965" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9965</a>  [Android] Can not interact with second incoming call while being in a call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are using `hashCode` for some notifications ids that must be unique, even though most likely there are no collisions, there is NO warranty that we are going to get unique ids for different objects.

### Solutions

For static notifications, ids (not generated by dynamic parameters) use an `Enum.ordinal` instead, so we will have some certainties

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
