### PR TITLE
fix: empty backup file name [WPB-10210]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/permission/IntentPermissionsRequestFlow.kt
+++ b/app/src/main/kotlin/com/wire/android/util/permission/IntentPermissionsRequestFlow.kt
@@ -52,6 +52,7 @@ fun <P, T> rememberCheckPermissionsAndLaunchIntentRequestFlow(
         }
 
     return rememberCheckPermissionsRequestFlow(
+        key = input,
         permissions = requiredPermissions,
         onAllPermissionsGranted = {
             try {

--- a/app/src/main/kotlin/com/wire/android/util/permission/PermissionsRequestFlow.kt
+++ b/app/src/main/kotlin/com/wire/android/util/permission/PermissionsRequestFlow.kt
@@ -39,7 +39,8 @@ fun rememberCheckPermissionsRequestFlow(
     permissions: Array<String>,
     onAllPermissionsGranted: () -> Unit,
     onAnyPermissionDenied: () -> Unit,
-    onAnyPermissionPermanentlyDenied: () -> Unit
+    onAnyPermissionPermanentlyDenied: () -> Unit,
+    key: Any? = null
 ): RequestLauncher {
     val context = LocalContext.current
 
@@ -62,7 +63,7 @@ fun rememberCheckPermissionsRequestFlow(
             }
         }
 
-    return remember {
+    return remember(key) {
         RequestLauncher {
             when {
                 permissions.isEmpty() -> onAllPermissionsGranted()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10210" title="WPB-10210" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10210</a>  [Android] When saving a backup, we do not show the backup name anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When create dialog is showed there is empty file name, because it's created after creating backup. Because of that `rememberCheckPermissionsRequestFlow` is only composed at start with empty value and it's not recomposing after file name is updated.

### Causes (Optional)

Empty file name when user wants to save a backup

### Solutions

Add key to `rememberCheckPermissionsRequestFlow` to recompose it when file name will change

