### PR TITLE
chore: wait for isSelfATeamMember when setting up Analytics - (WPB-8978)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -195,6 +195,7 @@ class WireApplication : BaseApp() {
         val analyticsResultFlow = ObserveCurrentSessionAnalyticsUseCase(
             currentSessionFlow = coreLogic.get().getGlobalScope().session.currentSessionFlow(),
             isUserTeamMember = {
+                coreLogic.get().getSessionScope(it).syncManager.waitUntilLive()
                 coreLogic.get().getSessionScope(it).team.isSelfATeamMember()
             },
             observeAnalyticsTrackingIdentifierStatusFlow = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8978" title="WPB-8978" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8978</a>  [Android] Countly analytics ID and user properties
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

With our last implementation of Analytics and setting user profile, we needed to set if user is a team member

### Causes (Optional)

The way we were getting the value it was getting the default value (false) and not properly waiting for its updated value.

### Solutions

Use waitUntilLive() from syncManager to wait until we have the proper value for this property

### Dependencies (Optional)

Needs releases with:

- [X] #3226 

### Testing

#### How to Test

- Open App
- Login
- Wait until sync is done
- Verify your analytics ID against our analytics dashboard and that the user custom properties is set with the correct value