### PR TITLE
fix: add loading screen when importing asset (WPB-10217)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/FeatureFlagState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/FeatureFlagState.kt
@@ -24,7 +24,7 @@ import kotlin.time.Duration
 
 data class FeatureFlagState(
     val showFileSharingDialog: Boolean = false,
-    val isFileSharingState: FileSharingState = FileSharingState.NoUser,
+    val isFileSharingState: FileSharingState = FileSharingState.Loading,
     val shouldShowGuestRoomLinkDialog: Boolean = false,
     val shouldShowE2eiCertificateRevokedDialog: Boolean = false,
     val shouldShowTeamAppLockDialog: Boolean = false,
@@ -42,6 +42,7 @@ data class FeatureFlagState(
 ) {
 
     sealed interface FileSharingState {
+        data object Loading : FileSharingState
         data object NoUser : FileSharingState
         data object AllowAll : FileSharingState
         data class AllowSome(val allowedList: List<String>) : FileSharingState

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -15,6 +15,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+
+@file:Suppress("TooManyFunctions")
+
 package com.wire.android.ui.sharing
 
 import androidx.activity.compose.BackHandler

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -87,6 +87,7 @@ import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
 import com.wire.android.ui.home.newconversation.common.SendContentButton
 import com.wire.android.ui.home.sync.FeatureFlagNotificationViewModel
 import com.wire.android.ui.theme.WireTheme
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.extension.getActivity
@@ -111,6 +112,11 @@ fun ImportMediaScreen(
     featureFlagNotificationViewModel: FeatureFlagNotificationViewModel = hiltViewModel(),
 ) {
     when (val fileSharingRestrictedState = featureFlagNotificationViewModel.featureFlagState.isFileSharingState) {
+        FeatureFlagState.FileSharingState.Loading -> {
+            ImportMediaLoadingContent(
+                navigateBack = navigator.finish
+            )
+        }
         FeatureFlagState.FileSharingState.NoUser -> {
             ImportMediaLoggedOutContent(
                 fileSharingRestrictedState = fileSharingRestrictedState,
@@ -132,6 +138,37 @@ fun ImportMediaScreen(
     }
 
     BackHandler { navigator.finish() }
+}
+
+@Composable
+private fun ImportMediaLoadingContent(navigateBack: () -> Unit) {
+    WireScaffold(
+        topBar = {
+            WireCenterAlignedTopAppBar(
+                elevation = dimensions().spacing0x,
+                onNavigationPressed = navigateBack,
+                navigationIconType = NavigationIconType.Close,
+                title = stringResource(id = R.string.import_media_content_title),
+            )
+        },
+        modifier = Modifier.background(colorsScheme().background),
+        content = { internalPadding ->
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(internalPadding)
+                    .padding(horizontal = dimensions().spacing48x)
+            ) {
+                WireCircularProgressIndicator(
+                    progressColor = MaterialTheme.wireColorScheme.onSurface,
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                    size = dimensions().spacing32x
+                )
+            }
+        }
+    )
 }
 
 @Composable


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10217" title="WPB-10217" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10217</a>  [Android] App stays on login page for a second when sharing image from galery
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When sharing an asset from the Gallery/Files and the app was previously closed, it would show a screen for the user to login for a split second even though the user was logged in.

### Causes (Optional)

There was no state for loading while we fetch current logged in user.

### Solutions

Add a new state for `Loading` in `FeatureFlagState.FileSharingState` so it can display the default loading screen for the split second.

### Testing

#### How to Test

- Open app login(be logged in)
- Kill the app
- Go to gallery and select an image to share
- Select wire app
- If you device is a bit slow you will notice the loading screen

### Attachments (Optional)

<img src="https://github.com/user-attachments/assets/0555f629-781d-475f-9c66-3019e22812ee" width="200" height="400" alt="Loading Screen" />
