### PR TITLE
fix: Analytics crashing on second account removed (WPB-8978)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -195,7 +195,6 @@ class WireApplication : BaseApp() {
         val analyticsResultFlow = ObserveCurrentSessionAnalyticsUseCase(
             currentSessionFlow = coreLogic.get().getGlobalScope().session.currentSessionFlow(),
             isUserTeamMember = {
-                coreLogic.get().getSessionScope(it).syncManager.waitUntilLive()
                 coreLogic.get().getSessionScope(it).team.isSelfATeamMember()
             },
             observeAnalyticsTrackingIdentifierStatusFlow = {

--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
@@ -67,6 +67,7 @@ class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
     }
 
     override fun halt() {
+        isConfigured = false
         Countly.sharedInstance().halt()
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8978" title="WPB-8978" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8978</a>  [Android] Countly analytics ID and user properties
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

2 Issues:
- there is no need to use `waitUntilLive()` anymore as we have a change on [isSelfATeamMember](https://github.com/wireapp/kalium/pull/2924)
- When Analytics is enabled on both accounts and second account is removed, the app crashes

### Causes (Optional)

For the second issue (crash) it is because the Analytics was being halted and not properly initialized again when switching accounts.

### Solutions

- Remove `waitUntilLive()`
- set `isConfigured = false` when halting analytics instance.

### Dependencies (Optional)

Needs releases with:

- [X] https://github.com/wireapp/kalium/pull/2924

### Testing

<!--
#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution
-->

#### How to Test

- Open App
- Login to account1
- Login to account2 (and stay active in this account)
- Put app in the background
- remove account2 device from another device
- Open App through home screen icon
- Dialog of removed device is shown and when switched to account1 the app doesn't crash.