### PR TITLE
fix: Shields not shown in group participants list [WPB-10255]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
@@ -73,9 +73,9 @@ class ObserveParticipantsForConversationUseCase @Inject constructor(
 
                 ConversationParticipantsData(
                     admins = visibleAdminsWithoutServices
-                        .map { uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.user.id].let { false }) },
+                        .map { uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.user.id] ?: false ) },
                     participants = visibleParticipants
-                        .map { uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.user.id].let { false }) },
+                        .map { uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.user.id] ?: false ) },
                     allAdminsCount = allAdminsWithoutServices.size,
                     allParticipantsCount = allParticipants.size,
                     isSelfAnAdmin = allAdminsWithoutServices.any { it.user is SelfUser }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
@@ -73,9 +73,9 @@ class ObserveParticipantsForConversationUseCase @Inject constructor(
 
                 ConversationParticipantsData(
                     admins = visibleAdminsWithoutServices
-                        .map { uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.user.id] ?: false ) },
+                        .map { uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.user.id] ?: false) },
                     participants = visibleParticipants
-                        .map { uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.user.id] ?: false ) },
+                        .map { uiParticipantMapper.toUIParticipant(it.user, mlsVerificationMap[it.user.id] ?: false) },
                     allAdminsCount = allAdminsWithoutServices.size,
                     allParticipantsCount = allParticipants.size,
                     isSelfAnAdmin = allAdminsWithoutServices.any { it.user is SelfUser }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
@@ -89,7 +89,7 @@ class ObserveParticipantsForConversationUseCaseTest {
             assert(data.allParticipantsCount == members.size)
             assertEquals(true, data.participants.firstOrNull { it.id == userId1 }?.isMLSVerified)
             assertEquals(false, data.participants.firstOrNull { it.id == userId2 }?.isMLSVerified)
-            assertEquals(false, data.participants.firstOrNull { it.id == userId3 }?.isMLSVerified)  // false if null
+            assertEquals(false, data.participants.firstOrNull { it.id == userId3 }?.isMLSVerified) // false if null
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
@@ -75,14 +75,21 @@ class ObserveParticipantsForConversationUseCaseTest {
                 add(MemberDetails(testOtherUser(i).copy(userType = UserType.INTERNAL), Member.Role.Member))
             }
         }
+        val userId1 = UserId(value = "value1", domain = "domain1")
+        val userId2 = UserId(value = "value2", domain = "domain2")
+        val userId3 = UserId(value = "value3", domain = "domain3")
         val (_, useCase) = ObserveParticipantsForConversationUseCaseArrangement()
             .withConversationParticipantsUpdate(members)
+            .withE2EICertificateStatuses(mapOf(userId1 to true, userId2 to false))
             .arrange()
         // When - Then
         useCase(ConversationId("", "")).test {
             val data = awaitItem()
             assert(data.participants.size == members.size)
             assert(data.allParticipantsCount == members.size)
+            assertEquals(true, data.participants.firstOrNull { it.id == userId1 }?.isMLSVerified)
+            assertEquals(false, data.participants.firstOrNull { it.id == userId2 }?.isMLSVerified)
+            assertEquals(false, data.participants.firstOrNull { it.id == userId3 }?.isMLSVerified)  // false if null
         }
     }
 
@@ -213,6 +220,10 @@ internal class ObserveParticipantsForConversationUseCaseArrangement {
         coEvery { observeConversationMembersUseCase(any()) } returns conversationMembersChannel.consumeAsFlow()
         conversationMembersChannel.send(members)
         return this
+    }
+
+    suspend fun withE2EICertificateStatuses(result: Map<UserId, Boolean>) = apply {
+        coEvery { getMembersE2EICertificateStatuses(any(), any()) } answers { result }
     }
 
     fun arrange() = this to useCase


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10255" title="WPB-10255" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10255</a>  [Android] Shields not shown anymore on group participants list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

In group participance screen: green shields (E2EI verification) are not shown anymore

### Causes (Optional)

Small "if null" mistake in mapping E2EI into "is verified" boolean. 

### Solutions

Fix it and add tests to cover that case
