### PR TITLE
fix: app registering many config sync jobs [WPB-10234]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.asset.GetAvatarAssetUseCase
 import com.wire.kalium.logic.feature.client.FinalizeMLSClientAfterE2EIEnrollment
 import com.wire.kalium.logic.feature.conversation.GetAllContactsNotInConversationUseCase
-import com.wire.kalium.logic.feature.e2ei.CertificateRevocationListCheckWorker
+import com.wire.kalium.logic.feature.e2ei.SyncCertificateRevocationListUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetE2eiCertificateUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMembersE2EICertificateStatusesUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusUseCase
@@ -232,8 +232,8 @@ class UserModule {
 
     @ViewModelScoped
     @Provides
-    fun provideCertificateRevocationListCheckWorker(userScope: UserScope): CertificateRevocationListCheckWorker =
-        userScope.certificateRevocationListCheckWorker
+    fun provideCertificateRevocationListCheckWorker(userScope: UserScope): SyncCertificateRevocationListUseCase =
+        userScope.syncCertificateRevocationListUseCase
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
@@ -17,11 +17,9 @@
  */
 package com.wire.android.ui.home
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
-import com.wire.android.navigation.SavedStateViewModel
 import com.wire.kalium.logic.feature.e2ei.SyncCertificateRevocationListUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
 import com.wire.kalium.logic.feature.featureConfig.FeatureFlagsSyncWorker
@@ -29,7 +27,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant

--- a/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
@@ -38,8 +38,9 @@ class AppSyncViewModel @Inject constructor(
     private val syncCertificateRevocationListUseCase: SyncCertificateRevocationListUseCase,
     private val observeCertificateRevocationForSelfClient: ObserveCertificateRevocationForSelfClientUseCase,
     private val featureFlagsSyncWorker: FeatureFlagsSyncWorker,
-    private val minIntervalBetweenPulls: Duration = MIN_INTERVAL_BETWEEN_PULLS
 ) : ViewModel() {
+
+    private val minIntervalBetweenPulls: Duration = MIN_INTERVAL_BETWEEN_PULLS
 
     private var lastPullInstant: Instant? = null
     private var syncDataJob: Job? = null
@@ -79,7 +80,7 @@ class AppSyncViewModel @Inject constructor(
         }
     }
 
-    private companion object {
+    companion object {
         val MIN_INTERVAL_BETWEEN_PULLS = 60.minutes
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
@@ -71,6 +71,7 @@ class AppSyncViewModel @Inject constructor(
         } ?: false
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private suspend fun runSyncTasks() {
         try {
             listOf(

--- a/app/src/test/kotlin/com/wire/android/ui/home/AppSyncViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/AppSyncViewModelTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home
+
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.kalium.logic.feature.e2ei.SyncCertificateRevocationListUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
+import com.wire.kalium.logic.feature.featureConfig.FeatureFlagsSyncWorker
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(CoroutineTestExtension::class)
+class AppSyncViewModelTest {
+    @Test
+    fun `when startSyncingAppConfig is called then it should call the use case`() = runTest {
+        val (arrangement, viewModel) = Arrangement().arange {
+            withObserveCertificateRevocationForSelfClient()
+            withFeatureFlagsSyncWorker()
+            withSyncCertificateRevocationListUseCase()
+        }
+
+        viewModel.startSyncingAppConfig()
+        advanceUntilIdle()
+
+        coVerify { arrangement.observeCertificateRevocationForSelfClient.invoke() }
+        coVerify { arrangement.syncCertificateRevocationListUseCase.invoke() }
+        coVerify { arrangement.featureFlagsSyncWorker.execute() }
+    }
+
+    @Test
+    fun `when startSyncingAppConfig is called multiple times then it should call the use case with delay`() = runTest {
+        val (arrangement, viewModel) = Arrangement().arange {
+            withObserveCertificateRevocationForSelfClient(1000)
+            withFeatureFlagsSyncWorker(1000)
+            withSyncCertificateRevocationListUseCase(1000)
+        }
+
+        viewModel.startSyncingAppConfig()
+        viewModel.startSyncingAppConfig()
+        viewModel.startSyncingAppConfig()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { arrangement.observeCertificateRevocationForSelfClient.invoke() }
+        coVerify(exactly = 1) { arrangement.syncCertificateRevocationListUseCase.invoke() }
+        coVerify(exactly = 1) { arrangement.featureFlagsSyncWorker.execute() }
+    }
+
+    private class Arrangement {
+
+        @MockK
+        lateinit var syncCertificateRevocationListUseCase: SyncCertificateRevocationListUseCase
+
+        @MockK
+        lateinit var observeCertificateRevocationForSelfClient: ObserveCertificateRevocationForSelfClientUseCase
+
+        @MockK
+        lateinit var featureFlagsSyncWorker: FeatureFlagsSyncWorker
+
+        init {
+            MockKAnnotations.init(this)
+        }
+
+        private val viewModel = AppSyncViewModel(
+            syncCertificateRevocationListUseCase,
+            observeCertificateRevocationForSelfClient,
+            featureFlagsSyncWorker
+        )
+
+        @OptIn(InternalCoroutinesApi::class)
+        fun withObserveCertificateRevocationForSelfClient(delayMs: Long = 0) {
+            coEvery { observeCertificateRevocationForSelfClient.invoke() } coAnswers {
+                delay(delayMs)
+            }
+        }
+
+        fun withSyncCertificateRevocationListUseCase(delayMs: Long = 0) {
+            coEvery { syncCertificateRevocationListUseCase.invoke() } coAnswers {
+                delay(delayMs)
+            }
+        }
+
+        fun withFeatureFlagsSyncWorker(delayMs: Long = 0) {
+            coEvery { featureFlagsSyncWorker.execute() } coAnswers {
+                delay(delayMs)
+            }
+        }
+
+        fun arange(block: Arrangement.() -> Unit) = apply(block).let {
+            this to viewModel
+        }
+    }
+
+}

--- a/app/src/test/kotlin/com/wire/android/ui/home/AppSyncViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/AppSyncViewModelTest.kt
@@ -112,5 +112,4 @@ class AppSyncViewModelTest {
             this to viewModel
         }
     }
-
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/AppSyncViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/AppSyncViewModelTest.kt
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 class AppSyncViewModelTest {
     @Test
     fun `when startSyncingAppConfig is called then it should call the use case`() = runTest {
-        val (arrangement, viewModel) = Arrangement().arange {
+        val (arrangement, viewModel) = Arrangement().arrange {
             withObserveCertificateRevocationForSelfClient()
             withFeatureFlagsSyncWorker()
             withSyncCertificateRevocationListUseCase()
@@ -52,7 +52,7 @@ class AppSyncViewModelTest {
 
     @Test
     fun `when startSyncingAppConfig is called multiple times then it should call the use case with delay`() = runTest {
-        val (arrangement, viewModel) = Arrangement().arange {
+        val (arrangement, viewModel) = Arrangement().arrange {
             withObserveCertificateRevocationForSelfClient(1000)
             withFeatureFlagsSyncWorker(1000)
             withSyncCertificateRevocationListUseCase(1000)
@@ -108,7 +108,7 @@ class AppSyncViewModelTest {
             }
         }
 
-        fun arange(block: Arrangement.() -> Unit) = apply(block).let {
+        fun arrange(block: Arrangement.() -> Unit) = apply(block).let {
             this to viewModel
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10234" title="WPB-10234" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10234</a>  [Android] app can register multiple SyncingAppConfig jobs at the same time
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. the config sync workers observe sync state and run every time the user is live
2. the sync is being called every time onResume for the home screen
3. each worker is running indefenatly

all of this is cauing multiple config sync jobs to run

### Solutions

1. change the workers to run once and not observe
2. check if a sync job isalready running and do not run agian
3. run once every 1h

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
