### PR TITLE
fix: multiline topbar title still sometimes not centered [WPB-9608]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/WireCenterAlignedTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/WireCenterAlignedTopAppBar.kt
@@ -127,6 +127,7 @@ fun WireTopAppBarTitle(
     // This workaround is based on this: https://stackoverflow.com/a/69947555, but instead of using SubcomposeLayout, we just measure text.
     BoxWithConstraints(
         modifier = modifier
+            .padding(horizontal = dimensions().spacing6x)
     ) {
         val textMeasurer = rememberTextMeasurer()
         val textLayoutResult: TextLayoutResult = textMeasurer.measure(
@@ -148,7 +149,6 @@ fun WireTopAppBarTitle(
         }
         Text(
             modifier = Modifier
-                .padding(horizontal = dimensions().spacing6x)
                 .width(width),
             text = title,
             style = style,
@@ -174,7 +174,7 @@ fun PreviewWireCenterAlignedTopAppBarWithDefaultTitle() = WireTheme {
 fun PreviewWireCenterAlignedTopAppBarWithDefaultTwoLinesTitle() = WireTheme {
     Box(modifier = Modifier.width(400.dp)) {
         WireCenterAlignedTopAppBar(
-            title = "This is title is very long this_is_a_very_long_word",
+            title = "This title is a quite long title another_line",
             titleStyle = MaterialTheme.wireTypography.title01
         )
     }
@@ -185,7 +185,7 @@ fun PreviewWireCenterAlignedTopAppBarWithDefaultTwoLinesTitle() = WireTheme {
 fun PreviewWireCenterAlignedTopAppBarWithDefaultTwoLinesTooLongTitle() = WireTheme {
     Box(modifier = Modifier.width(400.dp)) {
         WireCenterAlignedTopAppBar(
-            title = "This is title is even longer than previous one this_is_a_very_long_word",
+            title = "This title is even longer than one before another_line",
             titleStyle = MaterialTheme.wireTypography.title01
         )
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9608" title="WPB-9608" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9608</a>  [Android] Heading of own devices not centralised anymore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

It's a follow up to this PR https://github.com/wireapp/wire-android/pull/3239 to also fix one edge case.

### Issues

The title is not centered for some specific title text lenghts.

### Causes (Optional)

Text lines lengths was being calculated without taking paddings into account, so in some specific cases it could still be not centered - if the text without paddings (we use 6.dp) would fit in one line but with paddings included it would need to be splitted into two lines.

### Solutions

Move paddings to the parent box so that calculated text constraints and actual Text composable widths are exactly the same.
Title for one of previews is modified to also be just long enough to fall into this edge case.

### Testing

#### How to Test

On some devices the name created from the emulator "google sdk_gphone64_arm64 [beta_debug]" was just long enough to fall into this edge case.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <img width="422" alt="title_centered_padding_before" src="https://github.com/user-attachments/assets/b0382739-ed04-4191-b3f1-16795a7de892"> | <img width="426" alt="title_centered_padding_after" src="https://github.com/user-attachments/assets/e7d87b18-d7c0-431d-94bc-dc6c5617d689"> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
