### PR TITLE
fix: direct usage from Lazy<CoreLogic> (WPB-10304)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/deactivated/LegalHoldDeactivatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/deactivated/LegalHoldDeactivatedViewModel.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.feature.legalhold.LegalHoldState
 import com.wire.kalium.logic.feature.legalhold.MarkLegalHoldChangeAsNotifiedForSelfUseCase
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldChangeNotifiedForSelfUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import dagger.Lazy
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
@@ -42,14 +43,14 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LegalHoldDeactivatedViewModel @Inject constructor(
-    @KaliumCoreLogic private val coreLogic: CoreLogic,
+    @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>,
 ) : ViewModel() {
 
     var state: LegalHoldDeactivatedState by mutableStateOf(LegalHoldDeactivatedState.Hidden)
         private set
 
     private fun <T> currentSessionFlow(noSession: T, session: suspend UserSessionScope.(UserId) -> Flow<T>): Flow<T> =
-        coreLogic.getGlobalScope().session.currentSessionFlow()
+        coreLogic.get().getGlobalScope().session.currentSessionFlow()
             .flatMapLatest { currentSessionResult ->
                 when (currentSessionResult) {
                     is CurrentSessionResult.Failure.Generic -> {
@@ -59,7 +60,7 @@ class LegalHoldDeactivatedViewModel @Inject constructor(
 
                     CurrentSessionResult.Failure.SessionNotFound -> flowOf(noSession)
                     is CurrentSessionResult.Success ->
-                        currentSessionResult.accountInfo.userId.let { coreLogic.getSessionScope(it).session(it) }
+                        currentSessionResult.accountInfo.userId.let { coreLogic.get().getSessionScope(it).session(it) }
                 }
             }
 
@@ -78,7 +79,7 @@ class LegalHoldDeactivatedViewModel @Inject constructor(
                                 when (it.legalHoldState) {
                                     is LegalHoldState.Disabled -> LegalHoldDeactivatedState.Visible(userId)
                                     is LegalHoldState.Enabled -> { // for enabled we don't show the dialog, just mark as already notified
-                                        coreLogic.getSessionScope(userId).markLegalHoldChangeAsNotifiedForSelf()
+                                        coreLogic.get().getSessionScope(userId).markLegalHoldChangeAsNotifiedForSelf()
                                         LegalHoldDeactivatedState.Hidden
                                     }
                                 }
@@ -91,7 +92,7 @@ class LegalHoldDeactivatedViewModel @Inject constructor(
     fun dismiss() {
         viewModelScope.launch {
             (state as? LegalHoldDeactivatedState.Visible)?.let {
-                coreLogic.getSessionScope(it.userId).markLegalHoldChangeAsNotifiedForSelf().let {
+                coreLogic.get().getSessionScope(it.userId).markLegalHoldChangeAsNotifiedForSelf().let {
                     if (it is MarkLegalHoldChangeAsNotifiedForSelfUseCase.Result.Success) {
                         state = LegalHoldDeactivatedState.Hidden
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModel.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.feature.legalhold.ApproveLegalHoldRequestUseCase
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldRequestUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
+import dagger.Lazy
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -50,7 +51,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LegalHoldRequestedViewModel @Inject constructor(
     private val validatePassword: ValidatePasswordUseCase,
-    @KaliumCoreLogic private val coreLogic: CoreLogic,
+    @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>,
 ) : ViewModel() {
 
     val passwordTextState: TextFieldState = TextFieldState()
@@ -91,7 +92,7 @@ class LegalHoldRequestedViewModel @Inject constructor(
     }.stateIn(viewModelScope, SharingStarted.Eagerly, LegalHoldRequestData.None)
 
     private fun <T> currentSessionFlow(noSession: T, session: UserSessionScope.(UserId) -> Flow<T>): Flow<T> =
-        coreLogic.getGlobalScope().session.currentSessionFlow()
+        coreLogic.get().getGlobalScope().session.currentSessionFlow()
             .flatMapLatest { currentSessionResult ->
                 when (currentSessionResult) {
                     is CurrentSessionResult.Failure.Generic -> {
@@ -101,7 +102,7 @@ class LegalHoldRequestedViewModel @Inject constructor(
 
                     CurrentSessionResult.Failure.SessionNotFound -> flowOf(noSession)
                     is CurrentSessionResult.Success ->
-                        currentSessionResult.accountInfo.userId.let { coreLogic.getSessionScope(it).session(it) }
+                        currentSessionResult.accountInfo.userId.let { coreLogic.get().getSessionScope(it).session(it) }
                 }
             }
 
@@ -154,7 +155,7 @@ class LegalHoldRequestedViewModel @Inject constructor(
             } else {
                 val password = if (it.requiresPassword) passwordTextState.text.toString() else null
                 viewModelScope.launch {
-                    coreLogic.sessionScope(it.userId) {
+                    coreLogic.get().sessionScope(it.userId) {
                         approveLegalHoldRequest(password).let { approveLegalHoldResult ->
                             state = when (approveLegalHoldResult) {
                                 is ApproveLegalHoldRequestUseCase.Result.Success ->

--- a/app/src/test/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModelTest.kt
@@ -304,8 +304,8 @@ class CommonTopAppBarViewModelTest {
 
         private val commonTopAppBarViewModel by lazy {
             CommonTopAppBarViewModel(
-                currentScreenManager,
-                coreLogic
+                currentScreenManager = currentScreenManager,
+                coreLogic = { coreLogic }
             )
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
@@ -328,7 +328,7 @@ class FeatureFlagNotificationViewModelTest {
 
         val viewModel: FeatureFlagNotificationViewModel by lazy {
             FeatureFlagNotificationViewModel(
-                coreLogic = coreLogic,
+                coreLogic = { coreLogic },
                 currentSessionFlow = currentSessionFlow,
                 globalDataStore = globalDataStore,
                 disableAppLockUseCase = disableAppLockUseCase

--- a/app/src/test/kotlin/com/wire/android/ui/legalhold/dialog/deactivated/LegalHoldDeactivatedViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/legalhold/dialog/deactivated/LegalHoldDeactivatedViewModelTest.kt
@@ -107,7 +107,7 @@ class LegalHoldDeactivatedViewModelTest {
 
         @MockK
         lateinit var coreLogic: CoreLogic
-        val viewModel by lazy { LegalHoldDeactivatedViewModel(coreLogic) }
+        val viewModel by lazy { LegalHoldDeactivatedViewModel(coreLogic = { coreLogic }) }
 
         init { MockKAnnotations.init(this) }
         fun withNotCurrentSession() = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModelTest.kt
@@ -305,7 +305,12 @@ class LegalHoldRequestedViewModelTest {
 
         val userId = UserId("userId", "domain")
 
-        val viewModel by lazy { LegalHoldRequestedViewModel(validatePassword, coreLogic) }
+        val viewModel by lazy {
+            LegalHoldRequestedViewModel(
+                validatePassword = validatePassword,
+                coreLogic = { coreLogic }
+            )
+        }
 
         init {
             MockKAnnotations.init(this)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10304" title="WPB-10304" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10304</a>  [Android] circular dependency on app start
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Getting this crash when opening and closing the app multiple times in a sequence:
```
java.lang.IllegalStateException: Scoped provider was invoked recursively returning different results: Ub.r@6b06a8f & Ub.r@32f211c. This is likely due to a circular dependency.
```

### Causes (Optional)

Although it looked like a circular dependency in the first instance, looking at the code and the crash error, it felt more like a direct trying access to `Lazy<CoreLogic`.

My conclusion is that It was introduced from this PR : [fix: inject usecases lazily in WireActivityViewModel (WPB-6874)](https://github.com/wireapp/wire-android/pull/3096) by adding `CoreLogic` as `Lazy<CoreLogic>`

You can check datadog from here:
[DataDog All Errors](https://app.datadoghq.eu/logs?query=%22Scoped%20provider%20was%20invoked%20recursively%20returning%20different%20results%22%20&agg_m=count&agg_m_source=base&agg_q=%40network.client.geoip.city.name&agg_q_source=base&agg_t=count&cols=host%2Cservice&context_event=AY3KkGH0AACkpwmmZqGzMwBd&event=AgAAAZASe-KEUdy4HgAAAAAAAAAYAAAAAEFaQVNmV2hJQUFCRmpSTS1SRmVsLUFBSQAAACQAAAAAMDE5MDEzMmYtODVkOS00ZDY5LWIyZmUtMzI4NmFlNjBmMTE0&fromUser=false&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&view=spans&viz=stream&x_missing=true&from_ts=1717192800000&to_ts=1722590160000&live=false)

[DataDog First Error](https://app.datadoghq.eu/logs?query=service%3Acom.wire.android.internal%20%40session_id%3A00000000-0000-0000-0000-000000000000%20commit%20&agg_m=count&agg_m_source=base&agg_q=%40network.client.geoip.city.name&agg_q_source=base&agg_t=count&cols=host%2Cservice&context_event=AZASfWhIAABFjRM-RFel-AAI&event=AgAAAZASe9TDUdy4GQAAAAAAAAAYAAAAAEFaQVNmV2hJQUFCRmpSTS1SRmVsLUFBRAAAACQAAAAAMDE5MDEzMmYtODVkOS00ZDY5LWIyZmUtMzI4NmFlNjBmMTE0&fromUser=false&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&view=spans&viz=&x_missing=true&from_ts=1718296727204&to_ts=1718297138520&live=false)

### Solutions

2. Add `Lazy<>` for `CoreLogic` on these ViewModels:
* `FeatureFlagNotificationViewModel`
* `CommonTopAppBarViewModel`
* `LegalHoldRequestedViewModel`
* `LegalHoldDeactivatedViewModel`

The reason the issue crashes on `LegalHoldRequestedViewModel` is because as soon as `WireActivity` starts, it starts listening for legal hold status to show the dialog, thus invoking coreLogic when it needs a `.get()` before or something was it was not initialized in time.

- With the fix we can now monitor datadog for this specific crash if it happens again. If it does, we can then try another approach, which would be removing the changes from this PR and also remove the usage of `Lazy<CoreLogic` from `WireActivityViewModel`.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

Currently the only way to test (as from seeing from the ticket as well) is to open and close the app multiple times until there is a crash (but not very reliable).