### PR TITLE
fix: connection button not shown when partial metadata (WPB-10342)

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroupTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroupTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.userprofile.other
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import com.wire.android.ui.WireTestTheme
+import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.ui.userprofile.other.OtherUserStubs.provideState
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import org.junit.Rule
+import org.junit.Test
+
+class OtherUserProfileGroupTest {
+    @get:Rule
+    val composeTestRule by lazy { createComposeRule() }
+
+    @Test
+    fun givenARoleSelectionComponentIsShow_ShouldNotAllowModificationForTempUsers() = runTest {
+        composeTestRule.setContent {
+            WireTestTheme {
+                OtherUserProfileGroup(
+                    provideState(withExpireAt = Instant.DISTANT_FUTURE.toEpochMilliseconds()),
+                    onRemoveFromConversation = {},
+                    openChangeRoleBottomSheet = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Edit").assertDoesNotExist()
+    }
+
+    @Test
+    fun givenARoleSelectionComponentIsShow_ShouldNotAllowModificationForUsersWithoutMetadata() = runTest {
+        composeTestRule.setContent {
+            WireTestTheme {
+                OtherUserProfileGroup(
+                    provideState(withUserName = "", withFullName = ""),
+                    onRemoveFromConversation = {},
+                    openChangeRoleBottomSheet = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Edit").assertDoesNotExist()
+    }
+
+    @Test
+    fun givenARoleSelectionComponentIsShow_ShouldNotAllowModificationForFederatedUsers() = runTest {
+        composeTestRule.setContent {
+            WireTestTheme {
+                OtherUserProfileGroup(
+                    provideState(withMembership = Membership.Federated),
+                    onRemoveFromConversation = {},
+                    openChangeRoleBottomSheet = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Edit").assertDoesNotExist()
+    }
+
+    @Test
+    fun givenARoleSelectionComponentIsShow_ShouldNotAllowModificationForServices() = runTest {
+        composeTestRule.setContent {
+            WireTestTheme {
+                OtherUserProfileGroup(
+                    provideState(withMembership = Membership.Service),
+                    onRemoveFromConversation = {},
+                    openChangeRoleBottomSheet = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Edit").assertDoesNotExist()
+    }
+
+}

--- a/app/src/androidTest/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroupTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroupTest.kt
@@ -90,5 +90,4 @@ class OtherUserProfileGroupTest {
 
         composeTestRule.onNodeWithContentDescription("Edit").assertDoesNotExist()
     }
-
 }

--- a/app/src/androidTest/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import com.wire.android.ui.WireTestTheme
+import com.wire.android.ui.connection.CONNECTION_ACTION_BUTTONS_TEST_TAG
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.userprofile.other.OtherUserStubs.provideState
@@ -44,7 +45,7 @@ class OtherUserProfileScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithTag("connection_buttons").assertDoesNotExist()
+        composeTestRule.onNodeWithTag(CONNECTION_ACTION_BUTTONS_TEST_TAG).assertDoesNotExist()
     }
 
     @Test
@@ -58,7 +59,7 @@ class OtherUserProfileScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithTag("connection_buttons").assertDoesNotExist()
+        composeTestRule.onNodeWithTag(CONNECTION_ACTION_BUTTONS_TEST_TAG).assertDoesNotExist()
     }
 
     @Test
@@ -72,6 +73,6 @@ class OtherUserProfileScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithTag("connection_buttons").assertDoesNotExist()
+        composeTestRule.onNodeWithTag(CONNECTION_ACTION_BUTTONS_TEST_TAG).assertDoesNotExist()
     }
 }

--- a/app/src/androidTest/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.userprofile.other
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.wire.android.ui.WireTestTheme
+import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.userprofile.other.OtherUserStubs.provideState
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import org.junit.Rule
+import org.junit.Test
+
+class OtherUserProfileScreenTest {
+    @get:Rule
+    val composeTestRule by lazy { createComposeRule() }
+
+    @Test
+    fun givenOtherUserProfileFooter_ShouldNotShowConnectButtonForTempUsers() = runTest {
+        composeTestRule.setContent {
+            WireTestTheme {
+                ContentFooter(
+                    state = provideState(withExpireAt = Instant.DISTANT_FUTURE.toEpochMilliseconds()),
+                    maxBarElevation = MaterialTheme.wireDimensions.topBarShadowElevation
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("connection_buttons").assertDoesNotExist()
+    }
+
+    @Test
+    fun givenOtherUserProfileFooter_ShouldNotShowConnectButtonForUsersWithoutMetadata() = runTest {
+        composeTestRule.setContent {
+            WireTestTheme {
+                ContentFooter(
+                    state = provideState(withUserName = "", withFullName = ""),
+                    maxBarElevation = MaterialTheme.wireDimensions.topBarShadowElevation
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("connection_buttons").assertDoesNotExist()
+    }
+
+    @Test
+    fun givenOtherUserProfileFooter_ShouldNotShowConnectButtonForServices() = runTest {
+        composeTestRule.setContent {
+            WireTestTheme {
+                ContentFooter(
+                    state = provideState(withMembership = Membership.Service),
+                    maxBarElevation = MaterialTheme.wireDimensions.topBarShadowElevation
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("connection_buttons").assertDoesNotExist()
+    }
+}

--- a/app/src/androidTest/kotlin/com/wire/android/ui/userprofile/other/OtherUserStubs.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/userprofile/other/OtherUserStubs.kt
@@ -31,7 +31,10 @@ object OtherUserStubs {
         teamName = "team",
         email = "email",
         groupState = OtherUserProfileGroupState(
-            "group name", Member.Role.Member, true, ConversationId("some_user", "domain.com")
+            groupName = "group name",
+            role = Member.Role.Member,
+            isSelfAdmin = true,
+            conversationId = ConversationId("some_user", "domain.com")
         )
     )
 

--- a/app/src/androidTest/kotlin/com/wire/android/ui/userprofile/other/OtherUserStubs.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/userprofile/other/OtherUserStubs.kt
@@ -1,0 +1,51 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.userprofile.other
+
+import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.kalium.logic.data.conversation.Conversation.Member
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
+import kotlinx.datetime.Instant
+
+object OtherUserStubs {
+    private val baseState = OtherUserProfileState(
+        userId = UserId("some_user", "domain.com"),
+        fullName = "name",
+        userName = "username",
+        teamName = "team",
+        email = "email",
+        groupState = OtherUserProfileGroupState(
+            "group name", Member.Role.Member, true, ConversationId("some_user", "domain.com")
+        )
+    )
+
+    fun provideState(
+        withFullName: String = "name",
+        withUserName: String = "username",
+        withExpireAt: Long? = null,
+        withMembership: Membership = Membership.Standard
+    ): OtherUserProfileState {
+        return baseState.copy(
+            fullName = withFullName,
+            userName = withUserName,
+            expiresAt = withExpireAt?.let { Instant.fromEpochMilliseconds(it) },
+            membership = withMembership
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/mapper/ContactMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ContactMapper.kt
@@ -22,7 +22,7 @@ import com.wire.android.model.ImageAsset
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.newconversation.model.Contact
-import com.wire.android.ui.userprofile.common.UsernameMapper.mapUserLabel
+import com.wire.android.ui.userprofile.common.UsernameMapper
 import com.wire.android.util.EMPTY
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.publicuser.model.UserSearchDetails
@@ -44,7 +44,7 @@ class ContactMapper
                 id = id.value,
                 domain = id.domain,
                 name = name.orEmpty(),
-                label = mapUserLabel(otherUser),
+                label = UsernameMapper.fromOtherUser(otherUser),
                 avatarData = UserAvatarData(
                     asset = previewPicture?.let { ImageAsset.UserAvatarAsset(wireSessionImageLoader, it) },
                     connectionState = connectionStatus

--- a/app/src/main/kotlin/com/wire/android/mapper/UIParticipantMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/UIParticipantMapper.kt
@@ -58,6 +58,7 @@ class UIParticipantMapper @Inject constructor(
             isMLSVerified = isMLSVerified,
             supportedProtocolList = supportedProtocols.orEmpty().toList(),
             isUnderLegalHold = isUnderLegalHold,
+            expiresAt = user.expiresAt
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
@@ -98,6 +99,7 @@ fun ConnectionActionButton(
             loading = viewModel.actionableState().isPerformingAction,
             onClick = viewModel::onCancelConnectionRequest,
             clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
+            modifier = Modifier.testTag("connection_buttons"),
         )
 
         ConnectionState.ACCEPTED -> WirePrimaryButton(
@@ -108,6 +110,7 @@ fun ConnectionActionButton(
                     unableStartConversationDialogState.show(UnableStartConversationDialogState(fullName))
                 }
             },
+            modifier = Modifier.testTag("connection_buttons"),
         )
 
         ConnectionState.IGNORED -> WirePrimaryButton(
@@ -121,7 +124,8 @@ fun ConnectionActionButton(
                     contentDescription = stringResource(R.string.content_description_right_arrow),
                     modifier = Modifier.padding(dimensions().spacing8x)
                 )
-            }
+            },
+            modifier = Modifier.testTag("connection_buttons"),
         )
 
         ConnectionState.PENDING -> Column {
@@ -136,7 +140,8 @@ fun ConnectionActionButton(
                         contentDescription = stringResource(R.string.content_description_right_arrow),
                         modifier = Modifier.padding(dimensions().spacing8x)
                     )
-                }
+                },
+                modifier = Modifier.testTag("connection_buttons"),
             )
             Spacer(modifier = Modifier.height(dimensions().spacing8x))
             WirePrimaryButton(
@@ -155,7 +160,8 @@ fun ConnectionActionButton(
                         contentDescription = stringResource(R.string.content_description_right_arrow),
                         modifier = Modifier.padding(dimensions().spacing8x)
                     )
-                }
+                },
+                modifier = Modifier.testTag("connection_buttons"),
             )
         }
 
@@ -172,6 +178,7 @@ fun ConnectionActionButton(
                     )
                 },
                 clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
+                modifier = Modifier.testTag("connection_buttons"),
             )
         }
 
@@ -188,7 +195,8 @@ fun ConnectionActionButton(
                     contentDescription = stringResource(R.string.content_description_right_arrow),
                     modifier = Modifier.padding(dimensions().spacing8x)
                 )
-            }
+            },
+            modifier = Modifier.testTag("connection_buttons"),
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
@@ -57,6 +57,8 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 
+const val CONNECTION_ACTION_BUTTONS_TEST_TAG = "connection_buttons"
+
 @Composable
 fun ConnectionActionButton(
     userId: UserId,
@@ -99,7 +101,7 @@ fun ConnectionActionButton(
             loading = viewModel.actionableState().isPerformingAction,
             onClick = viewModel::onCancelConnectionRequest,
             clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
-            modifier = Modifier.testTag("connection_buttons"),
+            modifier = Modifier.testTag(CONNECTION_ACTION_BUTTONS_TEST_TAG),
         )
 
         ConnectionState.ACCEPTED -> WirePrimaryButton(
@@ -110,7 +112,7 @@ fun ConnectionActionButton(
                     unableStartConversationDialogState.show(UnableStartConversationDialogState(fullName))
                 }
             },
-            modifier = Modifier.testTag("connection_buttons"),
+            modifier = Modifier.testTag(CONNECTION_ACTION_BUTTONS_TEST_TAG),
         )
 
         ConnectionState.IGNORED -> WirePrimaryButton(
@@ -125,7 +127,7 @@ fun ConnectionActionButton(
                     modifier = Modifier.padding(dimensions().spacing8x)
                 )
             },
-            modifier = Modifier.testTag("connection_buttons"),
+            modifier = Modifier.testTag(CONNECTION_ACTION_BUTTONS_TEST_TAG),
         )
 
         ConnectionState.PENDING -> Column {
@@ -141,7 +143,7 @@ fun ConnectionActionButton(
                         modifier = Modifier.padding(dimensions().spacing8x)
                     )
                 },
-                modifier = Modifier.testTag("connection_buttons"),
+                modifier = Modifier.testTag(CONNECTION_ACTION_BUTTONS_TEST_TAG),
             )
             Spacer(modifier = Modifier.height(dimensions().spacing8x))
             WirePrimaryButton(
@@ -161,7 +163,7 @@ fun ConnectionActionButton(
                         modifier = Modifier.padding(dimensions().spacing8x)
                     )
                 },
-                modifier = Modifier.testTag("connection_buttons"),
+                modifier = Modifier.testTag(CONNECTION_ACTION_BUTTONS_TEST_TAG),
             )
         }
 
@@ -178,7 +180,7 @@ fun ConnectionActionButton(
                     )
                 },
                 clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
-                modifier = Modifier.testTag("connection_buttons"),
+                modifier = Modifier.testTag(CONNECTION_ACTION_BUTTONS_TEST_TAG),
             )
         }
 
@@ -196,7 +198,7 @@ fun ConnectionActionButton(
                     modifier = Modifier.padding(dimensions().spacing8x)
                 )
             },
-            modifier = Modifier.testTag("connection_buttons"),
+            modifier = Modifier.testTag(CONNECTION_ACTION_BUTTONS_TEST_TAG),
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/model/UIParticipant.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/model/UIParticipant.kt
@@ -44,4 +44,5 @@ data class UIParticipant(
     val isMLSVerified: Boolean = false,
     val supportedProtocolList: List<SupportedProtocol> = listOf(),
     val isUnderLegalHold: Boolean = false,
+    val expiresAt: Instant? = null
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/model/Contact.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/model/Contact.kt
@@ -30,8 +30,4 @@ data class Contact(
     val label: String = "",
     val connectionState: ConnectionState,
     val membership: Membership
-) {
-    fun isMetadataEmpty(): Boolean {
-        return name.isEmpty()
-    }
-}
+)

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UsernameMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UsernameMapper.kt
@@ -18,15 +18,20 @@
 
 package com.wire.android.ui.userprofile.common
 
+import com.wire.android.util.ifNotEmpty
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.type.UserType
 
 object UsernameMapper {
 
-    fun mapUserLabel(otherUser: OtherUser): String = with(otherUser) {
+    /**
+     * Returns the username for the given [OtherUser].
+     * The username is the handle if it exists, otherwise it is the handle@domain for federated users.
+     */
+    fun fromOtherUser(otherUser: OtherUser): String = with(otherUser) {
         val userId = otherUser.id
         return when (otherUser.userType) {
-            UserType.FEDERATED -> if (handle != null) "$handle@${userId.domain}" else ""
+            UserType.FEDERATED -> handle?.ifNotEmpty { "$handle@${userId.domain}" }.orEmpty()
             else -> handle.orEmpty()
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroup.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroup.kt
@@ -93,7 +93,7 @@ fun OtherUserProfileGroup(
                 value = AnnotatedString(state.groupState!!.role.name.asString()),
                 isSelfAdmin = state.groupState.isSelfAdmin,
                 openChangeRoleBottomSheet = openChangeRoleBottomSheet,
-                isRoleEditable = state.membership.allowsRoleEdition() && !state.isMetadataEmpty()
+                isRoleEditable = state.membership.allowsRoleEdition() && !state.isMetadataEmpty() && !state.isTemporaryUser()
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -201,7 +201,6 @@ fun OtherUserProfileScreen(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @SuppressLint("UnusedCrossfadeTargetStateParameter", "LongParameterList")
 @Composable
 fun OtherProfileScreenContent(
@@ -441,7 +440,6 @@ private fun TopBarCollapsing(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun TopBarFooter(
     state: OtherUserProfileState,
@@ -558,7 +556,7 @@ private fun ContentFooter(
         ) {
             Box(modifier = Modifier.padding(all = dimensions().spacing16x)) {
                 // TODO show open conversation button for service bots after AR-2135
-                if (!state.isMetadataEmpty() && state.membership != Membership.Service) {
+                if (!state.isMetadataEmpty() && state.membership != Membership.Service && !state.isTemporaryUser()) {
                     ConnectionActionButton(
                         state.userId,
                         state.userName,
@@ -578,6 +576,7 @@ enum class OtherUserProfileTabItem(@StringRes val titleResId: Int) : TabItem {
     GROUP(R.string.user_profile_group_tab),
     DETAILS(R.string.user_profile_details_tab),
     DEVICES(R.string.user_profile_devices_tab);
+
     override val title: UIText = UIText.StringResource(titleResId)
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -109,6 +109,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.ConnectionState
+import io.github.esentsov.PackagePrivate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.launch
@@ -539,8 +540,10 @@ private fun Content(
     }
 }
 
+@SuppressLint("ComposeModifierMissing")
+@PackagePrivate
 @Composable
-private fun ContentFooter(
+fun ContentFooter(
     state: OtherUserProfileState,
     maxBarElevation: Dp,
     onIgnoreConnectionRequest: (String) -> Unit = {},

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -112,6 +112,7 @@ import com.wire.kalium.logic.data.user.ConnectionState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Instant
 
 @RootNavGraph
 @WireDestination(
@@ -646,6 +647,31 @@ fun PreviewOtherProfileScreenContentNotConnected() {
             eventsHandler = OtherUserProfileEventsHandler.PREVIEW,
             bottomSheetEventsHandler = OtherUserProfileBottomSheetEventsHandler.PREVIEW,
             onSearchConversationMessagesClick = {}
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+@PreviewMultipleThemes
+fun PreviewOtherProfileScreenTempUser() {
+    WireTheme {
+        OtherProfileScreenContent(
+            scope = rememberCoroutineScope(),
+            state = OtherUserProfileState.PREVIEW.copy(
+                userName = "",
+                connectionState = ConnectionState.CANCELLED,
+                isUnderLegalHold = true,
+                expiresAt = Instant.DISTANT_FUTURE
+            ),
+            navigationIconType = NavigationIconType.Back,
+            requestInProgress = false,
+            sheetState = rememberWireModalSheetState(),
+            openBottomSheet = {},
+            closeBottomSheet = {},
+            eventsHandler = OtherUserProfileEventsHandler.PREVIEW,
+            bottomSheetEventsHandler = OtherUserProfileBottomSheetEventsHandler.PREVIEW,
+            onSearchConversationMessagesClick = {},
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -395,6 +395,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             blockingState = otherUser.BlockState,
             isProteusVerified = otherUser.isProteusVerified,
             isUnderLegalHold = otherUser.isUnderLegalHold,
+            expiresAt = otherUser.expiresAt,
             conversationSheetContent = conversation?.let {
                 ConversationSheetContent(
                     title = otherUser.name.orEmpty(),

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -37,7 +37,7 @@ import com.wire.android.ui.home.conversationslist.model.BlockState
 import com.wire.android.ui.home.conversationslist.model.DialogState
 import com.wire.android.ui.home.conversationslist.showLegalHoldIndicator
 import com.wire.android.ui.navArgs
-import com.wire.android.ui.userprofile.common.UsernameMapper.mapUserLabel
+import com.wire.android.ui.userprofile.common.UsernameMapper.fromOtherUser
 import com.wire.android.ui.userprofile.group.RemoveConversationMemberState
 import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.BlockingUserOperationError
 import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.BlockingUserOperationSuccess
@@ -384,7 +384,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             isAvatarLoading = false,
             userAvatarAsset = userAvatarAsset,
             fullName = otherUser.name.orEmpty(),
-            userName = mapUserLabel(otherUser),
+            userName = fromOtherUser(otherUser),
             teamName = userResult.team?.name.orEmpty(),
             email = otherUser.email.orEmpty(),
             phone = otherUser.phone.orEmpty(),

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -74,7 +74,7 @@ data class OtherUserProfileState(
     }
 
     fun isMetadataEmpty(): Boolean {
-        return fullName.isEmpty() || userName.isEmpty()
+        return fullName.isEmpty() && userName.isEmpty()
     }
 
     fun shouldShowSearchButton(): Boolean = (groupState == null

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.BotService
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
+import kotlinx.datetime.Instant
 
 data class OtherUserProfileState(
     val userId: UserId,
@@ -51,7 +52,8 @@ data class OtherUserProfileState(
     val isProteusVerified: Boolean = false,
     val isMLSVerified: Boolean = false,
     val isUnderLegalHold: Boolean = false,
-    val isConversationStarted: Boolean = false
+    val isConversationStarted: Boolean = false,
+    val expiresAt: Instant? = null
 ) {
     fun updateMuteStatus(status: MutedConversationStatus): OtherUserProfileState {
         return conversationSheetContent?.let {
@@ -76,6 +78,8 @@ data class OtherUserProfileState(
     fun isMetadataEmpty(): Boolean {
         return fullName.isEmpty() && userName.isEmpty()
     }
+
+    fun isTemporaryUser() = expiresAt != null
 
     fun shouldShowSearchButton(): Boolean = (groupState == null
             && connectionState in listOf(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10342" title="WPB-10342" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10342</a>  [Android] Accept connection request button is not visible for personal accounts
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There might be cases that metadata is incomplete (username or handle) 

### Causes (Optional)

We hide the action buttons for connection requests. 

### Solutions

- Treat partial metadata as enough to connect, since we have a cache of 5 minutes, where this data will be refreshed anyway.
- Add `expiresAt` mapping, so we also handle connection/role edition for temporary users.
- Add a bunch of UI tests to verify: Role selection and Connection action buttons.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
