### PR TITLE
fix: weird overscroll that makes conversation list disappear [WPB-9035]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -88,7 +88,7 @@ fun ConversationList(
      * automatically to that item and the newly added section on top is hidden above this previously top item, so for such situation
      * when the list is scrolled to the top and we want the new section to appear at the top we request to scroll to item at the top.
      * Implemented according to the templates from compose lazy list test cases - LazyListRequestScrollTest.kt.
-     * @see https://android.googlesource.com/platform/frameworks/support/+/refs/changes/93/2987293/35/compose/foundation/foundation/integration-tests/lazy-tests/src/androidTest/kotlin/androidx/compose/foundation/lazy/list/LazyListRequestScrollTest.kt
+     * https://android.googlesource.com/platform/frameworks/support/+/refs/changes/93/2987293/35/compose/foundation/foundation/integration-tests/lazy-tests/src/androidTest/kotlin/androidx/compose/foundation/lazy/list/LazyListRequestScrollTest.kt
      */
     SideEffect {
         if (lazyListState.firstVisibleItemIndex == 0 && lazyListState.firstVisibleItemScrollOffset == 0) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -22,12 +22,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.Dp
 import com.wire.android.ui.home.conversationslist.model.ConversationFolder
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.util.extension.folderWithElements
@@ -57,19 +55,6 @@ fun ConversationList(
         state = lazyListState,
         modifier = modifier.fillMaxSize()
     ) {
-        /*
-     * When the list is scrolled to top and new items (e.g. new activity section) should appear on top of the list, it appears above
-     * all current items, scroll is preserved so the list still shows the same item as the first one on list so it scrolls
-     * automatically to that item and the newly added section on top is hidden above this previously top item, so for such situation
-     * when the list is scrolled to the top and we want the new section to appear at the top we need a dummy top item which will make
-     *  it so it wants to keep this dummy top item as the first one on list and show all other items below it.
-     */
-        item("empty-top-header") {
-            HorizontalDivider(
-                thickness = Dp.Hairline,
-                color = Color.Transparent
-            )
-        }
         conversationListItems.forEach { (conversationFolder, conversationList) ->
             folderWithElements(
                 header = when (conversationFolder) {
@@ -94,6 +79,23 @@ fun ConversationList(
                     onAudioPermissionPermanentlyDenied = onAudioPermissionPermanentlyDenied,
                 )
             }
+        }
+    }
+
+    /**
+     * When the list is scrolled to top and new items (e.g. new activity section) should appear on top of the list, it appears above
+     * all current items, scroll is preserved so the list still shows the same item as the first one on list so it scrolls
+     * automatically to that item and the newly added section on top is hidden above this previously top item, so for such situation
+     * when the list is scrolled to the top and we want the new section to appear at the top we request to scroll to item at the top.
+     * Implemented according to the templates from compose lazy list test cases - LazyListRequestScrollTest.kt.
+     * @see https://android.googlesource.com/platform/frameworks/support/+/refs/changes/93/2987293/35/compose/foundation/foundation/integration-tests/lazy-tests/src/androidTest/kotlin/androidx/compose/foundation/lazy/list/LazyListRequestScrollTest.kt
+     */
+    SideEffect {
+        if (lazyListState.firstVisibleItemIndex == 0 && lazyListState.firstVisibleItemScrollOffset == 0) {
+            lazyListState.requestScrollToItem(
+                index = lazyListState.firstVisibleItemIndex,
+                scrollOffset = lazyListState.firstVisibleItemScrollOffset
+            )
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,8 +46,8 @@ androidx-compose-runtime = "1.6.7"
 
 # Compose
 composeBom = "2024.06.00"
-compose-foundation = "1.7.0-beta05" # remove when composeBom contains new stable version of BasicTextField2
-compose-material-android = "1.7.0-beta05" # remove when composeBom contains new stable version of BasicTextField2
+compose-foundation = "1.7.0-beta06" # remove when composeBom contains new stable version of BasicTextField2
+compose-material-android = "1.7.0-beta06" # remove when composeBom contains new stable version of BasicTextField2
 compose-activity = "1.9.0"
 compose-compiler = "1.5.11"
 compose-constraint = "1.0.1"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9035" title="WPB-9035" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9035</a>  [Android] When opening app, conversation list disappears when scrolling
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the user opens the app from scratch (after closing it from background or terminating), when he scrolls to the bottom on the conversation list, the conversation list disappears for a brief moment.

### Causes (Optional)

The combination of our top header which is only `Dp.Hairline` tall and animations for all list items. 
For some reason, this thin header disappears initially and appears only when the user scrolls but it messes up the order and animations. This header was added to make it so that when some conversation moves to "new activities" and the conversation list is fully scrolled to top, then "new activities" list should appear on top. Thanks to this header, there was always some element on top of the list so the list scroll stayed on that position.

### Solutions

Remove this thin header as it was causing this weird overscroll effect and replace this workaround with the solution suggested by Google in [`LazyListRequestScrollTest.kt`](https://android.googlesource.com/platform/frameworks/support/+/refs/changes/93/2987293/35/compose/foundation/foundation/integration-tests/lazy-tests/src/androidTest/kotlin/androidx/compose/foundation/lazy/list/LazyListRequestScrollTest.kt).
This solution uses `requestScrollToItem` which updates the scroll position to the requested position rather than maintaining the index based on the first visible item key (when a data set change will also be applied during the next remeasure), but only for the next remeasure. Thanks to that, if the list is scrolled to top, then we can use it to make sure it will always stay scrolled to top and show item with index 0.
This `requestScrollToItem` function has been added recently to compose, so library versions are updated to make use of that.

### Testing

#### How to Test

STR:
-open app freshly
-on conversation list, scroll from top to bottom

Expected: 
nothing should happen since conversation list can not be scrolled in the direction

Actual: 
Conversation list disappears when scrolling in that direction

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
