### PR TITLE
chore: Do not send data to Analytics on custom backend (WPB-10020)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -203,7 +203,10 @@ class WireApplication : BaseApp() {
             analyticsIdentifierManagerProvider = {
                 coreLogic.get().getSessionScope(it).analyticsIdentifierManager
             },
-            userDataStoreProvider = userDataStoreProvider.get()
+            userDataStoreProvider = userDataStoreProvider.get(),
+            currentBackend = {
+                coreLogic.get().getSessionScope(it).users.serverLinks()
+            }
         ).invoke()
 
         AnonymousAnalyticsManagerImpl.init(

--- a/app/src/main/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCase.kt
@@ -77,7 +77,7 @@ fun ObserveCurrentSessionAnalyticsUseCase(
                 ) { identifierResult, enabled ->
                     previousAnalyticsResult = identifierResult
 
-                    val isProdBackend = when(val serverConfig = currentBackend(userId)) {
+                    val isProdBackend = when (val serverConfig = currentBackend(userId)) {
                         is SelfServerConfigUseCase.Result.Success -> serverConfig.serverLinks.links.api == ServerConfig.PRODUCTION.api
                         is SelfServerConfigUseCase.Result.Failure -> false
                     }

--- a/app/src/main/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCase.kt
@@ -44,7 +44,7 @@ interface ObserveCurrentSessionAnalyticsUseCase {
     operator fun invoke(): Flow<AnalyticsResult<AnalyticsIdentifierManager>>
 }
 
-@Suppress("FunctionNaming")
+@Suppress("FunctionNaming", "LongParameterList")
 fun ObserveCurrentSessionAnalyticsUseCase(
     currentSessionFlow: Flow<CurrentSessionResult>,
     isUserTeamMember: suspend (UserId) -> Boolean,
@@ -77,7 +77,7 @@ fun ObserveCurrentSessionAnalyticsUseCase(
                 ) { identifierResult, enabled ->
                     previousAnalyticsResult = identifierResult
 
-                    val isProdBackend = when(val serverConfig = currentBackend(userId)) {
+                    val isProdBackend = when (val serverConfig = currentBackend(userId)) {
                         is SelfServerConfigUseCase.Result.Success -> serverConfig.serverLinks.links.api == ServerConfig.PRODUCTION.api
                         is SelfServerConfigUseCase.Result.Failure -> false
                     }

--- a/app/src/test/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCaseTest.kt
@@ -22,11 +22,15 @@ import com.wire.android.assertIs
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.framework.TestUser
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.configuration.server.CommonApiVersionType
+import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.analytics.AnalyticsIdentifierResult
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.analytics.AnalyticsIdentifierManager
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -66,6 +70,7 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
                 setCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
                 setIsTeamMember(TestUser.SELF_USER.id)
                 setObservingTrackingIdentifierStatus(AnalyticsIdentifierResult.ExistingIdentifier(Arrangement.CURRENT_TRACKING_IDENTIFIER))
+                setSelfServerConfig(Arrangement.SEVER_CONFIG_PRODUCTION)
             }.arrange()
 
         // when
@@ -89,6 +94,61 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
                     setObservingTrackingIdentifierStatus(
                         AnalyticsIdentifierResult.ExistingIdentifier(Arrangement.CURRENT_TRACKING_IDENTIFIER)
                     )
+                    setSelfServerConfig(Arrangement.SEVER_CONFIG_PRODUCTION)
+                }.arrange()
+
+            // when
+            useCase.invoke().test {
+                // then
+                val item = awaitItem()
+                assertIs<AnalyticsIdentifierResult.Disabled>(item.identifierResult)
+                assertEquals(true, item.isTeamMember)
+                assertEquals(true, item.manager != null)
+            }
+        }
+
+    @Test
+    fun givenThereIsAValidSessionButCustomBackend_whenObservingCurrentSessionAnalytics_thenDisabledAnalyticsResultIsReturned() =
+        runTest {
+            // given
+            val (_, useCase) = Arrangement()
+                .withIsAnonymousUsageDataEnabled(true)
+                .apply {
+                    setCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
+                    setIsTeamMember(TestUser.SELF_USER.id)
+                    setObservingTrackingIdentifierStatus(
+                        AnalyticsIdentifierResult.ExistingIdentifier(Arrangement.CURRENT_TRACKING_IDENTIFIER)
+                    )
+                    setSelfServerConfig(
+                        Arrangement.SEVER_CONFIG_PRODUCTION.copy(
+                            serverLinks = Arrangement.SEVER_CONFIG_PRODUCTION.serverLinks.copy(links = ServerConfig.STAGING)
+                        )
+                    )
+                }.arrange()
+
+            // when
+            useCase.invoke().test {
+                // then
+                val item = awaitItem()
+                assertIs<AnalyticsIdentifierResult.Disabled>(item.identifierResult)
+                assertEquals(true, item.isTeamMember)
+                assertEquals(true, item.manager != null)
+            }
+        }
+
+    @Test
+    fun givenThereIsAValidSessionButFailureOnCustomBackend_whenObservingCurrentSessionAnalytics_thenDisabledAnalyticsResultIsReturned() =
+        runTest {
+            // given
+            val (_, useCase) = Arrangement()
+                .withIsAnonymousUsageDataEnabled(true)
+                .apply {
+                    setCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
+                    setIsTeamMember(TestUser.SELF_USER.id)
+                    setObservingTrackingIdentifierStatus(
+                        AnalyticsIdentifierResult.ExistingIdentifier(Arrangement.CURRENT_TRACKING_IDENTIFIER)
+                    )
+                    setSelfServerConfig(SelfServerConfigUseCase.Result.Failure(CoreFailure.Unknown(null)))
                 }.arrange()
 
             // when
@@ -110,6 +170,7 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
                 setCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
                 setIsTeamMember(TestUser.SELF_USER.id)
                 setObservingTrackingIdentifierStatus(AnalyticsIdentifierResult.ExistingIdentifier(Arrangement.CURRENT_TRACKING_IDENTIFIER))
+                setSelfServerConfig(Arrangement.SEVER_CONFIG_PRODUCTION)
             }.arrange()
 
         // when
@@ -124,6 +185,7 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
             arrangement.setObservingTrackingIdentifierStatus(
                 AnalyticsIdentifierResult.ExistingIdentifier(Arrangement.OTHER_TRACKING_IDENTIFIER)
             )
+            arrangement.setSelfServerConfig(Arrangement.SEVER_CONFIG_PRODUCTION)
             arrangement.withIsAnonymousUsageDataEnabled(true)
 
             // then
@@ -148,6 +210,8 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
 
         private val analyticsTrackingIdentifierStatusChannel = Channel<AnalyticsIdentifierResult>(Channel.UNLIMITED)
 
+        private val selfServerConfigChannel = Channel<SelfServerConfigUseCase.Result>(Channel.UNLIMITED)
+
         private val teamMembers = mutableSetOf<UserId>()
 
         private val isTeamMember: (UserId) -> Boolean = { teamMembers.contains(it) }
@@ -169,6 +233,10 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
             analyticsTrackingIdentifierStatusChannel.send(result)
         }
 
+        suspend fun setSelfServerConfig(result: SelfServerConfigUseCase.Result) {
+            selfServerConfigChannel.send(result)
+        }
+
         fun withIsAnonymousUsageDataEnabled(result: Boolean): Arrangement = apply {
             every { userDataStoreProvider.getOrCreate(any()) } returns userDataStore
             coEvery { userDataStore.isAnonymousUsageDataEnabled() } returns flowOf(result)
@@ -183,7 +251,10 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
             analyticsIdentifierManagerProvider = {
                 analyticsIdentifierManager
             },
-            userDataStoreProvider = userDataStoreProvider
+            userDataStoreProvider = userDataStoreProvider,
+            currentBackend = {
+                selfServerConfigChannel.receive()
+            }
         )
 
         fun arrange() = this to useCase
@@ -191,6 +262,18 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
         companion object {
             const val CURRENT_TRACKING_IDENTIFIER = "abcd-1234"
             const val OTHER_TRACKING_IDENTIFIER = "aaaa-bbbb-1234"
+
+            val SEVER_CONFIG_PRODUCTION = SelfServerConfigUseCase.Result.Success(
+                serverLinks = ServerConfig(
+                    id = "server_id",
+                    links = ServerConfig.PRODUCTION,
+                    metaData = ServerConfig.MetaData(
+                        federation = false,
+                        commonApiVersion = CommonApiVersionType.New,
+                        domain = null
+                    )
+                )
+            )
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10020" title="WPB-10020" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10020</a>  [Android] Do not send data to Countly from custom backends
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We were sending analytics to custom backends (and not only prod)

### Causes (Optional)

No verification was implemented

### Solutions

Add verification of current API URL and verify agains PROD API URL so ignoring any other custom backend (staging included).

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

-- Test 1
- Having analytics enabled
- Login to prod and check that data is sent to analytics

-- Test 2
- Having analytics enabled
- Login to a custom backend and check that data is not sent to analytics