### PR TITLE
ci: create 'beta' builds for nightly tests suite (WPB-10408)

### DIFF
--- a/.github/actions/deploy-to-s3/action.yml
+++ b/.github/actions/deploy-to-s3/action.yml
@@ -49,7 +49,7 @@ runs:
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-        aws-region: 'us-west-1'
+        aws-region: 'eu-central-1'
         aws-bucket: ${{ inputs.aws-bucket }}
         destination-dir: "megazord/android/reloaded/${{ inputs.build-flavour }}/${{ inputs.build-variant }}/"
         file-path: ${{ steps.path.outputs.apk_full_path }}

--- a/.github/workflows/build-rc-app.yml
+++ b/.github/workflows/build-rc-app.yml
@@ -100,3 +100,56 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           build-flavour: internal
           build-variant: compat
+
+  ## build release candidate for nightly runs.
+  build-rc:
+    needs: [ code-analysis, ui-tests, unit-tests ]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref_name == 'release/candidate'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive # Needed in order to fetch Kalium sources for building
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: buildjet/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+      - name: Decode release Keystore
+        env:
+          ENCODED_STRING: ${{ secrets.ENCODED_KEYSTORE_PRE_RELEASE }}
+        run: |
+          TMP_KEYSTORE_FILE_PATH="${RUNNER_TEMP}"/keystore
+          echo $ENCODED_STRING | base64 -di > "${TMP_KEYSTORE_FILE_PATH}"/the.keystore
+      - name: Build Staging flavour
+        run:
+          ./gradlew app:assembleStagingRelease
+        env:
+          DATADOG_APP_ID: ${{ secrets.DATADOG_APP_ID }}
+          DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
+          KEYSTORE_FILE_PATH_DEBUG: ${{ vars.KEYSTORE_FILE_PATH }}
+          KEYSTORE_FILE_PATH_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}
+          KEYSTORE_FILE_PATH_COMPAT: ${{ vars.KEYSTORE_FILE_PATH }}
+          KEYSTORE_FILE_PATH_COMPAT_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}
+          KEYSTORE_KEY_NAME_RELEASE: ${{ secrets.SIGNING_KEY_ALIAS_PRE_RELEASE }}
+          KEYPWD_RELEASE: ${{ secrets.SIGNING_KEY_PASSWORD_PRE_RELEASE }}
+          KEYSTOREPWD_RELEASE: ${{ secrets.SIGNING_STORE_PASSWORD_PRE_RELEASE }}
+          ENABLE_SIGNING: ${{ secrets.ENABLE_SIGNING }}
+      - name: Upload
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Build Artifacts
+          path: app/build/outputs/
+      - name: Deploy StagingRelease to S3
+        uses: ./.github/actions/deploy-to-s3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-bucket: ${{ secrets.AWS_S3_BUCKET }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          build-flavour: staging
+          build-variant: release


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10408" title="WPB-10408" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10408</a>  [Android] Enable QA again to access release builds for nightly runs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

QA can not run anymore, 'nightly' runs, since the migration to gh actions.

### Causes (Optional)

We changed the flavors built, and they cannot differentiate between the ones coming from develop and release/candidate 

### Solutions

Create "beta" (staging release) for pushes on release candidate only. 

### Notes

- Do not merge yet, until we can validate with QA.
- After done, update the docs here https://wearezeta.atlassian.net/wiki/x/I4DYSw

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
