### PR TITLE
feat: generate effects file on demand [WPB-9713]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -66,7 +66,6 @@ class AudioMediaRecorder @Inject constructor(
     private var assetLimitInMB: Long = ASSET_SIZE_DEFAULT_LIMIT_BYTES
 
     var originalOutputPath: Path? = null
-    var effectsOutputPath: Path? = null
     var mp4OutputPath: Path? = null
 
     private val _maxFileSizeReached = MutableSharedFlow<RecordAudioDialogState>()
@@ -93,9 +92,6 @@ class AudioMediaRecorder @Inject constructor(
 
             originalOutputPath = kaliumFileSystem
                 .tempFilePath(getRecordingAudioFileName())
-
-            effectsOutputPath = kaliumFileSystem
-                .tempFilePath(getRecordingAudioEffectsFileName())
 
             mp4OutputPath = kaliumFileSystem
                 .tempFilePath(getRecordingMP4AudioFileName())
@@ -223,18 +219,12 @@ class AudioMediaRecorder @Inject constructor(
     }
 
     @Suppress("LongMethod", "CyclomaticComplexMethod")
-    suspend fun convertWavToMp4(shouldApplyEffects: Boolean): Boolean = withContext(Dispatchers.IO) {
+    suspend fun convertWavToMp4(inputFilePath: String): Boolean = withContext(Dispatchers.IO) {
         var codec: MediaCodec? = null
         var muxer: MediaMuxer? = null
         var fileInputStream: FileInputStream? = null
 
         try {
-            val inputFilePath = if (shouldApplyEffects) {
-                effectsOutputPath!!.toString()
-            } else {
-                originalOutputPath!!.toString()
-            }
-
             val inputFile = File(inputFilePath)
             fileInputStream = FileInputStream(inputFile)
 
@@ -339,7 +329,6 @@ class AudioMediaRecorder @Inject constructor(
     companion object {
         fun getRecordingAudioFileName(): String = "wire-audio-${DateTimeUtil.currentInstant().fileDateTime()}.wav"
         fun getRecordingMP4AudioFileName(): String = "wire-audio-${DateTimeUtil.currentInstant().fileDateTime()}.mp4"
-        fun getRecordingAudioEffectsFileName(): String = "wire-audio-${DateTimeUtil.currentInstant().fileDateTime()}-filter.wav"
 
         const val SIZE_OF_1MB = 1024 * 1024
         const val AUDIO_CHANNELS = 1 // Mono


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9713" title="WPB-9713" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9713</a>  [Android] Generate the audio filter file on demand when needed after recording
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

File containing recorded audio filter was created even when it was not needed after recording

### Causes (Optional)

Takes longer time to prepare audio file without filter

### Solutions

Create audio file with filter on demand, when:
- user clicks filter before recording -> prepare file after recording
- user clicks filter after recording -> show encoding state and prepare file with filter

