### PR TITLE
fix: Remove Reset Session for MLS conversations

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -366,7 +366,7 @@ fun ConversationScreen(
                     is ConversationDetailsData.Group ->
                         navigator.navigate(NavigationCommand(GroupConversationDetailsScreenDestination(conversationId)))
 
-                    ConversationDetailsData.None -> { /* do nothing */
+                    is ConversationDetailsData.None -> { /* do nothing */
                     }
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -250,7 +250,7 @@ fun PreviewConversationScreenTopAppBarLongTitle() {
             conversationName = UIText.DynamicString(
                 "This is some very very very very very very very very very very long conversation title"
             ),
-            conversationDetailsData = ConversationDetailsData.Group(QualifiedID("", "")),
+            conversationDetailsData = ConversationDetailsData.Group(null, QualifiedID("", "")),
             conversationAvatar = ConversationAvatar.OneOne(null, UserAvailabilityStatus.NONE),
         ),
         onBackButtonClick = {},
@@ -275,7 +275,7 @@ fun PreviewConversationScreenTopAppBarLongTitleWithSearch() {
             conversationName = UIText.DynamicString(
                 "This is some very very very very very very very very very very long conversation title"
             ),
-            conversationDetailsData = ConversationDetailsData.Group(QualifiedID("", "")),
+            conversationDetailsData = ConversationDetailsData.Group(null, QualifiedID("", "")),
             conversationAvatar = ConversationAvatar.OneOne(null, UserAvailabilityStatus.NONE),
         ),
         onBackButtonClick = {},
@@ -300,7 +300,7 @@ fun PreviewConversationScreenTopAppBarLongTitleWithSearchAndOngoingCall() {
             conversationName = UIText.DynamicString(
                 "This is some very very very very very very very very very very long conversation title"
             ),
-            conversationDetailsData = ConversationDetailsData.Group(QualifiedID("", "")),
+            conversationDetailsData = ConversationDetailsData.Group(null, QualifiedID("", "")),
             conversationAvatar = ConversationAvatar.OneOne(null, UserAvailabilityStatus.NONE),
         ),
         onBackButtonClick = {},
@@ -324,7 +324,7 @@ fun PreviewConversationScreenTopAppBarShortTitle() {
         ConversationInfoViewState(
             conversationId = ConversationId("value", "domain"),
             conversationName = UIText.DynamicString("Short title"),
-            conversationDetailsData = ConversationDetailsData.Group(conversationId),
+            conversationDetailsData = ConversationDetailsData.Group(null, conversationId),
             conversationAvatar = ConversationAvatar.Group(conversationId)
         ),
         onBackButtonClick = {},
@@ -348,7 +348,7 @@ fun PreviewConversationScreenTopAppBarShortTitleWithOngoingCall() {
         ConversationInfoViewState(
             conversationId = ConversationId("value", "domain"),
             conversationName = UIText.DynamicString("Short title"),
-            conversationDetailsData = ConversationDetailsData.Group(conversationId),
+            conversationDetailsData = ConversationDetailsData.Group(null, conversationId),
             conversationAvatar = ConversationAvatar.Group(conversationId)
         ),
         onBackButtonClick = {},
@@ -372,7 +372,7 @@ fun PreviewConversationScreenTopAppBarShortTitleWithVerified() {
         ConversationInfoViewState(
             conversationId = ConversationId("value", "domain"),
             conversationName = UIText.DynamicString("Short title"),
-            conversationDetailsData = ConversationDetailsData.Group(conversationId),
+            conversationDetailsData = ConversationDetailsData.Group(null, conversationId),
             conversationAvatar = ConversationAvatar.Group(conversationId),
             protocolInfo = Conversation.ProtocolInfo.Proteus,
             proteusVerificationStatus = Conversation.VerificationStatus.VERIFIED,
@@ -399,7 +399,7 @@ fun PreviewConversationScreenTopAppBarShortTitleWithLegalHold() {
         ConversationInfoViewState(
             conversationId = ConversationId("value", "domain"),
             conversationName = UIText.DynamicString("Short title"),
-            conversationDetailsData = ConversationDetailsData.Group(conversationId),
+            conversationDetailsData = ConversationDetailsData.Group(null, conversationId),
             conversationAvatar = ConversationAvatar.Group(conversationId),
             protocolInfo = Conversation.ProtocolInfo.Proteus,
             legalHoldStatus = Conversation.LegalHoldStatus.ENABLED,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -250,7 +250,10 @@ fun PreviewConversationScreenTopAppBarLongTitle() {
             conversationName = UIText.DynamicString(
                 "This is some very very very very very very very very very very long conversation title"
             ),
-            conversationDetailsData = ConversationDetailsData.Group(null, QualifiedID("", "")),
+            conversationDetailsData = ConversationDetailsData.Group(
+                conversationProtocol = null,
+                conversationId = QualifiedID("", "")
+            ),
             conversationAvatar = ConversationAvatar.OneOne(null, UserAvailabilityStatus.NONE),
         ),
         onBackButtonClick = {},
@@ -275,7 +278,10 @@ fun PreviewConversationScreenTopAppBarLongTitleWithSearch() {
             conversationName = UIText.DynamicString(
                 "This is some very very very very very very very very very very long conversation title"
             ),
-            conversationDetailsData = ConversationDetailsData.Group(null, QualifiedID("", "")),
+            conversationDetailsData = ConversationDetailsData.Group(
+                conversationProtocol = null,
+                conversationId = QualifiedID("", "")
+            ),
             conversationAvatar = ConversationAvatar.OneOne(null, UserAvailabilityStatus.NONE),
         ),
         onBackButtonClick = {},
@@ -300,7 +306,10 @@ fun PreviewConversationScreenTopAppBarLongTitleWithSearchAndOngoingCall() {
             conversationName = UIText.DynamicString(
                 "This is some very very very very very very very very very very long conversation title"
             ),
-            conversationDetailsData = ConversationDetailsData.Group(null, QualifiedID("", "")),
+            conversationDetailsData = ConversationDetailsData.Group(
+                conversationProtocol = null,
+                conversationId = QualifiedID("", "")
+            ),
             conversationAvatar = ConversationAvatar.OneOne(null, UserAvailabilityStatus.NONE),
         ),
         onBackButtonClick = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
@@ -55,6 +55,7 @@ import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.EMPTY
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
@@ -217,7 +218,8 @@ private fun SingleUserDeliveryFailure(
 internal fun MessageDecryptionFailure(
     messageHeader: MessageHeader,
     decryptionStatus: MessageFlowStatus.Failure.Decryption,
-    onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit
+    onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit,
+    conversationProtocol: Conversation.ProtocolInfo?
 ) {
     val context = LocalContext.current
     val learnMoreUrl = stringResource(R.string.url_decryption_failure_learn_more)
@@ -240,6 +242,9 @@ internal fun MessageDecryptionFailure(
                 text = stringResource(R.string.label_learn_more)
             )
             VerticalSpace.x4()
+
+            if (conversationProtocol !is Conversation.ProtocolInfo.Proteus) return@Column
+
             Text(
                 text = stringResource(R.string.label_message_decryption_failure_informative_message),
                 style = LocalTextStyle.current,
@@ -307,7 +312,12 @@ fun PreviewMessageSendFailureWarning() {
 @Composable
 fun PreviewMessageDecryptionFailure() {
     WireTheme {
-        MessageDecryptionFailure(mockHeader, MessageFlowStatus.Failure.Decryption(false)) { _, _ -> }
+        MessageDecryptionFailure(
+            mockHeader,
+            MessageFlowStatus.Failure.Decryption(false),
+            { _, _ -> },
+            null
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItemComponents.kt
@@ -316,7 +316,7 @@ fun PreviewMessageDecryptionFailure() {
             mockHeader,
             MessageFlowStatus.Failure.Decryption(false),
             { _, _ -> },
-            null
+            Conversation.ProtocolInfo.Proteus
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -133,8 +133,13 @@ class ConversationInfoViewModel @Inject constructor(
 
     private fun getConversationDetailsData(conversationDetails: ConversationDetails) =
         when (conversationDetails) {
-            is ConversationDetails.Group -> ConversationDetailsData.Group(conversationDetails.conversation.id)
+            is ConversationDetails.Group -> ConversationDetailsData.Group(
+                conversationDetails.conversation.protocol,
+                conversationDetails.conversation.id
+            )
+
             is ConversationDetails.OneOne -> ConversationDetailsData.OneOne(
+                conversationProtocol = conversationDetails.conversation.protocol,
                 otherUserId = conversationDetails.otherUser.id,
                 otherUserName = conversationDetails.otherUser.name,
                 connectionState = conversationDetails.otherUser.connectionStatus,
@@ -142,7 +147,7 @@ class ConversationInfoViewModel @Inject constructor(
                 isDeleted = conversationDetails.otherUser.deleted
             )
 
-            else -> ConversationDetailsData.None
+            else -> ConversationDetailsData.None(conversationDetails.conversation.protocol)
         }
 
     private fun getConversationAvatar(conversationDetails: ConversationDetails) =

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.data.user.UserId
 data class ConversationInfoViewState(
     val conversationId: QualifiedID,
     val conversationName: UIText = UIText.DynamicString(""),
-    val conversationDetailsData: ConversationDetailsData = ConversationDetailsData.None,
+    val conversationDetailsData: ConversationDetailsData = ConversationDetailsData.None(null),
     val conversationAvatar: ConversationAvatar = ConversationAvatar.None,
     val hasUserPermissionToEdit: Boolean = false,
     val conversationType: Conversation.Type = Conversation.Type.ONE_ON_ONE,
@@ -39,17 +39,21 @@ data class ConversationInfoViewState(
     val legalHoldStatus: Conversation.LegalHoldStatus = Conversation.LegalHoldStatus.UNKNOWN,
 )
 
-sealed class ConversationDetailsData {
-    data object None : ConversationDetailsData()
+sealed class ConversationDetailsData(open val conversationProtocol: Conversation.ProtocolInfo?) {
+    data class None(override val conversationProtocol: Conversation.ProtocolInfo?) : ConversationDetailsData(conversationProtocol)
     data class OneOne(
+        override val conversationProtocol: Conversation.ProtocolInfo?,
         val otherUserId: UserId,
         val otherUserName: String?,
         val connectionState: ConnectionState,
         val isBlocked: Boolean,
         val isDeleted: Boolean
-    ) : ConversationDetailsData()
+    ) : ConversationDetailsData(conversationProtocol)
 
-    data class Group(val conversationId: QualifiedID) : ConversationDetailsData()
+    data class Group(
+        override val conversationProtocol: Conversation.ProtocolInfo?,
+        val conversationId: QualifiedID
+    ) : ConversationDetailsData(conversationProtocol)
 }
 
 sealed class ConversationAvatar {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/FileAssetsContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/FileAssetsContent.kt
@@ -114,7 +114,7 @@ private fun AssetMessagesListContent(
                         is UIMessage.Regular -> {
                             MessageItem(
                                 message = message,
-                                conversationDetailsData = ConversationDetailsData.None,
+                                conversationDetailsData = ConversationDetailsData.None(null),
                                 audioMessagesState = audioMessagesState,
                                 onLongClicked = { },
                                 onAssetMessageClicked = onAssetItemClicked,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypesPreview.kt
@@ -31,9 +31,9 @@ import com.wire.android.ui.home.conversations.mock.mockAssetMessage
 import com.wire.android.ui.home.conversations.mock.mockFooter
 import com.wire.android.ui.home.conversations.mock.mockHeader
 import com.wire.android.ui.home.conversations.mock.mockMessageWithKnock
-import com.wire.android.ui.home.conversations.mock.mockMessageWithMarkdownTextAndLinks
 import com.wire.android.ui.home.conversations.mock.mockMessageWithMarkdownListAndImages
 import com.wire.android.ui.home.conversations.mock.mockMessageWithMarkdownTablesAndBlocks
+import com.wire.android.ui.home.conversations.mock.mockMessageWithMarkdownTextAndLinks
 import com.wire.android.ui.home.conversations.mock.mockMessageWithText
 import com.wire.android.ui.home.conversations.mock.mockedImageUIMessage
 import com.wire.android.ui.theme.WireTheme
@@ -58,7 +58,7 @@ fun PreviewMessage() {
                     )
                 )
             ),
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -87,7 +87,7 @@ fun PreviewMessageWithReactions() {
                 ),
                 messageFooter = mockFooter
             ),
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -127,7 +127,7 @@ fun PreviewMessageWithReply() {
                     )
                 )
             ),
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -157,7 +157,7 @@ fun PreviewDeletedMessage() {
                     )
                 )
             },
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -188,7 +188,7 @@ fun PreviewFailedSendMessage() {
                     messageFooter = mockFooter.copy(reactions = emptyMap(), ownReactions = emptySet())
                 )
             },
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -219,7 +219,7 @@ fun PreviewFailedDecryptionMessage() {
                     messageFooter = mockFooter.copy(reactions = emptyMap(), ownReactions = emptySet())
                 )
             },
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -240,7 +240,7 @@ fun PreviewAssetMessageWithReactions() {
     WireTheme {
         MessageItem(
             message = mockAssetMessage().copy(messageFooter = mockFooter),
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -329,7 +329,7 @@ fun PreviewImageMessageUploaded() {
     WireTheme {
         MessageItem(
             message = mockedImageUIMessage(Message.UploadStatus.UPLOADED),
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -350,7 +350,7 @@ fun PreviewImageMessageUploading() {
     WireTheme {
         MessageItem(
             message = mockedImageUIMessage(Message.UploadStatus.UPLOAD_IN_PROGRESS),
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -377,7 +377,7 @@ fun PreviewImageMessageFailedUpload() {
                     expirationStatus = ExpirationStatus.NotExpirable
                 )
             ),
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -399,7 +399,7 @@ fun PreviewMessageWithSystemMessage() {
         Column {
             MessageItem(
                 message = mockMessageWithText,
-                conversationDetailsData = ConversationDetailsData.None,
+                conversationDetailsData = ConversationDetailsData.None(null),
                 audioMessagesState = persistentMapOf(),
                 onLongClicked = {},
                 onAssetMessageClicked = {},
@@ -443,7 +443,7 @@ fun PreviewMessagesWithUnavailableQuotedMessage() {
                     )
                 )
             ),
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -465,7 +465,7 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
         Column {
             MessageItem(
                 message = mockMessageWithText,
-                conversationDetailsData = ConversationDetailsData.None,
+                conversationDetailsData = ConversationDetailsData.None(null),
                 audioMessagesState = persistentMapOf(),
                 onLongClicked = {},
                 onAssetMessageClicked = {},
@@ -486,7 +486,7 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                         )
                     )
                 ),
-                conversationDetailsData = ConversationDetailsData.None,
+                conversationDetailsData = ConversationDetailsData.None(null),
                 showAuthor = false,
                 audioMessagesState = persistentMapOf(),
                 onLongClicked = {},
@@ -508,7 +508,7 @@ fun PreviewAggregatedMessagesWithErrorMessage() {
                         )
                     )
                 ),
-                conversationDetailsData = ConversationDetailsData.None,
+                conversationDetailsData = ConversationDetailsData.None(null),
                 showAuthor = false,
                 audioMessagesState = persistentMapOf(),
                 onLongClicked = {},
@@ -531,7 +531,7 @@ fun PreviewMessageWithMarkdownTextAndLinks() {
     WireTheme {
         MessageItem(
             message = mockMessageWithMarkdownTextAndLinks,
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -552,7 +552,7 @@ fun PreviewMessageWithMarkdownListAndImages() {
     WireTheme {
         MessageItem(
             message = mockMessageWithMarkdownListAndImages,
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},
@@ -573,7 +573,7 @@ fun PreviewMessageWithMarkdownTablesAndBlocks() {
     WireTheme {
         MessageItem(
             message = mockMessageWithMarkdownTablesAndBlocks,
-            conversationDetailsData = ConversationDetailsData.None,
+            conversationDetailsData = ConversationDetailsData.None(null),
             audioMessagesState = persistentMapOf(),
             onLongClicked = {},
             onAssetMessageClicked = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesResultsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesResultsScreen.kt
@@ -53,7 +53,7 @@ fun SearchConversationMessagesResultsScreen(
                 is UIMessage.Regular -> {
                     MessageItem(
                         message = message,
-                        conversationDetailsData = ConversationDetailsData.None,
+                        conversationDetailsData = ConversationDetailsData.None(null),
                         searchQuery = searchQuery,
                         audioMessagesState = persistentMapOf(),
                         onLongClicked = { },
@@ -72,7 +72,8 @@ fun SearchConversationMessagesResultsScreen(
                         shouldDisplayFooter = false
                     )
                 }
-                is UIMessage.System -> { }
+
+                is UIMessage.System -> {}
             }
         }
     }


### PR DESCRIPTION
# What's new in this PR?

### Issues

When we receive decryption errors in an MLS conversation, we show a “reset session” button.
But this button does not help to reset the session and is useless.

Therefore, we should hide it and not show it to the user.

### Causes (Optional)

Nobody think about differences in MLS conversations :) 

### Solutions

Think about it and remove "Reset Session" btn and text "Try resetting the session ..." text
+ small refactoring in Compose MessageItem to make it bit more readable

