### PR TITLE
fix: keep OngoingCallService always running during call [WPB-10467]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
@@ -138,7 +138,7 @@ class CallNotificationManager @Inject constructor(
         hideIncomingCallNotification()
     }
 
-    fun hideIncomingCallNotification() {
+    private fun hideIncomingCallNotification() {
         appLogger.i("$TAG: hiding incoming call")
 
         // This delay is just so when the user receives two calling signals one straight after the other [INCOMING -> CANCEL]

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -270,7 +270,7 @@ class WireNotificationManager @Inject constructor(
         // start observing ongoing calls for all users, but only if not yet started
         if (observingJobs.ongoingCallJob.get().let { it == null || !it.isActive }) {
             val job = scope.launch(dispatcherProvider.default()) {
-                observeOngoingCalls(currentScreenState)
+                observeOngoingCalls()
             }
             observingJobs.ongoingCallJob.set(job)
         }
@@ -405,34 +405,23 @@ class WireNotificationManager @Inject constructor(
     /**
      * Infinitely listen for the established calls of a current user and run OngoingCall foreground Service
      * to show corresponding notification and do not lose a call.
-     * @param currentScreenState StateFlow that informs which screen is currently visible,
-     * so we can listen established calls only when the app is in background.
      */
-    private suspend fun observeOngoingCalls(currentScreenState: StateFlow<CurrentScreen>) {
-        currentScreenState
-            .flatMapLatest { currentScreen ->
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE && currentScreen !is CurrentScreen.InBackground) {
-                    flowOf(null)
+    private suspend fun observeOngoingCalls() {
+        coreLogic.getGlobalScope().session.currentSessionFlow()
+            .flatMapLatest {
+                if (it is CurrentSessionResult.Success && it.accountInfo.isValid()) {
+                    coreLogic.getSessionScope(it.accountInfo.userId).calls.establishedCall()
+                        .map { it.isNotEmpty() }
                 } else {
-                    coreLogic.getGlobalScope().session.currentSessionFlow()
-                        .flatMapLatest {
-                            if (it is CurrentSessionResult.Success && it.accountInfo.isValid()) {
-                                coreLogic.getSessionScope(it.accountInfo.userId).calls.establishedCall()
-                                    .map {
-                                        it.firstOrNull()
-                                    }
-                            } else {
-                                flowOf(null)
-                            }
-                        }
+                    flowOf(false)
                 }
             }
             .distinctUntilChanged()
             .onCompletion {
                 servicesManager.stopOngoingCallService()
             }
-            .collect { call ->
-                if (call != null) servicesManager.startOngoingCallService()
+            .collect { isOngoingCall ->
+                if (isOngoingCall) servicesManager.startOngoingCallService()
                 else servicesManager.stopOngoingCallService()
             }
     }

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -18,7 +18,6 @@
 
 package com.wire.android.notification
 
-import android.os.Build
 import androidx.annotation.VisibleForTesting
 import com.wire.android.R
 import com.wire.android.appLogger
@@ -480,12 +479,6 @@ class WireNotificationManager @Inject constructor(
             }
         }
     }
-
-    data class MessagesNotificationsData(
-        val newNotifications: List<LocalNotification>,
-        val userId: QualifiedID,
-        val userName: String
-    )
 
     private data class UserObservingJobs(
         val currentScreenJob: Job,

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -90,6 +90,7 @@ import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.minutes
 
+@Suppress("LargeClass")
 @OptIn(ExperimentalCoroutinesApi::class)
 class WireNotificationManagerTest {
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10467" title="WPB-10467" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10467</a>  [Android] crash after a call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There are some `ForegroundServiceStartNotAllowedException` crashes. 

### Causes (Optional)

This exception happens when when trying to start foreground service while the app is not allowed to do so, like when the app is considered to be in the background. More on that here: https://developer.android.com/develop/background-work/services/foreground-services#bg-access-restrictions
Sometimes the `onStop` event is emitted with some delay, we can't really make sure that the app will fit within the allowed time, it's not clear how the system determines whether the app is still able to start foreground service or not.

### Solutions

Instead of starting the `OngoingCallService` only when the app goes into background, start it always when there's a new ongoing call and keep it running until it ends, so that the service is not stopped and started again when user puts app into foreground and background, so it's way less error-prone, and in that case starting foreground service should always be allowed because it happens right when the user makes an action to start or answer the call.
We actually already have that logic for Android 14 upwards, because of the microphone background restrictions, so another benefit of this change is that we will have that unified for all Android versions.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Create or join a call, the notification about ongoing call indicating that the `OngoingCallService` is running should be visible during the entire call, no matter if the app is in the background or foreground and it shouldn't crash when putting the app into background during the call.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
