### PR TITLE
feat: delete old log files [WPB-9439]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/LogFileWriter.kt
+++ b/app/src/main/kotlin/com/wire/android/util/LogFileWriter.kt
@@ -150,7 +150,7 @@ class LogFileWriter(private val logsDirectory: File) {
 
     private fun compressedFileName(): String {
         val currentDate = logFileTimeFormat.format(Date())
-        return "${LOG_FILE_PREFIX}_${currentDate}.$LOG_COMPRESSED_FILE_EXTENSION"
+        return "${LOG_FILE_PREFIX}_$currentDate.$LOG_COMPRESSED_FILE_EXTENSION"
     }
 
     private fun deleteOldCompressedFiles() = getCompressedFilesList()

--- a/app/src/main/kotlin/com/wire/android/util/LogFileWriter.kt
+++ b/app/src/main/kotlin/com/wire/android/util/LogFileWriter.kt
@@ -154,7 +154,7 @@ class LogFileWriter(private val logsDirectory: File) {
     }
 
     private fun deleteOldCompressedFiles() = getCompressedFilesList()
-        .sortedBy { it.name } // name contains date-time so it's safe to sort it by name
+        .sortedBy { it.lastModified() }
         .dropLast(LOG_COMPRESSED_FILES_MAX_COUNT)
         .forEach {
             it.delete()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9439" title="WPB-9439" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-9439</a>  [Android] log file rotation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, logs are accumulated into multiple files and there's no mechanism to keep the max size or max count of log files resulting in lot of logs being generated, taking too much space and being too long to handle when debugging.

### Solutions

Keep only 10 most recent log files, remove too old ones when creating a new one. Currently, each compressed log file has 25MB of logs, so 250MB should be more than enough to debug.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
