### PR TITLE
feat: Add Analytics Usage opt-in dialog (WPB-9970) & (WPB-9973)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -243,6 +243,7 @@ dependencies {
     testImplementation(libs.androidx.test.archCore)
     testImplementation(libs.junit4) // Maybe migrate completely to Junit 5?
     testImplementation(libs.junit5.core)
+    testImplementation(libs.junit5.params)
     testImplementation(libs.coroutines.test)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.mockk.core)

--- a/app/src/main/kotlin/com/wire/android/datastore/UserDataStore.kt
+++ b/app/src/main/kotlin/com/wire/android/datastore/UserDataStore.kt
@@ -78,10 +78,16 @@ class UserDataStore(private val context: Context, userId: UserId) {
 
     suspend fun setInitialSyncCompleted() { context.dataStore.edit { it[INITIAL_SYNC_COMPLETED] = true } }
 
-    fun isAnonymousUsageDataEnabled(): Flow<Boolean> = context.dataStore.data.map { it[ANONYMOUS_ANALYTICS] ?: true }
+    fun isAnonymousUsageDataEnabled(): Flow<Boolean> = context.dataStore.data.map { it[ANONYMOUS_ANALYTICS] ?: false }
 
     suspend fun setIsAnonymousAnalyticsEnabled(enabled: Boolean) {
         context.dataStore.edit { it[ANONYMOUS_ANALYTICS] = enabled }
+    }
+
+    fun isAnalyticsDialogSeen(): Flow<Boolean> = context.dataStore.data.map { it[ANALYTICS_DIALOG_SEEN] ?: false }
+
+    suspend fun setIsAnalyticsDialogSeen() {
+        context.dataStore.edit { it[ANALYTICS_DIALOG_SEEN] = true }
     }
 
     companion object {
@@ -96,6 +102,7 @@ class UserDataStore(private val context: Context, userId: UserId) {
         private val INITIAL_SYNC_COMPLETED = booleanPreferencesKey("initial_sync_completed")
         private val LAST_BACKUP_DATE_INSTANT = longPreferencesKey("last_backup_date_instant")
         private val ANONYMOUS_ANALYTICS = booleanPreferencesKey("anonymous_analytics")
+        private val ANALYTICS_DIALOG_SEEN = booleanPreferencesKey("analytics_dialog_seen")
     }
 
 }

--- a/app/src/main/kotlin/com/wire/android/di/AppModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/AppModule.kt
@@ -26,6 +26,7 @@ import android.media.MediaPlayer
 import androidx.core.app.NotificationManagerCompat
 import com.wire.android.BuildConfig
 import com.wire.android.mapper.MessageResourceProvider
+import com.wire.android.ui.analytics.AnalyticsConfiguration
 import com.wire.android.ui.home.appLock.CurrentTimestampProvider
 import com.wire.android.ui.home.messagecomposer.location.LocationPickerParameters
 import com.wire.android.util.dispatchers.DefaultDispatcherProvider
@@ -90,4 +91,8 @@ object AppModule {
 
     @Provides
     fun provideLocationPickerParameters(): LocationPickerParameters = LocationPickerParameters()
+
+    @Provides
+    fun provideAnalyticsConfiguration() =
+        if (BuildConfig.ANALYTICS_ENABLED) AnalyticsConfiguration.Enabled else AnalyticsConfiguration.Disabled
 }

--- a/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsConfiguration.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsConfiguration.kt
@@ -17,10 +17,7 @@
  */
 package com.wire.android.ui.analytics
 
-import com.wire.android.BuildConfig
-import dagger.Provides
-
 sealed interface AnalyticsConfiguration {
-    data object Enabled: AnalyticsConfiguration
-    data object Disabled: AnalyticsConfiguration
+    data object Enabled : AnalyticsConfiguration
+    data object Disabled : AnalyticsConfiguration
 }

--- a/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsConfiguration.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsConfiguration.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.analytics
+
+import com.wire.android.BuildConfig
+import dagger.Provides
+
+sealed interface AnalyticsConfiguration {
+    data object Enabled: AnalyticsConfiguration
+    data object Disabled: AnalyticsConfiguration
+}

--- a/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsUsageState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsUsageState.kt
@@ -1,0 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.analytics
+
+data class AnalyticsUsageState(
+    val shouldDisplayDialog: Boolean = false
+)

--- a/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModel.kt
@@ -1,0 +1,84 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.analytics
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.appLogger
+import com.wire.android.datastore.UserDataStore
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AnalyticsUsageViewModel @Inject constructor(
+    private val analyticsEnabled: AnalyticsConfiguration,
+    private val dataStore: UserDataStore,
+    private val selfServerConfig: SelfServerConfigUseCase
+) : ViewModel() {
+
+    var state by mutableStateOf(AnalyticsUsageState())
+
+    init {
+        viewModelScope.launch {
+            val isDialogSeen = dataStore.isAnalyticsDialogSeen().first()
+            val isAnalyticsUsageEnabled = dataStore.isAnonymousUsageDataEnabled().first()
+            val isAnalyticsConfigurationEnabled = analyticsEnabled is AnalyticsConfiguration.Enabled
+            val isProdBackend = when (val serverConfig = selfServerConfig()) {
+                is SelfServerConfigUseCase.Result.Success -> serverConfig.serverLinks.links.api == ServerConfig.PRODUCTION.api
+                is SelfServerConfigUseCase.Result.Failure -> false
+            }
+
+            val shouldShowDialog = isProdBackend && !isAnalyticsUsageEnabled && isAnalyticsConfigurationEnabled && !isDialogSeen
+
+            state = state.copy(
+                shouldDisplayDialog = shouldShowDialog
+            )
+        }
+    }
+
+    fun agreeAnalyticsUsage() {
+        viewModelScope.launch {
+            dataStore.setIsAnonymousAnalyticsEnabled(enabled = true)
+            dataStore.setIsAnalyticsDialogSeen()
+
+            hideDialog()
+        }
+    }
+
+    fun declineAnalyticsUsage() {
+        viewModelScope.launch {
+            dataStore.setIsAnonymousAnalyticsEnabled(enabled = false)
+            dataStore.setIsAnalyticsDialogSeen()
+
+            hideDialog()
+        }
+    }
+
+    private fun hideDialog() {
+        state = state.copy(
+            shouldDisplayDialog = false
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModel.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.appLogger
 import com.wire.android.datastore.UserDataStore
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeDialogs.kt
@@ -58,10 +58,50 @@ fun WelcomeNewUserDialog(
     )
 }
 
+@Composable
+fun AnalyticsUsageDialog(
+    agreeOption: () -> Unit = {},
+    declineOption: () -> Unit = {},
+    context: Context = LocalContext.current
+) {
+    val privacyPolicyUrl = stringResource(id = R.string.url_privacy_policy)
+    WireDialog(
+        title = stringResource(id = R.string.analytics_usage_dialog_title),
+        text = stringResource(id = R.string.analytics_usage_dialog_text),
+        optionButton1Properties = WireDialogButtonProperties(
+            onClick = agreeOption,
+            text = stringResource(id = R.string.analytics_usage_dialog_button_agree),
+            type = WireDialogButtonType.Primary
+        ),
+        optionButton2Properties = WireDialogButtonProperties(
+            onClick = {
+                CustomTabsHelper.launchUrl(context, privacyPolicyUrl)
+            },
+            text = stringResource(id = R.string.analytics_usage_dialog_button_privacy_policy),
+            type = WireDialogButtonType.Secondary
+        ),
+        dismissButtonProperties = WireDialogButtonProperties(
+            onClick = declineOption,
+            text = stringResource(id = R.string.analytics_usage_dialog_button_decline),
+            type = WireDialogButtonType.Secondary
+        ),
+        buttonsHorizontalAlignment = false,
+        onDismiss = declineOption
+    )
+}
+
 @PreviewMultipleThemes
 @Composable
-fun previewWelcomeNewUserDialog() {
+fun PreviewWelcomeNewUserDialog() {
     WireTheme {
         WelcomeNewUserDialog({})
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewAnalyticsOptInDialog() {
+    WireTheme {
+        AnalyticsUsageDialog()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -60,6 +60,7 @@ import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.ramcosta.composedestinations.navigation.dependency
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultRecipient
+import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.navigation.HomeDestination
@@ -68,6 +69,7 @@ import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
 import com.wire.android.navigation.handleNavigation
 import com.wire.android.ui.NavGraphs
+import com.wire.android.ui.analytics.AnalyticsUsageViewModel
 import com.wire.android.ui.common.CollapsingTopBarScaffold
 import com.wire.android.ui.common.FloatingActionButton
 import com.wire.android.ui.common.dialogs.PermissionPermanentlyDeniedDialog
@@ -97,7 +99,8 @@ fun HomeScreen(
     otherUserProfileScreenResultRecipient: ResultRecipient<OtherUserProfileScreenDestination, String>,
     homeViewModel: HomeViewModel = hiltViewModel(),
     appSyncViewModel: AppSyncViewModel = hiltViewModel(),
-    homeDrawerViewModel: HomeDrawerViewModel = hiltViewModel()
+    homeDrawerViewModel: HomeDrawerViewModel = hiltViewModel(),
+    analyticsUsageViewModel: AnalyticsUsageViewModel = hiltViewModel()
 ) {
     homeViewModel.checkRequirements { it.navigate(navigator::navigate) }
     val homeScreenState = rememberHomeScreenState(navigator)
@@ -143,6 +146,13 @@ fun HomeScreen(
     if (homeViewModel.homeState.shouldDisplayWelcomeMessage) {
         WelcomeNewUserDialog(
             dismissDialog = homeViewModel::dismissWelcomeMessage
+        )
+    }
+
+    if(analyticsUsageViewModel.state.shouldDisplayDialog) {
+        AnalyticsUsageDialog(
+            agreeOption = analyticsUsageViewModel::agreeAnalyticsUsage,
+            declineOption = analyticsUsageViewModel::declineAnalyticsUsage
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -60,7 +60,6 @@ import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.ramcosta.composedestinations.navigation.dependency
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultRecipient
-import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.navigation.HomeDestination
@@ -149,7 +148,7 @@ fun HomeScreen(
         )
     }
 
-    if(analyticsUsageViewModel.state.shouldDisplayDialog) {
+    if (analyticsUsageViewModel.state.shouldDisplayDialog) {
         AnalyticsUsageDialog(
             agreeOption = analyticsUsageViewModel::agreeAnalyticsUsage,
             declineOption = analyticsUsageViewModel::declineAnalyticsUsage

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1158,6 +1158,12 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="cancel_login_button_label">Cancel</string>
     <string name="cancel_login_dialog_description">If you cancel now, you will be logged out.</string>
     <string name="cancel_login_dialog_title">Are you sure you want to cancel?</string>
+    <!-- Analytics Usage dialog -->
+    <string name="analytics_usage_dialog_title">Consent to share user data</string>
+    <string name="analytics_usage_dialog_text">Help to improve Wire by sharing your usage data via a pseudonymous ID.\n\nThe data is neither linked to your personal information nor shared with third parties besides Zeta Project Germany GmbH. It includes, for example, when you use a feature, your app version, device type, or your operating system. The ID will be deleted at the latest from your device after [28] days after the last activity.\n\nFind further details in our Privacy Policy (link). You can revoke your consent at any time.</string>
+    <string name="analytics_usage_dialog_button_agree">Agree</string>
+    <string name="analytics_usage_dialog_button_decline">Decline</string>
+    <string name="analytics_usage_dialog_button_privacy_policy">Privacy Policy</string>
     <!-- session reset -->
     <string name="label_system_message_session_reset">%1$s was unable to decrypt some of your messages but has solved the issue. This affected all conversations you share together.</string>
     <string name="label_manual_migration_title">Migrate from version 3.82.38</string>

--- a/app/src/test/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModelTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.analytics
+
+import android.preference.PreferenceManager
+import com.wire.android.BuildConfig
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.datastore.UserDataStore
+import com.wire.android.util.newServerConfig
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.robolectric.util.ReflectionHelpers
+
+@ExtendWith(CoroutineTestExtension::class)
+class AnalyticsUsageViewModelTest {
+
+    @ParameterizedTest
+    @EnumSource(TestParams::class)
+    fun `should hide or show Analytics Usage dialog - handle accordingly`(params: TestParams) = runTest {
+        // given
+        val (_, viewModel) = Arrangement()
+            .withProdBackend(params.isProdBackend)
+            .withAnalyticsUsageEnabled(params.isAnalyticsUsageEnabled)
+            .withIsDialogSeen(params.isDialogSeen)
+            .arrange(analyticsConfiguration = params.analyticsConfiguration)
+
+        advanceUntilIdle()
+
+        // when
+        // then
+        assertEquals(params.expected, viewModel.state.shouldDisplayDialog)
+    }
+
+    @Test
+    fun `given dialog is shown, when user agrees to analytics usage, then setting analytics to enabled and dialog to seen`() = runTest {
+        // given
+        val (arrangement, viewModel) = Arrangement()
+            .withProdBackend(true)
+            .withAnalyticsUsageEnabled(false)
+            .withIsDialogSeen(false)
+            .arrange(analyticsConfiguration = AnalyticsConfiguration.Enabled)
+
+        advanceUntilIdle()
+        assertEquals(true, viewModel.state.shouldDisplayDialog)
+
+        // when
+
+        viewModel.agreeAnalyticsUsage()
+
+        // then
+        coVerify { arrangement.dataStore.setIsAnonymousAnalyticsEnabled(enabled = true) }
+        coVerify { arrangement.dataStore.setIsAnalyticsDialogSeen() }
+        assertEquals(false, viewModel.state.shouldDisplayDialog)
+    }
+
+    @Test
+    fun `given dialog is shown, when user declines analytics usage, then setting analytics to disabled and dialog to seen`() = runTest {
+        // given
+        val (arrangement, viewModel) = Arrangement()
+            .withProdBackend(true)
+            .withAnalyticsUsageEnabled(false)
+            .withIsDialogSeen(false)
+            .arrange(analyticsConfiguration = AnalyticsConfiguration.Enabled)
+
+        advanceUntilIdle()
+        assertEquals(true, viewModel.state.shouldDisplayDialog)
+
+        // when
+
+        viewModel.declineAnalyticsUsage()
+
+        // then
+        coVerify { arrangement.dataStore.setIsAnonymousAnalyticsEnabled(enabled = false) }
+        coVerify { arrangement.dataStore.setIsAnalyticsDialogSeen() }
+        assertEquals(false, viewModel.state.shouldDisplayDialog)
+    }
+
+    private class Arrangement {
+        val dataStore = mockk<UserDataStore>()
+        val selfServerConfig = mockk<SelfServerConfigUseCase>()
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+
+            coEvery { dataStore.setIsAnonymousAnalyticsEnabled(any()) } returns Unit
+            coEvery { dataStore.setIsAnalyticsDialogSeen() } returns Unit
+        }
+
+        fun withProdBackend(isProd: Boolean) = apply {
+            coEvery { selfServerConfig() } returns SelfServerConfigUseCase.Result.Success(
+                serverLinks = if (isProd) PRODUCTION_SERVER_CONFIG else CUSTOM_SERVER_CONFIG
+            )
+        }
+        fun withAnalyticsUsageEnabled(enabled: Boolean) = apply {
+            coEvery { dataStore.isAnonymousUsageDataEnabled() } returns flowOf(enabled)
+        }
+        fun withIsDialogSeen(enabled: Boolean) = apply {
+            coEvery { dataStore.isAnalyticsDialogSeen() } returns flowOf(enabled)
+        }
+
+        fun arrange(analyticsConfiguration: AnalyticsConfiguration) = this to AnalyticsUsageViewModel(
+            analyticsEnabled = analyticsConfiguration,
+            dataStore = dataStore,
+            selfServerConfig = selfServerConfig
+        )
+
+        private companion object {
+            val PRODUCTION_SERVER_CONFIG = newServerConfig(1).copy(links = ServerConfig.PRODUCTION)
+            val CUSTOM_SERVER_CONFIG = newServerConfig(1).copy(links = ServerConfig.STAGING)
+        }
+    }
+
+    companion object {
+
+        enum class TestParams(
+            val isProdBackend: Boolean,
+            val isAnalyticsUsageEnabled: Boolean,
+            val isDialogSeen: Boolean,
+            val analyticsConfiguration: AnalyticsConfiguration,
+            val expected: Boolean
+        ) {
+            SHOULD_SHOW_DIALOG(
+                true,
+                false,
+                false,
+                AnalyticsConfiguration.Enabled,
+                true
+            ),
+            SHOULD_HIDE_DIALOG(
+                true,
+                false,
+                true,
+                AnalyticsConfiguration.Enabled,
+                false
+            ),
+            ANALYTICS_ALREADY_ENABLED(
+                true,
+                true,
+                true,
+                AnalyticsConfiguration.Enabled,
+                false
+            ),
+            CUSTOM_BACKEND(
+                false,
+                false,
+                false,
+                AnalyticsConfiguration.Enabled,
+                false
+            ),
+            ANALYTICS_CONFIGURATION_DISABLED(
+                true,
+                false,
+                false,
+                AnalyticsConfiguration.Disabled,
+                false
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModelTest.kt
@@ -17,8 +17,6 @@
  */
 package com.wire.android.ui.analytics
 
-import android.preference.PreferenceManager
-import com.wire.android.BuildConfig
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.util.newServerConfig
@@ -28,7 +26,6 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -37,7 +34,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.robolectric.util.ReflectionHelpers
 
 @ExtendWith(CoroutineTestExtension::class)
 class AnalyticsUsageViewModelTest {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -269,6 +269,7 @@ androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", vers
 androidx-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "androidx-espresso" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 junit5-core = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
+junit5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
 junit5-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
 junit5-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5" }  # needed for tests that use Robolectric because it doesn't yet support JUnit5
 kluent-android = { module = "org.amshove.kluent:kluent-android", version.ref = "kluent" }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9970" title="WPB-9970" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-9970</a>  [Android] Clients: usage data collection for team users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

New implementation of opt-in dialog for analytics usage.

### Causes (Optional)

Not implemented.

### Solutions

- Add new dialog for Analytics Usage data
- Changed default/starting value of analytics to `false`

Note: Also added `jUnit5 params` lib

### Dependencies (Optional)

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Open App / fresh login (have analytics enabled on build config)
- analytics usage dialog will be shown
- agree/decline -> does what it needs and hides dialog
- privacy policy -> only opens webpage of privacy policy URL, doesn't hide the dialog

### Notes (Optional)

Again, I added `jUnit5 params` lib to this PR in order to minimize the duplication of tests with different params.

The initial PR for develop is here : https://github.com/wireapp/wire-android/pull/3288

### Attachments (Optional)
<img src="https://github.com/user-attachments/assets/13febf74-8fae-4bd3-8b01-691b89aa2711" width="300" height="500" />
<img src="https://github.com/user-attachments/assets/08a20cb5-62cb-4b3f-b8f2-864729efce5f" width="300" height="500" />
