### PR TITLE
chore: Set analytics enabled for beta builds (WPB-10293)

### DIFF
--- a/default.json
+++ b/default.json
@@ -65,7 +65,7 @@
             "development_api_enabled": false,
             "mls_support_enabled": false,
             "encrypt_proteus_storage": true,
-            "analytics_enabled": false,
+            "analytics_enabled": true,
             "analytics_app_key": "8ffae535f1836ed5f58fd5c8a11c00eca07c5438",
             "analytics_server_url": "https://countly.wire.com/"
         },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10293" title="WPB-10293" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10293</a>  [Android] disable countly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We needed analytics enable on beta builds to be tested

### Solutions

Set analytics enabled flag to true only on beta builds