### PR TITLE
chore: show hide analytics toggle (WPB-10587)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.RootNavGraph
+import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.colorsScheme
@@ -90,12 +91,14 @@ fun PrivacySettingsScreenContent(
                 .fillMaxSize()
                 .padding(internalPadding)
         ) {
-            GroupConversationOptionsItem(
-                title = stringResource(id = R.string.settings_send_anonymous_usage_data_title),
-                switchState = SwitchState.Enabled(value = isAnonymousUsageDataEnabled, onCheckedChange = setAnonymousUsageDataEnabled),
-                arrowType = ArrowType.NONE,
-                subtitle = stringResource(id = R.string.settings_send_anonymous_usage_data_description)
-            )
+            if (BuildConfig.ANALYTICS_ENABLED) {
+                GroupConversationOptionsItem(
+                    title = stringResource(id = R.string.settings_send_anonymous_usage_data_title),
+                    switchState = SwitchState.Enabled(value = isAnonymousUsageDataEnabled, onCheckedChange = setAnonymousUsageDataEnabled),
+                    arrowType = ArrowType.NONE,
+                    subtitle = stringResource(id = R.string.settings_send_anonymous_usage_data_description)
+                )
+            }
             WireDivider(color = colorsScheme().outlineVariant)
             GroupConversationOptionsItem(
                 title = stringResource(R.string.settings_send_read_receipts),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10587" title="WPB-10587" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10587</a>  [Android] Hide/Show Analytics Toggle in Privacy Settings Screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Analytics Toggle was always being shown despite being disabled from build config

### Causes (Optional)

Not implemented

### Solutions

Verify if build config for `ANALYTICS_ENABLED` is enabled before showing toggle

### Testing

#### How to Test

- Open App
- Login
- Open Privacy Settings Screen
- Check if Analytics Toggle is shown/hidden based on build config

### Attachments (Optional)

<img src="https://github.com/user-attachments/assets/b60f73b8-b009-4b1d-a881-6964fae65041" width="200" height="400" />