### PR TITLE
fix: Small grey rect appears on the bottom of other user profile screen (WPB-10453)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -178,8 +178,24 @@ fun OtherUserProfileScreen(
             resultNavigator.setResult(it)
             resultNavigator.navigateBack()
         },
-        onOpenConversation = { navigator.navigate(NavigationCommand(ConversationScreenDestination(it), BackStackMode.UPDATE_EXISTED)) },
-        onOpenDeviceDetails = { navigator.navigate(NavigationCommand(DeviceDetailsScreenDestination(navArgs.userId, it.clientId))) },
+        onOpenConversation = {
+            navigator.navigate(
+                NavigationCommand(
+                    ConversationScreenDestination(it),
+                    BackStackMode.UPDATE_EXISTED
+                )
+            )
+        },
+        onOpenDeviceDetails = {
+            navigator.navigate(
+                NavigationCommand(
+                    DeviceDetailsScreenDestination(
+                        navArgs.userId,
+                        it.clientId
+                    )
+                )
+            )
+        },
         onSearchConversationMessagesClick = onSearchConversationMessagesClick,
         navigateBack = navigator::navigateBack,
         navigationIconType = NavigationIconType.Close,
@@ -199,7 +215,10 @@ fun OtherUserProfileScreen(
     }
 
     VisibilityState(legalHoldSubjectDialogState) {
-        LegalHoldSubjectProfileDialog(viewModel.state.userName, legalHoldSubjectDialogState::dismiss)
+        LegalHoldSubjectProfileDialog(
+            viewModel.state.userName,
+            legalHoldSubjectDialogState::dismiss
+        )
     }
 }
 
@@ -274,7 +293,9 @@ fun OtherProfileScreenContent(
     }
     val maxBarElevation = MaterialTheme.wireDimensions.topBarShadowElevation
     val tabBarElevationState by remember(tabItems, lazyListStates, currentTabState) {
-        derivedStateOf { lazyListStates[tabItems[currentTabState]]?.topBarElevation(maxBarElevation) ?: 0.dp }
+        derivedStateOf {
+            lazyListStates[tabItems[currentTabState]]?.topBarElevation(maxBarElevation) ?: 0.dp
+        }
     }
 
     if (!requestInProgress) {
@@ -303,7 +324,16 @@ fun OtherProfileScreenContent(
                 onLegalHoldLearnMoreClick = onLegalHoldLearnMoreClick,
             )
         },
-        topBarFooter = { TopBarFooter(state, pagerState, tabBarElevationState, tabItems, currentTabState, scope) },
+        topBarFooter = {
+            TopBarFooter(
+                state = state,
+                pagerState = pagerState,
+                tabBarElevation = tabBarElevationState,
+                tabItems = tabItems,
+                currentTab = currentTabState,
+                scope = scope
+            )
+        },
         content = {
             Content(
                 state = state,
@@ -325,7 +355,7 @@ fun OtherProfileScreenContent(
                 onOpenConversation
             )
         },
-        isSwipeable = state.connectionState == ConnectionState.ACCEPTED
+        isSwipeable = state.connectionState != ConnectionState.BLOCKED
     )
 
     WireModalSheetLayout(
@@ -502,7 +532,11 @@ private fun Content(
                         ) { pageIndex ->
                             when (val tabItem = tabItems[pageIndex]) {
                                 OtherUserProfileTabItem.DETAILS ->
-                                    OtherUserProfileDetails(state, otherUserProfileScreenState, lazyListStates[tabItem]!!)
+                                    OtherUserProfileDetails(
+                                        state,
+                                        otherUserProfileScreenState,
+                                        lazyListStates[tabItem]!!
+                                    )
 
                                 OtherUserProfileTabItem.GROUP ->
                                     OtherUserProfileGroup(
@@ -558,9 +592,9 @@ fun ContentFooter(
             shadowElevation = maxBarElevation,
             color = MaterialTheme.wireColorScheme.background
         ) {
-            Box(modifier = Modifier.padding(all = dimensions().spacing16x)) {
-                // TODO show open conversation button for service bots after AR-2135
-                if (!state.isMetadataEmpty() && state.membership != Membership.Service && !state.isTemporaryUser()) {
+            // TODO show open conversation button for service bots after AR-2135
+            if (!state.isMetadataEmpty() && state.membership != Membership.Service && !state.isTemporaryUser()) {
+                Box(modifier = Modifier.padding(all = dimensions().spacing16x)) {
                     ConnectionActionButton(
                         state.userId,
                         state.userName,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -588,12 +588,12 @@ fun ContentFooter(
         enter = fadeIn(),
         exit = fadeOut(),
     ) {
-        Surface(
-            shadowElevation = maxBarElevation,
-            color = MaterialTheme.wireColorScheme.background
-        ) {
-            // TODO show open conversation button for service bots after AR-2135
-            if (!state.isMetadataEmpty() && state.membership != Membership.Service && !state.isTemporaryUser()) {
+        // TODO show open conversation button for service bots after AR-2135
+        if (!state.isMetadataEmpty() && state.membership != Membership.Service && !state.isTemporaryUser()) {
+            Surface(
+                shadowElevation = maxBarElevation,
+                color = MaterialTheme.wireColorScheme.background
+            ) {
                 Box(modifier = Modifier.padding(all = dimensions().spacing16x)) {
                     ConnectionActionButton(
                         state.userId,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10453" title="WPB-10453" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10453</a>  [Android] Mysterious fragment displayed on bottom on user profile screens
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Small grey rect appears on the bottom of other user profile screen as shown in screenshot

![a4087432-1f94-44d9-b0a5-73e1ebb87de1](https://github.com/user-attachments/assets/4b144222-3a3b-4679-995a-ecc3ad349fdd)

### Causes (Optional)

We are checking if we should show connection button after showing a box that has some padding

### Solutions

Move if block before creating the surface

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
