### PR TITLE
fix: ensure request focus is called once after the first composition is done [WPB-10571]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeScreen.kt
@@ -187,11 +187,11 @@ private fun CodeContent(
             }
             Spacer(modifier = Modifier.weight(1f))
         }
-    }
-    LaunchedEffect(Unit) {
-        coroutineContext.job.invokeOnCompletion {
-            focusRequester.requestFocus()
-            keyboardController?.show()
+        LaunchedEffect(Unit) {
+            coroutineContext.job.invokeOnCompletion {
+                focusRequester.requestFocus()
+                keyboardController?.show()
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -83,6 +85,7 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.configuration.server.ServerConfig
+import kotlinx.coroutines.job
 
 @CreatePersonalAccountNavGraph
 @CreateTeamAccountNavGraph
@@ -185,6 +188,9 @@ private fun EmailContent(
             }
             Spacer(modifier = Modifier.weight(1f))
             EmailFooter(state = state, onLoginPressed = onLoginPressed, onContinuePressed = onContinuePressed)
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
         }
     }
     if (state.termsDialogVisible) {
@@ -197,9 +203,6 @@ private fun EmailContent(
     }
     if (state.error is CreateAccountEmailViewState.EmailError.DialogError.GenericError) {
         CoreFailureErrorDialog(state.error.coreFailure, onErrorDismiss)
-    }
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
@@ -34,8 +34,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -85,15 +83,14 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.configuration.server.ServerConfig
-import kotlinx.coroutines.job
 
 @CreatePersonalAccountNavGraph
 @CreateTeamAccountNavGraph
 @WireDestination(navArgsDelegate = CreateAccountNavArgs::class)
 @Composable
 fun CreateAccountEmailScreen(
-    createAccountEmailViewModel: CreateAccountEmailViewModel = hiltViewModel(),
-    navigator: Navigator
+    navigator: Navigator,
+    createAccountEmailViewModel: CreateAccountEmailViewModel = hiltViewModel()
 ) {
     with(createAccountEmailViewModel) {
         fun navigateToDetailsScreen() = navigator.navigate(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10571" title="WPB-10571" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10571</a>  [Android] crash in create account screen because of focus requester
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

IllegalStateException in create account screen 

### Causes (Optional)

request focus is called before the first compisition is done

### Solutions

thanks to @saleniuk who pointed out this [issue tracker ticket](https://issuetracker.google.com/issues/206249038#comment9) with the suggested fix to move the LaunchEffect inside the Scaffold 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
