### PR TITLE
refactor: unify modal bottom sheets [WPB-10610]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/PreviewWireModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/PreviewWireModalSheetLayout.kt
@@ -27,7 +27,7 @@ import com.wire.android.ui.home.conversationslist.common.GroupConversationAvatar
 @MultipleThemePreviews
 @Composable
 fun PreviewMenuModalSheetContentWithoutHeader() {
-    MenuModalSheetContent(
+    WireMenuModalSheetContent(
         header = MenuModalSheetHeader.Gone,
         menuItems = listOf { ReactionOption({}) }
     )
@@ -36,7 +36,7 @@ fun PreviewMenuModalSheetContentWithoutHeader() {
 @MultipleThemePreviews
 @Composable
 fun PreviewMenuModalSheetContentWithHeader() {
-    MenuModalSheetContent(
+    WireMenuModalSheetContent(
         header = MenuModalSheetHeader.Visible(
             "Title",
             { GroupConversationAvatar(colorsScheme().primary) },

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
@@ -45,7 +45,6 @@ fun ConversationSheetContent(
     unblockUser: (UnblockUserDialogState) -> Unit,
     leaveGroup: (GroupDialogState) -> Unit,
     deleteGroup: (GroupDialogState) -> Unit,
-    closeBottomSheet: () -> Unit = {},
     isBottomSheetVisible: () -> Boolean = { true }
 ) {
     // it may be null as initial state
@@ -73,8 +72,6 @@ fun ConversationSheetContent(
             val goBack: () -> Unit = {
                 if (conversationSheetState.startOptionNavigation == ConversationOptionNavigation.Home)
                     conversationSheetState.toHome()
-                else
-                    closeBottomSheet()
             }
             MutingOptionsSheetContent(
                 mutingConversationState = conversationSheetState.conversationSheetContent!!.mutingConversationState,

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
@@ -35,7 +35,7 @@ import com.wire.android.ui.common.ArrowRightIcon
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
 import com.wire.android.ui.common.bottomsheet.MenuItemIcon
-import com.wire.android.ui.common.bottomsheet.MenuModalSheetContent
+import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.conversationColor
@@ -66,7 +66,7 @@ internal fun ConversationMainSheetContent(
     deleteGroup: (GroupDialogState) -> Unit,
     navigateToNotification: () -> Unit
 ) {
-    MenuModalSheetContent(
+    WireMenuModalSheetContent(
         header = MenuModalSheetHeader.Visible(
             title = conversationSheetContent.title,
             leadingIcon = {

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
@@ -278,9 +278,10 @@ internal fun ConversationMainSheetContent(
 
 @Composable
 fun NotificationsOptionsItemAction(
-    mutedStatus: MutedConversationStatus
+    mutedStatus: MutedConversationStatus,
+    modifier: Modifier = Modifier,
 ) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         Text(
             text = mutedStatus.getMutedStatusTextResource(),
             style = MaterialTheme.wireTypography.body01,

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/MutingOptionsSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/MutingOptionsSheetContent.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.ArrowLeftIcon
-import com.wire.android.ui.common.bottomsheet.MenuModalSheetContent
+import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
 import com.wire.android.ui.common.bottomsheet.SelectableMenuBottomSheetItem
 import com.wire.android.ui.common.bottomsheet.RichMenuItemState
@@ -38,7 +38,7 @@ internal fun MutingOptionsSheetContent(
     onMuteConversation: (MutedConversationStatus) -> Unit,
     onBackClick: () -> Unit,
 ) {
-    MenuModalSheetContent(
+    WireMenuModalSheetContent(
         header = MenuModalSheetHeader.Visible(
             title = stringResource(R.string.label_notifications),
             leadingIcon = {

--- a/app/src/main/kotlin/com/wire/android/ui/edit/CopyItemMenuOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/CopyItemMenuOption.kt
@@ -15,12 +15,24 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.android.ui.home.messagecomposer.location
+package com.wire.android.ui.edit
 
-data class LocationPickerState(
-    val geoLocatedAddress: GeoLocatedAddress? = null,
-    val isLocationLoading: Boolean = false,
-    val isPermissionDiscarded: Boolean = false,
-    val showPermissionDeniedDialog: Boolean = false,
-    val showLocationSharingError: Boolean = false,
-)
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
+import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
+import com.wire.android.ui.common.bottomsheet.MenuItemIcon
+
+@Composable
+fun CopyItemMenuOption(onCopyItemClick: () -> Unit) {
+    MenuBottomSheetItem(
+        icon = {
+            MenuItemIcon(
+                id = R.drawable.ic_copy,
+                contentDescription = stringResource(R.string.content_description_copy_the_message),
+            )
+        },
+        title = stringResource(R.string.label_copy),
+        onItemClick = onCopyItemClick
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/edit/EditMessageMenuOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/EditMessageMenuOption.kt
@@ -15,12 +15,24 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.android.ui.home.messagecomposer.location
+package com.wire.android.ui.edit
 
-data class LocationPickerState(
-    val geoLocatedAddress: GeoLocatedAddress? = null,
-    val isLocationLoading: Boolean = false,
-    val isPermissionDiscarded: Boolean = false,
-    val showPermissionDeniedDialog: Boolean = false,
-    val showLocationSharingError: Boolean = false,
-)
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
+import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
+import com.wire.android.ui.common.bottomsheet.MenuItemIcon
+
+@Composable
+fun EditMessageMenuOption(onEditItemClick: () -> Unit) {
+    MenuBottomSheetItem(
+        icon = {
+            MenuItemIcon(
+                id = R.drawable.ic_edit,
+                contentDescription = stringResource(R.string.content_description_edit_the_message)
+            )
+        },
+        title = stringResource(R.string.label_edit),
+        onItemClick = onEditItemClick
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/edit/ShareAssetMenuOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/ShareAssetMenuOption.kt
@@ -15,12 +15,24 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.android.ui.home.messagecomposer.location
+package com.wire.android.ui.edit
 
-data class LocationPickerState(
-    val geoLocatedAddress: GeoLocatedAddress? = null,
-    val isLocationLoading: Boolean = false,
-    val isPermissionDiscarded: Boolean = false,
-    val showPermissionDeniedDialog: Boolean = false,
-    val showLocationSharingError: Boolean = false,
-)
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
+import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
+import com.wire.android.ui.common.bottomsheet.MenuItemIcon
+
+@Composable
+fun ShareAssetMenuOption(onShareAsset: () -> Unit) {
+    MenuBottomSheetItem(
+        icon = {
+            MenuItemIcon(
+                id = R.drawable.ic_share_file,
+                contentDescription = stringResource(R.string.content_description_share_the_file),
+            )
+        },
+        title = stringResource(R.string.label_share),
+        onItemClick = onShareAsset
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreenState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreenState.kt
@@ -19,14 +19,10 @@
 package com.wire.android.ui.home.conversations
 
 import android.content.Context
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -34,16 +30,16 @@ import androidx.compose.ui.text.AnnotatedString
 import com.wire.android.R
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
-import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
+import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun rememberConversationScreenState(
-    bottomSheetState: WireModalSheetState = rememberWireModalSheetState(),
+    editSheetState: WireModalSheetState<UIMessage.Regular> = rememberWireModalSheetState<UIMessage.Regular>(),
+    selfDeletingSheetState: WireModalSheetState<SelfDeletionTimer> = rememberWireModalSheetState<SelfDeletionTimer>(),
     coroutineScope: CoroutineScope = rememberCoroutineScope()
 ): ConversationScreenState {
     val context = LocalContext.current
@@ -55,7 +51,8 @@ fun rememberConversationScreenState(
             context = context,
             clipboardManager = clipboardManager,
             snackBarHostState = snackBarHostState,
-            modalBottomSheetState = bottomSheetState,
+            editSheetState = editSheetState,
+            selfDeletingSheetState = selfDeletingSheetState,
             coroutineScope = coroutineScope
         )
     }
@@ -66,42 +63,25 @@ class ConversationScreenState(
     val context: Context,
     val clipboardManager: ClipboardManager,
     val snackBarHostState: SnackbarHostState,
-    val modalBottomSheetState: WireModalSheetState,
+    val editSheetState: WireModalSheetState<UIMessage.Regular>,
+    val selfDeletingSheetState: WireModalSheetState<SelfDeletionTimer>,
     val coroutineScope: CoroutineScope
 ) {
-
-    var bottomSheetMenuType: BottomSheetMenuType by mutableStateOf(BottomSheetMenuType.None)
-
     fun showEditContextMenu(message: UIMessage.Regular) {
-        bottomSheetMenuType = BottomSheetMenuType.Edit(message)
-        coroutineScope.launch { modalBottomSheetState.show() }
-    }
-
-    fun hideContextMenu(onComplete: () -> Unit = {}) {
-        coroutineScope.launch {
-            modalBottomSheetState.hide()
-            onComplete()
-        }
+        editSheetState.show(message)
     }
 
     fun copyMessage(text: String) {
         clipboardManager.setText(AnnotatedString(text))
         coroutineScope.launch {
-            modalBottomSheetState.hide()
             snackBarHostState.showSnackbar(context.getString(R.string.info_message_copied))
         }
     }
 
     fun showSelfDeletionContextMenu(currentlySelected: SelfDeletionTimer) {
-        bottomSheetMenuType = BottomSheetMenuType.SelfDeletion(currentlySelected)
-        coroutineScope.launch { modalBottomSheetState.show() }
+        selfDeletingSheetState.show(currentlySelected)
     }
 
-    sealed class BottomSheetMenuType {
-        class Edit(val selectedMessage: UIMessage.Regular) : BottomSheetMenuType()
-
-        class SelfDeletion(val currentlySelected: SelfDeletionTimer) : BottomSheetMenuType()
-
-        data object None : BottomSheetMenuType()
-    }
+    val isAnySheetVisible: Boolean
+        get() = editSheetState.isVisible || selfDeletingSheetState.isVisible
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -80,6 +80,7 @@ import com.wire.android.ui.common.bottomsheet.conversation.ConversationSheetCont
 import com.wire.android.ui.common.bottomsheet.conversation.ConversationTypeDetail
 import com.wire.android.ui.common.bottomsheet.conversation.rememberConversationSheetState
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
+import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.calculateCurrentTab
 import com.wire.android.ui.common.dialogs.ArchiveConversationDialog
@@ -295,12 +296,10 @@ private fun GroupConversationDetailsContent(
 
     val conversationSheetState = rememberConversationSheetState(conversationSheetContent)
 
-    val sheetState = rememberWireModalSheetState()
-    val openBottomSheet: () -> Unit = remember { { scope.launch { sheetState.show() } } }
+    val sheetState = rememberWireModalSheetState<Unit>()
     val closeBottomSheetAndShowSnackbarMessage: (UIText) -> Unit = remember {
         {
-            scope.launch {
-                sheetState.hide()
+            sheetState.hide {
                 snackbarHostState.showSnackbar(it.asString(resources))
             }
         }
@@ -343,7 +342,7 @@ private fun GroupConversationDetailsContent(
                 },
                 navigationIconType = NavigationIconType.Close,
                 onNavigationPressed = onBackPressed,
-                actions = { MoreOptionIcon(onButtonClicked = openBottomSheet) }
+                actions = { MoreOptionIcon(onButtonClicked = sheetState::show) }
             )
         },
         topBarCollapsing = {
@@ -442,7 +441,6 @@ private fun GroupConversationDetailsContent(
 
     WireModalSheetLayout(
         sheetState = sheetState,
-        coroutineScope = rememberCoroutineScope(),
         sheetContent = {
             ConversationSheetContent(
                 isBottomSheetVisible = getBottomSheetVisibility,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/CreateGuestLinkBottomSheet.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/CreateGuestLinkBottomSheet.kt
@@ -18,26 +18,25 @@
 package com.wire.android.ui.home.conversations.details.editguestaccess
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.common.ArrowRightIcon
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
-import com.wire.android.ui.common.bottomsheet.MenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
+import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
+import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 
 @Composable
 fun CreateGuestLinkBottomSheet(
-    sheetState: WireModalSheetState,
+    sheetState: WireModalSheetState<Unit>,
     onItemClick: (passwordProtected: Boolean) -> Unit,
     isPasswordInviteLinksAllowed: Boolean,
 ) {
-    val coroutineScope = rememberCoroutineScope()
-    WireModalSheetLayout(sheetState = sheetState, coroutineScope = coroutineScope) {
-        MenuModalSheetContent(
+    WireModalSheetLayout(sheetState = sheetState) {
+        WireMenuModalSheetContent(
             header = MenuModalSheetHeader.Visible(title = stringResource(R.string.create_guest_link)),
             menuItems = buildList {
                 if (isPasswordInviteLinksAllowed) {
@@ -81,7 +80,7 @@ private fun CreateInviteLinkSheetItem(
 @Composable
 fun PreviewCreateGuestLinkBottomSheet() {
     CreateGuestLinkBottomSheet(
-        sheetState = WireModalSheetState(),
+        sheetState = rememberWireModalSheetState(),
         onItemClick = {},
         isPasswordInviteLinksAllowed = true,
     )
@@ -91,7 +90,7 @@ fun PreviewCreateGuestLinkBottomSheet() {
 @Composable
 fun PreviewCreateGuestLinkBottomSheetDisabled() {
     CreateGuestLinkBottomSheet(
-        sheetState = WireModalSheetState(),
+        sheetState = rememberWireModalSheetState(),
         onItemClick = {},
         isPasswordInviteLinksAllowed = false,
     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
@@ -76,27 +76,25 @@ fun EditGuestAccessScreen(
     val scrollState = rememberScrollState()
     val snackbarHostState = LocalSnackbarHostState.current
     val sheetState = rememberWireModalSheetState<Unit>()
-    val onSheetItemClick: (Boolean) -> Unit = remember {
-        { isPasswordProtected ->
-            sheetState.hide()
-            if (isPasswordProtected) {
-                navigator.navigate(
-                    NavigationCommand(
-                        CreatePasswordProtectedGuestLinkScreenDestination(
-                            CreatePasswordGuestLinkNavArgs(
-                                conversationId = editGuestAccessViewModel.conversationId
-                            )
+    val onSheetItemClick: (Boolean) -> Unit = { isPasswordProtected ->
+        sheetState.hide()
+        if (isPasswordProtected) {
+            navigator.navigate(
+                NavigationCommand(
+                    CreatePasswordProtectedGuestLinkScreenDestination(
+                        CreatePasswordGuestLinkNavArgs(
+                            conversationId = editGuestAccessViewModel.conversationId
                         )
                     )
                 )
-            } else {
-                editGuestAccessViewModel.onRequestGuestRoomLink()
-            }
+            )
+        } else {
+            editGuestAccessViewModel.onRequestGuestRoomLink()
         }
     }
     CreateGuestLinkBottomSheet(
         sheetState = sheetState,
-        onSheetItemClick,
+        onItemClick = remember { onSheetItemClick },
         isPasswordInviteLinksAllowed = editGuestAccessViewModel.editGuestAccessState.isPasswordProtectedLinksAllowed
     )
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
@@ -29,12 +29,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -47,21 +45,21 @@ import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
 import com.wire.android.navigation.rememberNavigator
-import com.wire.android.ui.common.bottomsheet.WireModalSheetState
+import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
+import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.rememberTopBarElevationState
 import com.wire.android.ui.common.scaffold.WireScaffold
+import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.destinations.CreatePasswordProtectedGuestLinkScreenDestination
 import com.wire.android.ui.home.conversations.details.editguestaccess.createPasswordProtectedGuestLink.CreatePasswordGuestLinkNavArgs
 import com.wire.android.ui.home.conversationslist.common.FolderHeader
-import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.copyLinkToClipboard
 import com.wire.android.util.shareViaIntent
-import kotlinx.coroutines.launch
 
 @Suppress("ComplexMethod")
 @OptIn(ExperimentalMaterial3Api::class)
@@ -72,17 +70,15 @@ import kotlinx.coroutines.launch
 @Composable
 fun EditGuestAccessScreen(
     navigator: Navigator,
-    editGuestAccessViewModel: EditGuestAccessViewModel = hiltViewModel(),
+    modifier: Modifier = Modifier,
+    editGuestAccessViewModel: EditGuestAccessViewModel = hiltViewModel()
 ) {
     val scrollState = rememberScrollState()
     val snackbarHostState = LocalSnackbarHostState.current
-    val coroutineScope = rememberCoroutineScope()
-    val sheetState = remember {
-        WireModalSheetState(SheetValue.Hidden)
-    }
+    val sheetState = rememberWireModalSheetState<Unit>()
     val onSheetItemClick: (Boolean) -> Unit = remember {
         { isPasswordProtected ->
-            coroutineScope.launch { sheetState.hide() }
+            sheetState.hide()
             if (isPasswordProtected) {
                 navigator.navigate(
                     NavigationCommand(
@@ -104,13 +100,15 @@ fun EditGuestAccessScreen(
         isPasswordInviteLinksAllowed = editGuestAccessViewModel.editGuestAccessState.isPasswordProtectedLinksAllowed
     )
 
-    WireScaffold(topBar = {
-        WireCenterAlignedTopAppBar(
-            elevation = scrollState.rememberTopBarElevationState().value,
-            onNavigationPressed = navigator::navigateBack,
-            title = stringResource(id = R.string.conversation_options_guests_label)
-        )
-    }) { internalPadding ->
+    WireScaffold(
+        modifier = modifier,
+        topBar = {
+            WireCenterAlignedTopAppBar(
+                elevation = scrollState.rememberTopBarElevationState().value,
+                onNavigationPressed = navigator::navigateBack,
+                title = stringResource(id = R.string.conversation_options_guests_label)
+            )
+        }) { internalPadding ->
         Column {
             LazyColumn(
                 modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
@@ -108,7 +108,8 @@ fun EditGuestAccessScreen(
                 onNavigationPressed = navigator::navigateBack,
                 title = stringResource(id = R.string.conversation_options_guests_label)
             )
-        }) { internalPadding ->
+        }
+    ) { internalPadding ->
         Column {
             LazyColumn(
                 modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/AssetOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/AssetOptionsMenuItems.kt
@@ -24,19 +24,21 @@ import com.wire.android.ui.edit.MessageDetailsMenuOption
 import com.wire.android.ui.edit.OpenAssetExternallyOption
 import com.wire.android.ui.edit.ReactionOption
 import com.wire.android.ui.edit.ReplyMessageOption
+import com.wire.android.ui.edit.ShareAssetMenuOption
 
+// menu items with both asset options enabled (like share, download, etc.) and message options enabled (like reply, reaction, etc.)
 @Composable
-fun assetEditMenuItems(
+fun assetMessageOptionsMenuItems(
     isEphemeral: Boolean,
-    messageOptionsEnabled: Boolean,
     onDeleteClick: () -> Unit,
     onDetailsClick: () -> Unit,
     onShareAsset: () -> Unit,
     onDownloadAsset: () -> Unit,
     onReplyClick: () -> Unit,
-    onReactionClick: (String) -> Unit,
+    onReactionClick: (emoji: String) -> Unit,
+    isOpenable: Boolean = false,
+    onOpenAsset: () -> Unit = {},
     isUploading: Boolean = false,
-    onOpenAsset: (() -> Unit)? = null
 ): List<@Composable () -> Unit> {
     return buildList {
         when {
@@ -45,16 +47,9 @@ fun assetEditMenuItems(
             }
 
             isEphemeral -> {
-                if (messageOptionsEnabled) {
-                    add { MessageDetailsMenuOption(onDetailsClick) }
-                }
+                add { MessageDetailsMenuOption(onDetailsClick) }
                 add { DownloadAssetExternallyOption(onDownloadAsset) }
-                add { DeleteItemMenuOption(onDeleteClick) }
-            }
-
-            !messageOptionsEnabled -> {
-                add { DownloadAssetExternallyOption(onDownloadAsset) }
-                add { ShareAssetMenuOption(onShareAsset) }
+                if (isOpenable) add { OpenAssetExternallyOption(onOpenAsset) }
                 add { DeleteItemMenuOption(onDeleteClick) }
             }
 
@@ -64,9 +59,29 @@ fun assetEditMenuItems(
                 add { ReplyMessageOption(onReplyClick) }
                 add { DownloadAssetExternallyOption(onDownloadAsset) }
                 add { ShareAssetMenuOption(onShareAsset) }
-                if (onOpenAsset != null) add { OpenAssetExternallyOption(onOpenAsset) }
+                if (isOpenable) add { OpenAssetExternallyOption(onOpenAsset) }
                 add { DeleteItemMenuOption(onDeleteClick) }
             }
         }
     }
+}
+
+// menu items with only asset options enabled (like share, download, etc.)
+@Composable
+fun assetOptionsMenuItems(
+    isEphemeral: Boolean,
+    onDeleteClick: () -> Unit,
+    onShareAsset: () -> Unit,
+    onDownloadAsset: () -> Unit,
+    isOpenable: Boolean = false,
+    onOpenAsset: () -> Unit = {},
+    isUploading: Boolean = false,
+): List<@Composable () -> Unit> = buildList {
+    if (!isUploading) {
+        add { DownloadAssetExternallyOption(onDownloadAsset) }
+        if (!isEphemeral) add { ShareAssetMenuOption(onShareAsset) }
+        if (isOpenable) add { OpenAssetExternallyOption(onOpenAsset) }
+        add { DeleteItemMenuOption(onDeleteClick) }
+    }
+    add { DeleteItemMenuOption(onDeleteClick) }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsMenuItems.kt
@@ -66,10 +66,10 @@ fun messageOptionsMenuItems(
             }
         }
     }
-    val onReactionItemClick = remember(message.header.messageId) {
-        { emoji: String ->
+    val onReactionItemClick: (emoji: String) -> Unit = remember(message.header.messageId) {
+        {
             hideEditMessageMenu {
-                onReactionClick(message.header.messageId, emoji)
+                onReactionClick(message.header.messageId, it)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsMenuItems.kt
@@ -21,10 +21,6 @@ package com.wire.android.ui.home.conversations.edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import com.wire.android.R
-import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
-import com.wire.android.ui.common.bottomsheet.MenuItemIcon
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent
@@ -33,32 +29,34 @@ import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.message.mention.MessageMention
 
 @Composable
-fun editMessageMenuItems(
+fun messageOptionsMenuItems(
     message: UIMessage.Regular,
-    messageOptionsEnabled: Boolean,
     hideEditMessageMenu: (OnComplete) -> Unit,
-    onCopyClick: (String) -> Unit,
-    onDeleteClick: (messageId: String, Boolean) -> Unit,
+    onCopyClick: (text: String) -> Unit,
+    onDeleteClick: (messageId: String, isMyMessage: Boolean) -> Unit,
     onReactionClick: (messageId: String, reactionEmoji: String) -> Unit,
     onDetailsClick: (messageId: String, isSelfMessage: Boolean) -> Unit,
     onReplyClick: (UIMessage.Regular) -> Unit,
-    onEditClick: (String, String, List<MessageMention>) -> Unit,
-    onShareAssetClick: () -> Unit,
-    onDownloadAssetClick: (String) -> Unit,
-    onOpenAssetClick: (String) -> Unit
+    onEditClick: (messageId: String, messageBody: String, mentions: List<MessageMention>) -> Unit,
+    onShareAssetClick: (messageId: String) -> Unit,
+    onDownloadAssetClick: (messageId: String) -> Unit,
+    onOpenAssetClick: (messageId: String) -> Unit
 ): List<@Composable () -> Unit> {
     val localContext = LocalContext.current
+    val isUploading = message.isPending
+    val isDeleted = message.isDeleted
+    val isMyMessage = message.isMyMessage
+    val isComposite = message.messageContent is UIMessageContent.Composite
+    val isEphemeral = message.header.messageStatus.expirationStatus is ExpirationStatus.Expirable
+    val isEditable = !isUploading && !isDeleted && message.messageContent is UIMessageContent.TextMessage && isMyMessage
+    val isCopyable = !isUploading && !isDeleted && message.messageContent is Copyable
 
-    val isComposite = remember(message.header.messageId) {
-        message.messageContent is UIMessageContent.Composite
-    }
-
-    val onCopyItemClick: (() -> Unit)? = remember(message.header.messageId) {
+    val onCopyItemClick = remember(message.messageContent) {
         (message.messageContent as? Copyable)?.textToCopy(localContext.resources)?.let {
             {
                 hideEditMessageMenu { onCopyClick(it) }
             }
-        }
+        } ?: {}
     }
 
     val onDeleteItemClick = remember(message.header.messageId) {
@@ -116,76 +114,42 @@ fun editMessageMenuItems(
             }
         }
     }
+    val onShareAssetItemClick = remember(message) {
+        {
+            hideEditMessageMenu {
+                onShareAssetClick(message.header.messageId)
+            }
+        }
+    }
 
     return if (message.isAssetMessage) {
-        assetEditMenuItems(
-            messageOptionsEnabled = messageOptionsEnabled,
-            isEphemeral = message.header.messageStatus.expirationStatus is ExpirationStatus.Expirable,
-            isUploading = message.isPending,
+        assetMessageOptionsMenuItems(
+            isEphemeral = isEphemeral,
+            isUploading = isUploading,
+            isOpenable = true,
             onDeleteClick = onDeleteItemClick,
             onDetailsClick = onDetailsItemClick,
-            onShareAsset = onShareAssetClick,
+            onShareAsset = onShareAssetItemClick,
             onDownloadAsset = onDownloadAssetItemClick,
             onReplyClick = onReplyItemClick,
             onReactionClick = onReactionItemClick,
-            onOpenAsset = onOpenAssetItemClick
+            onOpenAsset = onOpenAssetItemClick,
         )
     } else {
-        TextMessageEditMenuItems(
-            isEphemeral = message.header.messageStatus.expirationStatus is ExpirationStatus.Expirable,
-            isUploading = message.isPending,
+        textMessageEditMenuItems(
+            isEphemeral = isEphemeral,
+            isUploading = isUploading,
             isComposite = isComposite,
-            isLocation = message.isLocation,
+            isEditable = isEditable,
+            isCopyable = isCopyable,
             onDeleteClick = onDeleteItemClick,
             onDetailsClick = onDetailsItemClick,
             onReactionClick = onReactionItemClick,
-            onEditClick = if (message.isMyMessage && !message.isDeleted) onEditItemClick else null,
+            onEditClick = onEditItemClick,
             onCopyClick = onCopyItemClick,
             onReplyClick = onReplyItemClick
         )
     }
-}
-
-@Composable
-fun CopyItemMenuOption(onCopyItemClick: () -> Unit) {
-    MenuBottomSheetItem(
-        icon = {
-            MenuItemIcon(
-                id = R.drawable.ic_copy,
-                contentDescription = stringResource(R.string.content_description_copy_the_message),
-            )
-        },
-        title = stringResource(R.string.label_copy),
-        onItemClick = onCopyItemClick
-    )
-}
-
-@Composable
-fun ShareAssetMenuOption(onShareAsset: () -> Unit) {
-    MenuBottomSheetItem(
-        icon = {
-            MenuItemIcon(
-                id = R.drawable.ic_share_file,
-                contentDescription = stringResource(R.string.content_description_share_the_file),
-            )
-        },
-        title = stringResource(R.string.label_share),
-        onItemClick = onShareAsset
-    )
-}
-
-@Composable
-fun EditMessageMenuOption(onEditItemClick: () -> Unit) {
-    MenuBottomSheetItem(
-        icon = {
-            MenuItemIcon(
-                id = R.drawable.ic_edit,
-                contentDescription = stringResource(R.string.content_description_edit_the_message)
-            )
-        },
-        title = stringResource(R.string.label_edit),
-        onItemClick = onEditItemClick
-    )
 }
 
 typealias OnComplete = () -> Unit

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/TextMessageOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/TextMessageOptionsMenuItems.kt
@@ -18,31 +18,34 @@
 package com.wire.android.ui.home.conversations.edit
 
 import androidx.compose.runtime.Composable
+import com.wire.android.ui.edit.CopyItemMenuOption
 import com.wire.android.ui.edit.DeleteItemMenuOption
+import com.wire.android.ui.edit.EditMessageMenuOption
 import com.wire.android.ui.edit.MessageDetailsMenuOption
 import com.wire.android.ui.edit.ReactionOption
 import com.wire.android.ui.edit.ReplyMessageOption
 
 @Composable
-fun TextMessageEditMenuItems(
+fun textMessageEditMenuItems(
     isEphemeral: Boolean,
     isUploading: Boolean,
     isComposite: Boolean,
-    isLocation: Boolean,
+    isEditable: Boolean,
+    isCopyable: Boolean,
     onDeleteClick: () -> Unit,
     onDetailsClick: () -> Unit,
     onReplyClick: () -> Unit,
-    onCopyClick: (() -> Unit)?,
-    onReactionClick: (String) -> Unit,
-    onEditClick: (() -> Unit)? = null
+    onCopyClick: () -> Unit,
+    onReactionClick: (emoji: String) -> Unit,
+    onEditClick: (() -> Unit),
 ): List<@Composable () -> Unit> {
     return buildList {
         if (!isUploading) {
             if (!isEphemeral && !isComposite) add { ReactionOption(onReactionClick) }
             add { MessageDetailsMenuOption(onDetailsClick) }
-            onCopyClick?.also { add { CopyItemMenuOption(it) } }
+            if (isCopyable) { add { CopyItemMenuOption(onCopyClick) } }
             if (!isEphemeral && !isComposite) add { ReplyMessageOption(onReplyClick) }
-            if (!isEphemeral && !isLocation && onEditClick != null) add { EditMessageMenuOption(onEditClick) }
+            if (isEditable) add { EditMessageMenuOption(onEditClick) }
         }
         add { DeleteItemMenuOption(onDeleteClick) }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
@@ -325,13 +325,18 @@ fun mockAssetMessage() = UIMessage.Regular(
 
 @Suppress("MagicNumber")
 fun mockedImg() = UIMessageContent.ImageMessage(
-    UserAssetId("a", "domain"),
-    mockedPrivateAsset(),
-    800,
-    600
+    assetId = UserAssetId("a", "domain"),
+    asset = mockedPrivateAsset(),
+    width = 800,
+    height = 600
 )
 
-fun mockedPrivateAsset() = ImageAsset.PrivateAsset(mockImageLoader, ConversationId("id", "domain"), "messageId", true)
+fun mockedPrivateAsset() = ImageAsset.PrivateAsset(
+    imageLoader = mockImageLoader,
+    conversationId = ConversationId("id", "domain"),
+    messageId = "messageId",
+    isSelfAsset = true
+)
 
 @Suppress("MagicNumber")
 fun mockedImageUIMessage(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
@@ -326,9 +326,11 @@ fun mockAssetMessage() = UIMessage.Regular(
 @Suppress("MagicNumber")
 fun mockedImg() = UIMessageContent.ImageMessage(
     UserAssetId("a", "domain"),
-    ImageAsset.PrivateAsset(mockImageLoader, ConversationId("id", "domain"), "messageId", true),
+    mockedPrivateAsset(),
     800, 600
 )
+
+fun mockedPrivateAsset() = ImageAsset.PrivateAsset(mockImageLoader, ConversationId("id", "domain"), "messageId", true)
 
 @Suppress("MagicNumber")
 fun mockedImageUIMessage(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
@@ -327,7 +327,8 @@ fun mockAssetMessage() = UIMessage.Regular(
 fun mockedImg() = UIMessageContent.ImageMessage(
     UserAssetId("a", "domain"),
     mockedPrivateAsset(),
-    800, 600
+    800,
+    600
 )
 
 fun mockedPrivateAsset() = ImageAsset.PrivateAsset(mockImageLoader, ConversationId("id", "domain"), "messageId", true)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/selfdeletion/SelfDeletionMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/selfdeletion/SelfDeletionMenuItems.kt
@@ -22,31 +22,21 @@ import androidx.compose.runtime.Composable
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.bottomsheet.RichMenuItemState
 import com.wire.android.ui.common.bottomsheet.SelectableMenuBottomSheetItem
-import com.wire.android.ui.home.conversations.edit.OnComplete
 import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
 import com.wire.android.ui.theme.wireTypography
 
 @Composable
 fun selfDeletionMenuItems(
     currentlySelected: SelfDeletionDuration,
-    hideEditMessageMenu: (OnComplete) -> Unit,
     onSelfDeletionDurationChanged: (SelfDeletionDuration) -> Unit,
-): List<@Composable () -> Unit> {
-    val onSelfDeletionDurationSelected: (SelfDeletionDuration) -> Unit = { selfDeleteDuration ->
-        hideEditMessageMenu {
-            onSelfDeletionDurationChanged(selfDeleteDuration)
-        }
-    }
-
-    return buildList {
-        SelfDeletionDuration.customValues().forEach { duration ->
-            add {
-                SelfDeletionDurationMenuItem(
-                    duration = duration,
-                    isSelected = currentlySelected == duration,
-                    onSelfDeletionDurationSelected = onSelfDeletionDurationSelected
-                )
-            }
+): List<@Composable () -> Unit> = buildList {
+    SelfDeletionDuration.customValues().forEach { duration ->
+        add {
+            SelfDeletionDurationMenuItem(
+                duration = duration,
+                isSelected = currentlySelected == duration,
+                onSelfDeletionDurationSelected = onSelfDeletionDurationChanged
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -212,8 +212,8 @@ private fun MediaGalleryOptionsBottomSheetLayout(
         sheetState = sheetState,
         sheetContent = {
             WireMenuModalSheetContent(
-                menuItems = when (messageBottomSheetOptionsEnabled) {
-                    true -> assetMessageOptionsMenuItems(
+                menuItems = if (messageBottomSheetOptionsEnabled) {
+                    assetMessageOptionsMenuItems(
                         isUploading = false,
                         isEphemeral = isEphemeral,
                         onReplyClick = onReplyClick,
@@ -223,7 +223,8 @@ private fun MediaGalleryOptionsBottomSheetLayout(
                         onShareAsset = onShareAssetClick,
                         onDownloadAsset = downloadAsset,
                     )
-                    false -> assetOptionsMenuItems(
+                } else {
+                    assetOptionsMenuItems(
                         isUploading = false,
                         isEphemeral = isEphemeral,
                         onDeleteClick = onDeleteClick,

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -257,7 +257,7 @@ private fun SnackbarMessageHandler(snackbarMessage: SharedFlow<MediaGallerySnack
 private fun getSnackbarMessage(messageCode: MediaGallerySnackbarMessages, resources: Resources): Pair<String, String?> {
     val msg = when (messageCode) {
         is MediaGallerySnackbarMessages.OnImageDownloaded -> resources.getString(R.string.media_gallery_on_image_downloaded)
-        is MediaGallerySnackbarMessages.OnImageDownloadError -> resources.getString(R.string.media_gallery_on_image_downloaded)
+        is MediaGallerySnackbarMessages.OnImageDownloadError -> resources.getString(R.string.media_gallery_on_image_download_error)
         is MediaGallerySnackbarMessages.DeletingMessageError -> resources.getString(R.string.error_conversation_deleting_message)
     }
     val actionLabel = when (messageCode) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreenState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreenState.kt
@@ -18,7 +18,6 @@
 
 package com.wire.android.ui.home.gallery
 
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -27,25 +26,16 @@ import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 data class MediaGalleryScreenState(
     val snackbarHostState: SnackbarHostState,
-    val modalBottomSheetState: WireModalSheetState,
+    val modalBottomSheetState: WireModalSheetState<Unit>,
     val coroutineScope: CoroutineScope
-) {
-    fun showContextualMenu(show: Boolean) {
-        coroutineScope.launch {
-            if (show) modalBottomSheetState.show()
-            else modalBottomSheetState.hide()
-        }
-    }
-}
+)
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun rememberMediaGalleryScreenState(
-    bottomSheetState: WireModalSheetState = rememberWireModalSheetState(),
+    bottomSheetState: WireModalSheetState<Unit> = rememberWireModalSheetState(),
     coroutineScope: CoroutineScope = rememberCoroutineScope()
 ): MediaGalleryScreenState {
     val snackbarHostState = LocalSnackbarHostState.current

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -111,15 +111,6 @@ fun EnabledMessageComposer(
             }
         }
 
-        LaunchedEffect(modalBottomSheetState.isVisible) {
-            if (modalBottomSheetState.isVisible) {
-                messageCompositionInputStateHolder.clearFocus()
-            } else if (additionalOptionStateHolder.selectedOption == AdditionalOptionSelectItem.SelfDeleting) {
-                messageCompositionInputStateHolder.requestFocus()
-                additionalOptionStateHolder.unselectAdditionalOptionsMenu()
-            }
-        }
-
         Surface(
             modifier = modifier,
             color = colorsScheme().messageComposerBackgroundColor

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -50,7 +49,6 @@ import androidx.compose.ui.text.TextLayoutResult
 import com.wire.android.R
 import com.wire.android.ui.common.TextWithLearnMore
 import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
-import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.ConversationActionPermissionType
@@ -240,7 +238,6 @@ private fun DisabledInteractionMessageComposer(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BaseComposerPreview(
     interactionAvailability: InteractionAvailability = InteractionAvailability.ENABLED,
@@ -271,7 +268,6 @@ private fun BaseComposerPreview(
                 onTypingEvent = {}
             ),
             additionalOptionStateHolder = AdditionalOptionStateHolder(),
-            modalBottomSheetState = WireModalSheetState()
         ),
         messageListContent = { },
         onChangeSelfDeletionClicked = { },

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerComponent.kt
@@ -28,9 +28,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Send
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -39,7 +37,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -49,10 +46,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.R
 import com.wire.android.ui.common.Icon
 import com.wire.android.ui.common.bottomsheet.MenuItemIcon
-import com.wire.android.ui.common.bottomsheet.MenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
+import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
-import com.wire.android.ui.common.bottomsheet.rememberDismissibleWireModalSheetState
+import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
+import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.dimensions
@@ -64,13 +62,11 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.orDefault
 import com.wire.android.util.permission.PermissionsDeniedRequestDialog
 import com.wire.android.util.permission.rememberCurrentLocationPermissionFlow
-import kotlinx.coroutines.launch
 
 /**
  * Component to pick the current location to send.
  * Later can be expanded/refactored to allow to pick a location from the map.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LocationPickerComponent(
     onLocationPicked: (GeoLocatedAddress) -> Unit,
@@ -78,8 +74,7 @@ fun LocationPickerComponent(
     modifier: Modifier = Modifier,
     viewModel: LocationPickerViewModel = hiltViewModel<LocationPickerViewModel>()
 ) {
-    val coroutineScope = rememberCoroutineScope()
-    val sheetState = rememberDismissibleWireModalSheetState(initialValue = SheetValue.Expanded, onLocationClosed)
+    val sheetState = rememberWireModalSheetState<Unit>(onDismissAction = onLocationClosed)
 
     val locationFlow = rememberCurrentLocationPermissionFlow(
         onAllPermissionsGranted = viewModel::getCurrentLocation,
@@ -88,6 +83,7 @@ fun LocationPickerComponent(
     )
 
     LaunchedEffect(Unit) {
+        sheetState.show()
         locationFlow.launch()
     }
 
@@ -95,9 +91,8 @@ fun LocationPickerComponent(
         WireModalSheetLayout(
             modifier = modifier,
             sheetState = sheetState,
-            coroutineScope = coroutineScope
         ) {
-            MenuModalSheetContent(
+            WireMenuModalSheetContent(
                 header = MenuModalSheetHeader.Visible(title = stringResource(R.string.location_attachment_share_title)),
                 menuItems = buildList {
                     add {
@@ -124,8 +119,7 @@ fun LocationPickerComponent(
                         ) {
                             if (showLocationSharingError) {
                                 LocationErrorMessage {
-                                    coroutineScope.launch {
-                                        sheetState.hide()
+                                    sheetState.hide {
                                         viewModel.onLocationSharingErrorDialogDiscarded()
                                         onLocationClosed()
                                     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalDensity
-import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.home.conversations.MessageComposerViewState
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
@@ -39,7 +38,6 @@ import com.wire.kalium.logic.data.message.mention.MessageMention
 @Composable
 fun rememberMessageComposerStateHolder(
     messageComposerViewState: State<MessageComposerViewState>,
-    modalBottomSheetState: WireModalSheetState,
     draftMessageComposition: MessageComposition,
     onSaveDraft: (MessageDraft) -> Unit,
     onSearchMentionQueryChanged: (String) -> Unit,
@@ -92,7 +90,6 @@ fun rememberMessageComposerStateHolder(
     return remember {
         MessageComposerStateHolder(
             messageComposerViewState = messageComposerViewState,
-            modalBottomSheetState = modalBottomSheetState,
             messageCompositionInputStateHolder = messageCompositionInputStateHolder,
             messageCompositionHolder = messageCompositionHolder,
             additionalOptionStateHolder = additionalOptionStateHolder,
@@ -109,7 +106,6 @@ class MessageComposerStateHolder(
     val messageCompositionInputStateHolder: MessageCompositionInputStateHolder,
     val messageCompositionHolder: MessageCompositionHolder,
     val additionalOptionStateHolder: AdditionalOptionStateHolder,
-    val modalBottomSheetState: WireModalSheetState
 ) {
     val messageComposition = messageCompositionHolder.messageComposition
 

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsBottomSheet.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsBottomSheet.kt
@@ -18,32 +18,31 @@
 package com.wire.android.ui.settings.devices.e2ei
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
 import com.wire.android.ui.common.bottomsheet.MenuItemIcon
-import com.wire.android.ui.common.bottomsheet.MenuModalSheetContent
+import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
+import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.util.permission.rememberWriteStoragePermissionFlow
 
 @Composable
 fun E2eiCertificateDetailsBottomSheet(
-    sheetState: WireModalSheetState,
+    sheetState: WireModalSheetState<Unit>,
     onCopyToClipboard: () -> Unit,
     onDownload: () -> Unit,
 ) {
-    val coroutineScope = rememberCoroutineScope()
     val onSaveFileWriteStorageRequest = rememberWriteStoragePermissionFlow(
         onPermissionGranted = onDownload,
         onPermissionDenied = { },
         onPermissionPermanentlyDenied = { }
     )
-    WireModalSheetLayout(sheetState = sheetState, coroutineScope = coroutineScope) {
-        MenuModalSheetContent(
+    WireModalSheetLayout(sheetState = sheetState) {
+        WireMenuModalSheetContent(
             header = MenuModalSheetHeader.Gone,
             menuItems = buildList {
                 add {
@@ -91,7 +90,7 @@ private fun CreateCertificateSheetItem(
 @Composable
 fun PreviewE2eiCertificateDetailsBottomSheet() {
     E2eiCertificateDetailsBottomSheet(
-        sheetState = WireModalSheetState(),
+        sheetState = rememberWireModalSheetState(),
         onCopyToClipboard = { },
         onDownload = { }
     )

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
@@ -39,6 +39,9 @@ import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
 import com.wire.android.navigation.style.PopUpNavigationAnimation
+import com.wire.android.ui.common.bottomsheet.WireModalSheetState
+import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
+import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
@@ -59,12 +62,13 @@ import kotlinx.coroutines.withContext
 )
 @Composable
 fun E2eiCertificateDetailsScreen(
-    e2eiCertificateDetailsViewModel: E2eiCertificateDetailsViewModel = hiltViewModel(),
-    navigator: Navigator
+    navigator: Navigator,
+    e2eiCertificateDetailsViewModel: E2eiCertificateDetailsViewModel = hiltViewModel()
 ) {
     val snackbarHostState = LocalSnackbarHostState.current
     val scope = rememberCoroutineScope()
     val downloadedString = stringResource(id = R.string.media_gallery_on_image_downloaded)
+    val sheetState: WireModalSheetState<Unit> = rememberWireModalSheetState()
 
     WireScaffold(
         topBar = {
@@ -74,9 +78,7 @@ fun E2eiCertificateDetailsScreen(
                 navigationIconType = NavigationIconType.Back,
                 actions = {
                     WireSecondaryIconButton(
-                        onButtonClicked = {
-                            e2eiCertificateDetailsViewModel.state.wireModalSheetState.show()
-                        },
+                        onButtonClicked = sheetState::show,
                         iconResource = R.drawable.ic_more,
                         contentDescription = R.string.content_description_more_options
                     )
@@ -95,11 +97,10 @@ fun E2eiCertificateDetailsScreen(
                 certificateString = getCertificate()
             )
             E2eiCertificateDetailsBottomSheet(
-                sheetState = state.wireModalSheetState,
+                sheetState = sheetState,
                 onCopyToClipboard = {
                     clipboardManager.copyLinkToClipboard(getCertificate())
-                    scope.launch {
-                        state.wireModalSheetState.hide()
+                    sheetState.hide {
                         snackbarHostState.showSnackbar(copiedToClipboardString)
                     }
                 },
@@ -111,8 +112,9 @@ fun E2eiCertificateDetailsScreen(
                                 content = getCertificate()
                             )
                         }
-                        state.wireModalSheetState.hide()
-                        snackbarHostState.showSnackbar(downloadedString)
+                        sheetState.hide {
+                            snackbarHostState.showSnackbar(downloadedString)
+                        }
                     }
                 }
             )
@@ -123,7 +125,8 @@ fun E2eiCertificateDetailsScreen(
 @Composable
 fun E2eiCertificateDetailsContent(
     padding: PaddingValues,
-    certificateString: String
+    certificateString: String,
+    modifier: Modifier = Modifier,
 ) {
     val textStyle = TextStyle(
         textAlign = TextAlign.Justify,
@@ -133,7 +136,7 @@ fun E2eiCertificateDetailsContent(
     )
     val scroll = rememberScrollState(0)
     Text(
-        modifier = Modifier
+        modifier = modifier
             .verticalScroll(scroll)
             .padding(
                 top = padding.calculateTopPadding() + dimensions().spacing16x,

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
@@ -38,10 +38,6 @@ class E2eiCertificateDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val observerSelfUser: GetSelfUserUseCase,
 ) : ViewModel() {
-
-    var state: E2eiCertificateDetailsState by mutableStateOf(E2eiCertificateDetailsState())
-        private set
-
     private val navArgs: E2eiCertificateDetailsScreenNavArgs =
         savedStateHandle.navArgs()
 
@@ -80,7 +76,3 @@ class E2eiCertificateDetailsViewModel @Inject constructor(
         return "wire-certificate-${userHandle()}-$date.txt"
     }
 }
-
-data class E2eiCertificateDetailsState(
-    val wireModalSheetState: WireModalSheetState = WireModalSheetState()
-)

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
@@ -17,13 +17,9 @@
  */
 package com.wire.android.ui.settings.devices.e2ei
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.navArgs
 import com.wire.android.util.fileDateTime
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -65,7 +65,9 @@ import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
 import com.wire.android.ui.common.UserProfileAvatar
-import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
+import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
+import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
+import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
@@ -324,14 +326,22 @@ fun ImportMediaRegularContent(
                 )
             }
         )
-        MenuModalSheetLayout(
-            menuItems = selfDeletionMenuItems(
-                currentlySelected = importMediaAuthenticatedState.selfDeletingTimer.duration.toSelfDeletionDuration(),
-                hideEditMessageMenu = importMediaScreenState::hideBottomSheetMenu,
-                onSelfDeletionDurationChanged = onNewSelfDeletionTimerPicked,
-            ),
+        WireModalSheetLayout(
             sheetState = importMediaScreenState.bottomSheetState,
-            coroutineScope = importMediaScreenState.coroutineScope
+            sheetContent = {
+                WireMenuModalSheetContent(
+                    menuItems = selfDeletionMenuItems(
+                        currentlySelected = importMediaAuthenticatedState.selfDeletingTimer.duration.toSelfDeletionDuration(),
+                        onSelfDeletionDurationChanged = remember {
+                            {
+                                importMediaScreenState.bottomSheetState.hide {
+                                    onNewSelfDeletionTimerPicked(it)
+                                }
+                            }
+                        },
+                    )
+                )
+            },
         )
     }
     SnackBarMessage(infoMessage, importMediaScreenState.snackbarHostState)
@@ -437,7 +447,7 @@ private fun ImportMediaBottomBar(
         count = buttonCount,
         onMainButtonClick = checkRestrictionsAndSendImportedMedia,
         selfDeletionTimer = selfDeletionTimer,
-        onSelfDeletionTimerClicked = importMediaScreenState::showBottomSheetMenu,
+        onSelfDeletionTimerClicked = importMediaScreenState.bottomSheetState::show,
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreenState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreenState.kt
@@ -17,24 +17,21 @@
  */
 package com.wire.android.ui.sharing
 
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
+import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.topappbar.search.SearchBarState
 import com.wire.android.ui.common.topappbar.search.rememberSearchbarState
-import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun rememberImportMediaScreenState(
     searchBarState: SearchBarState = rememberSearchbarState(),
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
-    bottomSheetState: WireModalSheetState = rememberWireModalSheetState()
+    bottomSheetState: WireModalSheetState<Unit> = rememberWireModalSheetState()
 ): ImportMediaScreenState {
     val snackbarHostState = LocalSnackbarHostState.current
 
@@ -50,19 +47,5 @@ class ImportMediaScreenState(
     val snackbarHostState: SnackbarHostState,
     val searchBarState: SearchBarState,
     val coroutineScope: CoroutineScope,
-    val bottomSheetState: WireModalSheetState
-) {
-
-    fun showBottomSheetMenu() {
-        coroutineScope.launch {
-            bottomSheetState.show()
-        }
-    }
-
-    fun hideBottomSheetMenu(onComplete: () -> Unit = {}) {
-        coroutineScope.launch {
-            bottomSheetState.hide()
-            onComplete()
-        }
-    }
-}
+    val bottomSheetState: WireModalSheetState<Unit>
+)

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
@@ -50,7 +50,8 @@ import com.wire.android.ui.common.ArrowRightIcon
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
 import com.wire.android.ui.common.bottomsheet.MenuItemIcon
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
-import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
+import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
+import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
@@ -190,37 +191,40 @@ private fun AvatarPickerContent(
         }
     }
 
-    MenuModalSheetLayout(
+    WireModalSheetLayout(
         sheetState = state.modalBottomSheetState,
-        coroutineScope = rememberCoroutineScope(),
-        header = MenuModalSheetHeader.Visible(title = stringResource(R.string.profile_image_modal_sheet_header_title)),
-        menuItems = listOf(
-            {
-                MenuBottomSheetItem(
-                    title = stringResource(R.string.profile_image_choose_from_gallery_menu_item),
-                    icon = {
-                        MenuItemIcon(
-                            id = R.drawable.ic_gallery,
-                            contentDescription = stringResource(R.string.content_description_choose_from_gallery)
+        sheetContent = {
+            WireMenuModalSheetContent(
+                header = MenuModalSheetHeader.Visible(title = stringResource(R.string.profile_image_modal_sheet_header_title)),
+                menuItems = listOf(
+                    {
+                        MenuBottomSheetItem(
+                            title = stringResource(R.string.profile_image_choose_from_gallery_menu_item),
+                            icon = {
+                                MenuItemIcon(
+                                    id = R.drawable.ic_gallery,
+                                    contentDescription = stringResource(R.string.content_description_choose_from_gallery)
+                                )
+                            },
+                            action = { ArrowRightIcon() },
+                            onItemClick = state::openGallery
                         )
-                    },
-                    action = { ArrowRightIcon() },
-                    onItemClick = state::openGallery
-                )
-            }, {
-                MenuBottomSheetItem(
-                    title = stringResource(R.string.profile_image_take_a_picture_menu_item),
-                    icon = {
-                        MenuItemIcon(
-                            id = R.drawable.ic_camera,
-                            contentDescription = stringResource(R.string.content_description_take_a_picture)
+                    }, {
+                        MenuBottomSheetItem(
+                            title = stringResource(R.string.profile_image_take_a_picture_menu_item),
+                            icon = {
+                                MenuItemIcon(
+                                    id = R.drawable.ic_camera,
+                                    contentDescription = stringResource(R.string.content_description_take_a_picture)
+                                )
+                            },
+                            action = { ArrowRightIcon() },
+                            onItemClick = state::openCamera
                         )
-                    },
-                    action = { ArrowRightIcon() },
-                    onItemClick = state::openCamera
+                    }
                 )
-            }
-        )
+            )
+        }
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerState.kt
@@ -20,7 +20,6 @@ package com.wire.android.ui.userprofile.avatarpicker
 
 import android.content.Context
 import android.net.Uri
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -35,7 +34,6 @@ import com.wire.android.util.ui.UIText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun rememberAvatarPickerState(
     onImageSelected: (Uri) -> Unit,
@@ -44,7 +42,7 @@ fun rememberAvatarPickerState(
     onPictureTaken: () -> Unit,
     targetPictureFileUri: Uri,
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
-    modalBottomSheetState: WireModalSheetState = rememberWireModalSheetState()
+    modalBottomSheetState: WireModalSheetState<Unit> = rememberWireModalSheetState()
 ): AvatarPickerState {
     val context = LocalContext.current
     val snackbarHostState = LocalSnackbarHostState.current
@@ -72,12 +70,12 @@ class AvatarPickerState(
     private val context: Context,
     private val coroutineScope: CoroutineScope,
     val snackbarHostState: SnackbarHostState,
-    val modalBottomSheetState: WireModalSheetState,
+    val modalBottomSheetState: WireModalSheetState<Unit>,
     private val avatarPickerFlow: AvatarPickerFlow,
 ) {
 
     fun showModalBottomSheet() {
-        coroutineScope.launch { modalBottomSheetState.show() }
+        modalBottomSheetState.show(Unit)
     }
 
     fun showSnackbar(uiText: UIText) {
@@ -87,8 +85,9 @@ class AvatarPickerState(
     }
 
     private fun openImageSource(imageSource: ImageSource) {
-        avatarPickerFlow.launch(imageSource)
-        coroutineScope.launch { modalBottomSheetState.hide() }
+        modalBottomSheetState.hide {
+            avatarPickerFlow.launch(imageSource)
+        }
     }
 
     fun openCamera() {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -72,6 +72,7 @@ import com.wire.android.ui.common.WireTabRow
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
+import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.calculateCurrentTab
 import com.wire.android.ui.common.dialogs.ArchiveConversationDialog
@@ -120,22 +121,19 @@ import kotlinx.datetime.Instant
     navArgsDelegate = OtherUserProfileNavArgs::class,
     style = PopUpNavigationAnimation::class,
 )
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OtherUserProfileScreen(
     navigator: Navigator,
     navArgs: OtherUserProfileNavArgs,
-    viewModel: OtherUserProfileScreenViewModel = hiltViewModel(),
-    resultNavigator: ResultBackNavigator<String>
+    resultNavigator: ResultBackNavigator<String>,
+    viewModel: OtherUserProfileScreenViewModel = hiltViewModel()
 ) {
     val snackbarHostState = LocalSnackbarHostState.current
     val context = LocalContext.current
 
     val scope = rememberCoroutineScope()
 
-    val sheetState = rememberWireModalSheetState()
-    val openBottomSheet: () -> Unit = remember { { scope.launch { sheetState.show() } } }
-    val closeBottomSheet: () -> Unit = remember { { scope.launch { sheetState.hide() } } }
+    val sheetState = rememberWireModalSheetState<Unit>()
 
     val conversationId = viewModel.state.conversationId
         ?: viewModel.state.conversationSheetContent?.conversationId
@@ -170,10 +168,10 @@ fun OtherUserProfileScreen(
         state = viewModel.state,
         requestInProgress = viewModel.requestInProgress,
         sheetState = sheetState,
-        openBottomSheet = openBottomSheet,
-        closeBottomSheet = closeBottomSheet,
-        eventsHandler = viewModel,
-        bottomSheetEventsHandler = viewModel,
+        openBottomSheet = sheetState::show,
+        closeBottomSheet = sheetState::hide,
+        eventsHandler = viewModel as OtherUserProfileEventsHandler,
+        bottomSheetEventsHandler = viewModel as OtherUserProfileBottomSheetEventsHandler,
         onIgnoreConnectionRequest = {
             resultNavigator.setResult(it)
             resultNavigator.navigateBack()
@@ -210,18 +208,18 @@ fun OtherProfileScreenContent(
     state: OtherUserProfileState,
     navigationIconType: NavigationIconType,
     requestInProgress: Boolean,
-    sheetState: WireModalSheetState,
+    sheetState: WireModalSheetState<Unit>,
     openBottomSheet: () -> Unit,
     closeBottomSheet: () -> Unit,
     eventsHandler: OtherUserProfileEventsHandler,
     bottomSheetEventsHandler: OtherUserProfileBottomSheetEventsHandler,
+    onSearchConversationMessagesClick: () -> Unit,
     onIgnoreConnectionRequest: (String) -> Unit = { },
     onOpenConversation: (ConversationId) -> Unit = {},
     onOpenDeviceDetails: (Device) -> Unit = {},
-    onSearchConversationMessagesClick: () -> Unit,
     onConversationMediaClick: () -> Unit = {},
     navigateBack: () -> Unit = {},
-    onLegalHoldLearnMoreClick: () -> Unit = {},
+    onLegalHoldLearnMoreClick: () -> Unit = {}
 ) {
     val otherUserProfileScreenState = rememberOtherUserProfileScreenState()
     val blockUserDialogState = rememberVisibilityState<BlockUserDialogState>()
@@ -330,7 +328,6 @@ fun OtherProfileScreenContent(
 
     WireModalSheetLayout(
         sheetState = sheetState,
-        coroutineScope = scope,
         sheetContent = {
             OtherUserProfileBottomSheetContent(
                 getBottomSheetVisibility = getBottomSheetVisibility,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/bottomsheet/EditGroupRoleBottomSheet.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/bottomsheet/EditGroupRoleBottomSheet.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.model.Clickable
-import com.wire.android.ui.common.bottomsheet.MenuModalSheetContent
+import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
 import com.wire.android.ui.common.bottomsheet.SelectableMenuBottomSheetItem
 import com.wire.android.ui.common.bottomsheet.RichMenuItemState
@@ -38,7 +38,7 @@ fun EditGroupRoleBottomSheet(
     changeMemberRole: (Member.Role) -> Unit,
     closeChangeRoleBottomSheet: () -> Unit
 ) {
-    MenuModalSheetContent(
+    WireMenuModalSheetContent(
         header = MenuModalSheetHeader.Visible(title = stringResource(R.string.user_profile_role_in_group, groupState.groupName)),
         menuItems = listOf(
             { EditGroupRoleItem(Member.Role.Admin, groupState.role, changeMemberRole, closeChangeRoleBottomSheet) },

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerStateHolderTest.kt
@@ -21,13 +21,11 @@ package com.wire.android.ui.home.messagecomposer
 import android.content.Context
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.SnapshotExtension
 import com.wire.android.framework.TestConversation
-import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.home.conversations.MessageComposerViewState
 import com.wire.android.ui.home.conversations.mock.mockMessageWithText
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
@@ -49,7 +47,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class)
 class MessageComposerStateHolderTest {
 
@@ -61,7 +59,6 @@ class MessageComposerStateHolderTest {
     private lateinit var messageCompositionInputStateHolder: MessageCompositionInputStateHolder
     private lateinit var messageCompositionHolder: MessageCompositionHolder
     private lateinit var additionalOptionStateHolder: AdditionalOptionStateHolder
-    private lateinit var modalBottomSheetState: WireModalSheetState
     private lateinit var state: MessageComposerStateHolder
     private lateinit var messageTextState: TextFieldState
 
@@ -81,14 +78,12 @@ class MessageComposerStateHolderTest {
             onTypingEvent = {},
         )
         additionalOptionStateHolder = AdditionalOptionStateHolder()
-        modalBottomSheetState = WireModalSheetState()
 
         state = MessageComposerStateHolder(
             messageComposerViewState = messageComposerViewState,
             messageCompositionInputStateHolder = messageCompositionInputStateHolder,
             messageCompositionHolder = messageCompositionHolder,
             additionalOptionStateHolder = additionalOptionStateHolder,
-            modalBottomSheetState = modalBottomSheetState
         )
     }
 

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun <T: Any> WireModalSheetLayout(
+fun <T : Any> WireModalSheetLayout(
     sheetState: WireModalSheetState<T>,
     modifier: Modifier = Modifier,
     sheetShape: Shape = WireBottomSheetDefaults.WireBottomSheetShape,

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
@@ -25,23 +25,17 @@ import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetState
-import androidx.compose.material3.SheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-@Deprecated("Use WireModalSheetLayout2")
-fun WireModalSheetLayout(
-    sheetState: WireModalSheetState,
-    coroutineScope: CoroutineScope,
+fun <T: Any> WireModalSheetLayout(
+    sheetState: WireModalSheetState<T>,
     modifier: Modifier = Modifier,
     sheetShape: Shape = WireBottomSheetDefaults.WireBottomSheetShape,
     containerColor: Color = WireBottomSheetDefaults.WireSheetContainerColor,
@@ -49,13 +43,13 @@ fun WireModalSheetLayout(
     tonalElevation: Dp = WireBottomSheetDefaults.WireSheetTonalElevation,
     scrimColor: Color = BottomSheetDefaults.ScrimColor,
     dragHandle: @Composable (() -> Unit)? = { WireBottomSheetDefaults.WireDragHandle() },
-    sheetContent: @Composable ColumnScope.() -> Unit
+    sheetContent: @Composable ColumnScope.(T) -> Unit
 ) {
-    if (sheetState.currentValue != SheetValue.Hidden) {
+    (sheetState.currentValue as? WireSheetValue.Expanded<T>)?.let { expandedValue ->
         ModalBottomSheet(
             sheetState = sheetState.sheetState,
             shape = sheetShape,
-            content = sheetContent,
+            content = { sheetContent(expandedValue.value) },
             containerColor = containerColor,
             contentColor = contentColor,
             scrimColor = scrimColor,
@@ -65,33 +59,13 @@ fun WireModalSheetLayout(
             modifier = modifier.absoluteOffset(y = 1.dp)
         )
     }
-
     BackHandler(enabled = sheetState.isVisible) {
-        coroutineScope.launch { sheetState.hide() }
+        sheetState.hide()
     }
 }
 
 @Composable
-fun MenuModalSheetLayout(
-    sheetState: WireModalSheetState,
-    coroutineScope: CoroutineScope,
-    menuItems: List<@Composable () -> Unit>,
-    header: MenuModalSheetHeader = MenuModalSheetHeader.Gone
-) {
-    WireModalSheetLayout(
-        sheetState = sheetState,
-        coroutineScope = coroutineScope,
-        sheetContent = {
-            MenuModalSheetContent(
-                menuItems = menuItems,
-                header = header
-            )
-        }
-    )
-}
-
-@Composable
-fun MenuModalSheetContent(
+fun WireMenuModalSheetContent(
     menuItems: List<@Composable () -> Unit>,
     modifier: Modifier = Modifier,
     header: MenuModalSheetHeader = MenuModalSheetHeader.Gone
@@ -99,46 +73,5 @@ fun MenuModalSheetContent(
     Column(modifier = modifier) {
         ModalSheetHeaderItem(header = header)
         buildMenuSheetItems(items = menuItems)
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun WireModalSheetLayout2(
-    sheetState: SheetState,
-    coroutineScope: CoroutineScope,
-    sheetContent: @Composable ColumnScope.() -> Unit,
-    modifier: Modifier = Modifier,
-    sheetShape: Shape = WireBottomSheetDefaults.WireBottomSheetShape,
-    containerColor: Color = WireBottomSheetDefaults.WireSheetContainerColor,
-    contentColor: Color = WireBottomSheetDefaults.WireSheetContentColor,
-    tonalElevation: Dp = WireBottomSheetDefaults.WireSheetTonalElevation,
-    scrimColor: Color = BottomSheetDefaults.ScrimColor,
-    dragHandle: @Composable (() -> Unit)? = { WireBottomSheetDefaults.WireDragHandle() },
-    onCloseBottomSheet: () -> Unit
-) {
-    ModalBottomSheet(
-        sheetState = sheetState,
-        shape = sheetShape,
-        content = sheetContent,
-        containerColor = containerColor,
-        contentColor = contentColor,
-        scrimColor = scrimColor,
-        tonalElevation = tonalElevation,
-        onDismissRequest = {
-            coroutineScope.launch {
-                sheetState.hide()
-            }
-        },
-        dragHandle = dragHandle,
-        modifier = modifier.absoluteOffset(y = 1.dp)
-    )
-
-    BackHandler(enabled = sheetState.isVisible) {
-        coroutineScope.launch { sheetState.hide() }.invokeOnCompletion {
-            if (!sheetState.isVisible) {
-                onCloseBottomSheet()
-            }
-        }
     }
 }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
@@ -23,63 +23,89 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
-class WireModalSheetState(
-    initialValue: SheetValue = SheetValue.Hidden,
+open class WireModalSheetState<T : Any> internal constructor(
+    density: Density,
+    private val scope: CoroutineScope,
+    initialValue: WireSheetValue<T> = WireSheetValue.Hidden,
     private val onDismissAction: () -> Unit = {}
 ) {
     val sheetState: SheetState = SheetState(
+        density = density,
         skipPartiallyExpanded = true,
-        initialValue = initialValue,
+        initialValue = initialValue.originalValue,
         confirmValueChange = { true },
         skipHiddenState = false
     )
 
-    var currentValue: SheetValue by mutableStateOf(initialValue)
+    var currentValue: WireSheetValue<T> by mutableStateOf(initialValue)
         private set
 
-    fun show() {
-        currentValue = SheetValue.Expanded
+    fun show(value: T) {
+        currentValue = WireSheetValue.Expanded(value)
     }
 
-    suspend fun hide() {
+    fun hide(onComplete: suspend () -> Unit = {}) = scope.launch {
         sheetState.hide()
-        currentValue = SheetValue.Hidden
+        currentValue = WireSheetValue.Hidden
+        onComplete()
     }
+    fun hide() = hide {}
 
     fun onDismissRequest() {
         onDismissAction()
-        currentValue = SheetValue.Hidden
+        currentValue = WireSheetValue.Hidden
     }
 
-    // When the available screen height changes, for instance when keyboard disappears, for a brief moment the sheet's content is visible
-    // so change in elevation and alpha according to this flag is just to make sure that the content isn't visible until it's really needed.
-    val visibleContent = sheetState.currentValue != SheetValue.Hidden || sheetState.targetValue != SheetValue.Hidden
-
     val isVisible
-        get() = currentValue != SheetValue.Hidden
+        get() = currentValue !is WireSheetValue.Hidden
 
     companion object {
-        fun saver() = Saver<WireModalSheetState, SheetValue>(
-            save = { it.currentValue },
-            restore = { savedValue -> WireModalSheetState(savedValue) }
+        @Suppress("UNCHECKED_CAST")
+        fun <T : Any> saver(density: Density, scope: CoroutineScope): Saver<WireModalSheetState<T>, *> = Saver(
+            save = {
+                val isExpanded = it.currentValue is WireSheetValue.Expanded<T>
+                val (isValueOfTypeUnit, value) = (it.currentValue as? WireSheetValue.Expanded<T>)?.let {
+                    val isValueOfTypeUnit = it.value is Unit // Unit cannot be saved into Bundle, need to handle it separately
+                    val value = if (isValueOfTypeUnit) null else it.value
+                    isValueOfTypeUnit to value
+                } ?: (false to null)
+                listOf(isExpanded, isValueOfTypeUnit, value)
+            },
+            restore = { savedValue ->
+                val isExpanded = savedValue[0] as Boolean
+                val sheetValue = when (isExpanded) {
+                    true -> {
+                        val isValueOfTypeUnit = savedValue[1] as Boolean
+                        if (isValueOfTypeUnit) {
+                            WireSheetValue.Expanded(Unit as T)
+                        } else {
+                            val value = savedValue[2] as T
+                            WireSheetValue.Expanded(value)
+                        }
+                    }
+                    false -> WireSheetValue.Hidden
+                }
+                WireModalSheetState(density, scope, sheetValue)
+            }
         )
     }
 }
 
-/**
- * Creates a Default [WireModalSheetState] that can be used to show and hide a [WireModalSheetLayout].
- */
 @OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun rememberWireModalSheetState(initialValue: SheetValue = SheetValue.Hidden): WireModalSheetState =
-    rememberSaveable(saver = WireModalSheetState.saver()) {
-        WireModalSheetState(initialValue)
-    }
+sealed class WireSheetValue<out T : Any>(val originalValue: SheetValue) {
+    data object Hidden : WireSheetValue<Nothing>(SheetValue.Hidden)
+    data class Expanded<T : Any>(val value: T) : WireSheetValue<T>(SheetValue.Expanded)
+}
 
 /**
  * Creates a [WireModalSheetState] that can be used to show and hide a [WireModalSheetLayout],
@@ -88,12 +114,17 @@ fun rememberWireModalSheetState(initialValue: SheetValue = SheetValue.Hidden): W
  * @param initialValue The initial value of the sheet.
  * @param onDismissAction The action to be executed when the sheet is dismissed.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun rememberDismissibleWireModalSheetState(
-    initialValue: SheetValue = SheetValue.Hidden,
-    onDismissAction: () -> Unit
-): WireModalSheetState =
-    rememberSaveable(saver = WireModalSheetState.saver()) {
-        WireModalSheetState(initialValue, onDismissAction)
+fun <T : Any> rememberWireModalSheetState(
+    initialValue: WireSheetValue<T> = WireSheetValue.Hidden,
+    onDismissAction: () -> Unit = {}
+): WireModalSheetState<T> {
+    val density = LocalDensity.current
+    val scope = rememberCoroutineScope()
+    return rememberSaveable(saver = WireModalSheetState.saver(density, scope)) {
+        WireModalSheetState(density, scope, initialValue, onDismissAction)
     }
+}
+
+// to simplify execution of the sheet with Unit value
+fun WireModalSheetState<Unit>.show() = this.show(Unit)

--- a/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingCanvasBottomSheet.kt
+++ b/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingCanvasBottomSheet.kt
@@ -53,6 +53,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.wire.android.feature.sketch.model.DrawingState
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
+import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.button.IconAlignment
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryIconButton
@@ -73,8 +74,9 @@ fun DrawingCanvasBottomSheet(
     onDismissSketch: () -> Unit,
     onSendSketch: (Uri) -> Unit,
     tempWritableImageUri: Uri?,
+    modifier: Modifier = Modifier,
     conversationTitle: String = "",
-    viewModel: DrawingCanvasViewModel = viewModel(),
+    viewModel: DrawingCanvasViewModel = viewModel()
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -96,6 +98,7 @@ fun DrawingCanvasBottomSheet(
     }
 
     ModalBottomSheet(
+        modifier = modifier,
         shape = CutCornerShape(dimensions().spacing0x),
         containerColor = colorsScheme().background,
         dragHandle = {
@@ -179,17 +182,13 @@ internal fun DrawingTopBar(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun DrawingToolbar(
     state: DrawingState,
     onColorChanged: (Color) -> Unit,
     onSendSketch: () -> Unit = {},
 ) {
-    val scope = rememberCoroutineScope()
-    val sheetState = rememberWireModalSheetState()
-    val openColorPickerSheet: () -> Unit = remember { { scope.launch { sheetState.show() } } }
-    val closeColorPickerSheet: () -> Unit = remember { { scope.launch { sheetState.hide() } } }
+    val sheetState = rememberWireModalSheetState<Unit>()
     Row(
         Modifier
             .height(dimensions().spacing80x)
@@ -199,7 +198,7 @@ internal fun DrawingToolbar(
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         WireSecondaryButton(
-            onClick = openColorPickerSheet,
+            onClick = sheetState::show,
             leadingIcon = {
                 Icon(
                     Icons.Default.Circle,
@@ -238,7 +237,7 @@ internal fun DrawingToolbar(
         currentColor = state.currentPath.color,
         onColorSelected = {
             onColorChanged(it)
-            closeColorPickerSheet()
+            sheetState.hide()
         }
     )
 }

--- a/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingToolPicker.kt
+++ b/features/sketch/src/main/java/com/wire/android/feature/sketch/DrawingToolPicker.kt
@@ -42,22 +42,21 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconToggleButtonColors
 import androidx.compose.material3.OutlinedIconToggleButton
-import androidx.compose.material3.SheetValue
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.ui.common.bottomsheet.MenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
+import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
+import com.wire.android.ui.common.bottomsheet.WireSheetValue
+import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireColorPalette
@@ -66,16 +65,16 @@ import com.wire.android.ui.theme.WireTheme
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun DrawingToolPicker(
-    sheetState: WireModalSheetState,
+    sheetState: WireModalSheetState<Unit>,
     currentColor: Color,
     onColorSelected: (Color) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    val scope = rememberCoroutineScope()
     val colorPalette = colorsScheme().sketchColorPalette
     WireModalSheetLayout(
+        modifier = modifier,
         dragHandle = null,
         sheetState = sheetState,
-        coroutineScope = scope,
     ) {
         Column(
             modifier = Modifier
@@ -90,7 +89,7 @@ fun DrawingToolPicker(
                     .background(color = colorsScheme().background, shape = RoundedCornerShape(size = dimensions().spacing2x))
 
             )
-            MenuModalSheetContent(
+            WireMenuModalSheetContent(
                 header = MenuModalSheetHeader.Visible(title = stringResource(id = R.string.title_color_picker)),
                 menuItems = listOf {
                     LazyVerticalGrid(
@@ -192,26 +191,24 @@ private const val GRID_CELLS = 6
 
 private fun Color.isWhite() = this == Color.White
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Preview(showSystemUi = true, device = Devices.NEXUS_5)
 @Composable
 fun PreviewDrawingToolPickerSelectedNonWhite() {
     WireTheme {
         DrawingToolPicker(
-            sheetState = WireModalSheetState(SheetValue.Expanded),
+            sheetState = rememberWireModalSheetState(WireSheetValue.Expanded(Unit)),
             currentColor = WireColorPalette.LightBlue500,
             onColorSelected = {}
         )
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewDrawingToolPickerSelectedWhite() {
     WireTheme {
         DrawingToolPicker(
-            sheetState = WireModalSheetState(SheetValue.Expanded),
+            sheetState = rememberWireModalSheetState(WireSheetValue.Expanded(Unit)),
             currentColor = Color.White,
             onColorSelected = {}
         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10610" title="WPB-10610" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10610</a>  [Android] Refactor and unify modal bottom sheets
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently we have 3 different modal bottom sheets, each of them with each own logic.

### Solutions

Create single unified modal bottom sheet that contains advantages of all three previous ones so that modal bottom sheet is always created the same way, showing and hiding is encapsulated inside sheet state so there is no need to create any `LaunchedEffects` to handle it, and it provides a parameter when expanded to generate content according to it. Now, show and hide functions can be called outside of coroutines, hide will execute animation and then call `onComplete` action if needed so no need to wrap any click lambdas with a function to hide a sheet first and it should always look good from UI perspective.
Also: split bottom sheet into two dedicated for self deleting options and message options on `ConversationScreen`, moved some menu options composables to dedicated files, cleaned up `MediaGalleryScreen` and added preview, simplified hide/show calls, removed sheet state from some view states and moved it up when it's not required to pass it that deep, cleaned up and unified message and asset options depending on the message type.

### Testing

#### How to Test

Use one of bottom sheets.
----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
