### PR TITLE
feat: show analytics initialized for automation (WPB-10600) 🍒

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.analytics.GetCurrentAnalyticsTrackingIdentifierUseCase
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
 import com.wire.kalium.logic.feature.connection.BlockUserUseCase
@@ -473,4 +474,11 @@ class UseCaseModule {
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
     ): FetchConversationMLSVerificationStatusUseCase = coreLogic.getSessionScope(currentAccount).fetchConversationMLSVerificationStatus
+
+    @ViewModelScoped
+    @Provides
+    fun provideGetCurrentAnalyticsTrackingIdentifierUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): GetCurrentAnalyticsTrackingIdentifierUseCase = coreLogic.getSessionScope(currentAccount).getCurrentAnalyticsTrackingIdentifier
 }

--- a/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModel.kt
@@ -45,7 +45,9 @@ class AnalyticsUsageViewModel @Inject constructor(
             val isAnalyticsUsageEnabled = dataStore.isAnonymousUsageDataEnabled().first()
             val isAnalyticsConfigurationEnabled = analyticsEnabled is AnalyticsConfiguration.Enabled
             val isProdBackend = when (val serverConfig = selfServerConfig()) {
-                is SelfServerConfigUseCase.Result.Success -> serverConfig.serverLinks.links.api == ServerConfig.PRODUCTION.api
+                is SelfServerConfigUseCase.Result.Success ->
+                    serverConfig.serverLinks.links.api == ServerConfig.PRODUCTION.api
+                            || serverConfig.serverLinks.links.api == ServerConfig.STAGING.api
                 is SelfServerConfigUseCase.Result.Failure -> false
             }
 

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.res.stringResource
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.feature.analytics.AnonymousAnalyticsManagerImpl
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.RowItemTemplate
 import com.wire.android.ui.common.WireDialog
@@ -136,6 +137,22 @@ fun DebugDataOptionsContent(
                     onClick = { onCopyText(state.debugId) }
                 )
             )
+
+            SettingsItem(
+                title = stringResource(id = R.string.debug_analytics_enabled_title),
+                text = AnonymousAnalyticsManagerImpl.isAnalyticsInitialized().toString()
+            )
+
+            SettingsItem(
+                title = stringResource(id = R.string.debug_analytics_tracking_identifier_title),
+                text = state.analyticsTrackingId,
+                trailingIcon = R.drawable.ic_copy,
+                onIconPressed = Clickable(
+                    enabled = true,
+                    onClick = { onCopyText(state.analyticsTrackingId) }
+                )
+            )
+
             if (BuildConfig.DEBUG) {
                 GetE2EICertificateSwitch(
                     enrollE2EI = enrollE2EICertificate

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsState.kt
@@ -29,4 +29,5 @@ data class DebugDataOptionsState(
     val certificate: String = "null",
     val showCertificate: Boolean = false,
     val startGettingE2EICertificate: Boolean = false,
+    val analyticsTrackingId: String = "null"
 )

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsViewModel.kt
@@ -33,6 +33,7 @@ import com.wire.android.util.getGitBuildId
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.E2EIFailure
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.analytics.GetCurrentAnalyticsTrackingIdentifierUseCase
 import com.wire.kalium.logic.feature.e2ei.CheckCrlRevocationListUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.E2EIEnrollmentResult
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountResult
@@ -73,7 +74,8 @@ class DebugDataOptionsViewModelImpl
     private val updateApiVersions: UpdateApiVersionsScheduler,
     private val mlsKeyPackageCount: MLSKeyPackageCountUseCase,
     private val restartSlowSyncProcessForRecovery: RestartSlowSyncProcessForRecoveryUseCase,
-    private val checkCrlRevocationList: CheckCrlRevocationListUseCase
+    private val checkCrlRevocationList: CheckCrlRevocationListUseCase,
+    private val getCurrentAnalyticsTrackingIdentifier: GetCurrentAnalyticsTrackingIdentifierUseCase
 ) : ViewModel(), DebugDataOptionsViewModel {
 
     var state by mutableStateOf(
@@ -85,6 +87,17 @@ class DebugDataOptionsViewModelImpl
         observeMlsMetadata()
         checkIfCanTriggerManualMigration()
         setGitHashAndDeviceId()
+        setAnalyticsTrackingId()
+    }
+
+    private fun setAnalyticsTrackingId() {
+        viewModelScope.launch {
+            getCurrentAnalyticsTrackingIdentifier()?.let { trackingId ->
+                state = state.copy(
+                    analyticsTrackingId = trackingId
+                )
+            }
+        }
     }
 
     private fun setGitHashAndDeviceId() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
@@ -50,7 +50,7 @@ fun PrivacySettingsConfigScreen(
 ) {
     with(viewModel) {
         PrivacySettingsScreenContent(
-            isAnonymousUsageDataEnabled = state.isAnonymousUsageDataEnabled,
+            isAnonymousUsageDataEnabled = state.isAnalyticsUsageEnabled,
             areReadReceiptsEnabled = state.areReadReceiptsEnabled,
             setReadReceiptsState = ::setReadReceiptsState,
             isTypingIndicatorEnabled = state.isTypingIndicatorEnabled,

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsState.kt
@@ -19,7 +19,8 @@
 package com.wire.android.ui.home.settings.privacy
 
 data class PrivacySettingsState(
-    val isAnonymousUsageDataEnabled: Boolean = true,
+    val isAnalyticsUsageEnabled: Boolean = true,
+    val shouldShowAnalyticsUsage: Boolean = false,
     val areReadReceiptsEnabled: Boolean = true,
     val isTypingIndicatorEnabled: Boolean = true,
     val screenshotCensoringConfig: ScreenshotCensoringConfig = ScreenshotCensoringConfig.ENABLED_BY_USER,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,10 @@
     <string name="app_version">App version</string>
     <string name="build_variant_name">Build variant</string>
     <string name="debug_id" translatable="false">Debug Identifier</string>
+    <string name="debug_analytics_enabled_title" translatable="false">Analytics Initialized</string>
+    <string name="debug_analytics_tracking_identifier_title" translatable="false">
+        Analytics Tracking Identifier
+    </string>
     <string name="label_new">New</string>
     <string name="label_login">Login</string>
     <string name="label_ok">OK</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModelTest.kt
@@ -20,6 +20,10 @@ package com.wire.android.ui.home.settings.privacy
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.datastore.UserDataStore
+import com.wire.android.ui.analytics.AnalyticsConfiguration
+import com.wire.android.util.newServerConfig
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import com.wire.kalium.logic.feature.user.readReceipts.ObserveReadReceiptsEnabledUseCase
 import com.wire.kalium.logic.feature.user.readReceipts.PersistReadReceiptsStatusConfigUseCase
 import com.wire.kalium.logic.feature.user.readReceipts.ReadReceiptStatusConfigResult
@@ -54,7 +58,7 @@ class PrivacySettingsViewModelTest {
         // then
         assertEquals(
             true,
-            viewModel.state.isAnonymousUsageDataEnabled
+            viewModel.state.isAnalyticsUsageEnabled
         )
     }
 
@@ -69,7 +73,7 @@ class PrivacySettingsViewModelTest {
         // then
         assertEquals(
             false,
-            viewModel.state.isAnonymousUsageDataEnabled
+            viewModel.state.isAnalyticsUsageEnabled
         )
     }
 
@@ -86,7 +90,7 @@ class PrivacySettingsViewModelTest {
         // then
         assertEquals(
             false,
-            viewModel.state.isAnonymousUsageDataEnabled
+            viewModel.state.isAnalyticsUsageEnabled
         )
     }
 
@@ -103,7 +107,7 @@ class PrivacySettingsViewModelTest {
         // then
         assertEquals(
             true,
-            viewModel.state.isAnonymousUsageDataEnabled
+            viewModel.state.isAnalyticsUsageEnabled
         )
     }
 
@@ -114,6 +118,7 @@ class PrivacySettingsViewModelTest {
         val observeScreenshotCensoringConfig = mockk<ObserveScreenshotCensoringConfigUseCase>()
         val persistTypingIndicatorStatusConfig = mockk<PersistTypingIndicatorStatusConfigUseCase>()
         val observeTypingIndicatorEnabled = mockk<ObserveTypingIndicatorEnabledUseCase>()
+        val selfServerConfig = mockk<SelfServerConfigUseCase>()
         val dataStore = mockk<UserDataStore>()
 
         val viewModel by lazy {
@@ -125,6 +130,8 @@ class PrivacySettingsViewModelTest {
                 observeScreenshotCensoringConfig = observeScreenshotCensoringConfig,
                 persistTypingIndicatorStatusConfig = persistTypingIndicatorStatusConfig,
                 observeTypingIndicatorEnabled = observeTypingIndicatorEnabled,
+                analyticsEnabled = AnalyticsConfiguration.Enabled,
+                selfServerConfig = selfServerConfig,
                 dataStore = dataStore
             )
         }
@@ -140,6 +147,9 @@ class PrivacySettingsViewModelTest {
             coEvery { persistTypingIndicatorStatusConfig.invoke(true) } returns TypingIndicatorConfigResult.Success
             coEvery { observeTypingIndicatorEnabled() } returns flowOf(true)
             coEvery { dataStore.setIsAnonymousAnalyticsEnabled(any()) } returns Unit
+            coEvery { selfServerConfig.invoke() } returns SelfServerConfigUseCase.Result.Success(
+                serverLinks = newServerConfig(1).copy(links = ServerConfig.STAGING)
+            )
         }
 
         fun withEnabledAnonymousUsageData() = apply {

--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerImpl.kt
@@ -167,4 +167,10 @@ object AnonymousAnalyticsManagerImpl : AnonymousAnalyticsManager {
             is AnalyticsIdentifierResult.Disabled -> {}
         }
     }
+
+    override fun isAnalyticsInitialized(): Boolean =
+        anonymousAnalyticsRecorder?.isAnalyticsInitialized() ?: run {
+            Log.w(TAG, "Calling isAnalyticsInitialized with a null recorder.")
+            false
+        }
 }

--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
@@ -105,4 +105,6 @@ class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
         )
         Countly.sharedInstance().userProfile().save()
     }
+
+    override fun isAnalyticsInitialized(): Boolean = Countly.sharedInstance().isInitialized
 }

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManager.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManager.kt
@@ -47,4 +47,6 @@ interface AnonymousAnalyticsManager {
     fun onStart(activity: Activity)
 
     fun onStop(activity: Activity)
+
+    fun isAnalyticsInitialized(): Boolean
 }

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerStub.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerStub.kt
@@ -44,4 +44,6 @@ open class AnonymousAnalyticsManagerStub : AnonymousAnalyticsManager {
     override fun onStart(activity: Activity) = Unit
 
     override fun onStop(activity: Activity) = Unit
+
+    override fun isAnalyticsInitialized(): Boolean = false
 }

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorder.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorder.kt
@@ -48,4 +48,6 @@ interface AnonymousAnalyticsRecorder {
         isTeamMember: Boolean,
         propagateIdentifier: suspend () -> Unit
     )
+
+    fun isAnalyticsInitialized(): Boolean
 }

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderStub.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderStub.kt
@@ -45,4 +45,6 @@ open class AnonymousAnalyticsRecorderStub : AnonymousAnalyticsRecorder {
         isTeamMember: Boolean,
         propagateIdentifier: suspend () -> Unit
     ) = Unit
+
+    override fun isAnalyticsInitialized(): Boolean = false
 }

--- a/default.json
+++ b/default.json
@@ -52,7 +52,7 @@
             "default_backend_url_website": "https://wire.com",
             "default_backend_title": "wire-staging",
             "encrypt_proteus_storage": true,
-            "analytics_enabled": false,
+            "analytics_enabled": true,
             "analytics_app_key": "8ffae535f1836ed5f58fd5c8a11c00eca07c5438",
             "analytics_server_url": "https://countly.wire.com/"
         },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10600" title="WPB-10600" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10600</a>  [Android] Show countly details in debug settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was no way for automation (or our Playtest users) to verify if Analytics was enabled or disabled + tracking identifier through the app. (without having to run locally and check manually)

### Causes (Optional)

Not implemented

### Solutions

- Add item in Debug Screen if Analytics is enabled or disabled
- Add item in Debug Screen to show tracking identifier if it is enabled
- Added STAGING env. along with PROD env. for verifications of analytics.
- Show privacy settings toggle based on verifications (PROD/STAGING env)

### Dependencies (Optional)

Needs releases with:

- [X] https://github.com/wireapp/kalium/pull/2949

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Open  App (Beta or Staging) with PROD or STAGING env.
- Login
- Agree or Decline with Analytics
- Open Debug Settings Screen 
- Check for Analytics status and tracking ID (if enabled)


### Attachments (Optional)

<img src="https://github.com/user-attachments/assets/2471cfa4-ba13-49a6-9030-ac08525fd364" width="200" height="400" />