### PR TITLE
chore: Improve Analytics dialog (WPB-10601)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModel.kt
@@ -44,14 +44,14 @@ class AnalyticsUsageViewModel @Inject constructor(
             val isDialogSeen = dataStore.isAnalyticsDialogSeen().first()
             val isAnalyticsUsageEnabled = dataStore.isAnonymousUsageDataEnabled().first()
             val isAnalyticsConfigurationEnabled = analyticsEnabled is AnalyticsConfiguration.Enabled
-            val isProdBackend = when (val serverConfig = selfServerConfig()) {
+            val isValidBackend = when (val serverConfig = selfServerConfig()) {
                 is SelfServerConfigUseCase.Result.Success ->
                     serverConfig.serverLinks.links.api == ServerConfig.PRODUCTION.api
                             || serverConfig.serverLinks.links.api == ServerConfig.STAGING.api
                 is SelfServerConfigUseCase.Result.Failure -> false
             }
 
-            val shouldShowDialog = isProdBackend && !isAnalyticsUsageEnabled && isAnalyticsConfigurationEnabled && !isDialogSeen
+            val shouldShowDialog = isValidBackend && !isAnalyticsUsageEnabled && isAnalyticsConfigurationEnabled && !isDialogSeen
 
             state = state.copy(
                 shouldDisplayDialog = shouldShowDialog

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeDialogs.kt
@@ -86,7 +86,7 @@ fun AnalyticsUsageDialog(
             type = WireDialogButtonType.Secondary
         ),
         buttonsHorizontalAlignment = false,
-        onDismiss = declineOption
+        onDismiss = {}
     )
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1164,7 +1164,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="cancel_login_dialog_title">Are you sure you want to cancel?</string>
     <!-- Analytics Usage dialog -->
     <string name="analytics_usage_dialog_title">Consent to share user data</string>
-    <string name="analytics_usage_dialog_text">Help to improve the app by sharing usage data with Wire.\n\nThe data is anonymous and doesn\'t include any content of your communication (such as messages, files, location, or calls).</string>
+    <string name="analytics_usage_dialog_text">Help to improve Wire by sharing your usage data via a pseudonymous ID. The data is neither linked to your personal information nor shared with third parties besides Zeta Project Germany GmbH. It includes, for example, when you use a feature, your app version, device type, or your operating system. The ID will be deleted at the latest from your device after 365 days after the last activity.Find further details in our\n\nPrivacy Policy (link). You can revoke your consent at any time.</string>
     <string name="analytics_usage_dialog_button_agree">Agree</string>
     <string name="analytics_usage_dialog_button_decline">Decline</string>
     <string name="analytics_usage_dialog_button_privacy_policy">Privacy Policy</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1164,7 +1164,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="cancel_login_dialog_title">Are you sure you want to cancel?</string>
     <!-- Analytics Usage dialog -->
     <string name="analytics_usage_dialog_title">Consent to share user data</string>
-    <string name="analytics_usage_dialog_text">Help to improve Wire by sharing your usage data via a pseudonymous ID.\n\nThe data is neither linked to your personal information nor shared with third parties besides Zeta Project Germany GmbH. It includes, for example, when you use a feature, your app version, device type, or your operating system. The ID will be deleted at the latest from your device after [28] days after the last activity.\n\nFind further details in our Privacy Policy (link). You can revoke your consent at any time.</string>
+    <string name="analytics_usage_dialog_text">Help to improve the app by sharing usage data with Wire.\n\nThe data is anonymous and doesn\'t include any content of your communication (such as messages, files, location, or calls).</string>
     <string name="analytics_usage_dialog_button_agree">Agree</string>
     <string name="analytics_usage_dialog_button_decline">Decline</string>
     <string name="analytics_usage_dialog_button_privacy_policy">Privacy Policy</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1012,7 +1012,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="settings_show_typing_indicator_description">When this is on, you see when other people are writing a message, and others notice when you are typing. This setting applies to all conversations on this device.</string>
     <string name="settings_app_lock_title">Lock with passcode</string>
     <string name="settings_send_anonymous_usage_data_title">Send anonymous usage data</string>
-    <string name="settings_send_anonymous_usage_data_description">Usage data allows Wire to understand how the app is being used and how it can be improved. The data is anonymous and does not include the content of your communications (such as messages, files, locations, or calls).</string>
+    <string name="settings_send_anonymous_usage_data_description">Help to improve the app by sharing usage data with Wire. The data is anonymous and doesn\'t include any content of your communication (such as messages, files, location, or calls).</string>
     <!--Privacy Settings, App lock -->
     <string name="settings_set_lock_screen_title">Set app lock passcode</string>
     <string name="settings_set_lock_screen_description">The app will lock itself after %1$s of inactivity. To unlock the app you need to enter this passcode or use biometric authentication.\n\nMake sure to remember this passcode as there is no way to recover it.</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10601" title="WPB-10601" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10601</a>  [Android] Make countly dialogue not dismissible
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Dialog is dismissable
- Text copy was updated

### Solutions

- Remove the possibility to dismiss the dialog without properly selecting a action button.
- Update text copy of dialog
- rename variable naming (previously added staging to valid backend verification)

### Dependencies (Optional)

### Testing

#### How to Test

- Fresh login with analytics enabled in build level
- dialog is shown and is not dismissible

### Attachments (Optional)

| Dialog | Toggle |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/d5542e1f-f9a4-4221-a31d-5011c82e8e36" width="200" height="400" /> | <img src="https://github.com/user-attachments/assets/858b4ae4-bcfe-450a-8e5a-30ad0ff72823" width="200" height="400" /> |
