### PR TITLE
fix: hiding bottom sheet when editing message [WPB-10679]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
@@ -106,11 +106,13 @@ fun MessageOptionsModalSheetLayout(
                     onEditClick = remember(message.header.messageId, message.messageContent) {
                         {
                             (message.messageContent as? UIMessageContent.TextMessage)?.let {
-                                onEditClick(
-                                    message.header.messageId,
-                                    message.messageContent.messageBody.message.asString(context.resources),
-                                    (message.messageContent.messageBody.message as? UIText.DynamicString)?.mentions ?: listOf()
-                                )
+                                sheetState.hide {
+                                    onEditClick(
+                                        message.header.messageId,
+                                        message.messageContent.messageBody.message.asString(context.resources),
+                                        (message.messageContent.messageBody.message as? UIText.DynamicString)?.mentions ?: listOf()
+                                    )
+                                }
                             }
                         }
                     },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10679" title="WPB-10679" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10679</a>  [Android] When editing a message, bottom sheet does not disappear automatically to edit message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When editing a message, bottom sheet does not disappear automatically to edit message.

### Causes (Optional)

`onEditClick` does not use `sheetState.hide { }` like all other click actions.

### Solutions

Wrap `onEditClick` with `sheetState.hide { }`

### Testing

#### How to Test

STR:
- open any conversation
- send a message
- longtap on message
- select Edit

Expected:
bottom sheet should disappear and I should be able to edit my message

Actual:
The bottom sheet does not disappear automatically after editing. The user needs to use the phones back button to close the bottom sheet. Only then he sees the text input field and can edit his message

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
