### PR TITLE
fix(conversation): disable addMember on a one-on-one conversation with deleted account (WPB-10259)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
@@ -152,4 +152,6 @@ data class ConversationSheetContent(
     fun canAddToFavourite(): Boolean =
         (conversationTypeDetail is ConversationTypeDetail.Private && conversationTypeDetail.blockingState != BlockingState.BLOCKED)
                 || conversationTypeDetail is ConversationTypeDetail.Group
+
+    fun isAbandonedOneOnOneConversation(participantsCount: Int): Boolean = title.isEmpty() && participantsCount == 1
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.ui.home.conversations.details
 
+import SwipeableSnackbar
 import androidx.annotation.StringRes
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalOverscrollConfiguration
@@ -34,6 +35,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -111,8 +113,6 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.Conversation
 import kotlinx.coroutines.launch
-import SwipeableSnackbar
-import androidx.compose.material3.SnackbarHost
 
 @RootNavGraph
 @WireDestination(
@@ -394,7 +394,8 @@ private fun GroupConversationDetailsContent(
                         openFullListPressed = openFullListPressed,
                         onAddParticipantsPressed = onAddParticipantsPressed,
                         onProfilePressed = onProfilePressed,
-                        lazyListState = lazyListStates[pageIndex]
+                        lazyListState = lazyListStates[pageIndex],
+                        allowAddMember = conversationSheetState.conversationSheetContent?.title?.isNotEmpty() ?:false
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -395,7 +395,7 @@ private fun GroupConversationDetailsContent(
                         onAddParticipantsPressed = onAddParticipantsPressed,
                         onProfilePressed = onProfilePressed,
                         lazyListState = lazyListStates[pageIndex],
-                        allowAddMember = conversationSheetState.conversationSheetContent?.title?.isNotEmpty() ?:false
+                        allowAddMember = conversationSheetState.conversationSheetContent?.title?.isNotEmpty() ?: false
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -395,8 +395,10 @@ private fun GroupConversationDetailsContent(
                         onAddParticipantsPressed = onAddParticipantsPressed,
                         onProfilePressed = onProfilePressed,
                         lazyListState = lazyListStates[pageIndex],
-                        allowAddMember = conversationSheetState.conversationSheetContent?.title?.isNotEmpty() == true
-                                || groupParticipantsState.data.allCount > 1
+                        isAbandonedOneOnOneConversation = conversationSheetState.conversationSheetContent?.isAbandonedOneOnOneConversation(
+                            groupParticipantsState.data.allCount
+                        ) ?: false
+
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -395,7 +395,8 @@ private fun GroupConversationDetailsContent(
                         onAddParticipantsPressed = onAddParticipantsPressed,
                         onProfilePressed = onProfilePressed,
                         lazyListState = lazyListStates[pageIndex],
-                        allowAddMember = conversationSheetState.conversationSheetContent?.title?.isNotEmpty() ?: false
+                        allowAddMember = conversationSheetState.conversationSheetContent?.title?.isNotEmpty() == true
+                                || groupParticipantsState.data.allCount > 1
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsTopBarCollapsing.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsTopBarCollapsing.kt
@@ -99,7 +99,7 @@ fun GroupConversationDetailsTopBarCollapsing(
                     Text(
                         text = title.ifBlank {
                             if (isLoading) ""
-                            else UIText.StringResource(R.string.group_unavailable_label).asString()
+                            else UIText.StringResource(R.string.member_name_deleted_label).asString()
                         },
                         overflow = TextOverflow.Ellipsis,
                         maxLines = 1,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipants.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipants.kt
@@ -61,7 +61,8 @@ fun GroupConversationParticipants(
     onProfilePressed: (UIParticipant) -> Unit,
     onAddParticipantsPressed: () -> Unit,
     groupParticipantsState: GroupConversationParticipantsState,
-    lazyListState: LazyListState = rememberLazyListState()
+    lazyListState: LazyListState = rememberLazyListState(),
+    allowAddMember: Boolean = true
 ) {
     val context = LocalContext.current
     Column {
@@ -86,7 +87,7 @@ fun GroupConversationParticipants(
                             groupParticipantsState.data.allCount.toString()
                         )
                     )
-                    if (groupParticipantsState.data.isSelfAnAdmin) {
+                    if (groupParticipantsState.data.isSelfAnAdmin && allowAddMember) {
                         WirePrimaryButton(
                             text = stringResource(R.string.conversation_details_group_participants_add),
                             fillMaxWidth = true,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipants.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipants.kt
@@ -62,7 +62,7 @@ fun GroupConversationParticipants(
     onAddParticipantsPressed: () -> Unit,
     groupParticipantsState: GroupConversationParticipantsState,
     lazyListState: LazyListState = rememberLazyListState(),
-    allowAddMember: Boolean = true
+    isAbandonedOneOnOneConversation: Boolean = false
 ) {
     val context = LocalContext.current
     Column {
@@ -87,7 +87,7 @@ fun GroupConversationParticipants(
                             groupParticipantsState.data.allCount.toString()
                         )
                     )
-                    if (groupParticipantsState.data.isSelfAnAdmin && allowAddMember) {
+                    if (groupParticipantsState.data.isSelfAnAdmin && !isAbandonedOneOnOneConversation) {
                         WirePrimaryButton(
                             text = stringResource(R.string.conversation_details_group_participants_add),
                             fillMaxWidth = true,

--- a/app/src/test/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContentTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContentTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.common.bottomsheet.conversation
+
+import com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModelTest.Companion.testGroup
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.TeamId
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+
+class ConversationSheetContentTest {
+
+    @Test
+    fun givenTitleIsEmptyAndTheGroupSizeIsOne_whenCallingIsTheGroupAbandoned_returnsTrue() = runTest {
+        val details = testGroup.copy(conversation = testGroup.conversation.copy(teamId = TeamId("team_id")))
+
+        val givenConversationSheetContent = ConversationSheetContent(
+            title = "",
+            conversationId = details.conversation.id,
+            mutingConversationState = details.conversation.mutedStatus,
+            conversationTypeDetail = ConversationTypeDetail.Group(details.conversation.id, details.isSelfUserCreator),
+            selfRole = Conversation.Member.Role.Member,
+            isTeamConversation = details.conversation.isTeamGroup(),
+            isArchived = false,
+            protocol = Conversation.ProtocolInfo.Proteus,
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        )
+        val givenParticipantsCount = 1
+
+        assertEquals(true, givenConversationSheetContent.isAbandonedOneOnOneConversation(givenParticipantsCount))
+    }
+
+    @Test
+    fun givenTitleIsEmptyAndTheGroupSizeIsGtOne_whenCallingIsTheGroupAbandoned_returnsFalse() = runTest {
+        val details = testGroup.copy(conversation = testGroup.conversation.copy(teamId = TeamId("team_id")))
+
+        val givenConversationSheetContent = ConversationSheetContent(
+            title = "",
+            conversationId = details.conversation.id,
+            mutingConversationState = details.conversation.mutedStatus,
+            conversationTypeDetail = ConversationTypeDetail.Group(details.conversation.id, details.isSelfUserCreator),
+            selfRole = Conversation.Member.Role.Member,
+            isTeamConversation = details.conversation.isTeamGroup(),
+            isArchived = false,
+            protocol = Conversation.ProtocolInfo.Proteus,
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        )
+        val givenParticipantsCount = 3
+
+        assertEquals(false, givenConversationSheetContent.isAbandonedOneOnOneConversation(givenParticipantsCount))
+    }
+
+    @Test
+    fun givenTitleIsNotEmptyAndTheGroupSizeIsOne_whenCallingIsTheGroupAbandoned_returnsFalse() = runTest {
+        val details = testGroup.copy(conversation = testGroup.conversation.copy(teamId = TeamId("team_id")))
+
+        val givenConversationSheetContent = ConversationSheetContent(
+            title = "notEmpty",
+            conversationId = details.conversation.id,
+            mutingConversationState = details.conversation.mutedStatus,
+            conversationTypeDetail = ConversationTypeDetail.Group(details.conversation.id, details.isSelfUserCreator),
+            selfRole = Conversation.Member.Role.Member,
+            isTeamConversation = details.conversation.isTeamGroup(),
+            isArchived = false,
+            protocol = Conversation.ProtocolInfo.Proteus,
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        )
+        val givenParticipantsCount = 3
+
+        assertEquals(false, givenConversationSheetContent.isAbandonedOneOnOneConversation(givenParticipantsCount))
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10259" title="WPB-10259" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10259</a>  [Android] : Duplicate 1:1 conversation - not showing one of the conv
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

…h deleted account

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
When the other peer of a one-on-one conversation gets deleted, the backend changes the conversation to a group conversation. Android app was allowing the user to add member to that conversation and it was a confusing flow; in this PR we're preventing this.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
