### PR TITLE
fix: Crash when starting starting PersistentWebsocketService (WPB-10712)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -342,7 +342,7 @@
         <service
                 android:name=".services.PersistentWebSocketService"
                 android:exported="false"
-                android:foregroundServiceType="specialUse"></service>
+                android:foregroundServiceType="specialUse"/>
 
         <service
                 android:name=".services.OngoingCallService"

--- a/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
@@ -28,7 +28,6 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import com.wire.android.R
 import com.wire.android.appLogger
-import com.wire.android.di.CurrentSessionFlowService
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants.WEB_SOCKET_CHANNEL_ID
@@ -39,7 +38,6 @@ import com.wire.android.notification.openAppPendingIntent
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.sync.ConnectionPolicy
-import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
@@ -65,11 +65,6 @@ class PersistentWebSocketService : Service() {
     @Inject
     lateinit var notificationManager: WireNotificationManager
 
-    // TODO: remove since it is not used
-    @Inject
-    @CurrentSessionFlowService
-    lateinit var currentSessionFlow: CurrentSessionFlowUseCase
-
     @Inject
     lateinit var notificationChannelsManager: NotificationChannelsManager
 
@@ -84,6 +79,15 @@ class PersistentWebSocketService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        /**
+         * When service is restarted by system onCreate lifecycle method is not guaranteed to be called
+         * so we need to check if service is already started and if not generate notification and call startForeground()
+         * https://issuetracker.google.com/issues/307329994#comment100
+         */
+        if (!isServiceStarted) {
+            isServiceStarted = true
+            generateForegroundNotification()
+        }
         scope.launch {
             coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus().let { result ->
                 when (result) {

--- a/app/src/main/kotlin/com/wire/android/ui/debug/StartServiceReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/StartServiceReceiver.kt
@@ -49,7 +49,8 @@ class StartServiceReceiver : BroadcastReceiver() {
         appLogger.i("$TAG: onReceive called with action ${intent?.action}")
         /**
          * We may get any event from the system, so we need to check if the action is ACTION_BOOT_COMPLETED or
-         * ACTION_LOCKED_BOOT_COMPLETED to start the persistentWebSocketService otherwise ForegroundServiceStartNotAllowedException will be thrown.
+         * ACTION_LOCKED_BOOT_COMPLETED to start the persistentWebSocketService otherwise
+         * ForegroundServiceStartNotAllowedException will be thrown.
          */
         if (intent?.action == Intent.ACTION_BOOT_COMPLETED || intent?.action == Intent.ACTION_LOCKED_BOOT_COMPLETED) {
             scope.launch { startPersistentWebSocketService() }

--- a/app/src/main/kotlin/com/wire/android/ui/debug/StartServiceReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/StartServiceReceiver.kt
@@ -47,7 +47,13 @@ class StartServiceReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
         appLogger.i("$TAG: onReceive called with action ${intent?.action}")
-        scope.launch { startPersistentWebSocketService() }
+        /**
+         * We may get any event from the system, so we need to check if the action is ACTION_BOOT_COMPLETED or
+         * ACTION_LOCKED_BOOT_COMPLETED to start the persistentWebSocketService otherwise ForegroundServiceStartNotAllowedException will be thrown.
+         */
+        if (intent?.action == Intent.ACTION_BOOT_COMPLETED || intent?.action == Intent.ACTION_LOCKED_BOOT_COMPLETED) {
+            scope.launch { startPersistentWebSocketService() }
+        }
     }
 
     companion object {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10712" title="WPB-10712" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10712</a>  Crash when starting starting PersistentWebsocketService
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app is crashing when we start PersistentWebsocketService

```
Exception java.lang.RuntimeException: Unable to create service com.wire.android.services.PersistentWebSocketService: android.app.ForegroundServiceStartNotAllowedException: Service.startForeground() not allowed due to mAllowStartForeground false: service com.wire/.android.services.PersistentWebSocketService
  at android.app.ActivityThread.handleCreateService (ActivityThread.java:5111)
  at android.app.ActivityThread.-$$Nest$mhandleCreateService
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2506)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:8918)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:608)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
```

### Causes (Optional)

1. There are few exemptions according to [documentation](https://developer.android.com/develop/background-work/services/foreground-services#background-start-restriction-exemptions:~:text=After%20the%20device%20reboots%20and%20receives%20the%20ACTION_BOOT_COMPLETED%2C%20ACTION_LOCKED_BOOT_COMPLETED%2C%20or%20ACTION_MY_PACKAGE_REPLACED%20intent%20action%20in%20a%20broadcast%20receiver.) to start a service from background. In our case, there is a chance that we don't respect the rule as `StartServiceReceiver` can receive any event when the app is in background.

2. We are calling `startForeground()` in `onCreate()`, that lifecycle method is not guaranteed to be called when system restarts the service according to this [comment](https://issuetracker.google.com/issues/307329994#comment100) from a Google employee

### Solutions

1. Check if the action, received in `StartServiceReceiver`,  is `ACTION_BOOT_COMPLETED` or `ACTION_LOCKED_BOOT_COMPLETED` to start the persistentWebSocketService .
2. Call `startForeground()` in `startCommand()` as well if the service is not started. 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
