### PR TITLE
fix: Add missing staging backend verification for analytics (WPB-10736)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCase.kt
@@ -78,7 +78,9 @@ fun ObserveCurrentSessionAnalyticsUseCase(
                     previousAnalyticsResult = identifierResult
 
                     val isProdBackend = when (val serverConfig = currentBackend(userId)) {
-                        is SelfServerConfigUseCase.Result.Success -> serverConfig.serverLinks.links.api == ServerConfig.PRODUCTION.api
+                        is SelfServerConfigUseCase.Result.Success ->
+                            serverConfig.serverLinks.links.api == ServerConfig.PRODUCTION.api
+                                    || serverConfig.serverLinks.links.api == ServerConfig.STAGING.api
                         is SelfServerConfigUseCase.Result.Failure -> false
                     }
 

--- a/app/src/test/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCaseTest.kt
@@ -142,7 +142,7 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
                     )
                     setSelfServerConfig(
                         Arrangement.SERVER_CONFIG_PRODUCTION.copy(
-                            serverLinks = Arrangement.SERVER_CONFIG_PRODUCTION.serverLinks.copy(links = ServerConfig.STAGING)
+                            serverLinks = Arrangement.SERVER_CONFIG_PRODUCTION.serverLinks.copy(links = ServerConfig.DUMMY)
                         )
                     )
                 }.arrange()

--- a/app/src/test/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCaseTest.kt
@@ -70,7 +70,28 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
                 setCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
                 setIsTeamMember(TestUser.SELF_USER.id)
                 setObservingTrackingIdentifierStatus(AnalyticsIdentifierResult.ExistingIdentifier(Arrangement.CURRENT_TRACKING_IDENTIFIER))
-                setSelfServerConfig(Arrangement.SEVER_CONFIG_PRODUCTION)
+                setSelfServerConfig(Arrangement.SERVER_CONFIG_PRODUCTION)
+            }.arrange()
+
+        // when
+        useCase.invoke().test {
+            // then
+            val item = awaitItem()
+            assertIs<AnalyticsIdentifierResult.ExistingIdentifier>(item.identifierResult)
+            assertEquals(true, item.isTeamMember)
+        }
+    }
+
+    @Test
+    fun givenStagingBackendApi_whenObservingCurrentSessionAnalytics_thenExistingIdentifierAnalyticsResultIsReturned() = runTest {
+        // given
+        val (_, useCase) = Arrangement()
+            .withIsAnonymousUsageDataEnabled(true)
+            .apply {
+                setCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
+                setIsTeamMember(TestUser.SELF_USER.id)
+                setObservingTrackingIdentifierStatus(AnalyticsIdentifierResult.ExistingIdentifier(Arrangement.CURRENT_TRACKING_IDENTIFIER))
+                setSelfServerConfig(Arrangement.SERVER_CONFIG_STAGING)
             }.arrange()
 
         // when
@@ -94,7 +115,7 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
                     setObservingTrackingIdentifierStatus(
                         AnalyticsIdentifierResult.ExistingIdentifier(Arrangement.CURRENT_TRACKING_IDENTIFIER)
                     )
-                    setSelfServerConfig(Arrangement.SEVER_CONFIG_PRODUCTION)
+                    setSelfServerConfig(Arrangement.SERVER_CONFIG_PRODUCTION)
                 }.arrange()
 
             // when
@@ -120,8 +141,8 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
                         AnalyticsIdentifierResult.ExistingIdentifier(Arrangement.CURRENT_TRACKING_IDENTIFIER)
                     )
                     setSelfServerConfig(
-                        Arrangement.SEVER_CONFIG_PRODUCTION.copy(
-                            serverLinks = Arrangement.SEVER_CONFIG_PRODUCTION.serverLinks.copy(links = ServerConfig.STAGING)
+                        Arrangement.SERVER_CONFIG_PRODUCTION.copy(
+                            serverLinks = Arrangement.SERVER_CONFIG_PRODUCTION.serverLinks.copy(links = ServerConfig.STAGING)
                         )
                     )
                 }.arrange()
@@ -170,7 +191,7 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
                 setCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
                 setIsTeamMember(TestUser.SELF_USER.id)
                 setObservingTrackingIdentifierStatus(AnalyticsIdentifierResult.ExistingIdentifier(Arrangement.CURRENT_TRACKING_IDENTIFIER))
-                setSelfServerConfig(Arrangement.SEVER_CONFIG_PRODUCTION)
+                setSelfServerConfig(Arrangement.SERVER_CONFIG_PRODUCTION)
             }.arrange()
 
         // when
@@ -185,7 +206,7 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
             arrangement.setObservingTrackingIdentifierStatus(
                 AnalyticsIdentifierResult.ExistingIdentifier(Arrangement.OTHER_TRACKING_IDENTIFIER)
             )
-            arrangement.setSelfServerConfig(Arrangement.SEVER_CONFIG_PRODUCTION)
+            arrangement.setSelfServerConfig(Arrangement.SERVER_CONFIG_PRODUCTION)
             arrangement.withIsAnonymousUsageDataEnabled(true)
 
             // then
@@ -263,7 +284,7 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
             const val CURRENT_TRACKING_IDENTIFIER = "abcd-1234"
             const val OTHER_TRACKING_IDENTIFIER = "aaaa-bbbb-1234"
 
-            val SEVER_CONFIG_PRODUCTION = SelfServerConfigUseCase.Result.Success(
+            val SERVER_CONFIG_PRODUCTION = SelfServerConfigUseCase.Result.Success(
                 serverLinks = ServerConfig(
                     id = "server_id",
                     links = ServerConfig.PRODUCTION,
@@ -272,6 +293,12 @@ class ObserveCurrentSessionAnalyticsUseCaseTest {
                         commonApiVersion = CommonApiVersionType.New,
                         domain = null
                     )
+                )
+            )
+
+            val SERVER_CONFIG_STAGING = SERVER_CONFIG_PRODUCTION.copy(
+                serverLinks = SERVER_CONFIG_PRODUCTION.serverLinks.copy(
+                    links = ServerConfig.STAGING
                 )
             )
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10736" title="WPB-10736" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10736</a>  [Android] Analytics enabled shows false for users on staging, after they agreed to share data
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

…ifier

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was no verification for staging backend api when observing analytics toggle change

### Causes (Optional)

Missed out this part

### Solutions

Add staging backend api when observing analytics toggle change to propagate identifier and initialize analytics
