### PR TITLE
fix: button keeps spinning when user starts a conversation and back (WPB-5862)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModel.kt
@@ -206,9 +206,11 @@ class ConnectionActionButtonViewModelImpl @Inject constructor(
                     onFailure(result.coreFailure)
                 }
 
-                is CreateConversationResult.Success -> onSuccess(result.conversation.id)
+                is CreateConversationResult.Success -> {
+                    state = state.finishAction()
+                    onSuccess(result.conversation.id)
+                }
             }
-            state.finishAction()
         }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModelTest.kt
@@ -256,6 +256,7 @@ class ConnectionActionButtonViewModelTest {
             }
             verify { arrangement.onOpenConversation(any()) }
             verify { arrangement.onStartConversationError wasNot Called }
+            assertEquals(false, viewModel.actionableState().isPerformingAction)
         }
 
     @Test
@@ -275,6 +276,7 @@ class ConnectionActionButtonViewModelTest {
             }
             verify { arrangement.onOpenConversation wasNot Called }
             verify { arrangement.onStartConversationError(eq(failure)) }
+            assertEquals(false, viewModel.actionableState().isPerformingAction)
         }
 
     @Test
@@ -295,6 +297,7 @@ class ConnectionActionButtonViewModelTest {
             }
             verify { arrangement.onOpenConversation wasNot Called }
             verify { arrangement.onStartConversationError(eq(errorResult)) }
+            assertEquals(false, viewModel.actionableState().isPerformingAction)
         }
 
     companion object {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5862" title="WPB-5862" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5862</a>  [Android] "Start conversation" button keeps spinning when user starts a conversation and clicks on back button.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the user goes to open conversation, and comes back, the loading indicator keeps loading indefinitely.

### Causes (Optional)

Not reassigning new state in view model.

### Solutions

Fix it, and add missing checks in tests

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
