### PR TITLE
fix: missing verification for analytics toggle (WPB-10587)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.RootNavGraph
-import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.colorsScheme

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
@@ -51,6 +51,7 @@ fun PrivacySettingsConfigScreen(
     with(viewModel) {
         PrivacySettingsScreenContent(
             isAnonymousUsageDataEnabled = state.isAnalyticsUsageEnabled,
+            shouldShowAnalyticsUsage = state.shouldShowAnalyticsUsage,
             areReadReceiptsEnabled = state.areReadReceiptsEnabled,
             setReadReceiptsState = ::setReadReceiptsState,
             isTypingIndicatorEnabled = state.isTypingIndicatorEnabled,
@@ -66,6 +67,7 @@ fun PrivacySettingsConfigScreen(
 @Composable
 fun PrivacySettingsScreenContent(
     isAnonymousUsageDataEnabled: Boolean,
+    shouldShowAnalyticsUsage: Boolean,
     areReadReceiptsEnabled: Boolean,
     setReadReceiptsState: (Boolean) -> Unit,
     isTypingIndicatorEnabled: Boolean,
@@ -91,7 +93,7 @@ fun PrivacySettingsScreenContent(
                 .fillMaxSize()
                 .padding(internalPadding)
         ) {
-            if (BuildConfig.ANALYTICS_ENABLED) {
+            if (shouldShowAnalyticsUsage) {
                 GroupConversationOptionsItem(
                     title = stringResource(id = R.string.settings_send_anonymous_usage_data_title),
                     switchState = SwitchState.Enabled(value = isAnonymousUsageDataEnabled, onCheckedChange = setAnonymousUsageDataEnabled),
@@ -143,6 +145,7 @@ fun PrivacySettingsScreenContent(
 fun PreviewSendReadReceipts() = WireTheme {
     PrivacySettingsScreenContent(
         isAnonymousUsageDataEnabled = true,
+        shouldShowAnalyticsUsage = true,
         areReadReceiptsEnabled = true,
         setReadReceiptsState = {},
         isTypingIndicatorEnabled = true,

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModel.kt
@@ -90,6 +90,7 @@ class PrivacySettingsViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
+            // TODO(Analytics): To be changed with UseCase
             val isAnalyticsConfigurationEnabled = analyticsEnabled is AnalyticsConfiguration.Enabled
             val isValidBackend = when (val serverConfig = selfServerConfig()) {
                 is SelfServerConfigUseCase.Result.Success ->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10587" title="WPB-10587" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10587</a>  [Android] Hide/Show Analytics Toggle in Privacy Settings Screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When on custom backends (different from PROD or STAGING) we were showing the analytics toggle in Privacy Settings Screen

### Causes (Optional)

We had the verification already set but was not being used

### Solutions

Use state attribute containing the value to show or hide the analytics toggle

### Testing

#### How to Test

- Run App on PROD/STAGING -> dialog/toggle should be shown
- Run App on custom backend (Anta for example) -> dialog/toggle should NOT be shown