### PR TITLE
ci: set the correct version name for fdroid updates [WPB-10569]

### DIFF
--- a/build-logic/plugins/src/main/kotlin/AppVersionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AppVersionPlugin.kt
@@ -41,7 +41,7 @@ class AppVersionPlugin : Plugin<Project> {
                 // git commit hash code
                 val gitRevision = "git rev-parse --short HEAD".execute().text.trim()
                 println("VersionCode: $versionCode")
-                println("VersionName: $versionName")
+                println("VersionName: $versionName-fdroid")
                 println("Revision: $gitRevision")
                 println("Buildtime: $buildTime")
                 println("Application-name: $appName")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10569" title="WPB-10569" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10569</a>  [Android] publish fdroid
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

set the correct version name for fdroid updates 

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
