### PR TITLE
ci: fix apk path when uploading release apk to gh releases (WPB-8645)

### DIFF
--- a/.github/workflows/build-prod-app.yml
+++ b/.github/workflows/build-prod-app.yml
@@ -117,5 +117,5 @@ jobs:
         uses: softprops/action-gh-release@v2.0.8
         with:
           files: |
-            app/build/outputs/apk/prodCompatrelease/*.apk
+            app/build/outputs/apk/prod/Compatrelease/*.apk
             app/version.txt

--- a/.github/workflows/build-prod-app.yml
+++ b/.github/workflows/build-prod-app.yml
@@ -117,5 +117,5 @@ jobs:
         uses: softprops/action-gh-release@v2.0.8
         with:
           files: |
-            app/build/outputs/apk/prod/Compatrelease/*.apk
+            app/build/outputs/apk/prod/compatrelease/*.apk
             app/version.txt


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8645" title="WPB-8645" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-8645</a>  [Android] Infrastructure code and developer experience
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

fix apk path when uploading release apk to gh releases

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
