### PR TITLE
chore: limit release notes to 500 char  limit release notes to 500 char [WPB-10569]

### DIFF
--- a/app/src/main/play/release-notes/en-US/default.txt
+++ b/app/src/main/play/release-notes/en-US/default.txt
@@ -1,27 +1,16 @@
 New
-    Fresh design - completely rebuilt
-    Ability to add Reactions to messages
-    Swipe left to reply
-    Button to scroll to end of conversation
-    Drafts: keep your message in text field after leaving conversation
-    Navigate to original message from a reply
-    Preview a picture before sending
-    Time dividers and grouping of messages
-    Easy accessible main navigation and an updated conversation list with a new activity section
-    Improved search for a conversation
-    Easier to create 1:1 and group conversations
-    Group conversations are marked with different colors to distinguish easily between 1:1 and group conversations
-    Calling controls are accessible all the time during a call
-    More comfortable to write longer messages as the text field adjusts accordingly
-    Improved dark and light mode – fully aligned with your system settings
-    Select a profile picture in your conversation to access your contact’s profiles easily
-    Quickly change your availability status or switch between accounts for teams
-    Log out directly from your profile and decide if you want to keep your history
+- Fresh design - completely rebuilt
+- Add Reactions to messages
+- Swipe left to reply
+- Scroll to end button
+- Navigate to original message from a reply
+- Accessible main navigation & updated conversation list with activity section
+- Improved conversation search
+- Easier 1:1 & group creation
+- Group chats have distinct colors
+- Call controls always accessible
+- Text field adjusts for longer messages
 
 Improved
-    Less storage space and lower battery consumption
-    Reliable app notifications and messaging
-    Indication of guests, federated and external contacts are more recognizable
-    Improved visual contrast ratios (colors) – following accessibility standard WCAG 2.1 (level AA)
-    Share your location
-    Search in conversation for text messages and files
+- Reliable notifications
+- Better visual contrast (WCAG 2.1 AA)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10569" title="WPB-10569" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10569</a>  [Android] publish fdroid
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

 limit release notes to 500 char
