### PR TITLE
fix: Fresh install crash [WPB-9452] 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -227,7 +227,7 @@ class FeatureFlagNotificationViewModel @Inject constructor(
 
     private suspend fun observeAskCallFeedback(userId: UserId) =
         coreLogic.getSessionScope(userId).calls.observeAskCallFeedbackUseCase().collect { shouldAskFeedback ->
-            if (!isAnalyticsAvailable()) {
+            if (!isAnalyticsAvailable(userId)) {
                 // Analytics is disabled. Do nothing.
             } else if (shouldAskFeedback) {
                 showCallFeedbackFlow.emit(Unit)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9452" title="WPB-9452" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9452</a>  [Android] : Call Quality Feedback - First Pass
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

App crashes on fresh install 

### Causes (Optional)

`IsAnalyticsAvailableUseCase` (which is used in `FeatureFlagNotificationViewModel`) requires `SelfServerConfigUseCase` and  `UserDataStore`  which requires currentUserId, and there is no any.

### Solutions

Update `IsAnalyticsAvailableUseCase` to get `userId` and use it for getting `SelfServerConfigUseCase` and  `UserDataStore` by CoreLogic and UserDataStoreProvider. 
