### PR TITLE
feat: Display ErrorCode for DecryptionError [WPB-1795]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -50,7 +50,6 @@ import com.wire.kalium.logic.feature.session.UpdateCurrentSessionUseCase
 import com.wire.kalium.logic.feature.user.MarkFileSharingChangeAsNotifiedUseCase
 import com.wire.kalium.logic.feature.user.MarkSelfDeletionStatusAsNotifiedUseCase
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
-import com.wire.kalium.logic.feature.user.UserScope
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.PersistScreenshotCensoringConfigUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -36,6 +36,7 @@ import com.wire.kalium.logic.feature.connection.BlockUserUseCase
 import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveOtherUserSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
+import com.wire.kalium.logic.feature.debug.BreakSessionUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.FetchConversationMLSVerificationStatusUseCase
 import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
@@ -49,6 +50,7 @@ import com.wire.kalium.logic.feature.session.UpdateCurrentSessionUseCase
 import com.wire.kalium.logic.feature.user.MarkFileSharingChangeAsNotifiedUseCase
 import com.wire.kalium.logic.feature.user.MarkSelfDeletionStatusAsNotifiedUseCase
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
+import com.wire.kalium.logic.feature.user.UserScope
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.PersistScreenshotCensoringConfigUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
@@ -481,4 +483,9 @@ class UseCaseModule {
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
     ): GetCurrentAnalyticsTrackingIdentifierUseCase = coreLogic.getSessionScope(currentAccount).getCurrentAnalyticsTrackingIdentifier
+
+    @ViewModelScoped
+    @Provides
+    fun provideBreakSessionUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): BreakSessionUseCase =
+        coreLogic.getSessionScope(currentAccount).debug.breakSession
 }

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -170,7 +170,7 @@ class MessageMapper @Inject constructor(
 
         val content = message.content
         val flowStatus = if (content is MessageContent.FailedDecryption) {
-            MessageFlowStatus.Failure.Decryption(content.isDecryptionResolved)
+            MessageFlowStatus.Failure.Decryption(content.isDecryptionResolved, content.errorCode)
         } else {
             when (val status = message.status) {
                 Message.Status.Pending -> MessageFlowStatus.Sending

--- a/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
@@ -178,7 +178,12 @@ class RegularMessageMapper @Inject constructor(
                     )
                 } ?: UIText.StringResource(R.string.sent_a_message_with_unknown_content)
 
-                is MessageContent.FailedDecryption -> UIText.StringResource(R.string.label_message_decryption_failure_message)
+                is MessageContent.FailedDecryption -> {
+                    content.errorCode?.let {
+                        UIText.StringResource(R.string.label_message_decryption_failure_message_with_error_code, it)
+                    } ?: UIText.StringResource(R.string.label_message_decryption_failure_message)
+                }
+
                 else -> UIText.StringResource(R.string.sent_a_message_with_unknown_content)
             },
             quotedMessage = quotedMessage

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageItemComponents.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageItemComponents.kt
@@ -369,7 +369,7 @@ fun PreviewMessageDecryptionFailure() {
     WireTheme {
         MessageDecryptionFailure(
             mockHeader,
-            MessageFlowStatus.Failure.Decryption(false),
+            MessageFlowStatus.Failure.Decryption(false, 0),
             { _, _ -> },
             Conversation.ProtocolInfo.Proteus
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageTypesPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageTypesPreview.kt
@@ -221,7 +221,7 @@ fun PreviewFailedDecryptionMessage() {
                 it.copy(
                     header = it.header.copy(
                         messageStatus = MessageStatus(
-                            flowStatus = MessageFlowStatus.Failure.Decryption(false),
+                            flowStatus = MessageFlowStatus.Failure.Decryption(false, 222),
                             expirationStatus = ExpirationStatus.NotExpirable
                         )
                     ),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -190,8 +190,10 @@ sealed class MessageFlowStatus {
             )
         }
 
-        data class Decryption(val isDecryptionResolved: Boolean) : Failure(
-            UIText.StringResource(R.string.label_message_decryption_failure_message)
+        data class Decryption(val isDecryptionResolved: Boolean, private val errorCode: Int?) : Failure(
+            errorCode?.let {
+                UIText.StringResource(R.string.label_message_decryption_failure_message_with_error_code, it)
+            } ?: UIText.StringResource(R.string.label_message_decryption_failure_message)
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -59,7 +59,6 @@ import com.wire.android.ui.authentication.devices.remove.RemoveDeviceError
 import com.wire.android.ui.common.CopyButton
 import com.wire.android.ui.common.MLSVerificationIcon
 import com.wire.android.ui.common.ProteusVerifiedIcon
-import com.wire.android.ui.common.RowItemTemplate
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -59,6 +59,7 @@ import com.wire.android.ui.authentication.devices.remove.RemoveDeviceError
 import com.wire.android.ui.common.CopyButton
 import com.wire.android.ui.common.MLSVerificationIcon
 import com.wire.android.ui.common.ProteusVerifiedIcon
+import com.wire.android.ui.common.RowItemTemplate
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
@@ -134,7 +135,8 @@ fun DeviceDetailsScreen(
                 )
             },
             onEnrollE2EIErrorDismiss = viewModel::hideEnrollE2EICertificateError,
-            onEnrollE2EISuccessDismiss = viewModel::hideEnrollE2EICertificateSuccess
+            onEnrollE2EISuccessDismiss = viewModel::hideEnrollE2EICertificateSuccess,
+            onBreakSession = viewModel::breakSession
         )
     }
 }
@@ -155,7 +157,8 @@ fun DeviceDetailsContent(
     enrollE2eiCertificate: () -> Unit = {},
     onUpdateClientVerification: (Boolean) -> Unit = {},
     onEnrollE2EIErrorDismiss: () -> Unit = {},
-    onEnrollE2EISuccessDismiss: () -> Unit = {}
+    onEnrollE2EISuccessDismiss: () -> Unit = {},
+    onBreakSession: () -> Unit = {}
 ) {
     val screenState = rememberConversationScreenState()
     WireScaffold(
@@ -268,6 +271,10 @@ fun DeviceDetailsContent(
                     HorizontalDivider(color = MaterialTheme.wireColorScheme.background)
                 }
             }
+
+            if (BuildConfig.DEBUG && !state.isCurrentDevice) {
+                item { BreakSessionButton(onBreakSession) }
+            }
         }
         if (state.removeDeviceDialogState is RemoveDeviceDialogState.Visible) {
             RemoveDeviceDialog(
@@ -315,6 +322,21 @@ fun DeviceDetailsContent(
             )
         }
     }
+}
+
+@Composable
+private fun BreakSessionButton(onBreakSession: () -> Unit) {
+    WirePrimaryButton(
+        text = stringResource(R.string.debug_settings_break_session),
+        onClick = onBreakSession,
+        colors = wirePrimaryButtonColors(),
+        modifier = Modifier.padding(
+            start = dimensions().spacing16x,
+            top = dimensions().spacing16x,
+            end = dimensions().spacing16x,
+            bottom = dimensions().spacing16x
+        )
+    )
 }
 
 @Composable
@@ -391,17 +413,17 @@ fun DeviceMLSSignatureItem(
 ) {
     Column(modifier = modifier) {
 
-    DeviceDetailSectionContent(
-        stringResource(id = R.string.label_mls_thumbprint),
-        sectionText = mlsThumbprint.formatAsFingerPrint(),
-        titleTrailingItem = {
-            CopyButton(
-                onCopyClicked = { onCopy(mlsThumbprint) },
-                state = WireButtonState.Default
-            )
-        }
-    )
-        }
+        DeviceDetailSectionContent(
+            stringResource(id = R.string.label_mls_thumbprint),
+            sectionText = mlsThumbprint.formatAsFingerPrint(),
+            titleTrailingItem = {
+                CopyButton(
+                    onCopyClicked = { onCopy(mlsThumbprint) },
+                    state = WireButtonState.Default
+                )
+            }
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
@@ -45,6 +45,7 @@ import com.wire.kalium.logic.feature.client.GetClientDetailsResult
 import com.wire.kalium.logic.feature.client.ObserveClientDetailsUseCase
 import com.wire.kalium.logic.feature.client.Result
 import com.wire.kalium.logic.feature.client.UpdateClientVerificationStatusUseCase
+import com.wire.kalium.logic.feature.debug.BreakSessionUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.E2EIEnrollmentResult
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMLSClientIdentityUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
@@ -72,6 +73,7 @@ class DeviceDetailsViewModel @Inject constructor(
     private val updateClientVerificationStatus: UpdateClientVerificationStatusUseCase,
     private val observeUserInfo: ObserveUserInfoUseCase,
     private val e2eiCertificate: GetMLSClientIdentityUseCase,
+    private val breakSession: BreakSessionUseCase,
     isE2EIEnabledUseCase: IsE2EIEnabledUseCase
 ) : SavedStateViewModel(savedStateHandle) {
 
@@ -286,5 +288,9 @@ class DeviceDetailsViewModel @Inject constructor(
 
     fun hideEnrollE2EICertificateSuccess() {
         state = state.copy(isE2EICertificateEnrollSuccess = false)
+    }
+
+    fun breakSession() {
+        viewModelScope.launch { breakSession(userId, deviceId) }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="label_message_edit_sent_remotely_failure">The edited message could not be sent, as the backend of %s could not be reached.</string>
     <string name="label_message_receive_failure">Download Error</string>
     <string name="label_message_decryption_failure_message">Message could not be decrypted.</string>
+    <string name="label_message_decryption_failure_message_with_error_code">Message could not be decrypted (Error %s).</string>
     <string name="label_message_decryption_failure_informative_message">Try resetting the session to generate new encryption keys.</string>
     <string name="label_system_message_self_user_knock">%s pinged</string>
     <string name="label_system_message_other_user_knock">%s pinged</string>
@@ -222,6 +223,7 @@
     <string name="debug_settings_api_versioning_title" translatable="false">API VERSIONING</string>
     <string name="debug_settings_e2ei_enrollment_title" translatable="false">E2EI Manual Enrollment</string>
     <string name="debug_settings_force_api_versioning_update" translatable="false">Force API versioning update</string>
+    <string name="debug_settings_break_session" translatable="false">⚠️ Break Session</string>
     <string name="item_dependencies_title">Dependencies:</string>
     <string name="debug_settings_force_api_versioning_update_button_text" translatable="false">Update</string>
     <string name="support_screen_title">Support</string>

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -43,7 +43,8 @@ object TestMessage {
         content = MessageContent.FailedDecryption(
             null,
             senderUserId = UserId("user-id", "domain"),
-            isDecryptionResolved = false
+            isDecryptionResolved = false,
+            errorCode = null
         ),
         conversationId = ConversationId("convo-id", "convo.domain"),
         date = Instant.parse("2022-03-30T15:36:00.000Z"),

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageMapperTest.kt
@@ -276,6 +276,7 @@ private fun Message.Regular.failureToDecrypt(isDecryptionResolved: Boolean) =
         .copy(
             content = MessageContent.FailedDecryption(
                 encodedData = null,
+                errorCode = null,
                 senderUserId = this.senderUserId,
                 isDecryptionResolved = isDecryptionResolved
             )

--- a/app/src/test/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModelTest.kt
@@ -41,6 +41,8 @@ import com.wire.kalium.logic.feature.client.GetClientDetailsResult
 import com.wire.kalium.logic.feature.client.ObserveClientDetailsUseCase
 import com.wire.kalium.logic.feature.client.Result
 import com.wire.kalium.logic.feature.client.UpdateClientVerificationStatusUseCase
+import com.wire.kalium.logic.feature.debug.BreakSessionResult
+import com.wire.kalium.logic.feature.debug.BreakSessionUseCase
 import com.wire.kalium.logic.feature.e2ei.Handle
 import com.wire.kalium.logic.feature.e2ei.MLSClientE2EIStatus
 import com.wire.kalium.logic.feature.e2ei.MLSClientIdentity
@@ -360,6 +362,9 @@ class DeviceDetailsViewModelTest {
         @MockK
         lateinit var isE2EIEnabledUseCase: IsE2EIEnabledUseCase
 
+        @MockK
+        lateinit var breakSession: BreakSessionUseCase
+
         val currentUserId = UserId("currentUserId", "currentUserDomain")
 
         val viewModel by lazy {
@@ -373,7 +378,8 @@ class DeviceDetailsViewModelTest {
                 currentUserId = currentUserId,
                 observeUserInfo = observeUserInfo,
                 e2eiCertificate = getE2eiCertificate,
-                isE2EIEnabledUseCase = isE2EIEnabledUseCase
+                isE2EIEnabledUseCase = isE2EIEnabledUseCase,
+                breakSession = breakSession
             )
         }
 
@@ -383,6 +389,7 @@ class DeviceDetailsViewModelTest {
             coEvery { observeUserInfo(any()) } returns flowOf(GetUserInfoResult.Success(TestUser.OTHER_USER, null))
             coEvery { getE2eiCertificate(any()) } returns MLS_CLIENT_IDENTITY_WITHOUT_E2EI.right()
             coEvery { isE2EIEnabledUseCase() } returns true
+            coEvery { breakSession(any(), any()) } returns BreakSessionResult.Success
         }
 
         fun withUserRequiresPasswordResult(result: IsPasswordRequiredUseCase.Result = IsPasswordRequiredUseCase.Result.Success(true)) =

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -184,7 +184,7 @@ private val LightWireColorScheme = WireColorScheme(
     disabledCheckedColor = WireColorPalette.Gray80,
     disabledIndeterminateColor = WireColorPalette.Gray80,
     disabledUncheckedColor = WireColorPalette.Gray80,
-    messageErrorBackgroundColor = WireColorPalette.DarkRed50,
+    messageErrorBackgroundColor = WireColorPalette.LightRed50,
     groupAvatarColors = listOf(
         // Red
         WireColorPalette.LightRed300,


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1795" title="WPB-1795" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-1795</a>  Display Decryption error message according to Design
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----

# What's new in this PR?

### Issues

We want to inform user what is the exact error code which caused Decryption error. 

### Solutions

Update kalium to store that code and display it in UI
Also added "Break the session" button in device details screen (for debug builds) so it would be easier to test such a scenarios.

### Dependencies (Optional)

Waiting for kalium PR be merged https://github.com/wireapp/kalium/pull/2989

### Attachments (Optional)

<img width="1056" alt="Screenshot 2024-09-03 at 16 41 56" src="https://github.com/user-attachments/assets/af7cdcf8-4208-428d-b79e-c1f2dca5794b">


<img width="403" alt="Screenshot 2024-09-03 at 16 42 08" src="https://github.com/user-attachments/assets/db64d511-0043-437d-b59c-fdb9a1ae01c3">
