### PR TITLE
feat: support sending GIFs from keyboard [WPB-1715]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/CheckAssetRestrictionsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/CheckAssetRestrictionsViewModel.kt
@@ -41,7 +41,7 @@ class CheckAssetRestrictionsViewModel @Inject constructor() : ViewModel() {
                 assetType = it.assetBundle.assetType,
                 maxLimitInMB = it.assetSizeExceeded!!,
                 savedToDevice = false,
-                multipleAssets = true
+                multipleAssets = importedMediaList.size > 1,
             )
         } ?: onSuccess(importedMediaList.map { it.assetBundle })
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/ImagesPreviewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/ImagesPreviewScreen.kt
@@ -292,7 +292,6 @@ private fun BoxScope.ThumbnailsRow(
             }
         }
     }
-
 }
 
 @PreviewMultipleThemes
@@ -389,4 +388,3 @@ fun PreviewImagesPreviewScreenSingleAsset() {
         )
     }
 }
-

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/ImagesPreviewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/ImagesPreviewScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -230,57 +231,73 @@ private fun Content(
                 )
             }
 
-            LazyRow(
-                modifier = Modifier
-                    .padding(bottom = dimensions().spacing8x)
-                    .height(dimensions().spacing80x)
-                    .align(Alignment.BottomCenter),
-                horizontalArrangement = Arrangement.spacedBy(dimensions().spacing4x),
-                contentPadding = PaddingValues(start = dimensions().spacing16x, end = dimensions().spacing16x)
-            ) {
-                items(
-                    count = previewState.assetBundleList.size,
-                ) { index ->
-                    Box(
-                        modifier = Modifier
-                            .width(dimensions().spacing80x)
-                            .fillMaxHeight()
-                    ) {
-                        AssetTilePreview(
-                            modifier = Modifier
-                                .size(dimensions().spacing64x)
-                                .align(Alignment.Center),
-                            assetBundle = previewState.assetBundleList[index].assetBundle,
-                            isSelected = previewState.selectedIndex == index,
-                            showOnlyExtension = true,
-                            onClick = { onSelected(index) }
-                        )
-
-                        if (previewState.assetBundleList.size > 1) {
-                            RemoveIcon(
-                                modifier = Modifier.align(Alignment.TopEnd),
-                                onClick = {
-                                    onRemoveAsset(index)
-                                },
-                                contentDescription = stringResource(id = R.string.remove_asset_description)
-                            )
-                        }
-                        if (previewState.assetBundleList[index].assetSizeExceeded != null) {
-                            ErrorIcon(
-                                stringResource(id = R.string.asset_attention_description),
-                                modifier = Modifier.align(Alignment.Center)
-                            )
-                        }
-                    }
-                }
+            if (previewState.assetBundleList.size > 1) {
+                ThumbnailsRow(
+                    previewState = previewState,
+                    onSelected = onSelected,
+                    onRemoveAsset = onRemoveAsset
+                )
             }
         }
     }
 }
 
+@Composable
+private fun BoxScope.ThumbnailsRow(
+    previewState: ImagesPreviewState,
+    onSelected: (index: Int) -> Unit,
+    onRemoveAsset: (index: Int) -> Unit
+) {
+    LazyRow(
+        modifier = Modifier
+            .padding(bottom = dimensions().spacing8x)
+            .height(dimensions().spacing80x)
+            .align(Alignment.BottomCenter),
+        horizontalArrangement = Arrangement.spacedBy(dimensions().spacing4x),
+        contentPadding = PaddingValues(start = dimensions().spacing16x, end = dimensions().spacing16x)
+    ) {
+        items(
+            count = previewState.assetBundleList.size,
+        ) { index ->
+            Box(
+                modifier = Modifier
+                    .width(dimensions().spacing80x)
+                    .fillMaxHeight()
+            ) {
+                AssetTilePreview(
+                    modifier = Modifier
+                        .size(dimensions().spacing64x)
+                        .align(Alignment.Center),
+                    assetBundle = previewState.assetBundleList[index].assetBundle,
+                    isSelected = previewState.selectedIndex == index,
+                    showOnlyExtension = true,
+                    onClick = { onSelected(index) }
+                )
+
+                if (previewState.assetBundleList.size > 1) {
+                    RemoveIcon(
+                        modifier = Modifier.align(Alignment.TopEnd),
+                        onClick = {
+                            onRemoveAsset(index)
+                        },
+                        contentDescription = stringResource(id = R.string.remove_asset_description)
+                    )
+                }
+                if (previewState.assetBundleList[index].assetSizeExceeded != null) {
+                    ErrorIcon(
+                        stringResource(id = R.string.asset_attention_description),
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+            }
+        }
+    }
+
+}
+
 @PreviewMultipleThemes
 @Composable
-fun PreviewImagesPreviewScreen() {
+fun PreviewImagesPreviewScreenMultipleAssets() {
     WireTheme {
         Content(
             previewState = ImagesPreviewState(
@@ -341,3 +358,35 @@ fun PreviewImagesPreviewScreen() {
         )
     }
 }
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewImagesPreviewScreenSingleAsset() {
+    WireTheme {
+        Content(
+            previewState = ImagesPreviewState(
+                ConversationId("value", "domain"),
+                selectedIndex = 0,
+                conversationName = "Conversation",
+                assetBundleList = persistentListOf(
+                    ImportedMediaAsset(
+                        AssetBundle(
+                            "key",
+                            "image/png",
+                            "".toPath(),
+                            20,
+                            "preview.png",
+                            assetType = AttachmentType.IMAGE
+                        ),
+                        assetSizeExceeded = null
+                    )
+                ),
+            ),
+            onNavigationPressed = {},
+            onSendMessages = {},
+            onSelected = {},
+            onRemoveAsset = {}
+        )
+    }
+}
+

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -201,28 +201,32 @@ suspend fun Uri.resampleImageAndCopyToTempPath(
     dispatcher: DispatcherProvider = DefaultDispatcherProvider()
 ): Long {
     return withContext(dispatcher.io()) {
-        var size: Long
         val originalImage = toByteArray(context, dispatcher)
         if (originalImage.isEmpty()) return@withContext 0L // if the image is empty, resampling it would cause an exception
 
-        ImageUtil.resample(originalImage, sizeClass).let { processedImage ->
-            val file = tempCachePath.toFile()
-            try {
-                size = processedImage.size.toLong()
-                file.setWritable(true)
-                file.outputStream().use { it.write(processedImage) }
-            } catch (e: FileNotFoundException) {
-                appLogger.e("[ResampleImage] Cannot find file ${file.path}", e)
-                throw e
-            } catch (e: IOException) {
-                appLogger.e("[ResampleImage] I/O error while writing the image", e)
-                throw e
-            }
+        val mimeType = this@resampleImageAndCopyToTempPath.getMimeType(context)
+        if (mimeType == "image/gif") {
+            // GIFs are not resampled, it takes long and usually GIFs are small enough to be shared as is.
+            // If the GIF is too large, the user will be informed about that, just like for all other files.
+            originalImage.writeToFile(tempCachePath.toFile())
+        } else {
+            ImageUtil.resample(originalImage, sizeClass).writeToFile(tempCachePath.toFile())
         }
-
-        size
     }
 }
+
+private fun ByteArray.writeToFile(file: File): Long =
+    try {
+        file.setWritable(true)
+        file.outputStream().use { it.write(this) }
+        this.size.toLong()
+    } catch (e: FileNotFoundException) {
+        appLogger.e("[ResampleImage] Cannot find file ${file.path}", e)
+        throw e
+    } catch (e: IOException) {
+        appLogger.e("[ResampleImage] I/O error while writing the image", e)
+        throw e
+    }
 
 fun Context.getFileName(uri: Uri): String? = when (uri.scheme) {
     ContentResolver.SCHEME_CONTENT -> getContentFileName(uri)

--- a/app/src/main/kotlin/com/wire/android/util/ImageUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ImageUtil.kt
@@ -148,7 +148,7 @@ fun Uri.toBitmap(context: Context): Bitmap? {
 /**
  * Checks whether it is the URI of the image
  */
-fun Uri.isImage(context: Context): Boolean = this.getMimeType(context)?.startsWith("image/") == true
+fun Uri.isImage(context: Context): Boolean = isImageFile(this.getMimeType(context))
 
 /**
  * Rotates the image to its [ExifInterface.ORIENTATION_NORMAL] in case it's rotated with a different orientation than

--- a/app/src/main/kotlin/com/wire/android/util/ImageUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ImageUtil.kt
@@ -146,6 +146,11 @@ fun Uri.toBitmap(context: Context): Bitmap? {
 }
 
 /**
+ * Checks whether it is the URI of the image
+ */
+fun Uri.isImage(context: Context): Boolean = this.getMimeType(context)?.startsWith("image/") == true
+
+/**
  * Rotates the image to its [ExifInterface.ORIENTATION_NORMAL] in case it's rotated with a different orientation than
  * landscape or portrait See more about exif interface at:
  * https://developer.android.com/reference/androidx/exifinterface/media/ExifInterface


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1715" title="WPB-1715" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-1715</a>  Support Sending GIFs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- implemented support of sending GIFs using third-party keyboards that support GIF functionality (e.g., Gboard, SwiftKey)
- updated image preview screen to match designs when single image is being shown
- removed resampling when GIF has too large dimensions as it changes GIF into PNG or JPEG - static image instead of GIF 

### Testing

#### How to Test

You need to use one of the keyboards that support GIF functionality (e.g. Gboard, SwiftKey).
Open conversation, click on text input, open GIF selector and choose one GIF - image preview screen with this GIF should be opened and you should be able to send this gif (if the size of this GIF file is not too big, of course).

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/user-attachments/assets/f76d86dd-9bc0-4e29-b445-3fb9d261dd01"/> | <video width="400" src="https://github.com/user-attachments/assets/5fe78ecc-9f36-4c55-bb14-4e49c10f82f0"/> |
| <video width="400" src="https://github.com/user-attachments/assets/ef153aae-a7a6-409c-a510-9b8f0fc58ae2"/> | <video width="400" src="https://github.com/user-attachments/assets/1db5dc5d-61b5-4c65-b86e-d39dfc05fde6"/> |
| <img width="300" src="https://github.com/user-attachments/assets/20ba65ef-e3d7-4e33-a517-3e4ca63c1057"/> | <img width="300" src="https://github.com/user-attachments/assets/1bf97276-dc98-4b56-b904-3cdc776dfbf5"/> |
| <img width="300" src="https://github.com/user-attachments/assets/eecbd50b-967e-4ca2-ae71-fe93a33d0737"/> | <img width="300" src="https://github.com/user-attachments/assets/b6577586-72bc-4440-b347-b157187b2d11"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
