### PR TITLE
refactor: deeplink handling [WPB-10182]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -558,6 +558,7 @@ class WireActivity : AppCompatActivity() {
                 onOpenConversation = {
                     if (it.switchedAccount) {
                         navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
+                        navigate(NavigationCommand(ConversationScreenDestination(it.conversationId), BackStackMode.UPDATE_EXISTED))
                     } else {
                         navigate(NavigationCommand(ConversationScreenDestination(it.conversationId), BackStackMode.UPDATE_EXISTED))
                     }
@@ -594,6 +595,7 @@ class WireActivity : AppCompatActivity() {
                 onOpenOtherUserProfile = {
                     if (it.switchedAccount) {
                         navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
+                        navigate(NavigationCommand(OtherUserProfileScreenDestination(it.userId), BackStackMode.UPDATE_EXISTED))
                     } else {
                         navigate(NavigationCommand(OtherUserProfileScreenDestination(it.userId), BackStackMode.UPDATE_EXISTED))
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -539,7 +539,7 @@ class WireActivity : AppCompatActivity() {
         }
     }
 
-    @Suppress("ComplexCondition")
+    @Suppress("ComplexCondition", "LongMethod")
     private fun handleDeepLink(
         intent: Intent?,
         savedInstanceState: Bundle? = null
@@ -555,11 +555,11 @@ class WireActivity : AppCompatActivity() {
             val navigate: (NavigationCommand) -> Unit = { lifecycleScope.launch { navigationCommands.emit(it) } }
             viewModel.handleDeepLink(
                 intent = intent,
-                onOpenConversation = { conversationId, switchedAccount ->
-                    if (switchedAccount) {
+                onOpenConversation = {
+                    if (it.switchedAccount) {
                         navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
                     } else {
-                        navigate(NavigationCommand(ConversationScreenDestination(conversationId), BackStackMode.UPDATE_EXISTED))
+                        navigate(NavigationCommand(ConversationScreenDestination(it.conversationId), BackStackMode.UPDATE_EXISTED))
                     }
                 },
                 onIsSharingIntent = {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -80,6 +80,7 @@ import com.wire.android.ui.destinations.HomeScreenDestination
 import com.wire.android.ui.destinations.ImportMediaScreenDestination
 import com.wire.android.ui.destinations.LoginScreenDestination
 import com.wire.android.ui.destinations.MigrationScreenDestination
+import com.wire.android.ui.destinations.OtherUserProfileScreenDestination
 import com.wire.android.ui.destinations.SelfDevicesScreenDestination
 import com.wire.android.ui.destinations.SelfUserProfileScreenDestination
 import com.wire.android.ui.destinations.WelcomeScreenDestination
@@ -590,7 +591,13 @@ class WireActivity : AppCompatActivity() {
                 onMigrationLogin = {
                     navigate(NavigationCommand(LoginScreenDestination(it.userHandle), BackStackMode.UPDATE_EXISTED))
                 },
-                onOpenOtherUserProfile = {},
+                onOpenOtherUserProfile = {
+                    if (it.switchedAccount) {
+                        navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
+                    } else {
+                        navigate(NavigationCommand(OtherUserProfileScreenDestination(it.userId), BackStackMode.UPDATE_EXISTED))
+                    }
+                },
                 onSSOLogin = {
                     navigate(NavigationCommand(LoginScreenDestination(ssoLoginResult = it), BackStackMode.UPDATE_EXISTED))
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -558,10 +558,8 @@ class WireActivity : AppCompatActivity() {
                 onOpenConversation = {
                     if (it.switchedAccount) {
                         navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
-                        navigate(NavigationCommand(ConversationScreenDestination(it.conversationId), BackStackMode.UPDATE_EXISTED))
-                    } else {
-                        navigate(NavigationCommand(ConversationScreenDestination(it.conversationId), BackStackMode.UPDATE_EXISTED))
                     }
+                    navigate(NavigationCommand(ConversationScreenDestination(it.conversationId), BackStackMode.UPDATE_EXISTED))
                 },
                 onIsSharingIntent = {
                     navigate(
@@ -595,10 +593,8 @@ class WireActivity : AppCompatActivity() {
                 onOpenOtherUserProfile = {
                     if (it.switchedAccount) {
                         navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
-                        navigate(NavigationCommand(OtherUserProfileScreenDestination(it.userId), BackStackMode.UPDATE_EXISTED))
-                    } else {
-                        navigate(NavigationCommand(OtherUserProfileScreenDestination(it.userId), BackStackMode.UPDATE_EXISTED))
                     }
+                    navigate(NavigationCommand(OtherUserProfileScreenDestination(it.userId), BackStackMode.UPDATE_EXISTED))
                 },
                 onSSOLogin = {
                     navigate(NavigationCommand(LoginScreenDestination(ssoLoginResult = it), BackStackMode.UPDATE_EXISTED))

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -119,7 +119,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-
 @AndroidEntryPoint
 @Suppress("TooManyFunctions")
 class WireActivity : AppCompatActivity() {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -310,7 +310,7 @@ class WireActivityViewModel @Inject constructor(
     fun handleDeepLink(
         intent: Intent?,
         onIsSharingIntent: () -> Unit,
-        onOpenConversation: (conversationId: ConversationId, switchedAccount: Boolean) -> Unit,
+        onOpenConversation: (DeepLinkResult.OpenConversation) -> Unit,
         onSSOLogin: (DeepLinkResult.SSOLogin) -> Unit,
         onMigrationLogin: (DeepLinkResult.MigrationLogin) -> Unit,
         onOpenOtherUserProfile: (DeepLinkResult.OpenOtherUserProfile) -> Unit,
@@ -341,10 +341,10 @@ class WireActivityViewModel @Inject constructor(
                     result.code,
                     result.key,
                     result.domain
-                ) { conversationId -> onOpenConversation(conversationId, result.switchedAccount) }
+                ) { conversationId -> onOpenConversation(DeepLinkResult.OpenConversation(conversationId, result.switchedAccount)) }
 
                 is DeepLinkResult.MigrationLogin -> onMigrationLogin(result)
-                is DeepLinkResult.OpenConversation -> onOpenConversation(result.conversationId, result.switchedAccount)
+                is DeepLinkResult.OpenConversation -> onOpenConversation(result)
                 is DeepLinkResult.OpenOtherUserProfile -> onOpenOtherUserProfile(result)
 
                 DeepLinkResult.SharingIntent -> onIsSharingIntent()

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -330,13 +330,8 @@ class WireActivityViewModel @Inject constructor(
                 DeepLinkResult.AuthorizationNeeded -> onAuthorizationNeeded()
                 is DeepLinkResult.SSOLogin -> onSSOLogin(result)
                 is DeepLinkResult.CustomServerConfig -> onCustomServerConfig(result)
-                is DeepLinkResult.Failure -> {
-                    when (result.reason) {
-                        DeepLinkResult.FailureReason.OngoingCall -> onCannotLoginDuringACall()
-                        DeepLinkResult.FailureReason.Unknown -> appLogger.e("unknown deeplink failure")
-                    }
-                }
-
+                is DeepLinkResult.Failure.OngoingCall -> onCannotLoginDuringACall()
+                is DeepLinkResult.Failure.Unknown -> appLogger.e("unknown deeplink failure")
                 is DeepLinkResult.JoinConversation -> onConversationInviteDeepLink(
                     result.code,
                     result.key,

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -19,7 +19,6 @@
 package com.wire.android.ui
 
 import android.content.Intent
-import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -307,22 +306,15 @@ class WireActivityViewModel @Inject constructor(
         return intent?.action == Intent.ACTION_SEND || intent?.action == Intent.ACTION_SEND_MULTIPLE
     }
 
-    @VisibleForTesting
-    internal suspend fun canLoginThroughDeepLinks() = viewModelScope.async {
-        coreLogic.getGlobalScope().session.currentSession().takeIf {
-            it is CurrentSessionResult.Success
-        }?.let {
-            val currentUserId = (it as CurrentSessionResult.Success).accountInfo.userId
-            coreLogic.getSessionScope(currentUserId).calls.establishedCall().first().isEmpty()
-        } ?: true
-    }
-
     @Suppress("ComplexMethod")
     fun handleDeepLink(
         intent: Intent?,
         onIsSharingIntent: () -> Unit,
-        onOpenConversation: (ConversationId) -> Unit,
-        onResult: (DeepLinkResult) -> Unit,
+        onOpenConversation: (conversationId: ConversationId, switchedAccount: Boolean) -> Unit,
+        onSSOLogin: (DeepLinkResult.SSOLogin) -> Unit,
+        onMigrationLogin: (DeepLinkResult.MigrationLogin) -> Unit,
+        onOpenOtherUserProfile: (DeepLinkResult.OpenOtherUserProfile) -> Unit,
+        onAuthorizationNeeded: () -> Unit,
         onCannotLoginDuringACall: () -> Unit
     ) {
         viewModelScope.launch(dispatchers.io()) {
@@ -331,41 +323,32 @@ class WireActivityViewModel @Inject constructor(
                 // so we need to finish migration first.
                 return@launch
             }
-            val result = intent?.data?.let { deepLinkProcessor.get().invoke(it) }
-            when {
-                result is DeepLinkResult.SSOLogin -> {
-                    if (canLoginThroughDeepLinks().await()) {
-                        onResult(result)
-                    } else {
-                        onCannotLoginDuringACall()
+            val isSharingIntent = isSharingIntent(intent)
+            val result = intent?.data?.let { deepLinkProcessor.get().invoke(it, isSharingIntent) } ?: DeepLinkResult.Unknown
+
+            when (result) {
+                DeepLinkResult.AuthorizationNeeded -> onAuthorizationNeeded()
+                is DeepLinkResult.SSOLogin -> onSSOLogin(result)
+                is DeepLinkResult.CustomServerConfig -> onCustomServerConfig(result)
+                is DeepLinkResult.Failure -> {
+                    when (result.reason) {
+                        DeepLinkResult.FailureReason.OngoingCall -> onCannotLoginDuringACall()
+                        DeepLinkResult.FailureReason.Unknown -> appLogger.e("unknown deeplink failure")
                     }
                 }
 
-                result is DeepLinkResult.MigrationLogin -> onResult(result)
-                result is DeepLinkResult.CustomServerConfig -> {
-                    if (canLoginThroughDeepLinks().await()) {
-                        onCustomServerConfig(result)
-                    } else {
-                        onCannotLoginDuringACall()
-                    }
-                }
+                is DeepLinkResult.JoinConversation -> onConversationInviteDeepLink(
+                    result.code,
+                    result.key,
+                    result.domain
+                ) { conversationId -> onOpenConversation(conversationId, result.switchedAccount) }
 
-                isSharingIntent(intent) -> onIsSharingIntent()
-                shouldLogIn() -> {
-                    // to handle the deepLinks above user needs to be Logged in
-                    // do nothing, already handled by initialAppState
-                }
+                is DeepLinkResult.MigrationLogin -> onMigrationLogin(result)
+                is DeepLinkResult.OpenConversation -> onOpenConversation(result.conversationId, result.switchedAccount)
+                is DeepLinkResult.OpenOtherUserProfile -> onOpenOtherUserProfile(result)
 
-                result is DeepLinkResult.JoinConversation ->
-                    onConversationInviteDeepLink(
-                        result.code,
-                        result.key,
-                        result.domain,
-                        onOpenConversation
-                    )
-
-                result != null -> onResult(result)
-                result is DeepLinkResult.Unknown -> appLogger.e("unknown deeplink result $result")
+                DeepLinkResult.SharingIntent -> onIsSharingIntent()
+                DeepLinkResult.Unknown -> appLogger.e("unknown deeplink result $result")
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -226,6 +226,7 @@ class SelfUserProfileViewModel @Inject constructor(
         viewModelScope.launch {
             userProfileState = userProfileState.copy(isLoggingOut = true)
             launch {
+                // TODO instead of ending calls show toast that cannot logout during call
                 establishedCallsList.value.forEach { call ->
                     endCall(call.conversationId)
                 }

--- a/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
@@ -56,14 +56,14 @@ sealed class DeepLinkResult {
         val switchedAccount: Boolean = false
     ) : DeepLinkResult()
 
-    data class OpenOtherUserProfile(val userId: QualifiedID, val switchedAccount: Boolean = false) :
-        DeepLinkResult()
+    data class OpenOtherUserProfile(val userId: QualifiedID, val switchedAccount: Boolean = false) : DeepLinkResult()
 
     data class JoinConversation(
-        val code: String, val key: String, val domain: String?,
+        val code: String,
+        val key: String,
+        val domain: String?,
         val switchedAccount: Boolean = false
-    ) :
-        DeepLinkResult()
+    ) : DeepLinkResult()
 
     data class MigrationLogin(val userHandle: String) : DeepLinkResult()
 
@@ -133,7 +133,6 @@ class DeepLinkProcessor @Inject constructor(
         }
     }
 
-
     private fun handleNotAuthorizedDeepLinks(uri: Uri): DeepLinkResult {
         return when (uri.host) {
             ACCESS_DEEPLINK_HOST -> getCustomServerConfigDeepLinkResult(uri)
@@ -141,7 +140,6 @@ class DeepLinkProcessor @Inject constructor(
             MIGRATION_LOGIN_HOST -> getOpenMigrationLoginDeepLinkResult(uri)
             else -> DeepLinkResult.AuthorizationNeeded
         }
-
     }
 
     private fun handleAuthorizedDeepLinks(uri: Uri, accountInfo: AccountInfo.Valid, switchedAccount: Boolean): DeepLinkResult {
@@ -153,7 +151,6 @@ class DeepLinkProcessor @Inject constructor(
             else -> DeepLinkResult.Unknown
         }
     }
-
 
     private fun getConnectingUserProfile(uri: Uri, switchedAccount: Boolean, accountInfo: AccountInfo.Valid): DeepLinkResult {
         return uri.lastPathSegment?.toDefaultQualifiedId(accountInfo.userId.domain)?.let {
@@ -174,7 +171,7 @@ class DeepLinkProcessor @Inject constructor(
         return QualifiedID(this.lowercase(), domain)
     }
 
-    private suspend fun switchAccountIfNeeded(uri: Uri, accountInfo: AccountInfo.Valid): SwitchAccountStatus {
+    private suspend fun switchAccountIfNeeded(uri: Uri, accountInfo: AccountInfo.Valid): SwitchAccountStatus =
         uri.getQueryParameter(USER_TO_USE_QUERY_PARAM)?.toQualifiedID(qualifiedIdMapper)
             ?.let { userId ->
                 val shouldSwitchAccount = if (accountInfo.userId != userId) {
@@ -192,9 +189,7 @@ class DeepLinkProcessor @Inject constructor(
                 } else {
                     return SwitchAccountStatus.FailedDueToCall
                 }
-            }
-        return SwitchAccountStatus.NoNeeded
-    }
+            } ?: SwitchAccountStatus.NoNeeded
 
     private fun getOpenConversationDeepLinkResult(
         uri: Uri,

--- a/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
@@ -20,16 +20,20 @@ package com.wire.android.util.deeplink
 
 import android.net.Uri
 import androidx.annotation.VisibleForTesting
+import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
 import com.wire.android.feature.SwitchAccountResult
 import com.wire.android.util.EMPTY
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
 import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
+import kotlinx.coroutines.flow.first
 import kotlinx.serialization.Serializable
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -48,47 +52,111 @@ sealed class DeepLinkResult {
     }
 
     data class OpenConversation(
-        val conversationsId: ConversationId,
+        val conversationId: ConversationId,
         val switchedAccount: Boolean = false
     ) : DeepLinkResult()
 
     data class OpenOtherUserProfile(val userId: QualifiedID, val switchedAccount: Boolean = false) :
         DeepLinkResult()
 
-    data class JoinConversation(val code: String, val key: String, val domain: String?) :
+    data class JoinConversation(
+        val code: String, val key: String, val domain: String?,
+        val switchedAccount: Boolean = false
+    ) :
         DeepLinkResult()
 
     data class MigrationLogin(val userHandle: String) : DeepLinkResult()
+
+    data object SharingIntent : DeepLinkResult()
+
+    data object AuthorizationNeeded : DeepLinkResult()
+
+    data class Failure(val reason: FailureReason) : DeepLinkResult()
+
+    enum class FailureReason {
+        OngoingCall,
+        Unknown
+    }
 }
 
 @Singleton
 class DeepLinkProcessor @Inject constructor(
     private val accountSwitch: AccountSwitchUseCase,
-    private val currentSession: CurrentSessionUseCase
+    private val currentSession: CurrentSessionUseCase,
+    @KaliumCoreLogic private val coreLogic: CoreLogic,
 ) {
     private val qualifiedIdMapper = QualifiedIdMapperImpl(null)
 
-    suspend operator fun invoke(uri: Uri): DeepLinkResult {
-        val switchedAccount = switchAccountIfNeeded(uri)
+    suspend operator fun invoke(uri: Uri, isSharingIntent: Boolean): DeepLinkResult {
+        return when (val sessionResult = currentSession()) {
+            is CurrentSessionResult.Failure.Generic,
+            CurrentSessionResult.Failure.SessionNotFound -> handleNotAuthorizedDeepLinks(uri)
 
+            is CurrentSessionResult.Success -> {
+                if (isSharingIntent) {
+                    return DeepLinkResult.SharingIntent
+                } else {
+                    handleDeepLinks(uri, sessionResult.accountInfo)
+                }
+            }
+        }
+    }
+
+    private suspend fun handleDeepLinks(uri: Uri, accountInfo: AccountInfo): DeepLinkResult {
+        return when (accountInfo) {
+            is AccountInfo.Invalid -> {
+                handleNotAuthorizedDeepLinks(uri)
+            }
+
+            is AccountInfo.Valid -> {
+                return when (switchAccountIfNeeded(uri, accountInfo)) {
+                    SwitchAccountStatus.Switched -> {
+                        var deepLinkResult = handleNotAuthorizedDeepLinks(uri)
+                        if (deepLinkResult == DeepLinkResult.AuthorizationNeeded) {
+                            deepLinkResult = handleAuthorizedDeepLinks(uri, accountInfo, true)
+                        }
+                        deepLinkResult
+                    }
+
+                    SwitchAccountStatus.NoNeeded -> {
+                        var deepLinkResult = handleNotAuthorizedDeepLinks(uri)
+                        if (deepLinkResult == DeepLinkResult.AuthorizationNeeded) {
+                            deepLinkResult = handleAuthorizedDeepLinks(uri, accountInfo, false)
+                        }
+                        deepLinkResult
+                    }
+
+                    SwitchAccountStatus.FailedDueToCall -> DeepLinkResult.Failure(DeepLinkResult.FailureReason.OngoingCall)
+                    SwitchAccountStatus.FailedDueToUnknownError -> DeepLinkResult.Failure(DeepLinkResult.FailureReason.Unknown)
+                }
+            }
+        }
+    }
+
+
+    private fun handleNotAuthorizedDeepLinks(uri: Uri): DeepLinkResult {
         return when (uri.host) {
             ACCESS_DEEPLINK_HOST -> getCustomServerConfigDeepLinkResult(uri)
             SSO_LOGIN_DEEPLINK_HOST -> getSSOLoginDeepLinkResult(uri)
-            CONVERSATION_DEEPLINK_HOST -> getOpenConversationDeepLinkResult(uri, switchedAccount)
-            OTHER_USER_PROFILE_DEEPLINK_HOST -> getOpenOtherUserProfileDeepLinkResult(
-                uri,
-                switchedAccount
-            )
-
             MIGRATION_LOGIN_HOST -> getOpenMigrationLoginDeepLinkResult(uri)
-            JOIN_CONVERSATION_DEEPLINK_HOST -> getJoinConversationDeepLinkResult(uri)
-            OPEN_USER_PROFILE_DEEPLINK_HOST -> getConnectingUserProfile(uri, switchedAccount)
+            else -> DeepLinkResult.AuthorizationNeeded
+        }
+
+    }
+
+    private fun handleAuthorizedDeepLinks(uri: Uri, accountInfo: AccountInfo.Valid, switchedAccount: Boolean): DeepLinkResult {
+        return when (uri.host) {
+            CONVERSATION_DEEPLINK_HOST -> getOpenConversationDeepLinkResult(uri, switchedAccount)
+            OTHER_USER_PROFILE_DEEPLINK_HOST -> getOpenOtherUserProfileDeepLinkResult(uri, switchedAccount)
+            JOIN_CONVERSATION_DEEPLINK_HOST -> getJoinConversationDeepLinkResult(uri, switchedAccount)
+            OPEN_USER_PROFILE_DEEPLINK_HOST -> getConnectingUserProfile(uri, switchedAccount, accountInfo)
             else -> DeepLinkResult.Unknown
         }
     }
 
-    private suspend fun getConnectingUserProfile(uri: Uri, switchedAccount: Boolean): DeepLinkResult {
-        return uri.lastPathSegment?.toDefaultQualifiedId()?.let {
+
+    private fun getConnectingUserProfile(uri: Uri, switchedAccount: Boolean, accountInfo: AccountInfo.Valid): DeepLinkResult {
+        return uri.lastPathSegment?.toDefaultQualifiedId(accountInfo.userId.domain)?.let {
             DeepLinkResult.OpenOtherUserProfile(it, switchedAccount)
         } ?: DeepLinkResult.Unknown
     }
@@ -100,28 +168,32 @@ class DeepLinkProcessor @Inject constructor(
      * TODO: replace and remove this with String.toQualifiedID() when web sends qualified id.
      * REF: WPB-10532
      */
-    private suspend fun String.toDefaultQualifiedId(): QualifiedID {
-        val domain = when (val result = currentSession()) {
-            is CurrentSessionResult.Success -> result.accountInfo.userId.domain
-            else -> "wire.com"
-        }
+    private fun String.toDefaultQualifiedId(currentUserDomain: String?): QualifiedID {
+        val domain = currentUserDomain ?: "wire.com"
         // This lowercase is important, since web/iOS is sending/handling this as uppercase.
         return QualifiedID(this.lowercase(), domain)
     }
 
-    private suspend fun switchAccountIfNeeded(uri: Uri): Boolean {
+    private suspend fun switchAccountIfNeeded(uri: Uri, accountInfo: AccountInfo.Valid): SwitchAccountStatus {
         uri.getQueryParameter(USER_TO_USE_QUERY_PARAM)?.toQualifiedID(qualifiedIdMapper)
             ?.let { userId ->
-                val shouldSwitchAccount = when (val result = currentSession()) {
-                    is CurrentSessionResult.Failure.Generic -> true
-                    CurrentSessionResult.Failure.SessionNotFound -> true
-                    is CurrentSessionResult.Success -> result.accountInfo.userId != userId
+                val shouldSwitchAccount = if (accountInfo.userId != userId) {
+                    coreLogic.getSessionScope(accountInfo.userId).calls.establishedCall().first().isEmpty()
+                } else {
+                    false
                 }
                 if (shouldSwitchAccount) {
-                    return accountSwitch(SwitchAccountParam.SwitchToAccount(userId)) == SwitchAccountResult.SwitchedToAnotherAccount
+                    return when (accountSwitch(SwitchAccountParam.SwitchToAccount(userId))) {
+                        SwitchAccountResult.Failure -> SwitchAccountStatus.FailedDueToUnknownError
+                        SwitchAccountResult.GivenAccountIsInvalid -> SwitchAccountStatus.FailedDueToUnknownError
+                        SwitchAccountResult.NoOtherAccountToSwitch -> SwitchAccountStatus.NoNeeded
+                        SwitchAccountResult.SwitchedToAnotherAccount -> SwitchAccountStatus.Switched
+                    }
+                } else {
+                    return SwitchAccountStatus.FailedDueToCall
                 }
             }
-        return false
+        return SwitchAccountStatus.NoNeeded
     }
 
     private fun getOpenConversationDeepLinkResult(
@@ -169,12 +241,12 @@ class DeepLinkProcessor @Inject constructor(
         }
     }
 
-    private fun getJoinConversationDeepLinkResult(uri: Uri): DeepLinkResult {
+    private fun getJoinConversationDeepLinkResult(uri: Uri, switchedAccount: Boolean): DeepLinkResult {
         val code = uri.getQueryParameter(JOIN_CONVERSATION_CODE_PARAM)
         val key = uri.getQueryParameter(JOIN_CONVERSATION_KEY_PARAM)
         val domain = uri.getQueryParameter(JOIN_CONVERSATION_DOMAIN_PARAM)
         if (code == null || key == null) return DeepLinkResult.Unknown
-        return DeepLinkResult.JoinConversation(code, key, domain)
+        return DeepLinkResult.JoinConversation(code, key, domain, switchedAccount)
     }
 
     companion object {
@@ -241,4 +313,11 @@ enum class SSOFailureCodes(val label: String, val errorCode: Int) {
         @VisibleForTesting
         const val UNKNOWN = 0
     }
+}
+
+enum class SwitchAccountStatus {
+    Switched,
+    NoNeeded,
+    FailedDueToCall,
+    FailedDueToUnknownError
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1064,6 +1064,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     </plurals>
     <string name="max_account_reached_dialog_button_open_profile">Open Profile</string>
     <string name="cant_switch_account_in_call">You can\'t switch accounts while in a call</string>
+    <string name="deeplink_authorization_needed">You must login to perform this action</string>
     <string name="custom_backend_dialog_title">Redirect to an on-premises backend?</string>
     <string name="custom_backend_dialog_body">If you proceed, your client will be redirected to the following on-premises backend:</string>
     <string name="custom_backend_dialog_body_backend_name">Backend name:</string>

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -169,7 +169,7 @@ class WireActivityViewModelTest {
     @Test
     fun `given Intent with ServerConfig during an ongoing call, when handling deep links, then onCannotLoginDuringACall is called `() =
         runTest {
-            val result = DeepLinkResult.Failure(DeepLinkResult.FailureReason.OngoingCall)
+            val result = DeepLinkResult.Failure.OngoingCall
             val (arrangement, viewModel) = Arrangement()
                 .withSomeCurrentSession()
                 .withDeepLinkResult(result)

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -103,7 +103,7 @@ class WireActivityViewModelTest {
             .withSomeCurrentSession()
             .arrange()
 
-        viewModel.handleDeepLink(null, {}, {}, {}, {})
+        viewModel.handleDeepLink(null, {}, {}, {}, {}, {}, {}, {})
 
         assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
     }
@@ -114,7 +114,7 @@ class WireActivityViewModelTest {
             .withNoCurrentSession()
             .arrange()
 
-        viewModel.handleDeepLink(null, {}, {}, {}, {})
+        viewModel.handleDeepLink(null, {}, {}, {}, {}, {}, {}, {})
 
         assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
     }
@@ -128,7 +128,7 @@ class WireActivityViewModelTest {
             .withNoOngoingCall()
             .arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
         coVerify(exactly = 1) { arrangement.deepLinkProcessor.invoke(any(), false) }
         verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
     }
@@ -143,7 +143,7 @@ class WireActivityViewModelTest {
                 .withNoOngoingCall()
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
 
             assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
@@ -159,7 +159,7 @@ class WireActivityViewModelTest {
                 .withNoOngoingCall()
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
 
             assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
@@ -169,14 +169,14 @@ class WireActivityViewModelTest {
     @Test
     fun `given Intent with ServerConfig during an ongoing call, when handling deep links, then onCannotLoginDuringACall is called `() =
         runTest {
-            val result = DeepLinkResult.CustomServerConfig("url")
+            val result = DeepLinkResult.Failure(DeepLinkResult.FailureReason.OngoingCall)
             val (arrangement, viewModel) = Arrangement()
                 .withSomeCurrentSession()
                 .withDeepLinkResult(result)
                 .withOngoingCall()
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, arrangement.onCannotLoginDuringACall)
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, {}, {}, {}, arrangement.onCannotLoginDuringACall)
 
             verify(exactly = 1) { arrangement.onCannotLoginDuringACall() }
         }
@@ -191,7 +191,7 @@ class WireActivityViewModelTest {
                 .withCurrentScreen(MutableStateFlow<CurrentScreen>(CurrentScreen.Home))
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
 
             assertEquals(InitialAppState.NOT_MIGRATED, viewModel.initialAppState())
             verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
@@ -207,26 +207,11 @@ class WireActivityViewModelTest {
             .withNoOngoingCall()
             .arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
 
         assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
         verify(exactly = 1) { arrangement.onDeepLinkResult(ssoLogin) }
     }
-
-    @Test
-    fun `given Intent with SSOLogin during an ongoing call, when handling deep links, then onCannotLoginDuringACall is called `() =
-        runTest {
-            val ssoLogin = DeepLinkResult.SSOLogin.Success("cookie", "serverConfig")
-            val (arrangement, viewModel) = Arrangement()
-                .withSomeCurrentSession()
-                .withDeepLinkResult(ssoLogin)
-                .withOngoingCall()
-                .arrange()
-
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, arrangement.onCannotLoginDuringACall)
-
-            verify(exactly = 1) { arrangement.onCannotLoginDuringACall() }
-        }
 
     @Test
     fun `given Intent with SSOLogin, when currentSession is absent, then initialAppState is NOT_LOGGED_IN and result SSOLogin`() = runTest {
@@ -237,7 +222,7 @@ class WireActivityViewModelTest {
             .withNoOngoingCall()
             .arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
 
         assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
         verify(exactly = 1) { arrangement.onDeepLinkResult(ssoLogin) }
@@ -252,7 +237,7 @@ class WireActivityViewModelTest {
                 .withDeepLinkResult(result)
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, arrangement.onDeepLinkResult, {}, {}, {})
 
             assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
@@ -267,7 +252,7 @@ class WireActivityViewModelTest {
                 .withDeepLinkResult(result)
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, arrangement.onDeepLinkResult, {}, {}, {})
 
             assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
@@ -282,7 +267,7 @@ class WireActivityViewModelTest {
                 .withDeepLinkResult(result)
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
 
             assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
@@ -296,7 +281,7 @@ class WireActivityViewModelTest {
             .withDeepLinkResult(result)
             .arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
 
         assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
         verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
@@ -312,7 +297,7 @@ class WireActivityViewModelTest {
                 .withDeepLinkResult(result)
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, {}, arrangement.onDeepLinkResult, {}, {})
 
             assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
@@ -326,7 +311,7 @@ class WireActivityViewModelTest {
             .withDeepLinkResult(result)
             .arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
 
         assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
         verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
@@ -338,7 +323,7 @@ class WireActivityViewModelTest {
             .withSomeCurrentSession()
             .arrange()
 
-        viewModel.handleDeepLink(null, {}, {}, arrangement.onDeepLinkResult, {})
+        viewModel.handleDeepLink(null, {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
 
         verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
     }
@@ -374,7 +359,7 @@ class WireActivityViewModelTest {
             )
             .arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
+        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
 
         viewModel.globalAppState.conversationJoinedDialog `should be equal to` JoinConversationViaCodeState.Show(
             conversationName,
@@ -407,11 +392,20 @@ class WireActivityViewModelTest {
                 )
             ).arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, arrangement.onSuccess, arrangement.onDeepLinkResult, {})
+        viewModel.handleDeepLink(
+            intent = mockedIntent(),
+            onIsSharingIntent = {},
+            onOpenConversation = arrangement.onOpenConversation,
+            onSSOLogin = arrangement.onDeepLinkResult,
+            onMigrationLogin = {},
+            onOpenOtherUserProfile = {},
+            onAuthorizationNeeded = {},
+            onCannotLoginDuringACall = {}
+        )
 
         viewModel.globalAppState.conversationJoinedDialog `should be equal to` null
         verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
-        verify(exactly = 1) { arrangement.onSuccess(conversationId) }
+        verify(exactly = 1) { arrangement.onOpenConversation(DeepLinkResult.OpenConversation(conversationId, false)) }
     }
 
     @Test
@@ -603,44 +597,6 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given no active session, when canLoginThroughDeepLinks is called, then return true`() =
-        runTest {
-            val (_, viewModel) = Arrangement()
-                .withNoCurrentSession()
-                .arrange()
-
-            val result = viewModel.canLoginThroughDeepLinks()
-
-            result.await() `should be equal to` true
-        }
-
-    @Test
-    fun `given an established call, when canLoginThroughDeepLinks is called, then return false`() =
-        runTest {
-            val (_, viewModel) = Arrangement()
-                .withSomeCurrentSession()
-                .withOngoingCall()
-                .arrange()
-
-            val result = viewModel.canLoginThroughDeepLinks()
-
-            result.await() `should be equal to` false
-        }
-
-    @Test
-    fun `given no established call, when canLoginThroughDeepLinks is called, then return true`() =
-        runTest {
-            val (_, viewModel) = Arrangement()
-                .withNoCurrentSession()
-                .withNoOngoingCall()
-                .arrange()
-
-            val result = viewModel.canLoginThroughDeepLinks()
-
-            result.await() `should be equal to` true
-        }
-
-    @Test
     fun `given user, when current client was removed, then use should see logged out dialog`() =
         runTest {
             val (_, viewModel) = Arrangement()
@@ -662,7 +618,7 @@ class WireActivityViewModelTest {
             mockUri()
             coEvery { currentSessionFlow() } returns flowOf()
             coEvery { getServerConfigUseCase(any()) } returns GetServerConfigResult.Success(newServerConfig(1).links)
-            coEvery { deepLinkProcessor(any()) } returns DeepLinkResult.Unknown
+            coEvery { deepLinkProcessor(any(), any()) } returns DeepLinkResult.Unknown
             coEvery { getSessionsUseCase.invoke() }
             coEvery { migrationManager.shouldMigrate() } returns false
             every { observeSyncStateUseCaseProviderFactory.create(any()).observeSyncState } returns observeSyncStateUseCase
@@ -752,7 +708,7 @@ class WireActivityViewModelTest {
         lateinit var onCannotLoginDuringACall: () -> Unit
 
         @MockK(relaxed = true)
-        lateinit var onSuccess: (ConversationId) -> Unit
+        lateinit var onOpenConversation: (DeepLinkResult.OpenConversation) -> Unit
 
         private val viewModel by lazy {
             WireActivityViewModel(
@@ -802,8 +758,8 @@ class WireActivityViewModelTest {
             return this
         }
 
-        fun withDeepLinkResult(result: DeepLinkResult): Arrangement {
-            coEvery { deepLinkProcessor(any()) } returns result
+        fun withDeepLinkResult(result: DeepLinkResult, isSharingIntent: Boolean = false): Arrangement {
+            coEvery { deepLinkProcessor(any(), isSharingIntent) } returns result
             return this
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -129,7 +129,7 @@ class WireActivityViewModelTest {
             .arrange()
 
         viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {})
-        coVerify(exactly = 1) { arrangement.deepLinkProcessor.invoke(any()) }
+        coVerify(exactly = 1) { arrangement.deepLinkProcessor.invoke(any(), false) }
         verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
     }
 

--- a/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
@@ -28,7 +28,6 @@ import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
@@ -186,9 +185,6 @@ class DeepLinkProcessorTest {
 
         @MockK
         private lateinit var coreLogic: CoreLogic
-
-        @MockK
-        private lateinit var userSessionScope: UserSessionScope
 
         @MockK
         private lateinit var establishedCallsUseCase: ObserveEstablishedCallsUseCase

--- a/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
@@ -189,7 +189,7 @@ class DeepLinkProcessorTest {
             .arrange()
         val result = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.Failure::class.java, result)
-        assertEquals(DeepLinkResult.Failure(DeepLinkResult.FailureReason.OngoingCall), result)
+        assertEquals(DeepLinkResult.Failure.OngoingCall, result)
     }
 
     @Test
@@ -201,7 +201,7 @@ class DeepLinkProcessorTest {
             .arrange()
         val result = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.Failure::class.java, result)
-        assertEquals(DeepLinkResult.Failure(DeepLinkResult.FailureReason.Unknown), result)
+        assertEquals(DeepLinkResult.Failure.Unknown, result)
     }
 
     @Test
@@ -265,6 +265,7 @@ class DeepLinkProcessorTest {
         fun withSwitchedAccount(switchAccountResult: SwitchAccountResult) = apply {
             coEvery { accountSwitchUseCase(any()) } returns switchAccountResult
         }
+
         fun withRemoteConfigDeeplink(url: String?) = apply {
             coEvery { uri.host } returns DeepLinkProcessor.ACCESS_DEEPLINK_HOST
             coEvery { uri.getQueryParameter(DeepLinkProcessor.SERVER_CONFIG_PARAM) } returns url

--- a/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
@@ -21,11 +21,15 @@ package com.wire.android.util
 import android.net.Uri
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountResult
+import com.wire.android.ui.common.topappbar.CommonTopAppBarViewModelTest
 import com.wire.android.util.deeplink.DeepLinkProcessor
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.deeplink.SSOFailureCodes
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.auth.AccountInfo
+import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
@@ -48,7 +52,7 @@ class DeepLinkProcessorTest {
         val (arrangement, deepLinkProcessor) = Arrangement()
             .withRemoteConfigDeeplink(FAKE_REMOTE_SERVER_URL)
             .arrange()
-        val result = deepLinkProcessor(arrangement.uri)
+        val result = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.CustomServerConfig::class.java, result)
         assertEquals(DeepLinkResult.CustomServerConfig(url = FAKE_REMOTE_SERVER_URL), result)
     }
@@ -58,7 +62,7 @@ class DeepLinkProcessorTest {
         val (arrangement, deepLinkProcessor) = Arrangement()
             .withRemoteConfigDeeplink(null)
             .arrange()
-        val result = deepLinkProcessor(arrangement.uri)
+        val result = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.Unknown::class.java, result)
         assertEquals(DeepLinkResult.Unknown, result)
     }
@@ -68,7 +72,7 @@ class DeepLinkProcessorTest {
         val (arrangement, deepLinkProcessor) = Arrangement()
             .withSSOLoginSuccessDeeplink(FAKE_COOKIE, FAKE_REMOTE_SERVER_ID)
             .arrange()
-        val result = deepLinkProcessor(arrangement.uri)
+        val result = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.SSOLogin.Success::class.java, result)
         assertEquals(DeepLinkResult.SSOLogin.Success(FAKE_COOKIE, FAKE_REMOTE_SERVER_ID), result)
     }
@@ -78,7 +82,7 @@ class DeepLinkProcessorTest {
         val (arrangement, deepLinkProcessor) = Arrangement()
             .withSSOLoginSuccessDeeplink(null, null)
             .arrange()
-        val loginSuccessNullResult = deepLinkProcessor(arrangement.uri)
+        val loginSuccessNullResult = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.SSOLogin.Failure::class.java, loginSuccessNullResult)
         assertEquals(
             DeepLinkResult.SSOLogin.Failure(SSOFailureCodes.getByCode(SSOFailureCodes.SSOServerErrorCode.UNKNOWN)),
@@ -91,7 +95,7 @@ class DeepLinkProcessorTest {
         val (arrangement, deepLinkProcessor) = Arrangement()
             .withSSOLoginFailureDeeplink(FAKE_ERROR)
             .arrange()
-        val result = deepLinkProcessor(arrangement.uri)
+        val result = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.SSOLogin.Failure::class.java, result)
         assertEquals(DeepLinkResult.SSOLogin.Failure(SSOFailureCodes.getByLabel(FAKE_ERROR)), result)
     }
@@ -101,7 +105,7 @@ class DeepLinkProcessorTest {
         val (arrangement, deepLinkProcessor) = Arrangement()
             .withSSOLoginFailureDeeplink(null)
             .arrange()
-        val loginFailureNullResult = deepLinkProcessor(arrangement.uri)
+        val loginFailureNullResult = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.SSOLogin.Failure::class.java, loginFailureNullResult)
         assertEquals(
             DeepLinkResult.SSOLogin.Failure(SSOFailureCodes.getByCode(SSOFailureCodes.SSOServerErrorCode.UNKNOWN)),
@@ -114,7 +118,7 @@ class DeepLinkProcessorTest {
         val (arrangement, deepLinkProcessor) = Arrangement()
             .withInvalidDeeplink()
             .arrange()
-        val result = deepLinkProcessor(arrangement.uri)
+        val result = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.Unknown::class.java, result)
         assertEquals(DeepLinkResult.Unknown, result)
     }
@@ -125,7 +129,7 @@ class DeepLinkProcessorTest {
             .withConversationDeepLink(CURRENT_USER_ID)
             .withCurrentSessionSuccess(CURRENT_USER_ID)
             .arrange()
-        val conversationResult = deepLinkProcessor(arrangement.uri)
+        val conversationResult = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.OpenConversation::class.java, conversationResult)
         assertEquals(
             DeepLinkResult.OpenConversation(CONVERSATION_ID, false),
@@ -139,7 +143,7 @@ class DeepLinkProcessorTest {
             .withConversationDeepLink(OTHER_USER_ID)
             .withCurrentSessionSuccess(CURRENT_USER_ID)
             .arrange()
-        val conversationResult = deepLinkProcessor(arrangement.uri)
+        val conversationResult = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.OpenConversation::class.java, conversationResult)
         assertEquals(
             DeepLinkResult.OpenConversation(CONVERSATION_ID, true),
@@ -148,12 +152,13 @@ class DeepLinkProcessorTest {
     }
 
     @Test
-    fun `given an other profil deeplink for current user, returns Conversation with conversationId and not switched account`() = runTest {
+    fun `given an other profile deeplink for current user, returns Conversation with conversationId and not switched account`() = runTest {
         val (arrangement, deepLinkProcessor) = Arrangement()
             .withOtherUserProfileDeepLink(userIdToOpen = OTHER_USER_ID, userId = CURRENT_USER_ID)
             .withCurrentSessionSuccess(CURRENT_USER_ID)
+            .withSwitchedAccount(SwitchAccountResult.SwitchedToAnotherAccount)
             .arrange()
-        val conversationResult = deepLinkProcessor(arrangement.uri)
+        val conversationResult = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.OpenOtherUserProfile::class.java, conversationResult)
         assertEquals(
             DeepLinkResult.OpenOtherUserProfile(OTHER_USER_ID, false),
@@ -167,12 +172,67 @@ class DeepLinkProcessorTest {
             .withOtherUserProfileDeepLink(userIdToOpen = OTHER_USER_ID, userId = OTHER_USER_ID)
             .withCurrentSessionSuccess(CURRENT_USER_ID)
             .arrange()
-        val conversationResult = deepLinkProcessor(arrangement.uri)
+        val conversationResult = deepLinkProcessor(arrangement.uri, false)
         assertInstanceOf(DeepLinkResult.OpenOtherUserProfile::class.java, conversationResult)
         assertEquals(
             DeepLinkResult.OpenOtherUserProfile(OTHER_USER_ID, true),
             conversationResult
         )
+    }
+
+    @Test
+    fun `given a deeplink requiring account switch during an ongoing call, returns Failure with OngoingCall reason`() = runTest {
+        val (arrangement, deepLinkProcessor) = Arrangement()
+            .withCurrentSessionSuccess(CURRENT_USER_ID)
+            .withConversationDeepLink(userId = OTHER_USER_ID)
+            .withOngoingCall()
+            .arrange()
+        val result = deepLinkProcessor(arrangement.uri, false)
+        assertInstanceOf(DeepLinkResult.Failure::class.java, result)
+        assertEquals(DeepLinkResult.Failure(DeepLinkResult.FailureReason.OngoingCall), result)
+    }
+
+    @Test
+    fun `given a deeplink requiring account switch that fails due to unknown error, returns Failure with Unknown reason`() = runTest {
+        val (arrangement, deepLinkProcessor) = Arrangement()
+            .withCurrentSessionSuccess(CURRENT_USER_ID)
+            .withConversationDeepLink(userId = OTHER_USER_ID)
+            .withSwitchedAccount(SwitchAccountResult.Failure)
+            .arrange()
+        val result = deepLinkProcessor(arrangement.uri, false)
+        assertInstanceOf(DeepLinkResult.Failure::class.java, result)
+        assertEquals(DeepLinkResult.Failure(DeepLinkResult.FailureReason.Unknown), result)
+    }
+
+    @Test
+    fun `given a deeplink accessed by an unauthorized user, returns AuthorizationNeeded`() = runTest {
+        val (arrangement, deepLinkProcessor) = Arrangement()
+            .withCurrentSessionError(CurrentSessionResult.Failure.SessionNotFound)
+            .withConversationDeepLink(userId = OTHER_USER_ID)
+            .arrange()
+        val result = deepLinkProcessor(arrangement.uri, false)
+        assertInstanceOf(DeepLinkResult.AuthorizationNeeded::class.java, result)
+    }
+
+    @Test
+    fun `given a valid deeplink for an authorized session without account switch, returns appropriate deep link result`() = runTest {
+        val (arrangement, deepLinkProcessor) = Arrangement()
+            .withCurrentSessionSuccess(CURRENT_USER_ID)
+            .withRemoteConfigDeeplink(FAKE_REMOTE_SERVER_URL)
+            .arrange()
+        val result = deepLinkProcessor(arrangement.uri, false)
+        assertInstanceOf(DeepLinkResult.CustomServerConfig::class.java, result)
+        assertEquals(DeepLinkResult.CustomServerConfig(FAKE_REMOTE_SERVER_URL), result)
+    }
+
+    @Test
+    fun `given a deeplink with a sharing intent, returns SharingIntent result`() = runTest {
+        val (arrangement, deepLinkProcessor) = Arrangement()
+            .withCurrentSessionSuccess(CURRENT_USER_ID)
+            .arrange()
+        val result = deepLinkProcessor(arrangement.uri, true)
+        assertInstanceOf(DeepLinkResult.SharingIntent::class.java, result)
+        assertEquals(DeepLinkResult.SharingIntent, result)
     }
 
     class Arrangement {
@@ -195,12 +255,16 @@ class DeepLinkProcessorTest {
         init {
             MockKAnnotations.init(this)
             coEvery { accountSwitchUseCase(any()) } returns SwitchAccountResult.SwitchedToAnotherAccount
+            coEvery { currentSession() } returns CurrentSessionResult.Success(AccountInfo.Valid(CURRENT_USER_ID))
             coEvery { establishedCallsUseCase.invoke() } returns flowOf(emptyList())
             every { coreLogic.getSessionScope(any()).calls.establishedCall } returns establishedCallsUseCase
         }
 
         fun arrange() = this to DeepLinkProcessor(accountSwitchUseCase, currentSession, coreLogic)
 
+        fun withSwitchedAccount(switchAccountResult: SwitchAccountResult) = apply {
+            coEvery { accountSwitchUseCase(any()) } returns switchAccountResult
+        }
         fun withRemoteConfigDeeplink(url: String?) = apply {
             coEvery { uri.host } returns DeepLinkProcessor.ACCESS_DEEPLINK_HOST
             coEvery { uri.getQueryParameter(DeepLinkProcessor.SERVER_CONFIG_PARAM) } returns url
@@ -252,8 +316,12 @@ class DeepLinkProcessorTest {
             withCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(userId = userId)))
         }
 
-        fun withCurrentSessionError() = apply {
-            withCurrentSession(CurrentSessionResult.Failure.SessionNotFound)
+        fun withCurrentSessionError(failure: CurrentSessionResult.Failure) = apply {
+            withCurrentSession(failure)
+        }
+
+        fun withOngoingCall() = apply {
+            coEvery { establishedCallsUseCase.invoke() } returns flowOf(listOf(ONGOING_CALL))
         }
     }
 
@@ -266,5 +334,17 @@ class DeepLinkProcessorTest {
         val CONVERSATION_ID = ConversationId("some_conversation", "domain")
         val CURRENT_USER_ID = UserId("some_user", "domain")
         val OTHER_USER_ID = UserId("other_user", "other_domain")
+        val ONGOING_CALL = Call(
+            CommonTopAppBarViewModelTest.conversationId,
+            CallStatus.ESTABLISHED,
+            isMuted = true,
+            isCameraOn = false,
+            isCbrEnabled = false,
+            callerId = "caller-id",
+            conversationName = "ONE_ON_ONE Name",
+            conversationType = Conversation.Type.ONE_ON_ONE,
+            callerName = "otherUsername",
+            callerTeamName = "team1"
+        )
     }
 }

--- a/docs/adr/0004-deeplink-handling-refactor.md
+++ b/docs/adr/0004-deeplink-handling-refactor.md
@@ -1,0 +1,58 @@
+# 4. Deeplink handling refactor
+
+Date: 2024-09-05
+
+## Status
+
+Proposed
+
+TODO:
+- fix and write more tests when ADR will be accepted
+
+## Context
+
+The existing implementation of deeplink handling within our ViewModel is characterized by complex,
+bulky logic that makes maintenance and scalability challenging. Current handling involves redundant
+checks for each deeplink type and duplicated error logging. Additionally, the logic to handle toast
+errors for deeplinks requiring authorization and the management of user session state during calls
+(to prevent account switching) are not centralized, leading to repeated code and scattered handling
+across components.
+
+## Decision
+
+We have decided to refactor the existing handleDeepLink function in the ViewModel by consolidating
+the URI deeplink processing logic into a dedicated class, DeepLinkProcessor. This class will now
+centralize the interpretation and validation of deeplinks, and manage user session states more
+effectively, including checks for ongoing calls before allowing account switches. The
+DeepLinkProcessor will handle:
+
+- Duplicate checks and error logging by centralizing deeplink type verification.
+- Displaying toast errors when deeplink operations require user authorization and preventing
+  operations during calls.
+- Secure and condition-based account switching.
+
+## Consequences
+
+1. Reduced Duplication: Centralizing deeplink handling reduces duplicated logic across the
+   application, especially for checking deeplink types and logging errors, ensuring a cleaner
+   codebase.
+
+2. Centralized Authorization Management: Toast messages to inform users about the need for
+   authorization if they attempt to access resources that require authentication are managed
+   centrally, enhancing user experience and security.
+
+3. Enhanced Call State Management: The new implementation prevents account switching during active
+   calls by checking the user's call status directly within DeepLinkProcessor. This is vital for
+   maintaining session integrity and user experience.
+
+4. Improved Error Handling: By centralizing error handling and response mechanisms, the application
+   can more effectively manage and respond to deeplink processing errors, providing a more robust
+   and fault-tolerant system.
+
+5. Streamlined Testing and Maintenance: With deeplink logic isolated in a single class, testing
+   becomes more focused and efficient, allowing for targeted testing strategies and easier
+   maintenance.
+
+This decision involves careful re-engineering of the deeplink processing mechanisms to ensure
+compatibility and functionality across all current and potential future deeplink scenarios,
+requiring comprehensive testing and validation to ensure seamless integration.

--- a/docs/adr/0004-deeplink-handling-refactor.md
+++ b/docs/adr/0004-deeplink-handling-refactor.md
@@ -1,13 +1,10 @@
 # 4. Deeplink handling refactor
 
-Date: 2024-09-05
+Date: 2024-09-06
 
 ## Status
 
-Proposed
-
-TODO:
-- fix and write more tests when ADR will be accepted
+Accepted
 
 ## Context
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10182" title="WPB-10182" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10182</a>  [Android] While in a call i can switch accounts over notification
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# 4. Deeplink handling refactor

Date: 2024-09-05

## Status

Proposed

TODO:
- fix and write more tests when ADR will be accepted

## Context

The existing implementation of deeplink handling within our ViewModel is characterized by complex,
bulky logic that makes maintenance and scalability challenging. Current handling involves redundant
checks for each deeplink type and duplicated error logging. Additionally, the logic to handle toast
errors for deeplinks requiring authorization and the management of user session state during calls
(to prevent account switching) are not centralized, leading to repeated code and scattered handling
across components.

## Decision

We have decided to refactor the existing handleDeepLink function in the ViewModel by consolidating
the URI deeplink processing logic into a dedicated class, DeepLinkProcessor. This class will now
centralize the interpretation and validation of deeplinks, and manage user session states more
effectively, including checks for ongoing calls before allowing account switches. The
DeepLinkProcessor will handle:

- Duplicate checks and error logging by centralizing deeplink type verification.
- Displaying toast errors when deeplink operations require user authorization and preventing
  operations during calls.
- Secure and condition-based account switching.

## Consequences

1. Reduced Duplication: Centralizing deeplink handling reduces duplicated logic across the
   application, especially for checking deeplink types and logging errors, ensuring a cleaner
   codebase.

2. Centralized Authorization Management: Toast messages to inform users about the need for
   authorization if they attempt to access resources that require authentication are managed
   centrally, enhancing user experience and security.

3. Enhanced Call State Management: The new implementation prevents account switching during active
   calls by checking the user's call status directly within DeepLinkProcessor. This is vital for
   maintaining session integrity and user experience.

4. Improved Error Handling: By centralizing error handling and response mechanisms, the application
   can more effectively manage and respond to deeplink processing errors, providing a more robust
   and fault-tolerant system.

5. Streamlined Testing and Maintenance: With deeplink logic isolated in a single class, testing
   becomes more focused and efficient, allowing for targeted testing strategies and easier
   maintenance.

This decision involves careful re-engineering of the deeplink processing mechanisms to ensure
compatibility and functionality across all current and potential future deeplink scenarios,
requiring comprehensive testing and validation to ensure seamless integration.