### PR TITLE
fix: bottom buttons hidden underneath keyboard on Androids 8 to 10 [WPB-10868]

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -115,7 +115,7 @@
                 android:launchMode="singleTask"
                 android:screenOrientation="portrait"
                 android:theme="@style/AppTheme.SplashScreen"
-                android:windowSoftInputMode="adjustNothing|stateHidden">
+                android:windowSoftInputMode="adjustResize|stateHidden">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10868" title="WPB-10868" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10868</a>  [Android] Login button and continue buttons on team creation pages hidden underneath keyboard (android 8-10)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Bottom buttons on some screens, like "login" or "continue" are hidden underneath the keyboard on Androids 8-10.

### Causes (Optional)

It's because of the change from `adjustResize` to `adjustNothing` - without `adjustResize` setting `imePadding` doesn't work for Androids up to 10: https://issuetracker.google.com/issues/266331465#comment17

### Solutions

The official doc says that in order to manually handle insets, adjustResize should be used:
https://developer.android.com/develop/ui/compose/layouts/insets#insets-setup

According to someone from Google, `adjustResize` with `decorFitsSystemWindows = false` (we use that already) doesn't result in any resizing, so it’s the same effect as `adjustNothing` (https://issuetracker.google.com/issues/260280334#comment3), but it makes `imePadding` work for Androids up to 10 so probably `adjustNothing` is not required for this new attachments popup to work.

Recent changes in attachment options actually work the same with `adjustResize` on both Android 9 and 14 so this change is reverted in the manifest.

### Testing

#### How to Test

Open the app on Android 8-10, open login or account creation screen and click on text input - bottom button should still be visible above the keyboard.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <img src="https://github.com/user-attachments/assets/21d493ae-e63b-49c4-93f0-61e3b7158104"/> | <img src="https://github.com/user-attachments/assets/460d3b24-2f00-4672-b50e-c947aff8cb09"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
