### PR TITLE
fix: some files not visible in downloads folder [WPB-1854]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -117,7 +117,7 @@ private fun Context.saveFileDataToDownloadsFolder(assetName: String, downloadedD
                 /* title = */ availableAssetName,
                 /* description = */ availableAssetName,
                 /* isMediaScannerScannable = */ true,
-                /* mimeType = */ mimeType ?: "*/*",
+                /* mimeType = */ mimeType.orEmpty().ifEmpty { "*/*" },
                 /* path = */ destinationFile.absolutePath,
                 /* length = */ fileSize,
                 /* showNotification = */ false

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -104,25 +104,26 @@ private fun Context.saveFileDataToDownloadsFolder(assetName: String, downloadedD
             put(MIME_TYPE, mimeType)
             put(SIZE, fileSize)
         }
-        resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
+        resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)?.also { downloadedUri ->
+            resolver.copyFile(downloadedUri, downloadedDataPath)
+        }
     } else {
         val authority = getProviderAuthority()
         val destinationFile = File(downloadsDir, availableAssetName)
-        val uri = FileProvider.getUriForFile(this, authority, destinationFile)
-        if (mimeType?.isNotEmpty() == true) {
-            val downloadManager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        val downloadManager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        FileProvider.getUriForFile(this, authority, destinationFile).also { downloadedUri ->
+            resolver.copyFile(downloadedUri, downloadedDataPath)
             downloadManager.addCompletedDownload(
                 /* title = */ availableAssetName,
                 /* description = */ availableAssetName,
                 /* isMediaScannerScannable = */ true,
-                /* mimeType = */ mimeType,
+                /* mimeType = */ mimeType ?: "*/*",
                 /* path = */ destinationFile.absolutePath,
                 /* length = */ fileSize,
                 /* showNotification = */ false
             )
         }
-        uri
-    }?.also { downloadedUri -> resolver.copyFile(downloadedUri, downloadedDataPath) }
+    }
 }
 
 fun ContentResolver.copyFile(destinationUri: Uri, sourcePath: Path) {

--- a/app/src/test/kotlin/com/wire/android/util/FileUtilTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/FileUtilTest.kt
@@ -18,44 +18,71 @@
 
 package com.wire.android.util
 
+import android.app.Application
+import android.app.DownloadManager
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import androidx.core.content.FileProvider
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkStatic
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toOkioPath
 import org.amshove.kluent.internal.assertEquals
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.TempDir
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import java.io.File
 
+@RunWith(RobolectricTestRunner::class)
+/*
+ * Run tests in isolation, use basic Application class instead of initializing WireApplication.
+ * It won't work with WireApplication because of Datadog - for each test new WireApplication instance is created but Datadog uses
+ * singleton and initializes itself only once for the first instance of WireApplication which then crashes for other instances.
+ */
+@Config(application = Application::class)
 class FileUtilTest {
 
-    @TempDir
-    lateinit var tempDir: File
+    @get:Rule
+    val tempDir: TemporaryFolder = TemporaryFolder()
 
     @Test
     fun `given file does not exist when finding first unique name in directory then return this name`() {
         val desired = "abc.jpg"
         val expected = "abc.jpg"
 
-        val result = findFirstUniqueName(tempDir, desired)
+        val result = findFirstUniqueName(tempDir.root, desired)
         assertEquals(expected, result)
     }
 
     @Test
     fun `given file already exists when finding unique name in directory then return next available name`() {
-        File(tempDir, "abc.jpg").createNewFile()
+        File(tempDir.root, "abc.jpg").createNewFile()
         val desired = "abc.jpg"
         val expected = "abc (1).jpg"
 
-        val result = findFirstUniqueName(tempDir, desired)
+        val result = findFirstUniqueName(tempDir.root, desired)
         assertEquals(expected, result)
     }
 
     @Test
     fun `given file and its copies already exist when finding unique name in directory then return next available name`() {
-        File(tempDir, "abc.jpg").createNewFile()
-        File(tempDir, "abc (1).jpg").createNewFile()
-        File(tempDir, "abc (2).jpg").createNewFile()
+        File(tempDir.root, "abc.jpg").createNewFile()
+        File(tempDir.root, "abc (1).jpg").createNewFile()
+        File(tempDir.root, "abc (2).jpg").createNewFile()
         val desired = "abc.jpg"
         val expected = "abc (3).jpg"
 
-        val result = findFirstUniqueName(tempDir, desired)
+        val result = findFirstUniqueName(tempDir.root, desired)
         assertEquals(expected, result)
     }
 
@@ -66,5 +93,98 @@ class FileUtilTest {
 
         val result = desired.sanitizeFilename()
         assertEquals(expected, result)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    @Test
+    fun `given Android 10, when saving file to downloads folder, then use correct order of executions`() = runTest {
+        // given
+        val arrangement = Arrangement()
+            .withUriMimeType("text/plain")
+            .arrange()
+        val downloadedFilePath = tempDir.newFile("filename.txt").toOkioPath()
+        // when
+        saveFileToDownloadsFolder("name", downloadedFilePath, 100L, arrangement.context)
+        // then
+        verifyOrder {
+            arrangement.contentResolver.insert(any(), any())
+            arrangement.contentResolver.copyFile(any(), any())
+        }
+        verify(exactly = 0) {
+            arrangement.downloadManager.addCompletedDownload(any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.P])
+    @Test
+    fun `given Android 9, when saving file to downloads folder, then use correct order of executions`() = runTest {
+        // given
+        val arrangement = Arrangement()
+            .withUriMimeType("text/plain")
+            .arrange()
+        val downloadedFilePath = tempDir.newFile("filename.txt").toOkioPath()
+        // when
+        saveFileToDownloadsFolder("name", downloadedFilePath, 100L, arrangement.context)
+        // then
+        verifyOrder {
+            arrangement.contentResolver.copyFile(any(), any())
+            arrangement.downloadManager.addCompletedDownload(any(), any(), any(), any(), any(), any(), any())
+        }
+        verify(exactly = 0) {
+            arrangement.contentResolver.insert(any(), any())
+        }
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.P])
+    @Test
+    fun `given Android 9 and null mimeType, when saving file to downloads folder, then use mimeType indicating all types`() = runTest {
+        // given
+        val arrangement = Arrangement()
+            .withUriMimeType(null)
+            .arrange()
+        val downloadedFilePath = tempDir.newFile("filename.txt").toOkioPath()
+        // when
+        saveFileToDownloadsFolder("name", downloadedFilePath, 100L, arrangement.context)
+        // then
+        verify {
+            arrangement.downloadManager.addCompletedDownload(any(), any(), any(), eq("*/*"), any(), any(), any())
+        }
+    }
+
+    inner class Arrangement {
+
+        @MockK
+        lateinit var context: Context
+
+        @MockK
+        lateinit var contentResolver: ContentResolver
+
+        @MockK
+        lateinit var downloadManager: DownloadManager
+
+        @MockK
+        lateinit var uri: Uri
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+            mockkStatic(Environment::class)
+            mockkStatic(FileProvider::class)
+            mockkStatic("com.wire.android.util.FileUtilKt")
+            coEvery { context.packageName } returns "com.wire"
+            coEvery { context.contentResolver } returns contentResolver
+            coEvery { context.getSystemService(Context.DOWNLOAD_SERVICE) } returns downloadManager
+            coEvery { Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) } returns tempDir.root
+            coEvery { FileProvider.getUriForFile(any(), any(), any()) } returns uri
+            coEvery { contentResolver.insert(any(), any()) } returns uri
+            coEvery { downloadManager.addCompletedDownload(any(), any(), any(), any(), any(), any(), any()) } returns 1L
+            coEvery { contentResolver.copyFile(any(), any()) } returns Unit
+            withUriMimeType(null)
+        }
+
+        fun withUriMimeType(mimeType: String?) = apply {
+            coEvery { uri.getMimeType(context) } returns mimeType
+        }
+
+        fun arrange() = this
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1854" title="WPB-1854" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-1854</a>  Files without mimetype are not shown in downloads when tapping "Show" after downloading
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When we receive a file without a mimetype that can be recognised by android, then it’s not shown in the downloads folder, to which we are redirected after tapping on “show”.

### Causes (Optional)

For Androids up to 10 the app uses deprecated `DownloadManager` to notify the system that there's a new file added to "downloads", but it required to pass non-null mime type, so there was a check and system was not notified about all files with null mime types. Also, even for files with proper mime types, the system could show that file after some time, it wasn't visible instantly.

### Solutions

For null mime types, just add general mime type `*/*` - it works.
For the case with files not being visible instantly, revert the order of actions on Androids up to 10 - on new ones, when `ContentResolver` is used, it's required to first notify the system by calling `insert` and then use the uri that's returned from that function to copy the file. Older approach for Androids up to 9 require the reverse order - first copy the file to the "downloads" folder and only after that, notify the system by calling `addCompletedDownload`.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Save a downloaded asset into "downloads" and click "show" on snackbar to navigate to "downloads" folder.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
