### PR TITLE
feat: Disable services for MLS conversation [WPB-10777]

### DIFF
--- a/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.datetime.Instant
 
@@ -156,5 +157,13 @@ object TestConversation {
         mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
         proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
         legalHoldStatus = Conversation.LegalHoldStatus.DISABLED
+    )
+
+    val MLS_PROTOCOL_INFO = ProtocolInfo.MLS(
+        GROUP_ID,
+        ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
+        0UL,
+        Instant.parse("2021-03-30T15:36:00.000Z"),
+        cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
     )
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -636,8 +636,11 @@ class GroupConversationDetailsViewModelTest {
                 .GROUP(if (params.isMLSConversation) TestConversation.MLS_PROTOCOL_INFO else Conversation.ProtocolInfo.Proteus)
                 .copy(
                     accessRole = listOf(Conversation.AccessRole.EXTERNAL).run {
-                        if (params.isServiceAllowed) plus(Conversation.AccessRole.SERVICE)
-                        else this
+                        if (params.isServiceAllowed) {
+                            plus(Conversation.AccessRole.SERVICE)
+                        } else {
+                            this
+                        }
                     }
                 )
         val (arrangement, viewModel) = GroupConversationDetailsViewModelArrangement()

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -629,18 +629,16 @@ class GroupConversationDetailsViewModelTest {
 
     @ParameterizedTest
     @EnumSource(IsServiceAllowedTestParams::class)
-    fun `isServicesAllowed test`(params: IsServiceAllowedTestParams) = runTest() {
+    fun `isServicesAllowed test`(params: IsServiceAllowedTestParams) = runTest {
         // given
         val conversation =
             TestConversation
                 .GROUP(if (params.isMLSConversation) TestConversation.MLS_PROTOCOL_INFO else Conversation.ProtocolInfo.Proteus)
                 .copy(
-                    accessRole = if (params.isServiceAllowed)
-                        listOf(
-                            Conversation.AccessRole.EXTERNAL,
-                            Conversation.AccessRole.SERVICE
-                        )
-                    else listOf(Conversation.AccessRole.EXTERNAL)
+                    accessRole = listOf(Conversation.AccessRole.EXTERNAL).run {
+                        if (params.isServiceAllowed) plus(Conversation.AccessRole.SERVICE)
+                        else this
+                    }
                 )
         val (arrangement, viewModel) = GroupConversationDetailsViewModelArrangement()
             .withDefaultProtocol(if (params.isMLSTeam) SupportedProtocol.MLS else SupportedProtocol.PROTEUS)

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
@@ -229,12 +229,10 @@ class EditGuestAccessViewModelTest {
                 TestConversation
                     .GROUP(if (params.isMLSConversation) TestConversation.MLS_PROTOCOL_INFO else Conversation.ProtocolInfo.Proteus)
                     .copy(
-                        accessRole = if (params.isServiceAllowed)
-                            listOf(
-                                Conversation.AccessRole.EXTERNAL,
-                                Conversation.AccessRole.SERVICE
-                            )
-                        else listOf(Conversation.AccessRole.EXTERNAL)
+                        accessRole = listOf(Conversation.AccessRole.EXTERNAL).run {
+                            if (params.isServiceAllowed) plus(Conversation.AccessRole.SERVICE)
+                            else this
+                        }
                     )
             val conversationResult = ObserveConversationDetailsUseCase.Result.Success(
                 TestConversationDetails.GROUP.copy(conversation = conversation)

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
@@ -230,8 +230,11 @@ class EditGuestAccessViewModelTest {
                     .GROUP(if (params.isMLSConversation) TestConversation.MLS_PROTOCOL_INFO else Conversation.ProtocolInfo.Proteus)
                     .copy(
                         accessRole = listOf(Conversation.AccessRole.EXTERNAL).run {
-                            if (params.isServiceAllowed) plus(Conversation.AccessRole.SERVICE)
-                            else this
+                            if (params.isServiceAllowed) {
+                                plus(Conversation.AccessRole.SERVICE)
+                            } else {
+                                this
+                            }
                         }
                     )
             val conversationResult = ObserveConversationDetailsUseCase.Result.Success(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
@@ -24,12 +24,16 @@ import androidx.lifecycle.SavedStateHandle
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
 import com.wire.android.config.TestDispatcherProvider
+import com.wire.android.framework.TestConversation
+import com.wire.android.framework.TestConversationDetails
 import com.wire.android.ui.home.conversations.details.participants.model.ConversationParticipantsData
 import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
 import com.wire.android.ui.navArgs
 import com.wire.android.ui.userprofile.other.OtherUserProfileScreenViewModelTest
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.SyncConversationCodeUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUseCase
@@ -39,6 +43,7 @@ import com.wire.kalium.logic.feature.conversation.guestroomlink.GenerateGuestRoo
 import com.wire.kalium.logic.feature.conversation.guestroomlink.ObserveGuestRoomLinkUseCase
 import com.wire.kalium.logic.feature.conversation.guestroomlink.RevokeGuestRoomLinkResult
 import com.wire.kalium.logic.feature.conversation.guestroomlink.RevokeGuestRoomLinkUseCase
+import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
 import com.wire.kalium.logic.feature.user.guestroomlink.ObserveGuestRoomLinkFeatureFlagUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -53,6 +58,8 @@ import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class, NavigationTestExtension::class)
@@ -213,6 +220,38 @@ class EditGuestAccessViewModelTest {
             assertEquals(true, editGuestAccessViewModel.editGuestAccessState.isGuestAccessAllowed)
         }
 
+    @ParameterizedTest
+    @EnumSource(IsServiceAllowedTestParams::class)
+    fun `isServicesAllowed test`(params: IsServiceAllowedTestParams) =
+        runTest(dispatcher.default()) {
+            // given
+            val conversation =
+                TestConversation
+                    .GROUP(if (params.isMLSConversation) TestConversation.MLS_PROTOCOL_INFO else Conversation.ProtocolInfo.Proteus)
+                    .copy(
+                        accessRole = if (params.isServiceAllowed)
+                            listOf(
+                                Conversation.AccessRole.EXTERNAL,
+                                Conversation.AccessRole.SERVICE
+                            )
+                        else listOf(Conversation.AccessRole.EXTERNAL)
+                    )
+            val conversationResult = ObserveConversationDetailsUseCase.Result.Success(
+                TestConversationDetails.GROUP.copy(conversation = conversation)
+            )
+            val (arrangement, editGuestAccessViewModel) = Arrangement(dispatcher)
+                .withConversationDetails(flowOf(conversationResult))
+                .withDefaultProtocol(if (params.isMLSTeam) SupportedProtocol.MLS else SupportedProtocol.PROTEUS)
+                .withConversationMembers(flowOf(ConversationParticipantsData()))
+                .arrange()
+            advanceUntilIdle()
+
+            // when
+
+            // then
+            assertEquals(params.expectedResult, editGuestAccessViewModel.editGuestAccessState.isServicesAccessAllowed)
+        }
+
     private class Arrangement(dispatcherProvider: TestDispatcherProvider) {
         @MockK
         lateinit var savedStateHandle: SavedStateHandle
@@ -244,6 +283,9 @@ class EditGuestAccessViewModelTest {
         @MockK
         lateinit var syncConversationCodeUseCase: SyncConversationCodeUseCase
 
+        @MockK
+        lateinit var getDefaultProtocolUseCase: GetDefaultProtocolUseCase
+
         val editGuestAccessViewModel: EditGuestAccessViewModel by lazy {
             EditGuestAccessViewModel(
                 savedStateHandle = savedStateHandle,
@@ -256,7 +298,8 @@ class EditGuestAccessViewModelTest {
                 observeGuestRoomLinkFeatureFlag = observeGuestRoomLinkFeatureFlag,
                 canCreatePasswordProtectedLinks = canCreatePasswordProtectedLinks,
                 dispatcher = dispatcherProvider,
-                syncConversationCode = syncConversationCodeUseCase
+                syncConversationCode = syncConversationCodeUseCase,
+                getDefaultProtocol = getDefaultProtocolUseCase
             )
         }
 
@@ -275,6 +318,7 @@ class EditGuestAccessViewModelTest {
             coEvery { observeGuestRoomLink(any()) } returns flowOf()
             coEvery { observeGuestRoomLinkFeatureFlag() } returns flowOf()
             coEvery { canCreatePasswordProtectedLinks() } returns true
+            every { getDefaultProtocolUseCase() } returns SupportedProtocol.PROTEUS
         }
 
         fun withSyncConversationCodeSuccess() = apply {
@@ -302,6 +346,23 @@ class EditGuestAccessViewModelTest {
             coEvery { updateConversationAccessRole(any(), any(), any()) } returns result
         }
 
+        fun withDefaultProtocol(protocol: SupportedProtocol) = apply {
+            every { getDefaultProtocolUseCase() } returns protocol
+        }
+
         fun arrange() = this to editGuestAccessViewModel
+    }
+
+    enum class IsServiceAllowedTestParams(
+        val isMLSTeam: Boolean,
+        val isMLSConversation: Boolean,
+        val isServiceAllowed: Boolean,
+        val expectedResult: Boolean
+    ) {
+        MLS_TEAM(true, false, true, false),
+        MLS_CONVERSATION(false, true, true, false),
+        MLS_CONVERSATION_AND_TEAM(true, true, true, false),
+        NO_SERVICES(false, false, false, false),
+        SERVICES(false, false, true, true)
     }
 }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10777" title="WPB-10777" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10777</a>  [Android] Disable Add Service interaction in MLS Conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# What's new in this PR?

### Issues

We need to disable adding services into the MLS group conversation, or if MLS is default protocol in MLS settings.
