### PR TITLE
fix: empty dependencies section [WPB-10929]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -512,6 +512,6 @@ fun PreviewOtherDebugOptions() {
         handleE2EIEnrollmentResult = {},
         dismissCertificateDialog = {},
         checkCrlRevocationList = {},
-        dependenciesMap = persistentMapOf("avs" to "1.0.0", "core-crypto" to "1.0.0")
+        dependenciesMap = persistentMapOf("preview dependency" to "1.0.0", "another dependency" to "1.0.0")
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -431,20 +431,23 @@ private fun DebugToolsOptions(
  */
 @Composable
 fun DependenciesItem(dependencies: ImmutableMap<String, String?>) {
-    val title = stringResource(id = R.string.item_dependencies_title)
-    val text = remember {
-        prettyPrintMap(dependencies, title)
+    val text = remember (dependencies) {
+        dependencies.prettyPrintMap()
     }
     RowItemTemplate(
-        modifier = Modifier.wrapContentWidth(),
+        modifier = Modifier.padding(dimensions().spacing8x),
         title = {
+            Text(
+                style = MaterialTheme.wireTypography.label01,
+                color = MaterialTheme.wireColorScheme.secondaryText,
+                text = stringResource(id = R.string.item_dependencies_title),
+            )
             Text(
                 style = MaterialTheme.wireTypography.body01,
                 color = MaterialTheme.wireColorScheme.onBackground,
                 text = text,
-                modifier = Modifier.padding(start = dimensions().spacing8x)
             )
-        }
+        },
     )
 }
 
@@ -478,12 +481,9 @@ private fun DisableEventProcessingSwitch(
 }
 
 @Stable
-private fun prettyPrintMap(map: Map<String, String?>, title: String): String = StringBuilder().apply {
-    append("$title\n")
-    map.forEach { (key, value) ->
-        append("$key: $value\n")
-    }
-}.toString()
+private fun Map<String, String?>.prettyPrintMap(): String = this
+    .map { (key, value) -> "$key: $value" }
+    .joinToString("\n")
 
 //endregion
 
@@ -512,6 +512,6 @@ fun PreviewOtherDebugOptions() {
         handleE2EIEnrollmentResult = {},
         dismissCertificateDialog = {},
         checkCrlRevocationList = {},
-        dependenciesMap = persistentMapOf()
+        dependenciesMap = persistentMapOf("avs" to "1.0.0", "core-crypto" to "1.0.0")
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -431,7 +431,7 @@ private fun DebugToolsOptions(
  */
 @Composable
 fun DependenciesItem(dependencies: ImmutableMap<String, String?>) {
-    val text = remember (dependencies) {
+    val text = remember(dependencies) {
         dependencies.prettyPrintMap()
     }
     RowItemTemplate(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,7 +214,7 @@
     <string name="debug_settings_api_versioning_title" translatable="false">API VERSIONING</string>
     <string name="debug_settings_e2ei_enrollment_title" translatable="false">E2EI Manual Enrollment</string>
     <string name="debug_settings_force_api_versioning_update" translatable="false">Force API versioning update</string>
-    <string name="item_dependencies_title">Dependencies:</string>
+    <string name="item_dependencies_title">Dependencies</string>
     <string name="debug_settings_force_api_versioning_update_button_text" translatable="false">Update</string>
     <string name="support_screen_title">Support</string>
     <string name="backup_and_restore_screen_title">Back up &amp; Restore Conversations</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10929" title="WPB-10929" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10929</a>  [Android] App does not show dependency versions (core-crypto, avs) on Bund version
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

 App does not show dependency versions (core-crypto, avs).

### Causes (Optional)

The string with dependencies is remembered to keep it during recompositions, but without any key and the dependencies map is empty initially, so when the proper data appears, it takes the remembered empty value instead of creating new proper one with dependencies.

### Solutions

Use `dependencies` as a key when remembering string so that when dependencies change, the string is rebuilt with current data.
Also, `DependenciesItem` texts stylings and paddings are unified with all other debug screen elements.

### Testing

#### How to Test

Open "Debug Settings" and check "Dependencies" section.


### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <img width="400" src="https://github.com/user-attachments/assets/8b8ed93d-7c70-401c-9a7c-2d52d42e4c8f"/> | <img width="400" src="https://github.com/user-attachments/assets/52c0f9c9-46ec-448d-bcd5-6a8529ef10b8"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
