### PR TITLE
feat: add analytics initial events (WPB-10589)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/AppModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/AppModule.kt
@@ -25,6 +25,8 @@ import android.media.AudioAttributes
 import android.media.MediaPlayer
 import androidx.core.app.NotificationManagerCompat
 import com.wire.android.BuildConfig
+import com.wire.android.feature.analytics.AnonymousAnalyticsManager
+import com.wire.android.feature.analytics.AnonymousAnalyticsManagerImpl
 import com.wire.android.mapper.MessageResourceProvider
 import com.wire.android.ui.analytics.AnalyticsConfiguration
 import com.wire.android.ui.home.appLock.CurrentTimestampProvider
@@ -95,4 +97,7 @@ object AppModule {
     @Provides
     fun provideAnalyticsConfiguration() =
         if (BuildConfig.ANALYTICS_ENABLED) AnalyticsConfiguration.Enabled else AnalyticsConfiguration.Disabled
+
+    @Provides
+    fun provideAnonymousAnalyticsManager(): AnonymousAnalyticsManager = AnonymousAnalyticsManagerImpl
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -78,6 +78,8 @@ import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.ramcosta.composedestinations.result.ResultRecipient
 import com.wire.android.R
 import com.wire.android.appLogger
+import com.wire.android.feature.analytics.AnonymousAnalyticsManagerImpl
+import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.mapper.MessageDateTimeGroup
 import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.model.Clickable
@@ -277,6 +279,7 @@ fun ConversationScreen(
                         getOngoingCallIntent(activity, it.toString()).run {
                             activity.startActivity(this)
                         }
+                        AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallJoined())
                     }
                 }
             )
@@ -290,6 +293,7 @@ fun ConversationScreen(
                     getOutgoingCallIntent(activity, conversationListCallViewModel.conversationId.toString()).run {
                         activity.startActivity(this)
                     }
+                    AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallJoined())
                 }
                 showDialog.value = ConversationScreenDialogType.NONE
             }, onDialogDismiss = {
@@ -316,12 +320,13 @@ fun ConversationScreen(
                             getOutgoingCallIntent(activity, it.toString()).run {
                                 activity.startActivity(this)
                             }
+                        },
+                        onOpenOngoingCallScreen =  {
+                            getOngoingCallIntent(activity, it.toString()).run {
+                                activity.startActivity(this)
+                            }
                         }
-                    ) {
-                        getOngoingCallIntent(activity, it.toString()).run {
-                            activity.startActivity(this)
-                        }
-                    }
+                    )
                 },
                 onDialogDismiss = {
                     showDialog.value = ConversationScreenDialogType.NONE
@@ -348,12 +353,13 @@ fun ConversationScreen(
                             getOutgoingCallIntent(activity, it.toString()).run {
                                 activity.startActivity(this)
                             }
+                        },
+                        onOpenOngoingCallScreen = {
+                            getOngoingCallIntent(activity, it.toString()).run {
+                                activity.startActivity(this)
+                            }
                         }
-                    ) {
-                        getOngoingCallIntent(activity, it.toString()).run {
-                            activity.startActivity(this)
-                        }
-                    }
+                    )
                 },
                 onDialogDismiss = { showDialog.value = ConversationScreenDialogType.NONE }
             )
@@ -423,15 +429,17 @@ fun ConversationScreen(
                     getOutgoingCallIntent(activity, it.toString()).run {
                         activity.startActivity(this)
                     }
+                },
+                onOpenOngoingCallScreen = {
+                    getOngoingCallIntent(activity, it.toString()).run {
+                        activity.startActivity(this)
+                    }
                 }
-            ) {
-                getOngoingCallIntent(activity, it.toString()).run {
-                    activity.startActivity(this)
-                }
-            }
+            )
         },
         onJoinCall = {
             conversationListCallViewModel.joinOngoingCall {
+                AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallJoined())
                 getOngoingCallIntent(activity, it.toString()).run {
                     activity.startActivity(this)
                 }
@@ -664,6 +672,7 @@ private fun startCallIfPossible(
                     } else {
                         conversationListCallViewModel.endEstablishedCallIfAny {
                             onOpenOutgoingCallScreen(conversationListCallViewModel.conversationId)
+                            AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallInitiated())
                         }
                         ConversationScreenDialogType.NONE
                     }
@@ -671,6 +680,7 @@ private fun startCallIfPossible(
 
                 ConferenceCallingResult.Disabled.Established -> {
                     onOpenOngoingCallScreen(conversationListCallViewModel.conversationId)
+                    AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallJoined())
                     ConversationScreenDialogType.NONE
                 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -321,7 +321,7 @@ fun ConversationScreen(
                                 activity.startActivity(this)
                             }
                         },
-                        onOpenOngoingCallScreen =  {
+                        onOpenOngoingCallScreen = {
                             getOngoingCallIntent(activity, it.toString()).run {
                                 activity.startActivity(this)
                             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.wire.android.R
 import com.wire.android.appLogger
+import com.wire.android.feature.analytics.AnonymousAnalyticsManagerImpl
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.media.PingRinger
 import com.wire.android.model.SnackBarMessage
@@ -252,17 +253,18 @@ class SendMessageViewModel @Inject constructor(
     }
 
     private fun handleContributionEvent(messageBundle: MessageBundle) {
-        // TODO(ym): handle the rest below, when doing so, assign when to a event var, and call send at the end
-        when (messageBundle) {
-            is ComposableMessageBundle.AttachmentPickedBundle,
-            is ComposableMessageBundle.AudioMessageBundle,
-            is ComposableMessageBundle.EditMessageBundle,
-            is ComposableMessageBundle.SendTextMessageBundle,
+        val event = when (messageBundle) {
             is ComposableMessageBundle.UriPickedBundle,
-            is Ping -> { /* do nothing */
-            }
+            is ComposableMessageBundle.AttachmentPickedBundle -> return
+
+            is ComposableMessageBundle.AudioMessageBundle -> AnalyticsEvent.Contributed.Audio()
             is ComposableMessageBundle.LocationBundle -> AnalyticsEvent.Contributed.Location()
+            is Ping -> AnalyticsEvent.Contributed.Ping()
+            is ComposableMessageBundle.EditMessageBundle,
+            is ComposableMessageBundle.SendTextMessageBundle -> AnalyticsEvent.Contributed.Text()
         }
+
+        AnonymousAnalyticsManagerImpl.sendEvent(event)
     }
 
     private suspend fun handleAssetMessageBundle(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.wire.android.R
 import com.wire.android.appLogger
+import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.media.PingRinger
 import com.wire.android.model.SnackBarMessage
 import com.wire.android.navigation.SavedStateViewModel
@@ -247,6 +248,21 @@ class SendMessageViewModel @Inject constructor(
                     .handleLegalHoldFailureAfterSendingMessage(messageBundle.conversationId)
             }
         }
+        handleContributionEvent(messageBundle)
+    }
+
+    private fun handleContributionEvent(messageBundle: MessageBundle) {
+        // TODO(ym): handle the rest below, when doing so, assign when to a event var, and call send at the end
+        when (messageBundle) {
+            is ComposableMessageBundle.AttachmentPickedBundle,
+            is ComposableMessageBundle.AudioMessageBundle,
+            is ComposableMessageBundle.EditMessageBundle,
+            is ComposableMessageBundle.SendTextMessageBundle,
+            is ComposableMessageBundle.UriPickedBundle,
+            is Ping -> { /* do nothing */
+            }
+            is ComposableMessageBundle.LocationBundle -> AnalyticsEvent.Contributed.Location()
+        }
     }
 
     private suspend fun handleAssetMessageBundle(
@@ -419,6 +435,7 @@ class SendMessageViewModel @Inject constructor(
         }
         sureAboutMessagingDialogState = SureAboutMessagingDialogState.Hidden
     }
+
     private companion object {
         const val MAX_LIMIT_MESSAGE_SEND = 20
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -341,8 +341,18 @@ class SendMessageViewModel @Inject constructor(
                             }
                         }
                     }
+                    handleAssetContributionEvent(assetType)
                 }
             }
+        }
+    }
+
+    private fun handleAssetContributionEvent(assetType: AttachmentType) {
+        when (assetType) {
+            AttachmentType.IMAGE -> AnonymousAnalyticsManagerImpl.sendEvent(AnalyticsEvent.Contributed.Photo())
+            AttachmentType.VIDEO -> AnonymousAnalyticsManagerImpl.sendEvent(AnalyticsEvent.Contributed.Video())
+            AttachmentType.GENERIC_FILE -> AnonymousAnalyticsManagerImpl.sendEvent(AnalyticsEvent.Contributed.File())
+            AttachmentType.AUDIO -> AnonymousAnalyticsManagerImpl.sendEvent(AnalyticsEvent.Contributed.Audio())
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
@@ -31,6 +31,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.R
+import com.wire.android.feature.analytics.AnonymousAnalyticsManagerImpl
+import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.LocalActivity
@@ -174,6 +176,7 @@ fun ConversationRouterHomeBridge(
         }
         val onJoinedCall: (ConversationId) -> Unit = remember(navigator) {
             {
+                AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallJoined())
                 getOngoingCallIntent(activity, it.toString()).run {
                     activity.startActivity(this)
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
@@ -30,6 +30,8 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.BuildConfig
 import com.wire.android.appLogger
 import com.wire.android.datastore.UserDataStore
+import com.wire.android.feature.analytics.AnonymousAnalyticsManagerImpl
+import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.util.FileManager
 import com.wire.android.util.dispatchers.DispatcherProvider
@@ -124,6 +126,7 @@ class BackupAndRestoreViewModel
             is CreateBackupResult.Failure -> {
                 state = state.copy(backupCreationProgress = BackupCreationProgress.Failed)
                 appLogger.e("Failed to create backup: ${result.coreFailure}")
+                AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.BackupExportFailed())
             }
         }
     }
@@ -185,6 +188,7 @@ class BackupAndRestoreViewModel
                             importDatabase(importedBackupPath)
                         } else {
                             state = state.copy(restoreFileValidation = RestoreFileValidation.IncompatibleBackup)
+                            AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.BackupRestoreFailed())
                         }
                     }
                 }
@@ -196,6 +200,8 @@ class BackupAndRestoreViewModel
                     is VerifyBackupResult.Failure.Generic -> result.error.toString()
                     VerifyBackupResult.Failure.InvalidBackupFile -> "No valid files found in the backup"
                 }
+
+                AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.BackupRestoreFailed())
                 appLogger.e("Failed to extract backup files: $errorMessage")
             }
         }
@@ -211,6 +217,7 @@ class BackupAndRestoreViewModel
                 updateCreationProgress(PROGRESS_75)
                 delay(SMALL_DELAY)
                 state = state.copy(backupRestoreProgress = BackupRestoreProgress.Finished)
+                AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.BackupRestoreSucceeded())
             }
 
             is RestoreBackupResult.Failure -> {
@@ -222,6 +229,7 @@ class BackupAndRestoreViewModel
                     restoreFileValidation = RestoreFileValidation.IncompatibleBackup,
                     backupRestoreProgress = BackupRestoreProgress.Failed
                 )
+                AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.BackupRestoreFailed())
             }
         }
     }
@@ -242,14 +250,17 @@ class BackupAndRestoreViewModel
                         restorePasswordValidation = PasswordValidation.Valid
                     )
                     restoreBackupPasswordState.clearText()
+                    AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.BackupRestoreSucceeded())
                 }
 
                 is RestoreBackupResult.Failure -> {
                     mapBackupRestoreFailure(result.failure)
+                    AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.BackupRestoreFailed())
                 }
             }
         } else {
             state = state.copy(backupRestoreProgress = BackupRestoreProgress.Failed)
+            AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.BackupRestoreFailed())
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelArrangement.kt
@@ -21,6 +21,7 @@ package com.wire.android.ui.home.conversations.sendmessage
 import androidx.lifecycle.SavedStateHandle
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
+import com.wire.android.feature.analytics.AnonymousAnalyticsManager
 import com.wire.android.framework.FakeKaliumFileSystem
 import com.wire.android.media.PingRinger
 import com.wire.android.ui.home.conversations.ConversationNavArgs
@@ -139,6 +140,9 @@ internal class SendMessageViewModelArrangement {
 
     private val fakeKaliumFileSystem = FakeKaliumFileSystem()
 
+    @MockK
+    lateinit var analyticsManager: AnonymousAnalyticsManager
+
     private val viewModel by lazy {
         SendMessageViewModel(
             sendTextMessage = sendTextMessage,
@@ -158,7 +162,8 @@ internal class SendMessageViewModelArrangement {
             observeConversationUnderLegalHoldNotified = observeConversationUnderLegalHoldNotified,
             sendLocation = sendLocation,
             removeMessageDraft = removeMessageDraftUseCase,
-            savedStateHandle = savedStateHandle
+            savedStateHandle = savedStateHandle,
+            analyticsManager = analyticsManager
         )
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelTest.kt
@@ -607,7 +607,7 @@ class SendMessageViewModelTest {
             // then
             coVerify(exactly = 1) { arrangement.retryFailedMessageUseCase.invoke(eq(messageId), any()) }
             assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
-            verify(exactly = 1) {
+            verify(exactly = 0) {
                 arrangement.analyticsManager.sendEvent(match {
                     it is AnalyticsEvent.Contributed.Text
                 })
@@ -678,7 +678,7 @@ class SendMessageViewModelTest {
                     )
                 }
                 assertEquals(ConversationSnackbarMessages.ErrorAssetRestriction, awaitItem())
-                verify(exactly = 1) {
+                verify(exactly = 0) {
                     arrangement.analyticsManager.sendEvent(any())
                 }
             }
@@ -725,7 +725,7 @@ class SendMessageViewModelTest {
                     )
                 }
                 assertEquals(ConversationSnackbarMessages.ErrorAssetRestriction, awaitItem())
-                verify(exactly = 1) {
+                verify(exactly = 0) {
                     arrangement.analyticsManager.sendEvent(any())
                 }
             }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelTest.kt
@@ -23,6 +23,7 @@ import androidx.core.net.toUri
 import app.cash.turbine.test
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
+import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.ui.home.conversations.AssetTooLargeDialogState
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
 import com.wire.android.ui.home.conversations.SureAboutMessagingDialogState
@@ -86,6 +87,12 @@ class SendMessageViewModelTest {
                     any()
                 )
             }
+
+            verify(exactly = 1) {
+                arrangement.analyticsManager.sendEvent(match {
+                    it is AnalyticsEvent.Contributed.File
+                })
+            }
         }
 
     @Test
@@ -123,6 +130,12 @@ class SendMessageViewModelTest {
                     any()
                 )
             }
+
+            verify(exactly = 1) {
+                arrangement.analyticsManager.sendEvent(match {
+                    it is AnalyticsEvent.Contributed.Photo
+                })
+            }
         }
 
     @Test
@@ -149,6 +162,10 @@ class SendMessageViewModelTest {
                     any(),
                     any()
                 )
+            }
+
+            verify(exactly = 0) {
+                arrangement.analyticsManager.sendEvent(any())
             }
         }
 
@@ -192,6 +209,9 @@ class SendMessageViewModelTest {
                 )
             }
             assert(viewModel.assetTooLargeDialogState is AssetTooLargeDialogState.Visible)
+            verify(exactly = 0) {
+                arrangement.analyticsManager.sendEvent(any())
+            }
         }
 
     @Test
@@ -234,6 +254,9 @@ class SendMessageViewModelTest {
                 )
             }
             assert(viewModel.assetTooLargeDialogState is AssetTooLargeDialogState.Visible)
+            verify(exactly = 0) {
+                arrangement.analyticsManager.sendEvent(any())
+            }
         }
 
     @Test
@@ -268,6 +291,9 @@ class SendMessageViewModelTest {
                     )
                 }
                 assertEquals(ConversationSnackbarMessages.ErrorPickingAttachment, awaitItem())
+                verify(exactly = 0) {
+                    arrangement.analyticsManager.sendEvent(any())
+                }
             }
         }
 
@@ -287,6 +313,11 @@ class SendMessageViewModelTest {
             // Then
             coVerify(exactly = 1) { arrangement.sendKnockUseCase.invoke(any(), any()) }
             verify(exactly = 1) { arrangement.pingRinger.ping(any(), isReceivingPing = false) }
+            verify(exactly = 1) {
+                arrangement.analyticsManager.sendEvent(match {
+                    it is AnalyticsEvent.Contributed.Ping
+                })
+            }
         }
 
     @Test
@@ -324,6 +355,11 @@ class SendMessageViewModelTest {
                     any()
                 )
             }
+            verify(exactly = 1) {
+                arrangement.analyticsManager.sendEvent(match {
+                    it is AnalyticsEvent.Contributed.Audio
+                })
+            }
         }
 
     @Test
@@ -354,6 +390,11 @@ class SendMessageViewModelTest {
         }
         coVerify(exactly = 1) {
             arrangement.removeMessageDraftUseCase.invoke(any())
+        }
+        verify(exactly = 1) {
+            arrangement.analyticsManager.sendEvent(match {
+                it is AnalyticsEvent.Contributed.Text
+            })
         }
     }
 
@@ -395,6 +436,11 @@ class SendMessageViewModelTest {
             coVerify(exactly = 1) {
                 arrangement.removeMessageDraftUseCase.invoke(any())
             }
+            verify(exactly = 1) {
+                arrangement.analyticsManager.sendEvent(match {
+                    it is AnalyticsEvent.Contributed.Text
+                })
+            }
         }
 
     @Test
@@ -423,6 +469,9 @@ class SendMessageViewModelTest {
                 SureAboutMessagingDialogState.Visible.ConversationVerificationDegraded(conversationId, listOf(messageBundle)),
                 viewModel.sureAboutMessagingDialogState
             )
+            verify(exactly = 0) {
+                arrangement.analyticsManager.sendEvent(any())
+            }
         }
 
     @Test
@@ -442,6 +491,9 @@ class SendMessageViewModelTest {
                 SureAboutMessagingDialogState.Visible.ConversationUnderLegalHold.BeforeSending(conversationId, listOf(messageBundle)),
                 viewModel.sureAboutMessagingDialogState
             )
+            verify(exactly = 0) {
+                arrangement.analyticsManager.sendEvent(any())
+            }
         }
 
     @Test
@@ -461,6 +513,9 @@ class SendMessageViewModelTest {
             // then
             coVerify(exactly = 0) { arrangement.sendTextMessage.invoke(any(), any(), any(), any()) }
             assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
+            verify(exactly = 0) {
+                arrangement.analyticsManager.sendEvent(any())
+            }
         }
 
     @Test
@@ -481,6 +536,11 @@ class SendMessageViewModelTest {
             // then
             coVerify(exactly = 1) { arrangement.sendTextMessage.invoke(any(), any(), any(), any()) }
             assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
+            verify(exactly = 1) {
+                arrangement.analyticsManager.sendEvent(match {
+                    it is AnalyticsEvent.Contributed.Text
+                })
+            }
         }
 
     @Test
@@ -501,6 +561,9 @@ class SendMessageViewModelTest {
                 SureAboutMessagingDialogState.Visible.ConversationUnderLegalHold.AfterSending(conversationId, listOf(messageId)),
                 viewModel.sureAboutMessagingDialogState
             )
+            verify(exactly = 0) {
+                arrangement.analyticsManager.sendEvent(any())
+            }
         }
 
     @Test
@@ -521,6 +584,9 @@ class SendMessageViewModelTest {
             // then
             coVerify(exactly = 0) { arrangement.retryFailedMessageUseCase.invoke(any(), any()) }
             assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
+            verify(exactly = 0) {
+                arrangement.analyticsManager.sendEvent(any())
+            }
         }
 
     @Test
@@ -541,6 +607,11 @@ class SendMessageViewModelTest {
             // then
             coVerify(exactly = 1) { arrangement.retryFailedMessageUseCase.invoke(eq(messageId), any()) }
             assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
+            verify(exactly = 1) {
+                arrangement.analyticsManager.sendEvent(match {
+                    it is AnalyticsEvent.Contributed.Text
+                })
+            }
         }
 
     @Test
@@ -563,6 +634,11 @@ class SendMessageViewModelTest {
             // then
             coVerify(exactly = 1) { arrangement.sendLocation.invoke(any(), any(), any(), any(), any()) }
             assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
+            verify(exactly = 1) {
+                arrangement.analyticsManager.sendEvent(match {
+                    it is AnalyticsEvent.Contributed.Location
+                })
+            }
         }
 
     @Test
@@ -602,6 +678,9 @@ class SendMessageViewModelTest {
                     )
                 }
                 assertEquals(ConversationSnackbarMessages.ErrorAssetRestriction, awaitItem())
+                verify(exactly = 1) {
+                    arrangement.analyticsManager.sendEvent(any())
+                }
             }
         }
 
@@ -646,6 +725,9 @@ class SendMessageViewModelTest {
                     )
                 }
                 assertEquals(ConversationSnackbarMessages.ErrorAssetRestriction, awaitItem())
+                verify(exactly = 1) {
+                    arrangement.analyticsManager.sendEvent(any())
+                }
             }
         }
 
@@ -659,6 +741,11 @@ class SendMessageViewModelTest {
             .arrange()
 
         coVerify { arrangement.sendTextMessage(any(), eq(textToShare), any(), any()) }
+        verify(exactly = 1) {
+            arrangement.analyticsManager.sendEvent(match {
+                it is AnalyticsEvent.Contributed.Text
+            })
+        }
     }
 
     @Test
@@ -700,6 +787,9 @@ class SendMessageViewModelTest {
                     any(),
                     any()
                 )
+            }
+            verify {
+                arrangement.analyticsManager.sendEvent(any())
             }
         }
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelTest.kt
@@ -89,9 +89,11 @@ class SendMessageViewModelTest {
             }
 
             verify(exactly = 1) {
-                arrangement.analyticsManager.sendEvent(match {
-                    it is AnalyticsEvent.Contributed.File
-                })
+                arrangement.analyticsManager.sendEvent(
+                    match {
+                        it is AnalyticsEvent.Contributed.File
+                    }
+                )
             }
         }
 
@@ -132,9 +134,11 @@ class SendMessageViewModelTest {
             }
 
             verify(exactly = 1) {
-                arrangement.analyticsManager.sendEvent(match {
-                    it is AnalyticsEvent.Contributed.Photo
-                })
+                arrangement.analyticsManager.sendEvent(
+                    match {
+                        it is AnalyticsEvent.Contributed.Photo
+                    }
+                )
             }
         }
 
@@ -314,9 +318,11 @@ class SendMessageViewModelTest {
             coVerify(exactly = 1) { arrangement.sendKnockUseCase.invoke(any(), any()) }
             verify(exactly = 1) { arrangement.pingRinger.ping(any(), isReceivingPing = false) }
             verify(exactly = 1) {
-                arrangement.analyticsManager.sendEvent(match {
-                    it is AnalyticsEvent.Contributed.Ping
-                })
+                arrangement.analyticsManager.sendEvent(
+                    match {
+                        it is AnalyticsEvent.Contributed.Ping
+                    }
+                )
             }
         }
 
@@ -356,9 +362,11 @@ class SendMessageViewModelTest {
                 )
             }
             verify(exactly = 1) {
-                arrangement.analyticsManager.sendEvent(match {
-                    it is AnalyticsEvent.Contributed.Audio
-                })
+                arrangement.analyticsManager.sendEvent(
+                    match {
+                        it is AnalyticsEvent.Contributed.Audio
+                    }
+                )
             }
         }
 
@@ -392,9 +400,11 @@ class SendMessageViewModelTest {
             arrangement.removeMessageDraftUseCase.invoke(any())
         }
         verify(exactly = 1) {
-            arrangement.analyticsManager.sendEvent(match {
-                it is AnalyticsEvent.Contributed.Text
-            })
+            arrangement.analyticsManager.sendEvent(
+                match {
+                    it is AnalyticsEvent.Contributed.Text
+                }
+            )
         }
     }
 
@@ -437,9 +447,11 @@ class SendMessageViewModelTest {
                 arrangement.removeMessageDraftUseCase.invoke(any())
             }
             verify(exactly = 1) {
-                arrangement.analyticsManager.sendEvent(match {
-                    it is AnalyticsEvent.Contributed.Text
-                })
+                arrangement.analyticsManager.sendEvent(
+                    match {
+                        it is AnalyticsEvent.Contributed.Text
+                    }
+                )
             }
         }
 
@@ -537,9 +549,11 @@ class SendMessageViewModelTest {
             coVerify(exactly = 1) { arrangement.sendTextMessage.invoke(any(), any(), any(), any()) }
             assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
             verify(exactly = 1) {
-                arrangement.analyticsManager.sendEvent(match {
-                    it is AnalyticsEvent.Contributed.Text
-                })
+                arrangement.analyticsManager.sendEvent(
+                    match {
+                        it is AnalyticsEvent.Contributed.Text
+                    }
+                )
             }
         }
 
@@ -608,9 +622,11 @@ class SendMessageViewModelTest {
             coVerify(exactly = 1) { arrangement.retryFailedMessageUseCase.invoke(eq(messageId), any()) }
             assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
             verify(exactly = 0) {
-                arrangement.analyticsManager.sendEvent(match {
-                    it is AnalyticsEvent.Contributed.Text
-                })
+                arrangement.analyticsManager.sendEvent(
+                    match {
+                        it is AnalyticsEvent.Contributed.Text
+                    }
+                )
             }
         }
 
@@ -635,9 +651,11 @@ class SendMessageViewModelTest {
             coVerify(exactly = 1) { arrangement.sendLocation.invoke(any(), any(), any(), any(), any()) }
             assertEquals(SureAboutMessagingDialogState.Hidden, viewModel.sureAboutMessagingDialogState)
             verify(exactly = 1) {
-                arrangement.analyticsManager.sendEvent(match {
-                    it is AnalyticsEvent.Contributed.Location
-                })
+                arrangement.analyticsManager.sendEvent(
+                    match {
+                        it is AnalyticsEvent.Contributed.Location
+                    }
+                )
             }
         }
 
@@ -742,9 +760,11 @@ class SendMessageViewModelTest {
 
         coVerify { arrangement.sendTextMessage(any(), eq(textToShare), any(), any()) }
         verify(exactly = 1) {
-            arrangement.analyticsManager.sendEvent(match {
-                it is AnalyticsEvent.Contributed.Text
-            })
+            arrangement.analyticsManager.sendEvent(
+                match {
+                    it is AnalyticsEvent.Contributed.Text
+                }
+            )
         }
     }
 

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/model/AnalyticsEvent.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/model/AnalyticsEvent.kt
@@ -123,5 +123,15 @@ object AnalyticsEventConstants {
      */
     const val CONTRIBUTED = "contributed"
     const val MESSAGE_ACTION_KEY = "message_action"
+
+    const val CONTRIBUTED_TEXT = "text"
+    const val CONTRIBUTED_PHOTO = "photo"
+    const val CONTRIBUTED_AUDIO_CALL = "audio_call"
+    const val CONTRIBUTED_VIDEO_CALL = "video_call"
+    const val CONTRIBUTED_GIF = "giphy"
+    const val CONTRIBUTED_PING = "ping"
+    const val CONTRIBUTED_FILE = "file"
+    const val CONTRIBUTED_VIDEO = "video"
+    const val CONTRIBUTED_AUDIO = "audio"
     const val CONTRIBUTED_LOCATION = "location"
 }

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/model/AnalyticsEvent.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/model/AnalyticsEvent.kt
@@ -42,13 +42,37 @@ interface AnalyticsEvent {
      *      }
      * }
      */
-    fun toSegmentation(): Map<String, Any>
+    fun toSegmentation(): Map<String, Any> = mapOf()
 
     data class AppOpen(
         override val key: String = AnalyticsEventConstants.APP_OPEN
-    ) : AnalyticsEvent {
-        override fun toSegmentation(): Map<String, Any> = mapOf()
-    }
+    ) : AnalyticsEvent
+
+    /**
+     * Calling
+     */
+    data class CallInitiated(
+        override val key: String = AnalyticsEventConstants.CALLING_INITIATED
+    ) : AnalyticsEvent
+
+    data class CallJoined(
+        override val key: String = AnalyticsEventConstants.CALLING_JOINED
+    ) : AnalyticsEvent
+
+    /**
+     * Backup
+     */
+    data class BackupExportFailed(
+        override val key: String = AnalyticsEventConstants.BACKUP_EXPORT_FAILED
+    ) : AnalyticsEvent
+
+    data class BackupRestoreSucceeded(
+        override val key: String = AnalyticsEventConstants.BACKUP_RESTORE_SUCCEEDED
+    ) : AnalyticsEvent
+
+    data class BackupRestoreFailed(
+        override val key: String = AnalyticsEventConstants.BACKUP_RESTORE_FAILED
+    ) : AnalyticsEvent
 }
 
 object AnalyticsEventConstants {
@@ -57,4 +81,17 @@ object AnalyticsEventConstants {
     const val APP_VERSION = "app_version"
     const val TEAM_IS_TEAM = "team_is_team"
     const val APP_OPEN = "app.open"
+
+    /**
+     * Calling
+     */
+    const val CALLING_INITIATED = "calling.initiated_call"
+    const val CALLING_JOINED = "calling.joined_call"
+
+    /**
+     * Backup
+     */
+    const val BACKUP_EXPORT_FAILED = "backup.export_failed"
+    const val BACKUP_RESTORE_SUCCEEDED = "backup.restore_succeeded"
+    const val BACKUP_RESTORE_FAILED = "backup.restore_failed"
 }

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/model/AnalyticsEvent.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/model/AnalyticsEvent.kt
@@ -95,6 +95,96 @@ interface AnalyticsEvent {
                 )
             }
         }
+
+        data class Text(
+            override val messageAction: String = AnalyticsEventConstants.CONTRIBUTED_TEXT
+        ) : Contributed {
+            override fun toSegmentation(): Map<String, Any> {
+                return mapOf(
+                    MESSAGE_ACTION_KEY to messageAction
+                )
+            }
+        }
+
+        data class Photo(
+            override val messageAction: String = AnalyticsEventConstants.CONTRIBUTED_PHOTO
+        ) : Contributed {
+            override fun toSegmentation(): Map<String, Any> {
+                return mapOf(
+                    MESSAGE_ACTION_KEY to messageAction
+                )
+            }
+        }
+
+        data class AudioCall(
+            override val messageAction: String = AnalyticsEventConstants.CONTRIBUTED_AUDIO_CALL
+        ) : Contributed {
+            override fun toSegmentation(): Map<String, Any> {
+                return mapOf(
+                    MESSAGE_ACTION_KEY to messageAction
+                )
+            }
+        }
+
+        data class VideoCall(
+            override val messageAction: String = AnalyticsEventConstants.CONTRIBUTED_VIDEO_CALL
+        ) : Contributed {
+            override fun toSegmentation(): Map<String, Any> {
+                return mapOf(
+                    MESSAGE_ACTION_KEY to messageAction
+                )
+            }
+        }
+
+        data class Gif(
+            override val messageAction: String = AnalyticsEventConstants.CONTRIBUTED_GIF
+        ) : Contributed {
+            override fun toSegmentation(): Map<String, Any> {
+                return mapOf(
+                    MESSAGE_ACTION_KEY to messageAction
+                )
+            }
+        }
+
+        data class Ping(
+            override val messageAction: String = AnalyticsEventConstants.CONTRIBUTED_PING
+        ) : Contributed {
+            override fun toSegmentation(): Map<String, Any> {
+                return mapOf(
+                    MESSAGE_ACTION_KEY to messageAction
+                )
+            }
+        }
+
+        data class File(
+            override val messageAction: String = AnalyticsEventConstants.CONTRIBUTED_FILE
+        ) : Contributed {
+            override fun toSegmentation(): Map<String, Any> {
+                return mapOf(
+                    MESSAGE_ACTION_KEY to messageAction
+                )
+            }
+        }
+
+        data class Video(
+            override val messageAction: String = AnalyticsEventConstants.CONTRIBUTED_VIDEO
+        ) : Contributed {
+            override fun toSegmentation(): Map<String, Any> {
+                return mapOf(
+                    MESSAGE_ACTION_KEY to messageAction
+                )
+            }
+        }
+
+        data class Audio(
+            override val messageAction: String = AnalyticsEventConstants.CONTRIBUTED_AUDIO
+        ) : Contributed {
+            override fun toSegmentation(): Map<String, Any> {
+                return mapOf(
+                    MESSAGE_ACTION_KEY to messageAction
+                )
+            }
+        }
     }
 }
 

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/model/AnalyticsEvent.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/model/AnalyticsEvent.kt
@@ -17,6 +17,9 @@
  */
 package com.wire.android.feature.analytics.model
 
+import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CONTRIBUTED_LOCATION
+import com.wire.android.feature.analytics.model.AnalyticsEventConstants.MESSAGE_ACTION_KEY
+
 interface AnalyticsEvent {
     /**
      * Key to be used to differentiate every event
@@ -73,6 +76,26 @@ interface AnalyticsEvent {
     data class BackupRestoreFailed(
         override val key: String = AnalyticsEventConstants.BACKUP_RESTORE_FAILED
     ) : AnalyticsEvent
+
+    /**
+     * Contributed, message action related
+     */
+    sealed interface Contributed : AnalyticsEvent {
+        override val key: String
+            get() = AnalyticsEventConstants.CONTRIBUTED
+
+        val messageAction: String
+
+        data class Location(
+            override val messageAction: String = CONTRIBUTED_LOCATION
+        ) : Contributed {
+            override fun toSegmentation(): Map<String, Any> {
+                return mapOf(
+                    MESSAGE_ACTION_KEY to messageAction
+                )
+            }
+        }
+    }
 }
 
 object AnalyticsEventConstants {
@@ -94,4 +117,11 @@ object AnalyticsEventConstants {
     const val BACKUP_EXPORT_FAILED = "backup.export_failed"
     const val BACKUP_RESTORE_SUCCEEDED = "backup.restore_succeeded"
     const val BACKUP_RESTORE_FAILED = "backup.restore_failed"
+
+    /**
+     * Contributed, message related
+     */
+    const val CONTRIBUTED = "contributed"
+    const val MESSAGE_ACTION_KEY = "message_action"
+    const val CONTRIBUTED_LOCATION = "location"
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10589" title="WPB-10589" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10589</a>  [Android] Implement events and segmentation as is on iOS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Implement anonymous analytics for events contribution,

### Causes (Optional)

Never implemented

### Solutions

Implement the same as the other platforms were doing

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
