### PR TITLE
fix: initials avatar use regex instead and add content description (WPB-10896)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/model/UserAvatarData.kt
+++ b/app/src/main/kotlin/com/wire/android/model/UserAvatarData.kt
@@ -46,7 +46,7 @@ data class NameBasedAvatar(val fullName: String?, val accentColor: Int) {
     val initials: String
         get() {
             if (fullName.isNullOrEmpty()) return String.EMPTY
-            val names = fullName.split(" ").map { it.uppercase() }
+            val names = fullName.split(EMPTY_REGEX).filter { it.isNotEmpty() }.map { it.uppercase() }
             return when {
                 names.size > 1 -> {
                     val initials = names.map { it.first() }
@@ -57,3 +57,5 @@ data class NameBasedAvatar(val fullName: String?, val accentColor: Int) {
             }
         }
 }
+
+val EMPTY_REGEX = "\\s".toRegex()

--- a/app/src/main/kotlin/com/wire/android/ui/common/UserProfileAvatar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/UserProfileAvatar.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -191,8 +193,10 @@ private fun DefaultInitialsAvatar(
     avatarBorderSize: Dp,
     size: Dp = MaterialTheme.wireDimensions.avatarDefaultSize
 ) {
+    val contentDescription = stringResource(R.string.content_description_user_avatar)
     Box(
         modifier = Modifier
+            .semantics { this.contentDescription = contentDescription }
             .withAvatarSize(size, avatarBorderSize, dimensions().avatarStatusBorderSize, type)
             .let { withAvatarBorders(type, avatarBorderSize, it) }
             .clip(CircleShape)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10896" title="WPB-10896" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10896</a>  [Android] App is crashing when user does not have an avatar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Crash when user had more than one space on their name

### Causes (Optional)

Not using regex for whitespace

### Solutions

- Use the regex instead
- Also add content description to the initials avatar for a11y

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
