### PR TITLE
fix: Long usernames are not displayed correctly when calling in a group conversation (WPB-992)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallerDetails.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallerDetails.kt
@@ -21,6 +21,8 @@ package com.wire.android.ui.calling.common
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -33,6 +35,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import com.wire.android.R
 import com.wire.android.model.ImageAsset
 import com.wire.android.model.NameBasedAvatar
@@ -49,13 +53,13 @@ import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.conversationslist.model.hasLabel
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
-import com.wire.android.util.EMPTY
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.call.ConversationTypeForCall
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import java.util.Locale
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun CallerDetails(
     conversationId: ConversationId,
@@ -66,7 +70,7 @@ fun CallerDetails(
     avatarAssetId: ImageAsset.UserAvatarAsset?,
     conversationTypeForCall: ConversationTypeForCall,
     membership: Membership,
-    callingLabel: String,
+    groupCallerName: String?,
     protocolInfo: Conversation.ProtocolInfo?,
     mlsVerificationStatus: Conversation.VerificationStatus?,
     proteusVerificationStatus: Conversation.VerificationStatus?,
@@ -119,12 +123,42 @@ fun CallerDetails(
                 proteusVerificationStatus
             )
         }
-        Text(
-            text = callingLabel,
-            color = colorsScheme().onBackground,
-            style = MaterialTheme.wireTypography.body01,
-            modifier = Modifier.padding(top = dimensions().spacing8x)
-        )
+
+        FlowRow(
+            modifier = Modifier.padding(
+                top = dimensions().spacing8x,
+                start = dimensions().spacing24x,
+                end = dimensions().spacing24x
+            ),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            groupCallerName?.let { name ->
+                Text(
+                    text = name,
+                    color = colorsScheme().onBackground,
+                    style = MaterialTheme.wireTypography.body01,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            val isCallingLabel =
+                if (conversationTypeForCall == ConversationTypeForCall.Conference) {
+                    stringResource(R.string.calling_label_incoming_call_someone_calling)
+                } else stringResource(R.string.calling_label_incoming_call)
+            Text(
+                modifier = Modifier.padding(
+                    start = dimensions().spacing2x,
+                ),
+                text = isCallingLabel,
+                color = colorsScheme().onBackground,
+                style = MaterialTheme.wireTypography.body01,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+
         if (membership.hasLabel()) {
             VerticalSpace.x16()
             MembershipQualifierLabel(membership)
@@ -139,7 +173,10 @@ fun CallerDetails(
             UserProfileAvatar(
                 avatarData = UserAvatarData(
                     asset = avatarAssetId,
-                    nameBasedAvatar = NameBasedAvatar((conversationName as? ConversationName.Known)?.name, accentId)
+                    nameBasedAvatar = NameBasedAvatar(
+                        (conversationName as? ConversationName.Known)?.name,
+                        accentId
+                    )
                 ),
                 size = dimensions().outgoingCallUserAvatarSize,
                 modifier = Modifier.padding(top = dimensions().spacing16x)
@@ -150,7 +187,7 @@ fun CallerDetails(
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewCallerDetails() {
+fun PreviewCallerDetailsOneOnOneCall() {
     WireTheme {
         CallerDetails(
             conversationId = ConversationId("value", "domain"),
@@ -160,7 +197,51 @@ fun PreviewCallerDetails() {
             avatarAssetId = null,
             conversationTypeForCall = ConversationTypeForCall.OneOnOne,
             membership = Membership.Guest,
-            callingLabel = String.EMPTY,
+            groupCallerName = null,
+            protocolInfo = null,
+            mlsVerificationStatus = null,
+            proteusVerificationStatus = Conversation.VerificationStatus.VERIFIED,
+            onMinimiseScreen = { },
+            accentId = -1
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewCallerDetailsGroupCallWithLongName() {
+    WireTheme {
+        CallerDetails(
+            conversationId = ConversationId("value", "domain"),
+            conversationName = ConversationName.Known("Some fake group name"),
+            isCameraOn = false,
+            isCbrEnabled = false,
+            avatarAssetId = null,
+            conversationTypeForCall = ConversationTypeForCall.Conference,
+            membership = Membership.Guest,
+            groupCallerName = "Caller name long name with lots of characters to make it a long name",
+            protocolInfo = null,
+            mlsVerificationStatus = null,
+            proteusVerificationStatus = Conversation.VerificationStatus.VERIFIED,
+            onMinimiseScreen = { },
+            accentId = -1
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewCallerDetailsGroupCallWithShortName() {
+    WireTheme {
+        CallerDetails(
+            conversationId = ConversationId("value", "domain"),
+            conversationName = ConversationName.Known("Some fake group name"),
+            isCameraOn = false,
+            isCbrEnabled = false,
+            avatarAssetId = null,
+            conversationTypeForCall = ConversationTypeForCall.Conference,
+            membership = Membership.Guest,
+            groupCallerName = "Caller name",
             protocolInfo = null,
             mlsVerificationStatus = null,
             proteusVerificationStatus = Conversation.VerificationStatus.VERIFIED,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallerDetails.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallerDetails.kt
@@ -145,7 +145,9 @@ fun CallerDetails(
             val isCallingLabel =
                 if (conversationTypeForCall == ConversationTypeForCall.Conference) {
                     stringResource(R.string.calling_label_incoming_call_someone_calling)
-                } else stringResource(R.string.calling_label_incoming_call)
+                } else {
+                    stringResource(R.string.calling_label_incoming_call)
+                }
             Text(
                 modifier = Modifier.padding(
                     start = dimensions().spacing2x,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
@@ -40,6 +40,7 @@ import com.wire.android.appLogger
 import com.wire.android.ui.LocalActivity
 import com.wire.android.ui.calling.CallActivity
 import com.wire.android.ui.calling.CallState
+import com.wire.android.ui.calling.ConversationName
 import com.wire.android.ui.calling.SharedCallingViewModel
 import com.wire.android.ui.calling.common.CallVideoPreview
 import com.wire.android.ui.calling.common.CallerDetails
@@ -246,9 +247,10 @@ private fun IncomingCallContent(
                 onVideoPreviewCreated = onVideoPreviewCreated,
                 onSelfClearVideoPreview = onSelfClearVideoPreview
             )
-            val isCallingString = if (callState.conversationTypeForCall == ConversationTypeForCall.Conference) {
-                stringResource(R.string.calling_label_incoming_call_someone_calling, callState.callerName ?: "")
-            } else stringResource(R.string.calling_label_incoming_call)
+
+            val groupCallerName = if (callState.conversationTypeForCall == ConversationTypeForCall.Conference) {
+                callState.callerName
+            } else null
 
             CallerDetails(
                 conversationId = callState.conversationId,
@@ -258,7 +260,7 @@ private fun IncomingCallContent(
                 avatarAssetId = callState.avatarAssetId,
                 conversationTypeForCall = callState.conversationTypeForCall,
                 membership = callState.membership,
-                callingLabel = isCallingString,
+                groupCallerName = groupCallerName,
                 protocolInfo = callState.protocolInfo,
                 mlsVerificationStatus = callState.mlsVerificationStatus,
                 proteusVerificationStatus = callState.proteusVerificationStatus,
@@ -284,9 +286,34 @@ fun AudioPermissionCheckFlow(
 
 @Preview
 @Composable
-fun PreviewIncomingCallScreen() {
+fun PreviewIncomingOneOnOneCallScreen() {
     IncomingCallContent(
-        callState = CallState(ConversationId("value", "domain")),
+        callState = CallState(
+            conversationId = ConversationId("value", "domain"),
+            conversationName = ConversationName.Known("Jon Doe"),
+            conversationTypeForCall = ConversationTypeForCall.OneOnOne
+        ),
+        toggleMute = { },
+        toggleVideo = { },
+        declineCall = { },
+        acceptCall = { },
+        onVideoPreviewCreated = { },
+        onSelfClearVideoPreview = { },
+        onCameraPermissionPermanentlyDenied = { },
+        onMinimiseScreen = { }
+    )
+}
+
+@Preview
+@Composable
+fun PreviewIncomingGroupCallScreen() {
+    IncomingCallContent(
+        callState = CallState(
+            conversationId = ConversationId("value", "domain"),
+            conversationName = ConversationName.Known("Fake group name"),
+            callerName = "Jon Doe",
+            conversationTypeForCall = ConversationTypeForCall.Conference
+        ),
         toggleMute = { },
         toggleVideo = { },
         declineCall = { },

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
@@ -250,7 +250,9 @@ private fun IncomingCallContent(
 
             val groupCallerName = if (callState.conversationTypeForCall == ConversationTypeForCall.Conference) {
                 callState.callerName
-            } else null
+            } else {
+                null
+            }
 
             CallerDetails(
                 conversationId = callState.conversationId,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/outgoing/OutgoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/outgoing/OutgoingCallScreen.kt
@@ -177,7 +177,7 @@ private fun OutgoingCallContent(
                 avatarAssetId = callState.avatarAssetId,
                 conversationTypeForCall = callState.conversationTypeForCall,
                 membership = callState.membership,
-                callingLabel = stringResource(id = R.string.calling_label_ringing_call),
+                groupCallerName = stringResource(id = R.string.calling_label_ringing_call),
                 protocolInfo = callState.protocolInfo,
                 mlsVerificationStatus = callState.mlsVerificationStatus,
                 proteusVerificationStatus = callState.proteusVerificationStatus,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -794,7 +794,7 @@
     <string name="calling_decline_call">Anruf ablehnen</string>
     <string name="calling_label_ringing_call">Klingeln…</string>
     <string name="calling_label_incoming_call">Ruft an…</string>
-    <string name="calling_label_incoming_call_someone_calling">%s ruft an…</string>
+    <string name="calling_label_incoming_call_someone_calling">ruft an…</string>
     <string name="calling_label_default_caller_name">Eingehender Anruf</string>
     <string name="calling_label_constant_bit_rate">KONSTANTE BITRATE</string>
     <string name="calling_minimize_view">Ansicht verkleinern</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -691,7 +691,7 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="calling_decline_call">Rechazar llamada</string>
     <string name="calling_label_ringing_call">Sonando...</string>
     <string name="calling_label_incoming_call">Llamando...</string>
-    <string name="calling_label_incoming_call_someone_calling">%s est&#225; llamando...</string>
+    <string name="calling_label_incoming_call_someone_calling">est&#225; llamando...</string>
     <string name="calling_label_default_caller_name">Llamada entrante</string>
     <string name="calling_label_constant_bit_rate">BIT RATE constante</string>
     <string name="calling_minimize_view">Minimizar vista</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -322,7 +322,7 @@
     <string name="calling_decline_call">Keeldu kõnest</string>
     <string name="calling_label_ringing_call">Heliseb…</string>
     <string name="calling_label_incoming_call">Helistab…</string>
-    <string name="calling_label_incoming_call_someone_calling">%s helistab…</string>
+    <string name="calling_label_incoming_call_someone_calling">helistab…</string>
     <string name="calling_label_default_caller_name">Sissetulev kõne</string>
     <string name="calling_label_constant_bit_rate">ÜHTLANE BITISAGEDUS</string>
     <string name="calling_minimize_view">Minimeeri vaade</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -826,7 +826,7 @@
     <string name="calling_decline_call">Hívás elutasítása</string>
     <string name="calling_label_ringing_call">Kicseng…</string>
     <string name="calling_label_incoming_call">Hívás…</string>
-    <string name="calling_label_incoming_call_someone_calling">%s hívja…</string>
+    <string name="calling_label_incoming_call_someone_calling">hívja…</string>
     <string name="calling_label_default_caller_name">Bejövő hívás</string>
     <string name="calling_label_constant_bit_rate">ÁLLANDÓ BITSEBESSÉG (CBR)</string>
     <string name="calling_minimize_view">Összecsukott nézet</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -795,7 +795,7 @@ Fino a 500 persone possono unirsi a una conversazione di gruppo.</string>
     <string name="calling_decline_call">Rifiuta la chiamata</string>
     <string name="calling_label_ringing_call">In chiamata...</string>
     <string name="calling_label_incoming_call">Chiamata in arrivo...</string>
-    <string name="calling_label_incoming_call_someone_calling">%s sta chiamando...</string>
+    <string name="calling_label_incoming_call_someone_calling">sta chiamando...</string>
     <string name="calling_label_default_caller_name">Chiamata in entrata</string>
     <string name="calling_label_constant_bit_rate">BIT RATE costante</string>
     <string name="calling_minimize_view">Minimizza la vista</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -666,7 +666,7 @@ Do grupy mo&#380;e do&#322;&#261;czy&#263; maksymalnie 500 os&#243;b.</string>
     <string name="calling_decline_call">Odrzu&#263; po&#322;&#261;czenie</string>
     <string name="calling_label_ringing_call">Dzwoni...</string>
     <string name="calling_label_incoming_call">Przychodz&#261;ce po&#322;&#261;czenie...</string>
-    <string name="calling_label_incoming_call_someone_calling">%s dzwoni...</string>
+    <string name="calling_label_incoming_call_someone_calling">dzwoni...</string>
     <string name="calling_label_default_caller_name">Przychodz&#261;ce po&#322;&#261;czenie</string>
     <string name="calling_label_constant_bit_rate">STA&#321;A PR&#280;DKO&#346;&#262; PO&#321;&#260;CZENIA</string>
     <string name="calling_minimize_view">Minimalizuj widok</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -731,7 +731,7 @@ Até 500 pessoas podem participar de uma conversa em grupo.</string>
     <string name="calling_decline_call">Recusar chamada</string>
     <string name="calling_label_ringing_call">Chamando…</string>
     <string name="calling_label_incoming_call">Chamada recebida</string>
-    <string name="calling_label_incoming_call_someone_calling">%s está chamando…</string>
+    <string name="calling_label_incoming_call_someone_calling">está chamando…</string>
     <string name="calling_label_default_caller_name">Chamada Recebida</string>
     <string name="calling_label_constant_bit_rate">TAXA DE BITS CONSTANTE</string>
     <string name="calling_minimize_view">Minimizar visualização</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -873,7 +873,7 @@
     <string name="calling_decline_call">Отклонить вызов</string>
     <string name="calling_label_ringing_call">Вызываем…</string>
     <string name="calling_label_incoming_call">Вызов…</string>
-    <string name="calling_label_incoming_call_someone_calling">%s вызывает…</string>
+    <string name="calling_label_incoming_call_someone_calling">вызывает…</string>
     <string name="calling_label_default_caller_name">Входящий вызов</string>
     <string name="calling_label_constant_bit_rate">ПОСТОЯННЫЙ БИТРЕЙТ</string>
     <string name="calling_minimize_view">Свернуть</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -802,7 +802,7 @@
     <string name="calling_decline_call">ඇමතුම නවතන්න</string>
     <string name="calling_label_ringing_call">නාද වෙමින්…</string>
     <string name="calling_label_incoming_call">අමතමින්…</string>
-    <string name="calling_label_incoming_call_someone_calling">%s අමතමින්…</string>
+    <string name="calling_label_incoming_call_someone_calling">අමතමින්…</string>
     <string name="calling_label_default_caller_name">ලැබෙන ඇමතුම</string>
     <string name="calling_label_constant_bit_rate">අචල බිටු අනුපාතය</string>
     <string name="calling_minimize_view">දැක්ම හකුළන්න</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -424,7 +424,7 @@
     <string name="calling_button_label_camera">Kamera</string>
     <string name="calling_button_label_speaker">Högtalare</string>
     <string name="calling_label_ringing_call">Ringer…</string>
-    <string name="calling_label_incoming_call_someone_calling">%s ringer…</string>
+    <string name="calling_label_incoming_call_someone_calling">ringer…</string>
     <string name="calling_label_default_caller_name">Inkommande samtal</string>
     <string name="calling_ongoing_call_start_anyway">Ring ändå</string>
     <!-- Connectivity Status Bar -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -879,7 +879,7 @@
     <string name="calling_decline_call">Decline call</string>
     <string name="calling_label_ringing_call">Ringing…</string>
     <string name="calling_label_incoming_call">Calling…</string>
-    <string name="calling_label_incoming_call_someone_calling">%s is calling…</string>
+    <string name="calling_label_incoming_call_someone_calling">is calling…</string>
     <string name="calling_label_default_caller_name">Incoming call</string>
     <string name="calling_label_constant_bit_rate">CONSTANT BIT RATE</string>
     <string name="calling_minimize_view">Minimize view</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-992" title="WPB-992" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-992</a>  Long usernames are not displayed correctly when calling in a group conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Long usernames are not displayed correctly when calling in a group conversation. 

<img width="435" alt="Screenshot 2024-09-12 at 17 09 45" src="https://github.com/user-attachments/assets/778720aa-4a3d-454c-8fed-e40aab26a46c">

### Solutions

I separated the text in two two Texts and put them inside a flowRow. This way if caller name is long then we will add 3 dots at the end and put "is calling" text in a new line.

<img width="205" alt="Screenshot 2024-09-12 at 17 07 34" src="https://github.com/user-attachments/assets/423a68e5-0b03-4568-87ed-abeda4b2b17b">

<img width="205" alt="Screenshot 2024-09-12 at 17 07 43" src="https://github.com/user-attachments/assets/2c0f7436-0098-4136-9fe4-704e58f6387b">

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
