### PR TITLE
fix: wav to mp4 conversion [WPB-11095]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -36,6 +36,7 @@ import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -278,6 +279,7 @@ class AudioMediaRecorder @Inject constructor(
                         muxer.start()
                         retryCount = 0
                     }
+
                     outputBufferIndex >= 0 -> {
                         val outputBuffer = codec.getOutputBuffer(outputBufferIndex)
 
@@ -304,9 +306,10 @@ class AudioMediaRecorder @Inject constructor(
                             sawOutputEOS = true
                         }
                     }
+
                     outputBufferIndex == MediaCodec.INFO_TRY_AGAIN_LATER -> {
                         retryCount++
-                        Thread.sleep(RETRY_DELAY_IN_MILLIS)
+                        delay(RETRY_DELAY_IN_MILLIS)
                     }
                 }
             }
@@ -376,7 +379,7 @@ class AudioMediaRecorder @Inject constructor(
         private const val BIT_RATE = 64000
         private const val TIMEOUT_US: Long = 10000
         const val NANOSECONDS_IN_MICROSECOND = 1000
-        const val MAX_RETRY_COUNT = 1000
-        const val RETRY_DELAY_IN_MILLIS = 10L
+        const val MAX_RETRY_COUNT = 100
+        const val RETRY_DELAY_IN_MILLIS = 100L
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11095" title="WPB-11095" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11095</a>  [Android] Crash after voice recording
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The application was experiencing a crash when converting WAV files to MP4 format on devices running Android 12 or lower. The crash was due to a `NullPointerException` occurring in the convertWavToMp4 method within the AudioMediaRecorder class.

### Causes (Optional)

- Incorrect Handling of `MediaCodec.INFO_TRY_AGAIN_LATER`: In the convertWavToMp4 method, the MediaCodec.dequeueOutputBuffer method could return MediaCodec.INFO_TRY_AGAIN_LATER, indicating that no output buffer is currently available and to try again later. The existing code was throwing an IllegalStateException when this happened, causing the encoding loop to exit prematurely. This improper handling led to variables not being properly initialized or resources not being correctly released, resulting in a NullPointerException and subsequent app crash.

- Infinite Loop Concern: There was a concern that by correctly handling INFO_TRY_AGAIN_LATER (i.e., by simply continuing the loop), we might inadvertently create an infinite loop if the codec continually fails to produce an output buffer.

### Solutions

- Proper Handling of `MediaCodec.INFO_TRY_AGAIN_LATER`: Updated the convertWavToMp4 method to correctly handle `INFO_TRY_AGAIN_LATER` by continuing the loop without throwing an exception. This allows the MediaCodec to eventually provide an output buffer when it's ready, which is the expected behavior.

- Maximum Retry Count: Introduced a maxRetries variable to limit the number of times the loop will attempt to dequeue an output buffer after receiving `INFO_TRY_AGAIN_LATER`. This ensures that if the codec fails to provide an output buffer after a reasonable number of attempts, the method will exit gracefully without causing an infinite loop.

- Delay Between Retries: Added a short delay (Thread.sleep(10)) between retries when `INFO_TRY_AGAIN_LATER` is received. This prevents a tight loop that could consume excessive CPU resources.

- Retry Count Reset: The retry count is reset whenever an output buffer is successfully dequeued or when the output format changes. This allows the retry mechanism to only count consecutive failures.