### PR TITLE
fix: move colliding file is prohibited text to new line (WPB-10181)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
@@ -232,6 +232,7 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
             val (
                 name, icon, size, message
             ) = createRefs()
+
             Text(
                 text = assetName,
                 style = MaterialTheme.wireTypography.body02,
@@ -251,7 +252,6 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
                     .width(dimensions().spacing12x)
                     .constrainAs(icon) {
                         top.linkTo(name.bottom)
-                        bottom.linkTo(parent.bottom)
                         start.linkTo(parent.start)
                     },
                 painter = painterResource(
@@ -269,7 +269,8 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
                     .padding(start = dimensions().spacing4x)
                     .constrainAs(size) {
                         start.linkTo(icon.end)
-                        top.linkTo(name.bottom)
+                        top.linkTo(icon.top)
+                        bottom.linkTo(icon.bottom)
                     }
             )
 
@@ -278,9 +279,11 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long) {
                 style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1,
-                modifier = Modifier.constrainAs(message) {
-                    end.linkTo(parent.end)
-                    top.linkTo(name.bottom)
+                modifier = Modifier
+                    .padding(top = dimensions().spacing4x)
+                    .constrainAs(message) {
+                    start.linkTo(parent.start)
+                    top.linkTo(icon.bottom)
                 }
             )
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10181" title="WPB-10181" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10181</a>  [Android] File name is colliding with "receiving of files is prohibited" text, when receiving files
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When files are prohibited on a team account and a guest with no restriction of sending files send a file, the prohibition text was colliding with file size information.

### Solutions

Move prohibition text to new line so its easily visible and not colliding.

### Testing

#### How to Test

- Have 2 accounts (1 team with assets prohibition, 1 account with no restrictions)
- have a group between them
- send a file from account 2 on the group
- account 1 should show that file receiving is prohibited and text is clearly visible

### Attachments (Optional)

<img src="https://github.com/user-attachments/assets/6260598d-b871-4811-b688-d2da9e320fb3" width="200" height="400" />