### PR TITLE
fix: crash on starting global analytics was not ready (WPB-11111)

### DIFF
--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerImpl.kt
@@ -42,10 +42,6 @@ object AnonymousAnalyticsManagerImpl : AnonymousAnalyticsManager {
     private val mutex = Mutex()
     private lateinit var coroutineScope: CoroutineScope
 
-    init {
-        globalAnalyticsManager = this
-    }
-
     override fun <T> init(
         context: Context,
         analyticsSettings: AnalyticsSettings,
@@ -57,6 +53,7 @@ object AnonymousAnalyticsManagerImpl : AnonymousAnalyticsManager {
     ) {
         this.coroutineScope = CoroutineScope(dispatcher)
         this.anonymousAnalyticsRecorder = anonymousAnalyticsRecorder
+        globalAnalyticsManager = this
 
         coroutineScope.launch {
             analyticsResultFlow


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11111" title="WPB-11111" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11111</a>  [Android] crash caused by countly on activity startup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

It can happen that Global analytics manager is being used before initialization

### Causes (Optional)

lateinit var not ready 

### Solutions

Delay globalanalytics manager after coroutine scope and dependencies are assigned


### Testing

Manually tested


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
