### PR TITLE
fix: crash on removing images on preview screen [WPB-11147]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/ImagesPreviewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/ImagesPreviewScreen.kt
@@ -202,6 +202,9 @@ private fun Content(
             CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
                 HorizontalPager(
                     state = pagerState,
+                    key = { index: Int ->
+                        previewState.assetBundleList.getOrNull(index)?.assetBundle?.key ?: ""
+                    },
                     modifier = Modifier
                         .width(configuration.screenWidthDp.dp)
                         .fillMaxHeight(),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11147" title="WPB-11147" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11147</a>  [Android] Crash on removing images on preview page
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app crashes when user tries to remove not currently selected image on preview screen.

### Causes (Optional)

`HorizontalPager` uses `SubcomposeLayout`, so after changing the state and removing some items, it still uses old state containing removed element when running the subcomposition to compose pages.

### Solutions

Provide a key which uniquely identifies each page, so if you add/remove items before the current visible item the item with the given key will be kept as the first visible one.

### Testing

#### How to Test

STR:
-open conversation
-tap on attachments > gallery
-select 3 images
-on preview screen, tap on the second image (to see it in full view)
-delete the first image
-app should not crash and the image should be removed

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
