### PR TITLE
fix: Crash on starting foreground service for calling (WPB-11112)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/services/CallService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/CallService.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -121,6 +122,8 @@ class CallService : Service() {
                     .distinctUntilChanged()
                     .flatMapRight { callData ->
                         callNotificationManager.reloadIfNeeded(callData)
+                    }.debounce {
+                        if (it is Either.Left) ServicesManager.DEBOUNCE_TIME else 0L
                     }
                     .collectLatest {
                         it.fold(

--- a/app/src/main/kotlin/com/wire/android/services/ServicesManager.kt
+++ b/app/src/main/kotlin/com/wire/android/services/ServicesManager.kt
@@ -52,7 +52,7 @@ class ServicesManager @Inject constructor(
     init {
         scope.launch {
             callServiceEvents
-                .debounce { if (!it) 0L else DEBOUNCE_TIME } // debounce to avoid starting and stopping service too fast
+                .debounce { if (it) 0L else DEBOUNCE_TIME } // debounce to avoid starting and stopping service too fast
                 .distinctUntilChanged()
                 .collectLatest { shouldBeStarted ->
                     if (!shouldBeStarted) {
@@ -127,6 +127,6 @@ class ServicesManager @Inject constructor(
 
     companion object {
         @VisibleForTesting
-        internal const val DEBOUNCE_TIME = 200L
+        const val DEBOUNCE_TIME = 500L
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11112" title="WPB-11112" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11112</a>  [Android] crash on starting foreground service for calling
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app is still crashing when the user starts a call, put it in background and then other user answer the call

### Causes (Optional)

When we start a call, a new service will start. That service can be stopped at the moment of accepting the call (`outgoingCallFlow` does not emit anything) and then started when the call is established. 
And this will cause the app to crash.

### Solutions

- Add some debounce before the service can stop itself. This way the stop event of service will be ignored as it will be followed by start event.
- Increase the debounce time, as the call can get established in more than 200ms.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
