### PR TITLE
fix: audio converting error on lower APIs [WPB-11242]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -298,8 +298,6 @@ class AudioMediaRecorder @Inject constructor(
                         val outputBuffer = codec.getOutputBuffer(outputBufferIndex)
 
                         if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG != 0) {
-//                            codec.releaseOutputBuffer(outputBufferIndex, false)
-//                            continue
                             bufferInfo.size = 0
                         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -259,6 +259,8 @@ class AudioMediaRecorder @Inject constructor(
             var sawOutputEOS = false
 
             var retryCount = 0
+            var totalBytesRead = 0L
+            val bytesPerSample = BITS_PER_SAMPLE / BITS_PER_BYTE // 16 / 8 = 2
 
             while (!sawOutputEOS && retryCount < MAX_RETRY_COUNT) {
                 if (!sawInputEOS) {
@@ -272,7 +274,11 @@ class AudioMediaRecorder @Inject constructor(
                             codec.queueInputBuffer(inputBufferIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
                             sawInputEOS = true
                         } else {
-                            val presentationTimeUs = System.nanoTime() / NANOSECONDS_IN_MICROSECOND
+                            totalBytesRead += sampleSize
+
+                            val totalSamplesRead = totalBytesRead / bytesPerSample
+                            val presentationTimeUs = (totalSamplesRead * 1_000_000L) / SAMPLING_RATE
+
                             codec.queueInputBuffer(inputBufferIndex, 0, sampleSize, presentationTimeUs, 0)
                         }
                     }
@@ -392,7 +398,6 @@ class AudioMediaRecorder @Inject constructor(
 
         private const val BIT_RATE = 64000
         private const val TIMEOUT_US: Long = 10000
-        const val NANOSECONDS_IN_MICROSECOND = 1000
         const val MAX_RETRY_COUNT = 100
         const val RETRY_DELAY_IN_MILLIS = 100L
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11242" title="WPB-11242" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11242</a>  [Android] Crash on Android 9 when sending recorded audio
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On Android 9, the app is crashing when sending a recorded audio.

### Causes (Optional)

Crash due to out of order frames.

### Solutions

Change the way `presentationTimeUs` is calculated, it looks like starting from some value different than 0 is error-prone, so make sure that it starts with 0. Returning `success` to not send faulty file if something wrong happened during the conversion. 

### Testing

#### How to Test

It was crashing on device with Android 9 when clicking "send" after user finished recording audio message.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
