### PR TITLE
feat: Hide Service switcher on creating MLS group [WPB-11156]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupMetadataState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupMetadataState.kt
@@ -34,6 +34,7 @@ data class GroupMetadataState(
     val mode: GroupNameMode = GroupNameMode.CREATION,
     val isSelfTeamMember: Boolean? = null,
     val isGroupCreatingAllowed: Boolean? = null,
+    val isServicesAllowed: Boolean = false
 ) {
     sealed interface NewGroupError {
         data object None : NewGroupError

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -66,7 +66,15 @@ class NewConversationViewModel @Inject constructor(
         }
     )
 
-    var groupOptionsState: GroupOptionState by mutableStateOf(GroupOptionState())
+    var groupOptionsState: GroupOptionState by mutableStateOf(
+        GroupOptionState().let {
+            val isMLS = newGroupState.groupProtocol == ConversationOptions.Protocol.MLS
+            it.copy(
+                isAllowServicesEnabled = !isMLS,
+                isAllowServicesPossible = !isMLS
+            )
+        }
+    )
     var createGroupState: CreateGroupState by mutableStateOf(CreateGroupState())
 
     init {
@@ -87,8 +95,8 @@ class NewConversationViewModel @Inject constructor(
             newGroupNameTextState.textAsFlow()
                 .dropWhile { it.isEmpty() } // ignore first empty value to not show the error before the user typed anything
                 .collectLatest {
-                newGroupState = GroupNameValidator.onGroupNameChange(it.toString(), newGroupState)
-            }
+                    newGroupState = GroupNameValidator.onGroupNameChange(it.toString(), newGroupState)
+                }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionState.kt
@@ -24,5 +24,6 @@ data class GroupOptionState(
     val isAllowGuestEnabled: Boolean = true,
     val isAllowServicesEnabled: Boolean = true,
     val isReadReceiptEnabled: Boolean = true,
-    val showAllowGuestsDialog: Boolean = false
+    val showAllowGuestsDialog: Boolean = false,
+    val isAllowServicesPossible: Boolean = true,
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
@@ -190,6 +190,8 @@ private fun GroupOptionState.ReadReceiptsOptions(onReadReceiptChanged: (Boolean)
 
 @Composable
 private fun GroupOptionState.AllowServicesOptions(onAllowServicesChanged: (Boolean) -> Unit) {
+    if (!isAllowServicesPossible) return
+    
     GroupConversationOptionsItem(
         title = stringResource(R.string.allow_services),
         switchState = SwitchState.Enabled(value = isAllowServicesEnabled,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
@@ -191,7 +191,7 @@ private fun GroupOptionState.ReadReceiptsOptions(onReadReceiptChanged: (Boolean)
 @Composable
 private fun GroupOptionState.AllowServicesOptions(onAllowServicesChanged: (Boolean) -> Unit) {
     if (!isAllowServicesPossible) return
-    
+
     GroupConversationOptionsItem(
         title = stringResource(R.string.allow_services),
         switchState = SwitchState.Enabled(value = isAllowServicesEnabled,

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -181,14 +181,6 @@ internal class NewConversationViewModelArrangement {
         ))
     }
 
-    fun withGuestEnabled(isGuestModeEnabled: Boolean) = apply {
-        groupOptionsState = groupOptionsState.copy(isAllowGuestEnabled = isGuestModeEnabled)
-    }
-
-    fun withServicesEnabled(areServicesEnabled: Boolean) = apply {
-        groupOptionsState = groupOptionsState.copy(isAllowServicesEnabled = areServicesEnabled)
-    }
-
     fun withDefaultProtocol(supportedProtocol: SupportedProtocol) = apply {
         every { getDefaultProtocol() } returns supportedProtocol
     }
@@ -198,7 +190,6 @@ internal class NewConversationViewModelArrangement {
         getSelfUser = getSelfUserUseCase,
         getDefaultProtocol = getDefaultProtocol
     ).also {
-        it.groupOptionsState = groupOptionsState
         it.createGroupState = createGroupState
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -21,7 +21,6 @@ package com.wire.android.ui.home.newconversation
 import com.wire.android.config.mockUri
 import com.wire.android.framework.TestUser
 import com.wire.android.ui.home.newconversation.common.CreateGroupState
-import com.wire.android.ui.home.newconversation.groupOptions.GroupOptionState
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -71,8 +71,6 @@ internal class NewConversationViewModelArrangement {
     @MockK
     lateinit var getDefaultProtocol: GetDefaultProtocolUseCase
 
-    private var groupOptionsState: GroupOptionState = GroupOptionState()
-
     private var createGroupState: CreateGroupState = CreateGroupState()
 
     private companion object {

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -128,10 +128,10 @@ class NewConversationViewModelTest {
         runTest {
             val (arrangement, viewModel) = NewConversationViewModelArrangement()
                 .withGetSelfUser(isTeamMember = true)
-                .withServicesEnabled(false)
-                .withGuestEnabled(true)
                 .arrange()
 
+            viewModel.onAllowServicesStatusChanged(false)
+            viewModel.onAllowGuestStatusChanged(true)
             viewModel.createGroup(arrangement.onGroupCreated)
             advanceUntilIdle()
 
@@ -158,32 +158,31 @@ class NewConversationViewModelTest {
         val (_, viewModel) = NewConversationViewModelArrangement()
             .withDefaultProtocol(SupportedProtocol.MLS)
             .withGetSelfUser(isTeamMember = true)
-            .withServicesEnabled(false)
-            .withGuestEnabled(true)
             .arrange()
 
         // when
         val result = viewModel.newGroupState.groupProtocol
+        val result2 = viewModel.groupOptionsState
 
         // then
-        assertEquals(
-            ConversationOptions.Protocol.MLS,
-            result
-        )
+        assertEquals(ConversationOptions.Protocol.MLS, result)
+        assertEquals(false, result2.isAllowServicesEnabled)
+        assertEquals(false, result2.isAllowServicesPossible)
     }
 
     @Test
     fun `given self is external team member, when creating group, then creating group should not be allowed`() = runTest {
-            // given
-            val (_, viewModel) = NewConversationViewModelArrangement()
-                .withGetSelfUser(isTeamMember = true, userType = UserType.EXTERNAL)
-                .arrange()
-            advanceUntilIdle()
-            // when
-            val result = viewModel.newGroupState.isGroupCreatingAllowed
-            // then
-            assertEquals(false, result)
-        }
+        // given
+        val (_, viewModel) = NewConversationViewModelArrangement()
+            .withGetSelfUser(isTeamMember = true, userType = UserType.EXTERNAL)
+            .arrange()
+        advanceUntilIdle()
+        // when
+        val result = viewModel.newGroupState.isGroupCreatingAllowed
+        // then
+        assertEquals(false, result)
+    }
+
     @Test
     fun `given self is internal team member, when creating group, then creating group should be allowed`() = runTest {
         // given


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11156" title="WPB-11156" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11156</a>  [Android] Hide and set to off the ability to toggle services in during group creation if MLS is standard protocol
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

As far as Services are not allowed in MLS conversation we should hide "Allow Services" switcher on creating MLS group conversations.

### Attachments (Optional)

<img width="270" alt="Screenshot 2024-09-25 at 14 30 24" src="https://github.com/user-attachments/assets/2efcab20-0b47-47a7-9e39-aec80c8fc8e8">
