### PR TITLE
fix: self-deleting asset message timer [WPB-1807] 🍒

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
@@ -32,9 +32,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.wire.android.R
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
-import com.wire.android.ui.home.conversations.model.UIMessageContent
-import com.wire.kalium.logic.data.asset.AssetTransferStatus
-import com.wire.kalium.logic.data.asset.isSaved
 import com.wire.kalium.logic.data.message.Message
 import kotlinx.coroutines.delay
 import kotlinx.datetime.Clock
@@ -250,62 +247,9 @@ class SelfDeletionTimerHelper(private val stringResourceProvider: StringResource
             }
 
             @Composable
-            fun startDeletionTimer(
-                message: UIMessage,
-                assetTransferStatus: AssetTransferStatus?,
-                onStartMessageSelfDeletion: (UIMessage) -> Unit
-            ) {
-                if (assetTransferStatus != null) {
-                    when (message.messageContent) {
-                        is UIMessageContent.AssetMessage -> startAssetDeletion(
-                            onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
-                            transferStatus = assetTransferStatus
-                        )
-
-                        is UIMessageContent.AudioAssetMessage -> startAssetDeletion(
-                            onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
-                            transferStatus = assetTransferStatus
-                        )
-
-                        is UIMessageContent.ImageMessage -> startAssetDeletion(
-                            onSelfDeletingMessageRead = { onStartMessageSelfDeletion(message) },
-                            transferStatus = assetTransferStatus
-                        )
-
-                        else -> startRegularDeletion(message = message, onStartMessageSelfDeletion = onStartMessageSelfDeletion)
-                    }
-                } else {
-                    startRegularDeletion(message = message, onStartMessageSelfDeletion = onStartMessageSelfDeletion)
-                }
-            }
-
-            @Composable
-            private fun startAssetDeletion(onSelfDeletingMessageRead: () -> Unit, transferStatus: AssetTransferStatus) {
-                LaunchedEffect(transferStatus) {
-                    if (transferStatus.isSaved()) {
-                        onSelfDeletingMessageRead()
-                    }
-                }
-                LaunchedEffect(key1 = timeLeft, key2 = transferStatus) {
-                    if (transferStatus.isSaved()) {
-                        if (timeLeft != ZERO) {
-                            delay(updateInterval())
-                            recalculateTimeLeft()
-                        }
-                    }
-                }
-                val lifecycleOwner = LocalLifecycleOwner.current
-                LaunchedEffect(lifecycleOwner) {
-                    lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                        recalculateTimeLeft()
-                    }
-                }
-            }
-
-            @Composable
-            private fun startRegularDeletion(message: UIMessage, onStartMessageSelfDeletion: (UIMessage) -> Unit) {
+            fun StartDeletionTimer(message: UIMessage, onSelfDeletingMessageRead: (UIMessage) -> Unit) {
                 LaunchedEffect(Unit) {
-                    onStartMessageSelfDeletion(message)
+                    onSelfDeletingMessageRead(message)
                 }
                 LaunchedEffect(timeLeft) {
                     if (timeLeft != ZERO) {
@@ -322,7 +266,7 @@ class SelfDeletionTimerHelper(private val stringResourceProvider: StringResource
             }
         }
 
-        object NotExpirable : SelfDeletionTimerState()
+        data object NotExpirable : SelfDeletionTimerState()
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContainerItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContainerItem.kt
@@ -85,10 +85,9 @@ fun MessageContainerItem(
         !message.isPending &&
         !message.sendingFailed
     ) {
-        selfDeletionTimerState.startDeletionTimer(
+        selfDeletionTimerState.StartDeletionTimer(
             message = message,
-            assetTransferStatus = assetStatus,
-            onStartMessageSelfDeletion = onSelfDeletingMessageRead
+            onSelfDeletingMessageRead = onSelfDeletingMessageRead
         )
     }
     Row(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
@@ -105,7 +105,6 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.launchGeoIntent
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
-import com.wire.kalium.logic.data.asset.isSaved
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import kotlin.math.absoluteValue

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
@@ -166,7 +166,7 @@ fun RegularMessageItem(
                         Spacer(modifier = Modifier.height(dimensions().spacing4x))
                     }
                     if (selfDeletionTimerState is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
-                        MessageExpireLabel(messageContent, assetStatus, selfDeletionTimerState.timeLeftFormatted)
+                        MessageExpireLabel(messageContent, selfDeletionTimerState.timeLeftFormatted)
 
                         // if the message is marked as deleted and is [SelfDeletionTimer.SelfDeletionTimerState.Expirable]
                         // the deletion responsibility belongs to the receiver, therefore we need to wait for the receiver
@@ -473,50 +473,14 @@ fun EphemeralMessageExpiredLabel(
 }
 
 @Composable
-fun MessageExpireLabel(messageContent: UIMessageContent?, assetTransferStatus: AssetTransferStatus?, timeLeft: String) {
+fun MessageExpireLabel(messageContent: UIMessageContent?, timeLeft: String) {
     when (messageContent) {
         is UIMessageContent.Location,
+        is UIMessageContent.AssetMessage,
+        is UIMessageContent.AudioAssetMessage,
+        is UIMessageContent.ImageMessage,
         is UIMessageContent.TextMessage -> {
             StatusBox(statusText = stringResource(R.string.self_deleting_message_time_left, timeLeft))
-        }
-
-        is UIMessageContent.AssetMessage -> {
-            StatusBox(
-                statusText = if (assetTransferStatus.isSaved()) {
-                    stringResource(
-                        R.string.self_deleting_message_time_left,
-                        timeLeft
-                    )
-                } else {
-                    stringResource(R.string.self_deleting_message_label, timeLeft)
-                }
-            )
-        }
-
-        is UIMessageContent.AudioAssetMessage -> {
-            StatusBox(
-                statusText = if (assetTransferStatus.isSaved()) {
-                    stringResource(
-                        R.string.self_deleting_message_time_left,
-                        timeLeft
-                    )
-                } else {
-                    stringResource(R.string.self_deleting_message_label, timeLeft)
-                }
-            )
-        }
-
-        is UIMessageContent.ImageMessage -> {
-            StatusBox(
-                statusText = if (assetTransferStatus.isSaved()) {
-                    stringResource(
-                        R.string.self_deleting_message_time_left,
-                        timeLeft
-                    )
-                } else {
-                    stringResource(R.string.self_deleting_message_label, timeLeft)
-                }
-            )
         }
 
         is UIMessageContent.Deleted -> {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1807" title="WPB-1807" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-1807</a>  Self-deleting: Delete assets from internal storage once the timer runs out
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

This PR was manually cherry-picked based on https://github.com/wireapp/wire-android/pull/3465

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

For self-deleting message with asset, the timer doesn't start counting down until the user opens the asset.

### Causes (Optional)

We had mixed old and new logic when it comes to starting the countdown. First we implemented self-deleting messages with asset in a way that it only starts counting down when the user actually opens the asset. It was changed some time ago to unify it with other platforms, so now it should start counting down at the moment the message is shown to the user, no matter if the user actually opens the asset or not. The problem is that part of the old logic was still in the code and because of that the timer was not being shown until the user opened the asset.

### Solutions

Show the timer at the moment the message is being shown on the screen, so the logic is now the same for all types of self-deleting messages, no matter what content it has and no matter if the content has actually been opened or not.
Also, it includes new changes regarding deleting asset files when self-deleting message disappears (https://github.com/wireapp/kalium/pull/3027).

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/3034

### Testing

#### How to Test

Send a self-deleting message with asset and check if the timer is clearly visible from the first moment the message appeared on the screen.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video src="https://github.com/user-attachments/assets/91603b9f-6abc-44ce-aa83-26ccbb4aa967"/> | <video src="https://github.com/user-attachments/assets/469e4e5d-dddc-48de-ac37-54073c5e9f84"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
