### PR TITLE
fix: wrong service opens when clicking on search result [WPB-11330]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchAllServicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchAllServicesScreen.kt
@@ -139,4 +139,3 @@ private fun SuccessServicesList(
         }
     }
 }
-

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchAllServicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchAllServicesScreen.kt
@@ -39,6 +39,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.CenteredCircularProgressBarIndicator
 import com.wire.android.ui.home.conversations.search.widget.SearchFailureBox
 import com.wire.android.ui.home.newconversation.model.Contact
+import com.wire.android.util.extension.folderWithElements
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
@@ -46,17 +47,17 @@ fun SearchAllServicesScreen(
     searchQuery: String,
     onServiceClicked: (Contact) -> Unit,
     searchServicesViewModel: SearchServicesViewModel = hiltViewModel(),
+    lazyListState: LazyListState = rememberLazyListState(),
 ) {
     LaunchedEffect(key1 = searchQuery) {
         searchServicesViewModel.searchQueryChanged(searchQuery)
     }
 
-    val lazyState = rememberLazyListState()
     SearchAllServicesContent(
         searchQuery = searchServicesViewModel.state.searchQuery,
         onServiceClicked = onServiceClicked,
         result = searchServicesViewModel.state.result,
-        lazyListState = lazyState,
+        lazyListState = lazyListState,
         error = searchServicesViewModel.state.error,
         isLoading = searchServicesViewModel.state.isLoading
     )
@@ -106,36 +107,36 @@ private fun SuccessServicesList(
             modifier = Modifier
                 .weight(1f)
         ) {
-            services
-                .forEach {
-                    item {
-                        RowItemTemplate(
-                            leadingIcon = {
-                                Row {
-                                    UserProfileAvatar(it.avatarData)
-                                }
-                            },
-                            titleStartPadding = dimensions().spacing0x,
-                            title = {
-                                Row(verticalAlignment = Alignment.CenterVertically) {
-                                    HighlightName(
-                                        name = it.name,
-                                        searchQuery = searchQuery,
-                                        modifier = Modifier.weight(weight = 1f, fill = false)
-                                    )
-                                    UserBadge(
-                                        membership = it.membership,
-                                        connectionState = it.connectionState,
-                                        startPadding = dimensions().spacing8x
-                                    )
-                                }
-                            },
-                            actions = {},
-                            clickable = remember { Clickable(enabled = true) { onServiceClicked(it) } },
-                            modifier = Modifier.padding(start = dimensions().spacing8x)
-                        )
-                    }
-                }
+            folderWithElements(
+                items = services.associateBy { it.id }
+            ) {
+                RowItemTemplate(
+                    leadingIcon = {
+                        Row {
+                            UserProfileAvatar(it.avatarData)
+                        }
+                    },
+                    titleStartPadding = dimensions().spacing0x,
+                    title = {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            HighlightName(
+                                name = it.name,
+                                searchQuery = searchQuery,
+                                modifier = Modifier.weight(weight = 1f, fill = false)
+                            )
+                            UserBadge(
+                                membership = it.membership,
+                                connectionState = it.connectionState,
+                                startPadding = dimensions().spacing8x
+                            )
+                        }
+                    },
+                    actions = {},
+                    clickable = remember(it) { Clickable(enabled = true) { onServiceClicked(it) } },
+                    modifier = Modifier.padding(start = dimensions().spacing8x)
+                )
+            }
         }
     }
 }
+


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11330" title="WPB-11330" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11330</a>  [Android] When searching for a service and clicking on search result, wrong service opens
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When searching for a service and clicking on search result, wrong service opens.

### Causes (Optional)

Items are not identified by any key, only by index and clickable is remembered without any key, so items can be reused with clickable remembered for other service.

### Solutions

Use `folderWithElements` which is our common way of showing lists and it already enforces associating key to each item. Use remembered with a key for clickable.

### Testing

#### How to Test

STR:
-have multiple services in your team available (Wire prod has them)
-open any group where you are admin
-tap on “add participants” tab
-tap on “services”
-search for a service (e.g. “Echo”)
-tap on the found service

Expected: I should see the service I searched for

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/user-attachments/assets/3c0e1ff7-e343-4977-b911-b4894c80f20b"/> | <video width="400" src="https://github.com/user-attachments/assets/7927a09e-3389-49ba-ae96-bb0cbb6c857c"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
