### PR TITLE
fix: showing user statuses on participants list [WPB-11191]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/UserProfileAvatar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/UserProfileAvatar.kt
@@ -95,7 +95,7 @@ sealed class UserProfileAvatarType {
      * This avatar has indicators in the form of borders around the avatar.
      */
     sealed class WithIndicators : UserProfileAvatarType() {
-        data class RegularUser(val legalHoldIndicatorVisible: Boolean) : WithIndicators()
+        data class RegularUser(val legalHoldIndicatorVisible: Boolean = false) : WithIndicators()
         data class TemporaryUser(val expiresAt: Instant) : WithIndicators()
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/ConversationParticipantItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/ConversationParticipantItem.kt
@@ -41,7 +41,6 @@ import com.wire.android.ui.common.RowItemTemplate
 import com.wire.android.ui.common.UserBadge
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.UserProfileAvatarType.WithIndicators
-import com.wire.android.ui.common.UserProfileAvatarType.WithoutIndicators
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.details.participants.model.UIParticipant
 import com.wire.android.ui.home.conversations.search.HighlightName
@@ -77,7 +76,7 @@ fun ConversationParticipantItem(
                 modifier = Modifier.padding(
                     start = dimensions().spacing8x
                 ),
-                type = uiParticipant.expiresAt?.let { WithIndicators.TemporaryUser(it) } ?: WithoutIndicators
+                type = uiParticipant.expiresAt?.let { WithIndicators.TemporaryUser(it) } ?: WithIndicators.RegularUser()
             )
         },
         titleStartPadding = dimensions().spacing0x,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11191" title="WPB-11191" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11191</a>  [Android] Missing user status next to avatar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

User statuses are still not visible on participants list.

### Causes (Optional)

Previous PR (https://github.com/wireapp/wire-android/pull/3460) missed one place where type should also be changed to proper one.

### Solutions

Change type of avatar from `WithoutIndicators` to `WithIndicators.RegularUser` for items on participants list.

### Testing

#### How to Test

Open group participants list and check if the statuses are visible.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <img width="400" src="https://github.com/user-attachments/assets/062cec39-d392-4237-8aba-ab5b68cfdea4"/> | <img width="400" src="https://github.com/user-attachments/assets/67a5fbd0-dfcf-47e2-a420-dc0907103eb3"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
