### PR TITLE
refactor: update designs for QR button (WPB-10539)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -19,26 +19,21 @@
 package com.wire.android.ui.userprofile.common
 
 import android.annotation.SuppressLint
-import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material.icons.Icons
@@ -56,14 +51,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.wire.android.R
 import com.wire.android.model.ClickBlockParams
@@ -78,12 +75,13 @@ import com.wire.android.ui.common.UserBadge
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.UserProfileAvatarType
 import com.wire.android.ui.common.banner.SecurityClassificationBannerForUser
-import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.ifNotEmpty
@@ -323,30 +321,17 @@ private fun createMiddleEllipsizeIfNeeded(
 fun QRCodeIcon(
     onQrCodeClick: () -> Unit,
     modifier: Modifier = Modifier,
-    @StringRes contentDescriptionId: Int = R.string.user_profile_qr_code_share_link
 ) {
-    Box(
-        modifier = Modifier
-            .clip(RoundedCornerShape(dimensions().spacing16x))
-            .background(colorsScheme().surface)
-            .border(
-                width = dimensions().spacing1x,
-                color = colorsScheme().callingInActiveBorderIndicator,
-                shape = RoundedCornerShape(dimensions().spacing16x)
-            )
-            .size(height = dimensions().spacing32x, width = dimensions().spacing40x)
-            .padding(dimensions().spacing1x, dimensions().spacing1x)
-            .clickable { onQrCodeClick() }
-    ) {
-        androidx.compose.material3.Icon(
-            imageVector = Icons.Filled.QrCode,
-            contentDescription = stringResource(contentDescriptionId),
-            modifier = modifier
-                .fillMaxSize()
-                .padding(dimensions().spacing2x),
-            tint = Color.Black
-        )
-    }
+    val contentDescription = stringResource(id = R.string.user_profile_qr_code_share_link)
+    WireSecondaryButton(
+        modifier = modifier.semantics { this.contentDescription = contentDescription },
+        leadingIcon = Icons.Filled.QrCode.Icon(),
+        contentPadding = PaddingValues(0.dp),
+        onClick = onQrCodeClick,
+        fillMaxWidth = false,
+        minSize = MaterialTheme.wireDimensions.buttonSmallMinSize,
+        minClickableSize = MaterialTheme.wireDimensions.buttonMinClickableSize,
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -232,15 +232,17 @@ fun UserProfileInfo(
 
             Column(
                 Modifier
-                    .padding(top = dimensions().spacing0x)
+                    .padding(top = dimensions().spacing0x, start = dimensions().spacing4x)
                     .constrainAs(qrIcon) {
-                        start.linkTo(displayName.end)
+                        start.linkTo(if (fullName.length > userName.length) displayName.end else username.end)
                         end.linkTo(parent.end)
                         top.linkTo(displayName.top)
                         bottom.linkTo(displayName.bottom)
                     }
             ) {
-                onQrCodeClick?.let { QRCodeIcon(it) }
+                if (isLoading.not()) {
+                    onQrCodeClick?.let { QRCodeIcon(it) }
+                }
             }
         }
         val localFeatureVisibilityFlags = LocalFeatureVisibilityFlags.current

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -240,7 +240,7 @@ fun UserProfileInfo(
                         bottom.linkTo(displayName.bottom)
                     }
             ) {
-                QRCodeIcon(onQrCodeClick!!)
+                onQrCodeClick?.let { QRCodeIcon(it) }
             }
         }
         val localFeatureVisibilityFlags = LocalFeatureVisibilityFlags.current

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -24,18 +24,21 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material.icons.Icons
@@ -53,6 +56,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Placeholder
@@ -321,14 +325,28 @@ fun QRCodeIcon(
     modifier: Modifier = Modifier,
     @StringRes contentDescriptionId: Int = R.string.user_profile_qr_code_share_link
 ) {
-    androidx.compose.material3.Icon(
-        imageVector = Icons.Filled.QrCode,
-        contentDescription = stringResource(contentDescriptionId),
-        modifier = modifier
-            .size(dimensions().spacing24x)
-            .clickable { onQrCodeClick() },
-        tint = colorsScheme().onBackground
-    )
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(dimensions().spacing16x))
+            .background(colorsScheme().surface)
+            .border(
+                width = dimensions().spacing1x,
+                color = colorsScheme().callingInActiveBorderIndicator,
+                shape = RoundedCornerShape(dimensions().spacing16x)
+            )
+            .size(height = dimensions().spacing32x, width = dimensions().spacing40x)
+            .padding(dimensions().spacing1x, dimensions().spacing1x)
+            .clickable { onQrCodeClick() }
+    ) {
+        androidx.compose.material3.Icon(
+            imageVector = Icons.Filled.QrCode,
+            contentDescription = stringResource(contentDescriptionId),
+            modifier = modifier
+                .fillMaxSize()
+                .padding(dimensions().spacing2x),
+            tint = Color.Black
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10539" title="WPB-10539" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10539</a>  [Android] Your Profile page - updated
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Designs were updated after syncing with the iOS platform

### Causes (Optional)

- We wanted to emphasize more the call to action of the button
- New designs were adjusted

### Solutions

Adjust the designs, to doing so, I fall back to the initial approach (before QR) and used constraint layout.

### Attachments (Optional)

###  Before:
<img width="283" alt="aa121" src="https://github.com/user-attachments/assets/0d0909d9-1465-4b1d-ab5d-450a00dd03b5">



### Now:

![Screenshot 2024-10-08 at 07 23 13](https://github.com/user-attachments/assets/a2daa237-4893-49ef-ae48-4cd91c8c7170)

<img src="https://github.com/user-attachments/assets/6b27f240-a821-467b-be9c-998f3a97b3be" width="300"/>


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
