### PR TITLE
chore: Update app version name #WPB-11429

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -36,6 +36,7 @@ import com.wire.android.feature.analytics.AnonymousAnalyticsRecorderImpl
 import com.wire.android.feature.analytics.globalAnalyticsManager
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.feature.analytics.model.AnalyticsSettings
+import com.wire.android.util.AppNameUtil
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.DataDogLogger
 import com.wire.android.util.LogFileWriter
@@ -240,7 +241,7 @@ class WireApplication : BaseApp() {
         appLogger.d(
             """
             > Device info: 
-                App version=${BuildConfig.VERSION_NAME} 
+                App version=${AppNameUtil.createAppName()} 
                 OS version=${Build.VERSION.SDK_INT}
                 Phone model=${Build.BRAND}/${Build.MODEL}
                 Commit hash=${applicationContext.getGitBuildId()}

--- a/app/src/main/kotlin/com/wire/android/migration/UpdateReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/UpdateReceiver.kt
@@ -21,8 +21,8 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import androidx.work.WorkManager
-import com.wire.android.BuildConfig
 import com.wire.android.appLogger
+import com.wire.android.util.AppNameUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.workmanager.worker.enqueueMigrationWorker
 import dagger.hilt.android.AndroidEntryPoint
@@ -46,7 +46,7 @@ class UpdateReceiver : BroadcastReceiver() {
     }
 
     override fun onReceive(context: Context, intent: Intent?) {
-        appLogger.i("App updated to ${BuildConfig.VERSION_NAME}")
+        appLogger.i("App updated to ${AppNameUtil.createAppName()}")
         scope.launch {
             if (migrationManager.shouldMigrate()) {
                 appLogger.i("Migration worker enqueued")

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
@@ -48,6 +48,7 @@ import com.wire.android.navigation.WireDestination
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.destinations.MigrationScreenDestination
+import com.wire.android.util.AppNameUtil
 import com.wire.android.util.getMimeType
 import com.wire.android.util.getUrisOfFilesInDirectory
 import com.wire.android.util.multipleFileSharingIntent
@@ -103,7 +104,7 @@ internal fun UserDebugContent(
                     onShareLogs = debugContentState::shareLogs,
                 )
                 DebugDataOptions(
-                    appVersion = BuildConfig.VERSION_NAME,
+                    appVersion = AppNameUtil.createAppName(),
                     buildVariant = "${BuildConfig.FLAVOR}${BuildConfig.BUILD_TYPE.replaceFirstChar { it.uppercase() }}",
                     onCopyText = debugContentState::copyToClipboard,
                     onManualMigrationPressed = onManualMigrationPressed

--- a/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.RootNavGraph
-import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.navigation.NavigationCommand
@@ -164,7 +163,7 @@ private fun AboutThisAppContent(
                 onIconPressed = Clickable(
                     enabled = true,
                     onClick = {
-                        aboutThisAppContentState.copyToClipboard(BuildConfig.VERSION_NAME)
+                        aboutThisAppContentState.copyToClipboard(state.appName)
                     }
                 )
             )

--- a/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppScreen.kt
@@ -159,7 +159,7 @@ private fun AboutThisAppContent(
             )
             SettingsItem(
                 title = stringResource(R.string.app_version),
-                text = BuildConfig.VERSION_NAME,
+                text = state.appName,
                 trailingIcon = R.drawable.ic_copy,
                 onIconPressed = Clickable(
                     enabled = true,
@@ -210,7 +210,7 @@ data class AboutThisAppContentState(
 @Composable
 private fun PreviewAboutThisAppScreen() = WireTheme {
     AboutThisAppContent(
-        state = AboutThisAppState(commitish = "abcd-1234"),
+        state = AboutThisAppState(commitish = "abcd-1234", appName = "4.1.9-1234-beta"),
         onBackPressed = { },
         onItemClicked = { }
     )

--- a/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppState.kt
@@ -18,5 +18,6 @@
 package com.wire.android.ui.settings.about
 
 data class AboutThisAppState(
-    val commitish: String = "null"
+    val commitish: String = "null",
+    val appName: String
 )

--- a/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppViewModel.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.BuildConfig
 import com.wire.android.util.getGitBuildId
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -35,7 +36,9 @@ class AboutThisAppViewModel @Inject constructor(
 ) : ViewModel() {
 
     var state by mutableStateOf(
-        AboutThisAppState()
+        AboutThisAppState(
+            appName = createAppName()
+        )
     )
 
     init {
@@ -49,5 +52,28 @@ class AboutThisAppViewModel @Inject constructor(
                 commitish = gitBuildId
             )
         }
+    }
+
+    private fun createAppName(): String {
+        return "${BuildConfig.VERSION_NAME}-${leastSignificantVersionCode()}-${BuildConfig.FLAVOR}"
+    }
+
+    /**
+     * The last 5 digits of the VersionCode. From 0 to 99_999.
+     * It's an [Int], so it can be less than 5 digits when doing [toString], of course.
+     * Considering versionCode bumps every 5min, these are
+     * 288 per day
+     * 8640 per month
+     * 51840 per semester
+     * 103_680 per year. ~99_999
+     *
+     * So it takes almost a whole year until it rotates back.
+     * It's very unlikely that two APKs with the same version (_e.g._ 4.8.0)
+     * will have the same [leastSignificantVersionCode],
+     * unless they are build almost one year apart.
+     */
+    @Suppress("MagicNumber")
+    private fun leastSignificantVersionCode(): Int {
+        return BuildConfig.VERSION_CODE % 100_000
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppViewModel.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.BuildConfig
+import com.wire.android.util.AppNameUtil
 import com.wire.android.util.getGitBuildId
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -37,7 +37,7 @@ class AboutThisAppViewModel @Inject constructor(
 
     var state by mutableStateOf(
         AboutThisAppState(
-            appName = createAppName()
+            appName = AppNameUtil.createAppName()
         )
     )
 
@@ -52,28 +52,5 @@ class AboutThisAppViewModel @Inject constructor(
                 commitish = gitBuildId
             )
         }
-    }
-
-    private fun createAppName(): String {
-        return "${BuildConfig.VERSION_NAME}-${leastSignificantVersionCode()}-${BuildConfig.FLAVOR}"
-    }
-
-    /**
-     * The last 5 digits of the VersionCode. From 0 to 99_999.
-     * It's an [Int], so it can be less than 5 digits when doing [toString], of course.
-     * Considering versionCode bumps every 5min, these are
-     * 288 per day
-     * 8640 per month
-     * 51840 per semester
-     * 103_680 per year. ~99_999
-     *
-     * So it takes almost a whole year until it rotates back.
-     * It's very unlikely that two APKs with the same version (_e.g._ 4.8.0)
-     * will have the same [leastSignificantVersionCode],
-     * unless they are build almost one year apart.
-     */
-    @Suppress("MagicNumber")
-    private fun leastSignificantVersionCode(): Int {
-        return BuildConfig.VERSION_CODE % 100_000
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/AppNameUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/AppNameUtil.kt
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import com.wire.android.BuildConfig
+
+internal object AppNameUtil {
+
+    fun createAppName(): String {
+        return "${BuildConfig.VERSION_NAME}-${leastSignificantVersionCode()}-${BuildConfig.FLAVOR}"
+    }
+
+    /**
+     * The last 5 digits of the VersionCode. From 0 to 99_999.
+     * It's an [Int], so it can be less than 5 digits when doing [toString], of course.
+     * Considering versionCode bumps every 5min, these are
+     * 288 per day
+     * 8640 per month
+     * 51840 per semester
+     * 103_680 per year. ~99_999
+     *
+     * So it takes almost a whole year until it rotates back.
+     * It's very unlikely that two APKs with the same version (_e.g._ 4.8.0)
+     * will have the same [leastSignificantVersionCode],
+     * unless they are build almost one year apart.
+     */
+    @Suppress("MagicNumber")
+    private fun leastSignificantVersionCode(): Int {
+        return BuildConfig.VERSION_CODE % 100_000
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/util/EmailComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/util/EmailComposer.kt
@@ -19,7 +19,6 @@
 package com.wire.android.util
 
 import android.os.Build
-import com.wire.android.BuildConfig
 import java.util.Date
 
 sealed interface EmailComposer {
@@ -52,7 +51,7 @@ sealed interface EmailComposer {
 
         private fun emailDebugHeader(deviceHash: String?, commitHash: String? = "unavailable"): String = """
         --- DO NOT EDIT---
-        App Version: ${BuildConfig.VERSION_NAME}
+        App Version: ${AppNameUtil.createAppName()}
         Device Hash: $deviceHash
         Device: ${Build.MANUFACTURER} - ${Build.MODEL}
         SDK: ${Build.VERSION.RELEASE}

--- a/app/src/main/kotlin/com/wire/android/util/UserAgentProvider.kt
+++ b/app/src/main/kotlin/com/wire/android/util/UserAgentProvider.kt
@@ -19,7 +19,6 @@ package com.wire.android.util
 
 import android.content.Context
 import android.os.Build
-import com.wire.android.BuildConfig
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -28,7 +27,7 @@ import javax.inject.Singleton
 class UserAgentProvider @Inject constructor(@ApplicationContext private val context: Context) {
 
     val defaultUserAgent =
-        "Wire/${BuildConfig.VERSION_NAME}/${context.getGitBuildId()}/${getAndroidVersion()}"
+        "Wire/${AppNameUtil.createAppName()}/${context.getGitBuildId()}/${getAndroidVersion()}"
 
     private fun getAndroidVersion(): String {
         val sdkVersion: Int = Build.VERSION.SDK_INT

--- a/build-logic/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -40,7 +40,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 applicationId = AndroidApp.id
                 defaultConfig.targetSdk = AndroidSdk.target
                 versionCode = AndroidApp.versionCode
-                versionName = "${AndroidApp.versionName}-${AndroidApp.leastSignificantVersionCode}"
+                versionName = AndroidApp.versionName
                 setProperty("archivesBaseName", "$applicationId-v$versionName")
             }
 

--- a/build-logic/plugins/src/main/kotlin/AndroidCoordinates.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidCoordinates.kt
@@ -35,23 +35,4 @@ object AndroidApp {
     fun setRootDir(rootDir: File) {
         this._rootDir = rootDir
     }
-
-    /**
-     * The last 5 digits of the VersionCode. From 0 to 99_999.
-     * It's an [Int], so it can be less than 5 digits when doing [toString], of course.
-     * Considering versionCode bumps every 5min, these are
-     * 288 per day
-     * 8640 per month
-     * 51840 per semester
-     * 103_680 per year. ~99_999
-     *
-     * So it takes almost a whole year until it rotates back.
-     * It's very unlikely that two APKs with the same version (_e.g._ 4.8.0)
-     * will have the same [leastSignificantVersionCode],
-     * unless they are build almost one year apart.
-     */
-    @Suppress("MagicNumber")
-    val leastSignificantVersionCode by lazy {
-        versionCode % 100_000
-    }
 }

--- a/build-logic/plugins/src/main/kotlin/AppVersionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AppVersionPlugin.kt
@@ -35,7 +35,7 @@ class AppVersionPlugin : Plugin<Project> {
                 val currentTime = LocalDateTime.now()
                 val versnisor = Versionizer(projectDir, currentTime)
                 val versionCode = versnisor.versionCode
-                val versionName = "${AndroidApp.versionName}-${AndroidApp.leastSignificantVersionCode}-fdroid"
+                val versionName = AndroidApp.versionName
                 val buildTime = currentTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")) ?: error("Failed to get build time")
                 val appName = "com.wire"
                 // git commit hash code

--- a/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
@@ -62,7 +62,6 @@ fun NamedDomainObjectContainer<ApplicationProductFlavor>.createAppFlavour(
     create(flavour.buildName) {
         dimension = flavour.dimensions
         applicationId = flavorApplicationId
-        versionNameSuffix = "-${flavour.buildName}"
         resValue("string", "app_name", flavour.appName)
         manifestPlaceholders["sharedUserId"] = sharedUserId
         manifestPlaceholders["appAuthRedirectScheme"] = flavorApplicationId


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11429" title="WPB-11429" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11429</a>  [Android] update app version name to for fdroid auto update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

Update app version name to contain only the version ie 4.9.0 without version code and flavor. This will simplify fdroid integration.

### Issues

There were issues with matching version name with tag for fdroid integration, thats why we're simplifying it.

### Solutions

Version names generated contain only raw version name, the UI representation is build exactly as it was before so `versionName-leastSignificantVersionCode-flavor`

### Testing

#### How to Test

Open the app and check in the settings that version name is in unchanged format ie `4.9.0-32599-beta` so `versionName-leastSignificantVersionCode-flavor`


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
