### PR TITLE
fix: Audio message slider style #WPB-11384

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -205,14 +205,14 @@ private fun RowScope.SuccessfulAudioMessageSlider(
         thumb = {
             SliderDefaults.Thumb(
                 interactionSource = remember { MutableInteractionSource() },
-                thumbSize = DpSize(20.dp, 20.dp)
+                thumbSize = DpSize(dimensions().spacing20x, dimensions().spacing20x)
             )
         },
         track = { sliderState ->
             SliderDefaults.Track(
-                modifier = Modifier.height(4.dp),
+                modifier = Modifier.height(dimensions().spacing4x),
                 sliderState = sliderState,
-                thumbTrackGapSize = 0.dp,
+                thumbTrackGapSize = dimensions().spacing0x,
                 drawStopIndicator = {
                     // nop we do not want to draw stop indicator at all.
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -161,7 +161,7 @@ private fun SuccessfulAudioMessage(
             onButtonClicked = onPlayButtonClick
         )
 
-        SuccessfulAudioMessageSlider(
+        AudioMessageSlider(
             audioDuration = audioDuration,
             totalTimeInMs = totalTimeInMs,
             onSliderPositionChange = onSliderPositionChange
@@ -193,7 +193,7 @@ private fun SuccessfulAudioMessage(
  */
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-private fun RowScope.SuccessfulAudioMessageSlider(
+private fun RowScope.AudioMessageSlider(
     audioDuration: AudioDuration,
     totalTimeInMs: AudioState.TotalTimeInMs,
     onSliderPositionChange: (Float) -> Unit,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -19,9 +19,11 @@ package com.wire.android.ui.home.conversations.model.messagetypes.audio
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -29,6 +31,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -43,6 +46,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.media.audiomessage.AudioMediaPlayingState
@@ -157,14 +161,10 @@ private fun SuccessfulAudioMessage(
             onButtonClicked = onPlayButtonClick
         )
 
-        Slider(
-            value = audioDuration.currentPositionInMs.toFloat(),
-            onValueChange = onSliderPositionChange,
-            valueRange = 0f..if (totalTimeInMs is AudioState.TotalTimeInMs.Known) totalTimeInMs.value.toFloat() else 0f,
-            colors = SliderDefaults.colors(
-                inactiveTrackColor = colorsScheme().secondaryButtonDisabledOutline
-            ),
-            modifier = Modifier.weight(1f)
+        SuccessfulAudioMessageSlider(
+            audioDuration = audioDuration,
+            totalTimeInMs = totalTimeInMs,
+            onSliderPositionChange = onSliderPositionChange
         )
 
         if (audioMediaPlayingState is AudioMediaPlayingState.Fetching) {
@@ -180,6 +180,49 @@ private fun SuccessfulAudioMessage(
             )
         }
     }
+}
+
+/**
+ * Material3 version 1.3.0 introduced several modifications to the Slider component.
+ * These changes may require adjustments to maintain the desired appearance and behavior in your app:
+ * - Thumb size changed to 4dp x 44dp - changed back to old 20dp x 20dp.
+ * - Thumb requires interactionSource - it must be different than Slider to not update thumb appearance during drag.
+ * - Track now draws stop indicator by default - turned off.
+ * - Track adds thumbTrackGapSize - set back to 0dp.
+ * - Track has different height than previously - changed back to old 4.dp.
+ */
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun RowScope.SuccessfulAudioMessageSlider(
+    audioDuration: AudioDuration,
+    totalTimeInMs: AudioState.TotalTimeInMs,
+    onSliderPositionChange: (Float) -> Unit,
+) {
+    Slider(
+        value = audioDuration.currentPositionInMs.toFloat(),
+        onValueChange = onSliderPositionChange,
+        valueRange = 0f..if (totalTimeInMs is AudioState.TotalTimeInMs.Known) totalTimeInMs.value.toFloat() else 0f,
+        thumb = {
+            SliderDefaults.Thumb(
+                interactionSource = remember { MutableInteractionSource() },
+                thumbSize = DpSize(20.dp, 20.dp)
+            )
+        },
+        track = { sliderState ->
+            SliderDefaults.Track(
+                modifier = Modifier.height(4.dp),
+                sliderState = sliderState,
+                thumbTrackGapSize = 0.dp,
+                drawStopIndicator = {
+                    // nop we do not want to draw stop indicator at all.
+                }
+            )
+        },
+        colors = SliderDefaults.colors(
+            inactiveTrackColor = colorsScheme().secondaryButtonDisabledOutline
+        ),
+        modifier = Modifier.weight(1f)
+    )
 }
 
 @Composable


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11384" title="WPB-11384" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11384</a>  [Android] Audio message sliders don't match design after library update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# What's new in this PR?

### Issues

Material3 version 1.3.0 has made some significant changes to the Slider.

### Solutions

We needed to adjust new parameters of Slider Thumb and Track in order to meet old view appearance.

### Testing


#### How to Test

- [ ] Record voice message
- [ ] Confirm that thumb is in right color and shape (circle)
- [ ] Track is slim and does not have any weird shapes on it
- [ ] When sliding the thumb by hand the thumb and track does not change size


### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
|   ![Screenshot_20241009_135618_Wire Beta](https://github.com/user-attachments/assets/5e45194d-7d3b-43e0-9098-748f6e809a26) |   ![Screenshot_20241009_135352_Wire Beta](https://github.com/user-attachments/assets/969443d4-af80-4995-8367-98e88bf7d4c1) |


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
