### PR TITLE
fix: conversation search not working [WPB-11473]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -48,7 +48,6 @@ import com.wire.android.ui.common.dialogs.BlockUserDialogContent
 import com.wire.android.ui.common.dialogs.PermissionPermanentlyDeniedDialog
 import com.wire.android.ui.common.dialogs.UnblockUserDialogContent
 import com.wire.android.ui.common.dialogs.calling.JoinAnywayDialog
-import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.ui.common.topappbar.search.SearchBarState
 import com.wire.android.ui.common.topappbar.search.rememberSearchbarState
 import com.wire.android.ui.common.visbility.rememberVisibilityState
@@ -69,7 +68,6 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.SnackBarMessageHandler
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
-import kotlinx.coroutines.flow.map
 
 /**
  * This is a base for creating screens for displaying list of conversations.
@@ -88,10 +86,7 @@ fun ConversationsScreenContent(
         else -> hiltViewModel<ConversationListViewModelImpl, ConversationListViewModelImpl.Factory>(
             key = "list_${conversationsSource.name}",
             creationCallback = { factory ->
-                factory.create(
-                    conversationsSource = conversationsSource,
-                    searchQueryFlow = searchBarState.searchQueryTextState.textAsFlow().map { it.toString() }
-                )
+                factory.create(conversationsSource = conversationsSource)
             }
         )
     },
@@ -126,6 +121,10 @@ fun ConversationsScreenContent(
         if (searchBarState.isSearchActive) {
             conversationListViewModel.refreshMissingMetadata()
         }
+    }
+
+    LaunchedEffect(searchBarState.searchQueryTextState.text) {
+        conversationListViewModel.searchQueryChanged(searchBarState.searchQueryTextState.text.toString())
     }
 
     fun showConfirmationDialogOrUnarchive(): (DialogState) -> Unit {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -50,7 +50,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -69,11 +68,11 @@ class ConversationListViewModelTest {
     fun `given empty search query, when collecting, then update state with all conversations`() = runTest(dispatcherProvider.main()) {
         // Given
         val searchQueryText = ""
-        val (arrangement, conversationListViewModel) = Arrangement().arrange()
+        val (_, conversationListViewModel) = Arrangement().arrange()
 
         // When
         advanceUntilIdle()
-        arrangement.searchQueryChanged(searchQueryText)
+        conversationListViewModel.searchQueryChanged(searchQueryText)
         advanceUntilIdle()
 
         // Then
@@ -89,11 +88,11 @@ class ConversationListViewModelTest {
         runTest(dispatcherProvider.main()) {
         // Given
         val searchQueryText = TestConversationDetails.CONVERSATION_ONE_ONE.conversation.name.orDefault("test")
-        val (arrangement, conversationListViewModel) = Arrangement().arrange()
+        val (_, conversationListViewModel) = Arrangement().arrange()
 
         // When
         advanceUntilIdle()
-        arrangement.searchQueryChanged(searchQueryText)
+        conversationListViewModel.searchQueryChanged(searchQueryText)
         advanceUntilIdle()
 
         // Then
@@ -185,8 +184,6 @@ class ConversationListViewModelTest {
         @MockK
         private lateinit var updateConversationArchivedStatus: UpdateConversationArchivedStatusUseCase
 
-        private val searchQueryFlow = MutableStateFlow("")
-
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
             coEvery { observeConversationListDetailsUseCase.invoke(false) } returns flowOf(
@@ -197,10 +194,6 @@ class ConversationListViewModelTest {
                 )
             )
             mockUri()
-        }
-
-        fun searchQueryChanged(searchQuery: String) = apply {
-            searchQueryFlow.value = searchQuery
         }
 
         fun updateConversationMutedStatusSuccess() = apply {
@@ -232,7 +225,6 @@ class ConversationListViewModelTest {
             refreshConversationsWithoutMetadata = refreshConversationsWithoutMetadata,
             userTypeMapper = UserTypeMapper(),
             updateConversationArchivedStatus = updateConversationArchivedStatus,
-            searchQueryFlow = searchQueryFlow
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11473" title="WPB-11473" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11473</a>  [Android] Search conversation filter not working 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Conversation list search not working after navigating and going back to conversation list screen.

### Causes (Optional)

`HomeStateHolder` was being remembered but with key `currentNavigationItem` which meant that for each navigation item, so after each navigation on home screen, new `HomeStateHolder` is created. Problem was that this holder was also being injected into each home destination, so changing it could potentially make it so that screen uses outdated instance of it. 
In this particular case, view model injection was changed to assisted inject the flow of search queries, but because this holder can change, then view model won't be recreated with new flow (it shouldn't be recreated anyway, it's always better to reuse the same one to not need to refetch the same list again).

### Solutions

Pass search queries dynamically by calling a view model function whenever it changes, so that it won't matter if the `HomeStateHolder` or `SearchBarState` was recreated and it's now a completely new instance.
Also, make sure `HomeStateHolder` is not recreated when it's not needed - remove key `currentNavigationItem` from `remember` and pass `currentNavigationItem` as a state so that only one instance of `HomeStateHolder` is needed.

### Testing

#### How to Test

-open the app
-search for conversation
-open any searched conversation
-go back
-search should still work

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
