### PR TITLE
fix: status bar colour during theme change #WPB-11158

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
@@ -36,15 +36,16 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntSize
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.wire.android.R
+import com.wire.android.ui.theme.ThemeOption
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -54,13 +55,16 @@ import com.wire.kalium.logic.data.id.ConversationId
 
 @Composable
 fun CommonTopAppBar(
+    themeOption: ThemeOption,
     commonTopAppBarState: CommonTopAppBarState,
     onReturnToCallClick: (ConnectivityUIState.EstablishedCall) -> Unit,
     onReturnToIncomingCallClick: (ConnectivityUIState.IncomingCall) -> Unit,
-    onReturnToOutgoingCallClick: (ConnectivityUIState.OutgoingCall) -> Unit
+    onReturnToOutgoingCallClick: (ConnectivityUIState.OutgoingCall) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    Column {
+    Column(modifier = modifier) {
         ConnectivityStatusBar(
+            themeOption = themeOption,
             connectivityInfo = commonTopAppBarState.connectivityState,
             onReturnToCallClick = onReturnToCallClick,
             onReturnToIncomingCallClick = onReturnToIncomingCallClick,
@@ -82,6 +86,7 @@ fun getBackgroundColor(connectivityInfo: ConnectivityUIState): Color {
 
 @Composable
 private fun ConnectivityStatusBar(
+    themeOption: ThemeOption,
     connectivityInfo: ConnectivityUIState,
     onReturnToCallClick: (ConnectivityUIState.EstablishedCall) -> Unit,
     onReturnToIncomingCallClick: (ConnectivityUIState.IncomingCall) -> Unit,
@@ -89,16 +94,22 @@ private fun ConnectivityStatusBar(
 ) {
     val isVisible = connectivityInfo !is ConnectivityUIState.None
     val backgroundColor = getBackgroundColor(connectivityInfo)
-    if (!isVisible) {
-        clearStatusBarColor()
-    }
 
     if (isVisible) {
         val darkIcons = MaterialTheme.wireColorScheme.connectivityBarShouldUseDarkIcons
-        rememberSystemUiController().setStatusBarColor(
+        val systemUiController = rememberSystemUiController()
+        systemUiController.setStatusBarColor(
             color = backgroundColor,
             darkIcons = darkIcons
         )
+        LaunchedEffect(themeOption) {
+            systemUiController.setStatusBarColor(
+                color = backgroundColor,
+                darkIcons = darkIcons
+            )
+        }
+    } else {
+        ClearStatusBarColor()
     }
 
     val barModifier = Modifier
@@ -220,16 +231,6 @@ private fun StatusLabelWithValue(
 }
 
 @Composable
-fun StatusLabel(message: String, color: Color = MaterialTheme.wireColorScheme.onPrimary) {
-    Text(
-        text = message,
-        textAlign = TextAlign.Center,
-        color = color,
-        style = MaterialTheme.wireTypography.title03,
-    )
-}
-
-@Composable
 private fun CameraIcon(tint: Color = MaterialTheme.wireColorScheme.onPositive) {
     Icon(
         painter = painterResource(id = R.drawable.ic_camera_white_paused),
@@ -261,7 +262,7 @@ private fun MicrophoneIcon(
 }
 
 @Composable
-private fun clearStatusBarColor() {
+private fun ClearStatusBarColor() {
     val backgroundColor = MaterialTheme.wireColorScheme.background
     val darkIcons = MaterialTheme.wireColorScheme.useDarkSystemBarIcons
 
@@ -274,7 +275,7 @@ private fun clearStatusBarColor() {
 @Composable
 private fun PreviewCommonTopAppBar(connectivityUIState: ConnectivityUIState) {
     WireTheme {
-        CommonTopAppBar(CommonTopAppBarState(connectivityUIState), {}, {}, {})
+        CommonTopAppBar(ThemeOption.SYSTEM, CommonTopAppBarState(connectivityUIState), {}, {}, {})
     }
 }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11158" title="WPB-11158" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11158</a>  [Android] edege to edge display is not working as expected when targeting android 15
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# What's new in this PR?

### Issues

If status bar had set color the color was overwritten by the night mode change. Now 

### Causes (Optional)

The night mode change was firing after status bar color change, overwriting the color. 

### Solutions

Now `CommonTopAppBar` listens to the theme changes so it can reapply the color. I tried do it on a higher level without adding this dependency but did not managed. ~~I also plan to replace `rememberSystemUiController` with `Activity.enableEdgeToEdge` that was added to the androidx.activity in a separate PR~~ Edit: not feasible at this time

#### How to Test

Start a call to your device. Status bar should be coloured to green
Go to settings - appearance while call is in progress
Start changing the theme
Status bar still should be coloured after change

### Attachments (Optional)

Before 

https://github.com/user-attachments/assets/121f5a27-aae3-43f0-825f-5e85b6a1682b

After

https://github.com/user-attachments/assets/52a9caa7-1d99-4ed9-ba5d-b494421909cb


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
