### PR TITLE
fix: Do not display copy option for ephemeral messages #WPB-6678

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
@@ -56,15 +56,16 @@ fun MessageOptionsModalSheetLayout(
             val isUploading = message.isPending
             val isDeleted = message.isDeleted
             val isMyMessage = message.isMyMessage
+            val isEphemeral = message.header.messageStatus.expirationStatus is ExpirationStatus.Expirable
             WireMenuModalSheetContent(
                 header = MenuModalSheetHeader.Gone,
                 menuItems = messageOptionsMenuItems(
                     isAssetMessage = message.isAssetMessage,
                     isUploading = message.isPending,
                     isComposite = message.messageContent is UIMessageContent.Composite,
-                    isEphemeral = message.header.messageStatus.expirationStatus is ExpirationStatus.Expirable,
+                    isEphemeral = isEphemeral,
                     isEditable = !isUploading && !isDeleted && message.messageContent is UIMessageContent.TextMessage && isMyMessage,
-                    isCopyable = !isUploading && !isDeleted && message.messageContent is Copyable,
+                    isCopyable = !isUploading && !isDeleted && !isEphemeral && message.messageContent is Copyable,
                     isOpenable = true,
                     onCopyClick = remember(message.messageContent) {
                         (message.messageContent as? Copyable)?.textToCopy(context.resources)?.let {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6678" title="WPB-6678" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6678</a>  [Android] Remove copy option for remote part at self deleting messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-6678

# What's new in this PR?

### Issues

We could copy text from ephemeral messages

### Solutions

Changed the logic to not show copy option for messages that are ephemeral

### Testing

#### How to Test

Send ephemeral message and open options menu - no copy option should be visible

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
