### PR TITLE
fix: Avatar cancel button not working #WPB-6679

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
@@ -92,9 +92,10 @@ class AvatarPickerViewModel @Inject constructor(
                     val avatarRawPath = (getAvatarAsset(assetKey = qualifiedAsset) as PublicAssetResult.Success).assetPath
                     val currentAvatarUri = avatarImageManager.getWritableAvatarUri(avatarRawPath)
                     initialPictureLoadingState = InitialPictureLoadingState.Loaded(currentAvatarUri)
-                    if (pictureState is PictureState.Empty) {
-                        pictureState = PictureState.Initial(currentAvatarUri)
-                    }
+                    pictureState = PictureState.Initial(currentAvatarUri)
+                } ?: run {
+                    initialPictureLoadingState = InitialPictureLoadingState.None
+                    pictureState = PictureState.Empty
                 }
             } catch (e: Exception) {
                 appLogger.e("There was an error loading the user avatar", e)

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/image/AvatarPickerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/image/AvatarPickerViewModelTest.kt
@@ -139,6 +139,30 @@ class AvatarPickerViewModelTest {
         assertInstanceOf(AvatarPickerViewModel.PictureState.Initial::class.java, avatarPickerViewModel.pictureState)
     }
 
+    @Test
+    fun `given current avatar present, when new avatar is picked and cancel button pressed, then set state to Initial`() = runTest {
+        val (arrangement, avatarPickerViewModel) = Arrangement()
+            .withSuccessfulInitialAvatarLoad()
+            .arrange()
+
+        avatarPickerViewModel.updatePickedAvatarUri(arrangement.mockUri)
+        assertInstanceOf(AvatarPickerViewModel.PictureState.Picked::class.java, avatarPickerViewModel.pictureState)
+        avatarPickerViewModel.loadInitialAvatarState()
+        assertInstanceOf(AvatarPickerViewModel.PictureState.Initial::class.java, avatarPickerViewModel.pictureState)
+    }
+
+    @Test
+    fun `given no avatar is present, when new avatar is picked and cancel button pressed, then set state to Empty`() = runTest {
+        val (arrangement, avatarPickerViewModel) = Arrangement()
+            .withNoInitialAvatar()
+            .arrange()
+
+        avatarPickerViewModel.updatePickedAvatarUri(arrangement.mockUri)
+        assertInstanceOf(AvatarPickerViewModel.PictureState.Picked::class.java, avatarPickerViewModel.pictureState)
+        avatarPickerViewModel.loadInitialAvatarState()
+        assertInstanceOf(AvatarPickerViewModel.PictureState.Empty::class.java, avatarPickerViewModel.pictureState)
+    }
+
     private class Arrangement {
 
         val userDataStore = mockk<UserDataStore>()
@@ -171,7 +195,7 @@ class AvatarPickerViewModelTest {
             )
         }
 
-        private val mockUri = mockk<Uri>()
+        val mockUri = mockk<Uri>()
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
@@ -205,6 +229,13 @@ class AvatarPickerViewModelTest {
             coEvery { avatarImageManager.getShareableTempAvatarUri(any()) } returns mockUri
             every { userDataStore.avatarAssetId } returns flow { emit(avatarAssetId) }
             every { qualifiedIdMapper.fromStringToQualifiedID(any()) } returns QualifiedID("avatar-value", "avatar-domain")
+
+            return this
+        }
+
+        fun withNoInitialAvatar(): Arrangement {
+            coEvery { avatarImageManager.getShareableTempAvatarUri(any()) } returns mockUri
+            every { userDataStore.avatarAssetId } returns flow { emit(null) }
 
             return this
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6679" title="WPB-6679" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6679</a>  [Android] Cancel button doesn't work while updating profile picture
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-6679

# What's new in this PR?

### Issues

Cancel button during avatar change flow was not working

### Solutions

We missied some states handling, now the cancel buttons goes back to the initial avatar state

### Testing

#### How to Test

Open avatar change flow, pick image from gallery and tap `cancel` action - the flow should get back to initial state

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
