### PR TITLE
fix: Change app versioning for fdroid #WPB-11429

### DIFF
--- a/.github/workflows/build-fdroid-app.yml
+++ b/.github/workflows/build-fdroid-app.yml
@@ -42,7 +42,8 @@ jobs:
         run: chmod +x ./gradlew
       - name: build prod flavour APK
         run:
-          ./gradlew app:assembleFdroidCompatrelease
+          ./gradlew app:assembleFdroidCompatrelease \
+            -PisFDroidRelease=true
         env:
           KEYSTORE_FILE_PATH_DEBUG: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}

--- a/app/src/main/kotlin/com/wire/android/util/AppNameUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/AppNameUtil.kt
@@ -24,7 +24,7 @@ internal object AppNameUtil {
     /**
      * We are supporting two different versions of app name:
      * - fDroid - this contains only version ie. 4.1.0 and we need to add leastSignificantVersionCode and build flavor
-     * - other - this contains version and leastSignificantVersionCode - in this case we add only flavor
+     * - other - this contains version, leastSignificantVersionCode and a build flavor out of the box
      *
      * We can simply distinguish those by checking if current [BuildConfig.VERSION_NAME] contains `-` char.
      */
@@ -32,7 +32,7 @@ internal object AppNameUtil {
         val currentAppName = BuildConfig.VERSION_NAME
 
         return if (currentAppName.contains("-")) {
-            "$currentAppName-${BuildConfig.FLAVOR}"
+            currentAppName
         } else {
             "${BuildConfig.VERSION_NAME}-${leastSignificantVersionCode()}-${BuildConfig.FLAVOR}"
         }

--- a/app/src/main/kotlin/com/wire/android/util/AppNameUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/AppNameUtil.kt
@@ -21,8 +21,21 @@ import com.wire.android.BuildConfig
 
 internal object AppNameUtil {
 
+    /**
+     * We are supporting two different versions of app name:
+     * - fDroid - this contains only version ie. 4.1.0 and we need to add leastSignificantVersionCode and build flavor
+     * - other - this contains version and leastSignificantVersionCode - in this case we add only flavor
+     *
+     * We can simply distinguish those by checking if current [BuildConfig.VERSION_NAME] contains `-` char.
+     */
     fun createAppName(): String {
-        return "${BuildConfig.VERSION_NAME}-${leastSignificantVersionCode()}-${BuildConfig.FLAVOR}"
+        val currentAppName = BuildConfig.VERSION_NAME
+
+        return if (currentAppName.contains("-")) {
+            "$currentAppName-${BuildConfig.FLAVOR}"
+        } else {
+            "${BuildConfig.VERSION_NAME}-${leastSignificantVersionCode()}-${BuildConfig.FLAVOR}"
+        }
     }
 
     /**

--- a/build-logic/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -32,15 +32,25 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
         extensions.configure<ApplicationExtension> {
             // TODO: Handle flavors. Currently implemented in `variants.gradle.kts` script
+
             namespace = AndroidApp.id
             configureKotlinAndroid(this)
+
+            val isFDroidRelease = (project.properties["isFDroidRelease"] as? String)?.toBoolean() ?: false
+
             defaultConfig {
-                AndroidApp.setRootDir(projectDir)
+                AndroidApp.setRootDir(project.projectDir)
+
+                val versionNameBasedOnFDroid = if (isFDroidRelease) {
+                    AndroidApp.versionName
+                } else {
+                    "${AndroidApp.versionName}-${AndroidApp.leastSignificantVersionCode}"
+                }
 
                 applicationId = AndroidApp.id
                 defaultConfig.targetSdk = AndroidSdk.target
                 versionCode = AndroidApp.versionCode
-                versionName = AndroidApp.versionName
+                versionName = versionNameBasedOnFDroid
                 setProperty("archivesBaseName", "$applicationId-v$versionName")
             }
 

--- a/build-logic/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -50,7 +50,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 applicationId = AndroidApp.id
                 defaultConfig.targetSdk = AndroidSdk.target
                 versionCode = AndroidApp.versionCode
-                versionName = versionNameBasedOnFDroid
+                versionName = resolvedVersionName
                 setProperty("archivesBaseName", "$applicationId-v$versionName")
             }
 

--- a/build-logic/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -41,7 +41,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             defaultConfig {
                 AndroidApp.setRootDir(project.projectDir)
 
-                val versionNameBasedOnFDroid = if (isFDroidRelease) {
+                val resolvedVersionName = if (isFDroidRelease) {
                     AndroidApp.versionName
                 } else {
                     "${AndroidApp.versionName}-${AndroidApp.leastSignificantVersionCode}"

--- a/build-logic/plugins/src/main/kotlin/AndroidCoordinates.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidCoordinates.kt
@@ -35,4 +35,23 @@ object AndroidApp {
     fun setRootDir(rootDir: File) {
         this._rootDir = rootDir
     }
+
+    /**
+     * The last 5 digits of the VersionCode. From 0 to 99_999.
+     * It's an [Int], so it can be less than 5 digits when doing [toString], of course.
+     * Considering versionCode bumps every 5min, these are
+     * 288 per day
+     * 8640 per month
+     * 51840 per semester
+     * 103_680 per year. ~99_999
+     *
+     * So it takes almost a whole year until it rotates back.
+     * It's very unlikely that two APKs with the same version (_e.g._ 4.8.0)
+     * will have the same [leastSignificantVersionCode],
+     * unless they are build almost one year apart.
+     */
+    @Suppress("MagicNumber")
+    val leastSignificantVersionCode by lazy {
+        versionCode % 100_000
+    }
 }

--- a/buildSrc/src/main/kotlin/flavor/ProductFlavors.kt
+++ b/buildSrc/src/main/kotlin/flavor/ProductFlavors.kt
@@ -24,6 +24,7 @@ object FlavorDimensions {
 sealed class ProductFlavors(
     val buildName: String,
     val appName: String,
+    val versionNameSuffix: String = "-${buildName}",
     val dimensions: String = FlavorDimensions.DEFAULT,
     val shareduserId: String = ""
 ) {
@@ -35,7 +36,12 @@ sealed class ProductFlavors(
     object Beta : ProductFlavors("beta", "Wire Beta")
     object Internal : ProductFlavors("internal", "Wire Internal")
     object Production : ProductFlavors("prod", "Wire", shareduserId = "com.waz.userid")
-    object Fdroid : ProductFlavors("fdroid", "Wire", shareduserId = "com.waz.userid")
+    object Fdroid : ProductFlavors(
+        buildName = "fdroid",
+        appName = "Wire",
+        shareduserId = "com.waz.userid",
+        versionNameSuffix = ""
+    )
 
     companion object {
         val all: Collection<ProductFlavors> = setOf(

--- a/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
@@ -62,6 +62,7 @@ fun NamedDomainObjectContainer<ApplicationProductFlavor>.createAppFlavour(
     create(flavour.buildName) {
         dimension = flavour.dimensions
         applicationId = flavorApplicationId
+        versionNameSuffix = flavour.versionNameSuffix
         resValue("string", "app_name", flavour.appName)
         manifestPlaceholders["sharedUserId"] = sharedUserId
         manifestPlaceholders["appAuthRedirectScheme"] = flavorApplicationId

--- a/docker-agent/builder.sh
+++ b/docker-agent/builder.sh
@@ -30,7 +30,7 @@ fi
 
 if [ "$BUILD_CLIENT" = true ] ; then
     echo "Compiling the client with Flavor:${CUSTOM_FLAVOR} and BuildType:${BUILD_TYPE}"
-    ./gradlew ${buildOption}assemble${FLAVOR_TYPE}${BUILD_TYPE}
+    ./gradlew ${buildOption}assemble${FLAVOR_TYPE}${BUILD_TYPE} -PisFDroidRelease=true
 else
     echo "Building the client will be skipped"
 fi


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11429" title="WPB-11429" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11429</a>  [Android] update app version name to for fdroid auto update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-11429

# What's new in this PR?

### Issues

Change the version name again, now we had a clean version for each build but this messes up with testing

### Solutions

So the idea is to differentiate builds for fdroid with a flag `isFDroidRelease` - and create version name based on that flag.
Then in the app we check if version name contains something other than plain version (simple `-` check should be enough) - and we also add a flavor to our displayed name.

### Testing

#### How to Test

Builds for testing should be in a form `version-code` and in the app settings we should always see `version-code-flavor`

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
