### PR TITLE
fix: learn more link color [WPB-11189]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
@@ -229,7 +229,7 @@ private fun EmailErrorText(error: CreateAccountEmailViewState.EmailError) {
             pushStringAnnotation(tag = learnMoreTag, annotation = learnMoreUrl)
             withStyle(
                 style = SpanStyle(
-                    color = MaterialTheme.wireColorScheme.onTertiaryButtonSelected,
+                    color = MaterialTheme.wireColorScheme.onBackground,
                     fontWeight = MaterialTheme.wireTypography.label05.fontWeight,
                     fontSize = MaterialTheme.wireTypography.label05.fontSize,
                     textDecoration = TextDecoration.Underline
@@ -257,37 +257,39 @@ private fun EmailErrorText(error: CreateAccountEmailViewState.EmailError) {
 
 @Composable
 private fun EmailFooter(state: CreateAccountEmailViewState, onLoginPressed: () -> Unit, onContinuePressed: () -> Unit) {
-    Row(
-        horizontalArrangement = Arrangement.Center,
-        modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing16x)
-    ) {
-        Text(
-            text = "${stringResource(R.string.create_account_email_footer_text)} ",
-            style = MaterialTheme.wireTypography.body02,
-            textAlign = TextAlign.Center,
-        )
-        Text(
-            text = stringResource(R.string.label_login),
-            style = MaterialTheme.wireTypography.body02.copy(textDecoration = TextDecoration.Underline),
-            color = MaterialTheme.colorScheme.primary,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-                onClick = onLoginPressed
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing16x)
+        ) {
+            Text(
+                text = "${stringResource(R.string.create_account_email_footer_text)} ",
+                style = MaterialTheme.wireTypography.body02,
+                textAlign = TextAlign.Center,
             )
+            Text(
+                text = stringResource(R.string.label_login),
+                style = MaterialTheme.wireTypography.body02.copy(textDecoration = TextDecoration.Underline),
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onLoginPressed
+                )
+            )
+        }
+        WirePrimaryButton(
+            text = stringResource(R.string.label_continue),
+            onClick = onContinuePressed,
+            fillMaxWidth = true,
+            loading = state.loading,
+            state = if (state.continueEnabled) WireButtonState.Default else WireButtonState.Disabled,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(MaterialTheme.wireDimensions.spacing16x)
         )
     }
-    WirePrimaryButton(
-        text = stringResource(R.string.label_continue),
-        onClick = onContinuePressed,
-        fillMaxWidth = true,
-        loading = state.loading,
-        state = if (state.continueEnabled) WireButtonState.Default else WireButtonState.Disabled,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(MaterialTheme.wireDimensions.spacing16x)
-    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreatePersonalAccountOverviewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreatePersonalAccountOverviewScreen.kt
@@ -53,6 +53,7 @@ import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.destinations.CreateAccountEmailScreenDestination
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
@@ -62,8 +63,8 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 @WireDestination
 @Composable
 fun CreatePersonalAccountOverviewScreen(
-    viewModel: CreateAccountOverviewViewModel = hiltViewModel(),
-    navigator: Navigator
+    navigator: Navigator,
+    viewModel: CreateAccountOverviewViewModel = hiltViewModel()
 ) {
     with(CreateAccountFlowType.CreatePersonalAccount) {
         fun navigateToEmailScreen() =
@@ -89,8 +90,8 @@ fun CreatePersonalAccountOverviewScreen(
 @WireDestination
 @Composable
 fun CreateTeamAccountOverviewScreen(
-    viewModel: CreateAccountOverviewViewModel = hiltViewModel(),
-    navigator: Navigator
+    navigator: Navigator,
+    viewModel: CreateAccountOverviewViewModel = hiltViewModel()
 ) {
     with(CreateAccountFlowType.CreateTeam) {
         fun navigateToEmailScreen() =
@@ -167,7 +168,11 @@ private fun OverviewContent(
 }
 
 @Composable
-private fun OverviewTexts(overviewParams: CreateAccountOverviewParams, modifier: Modifier, onLearnMoreClick: () -> Unit) {
+private fun OverviewTexts(
+    overviewParams: CreateAccountOverviewParams,
+    modifier: Modifier = Modifier,
+    onLearnMoreClick: () -> Unit
+) {
     Column(modifier = modifier) {
         if (overviewParams.contentTitle.isNotEmpty()) {
             Text(
@@ -188,8 +193,7 @@ private fun OverviewTexts(overviewParams: CreateAccountOverviewParams, modifier:
         Text(
             text = overviewParams.learnMoreText,
             style = MaterialTheme.wireTypography.body02.copy(
-                textDecoration = TextDecoration.Underline,
-                color = MaterialTheme.colorScheme.primary
+                textDecoration = TextDecoration.Underline
             ),
             textAlign = TextAlign.Center,
             modifier = Modifier
@@ -205,7 +209,7 @@ private fun OverviewTexts(overviewParams: CreateAccountOverviewParams, modifier:
 
 @Composable
 @Preview
-fun PreviewCreateAccountOverviewScreen() {
+fun PreviewCreateAccountOverviewScreen() = WireTheme {
     OverviewContent(
         onBackPressed = { },
         onContinuePressed = { },

--- a/app/src/main/kotlin/com/wire/android/ui/common/TextWithLearnMore.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/TextWithLearnMore.kt
@@ -38,8 +38,8 @@ import com.wire.android.util.ui.toSpanStyle
 fun TextWithLearnMore(
     textAnnotatedString: AnnotatedString,
     learnMoreLink: String,
-    onTextLayout: (TextLayoutResult) -> Unit = {},
     modifier: Modifier = Modifier,
+    onTextLayout: (TextLayoutResult) -> Unit = {}
 ) {
     val context = LocalContext.current
     val learnMoreText = stringResource(id = R.string.label_learn_more).replace(" ", "\u00A0") // non-breaking space
@@ -47,7 +47,7 @@ fun TextWithLearnMore(
         append(learnMoreText)
         addStyle(
             style = SpanStyle(
-                color = MaterialTheme.colorScheme.primary,
+                color = MaterialTheme.colorScheme.onBackground,
                 textDecoration = TextDecoration.Underline
             ),
             start = 0,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageItemComponents.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageItemComponents.kt
@@ -248,7 +248,7 @@ internal fun MessageDecryptionFailure(
                     .clickable { CustomTabsHelper.launchUrl(context, learnMoreUrl) },
                 style = LocalTextStyle.current,
                 textDecoration = TextDecoration.Underline,
-                color = MaterialTheme.wireColorScheme.onTertiaryButtonSelected,
+                color = MaterialTheme.wireColorScheme.onBackground,
                 text = stringResource(R.string.label_learn_more)
             )
             VerticalSpace.x4()
@@ -339,7 +339,7 @@ internal fun OfflineBackendsLearnMoreLink(context: Context = LocalContext.curren
     Text(
         modifier = Modifier.clickable { CustomTabsHelper.launchUrl(context, learnMoreUrl) },
         style = LocalTextStyle.current.copy(
-            color = MaterialTheme.wireColorScheme.onTertiaryButtonSelected,
+            color = MaterialTheme.wireColorScheme.onBackground,
             textDecoration = TextDecoration.Underline
         ),
         text = stringResource(R.string.label_learn_more)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/EmptySearchQueryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/EmptySearchQueryScreen.kt
@@ -68,7 +68,7 @@ fun EmptySearchQueryScreen() {
                 text = stringResource(R.string.label_learn_more_searching_user),
                 style = MaterialTheme.wireTypography.body02.copy(
                     textDecoration = TextDecoration.Underline,
-                    color = MaterialTheme.colorScheme.primary
+                    color = MaterialTheme.colorScheme.onBackground
                 ),
                 modifier = Modifier.clickable { CustomTabsHelper.launchUrl(context, aboutSearchUrl) }
             )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesEmptyScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesEmptyScreen.kt
@@ -43,9 +43,9 @@ import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
-fun SearchConversationMessagesEmptyScreen() {
+fun SearchConversationMessagesEmptyScreen(modifier: Modifier = Modifier) {
     val context = LocalContext.current
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -64,7 +64,7 @@ fun SearchConversationMessagesEmptyScreen() {
                 text = stringResource(R.string.label_learn_more),
                 style = MaterialTheme.wireTypography.body02.copy(
                     textDecoration = TextDecoration.Underline,
-                    color = MaterialTheme.colorScheme.primary
+                    color = MaterialTheme.colorScheme.onBackground
                 ),
                 modifier = Modifier.clickable {
                     CustomTabsHelper.launchUrl(

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -534,7 +534,7 @@ private fun DescriptionText(
             append(" ")
             withStyle(
                 style = SpanStyle(
-                    color = MaterialTheme.wireColorScheme.onTertiaryButtonSelected,
+                    color = MaterialTheme.wireColorScheme.onBackground,
                     fontWeight = MaterialTheme.wireTypography.label05.fontWeight,
                     fontSize = MaterialTheme.wireTypography.label05.fontSize,
                     textDecoration = TextDecoration.Underline

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
@@ -71,13 +71,13 @@ fun wireDialogPropertiesBuilder(
 fun WireDialog(
     title: String,
     text: String,
-    textSuffixLink: DialogTextSuffixLink? = null,
     onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    textSuffixLink: DialogTextSuffixLink? = null,
     optionButton1Properties: WireDialogButtonProperties? = null,
     optionButton2Properties: WireDialogButtonProperties? = null,
     dismissButtonProperties: WireDialogButtonProperties? = null,
     buttonsHorizontalAlignment: Boolean = true,
-    modifier: Modifier = Modifier,
     shape: Shape = RoundedCornerShape(MaterialTheme.wireDimensions.dialogCornerSize),
     contentPadding: PaddingValues = PaddingValues(MaterialTheme.wireDimensions.dialogContentPadding),
     properties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false),
@@ -116,14 +116,14 @@ fun WireDialog(
 @Composable
 fun WireDialog(
     title: String,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
     text: AnnotatedString? = null,
     textSuffixLink: DialogTextSuffixLink? = null,
-    onDismiss: () -> Unit,
     optionButton1Properties: WireDialogButtonProperties? = null,
     optionButton2Properties: WireDialogButtonProperties? = null,
     dismissButtonProperties: WireDialogButtonProperties? = null,
     buttonsHorizontalAlignment: Boolean = true,
-    modifier: Modifier = Modifier,
     shape: Shape = RoundedCornerShape(MaterialTheme.wireDimensions.dialogCornerSize),
     contentPadding: PaddingValues = PaddingValues(MaterialTheme.wireDimensions.dialogContentPadding),
     properties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false),
@@ -156,6 +156,7 @@ fun WireDialog(
 @Composable
 fun WireDialogContent(
     title: String,
+    modifier: Modifier = Modifier,
     titleLoading: Boolean = false,
     text: AnnotatedString? = null,
     textSuffixLink: DialogTextSuffixLink? = null,
@@ -163,7 +164,6 @@ fun WireDialogContent(
     optionButton2Properties: WireDialogButtonProperties? = null,
     dismissButtonProperties: WireDialogButtonProperties? = null,
     buttonsHorizontalAlignment: Boolean = true,
-    modifier: Modifier = Modifier,
     shape: Shape = RoundedCornerShape(MaterialTheme.wireDimensions.dialogCornerSize),
     contentPadding: PaddingValues = PaddingValues(MaterialTheme.wireDimensions.dialogContentPadding),
     centerContent: Boolean = false,
@@ -276,13 +276,13 @@ private fun WireDialogButtonProperties?.getButton(modifier: Modifier = Modifier)
         Box(modifier = modifier) {
             when (type) {
                 WireDialogButtonType.Primary ->
-                    WirePrimaryButton(onClick = onClick, text = text, state = state, loading = loading, modifier = modifier)
+                    WirePrimaryButton(onClick = onClick, text = text, state = state, loading = loading)
 
                 WireDialogButtonType.Secondary ->
-                    WireSecondaryButton(onClick = onClick, text = text, state = state, loading = loading, modifier = modifier)
+                    WireSecondaryButton(onClick = onClick, text = text, state = state, loading = loading)
 
                 WireDialogButtonType.Tertiary ->
-                    WireTertiaryButton(onClick = onClick, text = text, state = state, loading = loading, modifier = modifier)
+                    WireTertiaryButton(onClick = onClick, text = text, state = state, loading = loading)
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11189" title="WPB-11189" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11189</a>  [Android] Learn more links have wrong color
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- changed color of learn more links
- compose style fixes
