### PR TITLE
fix: home screen transition issues [WPB-11580]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeStateHolder.kt
@@ -24,8 +24,6 @@ import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -44,15 +42,12 @@ class HomeStateHolder(
     val coroutineScope: CoroutineScope,
     val navController: NavHostController,
     val drawerState: DrawerState,
+    val currentNavigationItem: HomeDestination,
     val searchBarState: SearchBarState,
     val navigator: Navigator,
-    private val currentNavigationItemState: State<HomeDestination>,
-    private val lazyListStates: Map<HomeDestination, LazyListState>,
+    lazyListStates: Map<HomeDestination, LazyListState>,
 ) {
-    val currentNavigationItem: HomeDestination
-        get() = currentNavigationItemState.value
-    val currentLazyListState: LazyListState
-        get() = lazyListStates[currentNavigationItem] ?: error("No LazyListState found for $currentNavigationItem")
+    val currentLazyListState = lazyListStates[currentNavigationItem] ?: error("No LazyListState found for $currentNavigationItem")
 
     fun closeDrawer() {
         coroutineScope.launch {
@@ -78,22 +73,23 @@ fun rememberHomeScreenState(
 ): HomeStateHolder {
     val searchBarState = rememberSearchbarState()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentNavigationItemState = remember {
-        derivedStateOf {
-            navBackStackEntry?.destination?.route?.let { HomeDestination.fromRoute(it) } ?: HomeDestination.Conversations
-        }
-    }
+    val currentRoute = navBackStackEntry?.destination?.route
+    val currentNavigationItem = currentRoute?.let { HomeDestination.fromRoute(it) } ?: HomeDestination.Conversations
     val lazyListStates = HomeDestination.values().associateWith { rememberLazyListState() }
 
-    return remember {
+    val homeState = remember(
+        currentNavigationItem
+    ) {
         HomeStateHolder(
-            coroutineScope = coroutineScope,
-            navController = navController,
-            drawerState = drawerState,
-            currentNavigationItemState = currentNavigationItemState,
-            searchBarState = searchBarState,
-            navigator = navigator,
-            lazyListStates = lazyListStates
+            coroutineScope,
+            navController,
+            drawerState,
+            currentNavigationItem,
+            searchBarState,
+            navigator,
+            lazyListStates
         )
     }
+
+    return homeState
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11580" title="WPB-11580" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11580</a>  [Android] Empty conversation list or settings list when navigating in the app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After implementing the fix for the conversation search (https://github.com/wireapp/wire-android/pull/3492), transitions when navigating between home screen destinations broke.

### Causes (Optional)

Not sure but with this fix there was also attempt to simplify `HomeStateHolder` and make it so that there's only one instance of it, not sure why but it actually created this regression, so looks like there are some other dependencies that rely on having different instances of it.

### Solutions

Revert changes related to `HomeStateHolder`.

### Testing

#### How to Test

Navigate between home screen destinations (all conversations, archive, settings, etc.).

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
