### PR TITLE
ci: fix for frdroid build and gh action for deps (WPB-8645)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       interval: "daily"
     reviewers:
       - "wireapp/android"
+    commit-message:
+      prefix: "chore(deps): [WPB-9777]"
 
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 1
@@ -20,3 +22,5 @@ updates:
       interval: "weekly"
     reviewers:
       - "wireapp/android"
+    commit-message:
+      prefix: "chore(deps): [WPB-9777]"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     reviewers:
       - "wireapp/android"
     commit-message:
-      prefix: "chore(deps): [WPB-9777]"
+      prefix: "chore(deps): [WPB-9777] "
 
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 1
@@ -23,4 +23,4 @@ updates:
     reviewers:
       - "wireapp/android"
     commit-message:
-      prefix: "chore(deps): [WPB-9777]"
+      prefix: "chore(deps): [WPB-9777] "

--- a/.github/workflows/build-fdroid-app.yml
+++ b/.github/workflows/build-fdroid-app.yml
@@ -42,8 +42,7 @@ jobs:
         run: chmod +x ./gradlew
       - name: build prod flavour APK
         run:
-          ./gradlew app:assembleFdroidCompatrelease \
-            -PisFDroidRelease=true
+          ./gradlew app:assembleFdroidCompatrelease -PisFDroidRelease=true
         env:
           KEYSTORE_FILE_PATH_DEBUG: ${{ vars.KEYSTORE_FILE_PATH }}
           KEYSTORE_FILE_PATH_RELEASE: ${{ vars.KEYSTORE_FILE_PATH }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8645" title="WPB-8645" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-8645</a>  [Android] Infrastructure code and developer experience
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fdroid builds are not running, because of a parsing error in the command 

### Solutions

Fix it and also added to dependabot the jira placeholder for dependencies update

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
