### PR TITLE
chore: Change user search name surname highlight logic #WPB-6536

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/HighLightName.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/HighLightName.kt
@@ -40,14 +40,12 @@ fun HighlightName(
     modifier: Modifier = Modifier
 ) {
 
-    val queryWithoutSuffix = searchQuery.removeQueryPrefix()
-
     val highlightIndexes = QueryMatchExtractor.extractQueryMatchIndexes(
-        matchText = queryWithoutSuffix,
+        matchText = searchQuery,
         text = name
     )
 
-    if (queryWithoutSuffix != String.EMPTY && highlightIndexes.isNotEmpty()) {
+    if (searchQuery != String.EMPTY && highlightIndexes.isNotEmpty()) {
         Text(
             buildAnnotatedString {
                 withStyle(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/HighLightSubtTitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/HighLightSubtTitle.kt
@@ -40,14 +40,14 @@ fun HighlightSubtitle(
         return
     }
 
-    val queryWithoutSuffix = searchQuery.removeQueryPrefix()
+    val subtitleWithPrefix = "$prefix$subTitle"
 
     val highlightIndexes = QueryMatchExtractor.extractQueryMatchIndexes(
-        matchText = queryWithoutSuffix,
-        text = subTitle
+        matchText = searchQuery,
+        text = subtitleWithPrefix
     )
 
-    if (queryWithoutSuffix != String.EMPTY && highlightIndexes.isNotEmpty()) {
+    if (searchQuery != String.EMPTY && highlightIndexes.isNotEmpty()) {
         Text(
             buildAnnotatedString {
                 withStyle(
@@ -59,7 +59,7 @@ fun HighlightSubtitle(
                         fontStyle = MaterialTheme.wireTypography.subline01.fontStyle
                     )
                 ) {
-                    append("$prefix$subTitle")
+                    append(subtitleWithPrefix)
                 }
 
                 highlightIndexes
@@ -70,8 +70,8 @@ fun HighlightSubtitle(
                                     background = MaterialTheme.wireColorScheme.highlight,
                                     color = MaterialTheme.wireColorScheme.onHighlight,
                                 ),
-                                start = highLightIndex.startIndex + prefix.length,
-                                end = highLightIndex.endIndex + prefix.length
+                                start = highLightIndex.startIndex,
+                                end = highLightIndex.endIndex
                             )
                         }
                     }
@@ -81,7 +81,7 @@ fun HighlightSubtitle(
         )
     } else {
         Text(
-            text = "$prefix$subTitle",
+            text = subtitleWithPrefix,
             style = MaterialTheme.wireTypography.subline01,
             color = MaterialTheme.wireColorScheme.secondaryText,
             maxLines = 1,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6536" title="WPB-6536" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6536</a>  [Android] Highlight missing at @ sign while searching for a user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-6536

# What's new in this PR?

### Issues

When we're searching for users, we were not highlighting `@` 

### Solutions

We take into considerations the prefix, and now queries with `@` highlight properly. There is an edge case where our search for `@mat` would return results without `@` and we do not highlight anything, but I confirmed with Vina that it is fine in that case.

### Testing


#### How to Test

Search for users with `@` and without, check if proper parts of name and surname are highlighted. In the task description there are also places where it shouldnt change after this changes

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
