### PR TITLE
fix: Wrap persistent connection service in try Cherry-pick [WPB-11113] 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/StartPersistentWebsocketIfNecessaryUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/StartPersistentWebsocketIfNecessaryUseCase.kt
@@ -24,17 +24,17 @@ import android.content.Intent
 import android.os.Build
 import com.wire.android.appLogger
 import com.wire.android.services.PersistentWebSocketService
+import com.wire.android.services.ServicesManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class StartPersistentWebsocketIfNecessaryUseCase @Inject constructor(
-    @ApplicationContext private val appContext: Context,
+    private val servicesManager: ServicesManager,
     private val shouldStartPersistentWebSocketService: ShouldStartPersistentWebSocketServiceUseCase
 ) {
     suspend operator fun invoke() {
-        val persistentWebSocketServiceIntent = PersistentWebSocketService.newIntent(appContext)
         shouldStartPersistentWebSocketService().let {
             when (it) {
                 is ShouldStartPersistentWebSocketServiceUseCase.Result.Failure -> {
@@ -43,28 +43,12 @@ class StartPersistentWebsocketIfNecessaryUseCase @Inject constructor(
 
                 is ShouldStartPersistentWebSocketServiceUseCase.Result.Success -> {
                     if (it.shouldStartPersistentWebSocketService) {
-                        startForegroundService(persistentWebSocketServiceIntent)
+                        appLogger.i("${TAG}: Starting PersistentWebsocketService")
+                        servicesManager.startPersistentWebSocketService()
                     } else {
                         appLogger.i("${TAG}: Stopping PersistentWebsocketService, no user with persistent web socket enabled found")
-                        appContext.stopService(persistentWebSocketServiceIntent)
+                        servicesManager.stopPersistentWebSocketService()
                     }
-                }
-            }
-        }
-    }
-
-    private fun startForegroundService(persistentWebSocketServiceIntent: Intent) {
-        when {
-            PersistentWebSocketService.isServiceStarted -> {
-                appLogger.i("${TAG}: PersistentWebsocketService already started, not starting again")
-            }
-
-            else -> {
-                appLogger.i("${TAG}: Starting PersistentWebsocketService")
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    appContext.startForegroundService(persistentWebSocketServiceIntent)
-                } else {
-                    appContext.startService(persistentWebSocketServiceIntent)
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/feature/StartPersistentWebsocketIfNecessaryUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/StartPersistentWebsocketIfNecessaryUseCase.kt
@@ -19,13 +19,8 @@
 
 package com.wire.android.feature
 
-import android.content.Context
-import android.content.Intent
-import android.os.Build
 import com.wire.android.appLogger
-import com.wire.android.services.PersistentWebSocketService
 import com.wire.android.services.ServicesManager
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/app/src/main/kotlin/com/wire/android/services/ServicesManager.kt
+++ b/app/src/main/kotlin/com/wire/android/services/ServicesManager.kt
@@ -18,7 +18,6 @@
 
 package com.wire.android.services
 
-import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -34,7 +33,6 @@ import kotlinx.coroutines.launch
 import org.jetbrains.annotations.VisibleForTesting
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.reflect.KClass
 
 /**
  * This is helper class that should be used for starting/stopping any services.

--- a/app/src/main/kotlin/com/wire/android/services/ServicesManager.kt
+++ b/app/src/main/kotlin/com/wire/android/services/ServicesManager.kt
@@ -102,11 +102,15 @@ class ServicesManager @Inject constructor(
 
     // Persistent WebSocket
     fun startPersistentWebSocketService() {
-        startService(PersistentWebSocketService.newIntent(context))
+        if (PersistentWebSocketService.isServiceStarted) {
+            appLogger.i("ServicesManager: PersistentWebsocketService already started, not starting again")
+        } else {
+            startService(PersistentWebSocketService.newIntent(context))
+        }
     }
 
     fun stopPersistentWebSocketService() {
-        stopService(PersistentWebSocketService::class)
+        stopService(PersistentWebSocketService.newIntent(context))
     }
 
     fun isPersistentWebSocketServiceRunning(): Boolean =
@@ -121,8 +125,9 @@ class ServicesManager @Inject constructor(
         }
     }
 
-    private fun stopService(serviceClass: KClass<out Service>) {
-        context.stopService(Intent(context, serviceClass.java))
+    private fun stopService(intent: Intent) {
+        appLogger.i("ServicesManager: stopping service for $intent")
+        context.stopService(intent)
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/feature/StartPersistentWebsocketIfNecessaryUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/StartPersistentWebsocketIfNecessaryUseCaseTest.kt
@@ -17,8 +17,6 @@
  */
 package com.wire.android.feature
 
-import android.content.ComponentName
-import android.content.Context
 import com.wire.android.services.ServicesManager
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery

--- a/app/src/test/kotlin/com/wire/android/feature/StartPersistentWebsocketIfNecessaryUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/StartPersistentWebsocketIfNecessaryUseCaseTest.kt
@@ -19,6 +19,7 @@ package com.wire.android.feature
 
 import android.content.ComponentName
 import android.content.Context
+import com.wire.android.services.ServicesManager
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -41,7 +42,7 @@ class StartPersistentWebsocketIfNecessaryUseCaseTest {
             sut.invoke()
 
             // then
-            verify(exactly = 1) { arrangement.applicationContext.startService(any()) }
+            verify(exactly = 1) { arrangement.servicesManager.startPersistentWebSocketService() }
         }
 
     @Test
@@ -56,7 +57,7 @@ class StartPersistentWebsocketIfNecessaryUseCaseTest {
             sut.invoke()
 
             // then
-            verify(exactly = 0) { arrangement.applicationContext.startService(any()) }
+            verify(exactly = 0) { arrangement.servicesManager.startPersistentWebSocketService() }
         }
 
     inner class Arrangement {
@@ -65,16 +66,16 @@ class StartPersistentWebsocketIfNecessaryUseCaseTest {
         lateinit var shouldStartPersistentWebSocketServiceUseCase: ShouldStartPersistentWebSocketServiceUseCase
 
         @MockK
-        lateinit var applicationContext: Context
+        lateinit var servicesManager: ServicesManager
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
-            every { applicationContext.startService(any()) } returns ComponentName.createRelative("dummy", "class")
-            every { applicationContext.stopService(any()) } returns true
+            every { servicesManager.startPersistentWebSocketService() } returns Unit
+            every { servicesManager.stopPersistentWebSocketService() } returns Unit
         }
 
         fun arrange() = this to StartPersistentWebsocketIfNecessaryUseCase(
-            applicationContext,
+            servicesManager,
             shouldStartPersistentWebSocketServiceUseCase
         )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11113" title="WPB-11113" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11113</a>  [Android] crash on starting foreground service
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Cherry-pick for RC from [develop PR](https://github.com/wireapp/wire-android/pull/3532)

# What's new in this PR?

### Issues

crashes in PlayStore https://play.google.com/console/u/0/developers/7098984309886892484/app/4973241010395499500/vitals/crashes/76ed8eaea06144fa56bcc122f39cd8a0/details?days=28&versionCode=100020981

### Causes (Optional)

this happens when PersistentConnection Service is killed by some reason and restarted by OS from background.

### Solutions

Basically the issue is on Android side, for now google suggests try-catch workaround only
https://issuetracker.google.com/issues/307329994#comment86

Also I've updated `StartPersistentWebsocketIfNecessaryUseCase` to use `ServicesManager` for starting Service instead of doing it directly. So we have 1 place where all the Services started from.
