### PR TITLE
fix: can't change email #WPB-11676

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/InputTransformations.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/InputTransformations.kt
@@ -68,9 +68,18 @@ fun InputTransformation.maxLengthWithCallback(maxLength: Int, onIncorrectChanges
     this.then(MaxLengthFilterWithCallback(maxLength, onIncorrectChangesFound))
 
 class PatternFilterWithCallback(private val pattern: Pattern, private val onIncorrectChangesFound: () -> Unit) : InputTransformation {
+
     override fun TextFieldBuffer.transformInput() {
-        if (!pattern.matcher(asCharSequence()).matches()) {
-            revertAllChanges()
+        val newText = asCharSequence()
+        val currentText = originalText
+
+        if (newText.length < currentText.length) {
+            // We are deleting characters, no need to check the pattern
+            return
+        }
+
+        val matchesPattern = pattern.matcher(newText).matches()
+        if (!matchesPattern) {
             onIncorrectChangesFound()
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/email/updateEmail/ChangeEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/email/updateEmail/ChangeEmailScreen.kt
@@ -45,7 +45,6 @@ import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
 import com.wire.android.ui.common.Icon
-import com.wire.android.ui.common.ShakeAnimation
 import com.wire.android.ui.common.button.WireButtonState.Default
 import com.wire.android.ui.common.button.WireButtonState.Disabled
 import com.wire.android.ui.common.button.WirePrimaryButton
@@ -55,14 +54,13 @@ import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.textfield.DefaultEmailDone
 import com.wire.android.ui.common.textfield.WireTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
-import com.wire.android.ui.common.textfield.patternWithCallback
+import com.wire.android.ui.common.textfield.forceLowercase
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.destinations.VerifyEmailScreenDestination
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
-import com.wire.android.util.Patterns
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @RootNavGraph
@@ -137,22 +135,17 @@ fun ChangeEmailContent(
                 Spacer(modifier = Modifier.weight(0.5f))
 
                 Box {
-                    ShakeAnimation { animate ->
-                        WireTextField(
-                            textState = textState,
-                            labelText = stringResource(R.string.email_label).uppercase(),
-                            inputTransformation = InputTransformation.patternWithCallback(
-                                Patterns.EMAIL_ADDRESS,
-                                animate
-                            ),
-                            state = computeEmailErrorState(state.flowState),
-                            keyboardOptions = KeyboardOptions.DefaultEmailDone,
-                            onKeyboardAction = { keyboardController?.hide() },
-                            modifier = Modifier.padding(
-                                horizontal = MaterialTheme.wireDimensions.spacing16x
-                            )
+                    WireTextField(
+                        textState = textState,
+                        labelText = stringResource(R.string.email_label).uppercase(),
+                        inputTransformation = InputTransformation.forceLowercase(),
+                        state = computeEmailErrorState(state.flowState),
+                        keyboardOptions = KeyboardOptions.DefaultEmailDone,
+                        onKeyboardAction = { keyboardController?.hide() },
+                        modifier = Modifier.padding(
+                            horizontal = MaterialTheme.wireDimensions.spacing16x
                         )
-                    }
+                    )
                 }
                 Spacer(modifier = Modifier.weight(1f))
             }

--- a/app/src/main/kotlin/com/wire/android/util/Patterns.kt
+++ b/app/src/main/kotlin/com/wire/android/util/Patterns.kt
@@ -20,8 +20,12 @@ package com.wire.android.util
 import java.util.regex.Pattern
 
 object Patterns {
+
+    /**
+     * RFC5322-compliant regex that covers 99.99% of input email addresses. http://emailregex.com/
+     */
     val EMAIL_ADDRESS: Pattern = Pattern.compile(
-        // RFC5322-compliant regex that covers 99.99% of input email addresses. http://emailregex.com/
+
         "(?:[a-z0-9!#\$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#\$%&'*+/=?^_`{|}~-]+)*|\"" +
                 "(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@" +
                 "(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?" +
@@ -29,5 +33,6 @@ object Patterns {
                 "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:" +
                 "(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
     )
+
     val HANDLE: Pattern = Pattern.compile("^[a-z0-9._-]*$")
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11676" title="WPB-11676" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11676</a>  [Android] User can not delete full email address
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

User was not able to change email from settings -> account detail

### Causes (Optional)

Text transform was matching pattern not allowing deletion action. Then shake animation was firing on each typed character until whole text was matching pattern.

### Solutions

Currently replaced shake animation with just to lowercase. Got a task to consult with design what to do about the shake in the future. Waiting for Wolfgang to comeback from sick leave.

### Testing

#### How to Test

Try to change your email

### Attachments (Optional)

Before

https://github.com/user-attachments/assets/b131f8b6-e21c-4342-9990-2b7f551b6bcc

After

https://github.com/user-attachments/assets/dd47b641-2717-4b73-9ef8-20cec3c53c35

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
