### PR TITLE
fix: Location services availability crash #WPB-11304 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
@@ -27,6 +27,7 @@ import android.os.CancellationSignal
 import androidx.annotation.VisibleForTesting
 import androidx.core.location.LocationManagerCompat
 import com.wire.android.AppJsonStyledLogger
+import com.wire.android.appLogger
 import com.wire.android.di.ApplicationScope
 import com.wire.android.ui.home.appLock.CurrentTimestampProvider
 import com.wire.kalium.logger.KaliumLogLevel
@@ -118,8 +119,16 @@ class LocationPickerHelper @Inject constructor(
     }
 
     internal fun isLocationServicesEnabled(): Boolean {
-        val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
-        return LocationManagerCompat.isLocationEnabled(locationManager)
+        return try {
+            val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+            LocationManagerCompat.isLocationEnabled(locationManager)
+        } catch (e: Exception) {
+            appLogger.i(
+                message = "Checking for location services availability failed",
+                throwable = e
+            )
+            false
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
@@ -118,6 +118,7 @@ class LocationPickerHelper @Inject constructor(
         timeoutJob.start()
     }
 
+    @Suppress("TooGenericExceptionCaught")
     internal fun isLocationServicesEnabled(): Boolean {
         return try {
             val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11304" title="WPB-11304" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11304</a>  [Android] C apps on ss4sk device crashing when sharing location
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-11304

# What's new in this PR?

### Issues

When location services were removed from device - checking for their availability is crashing the application

### Solutions

We need to try/catch the error.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
