### PR TITLE
chore: apply QR profile feature flag to deeplink processing (WPB-11921)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
@@ -25,6 +25,7 @@ import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
 import com.wire.android.feature.SwitchAccountResult
 import com.wire.android.util.EMPTY
+import com.wire.android.util.debug.FeatureVisibilityFlags
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.id.ConversationId
@@ -147,22 +148,35 @@ class DeepLinkProcessor @Inject constructor(
         }
     }
 
+    /**
+     * TODO(Rewrite)
+     * Wait for definitions of Deeplink processing RFC (https://wearezeta.atlassian.net/wiki/x/AgAsWg)
+     *
+     * REF: WPB-10532
+     */
     private fun getConnectingUserProfile(uri: Uri, switchedAccount: Boolean, accountInfo: AccountInfo.Valid): DeepLinkResult {
-        return uri.lastPathSegment?.toDefaultQualifiedId(accountInfo.userId.domain)?.let {
-            DeepLinkResult.OpenOtherUserProfile(it, switchedAccount)
-        } ?: DeepLinkResult.Unknown
+        return if (FeatureVisibilityFlags.QRCodeEnabled) {
+            // TODO: Wait for definitions of Deeplink processing RFC (https://wearezeta.atlassian.net/wiki/x/AgAsWg)
+            // TODO: define format of deeplink wire://user/domain/user-id
+            uri.lastPathSegment?.toDefaultQualifiedId(accountInfo.userId.domain)?.let {
+                DeepLinkResult.OpenOtherUserProfile(it, switchedAccount)
+            }
+            DeepLinkResult.Unknown
+        } else {
+            DeepLinkResult.Unknown
+        }
     }
 
     /**
-     * Currently the DeepLinks sent from web are not qualified.
-     * This is way to default to the current account domain as a best effort.
+     * TODO(Rewrite)
+     * Wait for definitions of Deeplink processing RFC (https://wearezeta.atlassian.net/wiki/x/AgAsWg)
+     * i.e. Define format of deeplink wire://user/domain/user-id
      *
-     * TODO: replace and remove this with String.toQualifiedID() when web sends qualified id.
      * REF: WPB-10532
      */
     private fun String.toDefaultQualifiedId(currentUserDomain: String?): QualifiedID {
         val domain = currentUserDomain ?: "wire.com"
-        // This lowercase is important, since web/iOS is sending/handling this as uppercase.
+        // TODO. This lowercase is important, since web/iOS is sending/handling this as uppercase!!
         return QualifiedID(this.lowercase(), domain)
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11921" title="WPB-11921" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11921</a>  [Android] Implement a feature flag for QR code feature
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There are some pending definitions for QR processing.

### Solutions

Put the deeplink processor under the feature flag so we wait for output of the [RFC](https://wearezeta.atlassian.net/wiki/x/AgAsWg)


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
