### PR TITLE
feat: Remove mls enabled build config field #WPB-10119

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -53,7 +53,6 @@ class KaliumConfigsModule {
             shouldEncryptData = !BuildConfig.DEBUG || Build.VERSION.SDK_INT < Build.VERSION_CODES.R,
             lowerKeyPackageLimits = BuildConfig.LOWER_KEYPACKAGE_LIMIT,
             lowerKeyingMaterialsUpdateThreshold = BuildConfig.PRIVATE_BUILD,
-            isMLSSupportEnabled = BuildConfig.MLS_SUPPORT_ENABLED,
             developmentApiEnabled = BuildConfig.DEVELOPMENT_API_ENABLED,
             ignoreSSLCertificatesForUnboundCalls = BuildConfig.IGNORE_SSL_CERTIFICATES,
             encryptProteusStorage = runBlocking { globalDataStore.isEncryptedProteusStorageEnabled().first() },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -186,29 +186,27 @@ fun ConversationProtocolDetails(
 ) {
     Column(modifier = modifier) {
         FolderHeader(name = stringResource(R.string.folder_label_protocol_details))
-        if (protocolInfo is Conversation.ProtocolInfo.MLS || BuildConfig.MLS_SUPPORT_ENABLED) {
+        if (protocolInfo is Conversation.ProtocolInfo.MLS) {
             ProtocolDetails(
                 label = UIText.StringResource(R.string.protocol),
                 text = UIText.DynamicString(protocolInfo.name())
             )
 
-            if (protocolInfo is Conversation.ProtocolInfo.MLS) {
+            ProtocolDetails(
+                label = UIText.StringResource(R.string.cipher_suite),
+                text = UIText.DynamicString(protocolInfo.cipherSuite.toString())
+            )
+
+            if (BuildConfig.PRIVATE_BUILD) {
                 ProtocolDetails(
-                    label = UIText.StringResource(R.string.cipher_suite),
-                    text = UIText.DynamicString(protocolInfo.cipherSuite.toString())
+                    label = UIText.StringResource(R.string.last_key_material_update_label),
+                    text = UIText.DynamicString(protocolInfo.keyingMaterialLastUpdate.toString())
                 )
 
-                if (BuildConfig.PRIVATE_BUILD) {
-                    ProtocolDetails(
-                        label = UIText.StringResource(R.string.last_key_material_update_label),
-                        text = UIText.DynamicString(protocolInfo.keyingMaterialLastUpdate.toString())
-                    )
-
-                    ProtocolDetails(
-                        label = UIText.StringResource(R.string.group_state_label),
-                        text = UIText.DynamicString(protocolInfo.groupState.name)
-                    )
-                }
+                ProtocolDetails(
+                    label = UIText.StringResource(R.string.group_state_label),
+                    text = UIText.DynamicString(protocolInfo.groupState.name)
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/ConversationParticipantItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/ConversationParticipantItem.kt
@@ -110,7 +110,7 @@ fun ConversationParticipantItem(
 
                 if (uiParticipant.isMLSVerified) MLSVerifiedIcon()
                 if (uiParticipant.isProteusVerified) ProteusVerifiedIcon()
-                if (BuildConfig.MLS_SUPPORT_ENABLED && BuildConfig.DEVELOPER_FEATURES_ENABLED) {
+                if (BuildConfig.DEVELOPER_FEATURES_ENABLED) {
                     uiParticipant.supportedProtocolList.map {
                         ProtocolLabel(
                             protocolName = it.name,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipants.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipants.kt
@@ -64,7 +64,7 @@ fun GroupConversationParticipants(
             state = lazyListState,
             modifier = Modifier.fillMaxSize()
         ) {
-            if (BuildConfig.MLS_SUPPORT_ENABLED && BuildConfig.DEVELOPER_FEATURES_ENABLED) {
+            if (BuildConfig.DEVELOPER_FEATURES_ENABLED) {
                 item(key = "participants_list_header") {
                     Column(
                         modifier = Modifier

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -53,7 +53,6 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
     /**
      * Security/Cryptography stuff
      */
-    MLS_SUPPORT_ENABLED("mls_support_enabled", ConfigType.BOOLEAN),
     LOWER_KEYPACKAGE_LIMIT("lower_keypackage_limit", ConfigType.BOOLEAN),
     ENCRYPT_PROTEUS_STORAGE("encrypt_proteus_storage", ConfigType.BOOLEAN),
     WIPE_ON_COOKIE_INVALID("wipe_on_cookie_invalid", ConfigType.BOOLEAN),

--- a/default.json
+++ b/default.json
@@ -6,7 +6,6 @@
             "logging_enabled": false,
             "application_is_private_build": false,
             "development_api_enabled": false,
-            "mls_support_enabled": false,
             "analytics_enabled": false,
             "analytics_app_key": "4483f7a58ae3e70b3780319c4ccb5c88a037be49",
             "analytics_server_url": "https://countly.wire.com/"
@@ -64,7 +63,6 @@
             "logging_enabled": true,
             "application_is_private_build": true,
             "development_api_enabled": false,
-            "mls_support_enabled": false,
             "encrypt_proteus_storage": true,
             "analytics_enabled": true,
             "analytics_app_key": "8ffae535f1836ed5f58fd5c8a11c00eca07c5438",
@@ -88,7 +86,6 @@
             "logging_enabled": false,
             "application_is_private_build": false,
             "development_api_enabled": false,
-            "mls_support_enabled": false,
             "analytics_enabled": false,
             "analytics_app_key": "",
             "analytics_server_url": ""
@@ -106,7 +103,6 @@
     "file_restriction_list": "3gpp, aac, amr, avi, bmp, css, csv, dib, doc, docx, eml, flac, gif, html, ico, jfif, jpeg, jpg, jpg-large, key, m4a, m4v, md, midi, mkv, mov, mp3, mp4, mpeg, mpeg3, mpg, msg, ods, odt, ogg, pdf, pjp, pjpeg, png, pps, ppt, pptx, psd, pst, rtf, sql, svg, tex, tiff, txt, vcf, vid, wav, webm, webp, wmv, xls, xlsx, xml",
     "force_constant_bitrate_calls": false,
     "ignore_ssl_certificates": false,
-    "mls_support_enabled": true,
     "lower_keypackage_limit": false,
     "encrypt_proteus_storage": false,
     "self_deleting_messages": true,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10119" title="WPB-10119" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10119</a>  [Android] Clients should initialize MLS clients according to backend feature flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

Removing mls build config field as we're no longer rely on it.

### Solutions

We moved away from this check, now backend is deciding about mls being enabled or not


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
