### PR TITLE
feat: Try testTagsAsResourceId to improve UI tests: RC [WPB-9284]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -40,9 +40,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
@@ -120,6 +123,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
+@OptIn(ExperimentalComposeUiApi::class)
 @AndroidEntryPoint
 @Suppress("TooManyFunctions")
 class WireActivity : AppCompatActivity() {
@@ -203,6 +207,7 @@ class WireActivity : AppCompatActivity() {
         }
     }
 
+    @Suppress("LongMethod")
     private fun setComposableContent(
         startDestination: Route,
         onComplete: () -> Unit
@@ -220,7 +225,11 @@ class WireActivity : AppCompatActivity() {
                 LocalActivity provides this
             ) {
                 WireTheme {
-                    Column(modifier = Modifier.statusBarsPadding()) {
+                    Column(
+                        modifier = Modifier
+                            .statusBarsPadding()
+                            .semantics { testTagsAsResourceId = true }
+                    ) {
                         val navigator = rememberNavigator(this@WireActivity::finish)
                         CommonTopAppBar(
                             themeOption = viewModel.globalAppState.themeOption,

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -74,6 +74,7 @@ import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.topappbar.CommonTopAppBar
+import com.wire.android.ui.common.topappbar.CommonTopAppBarState
 import com.wire.android.ui.common.topappbar.CommonTopAppBarViewModel
 import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.destinations.ConversationScreenDestination
@@ -207,7 +208,6 @@ class WireActivity : AppCompatActivity() {
         }
     }
 
-    @Suppress("LongMethod")
     private fun setComposableContent(
         startDestination: Route,
         onComplete: () -> Unit
@@ -231,34 +231,9 @@ class WireActivity : AppCompatActivity() {
                             .semantics { testTagsAsResourceId = true }
                     ) {
                         val navigator = rememberNavigator(this@WireActivity::finish)
-                        CommonTopAppBar(
+                        WireTopAppBar(
                             themeOption = viewModel.globalAppState.themeOption,
-                            commonTopAppBarState = commonTopAppBarViewModel.state,
-                            onReturnToCallClick = { establishedCall ->
-                                getOngoingCallIntent(
-                                    this@WireActivity,
-                                    establishedCall.conversationId.toString()
-                                ).run {
-                                    startActivity(this)
-                                }
-                            },
-                            onReturnToIncomingCallClick = {
-                                getIncomingCallIntent(
-                                    this@WireActivity,
-                                    it.conversationId.toString(),
-                                    null
-                                ).run {
-                                    startActivity(this)
-                                }
-                            },
-                            onReturnToOutgoingCallClick = {
-                                getOutgoingCallIntent(
-                                    this@WireActivity,
-                                    it.conversationId.toString()
-                                ).run {
-                                    startActivity(this)
-                                }
-                            }
+                            commonTopAppBarState = commonTopAppBarViewModel.state
                         )
                         CompositionLocalProvider(LocalNavigator provides navigator) {
                             MainNavHost(
@@ -276,6 +251,42 @@ class WireActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    @Composable
+    private fun WireTopAppBar(
+        themeOption: ThemeOption,
+        commonTopAppBarState: CommonTopAppBarState
+    ) {
+        CommonTopAppBar(
+            themeOption = themeOption,
+            commonTopAppBarState = commonTopAppBarState,
+            onReturnToCallClick = { establishedCall ->
+                getOngoingCallIntent(
+                    this@WireActivity,
+                    establishedCall.conversationId.toString()
+                ).run {
+                    startActivity(this)
+                }
+            },
+            onReturnToIncomingCallClick = {
+                getIncomingCallIntent(
+                    this@WireActivity,
+                    it.conversationId.toString(),
+                    null
+                ).run {
+                    startActivity(this)
+                }
+            },
+            onReturnToOutgoingCallClick = {
+                getOutgoingCallIntent(
+                    this@WireActivity,
+                    it.conversationId.toString()
+                ).run {
+                    startActivity(this)
+                }
+            }
+        )
     }
 
     @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/calling/StartingCallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/StartingCallActivity.kt
@@ -28,6 +28,10 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.core.view.WindowCompat
 import com.wire.android.appLogger
 import com.wire.android.navigation.style.TransitionAnimationType
@@ -52,6 +56,7 @@ import javax.inject.Inject
  * @see IncomingCallScreen
  * @see OutgoingCallScreen
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @AndroidEntryPoint
 class StartingCallActivity : CallActivity() {
     @Inject
@@ -90,6 +95,7 @@ class StartingCallActivity : CallActivity() {
                                     TransitionAnimationType.POP_UP.exitTransition
                                 )
                             },
+                            modifier = Modifier.semantics { testTagsAsResourceId = true },
                             label = currentScreenType.name
                         ) { screenType ->
                             conversationId?.let {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
@@ -31,6 +31,10 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.core.view.WindowCompat
 import com.wire.android.R
 import com.wire.android.appLogger
@@ -56,6 +60,7 @@ import javax.inject.Inject
  *
  * @see OngoingCallScreen
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @AndroidEntryPoint
 class OngoingCallActivity : CallActivity() {
     @Inject
@@ -91,6 +96,7 @@ class OngoingCallActivity : CallActivity() {
                                     TransitionAnimationType.POP_UP.exitTransition
                                 )
                             },
+                            modifier = Modifier.semantics { testTagsAsResourceId = true },
                             label = TAG
                         ) { _ ->
                             OngoingCallScreen(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9284" title="WPB-9284" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9284</a>  Try out `testTagsAsResourceIds` using Compose 1.2
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
RC cherry-pick of https://github.com/wireapp/wire-android/pull/3588

# What's new in this PR?

Add `testTagsAsResourceId` to WireActivity. So the ui elements become accessible to UI tests by `testTag`.


