### PR TITLE
chore: improve logging for backups (WPB-12113)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
@@ -212,7 +212,7 @@ class BackupAndRestoreViewModel
             restoreFileValidation = RestoreFileValidation.ValidNonEncryptedBackup,
             backupRestoreProgress = BackupRestoreProgress.InProgress(PROGRESS_75)
         )
-        when (importBackup(importedBackupPath, null)) {
+        when (val result = importBackup(importedBackupPath, null)) {
             RestoreBackupResult.Success -> {
                 updateCreationProgress(PROGRESS_75)
                 delay(SMALL_DELAY)
@@ -221,10 +221,7 @@ class BackupAndRestoreViewModel
             }
 
             is RestoreBackupResult.Failure -> {
-                appLogger.e(
-                    "Error when restoring the db file. The format or version of the backup is not compatible with this " +
-                            "version of the app"
-                )
+                appLogger.e("Error when restoring the backup db file caused by: ${result.failure.cause}")
                 state = state.copy(
                     restoreFileValidation = RestoreFileValidation.IncompatibleBackup,
                     backupRestoreProgress = BackupRestoreProgress.Failed


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12113" title="WPB-12113" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-12113</a>  [Android] Improve logging for backups
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->




----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Logging was not being performed for importing backups

### Causes (Optional)

Difficulty to troubleshoot problems related to it

### Solutions

Implement logging, to add more info about failures.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### Depends on

- https://github.com/wireapp/kalium/pull/3093

#### How to Test

Fail to import a backup, you should see more info related to the failure.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
