### PR TITLE
fix: TestTag for DeviceItem #WPB-9784

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/DeviceItem.kt
@@ -64,6 +64,8 @@ import com.wire.android.util.extension.formatAsString
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 
+const val DEVICE_ITEM_TEST_TAG = "device_item"
+
 @Composable
 fun DeviceItem(
     device: Device,
@@ -104,6 +106,7 @@ private fun DeviceItemContent(
     Row(
         verticalAlignment = Alignment.Top,
         modifier = modifier
+            .testTag(DEVICE_ITEM_TEST_TAG)
             .clickable(
                 enabled = isWholeItemClickable,
                 onClickLabel = stringResource(id = R.string.content_description_user_profile_open_device_btn)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9784" title="WPB-9784" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9784</a>  [Android] accessibility strings – Conversation details
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

After updating Accessibility strings deviceItem is un-accessible for UI tests. 

### Solutions

Add `testTag` to the DeviceItem

