### PR TITLE
fix: Username index out of bounds exception #WPB-12143

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/InputTransformations.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/InputTransformations.kt
@@ -90,7 +90,11 @@ fun InputTransformation.forceLowercase(): InputTransformation =
 
 class ForceLowercaseTransformation : InputTransformation {
     override fun TextFieldBuffer.transformInput() {
-        replace(0, length, asCharSequence().toString().lowercase())
+        val currentText = asCharSequence().toString()
+        val lowercasedText = currentText.lowercase()
+        if (currentText != lowercasedText) {
+            replace(0, length, lowercasedText)
+        }
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12143" title="WPB-12143" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-12143</a>  [Android] Crash when creating username
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-12143

# What's new in this PR?

### Issues

We are doing lowercase for our username when creating an account, now if we typed two the same letters ie tt ee mm the app was crashing

### Solutions

We now check if the lowercase text is different than the current one, if so we skip the update

### Testing

#### How to Test

Open username input field view
Type two same letters tt for example
The app should not crash
Make sure that aTbZc is correctly transformed into lowercase

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
