### PR TITLE
fix: Accessibility strings issues #WPB-9827

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/WireDropDown.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/WireDropDown.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
@@ -274,12 +275,15 @@ private fun DropdownItem(
         leadingIcon = leadingCompose,
         trailingIcon = {
             if (isSelected) {
-                WireCheckIcon(R.string.content_description_selected_label)
+                WireCheckIcon(R.string.content_description_empty)
             }
         },
         onClick = onClick,
         modifier = Modifier
-            .semantics { onClick(selectLabel) { false } }
+            .semantics {
+                onClick(selectLabel) { false }
+                if (isSelected) selected = true
+            }
             .background(
                 color = if (isSelected) MaterialTheme.wireColorScheme.secondaryButtonSelected
                 else MaterialTheme.wireColorScheme.tertiaryButtonEnabled

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/RichMenuBottomSheetItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/RichMenuBottomSheetItem.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/RichMenuBottomSheetItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/RichMenuBottomSheetItem.kt
@@ -33,6 +33,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
@@ -48,6 +51,7 @@ import io.github.esentsov.PackagePrivate
 @Composable
 fun SelectableMenuBottomSheetItem(
     title: String,
+    modifier: Modifier = Modifier,
     titleColor: Color? = null,
     titleStyleUnselected: TextStyle = MaterialTheme.wireTypography.body02,
     titleStyleSelected: TextStyle = MaterialTheme.wireTypography.body02,
@@ -58,12 +62,13 @@ fun SelectableMenuBottomSheetItem(
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
+        modifier = modifier
             .wrapContentHeight()
             .wrapContentWidth()
             .defaultMinSize(minHeight = dimensions().spacing48x)
             .let { if (isSelectedItem(state)) it.background(MaterialTheme.wireColorScheme.secondaryButtonSelected) else it }
             .clickable(onItemClick)
+            .semantics { if (isSelectedItem(state)) selected = true }
             .padding(vertical = dimensions().spacing12x, horizontal = dimensions().spacing16x)
     ) {
         icon()
@@ -92,7 +97,7 @@ fun SelectableMenuBottomSheetItem(
                     .padding(start = dimensions().spacing8x)
                     .align(Alignment.CenterVertically)
             ) {
-                WireCheckIcon(R.string.label_selected)
+                WireCheckIcon(contentDescription = R.string.content_description_empty)
             }
         }
     }
@@ -102,11 +107,11 @@ fun SelectableMenuBottomSheetItem(
 @Composable
 fun MenuItemHeading(
     title: String,
+    modifier: Modifier = Modifier,
     titleStyleUnselected: TextStyle = MaterialTheme.wireTypography.body02,
     titleStyleSelected: TextStyle = MaterialTheme.wireTypography.body02,
     state: RichMenuItemState = RichMenuItemState.DEFAULT,
-    color: Color? = null,
-    modifier: Modifier = Modifier
+    color: Color? = null
 ) {
     Text(
         style = if (isSelectedItem(state)) titleStyleSelected else titleStyleUnselected,

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/MutingOptionsSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/MutingOptionsSheetContent.kt
@@ -48,36 +48,48 @@ internal fun MutingOptionsSheetContent(
         ),
         menuItems = listOf(
             {
+                val state = if (mutingConversationState == MutedConversationStatus.AllAllowed) RichMenuItemState.SELECTED
+                else RichMenuItemState.DEFAULT
                 SelectableMenuBottomSheetItem(
                     title = stringResource(id = R.string.muting_option_all_allowed_title),
                     subLine = stringResource(id = R.string.muting_option_all_allowed_text),
-                    onItemClick = Clickable(onClickDescription = stringResource(id = R.string.content_description_select_label)) {
+                    onItemClick = Clickable(
+                        enabled = state == RichMenuItemState.DEFAULT,
+                        onClickDescription = stringResource(id = R.string.content_description_select_label)
+                    ) {
                         onMuteConversation(MutedConversationStatus.AllAllowed)
                     },
-                    state = if (mutingConversationState == MutedConversationStatus.AllAllowed) RichMenuItemState.SELECTED
-                    else RichMenuItemState.DEFAULT
+                    state = state
                 )
             },
             {
+                val state = if (mutingConversationState == MutedConversationStatus.OnlyMentionsAndRepliesAllowed) RichMenuItemState.SELECTED
+                else RichMenuItemState.DEFAULT
                 SelectableMenuBottomSheetItem(
                     title = stringResource(id = R.string.muting_option_only_mentions_title),
                     subLine = stringResource(id = R.string.muting_option_only_mentions_text),
-                    onItemClick = Clickable(onClickDescription = stringResource(id = R.string.content_description_select_label)) {
+                    onItemClick = Clickable(
+                        enabled = state == RichMenuItemState.DEFAULT,
+                        onClickDescription = stringResource(id = R.string.content_description_select_label)
+                    ) {
                         onMuteConversation(MutedConversationStatus.OnlyMentionsAndRepliesAllowed)
                     },
-                    state = if (mutingConversationState == MutedConversationStatus.OnlyMentionsAndRepliesAllowed)
-                        RichMenuItemState.SELECTED else RichMenuItemState.DEFAULT
+                    state = state
                 )
             },
             {
+                val state = if (mutingConversationState == MutedConversationStatus.AllMuted) RichMenuItemState.SELECTED
+                else RichMenuItemState.DEFAULT
                 SelectableMenuBottomSheetItem(
                     title = stringResource(id = R.string.muting_option_all_muted_title),
                     subLine = stringResource(id = R.string.muting_option_all_muted_text),
-                    onItemClick = Clickable(onClickDescription = stringResource(id = R.string.content_description_select_label)) {
+                    onItemClick = Clickable(
+                        enabled = state == RichMenuItemState.DEFAULT,
+                        onClickDescription = stringResource(id = R.string.content_description_select_label)
+                    ) {
                         onMuteConversation(MutedConversationStatus.AllMuted)
                     },
-                    state = if (mutingConversationState == MutedConversationStatus.AllMuted) RichMenuItemState.SELECTED
-                    else RichMenuItemState.DEFAULT
+                    state = state
                 )
             }
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -124,8 +124,11 @@ private fun ConversationScreenTopAppBarContent(
                     // spacing between navigation icon button and avatar according to the designs
                     .offset(x = -dimensions().spacing4x)
                     .clip(RoundedCornerShape(MaterialTheme.wireDimensions.buttonCornerSize))
-                    .clickable(onClick = onDropDownClick, enabled = isDropDownEnabled && isInteractionEnabled)
-
+                    .clickable(
+                        onClick = onDropDownClick,
+                        enabled = isDropDownEnabled && isInteractionEnabled,
+                        onClickLabel = stringResource(R.string.content_description_conversation_open_details_label)
+                    )
             ) {
                 val conversationAvatar: ConversationAvatar = conversationInfoViewState.conversationAvatar
                 Avatar(conversationAvatar, conversationInfoViewState)
@@ -148,7 +151,7 @@ private fun ConversationScreenTopAppBarContent(
                 if (isDropDownEnabled && isInteractionEnabled) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_dropdown_icon),
-                        contentDescription = stringResource(R.string.content_description_drop_down_icon)
+                        contentDescription = null
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/InternalContactSearchResultItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/InternalContactSearchResultItem.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
+import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.model.Clickable
 import com.wire.android.model.ItemActionType
@@ -91,7 +92,7 @@ fun InternalContactSearchResultItem(
                         .wrapContentWidth()
                         .padding(end = dimensions().spacing4x)
                 ) {
-                    ArrowRightIcon(Modifier.align(Alignment.TopEnd))
+                    ArrowRightIcon(Modifier.align(Alignment.TopEnd), R.string.content_description_empty)
                 }
             } else if (actionType.checkable) {
                 WireCheckbox(

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -147,6 +147,11 @@ fun UserProfileInfo(
                 label = "UserProfileInfoAvatar"
             ) { (userAvatarData, showPlaceholderIfNoAsset) ->
                 val onAvatarClickDescription = stringResource(R.string.content_description_change_it_label)
+                val contentDescription = if (editableState is EditableState.IsEditable) {
+                    stringResource(R.string.content_description_self_profile_avatar)
+                } else {
+                    null
+                }
                 UserProfileAvatar(
                     size = dimensions().avatarDefaultBigSize,
                     temporaryUserBorderWidth = dimensions().avatarBigTemporaryUserBorderWidth,
@@ -162,8 +167,7 @@ fun UserProfileInfo(
                     withCrossfadeAnimation = true,
                     type = expiresAt?.let { UserProfileAvatarType.WithIndicators.TemporaryUser(expiresAt) }
                         ?: UserProfileAvatarType.WithoutIndicators,
-                    contentDescription = if (editableState is EditableState.IsEditable)
-                        stringResource(R.string.content_description_self_profile_avatar) else null
+                    contentDescription = contentDescription
                 )
             }
             this@Column.AnimatedVisibility(visible = isLoading) {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -162,7 +162,8 @@ fun UserProfileInfo(
                     withCrossfadeAnimation = true,
                     type = expiresAt?.let { UserProfileAvatarType.WithIndicators.TemporaryUser(expiresAt) }
                         ?: UserProfileAvatarType.WithoutIndicators,
-                    contentDescription = stringResource(R.string.content_description_self_profile_avatar)
+                    contentDescription = if (editableState is EditableState.IsEditable)
+                        stringResource(R.string.content_description_self_profile_avatar) else null
                 )
             }
             this@Column.AnimatedVisibility(visible = isLoading) {
@@ -237,7 +238,11 @@ fun UserProfileInfo(
                     color = MaterialTheme.wireColorScheme.labelText,
                     modifier = Modifier.semantics(mergeDescendants = true) { contentDescription = usernameDescription }
                 )
-                UserBadge(membership, connection, topPadding = dimensions().spacing8x)
+                UserBadge(
+                    membership = membership,
+                    connectionState = connection,
+                    topPadding = dimensions().spacing8x
+                )
             }
 
             Column(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,7 @@
     <string name="content_description_conversation_send_gif">Send GIF button</string>
     <string name="content_description_conversation_mention_someone">Mention someone</string>
     <string name="content_description_conversation_back_btn">Go back to conversation list</string>
+    <string name="content_description_conversation_open_details_label">open conversation details</string>
     <string name="content_description_new_conversation">Search for people or create a new group</string>
     <string name="content_description_back_button">Back button</string>
     <string name="content_description_send_button">Send</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9827" title="WPB-9827" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9827</a>  [Android] accessibility strings – Archive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?
Quick fix of some small issues in Accessibility strings, like: 
"Your profile picture" in OtherUserProfileScreen, "Right arrow" when it's not needed, or "Drop down arrow" after conversationName in ConversationScreen etc.
