### PR TITLE
feat: enabling QR codes for users (WPB-12115) 🍒

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/UserNotFoundDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/UserNotFoundDialog.kt
@@ -1,0 +1,74 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.common.dialogs
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.DialogProperties
+import com.wire.android.R
+import com.wire.android.ui.common.WireDialog
+import com.wire.android.ui.common.WireDialogButtonProperties
+import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.common.wireDialogPropertiesBuilder
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.ui.PreviewMultipleThemes
+
+@Composable
+fun UserNotFoundDialog(
+    onActionButtonClicked: () -> Unit
+) {
+    UserNotFoundDialogContent(
+        onConfirm = onActionButtonClicked,
+        onDismiss = onActionButtonClicked,
+        buttonText = R.string.label_ok,
+        dialogProperties = wireDialogPropertiesBuilder(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        )
+    )
+}
+
+@Composable
+fun UserNotFoundDialogContent(
+    @StringRes buttonText: Int,
+    onConfirm: () -> Unit,
+    dialogProperties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false),
+    onDismiss: () -> Unit
+) {
+    WireDialog(
+        title = stringResource(R.string.connection_label_user_not_found_warning_title),
+        text = stringResource(R.string.connection_label_user_not_found_warning_description),
+        onDismiss = onDismiss,
+        optionButton1Properties = WireDialogButtonProperties(
+            text = stringResource(buttonText),
+            onClick = onConfirm,
+            type = WireDialogButtonType.Primary
+        ),
+        properties = dialogProperties
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewUserNotFoundDialog() {
+    WireTheme {
+        UserNotFoundDialogContent(onConfirm = { }, onDismiss = { }, buttonText = R.string.label_ok)
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -16,8 +16,6 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-@file:OptIn(ExperimentalMaterial3Api::class)
-
 package com.wire.android.ui.userprofile.other
 
 import android.annotation.SuppressLint
@@ -37,7 +35,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -79,6 +76,7 @@ import com.wire.android.ui.common.dialogs.BlockUserDialogContent
 import com.wire.android.ui.common.dialogs.BlockUserDialogState
 import com.wire.android.ui.common.dialogs.UnblockUserDialogContent
 import com.wire.android.ui.common.dialogs.UnblockUserDialogState
+import com.wire.android.ui.common.dialogs.UserNotFoundDialog
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.spacers.VerticalSpace
@@ -215,6 +213,10 @@ fun OtherUserProfileScreen(
             viewModel.state.userName,
             legalHoldSubjectDialogState::dismiss
         )
+    }
+
+    if (viewModel.state.errorLoadingUser != null) {
+        UserNotFoundDialog(onActionButtonClicked = navigator::navigateBack)
     }
 }
 
@@ -612,7 +614,6 @@ enum class OtherUserProfileTabItem(@StringRes val titleResId: Int) : TabItem {
     override val title: UIText = UIText.StringResource(titleResId)
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @PreviewMultipleThemes
 fun PreviewOtherProfileScreenGroupMemberContent() {
@@ -634,7 +635,6 @@ fun PreviewOtherProfileScreenGroupMemberContent() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @PreviewMultipleThemes
 fun PreviewOtherProfileScreenContent() {
@@ -657,7 +657,6 @@ fun PreviewOtherProfileScreenContent() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @PreviewMultipleThemes
 fun PreviewOtherProfileScreenContentNotConnected() {
@@ -679,7 +678,6 @@ fun PreviewOtherProfileScreenContentNotConnected() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @PreviewMultipleThemes
 fun PreviewOtherProfileScreenTempUser() {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -42,7 +42,6 @@ import com.wire.android.ui.userprofile.group.RemoveConversationMemberState
 import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.BlockingUserOperationError
 import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.BlockingUserOperationSuccess
 import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.ChangeGroupRoleError
-import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.LoadUserInformationError
 import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.MutingOperationError
 import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.RemoveConversationMemberError
 import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.UnblockingUserOperationError
@@ -70,8 +69,8 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationArchivedStat
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
-import com.wire.kalium.logic.feature.e2ei.usecase.IsOtherUserE2EIVerifiedUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.IsOtherUserE2EIVerifiedUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -189,8 +188,8 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                 .collect { (userResult, groupInfo, oneToOneConversation) ->
                     when (userResult) {
                         is GetUserInfoResult.Failure -> {
-                            appLogger.d("Couldn't not find the user with provided id: $userId")
-                            closeBottomSheetAndShowInfoMessage(LoadUserInformationError)
+                            appLogger.e("Couldn't not find the user with provided id: ${userId.toLogString()}")
+                            updateUserInfoStateForError()
                         }
 
                         is GetUserInfoResult.Success -> {
@@ -368,6 +367,14 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         } else {
             closeBottomSheetAndShowInfoMessage(OtherUserProfileInfoMessageType.ConversationContentDeleted)
         }
+    }
+
+    private fun updateUserInfoStateForError() {
+        state = state.copy(
+            isDataLoading = false,
+            isAvatarLoading = false,
+            errorLoadingUser = ErrorLoadingUser.USER_NOT_FOUND
+        )
     }
 
     private fun updateUserInfoState(

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -54,7 +54,8 @@ data class OtherUserProfileState(
     val isUnderLegalHold: Boolean = false,
     val isConversationStarted: Boolean = false,
     val expiresAt: Instant? = null,
-    val accentId: Int = -1
+    val accentId: Int = -1,
+    val errorLoadingUser: ErrorLoadingUser? = null
 ) {
     fun updateMuteStatus(status: MutedConversationStatus): OtherUserProfileState {
         return conversationSheetContent?.let {
@@ -96,3 +97,8 @@ data class OtherUserProfileGroupState(
     val isSelfAdmin: Boolean,
     val conversationId: ConversationId
 )
+
+enum class ErrorLoadingUser {
+    UNKNOWN, // We might want to expand other errors here as dialogs, ie: federation fallback.
+    USER_NOT_FOUND,
+}

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeScreen.kt
@@ -203,11 +203,7 @@ private fun SelfQRCodeContent(
                 color = colorsScheme().secondaryText
             )
             Spacer(modifier = Modifier.weight(1f))
-<<<<<<< HEAD
             ShareLinkButton(state.userProfileLink, trackAnalyticsEvent)
-=======
-            ShareLinkButton(state.userAccountProfileLink)
->>>>>>> 8cb199b6b (feat: enabling QR codes for users (WPB-12115) (#3616))
             VerticalSpace.x8()
             ShareQRCodeButton {
                 trackAnalyticsEvent(AnalyticsEvent.QrCode.Modal.ShareQrCode)

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeScreen.kt
@@ -188,7 +188,7 @@ private fun SelfQRCodeContent(
                 VerticalSpace.x16()
                 Text(
                     modifier = Modifier.padding(horizontal = dimensions().spacing24x),
-                    text = state.userProfileLink,
+                    text = state.userAccountProfileLink,
                     style = MaterialTheme.wireTypography.subline01,
                     color = Color.Black,
                     textAlign = TextAlign.Center
@@ -203,7 +203,11 @@ private fun SelfQRCodeContent(
                 color = colorsScheme().secondaryText
             )
             Spacer(modifier = Modifier.weight(1f))
+<<<<<<< HEAD
             ShareLinkButton(state.userProfileLink, trackAnalyticsEvent)
+=======
+            ShareLinkButton(state.userAccountProfileLink)
+>>>>>>> 8cb199b6b (feat: enabling QR codes for users (WPB-12115) (#3616))
             VerticalSpace.x8()
             ShareQRCodeButton {
                 trackAnalyticsEvent(AnalyticsEvent.QrCode.Modal.ShareQrCode)

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeState.kt
@@ -25,5 +25,6 @@ data class SelfQRCodeState(
     val avatarAsset: UserAvatarAsset? = null,
     val handle: String = "",
     val userProfileLink: String = "",
+    val userAccountProfileLink: String = "",
     val hasError: Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeViewModel.kt
@@ -100,21 +100,21 @@ class SelfQRCodeViewModel @Inject constructor(
         selfQRCodeState =
             when (val result = selfServerLinks()) {
                 is SelfServerConfigUseCase.Result.Failure -> selfQRCodeState.copy(hasError = true)
-                is SelfServerConfigUseCase.Result.Success -> generateSelfUserUrl(result.serverLinks.links.accounts)
+                is SelfServerConfigUseCase.Result.Success -> generateSelfUserUrls(result.serverLinks.links.accounts)
             }
     }
 
-    private fun generateSelfUserUrl(accountsUrl: String): SelfQRCodeState =
+    private fun generateSelfUserUrls(accountsUrl: String): SelfQRCodeState =
         selfQRCodeState.copy(
-            userProfileLink = String.format(BASE_USER_PROFILE_URL, accountsUrl, selfUserId.value),
+            userAccountProfileLink = String.format(BASE_USER_PROFILE_URL, accountsUrl, selfUserId.value),
+            userProfileLink = String.format(DIRECT_BASE_USER_PROFILE_URL, selfUserId.domain, selfUserId.value)
         )
 
     companion object {
         const val TEMP_SELF_QR_FILENAME = "temp_self_qr.jpg"
         const val BASE_USER_PROFILE_URL = "%s/user-profile/?id=%s"
 
-        // This URL, can be used when we have a direct link to user profile Milestone2
-        const val DIRECT_BASE_USER_PROFILE_URL = "wire://user/%s"
+        const val DIRECT_BASE_USER_PROFILE_URL = "wire://user/%s/%s"
         const val QR_QUALITY_COMPRESSION = 80
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/debug/FeatureVisibilityFlags.kt
+++ b/app/src/main/kotlin/com/wire/android/util/debug/FeatureVisibilityFlags.kt
@@ -56,7 +56,7 @@ object FeatureVisibilityFlags {
     const val MessageEditIcon = true
     const val SearchConversationMessages = true
     const val DrawingIcon = true
-    const val QRCodeEnabled = false
+    const val QRCodeEnabled = true
 }
 
 val LocalFeatureVisibilityFlags = staticCompositionLocalOf { FeatureVisibilityFlags }

--- a/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
@@ -25,7 +25,6 @@ import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
 import com.wire.android.feature.SwitchAccountResult
 import com.wire.android.util.EMPTY
-import com.wire.android.util.debug.FeatureVisibilityFlags
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.id.ConversationId
@@ -148,31 +147,18 @@ class DeepLinkProcessor @Inject constructor(
         }
     }
 
-    /**
-     * TODO(Rewrite)
-     * Wait for definitions of Deeplink processing RFC (https://wearezeta.atlassian.net/wiki/x/AgAsWg)
-     *
-     * REF: WPB-10532
-     */
     private fun getConnectingUserProfile(uri: Uri, switchedAccount: Boolean, accountInfo: AccountInfo.Valid): DeepLinkResult {
-        return if (FeatureVisibilityFlags.QRCodeEnabled) {
-            // TODO: Wait for definitions of Deeplink processing RFC (https://wearezeta.atlassian.net/wiki/x/AgAsWg)
-            // TODO: define format of deeplink wire://user/domain/user-id
-            uri.lastPathSegment?.toDefaultQualifiedId(accountInfo.userId.domain)?.let {
-                DeepLinkResult.OpenOtherUserProfile(it, switchedAccount)
-            }
-            DeepLinkResult.Unknown
-        } else {
-            DeepLinkResult.Unknown
-        }
+        // todo. handle with domain case, before lastPathSegment. format of deeplink wire://user/domain/user-id
+        return uri.lastPathSegment?.toDefaultQualifiedId(accountInfo.userId.domain)?.let {
+            DeepLinkResult.OpenOtherUserProfile(it, switchedAccount)
+        } ?: return DeepLinkResult.Unknown
     }
 
     /**
-     * TODO(Rewrite)
-     * Wait for definitions of Deeplink processing RFC (https://wearezeta.atlassian.net/wiki/x/AgAsWg)
-     * i.e. Define format of deeplink wire://user/domain/user-id
+     * Converts the string to a [QualifiedID] with the current user domain or default, to preserve retro compatibility.
+     * When implementing Milestone 2 this should be replaced with a new qualifiedIdMapper, implementing wire://user/domain/user-id
      *
-     * REF: WPB-10532
+     * - new mapper should follow "domain/user-id" parsing.
      */
     private fun String.toDefaultQualifiedId(currentUserDomain: String?): QualifiedID {
         val domain = currentUserDomain ?: "wire.com"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -995,6 +995,8 @@
     <string name="connection_label_ignore">Ignore</string>
     <string name="connection_label_send_unverified_warning">Get certainty about the identity of %s\'s before connecting.</string>
     <string name="connection_label_received_unverified_warning">Please verify the person\'s identity before accepting the connection request.</string>
+    <string name="connection_label_user_not_found_warning_title">Wire can\'t find this person</string>
+    <string name="connection_label_user_not_found_warning_description">You may not have permission with this account or the person may not be on Wire.</string>
     <!-- Missing keyPackages dialog -->
     <string name="missing_keypackage_dialog_title">Unable to start conversation</string>
     <string name="missing_keypackage_dialog_body">You can\'t start the conversation with %1$s right now. %1$s needs to open Wire or log in again first. Please try again later.</string>

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeViewModelTest.kt
@@ -34,8 +34,13 @@ class SelfQRCodeViewModelTest {
 
         // when - then
         assertEquals(
-            expected = "${ServerConfig.STAGING.accounts}/user-profile/?id=${TestUser.SELF_USER.id.value}",
+            expected = "wire://user/${TestUser.SELF_USER.id.domain}/${TestUser.SELF_USER.id.value}",
             actual = viewModel.selfQRCodeState.userProfileLink,
+        )
+
+        assertEquals(
+            expected = "${ServerConfig.STAGING.accounts}/user-profile/?id=${TestUser.SELF_USER.id.value}",
+            actual = viewModel.selfQRCodeState.userAccountProfileLink,
         )
     }
 

--- a/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
@@ -244,6 +244,20 @@ class DeepLinkProcessorTest {
         assertEquals(DeepLinkResult.SharingIntent, result)
     }
 
+    @Test
+    fun `given an other profile deeplink from QR code, returns Conversation with conversationId`() = runTest {
+        val (arrangement, deepLinkProcessor) = Arrangement()
+            .withOtherUserProfileQRDeepLink(userIdToOpen = OTHER_USER_ID, userId = CURRENT_USER_ID)
+            .withCurrentSessionSuccess(CURRENT_USER_ID)
+            .arrange()
+        val conversationResult = deepLinkProcessor(arrangement.uri, false)
+        assertInstanceOf(DeepLinkResult.OpenOtherUserProfile::class.java, conversationResult)
+        assertEquals(
+            DeepLinkResult.OpenOtherUserProfile(UserId("other_user", "domain"), false),
+            conversationResult
+        )
+    }
+
     class Arrangement {
 
         @MockK
@@ -315,6 +329,12 @@ class DeepLinkProcessorTest {
         fun withOtherUserProfileDeepLink(userIdToOpen: UserId = OTHER_USER_ID, userId: UserId = CURRENT_USER_ID) = apply {
             coEvery { uri.host } returns DeepLinkProcessor.OTHER_USER_PROFILE_DEEPLINK_HOST
             coEvery { uri.lastPathSegment } returns userIdToOpen.toString()
+            coEvery { uri.getQueryParameter(DeepLinkProcessor.USER_TO_USE_QUERY_PARAM) } returns userId.toString()
+        }
+
+        fun withOtherUserProfileQRDeepLink(userIdToOpen: UserId = OTHER_USER_ID, userId: UserId = CURRENT_USER_ID) = apply {
+            coEvery { uri.host } returns DeepLinkProcessor.OPEN_USER_PROFILE_DEEPLINK_HOST
+            coEvery { uri.lastPathSegment } returns userIdToOpen.value
             coEvery { uri.getQueryParameter(DeepLinkProcessor.USER_TO_USE_QUERY_PARAM) } returns userId.toString()
         }
 


### PR DESCRIPTION
This PR was automatically cherry-picked based on the following PR:
 - #3616 

and the one with conflicts 
- https://github.com/wireapp/wire-android/pull/3621

Original PR description:

-----


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12115" title="WPB-12115" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-12115</a>  [Android] : QR code opens up deeplinks which links directly to the app rather than going to the web
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Previously we had to disable the QR code feature, to assess some last moment requirements. #3569 
Now everything is sorted out, definitions done, so we need to modify the code and re-enable.

### Solutions

This PR:

- Enables QR code by feature flag
- Implement deeplink according to new specs (direct deeplink, instead of accounts)
- Handles the same error dialog for other user profiles, as in iOS and Web

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
