### PR TITLE
fix: blank lists or flickering on Home Destinations - wrong lazyListStates [WPB-14276]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -305,7 +305,7 @@ fun HomeContent(
                         }
                     },
                     collapsingEnabled = !searchBarState.isSearchActive,
-                    contentLazyListState = homeStateHolder.currentLazyListState,
+                    contentLazyListState = homeStateHolder.lazyListStateFor(currentNavigationItem),
                     content = {
                         /**
                          * This "if" is a workaround, otherwise it can crash because of the SubcomposeLayout's nature.

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeStateHolder.kt
@@ -24,6 +24,8 @@ import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -42,12 +44,15 @@ class HomeStateHolder(
     val coroutineScope: CoroutineScope,
     val navController: NavHostController,
     val drawerState: DrawerState,
-    val currentNavigationItem: HomeDestination,
     val searchBarState: SearchBarState,
     val navigator: Navigator,
-    lazyListStates: Map<HomeDestination, LazyListState>,
+    private val currentNavigationItemState: State<HomeDestination>,
+    private val lazyListStates: Map<HomeDestination, LazyListState>,
 ) {
-    val currentLazyListState = lazyListStates[currentNavigationItem] ?: error("No LazyListState found for $currentNavigationItem")
+    val currentNavigationItem
+        get() = currentNavigationItemState.value
+    fun lazyListStateFor(destination: HomeDestination): LazyListState =
+        lazyListStates[destination] ?: error("No LazyListState found for $destination")
 
     fun closeDrawer() {
         coroutineScope.launch {
@@ -73,23 +78,22 @@ fun rememberHomeScreenState(
 ): HomeStateHolder {
     val searchBarState = rememberSearchbarState()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute = navBackStackEntry?.destination?.route
-    val currentNavigationItem = currentRoute?.let { HomeDestination.fromRoute(it) } ?: HomeDestination.Conversations
+    val currentNavigationItemState = remember {
+        derivedStateOf {
+            navBackStackEntry?.destination?.route?.let { HomeDestination.fromRoute(it) } ?: HomeDestination.Conversations
+        }
+    }
     val lazyListStates = HomeDestination.values().associateWith { rememberLazyListState() }
 
-    val homeState = remember(
-        currentNavigationItem
-    ) {
+    return remember {
         HomeStateHolder(
-            coroutineScope,
-            navController,
-            drawerState,
-            currentNavigationItem,
-            searchBarState,
-            navigator,
-            lazyListStates
+            coroutineScope = coroutineScope,
+            navController = navController,
+            drawerState = drawerState,
+            searchBarState = searchBarState,
+            navigator = navigator,
+            currentNavigationItemState = currentNavigationItemState,
+            lazyListStates = lazyListStates
         )
     }
-
-    return homeState
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/archive/ArchiveScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/archive/ArchiveScreen.kt
@@ -20,6 +20,7 @@ package com.wire.android.ui.home.archive
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
+import com.wire.android.navigation.HomeDestination
 import com.wire.android.navigation.HomeNavGraph
 import com.wire.android.navigation.WireDestination
 import com.wire.android.navigation.rememberNavigator
@@ -42,7 +43,7 @@ fun ArchiveScreen(homeStateHolder: HomeStateHolder) {
             navigator = navigator,
             searchBarState = searchBarState,
             conversationsSource = ConversationsSource.ARCHIVE,
-            lazyListState = currentLazyListState,
+            lazyListState = lazyListStateFor(HomeDestination.Archive),
             emptyListContent = { ArchiveEmptyContent() }
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/AllConversationsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/AllConversationsScreen.kt
@@ -20,6 +20,7 @@ package com.wire.android.ui.home.conversationslist.all
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
+import com.wire.android.navigation.HomeDestination
 import com.wire.android.navigation.HomeNavGraph
 import com.wire.android.navigation.WireDestination
 import com.wire.android.navigation.rememberNavigator
@@ -42,7 +43,7 @@ fun AllConversationsScreen(homeStateHolder: HomeStateHolder) {
             navigator = navigator,
             searchBarState = searchBarState,
             conversationsSource = ConversationsSource.MAIN,
-            lazyListState = currentLazyListState,
+            lazyListState = lazyListStateFor(HomeDestination.Conversations),
             emptyListContent = { AllConversationsEmptyContent() }
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
@@ -33,6 +33,7 @@ import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.model.Clickable
 import com.wire.android.navigation.BackStackMode
+import com.wire.android.navigation.HomeDestination
 import com.wire.android.navigation.HomeNavGraph
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.WireDestination
@@ -62,7 +63,7 @@ fun SettingsScreen(
 
     val context = LocalContext.current
     SettingsScreenContent(
-        lazyListState = homeStateHolder.currentLazyListState,
+        lazyListState = homeStateHolder.lazyListStateFor(HomeDestination.Settings),
         settingsState = viewModel.state,
         onItemClicked = remember {
             {

--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewScreen.kt
@@ -33,6 +33,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.model.Clickable
+import com.wire.android.navigation.HomeDestination
 import com.wire.android.navigation.HomeNavGraph
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.WireDestination
@@ -51,7 +52,7 @@ fun WhatsNewScreen(
     val context = LocalContext.current
     WhatsNewScreenContent(
         state = whatsNewViewModel.state,
-        lazyListState = homeStateHolder.currentLazyListState,
+        lazyListState = homeStateHolder.lazyListStateFor(HomeDestination.WhatsNew),
         onItemClicked = remember {
             {
                 it.direction.handleNavigation(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14276" title="WPB-14276" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14276</a>  [Android] Conversation screen is not visible when navigating between screens
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When we navigate around screens sometimes the conversations are not visible until we scroll the list manually.
It looks like there are three different scenarios:
-the full list disappears for a moment when navigating back
-the list blinks quickly and then again blinks quickly when scrolling
-the list doesn't blink but then it disappears when scrolling

### Causes (Optional)

Each scrollable screen from "home" graph in theory has its own `LazyListState`, but each view for its own purposes gets it through the `currentLazyListState`. Now, when app executes navigation and changes the `currentNavigationItem`, if the screen that's being closed still needs to recompose during the transition animation or quickly before that, then it again gets the `LazyListState` for itself using `currentLazyListState` but now it returns the `LazyListState` for the new screen that's being navigated to, because `currentNavigationItem` is already changed, so it recomposes with wrong `LazyListState`.

### Solutions

Make each screen in the "home" graph to always and only use its dedicated `LazyListState`.

Thanks to that, it's finally possible to make `HomeStateHolder` not being `remember`ed with key `currentNavigationItem` thus recreated each time the app navigates, but instead there is only one instance of it remembered and the same one is used in each screen from "home" graph.

### Testing

#### How to Test

- Open navigation drawer
- Open settings 
- Open account details
- Get back to conversation list

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/user-attachments/assets/f6dfc111-e47b-4e11-b045-61e46569f32a"/> | <video width="400" src="https://github.com/user-attachments/assets/f9ca84c6-a373-49b4-962c-08a2ac826338"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
