### PR TITLE
fix: lateinit property selfUserId has not been initialized in ConversationInfoViewModel [WPB-14317]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.wire.android.R
 import com.wire.android.appLogger
+import com.wire.android.di.CurrentAccount
 import com.wire.android.model.ImageAsset
 import com.wire.android.navigation.SavedStateViewModel
 import com.wire.android.ui.home.conversations.ConversationNavArgs
@@ -52,9 +53,9 @@ class ConversationInfoViewModel @Inject constructor(
     private val qualifiedIdMapper: QualifiedIdMapper,
     override val savedStateHandle: SavedStateHandle,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
-    private val observerSelfUser: GetSelfUserUseCase,
     private val fetchConversationMLSVerificationStatus: FetchConversationMLSVerificationStatusUseCase,
     private val wireSessionImageLoader: WireSessionImageLoader,
+    @CurrentAccount private val selfUserId: UserId,
 ) : SavedStateViewModel(savedStateHandle) {
 
     private val conversationNavArgs: ConversationNavArgs = savedStateHandle.navArgs()
@@ -62,22 +63,13 @@ class ConversationInfoViewModel @Inject constructor(
 
     var conversationInfoViewState by mutableStateOf(ConversationInfoViewState(conversationId))
 
-    private lateinit var selfUserId: UserId
-
     init {
-        getSelfUserId()
         fetchMLSVerificationStatus()
     }
 
     private fun fetchMLSVerificationStatus() {
         viewModelScope.launch {
             fetchConversationMLSVerificationStatus(conversationId)
-        }
-    }
-
-    private fun getSelfUserId() {
-        viewModelScope.launch {
-            selfUserId = observerSelfUser().first().id
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -41,9 +41,7 @@ import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.FetchConversationMLSVerificationStatusUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
@@ -58,9 +58,6 @@ class ConversationInfoViewModelArrangement {
     lateinit var observeConversationDetails: ObserveConversationDetailsUseCase
 
     @MockK
-    lateinit var observerSelfUser: GetSelfUserUseCase
-
-    @MockK
     lateinit var fetchConversationMLSVerificationStatus: FetchConversationMLSVerificationStatusUseCase
 
     @MockK
@@ -74,9 +71,9 @@ class ConversationInfoViewModelArrangement {
             qualifiedIdMapper,
             savedStateHandle,
             observeConversationDetails,
-            observerSelfUser,
             fetchConversationMLSVerificationStatus,
-            wireSessionImageLoader
+            wireSessionImageLoader,
+            selfUserId = TestUser.SELF_USER_ID,
         )
     }
 
@@ -103,10 +100,6 @@ class ConversationInfoViewModelArrangement {
 
     suspend fun withConversationDetailFailure(failure: StorageFailure) = apply {
         coEvery { observeConversationDetails(any()) } returns flowOf(ObserveConversationDetailsUseCase.Result.Failure(failure))
-    }
-
-    suspend fun withSelfUser() = apply {
-        coEvery { observerSelfUser() } returns flowOf(TestUser.SELF_USER)
     }
 
     fun withMentionedUserId(id: UserId) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelArrangement.kt
@@ -32,7 +32,6 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.FetchConversationMLSVerificationStatusUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModelTest.kt
@@ -47,7 +47,6 @@ class ConversationInfoViewModelTest {
         val groupConversationDetails = mockConversationDetailsGroup("Conversation Name Goes Here")
         val (_, viewModel) = ConversationInfoViewModelArrangement()
             .withConversationDetailUpdate(conversationDetails = groupConversationDetails)
-            .withSelfUser()
             .withMentionedUserId(TestUser.SELF_USER.id)
             .arrange()
         // When
@@ -62,7 +61,6 @@ class ConversationInfoViewModelTest {
         val groupConversationDetails = mockConversationDetailsGroup("Conversation Name Goes Here")
         val (_, viewModel) = ConversationInfoViewModelArrangement()
             .withConversationDetailUpdate(conversationDetails = groupConversationDetails)
-            .withSelfUser()
             .withMentionedUserId(TestUser.OTHER_USER.id)
             .arrange()
         // When
@@ -79,7 +77,6 @@ class ConversationInfoViewModelTest {
             .withConversationDetailUpdate(
                 conversationDetails = oneToOneConversationDetails
             )
-            .withSelfUser()
             .arrange()
         launch { viewModel.observeConversationDetails {} }.run {
             advanceUntilIdle()
@@ -101,7 +98,6 @@ class ConversationInfoViewModelTest {
             .withConversationDetailUpdate(
                 conversationDetails = oneToOneConversationDetails
             )
-            .withSelfUser()
             .arrange()
         launch { viewModel.observeConversationDetails {} }.run {
             advanceUntilIdle()
@@ -117,7 +113,6 @@ class ConversationInfoViewModelTest {
         val groupConversationDetails = mockConversationDetailsGroup("Conversation Name Goes Here")
         val (_, viewModel) = ConversationInfoViewModelArrangement()
             .withConversationDetailUpdate(conversationDetails = groupConversationDetails)
-            .withSelfUser()
             .arrange()
         launch { viewModel.observeConversationDetails {} }.run {
             advanceUntilIdle()
@@ -140,7 +135,6 @@ class ConversationInfoViewModelTest {
             .withConversationDetailUpdate(
                 conversationDetails = firstConversationDetails
             )
-            .withSelfUser()
             .arrange()
         launch { viewModel.observeConversationDetails {} }.run {
             advanceUntilIdle()
@@ -169,7 +163,6 @@ class ConversationInfoViewModelTest {
         runTest {
             // Given
             val (_, viewModel) = ConversationInfoViewModelArrangement()
-                .withSelfUser()
                 .arrange()
 
             // When - Then
@@ -185,7 +178,6 @@ class ConversationInfoViewModelTest {
             .withConversationDetailUpdate(
                 conversationDetails = oneToOneConversationDetails
             )
-            .withSelfUser()
             .arrange()
         launch { viewModel.observeConversationDetails {} }.run {
             advanceUntilIdle()
@@ -202,7 +194,6 @@ class ConversationInfoViewModelTest {
         val otherUserAvatar = conversationDetails.otherUser.previewPicture
         val (_, viewModel) = ConversationInfoViewModelArrangement()
             .withConversationDetailUpdate(conversationDetails = conversationDetails)
-            .withSelfUser()
             .arrange()
         launch { viewModel.observeConversationDetails {} }.run {
             advanceUntilIdle()
@@ -220,7 +211,6 @@ class ConversationInfoViewModelTest {
         val groupConversationDetails = mockConversationDetailsGroup("Conversation Name Goes Here")
         val (_, viewModel) = ConversationInfoViewModelArrangement()
             .withConversationDetailUpdate(conversationDetails = groupConversationDetails)
-            .withSelfUser()
             .arrange()
 
         // then
@@ -244,7 +234,6 @@ class ConversationInfoViewModelTest {
         val groupConversationDetails = mockConversationDetailsGroup("Conversation Name Goes Here")
         val (_, viewModel) = ConversationInfoViewModelArrangement()
             .withConversationDetailUpdate(conversationDetails = groupConversationDetails)
-            .withSelfUser()
             .arrange()
 
         // then
@@ -268,7 +257,6 @@ class ConversationInfoViewModelTest {
         val groupConversationDetails = mockConversationDetailsGroup("Conversation Name Goes Here")
         val (_, viewModel) = ConversationInfoViewModelArrangement()
             .withConversationDetailUpdate(conversationDetails = groupConversationDetails)
-            .withSelfUser()
             .arrange()
 
         // then
@@ -290,7 +278,6 @@ class ConversationInfoViewModelTest {
     fun `given Failure while getting an MLS conversation's verification status, then mlsVerificationStatus is null`() = runTest {
         // Given
         val (_, viewModel) = ConversationInfoViewModelArrangement()
-            .withSelfUser()
             .arrange()
 
         // then
@@ -309,7 +296,6 @@ class ConversationInfoViewModelTest {
         // Given
         val (arrangement, viewModel) = ConversationInfoViewModelArrangement()
             .withConversationDetailFailure(StorageFailure.DataNotFound)
-            .withSelfUser()
             .arrange()
         launch { viewModel.observeConversationDetails(arrangement.onNotFound) }.run {
             advanceUntilIdle()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14317" title="WPB-14317" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14317</a>  [Android] crash in conversation details screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

lateinit property selfUserId has not been initialized in ConversationInfoViewModel

### Causes (Optional)

the lateinit property is updated in async and we can not guaranties that it will be fetched on time for when it is used

### Solutions

there is no need to fetch self user from the db and we can use in memory cache of the current user id

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
