### PR TITLE
fix: qr code link to user as text is incorrect, was wrongly cherrypicked (WPB-14416)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeScreen.kt
@@ -203,7 +203,7 @@ private fun SelfQRCodeContent(
                 color = colorsScheme().secondaryText
             )
             Spacer(modifier = Modifier.weight(1f))
-            ShareLinkButton(state.userProfileLink, trackAnalyticsEvent)
+            ShareLinkButton(state.userAccountProfileLink, trackAnalyticsEvent)
             VerticalSpace.x8()
             ShareQRCodeButton {
                 trackAnalyticsEvent(AnalyticsEvent.QrCode.Modal.ShareQrCode)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14416" title="WPB-14416" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14416</a>  [Android] User QR code share as text is not correct
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

While sharing the QR code link as text, button “Share profile link” is not working as expected on 4.10.0

Expected

https://account.wire.com/user-profile/?id=XXXXXXXX

Actual

wire://user/wire.com/XXXXXX

### Causes (Optional)

Was cherry-picked incorrectly

### Solutions

Fix it

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
