### PR TITLE
fix: Countly crash [WPB-14415]

### DIFF
--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
@@ -70,7 +70,7 @@ class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
 
     /**
      * We need to change our segmentation map to [MutableMap] because
-     * Cauntly is doing additional operations on it.
+     * Countly is doing additional operations on it.
      * See [UtilsInternalLimits.removeUnsupportedDataTypes]
      */
     override fun sendEvent(event: AnalyticsEvent) {

--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
@@ -25,6 +25,7 @@ import com.wire.android.feature.analytics.model.AnalyticsEventConstants
 import com.wire.android.feature.analytics.model.AnalyticsSettings
 import ly.count.android.sdk.Countly
 import ly.count.android.sdk.CountlyConfig
+import ly.count.android.sdk.UtilsInternalLimits
 
 class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
 
@@ -67,8 +68,13 @@ class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
         Countly.sharedInstance().onStop()
     }
 
+    /**
+     * We need to change our segmentation map to [MutableMap] because
+     * Cauntly is doing additional operations on it.
+     * See [UtilsInternalLimits.removeUnsupportedDataTypes]
+     */
     override fun sendEvent(event: AnalyticsEvent) {
-        Countly.sharedInstance().events().recordEvent(event.key, event.toSegmentation())
+        Countly.sharedInstance().events().recordEvent(event.key, event.toSegmentation().toMutableMap())
     }
 
     override fun halt() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14415" title="WPB-14415" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14415</a>  [Android] Crash when sharing assets when countly is enabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-14415

# What's new in this PR?

### Issues

Countly was crashing after version update

### Causes (Optional)

We've updated countly version recently and they have changed their implementation of  `UtilsInternalLimits.removeUnsupportedDataTypes` which require our segmentation map to be mutable

### Solutions

Change map to mutable right before sending event to countly

### Testing

#### How to Test

- Open the app
- Start a call
- App is not crashing :)

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
