### PR TITLE
feat: Allow admins to remove groups [WPB-11559]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails.Self
 import com.wire.kalium.logic.data.conversation.ConversationDetailsWithEvents
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.conversation.UnreadEventCount
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.message.UnreadEventType
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
@@ -43,6 +44,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
     wireSessionImageLoader: WireSessionImageLoader,
     userTypeMapper: UserTypeMapper,
     searchQuery: String,
+    selfUserTeamId: TeamId?
 ): ConversationItem = when (val conversationDetails = this.conversationDetails) {
     is Group -> {
         ConversationItem.GroupConversation(
@@ -56,7 +58,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
                 unreadEventCount = unreadEventCount
             ),
             hasOnGoingCall = conversationDetails.hasOngoingCall && conversationDetails.isSelfUserMember,
-            isSelfUserCreator = conversationDetails.isSelfUserCreator,
+            isFromTheSameTeam = conversationDetails.conversation.teamId == selfUserTeamId,
             isSelfUserMember = conversationDetails.isSelfUserMember,
             teamId = conversationDetails.conversation.teamId,
             selfMemberRole = conversationDetails.selfRole,

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
@@ -100,7 +100,7 @@ sealed class ConversationOptionNavigation {
 }
 
 sealed class ConversationTypeDetail {
-    data class Group(val conversationId: ConversationId, val isCreator: Boolean) : ConversationTypeDetail()
+    data class Group(val conversationId: ConversationId, val isFromTheSameTeam: Boolean) : ConversationTypeDetail()
     data class Private(
         val avatarAsset: UserAvatarAsset?,
         val userId: UserId,
@@ -134,10 +134,11 @@ data class ConversationSheetContent(
             && (conversationTypeDetail.blockingState != BlockingState.BLOCKED))
             || conversationTypeDetail is ConversationTypeDetail.Group)
 
-    fun canDeleteGroup(): Boolean =
-        conversationTypeDetail is ConversationTypeDetail.Group &&
+    fun canDeleteGroup(): Boolean {
+       return conversationTypeDetail is ConversationTypeDetail.Group &&
                 selfRole == Conversation.Member.Role.Admin &&
-                conversationTypeDetail.isCreator && isTeamConversation
+                conversationTypeDetail.isFromTheSameTeam && isTeamConversation
+    }
 
     fun canLeaveTheGroup(): Boolean = conversationTypeDetail is ConversationTypeDetail.Group && isSelfUserMember
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
@@ -70,7 +70,7 @@ fun rememberConversationSheetState(
                     mutingConversationState = mutedStatus,
                     conversationTypeDetail = ConversationTypeDetail.Group(
                         conversationId = conversationId,
-                        isCreator = isSelfUserCreator
+                        isFromTheSameTeam = isFromTheSameTeam
                     ),
                     isTeamConversation = teamId != null,
                     selfRole = selfMemberRole,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -73,6 +73,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
@@ -150,7 +151,10 @@ class GroupConversationDetailsViewModel @Inject constructor(
                     title = groupDetails.conversation.name.orEmpty(),
                     conversationId = conversationId,
                     mutingConversationState = groupDetails.conversation.mutedStatus,
-                    conversationTypeDetail = ConversationTypeDetail.Group(conversationId, groupDetails.isSelfUserCreator),
+                    conversationTypeDetail = ConversationTypeDetail.Group(
+                        conversationId = conversationId,
+                        isFromTheSameTeam = groupDetails.conversation.teamId == observerSelfUser().firstOrNull()?.teamId
+                    ),
                     isTeamConversation = groupDetails.conversation.teamId?.value != null,
                     selfRole = groupDetails.selfRole,
                     isArchived = groupDetails.conversation.archived,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
@@ -48,7 +48,7 @@ class GetConversationsFromSearchUseCase @Inject constructor(
     private val wireSessionImageLoader: WireSessionImageLoader,
     private val userTypeMapper: UserTypeMapper,
     private val dispatchers: DispatcherProvider,
-    private val observeSelfUserUseCase: GetSelfUserUseCase
+    private val observeSelfUser: GetSelfUserUseCase
 ) {
     suspend operator fun invoke(
         searchQuery: String = "",
@@ -102,7 +102,7 @@ class GetConversationsFromSearchUseCase @Inject constructor(
                         wireSessionImageLoader = wireSessionImageLoader,
                         userTypeMapper = userTypeMapper,
                         searchQuery = searchQuery,
-                        selfUserTeamId = observeSelfUserUseCase().firstOrNull()?.teamId
+                        selfUserTeamId = observeSelfUser().firstOrNull()?.teamId
                     )
                 }
             }.flowOn(dispatchers.io())

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
@@ -33,7 +33,9 @@ import com.wire.kalium.logic.data.conversation.ConversationQueryConfig
 import com.wire.kalium.logic.feature.conversation.GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCase
 import com.wire.kalium.logic.feature.conversation.folder.GetFavoriteFolderUseCase
 import com.wire.kalium.logic.feature.conversation.folder.ObserveConversationsFromFolderUseCase
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -46,6 +48,7 @@ class GetConversationsFromSearchUseCase @Inject constructor(
     private val wireSessionImageLoader: WireSessionImageLoader,
     private val userTypeMapper: UserTypeMapper,
     private val dispatchers: DispatcherProvider,
+    private val observeSelfUserUseCase: GetSelfUserUseCase
 ) {
     suspend operator fun invoke(
         searchQuery: String = "",
@@ -95,7 +98,12 @@ class GetConversationsFromSearchUseCase @Inject constructor(
         }
             .map { pagingData ->
                 pagingData.map {
-                    it.toConversationItem(wireSessionImageLoader, userTypeMapper, searchQuery)
+                    it.toConversationItem(
+                        wireSessionImageLoader = wireSessionImageLoader,
+                        userTypeMapper = userTypeMapper,
+                        searchQuery = searchQuery,
+                        selfUserTeamId = observeSelfUserUseCase().firstOrNull()?.teamId
+                    )
                 }
             }.flowOn(dispatchers.io())
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -70,6 +70,7 @@ import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserU
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.Result
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.util.DateTimeUtil
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -85,6 +86,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -142,6 +144,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
     @CurrentAccount val currentAccount: UserId,
     private val wireSessionImageLoader: WireSessionImageLoader,
     private val userTypeMapper: UserTypeMapper,
+    private val observeSelfUserUseCase: GetSelfUserUseCase
 ) : ConversationListViewModel, ViewModel() {
 
     @AssistedFactory
@@ -239,6 +242,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
                                     wireSessionImageLoader = wireSessionImageLoader,
                                     userTypeMapper = userTypeMapper,
                                     searchQuery = searchQuery,
+                                    selfUserTeamId = observeSelfUserUseCase().firstOrNull()?.teamId
                                 ).hideIndicatorForSelfUserUnderLegalHold(selfUserLegalHoldStatus)
                             } to searchQuery
                         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -456,7 +456,7 @@ private fun ConversationsSource.toFilter(): ConversationFilter = when (this) {
 }
 
 private fun ConversationItem.hideIndicatorForSelfUserUnderLegalHold(selfUserLegalHoldStatus: LegalHoldStateForSelfUser) =
-// if self user is under legal hold then we shouldn't show legal hold indicator next to every conversation
+    // if self user is under legal hold then we shouldn't show legal hold indicator next to every conversation
     // the indication is shown in the header of the conversation list for self user in that case and it's enough
     when (selfUserLegalHoldStatus) {
         is LegalHoldStateForSelfUser.Enabled -> when (this) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -144,7 +144,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
     @CurrentAccount val currentAccount: UserId,
     private val wireSessionImageLoader: WireSessionImageLoader,
     private val userTypeMapper: UserTypeMapper,
-    private val observeSelfUserUseCase: GetSelfUserUseCase
+    private val observeSelfUser: GetSelfUserUseCase
 ) : ConversationListViewModel, ViewModel() {
 
     @AssistedFactory
@@ -242,7 +242,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
                                     wireSessionImageLoader = wireSessionImageLoader,
                                     userTypeMapper = userTypeMapper,
                                     searchQuery = searchQuery,
-                                    selfUserTeamId = observeSelfUserUseCase().firstOrNull()?.teamId
+                                    selfUserTeamId = observeSelfUser().firstOrNull()?.teamId
                                 ).hideIndicatorForSelfUserUnderLegalHold(selfUserLegalHoldStatus)
                             } to searchQuery
                         }
@@ -456,7 +456,7 @@ private fun ConversationsSource.toFilter(): ConversationFilter = when (this) {
 }
 
 private fun ConversationItem.hideIndicatorForSelfUserUnderLegalHold(selfUserLegalHoldStatus: LegalHoldStateForSelfUser) =
-    // if self user is under legal hold then we shouldn't show legal hold indicator next to every conversation
+// if self user is under legal hold then we shouldn't show legal hold indicator next to every conversation
     // the indication is shown in the header of the conversation list for self user in that case and it's enough
     when (selfUserLegalHoldStatus) {
         is LegalHoldStateForSelfUser.Enabled -> when (this) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -310,6 +310,7 @@ fun PreviewGroupConversationItemWithUnreadCount() = WireTheme {
             selfMemberRole = null,
             teamId = null,
             isArchived = false,
+            isFromTheSameTeam = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         ),
@@ -335,6 +336,7 @@ fun PreviewGroupConversationItemWithNoBadges() = WireTheme {
             selfMemberRole = null,
             teamId = null,
             isArchived = false,
+            isFromTheSameTeam = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         ),
@@ -362,6 +364,7 @@ fun PreviewGroupConversationItemWithLastDeletedMessage() = WireTheme {
             selfMemberRole = null,
             teamId = null,
             isArchived = false,
+            isFromTheSameTeam = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         ),
@@ -387,6 +390,7 @@ fun PreviewGroupConversationItemWithMutedBadgeAndUnreadMentionBadge() = WireThem
             selfMemberRole = null,
             teamId = null,
             isArchived = false,
+            isFromTheSameTeam = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         ),
@@ -413,6 +417,7 @@ fun PreviewGroupConversationItemWithOngoingCall() = WireTheme {
             teamId = null,
             hasOnGoingCall = true,
             isArchived = false,
+            isFromTheSameTeam = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         ),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -201,6 +201,7 @@ fun previewConversationList(count: Int, startIndex: Int = 0, unread: Boolean = f
                     teamId = null,
                     hasOnGoingCall = false,
                     isArchived = false,
+                    isFromTheSameTeam = false,
                     mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
                     proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
                     searchQuery = searchQuery,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -48,8 +48,8 @@ sealed class ConversationItem : ConversationFolderItem {
     data class GroupConversation(
         val groupName: String,
         val hasOnGoingCall: Boolean = false,
-        val isSelfUserCreator: Boolean = false,
         val selfMemberRole: Conversation.Member.Role?,
+        val isFromTheSameTeam: Boolean,
         val isSelfUserMember: Boolean = true,
         override val conversationId: ConversationId,
         override val mutedStatus: MutedConversationStatus,

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversationItem.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversationItem.kt
@@ -56,6 +56,7 @@ object TestConversationItem {
         ),
         badgeEventType = BadgeEventType.UnreadMessage(100),
         selfMemberRole = null,
+        isFromTheSameTeam = false,
         teamId = null,
         isArchived = false,
         mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -153,7 +153,7 @@ class GroupConversationDetailsViewModelTest {
             conversationName = conversationDetails.conversation.name.orEmpty(),
             conversationTypeDetail = ConversationTypeDetail.Group(
                 conversationId = conversationDetails.conversation.id,
-                isCreator = conversationDetails.isSelfUserCreator
+                isFromTheSameTeam = false
             ),
             isArchived = conversationDetails.conversation.archived,
             isMember = true
@@ -202,7 +202,7 @@ class GroupConversationDetailsViewModelTest {
             conversationName = conversationDetails.conversation.name.orEmpty(),
             conversationTypeDetail = ConversationTypeDetail.Group(
                 conversationId = conversationDetails.conversation.id,
-                isCreator = conversationDetails.isSelfUserCreator
+                isFromTheSameTeam = false
             ),
             isArchived = conversationDetails.conversation.archived,
             isMember = true

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
@@ -22,6 +22,7 @@ import androidx.paging.testing.asSnapshot
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.TestConversationDetails
+import com.wire.android.framework.TestUser
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.util.ui.WireSessionImageLoader
@@ -33,6 +34,7 @@ import com.wire.kalium.logic.data.conversation.FolderType
 import com.wire.kalium.logic.feature.conversation.GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCase
 import com.wire.kalium.logic.feature.conversation.folder.GetFavoriteFolderUseCase
 import com.wire.kalium.logic.feature.conversation.folder.ObserveConversationsFromFolderUseCase
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -73,6 +75,7 @@ class GetConversationsFromSearchUseCaseTest {
         )
         val (arrangement, useCase) = Arrangement()
             .withPaginatedResult(conversationsList)
+            .withSelfUser()
             .arrange()
         // When
         val result = with(arrangement.queryConfig) {
@@ -99,6 +102,7 @@ class GetConversationsFromSearchUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withFavoriteFolderResult(folderResult)
             .withFolderConversationsResult(conversationsList)
+            .withSelfUser()
             .arrange()
 
         // When
@@ -133,6 +137,9 @@ class GetConversationsFromSearchUseCaseTest {
         @MockK
         lateinit var userTypeMapper: UserTypeMapper
 
+        @MockK
+        lateinit var observeSelfUser: GetSelfUserUseCase
+
         val queryConfig = ConversationQueryConfig(
             searchQuery = "search",
             fromArchive = false,
@@ -162,13 +169,18 @@ class GetConversationsFromSearchUseCaseTest {
             } returns flowOf(conversations)
         }
 
+        fun withSelfUser() = apply {
+            coEvery { observeSelfUser() } returns flowOf(TestUser.SELF_USER)
+        }
+
         fun arrange() = this to GetConversationsFromSearchUseCase(
             useCase,
             getFavoriteFolderUseCase,
             observeConversationsFromFolderUseCase,
             wireSessionImageLoader,
             userTypeMapper,
-            dispatcherProvider
+            dispatcherProvider,
+            observeSelfUser
         )
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -56,6 +56,7 @@ import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -274,6 +275,9 @@ class ConversationListViewModelTest {
         @MockK
         private lateinit var wireSessionImageLoader: WireSessionImageLoader
 
+        @MockK
+        private lateinit var observeSelfUser: GetSelfUserUseCase
+
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
             withConversationsPaginated(listOf(TestConversationItem.CONNECTION, TestConversationItem.PRIVATE, TestConversationItem.GROUP))
@@ -343,7 +347,8 @@ class ConversationListViewModelTest {
             observeLegalHoldStateForSelfUser = observeLegalHoldStateForSelfUserUseCase,
             userTypeMapper = UserTypeMapper(),
             wireSessionImageLoader = wireSessionImageLoader,
-            usePagination = true,
+            observeSelfUser = observeSelfUser,
+            usePagination = true
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11559" title="WPB-11559" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11559</a>  [Android] Delete a group as admin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-11559

# What's new in this PR?

### Issues

Allow not only creators of the groups to delete them but also admins who are in the same team.

### Solutions

Check if user has an admin role and is in the same team - if so allow him to delete the group

### Testing

#### How to Test

- Create a group in the same team -> make member an admin -> he is able to delete the group
- Create a group with user from different team -> make him an admin -> he is not able to delete the group

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
