### PR TITLE
feat: support Proteus federation if MLS not supported by backend (WPB-14456)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/SearchModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/SearchModule.kt
@@ -22,6 +22,7 @@ import com.wire.android.di.KaliumCoreLogic
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.search.FederatedSearchParser
+import com.wire.kalium.logic.feature.search.IsFederationSearchAllowedUseCase
 import com.wire.kalium.logic.feature.search.SearchByHandleUseCase
 import com.wire.kalium.logic.feature.search.SearchScope
 import com.wire.kalium.logic.feature.search.SearchUsersUseCase
@@ -53,4 +54,9 @@ class SearchModule {
     @ViewModelScoped
     @Provides
     fun provideFederatedSearchParser(searchScope: SearchScope): FederatedSearchParser = searchScope.federatedSearchParser
+
+    @ViewModelScoped
+    @Provides
+    fun provideIsFederationSearchAllowedUseCase(searchScope: SearchScope): IsFederationSearchAllowedUseCase =
+        searchScope.isFederationSearchAllowedUseCase
 }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14456" title="WPB-14456" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-14456</a>  [Android] Still allow usage of federation for proteus in some cases
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to support federation search, according to if MLS is enabled, or if it is configured or not in the backend.

### Solutions

Create a new use case centralizing the logic to decide if we need to support federation or not for this: team/conversation/backend.

Before the logic was in the view model in AR, but here is centralized and we can test all the cases for it, therefore now the view model just calls this use case to decide if we need to enable cross domain search.

### Dependencies (Optional)

A PR will follow in AR.

Needs releases with:

- https://github.com/wireapp/kalium/pull/3126

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
