### PR TITLE
chore: bulletproofing crypto box to cc migration (WPB-14250) (🍒4.6)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
@@ -166,6 +166,7 @@ class AccountSwitchUseCase @Inject constructor(
             LogoutReason.SELF_SOFT_LOGOUT, LogoutReason.SELF_HARD_LOGOUT -> {
                 deleteSession(invalidAccount.userId)
             }
+            LogoutReason.MIGRATION_TO_CC_FAILED,
             LogoutReason.DELETED_ACCOUNT,
             LogoutReason.REMOVED_CLIENT,
             LogoutReason.SESSION_EXPIRED -> deleteSession(invalidAccount.userId)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -231,7 +231,7 @@ class WireActivityViewModel @Inject constructor(
                     // Self logout is handled from the Self user profile screen directly
                 }
 
-                LogoutReason.REMOVED_CLIENT ->
+                LogoutReason.MIGRATION_TO_CC_FAILED, LogoutReason.REMOVED_CLIENT ->
                     globalAppState = globalAppState.copy(blockUserUI = CurrentSessionErrorState.RemovedClient)
 
                 LogoutReason.DELETED_ACCOUNT ->

--- a/default.json
+++ b/default.json
@@ -28,7 +28,7 @@
             "default_backend_url_website": "https://wire.com",
             "default_backend_title": "wire-staging",
             "is_password_protected_guest_link_enabled": true,
-            "encrypt_proteus_storage": true
+            "encrypt_proteus_storage": false
         },
         "staging": {
             "application_id": "com.waz.zclient.dev",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14250" title="WPB-14250" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-14250</a>  [Android] implement fall guards for CC migration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This PR was automatically cherry-picked based on the following PR:
 - #3123

Original PR description:

-----
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When enabling core crypto storage, if there are any Proteus clients, we need to migrate them from **CryptoBox**.
Things usually don't go as planned, so we need to have a recovery plan in place.

### Causes (Optional)

There might be some errors while migrating.

### Solutions

Implement a recovery plan for this case:
- Catch possible exceptions from migration, we were not handling it and assuming success
- Perform logout, using a new `LogoutReason`, so we can act (cleanup) accordingly
  - Cleanup local crypto files
  - Cleanup from Metadata all related client info (retained id, current id, prekeys, etc.)
  - Set the refresh token to needs update.

If everything goes smoothly, the user will be prompted to login again, preserving their local history.

### Dependencies (Optional)

- https://github.com/wireapp/kalium/pull/3136

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Notes (Optional)

> [!NOTE]
>This approach seems "more correct", since if we try to create a new device only -as the ticket suggested- we will run into the issue of the _refresh token not being valid anymore_, since it was associated with the broken client that we were trying to migrate. And we can't associate the previous refresh token with a different client, we get a 403. 

- We will avoid other edge cases that we might **not sure.** 
- All login cases will be covered (2FA, SCIM, etc.)
- We can expand this handling in the future (if we want) to other cases that we want to recover.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
