### PR TITLE
fix: crash when saving bottom sheet state for message with reply [WPB-14433]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/model/ImageAsset.kt
+++ b/app/src/main/kotlin/com/wire/android/model/ImageAsset.kt
@@ -58,6 +58,7 @@ sealed class ImageAsset {
         val idKey: String
     ) : ImageAsset()
 
+    @Serializable
     sealed class Remote : ImageAsset() {
 
         /**

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -215,8 +215,10 @@ sealed interface MessageFlowStatus {
         }
     }
 
+    @Serializable
     data object Delivered : MessageFlowStatus
 
+    @Serializable
     data class Read(val count: Long) : MessageFlowStatus
 }
 
@@ -285,7 +287,8 @@ sealed interface UIMessageContent {
     @Serializable
     data object IncompleteAssetMessage : UIMessageContent
 
-    interface PartialDeliverable {
+    @Serializable
+    sealed interface PartialDeliverable {
         val deliveryStatus: DeliveryStatusContent
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIQuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIQuotedMessage.kt
@@ -39,25 +39,34 @@ sealed class UIQuotedMessage {
         val quotedContent: Content
     ) : UIQuotedMessage() {
 
+        @Serializable
         sealed interface Content
 
+        @Serializable
         data class Text(val value: String) : Content
 
+        @Serializable
         data class GenericAsset(
             val assetName: String?,
             val assetMimeType: String
         ) : Content
 
+        @Serializable
         data class DisplayableImage(
             val displayable: ImageAsset.PrivateAsset
         ) : Content
 
+        @Serializable
         data class Location(val locationName: String) : Content
 
-        object AudioMessage : Content
+        @Serializable
+        data object AudioMessage : Content
 
-        object Deleted : Content
-        object Invalid : Content
+        @Serializable
+        data object Deleted : Content
+
+        @Serializable
+        data object Invalid : Content
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/util/ui/UIText.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/UIText.kt
@@ -25,8 +25,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import com.wire.android.appLogger
+import com.wire.android.util.AnyPrimitiveAsStringSerializer
 import com.wire.kalium.logic.data.message.mention.MessageMention
-import com.wire.kalium.util.serialization.AnyPrimitiveValueSerializer
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -41,14 +41,14 @@ sealed class UIText {
     @Serializable
     class StringResource(
         @StringRes val resId: Int,
-        vararg val formatArgs: @Serializable(with = AnyPrimitiveValueSerializer::class) Any
+        vararg val formatArgs: @Serializable(with = AnyPrimitiveAsStringSerializer::class) Any
     ) : UIText()
 
     @Serializable
     class PluralResource(
         @PluralsRes val resId: Int,
         val count: Int,
-        vararg val formatArgs: @Serializable(with = AnyPrimitiveValueSerializer::class) Any
+        vararg val formatArgs: @Serializable(with = AnyPrimitiveAsStringSerializer::class) Any
     ) : UIText()
 
     @Suppress("SpreadOperator")

--- a/core/ui-common/build.gradle.kts
+++ b/core/ui-common/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id(libs.plugins.wire.android.library.get().pluginId)
     id(libs.plugins.wire.kover.get().pluginId)
     alias(libs.plugins.kotlin.serialization)
+    id(BuildPlugins.junit5)
 }
 
 android {
@@ -35,7 +36,11 @@ dependencies {
     implementation(libs.coil.gif)
     implementation(libs.coil.compose)
 
-    testImplementation(libs.junit4)
+    testImplementation(libs.junit5.core)
+    testImplementation(libs.junit5.params)
+    testImplementation(libs.mockk.core)
+    testImplementation(libs.kluent.core)
+    testRuntimeOnly(libs.junit5.engine)
     androidTestImplementation(libs.androidx.test.extJunit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
@@ -24,9 +24,9 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -166,14 +166,9 @@ inline fun <reified T : Any> rememberWireModalSheetState(
     val softwareKeyboardController = LocalSoftwareKeyboardController.current
     val density = LocalDensity.current
     val scope = rememberCoroutineScope()
-    return rememberSaveable(
-        saver = WireModalSheetState.saver(
-            density = density,
-            softwareKeyboardController = softwareKeyboardController,
-            onDismissAction = onDismissAction,
-            scope = scope
-        )
-    ) {
+    // TODO: we can use rememberSaveable instead of remember to save the state but first we need to make sure that we don't store too much,
+    //  especially for conversations and messages to not keep such data unencrypted anywhere
+    return remember {
         WireModalSheetState(
             density = density,
             scope = scope,

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
@@ -95,7 +95,7 @@ open class WireModalSheetState<T : Any>(
             softwareKeyboardController: SoftwareKeyboardController?,
             noinline onDismissAction: () -> Unit,
             scope: CoroutineScope
-        ): Saver<WireModalSheetState<T>, *> = Saver(
+        ): Saver<WireModalSheetState<T>, List<Any>> = Saver(
             save = {
                 when (it.currentValue) {
                     is WireSheetValue.Hidden -> listOf(false) // hidden
@@ -109,7 +109,13 @@ open class WireModalSheetState<T : Any>(
                                 listOf(true, SavedType.Regular, value)
 
                             T::class.serializerOrNull() != null -> // expanded and with non-Unit value that can be serialized
-                                listOf(true, SavedType.SerializedBundle, Bundlizer.bundle(T::class.serializer(), value))
+                                try {
+                                    val serializedBundleValue = Bundlizer.bundle(T::class.serializer(), value)
+                                    listOf(true, SavedType.SerializedBundle, serializedBundleValue)
+                                } catch (e: Exception) {
+                                    e.printStackTrace()
+                                    listOf(false) // hidden because value cannot be serialized properly
+                                }
 
                             else -> listOf(false) // hidden because value cannot be saved
                         }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
@@ -89,6 +89,7 @@ open class WireModalSheetState<T : Any>(
     companion object {
         const val DELAY_TO_SHOW_BOTTOM_SHEET_WHEN_KEYBOARD_IS_OPEN = 300L
 
+        @Suppress("TooGenericExceptionCaught")
         @OptIn(InternalSerializationApi::class)
         inline fun <reified T : Any> saver(
             density: Density,

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/AnyPrimitiveAsStringSerializer.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/AnyPrimitiveAsStringSerializer.kt
@@ -1,0 +1,62 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object AnyPrimitiveAsStringSerializer : KSerializer<Any> {
+    override val descriptor: SerialDescriptor = AnyPrimitiveSurrogate.serializer().descriptor
+    override fun serialize(encoder: Encoder, value: Any) =
+        encoder.encodeSerializableValue(AnyPrimitiveSurrogate.serializer(), AnyPrimitiveSurrogate(value))
+    override fun deserialize(decoder: Decoder): Any =
+        decoder.decodeSerializableValue(AnyPrimitiveSurrogate.serializer()).value
+}
+
+@Serializable
+@SerialName("AnyPrimitive")
+private data class AnyPrimitiveSurrogate(private val kind: AnyPrimitiveKind, private val stringValue: String) {
+    constructor(value: Any) : this(
+        kind = when (value) {
+            is String -> AnyPrimitiveKind.STRING
+            is Int -> AnyPrimitiveKind.INT
+            is Long -> AnyPrimitiveKind.LONG
+            is Float -> AnyPrimitiveKind.FLOAT
+            is Double -> AnyPrimitiveKind.DOUBLE
+            is Boolean -> AnyPrimitiveKind.BOOLEAN
+            else -> throw IllegalArgumentException("Unsupported type: ${value::class}")
+        },
+        stringValue = value.toString()
+    )
+
+    val value: Any
+        get() = when (kind) {
+            AnyPrimitiveKind.STRING -> stringValue
+            AnyPrimitiveKind.INT -> stringValue.toInt()
+            AnyPrimitiveKind.LONG -> stringValue.toLong()
+            AnyPrimitiveKind.FLOAT -> stringValue.toFloat()
+            AnyPrimitiveKind.DOUBLE -> stringValue.toDouble()
+            AnyPrimitiveKind.BOOLEAN -> stringValue.toBoolean()
+        }
+}
+
+private enum class AnyPrimitiveKind { STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN }

--- a/core/ui-common/src/test/kotlin/com/wire/android/ui/common/ExampleUnitTest.kt
+++ b/core/ui-common/src/test/kotlin/com/wire/android/ui/common/ExampleUnitTest.kt
@@ -20,7 +20,6 @@ package com.wire.android.ui.common
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-
 /**
  * Example local unit test, which will execute on the development machine (host).
  *

--- a/core/ui-common/src/test/kotlin/com/wire/android/ui/common/ExampleUnitTest.kt
+++ b/core/ui-common/src/test/kotlin/com/wire/android/ui/common/ExampleUnitTest.kt
@@ -17,9 +17,9 @@
  */
 package com.wire.android.ui.common
 
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/core/ui-common/src/test/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetStateTest.kt
+++ b/core/ui-common/src/test/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetStateTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.common.bottomsheet
+
+import androidx.compose.runtime.saveable.SaverScope
+import com.wire.android.util.AnyPrimitiveAsStringSerializer
+import io.mockk.mockk
+import kotlinx.serialization.Serializable
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
+
+class WireModalSheetStateTest {
+
+    @Serializable
+    class SerializableTestModel(
+        val boolean: Boolean,
+        val int: Int,
+        val long: Long,
+        val float: Float,
+        val double: Double,
+        val char: Char,
+        val string: String,
+        val nullable: String?,
+        val list: List<String>,
+        vararg val any: @Serializable(with = AnyPrimitiveAsStringSerializer::class) Any
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is SerializableTestModel) return false
+
+            if (boolean != other.boolean) return false
+            if (int != other.int) return false
+            if (long != other.long) return false
+            if (float != other.float) return false
+            if (double != other.double) return false
+            if (char != other.char) return false
+            if (string != other.string) return false
+            if (nullable != other.nullable) return false
+            if (list != other.list) return false
+            if (!any.contentEquals(other.any)) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = boolean.hashCode()
+            result = 31 * result + int
+            result = 31 * result + long.hashCode()
+            result = 31 * result + float.hashCode()
+            result = 31 * result + double.hashCode()
+            result = 31 * result + char.hashCode()
+            result = 31 * result + string.hashCode()
+            result = 31 * result + (nullable?.hashCode() ?: 0)
+            result = 31 * result + list.hashCode()
+            result = 31 * result + any.contentHashCode()
+            return result
+        }
+    }
+
+    @Test
+    fun givenSerializableModel_whenSavingState_thenStateIsSavedAndRestoredProperly() {
+        // given
+        val model = SerializableTestModel(
+            boolean = true,
+            int = 1,
+            long = 2L,
+            float = 3.0f,
+            double = 4.0,
+            char = 'c',
+            string = "string",
+            nullable = null,
+            list = listOf("a", "b", "c"),
+            any = arrayOf(1, 2L, 3.0, 4f, true, false, 'c', "string")
+        )
+        val sheetValue = WireSheetValue.Expanded(model)
+        with(WireModalSheetState.saver<SerializableTestModel>(mockk(), mockk(), mockk(), mockk())) {
+            // when
+            val saved = SaverScope { true }.save(WireModalSheetState(mockk(), mockk(), mockk(), mockk(), sheetValue))
+            // then
+            assertInstanceOf<List<Any>>(saved).let {
+                val restored = restore(it)
+                assertInstanceOf<WireSheetValue.Expanded<SerializableTestModel>>(restored?.currentValue).let {
+                    assertEquals(sheetValue.value, it.value)
+                }
+            }
+        }
+    }
+}

--- a/core/ui-common/src/test/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetStateTest.kt
+++ b/core/ui-common/src/test/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetStateTest.kt
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.assertInstanceOf
 
 class WireModalSheetStateTest {
 
+    @Suppress("LongParameterList")
     @Serializable
     class SerializableTestModel(
         val boolean: Boolean,


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14433" title="WPB-14433" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14433</a>  [Android] Crash after longtapping on a conversation and putting phone to sleep
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After fixing bottom sheet crashes with this PR: https://github.com/wireapp/wire-android/pull/3670, still bottom sheet for message with a reply crashes.

### Causes (Optional)

Android Studio had some problems highlighting all models that need to be serialized so previous PR missed out some of them. Also, turns out that using multiple serializer types can lead to some problems (in this case it was Json and Bundlizer).

### Solutions

Make all classes used by `UIMessage` serializable, to be 100% sure. 
Replace Any primitive type serializer that uses Json with a more custom one that does it via surrogate.
Wrap serialization in try-catch so that if it fails, the app doesn't crash and only the bottom sheet is hidden as there's no saved state for it.

Update: after the discussion, it was decided to drop saving the state for now and come up with some solution to not store too much, especially for conversations and messages to not keep such data unencrypted anywhere, so in the future when there's time to do that we could slim down the models for the bottom sheets to save only required data and not any sensitive ones. For now `rememberSaveable` is replaced with regular `remember` so the bottom sheet won't be rebuilt and the only drawback would be that the user would need to open it again.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Open conversation, long-click on a message with a reply to open the bottom sheet and put the app into background.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
