### PR TITLE
fix: update api version on startup [WPB-14730]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -69,6 +69,7 @@ import com.wire.kalium.logic.feature.conversation.CheckConversationInviteCodeUse
 import com.wire.kalium.logic.feature.debug.SynchronizeExternalDataResult
 import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
+import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
@@ -122,7 +123,8 @@ class WireActivityViewModel @Inject constructor(
     private val observeScreenshotCensoringConfigUseCaseProviderFactory: ObserveScreenshotCensoringConfigUseCaseProvider.Factory,
     private val globalDataStore: Lazy<GlobalDataStore>,
     private val observeIfE2EIRequiredDuringLoginUseCaseProviderFactory: ObserveIfE2EIRequiredDuringLoginUseCaseProvider.Factory,
-    private val workManager: Lazy<WorkManager>
+    private val workManager: Lazy<WorkManager>,
+    private val updateApiVersions: UpdateApiVersionsUseCase
 ) : ViewModel() {
 
     var globalAppState: GlobalAppState by mutableStateOf(GlobalAppState())
@@ -157,6 +159,13 @@ class WireActivityViewModel @Inject constructor(
         observeScreenshotCensoringConfigState()
         observeAppThemeState()
         observeLogoutState()
+        updateApiVersionsOnStart()
+    }
+
+    private fun updateApiVersionsOnStart() {
+        viewModelScope.launch {
+            updateApiVersions()
+        }
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -69,7 +69,6 @@ import com.wire.kalium.logic.feature.conversation.CheckConversationInviteCodeUse
 import com.wire.kalium.logic.feature.debug.SynchronizeExternalDataResult
 import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
-import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
@@ -124,7 +123,6 @@ class WireActivityViewModel @Inject constructor(
     private val globalDataStore: Lazy<GlobalDataStore>,
     private val observeIfE2EIRequiredDuringLoginUseCaseProviderFactory: ObserveIfE2EIRequiredDuringLoginUseCaseProvider.Factory,
     private val workManager: Lazy<WorkManager>,
-    private val updateApiVersions: UpdateApiVersionsUseCase
 ) : ViewModel() {
 
     var globalAppState: GlobalAppState by mutableStateOf(GlobalAppState())
@@ -159,13 +157,6 @@ class WireActivityViewModel @Inject constructor(
         observeScreenshotCensoringConfigState()
         observeAppThemeState()
         observeLogoutState()
-        updateApiVersionsOnStart()
-    }
-
-    private fun updateApiVersionsOnStart() {
-        viewModelScope.launch {
-            updateApiVersions()
-        }
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
@@ -23,6 +23,7 @@ import com.wire.android.appLogger
 import com.wire.kalium.logic.feature.e2ei.SyncCertificateRevocationListUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
 import com.wire.kalium.logic.feature.featureConfig.FeatureFlagsSyncWorker
+import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.joinAll
@@ -38,6 +39,7 @@ class AppSyncViewModel @Inject constructor(
     private val syncCertificateRevocationListUseCase: SyncCertificateRevocationListUseCase,
     private val observeCertificateRevocationForSelfClient: ObserveCertificateRevocationForSelfClientUseCase,
     private val featureFlagsSyncWorker: FeatureFlagsSyncWorker,
+    private val updateApiVersions: UpdateApiVersionsUseCase
 ) : ViewModel() {
 
     private val minIntervalBetweenPulls: Duration = MIN_INTERVAL_BETWEEN_PULLS
@@ -73,7 +75,8 @@ class AppSyncViewModel @Inject constructor(
             listOf(
                 viewModelScope.launch { syncCertificateRevocationListUseCase() },
                 viewModelScope.launch { featureFlagsSyncWorker.execute() },
-                viewModelScope.launch { observeCertificateRevocationForSelfClient.invoke() }
+                viewModelScope.launch { observeCertificateRevocationForSelfClient.invoke() },
+                viewModelScope.launch { updateApiVersions() },
             ).joinAll()
         } catch (e: Exception) {
             appLogger.e("Error while syncing app config", e)

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -65,7 +65,6 @@ import com.wire.kalium.logic.feature.client.ObserveNewClientsUseCase
 import com.wire.kalium.logic.feature.conversation.CheckConversationInviteCodeUseCase
 import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
-import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
@@ -683,7 +682,6 @@ class WireActivityViewModelTest {
                     flowOf(false)
             every { workManager.cancelAllWorkByTag(any()) } returns OperationImpl()
             every { workManager.enqueueUniquePeriodicWork(any(), any(), any()) } returns OperationImpl()
-            coEvery { updateApiVersions() } returns Unit
         }
 
         @MockK
@@ -749,9 +747,6 @@ class WireActivityViewModelTest {
         lateinit var workManager: WorkManager
 
         @MockK
-        lateinit var updateApiVersions: UpdateApiVersionsUseCase
-
-        @MockK
         lateinit var observeEstablishedCalls: ObserveEstablishedCallsUseCase
 
         @MockK(relaxed = true)
@@ -784,8 +779,7 @@ class WireActivityViewModelTest {
                 observeScreenshotCensoringConfigUseCaseProviderFactory = observeScreenshotCensoringConfigUseCaseProviderFactory,
                 globalDataStore = { globalDataStore },
                 observeIfE2EIRequiredDuringLoginUseCaseProviderFactory = observeIfE2EIRequiredDuringLoginUseCaseProviderFactory,
-                workManager = { workManager },
-                updateApiVersions = updateApiVersions
+                workManager = { workManager }
             )
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -65,6 +65,7 @@ import com.wire.kalium.logic.feature.client.ObserveNewClientsUseCase
 import com.wire.kalium.logic.feature.conversation.CheckConversationInviteCodeUseCase
 import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
+import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
@@ -682,6 +683,7 @@ class WireActivityViewModelTest {
                     flowOf(false)
             every { workManager.cancelAllWorkByTag(any()) } returns OperationImpl()
             every { workManager.enqueueUniquePeriodicWork(any(), any(), any()) } returns OperationImpl()
+            coEvery { updateApiVersions() } returns Unit
         }
 
         @MockK
@@ -747,6 +749,9 @@ class WireActivityViewModelTest {
         lateinit var workManager: WorkManager
 
         @MockK
+        lateinit var updateApiVersions: UpdateApiVersionsUseCase
+
+        @MockK
         lateinit var observeEstablishedCalls: ObserveEstablishedCallsUseCase
 
         @MockK(relaxed = true)
@@ -779,7 +784,8 @@ class WireActivityViewModelTest {
                 observeScreenshotCensoringConfigUseCaseProviderFactory = observeScreenshotCensoringConfigUseCaseProviderFactory,
                 globalDataStore = { globalDataStore },
                 observeIfE2EIRequiredDuringLoginUseCaseProviderFactory = observeIfE2EIRequiredDuringLoginUseCaseProviderFactory,
-                workManager = { workManager }
+                workManager = { workManager },
+                updateApiVersions = updateApiVersions
             )
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/AppSyncViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/AppSyncViewModelTest.kt
@@ -21,6 +21,7 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.kalium.logic.feature.e2ei.SyncCertificateRevocationListUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
 import com.wire.kalium.logic.feature.featureConfig.FeatureFlagsSyncWorker
+import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -40,6 +41,7 @@ class AppSyncViewModelTest {
             withObserveCertificateRevocationForSelfClient()
             withFeatureFlagsSyncWorker()
             withSyncCertificateRevocationListUseCase()
+            withUpdateApiVersions()
         }
 
         viewModel.startSyncingAppConfig()
@@ -48,6 +50,7 @@ class AppSyncViewModelTest {
         coVerify { arrangement.observeCertificateRevocationForSelfClient.invoke() }
         coVerify { arrangement.syncCertificateRevocationListUseCase.invoke() }
         coVerify { arrangement.featureFlagsSyncWorker.execute() }
+        coVerify { arrangement.updateApiVersions() }
     }
 
     @Test
@@ -56,6 +59,7 @@ class AppSyncViewModelTest {
             withObserveCertificateRevocationForSelfClient(1000)
             withFeatureFlagsSyncWorker(1000)
             withSyncCertificateRevocationListUseCase(1000)
+            withUpdateApiVersions(1000)
         }
 
         viewModel.startSyncingAppConfig()
@@ -66,6 +70,7 @@ class AppSyncViewModelTest {
         coVerify(exactly = 1) { arrangement.observeCertificateRevocationForSelfClient.invoke() }
         coVerify(exactly = 1) { arrangement.syncCertificateRevocationListUseCase.invoke() }
         coVerify(exactly = 1) { arrangement.featureFlagsSyncWorker.execute() }
+        coVerify(exactly = 1) { arrangement.updateApiVersions() }
     }
 
     private class Arrangement {
@@ -79,6 +84,9 @@ class AppSyncViewModelTest {
         @MockK
         lateinit var featureFlagsSyncWorker: FeatureFlagsSyncWorker
 
+        @MockK
+        lateinit var updateApiVersions: UpdateApiVersionsUseCase
+
         init {
             MockKAnnotations.init(this)
         }
@@ -86,7 +94,8 @@ class AppSyncViewModelTest {
         private val viewModel = AppSyncViewModel(
             syncCertificateRevocationListUseCase,
             observeCertificateRevocationForSelfClient,
-            featureFlagsSyncWorker
+            featureFlagsSyncWorker,
+            updateApiVersions
         )
 
         @OptIn(InternalCoroutinesApi::class)
@@ -104,6 +113,12 @@ class AppSyncViewModelTest {
 
         fun withFeatureFlagsSyncWorker(delayMs: Long = 0) {
             coEvery { featureFlagsSyncWorker.execute() } coAnswers {
+                delay(delayMs)
+            }
+        }
+
+        fun withUpdateApiVersions(delayMs: Long = 0) {
+            coEvery { updateApiVersions() } coAnswers {
                 delay(delayMs)
             }
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14730" title="WPB-14730" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14730</a>  [Android] Fetch api version on app startup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- added update api version on app startup to resolve issue with updating flags right away not after 24h when on backend some flags has been changed
