### PR TITLE
fix: wrong error message background color [WPB-11475]

### DIFF
--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -119,7 +119,7 @@ private val LightWireColorScheme = WireColorScheme(
     primaryVariant = WireColorPalette.LightBlue50, onPrimaryVariant = WireColorPalette.LightBlue500,
     inversePrimary = WireColorPalette.DarkBlue500,
     error = WireColorPalette.LightRed500, onError = Color.White,
-    errorVariant = WireColorPalette.LightRed200, onErrorVariant = WireColorPalette.LightRed500,
+    errorVariant = WireColorPalette.LightRed50, onErrorVariant = WireColorPalette.LightRed500,
     warning = WireColorPalette.LightAmber500, onWarning = Color.White,
     highlight = WireColorPalette.DarkAmber200, onHighlight = Color.Black,
     positive = WireColorPalette.LightGreen500, onPositive = Color.White,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11475" title="WPB-11475" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11475</a>  Resolve custom colors in Android color scheme
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

After resolving custom colors, one was mapped wrongly, so in this PR `errorVariant` is changed to proper `LightRed50`.

### Testing

#### How to Test

Try to send a message without internet on light theme and check the message background color.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <img width="400" src="https://github.com/user-attachments/assets/9d30d922-0096-4986-85f6-5bf65b8bb232"/> | <img width="400" src="https://github.com/user-attachments/assets/52af5238-477f-4ec1-bd55-2f76308a44a6"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
