### PR TITLE
fix: image loading with multiple accounts from different backends [WPB-14433]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/model/ImageAsset.kt
+++ b/app/src/main/kotlin/com/wire/android/model/ImageAsset.kt
@@ -18,16 +18,13 @@
 
 package com.wire.android.model
 
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.wire.android.R
-import com.wire.android.ui.LocalActivity
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
@@ -72,15 +69,8 @@ sealed class ImageAsset {
             withCrossfadeAnimation: Boolean = false
         ) = when {
             LocalInspectionMode.current -> painterResource(id = R.drawable.ic_welcome_1)
-            else -> {
-                hiltViewModel<RemoteAssetImageViewModel>(
-                    // limit the scope of the ViewModel to the current activity so that there's one image loader instance for the Activity
-                    viewModelStoreOwner = checkNotNull(LocalActivity.current as? AppCompatActivity ?: LocalViewModelStoreOwner.current) {
-                        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
-                    },
-                    key = "remote_asset_image_loader"
-                ).imageLoader.paint(asset = this, fallbackData = fallbackData, withCrossfadeAnimation = withCrossfadeAnimation)
-            }
+            else -> hiltViewModel<RemoteAssetImageViewModel>().imageLoader
+                .paint(asset = this, fallbackData = fallbackData, withCrossfadeAnimation = withCrossfadeAnimation)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14433" title="WPB-14433" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14433</a>  [Android] Crash after longtapping on a conversation and putting phone to sleep
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Images for multiple accounts from different backends are not loading.

### Causes (Optional)

Image loader is now created once per activity but each user should have its own as it uses different addresses.

### Solutions

Remove caching view model responsible for image loading per activity, instead use the regular version which creates instance of view model per navigation entry.

### Testing

#### How to Test

Login with 2 accounts in different backends (staging and prod) and you should NOT have failed to load images.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
