### PR TITLE
revert: conference simulcast support (WPB-11480)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -177,8 +177,6 @@ fun OngoingCallScreen(
         clearVideoPreview = sharedCallingViewModel::clearVideoPreview,
         onCollapse = onCollapse,
         requestVideoStreams = ongoingCallViewModel::requestVideoStreams,
-        onSelectedParticipant = ongoingCallViewModel::onSelectedParticipant,
-        selectedParticipantForFullScreen = ongoingCallViewModel.selectedParticipant,
         hideDoubleTapToast = ongoingCallViewModel::hideDoubleTapToast,
         onCameraPermissionPermanentlyDenied = onCameraPermissionPermanentlyDenied,
         participants = sharedCallingViewModel.participantsState,
@@ -291,8 +289,6 @@ private fun OngoingCallContent(
     hideDoubleTapToast: () -> Unit,
     onCameraPermissionPermanentlyDenied: () -> Unit,
     requestVideoStreams: (participants: List<UICallParticipant>) -> Unit,
-    onSelectedParticipant: (selectedParticipant: SelectedParticipant) -> Unit,
-    selectedParticipantForFullScreen: SelectedParticipant,
     participants: PersistentList<UICallParticipant>,
     inPictureInPictureMode: Boolean,
     currentUserId: UserId,
@@ -307,6 +303,7 @@ private fun OngoingCallContent(
     )
 
     var shouldOpenFullScreen by remember { mutableStateOf(false) }
+    var selectedParticipantForFullScreen by remember { mutableStateOf(SelectedParticipant()) }
 
     WireBottomSheetScaffold(
         sheetDragHandle = null,
@@ -394,14 +391,11 @@ private fun OngoingCallContent(
                             selectedParticipant = selectedParticipantForFullScreen,
                             height = this@BoxWithConstraints.maxHeight - dimensions().spacing4x,
                             closeFullScreen = {
-                                onSelectedParticipant(SelectedParticipant())
                                 shouldOpenFullScreen = !shouldOpenFullScreen
                             },
                             onBackButtonClicked = {
-                                onSelectedParticipant(SelectedParticipant())
                                 shouldOpenFullScreen = !shouldOpenFullScreen
                             },
-                            requestVideoStreams = requestVideoStreams,
                             setVideoPreview = setVideoPreview,
                             clearVideoPreview = clearVideoPreview,
                             participants = participants
@@ -418,7 +412,7 @@ private fun OngoingCallContent(
                             requestVideoStreams = requestVideoStreams,
                             currentUserId = currentUserId,
                             onDoubleTap = { selectedParticipant ->
-                                onSelectedParticipant(selectedParticipant)
+                                selectedParticipantForFullScreen = selectedParticipant
                                 shouldOpenFullScreen = !shouldOpenFullScreen
                             },
                         )
@@ -586,8 +580,6 @@ fun PreviewOngoingCallContent(participants: PersistentList<UICallParticipant>) {
         participants = participants,
         inPictureInPictureMode = false,
         currentUserId = UserId("userId", "domain"),
-        onSelectedParticipant = {},
-        selectedParticipantForFullScreen = SelectedParticipant(),
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -28,10 +28,8 @@ import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.CurrentAccount
 import com.wire.android.ui.calling.model.UICallParticipant
-import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallClient
-import com.wire.kalium.logic.data.call.CallQuality
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
@@ -64,8 +62,6 @@ class OngoingCallViewModel @AssistedInject constructor(
     private var doubleTapIndicatorCountDownTimer: CountDownTimer? = null
 
     var state by mutableStateOf(OngoingCallState())
-        private set
-    var selectedParticipant by mutableStateOf(SelectedParticipant())
         private set
 
     init {
@@ -128,23 +124,11 @@ class OngoingCallViewModel @AssistedInject constructor(
                 .also {
                     if (it.isNotEmpty()) {
                         val clients: List<CallClient> = it.map { uiParticipant ->
-                            CallClient(
-                                userId = uiParticipant.id.toString(),
-                                clientId = uiParticipant.clientId,
-                                quality = mapQualityStream(uiParticipant)
-                            )
+                            CallClient(uiParticipant.id.toString(), uiParticipant.clientId)
                         }
                         requestVideoStreams(conversationId, clients)
                     }
                 }
-        }
-    }
-
-    private fun mapQualityStream(uiParticipant: UICallParticipant): CallQuality {
-        return if (uiParticipant.clientId == selectedParticipant.clientId) {
-            CallQuality.HIGH
-        } else {
-            CallQuality.LOW
         }
     }
 
@@ -153,7 +137,7 @@ class OngoingCallViewModel @AssistedInject constructor(
         doubleTapIndicatorCountDownTimer =
             object : CountDownTimer(DOUBLE_TAP_TOAST_DISPLAY_TIME, COUNT_DOWN_INTERVAL) {
                 override fun onTick(p0: Long) {
-                    appLogger.d("$TAG - startDoubleTapToastDisplayCountDown: $p0")
+                    appLogger.i("startDoubleTapToastDisplayCountDown: $p0")
                 }
 
                 override fun onFinish() {
@@ -187,16 +171,10 @@ class OngoingCallViewModel @AssistedInject constructor(
         }
     }
 
-    fun onSelectedParticipant(selectedParticipant: SelectedParticipant) {
-        appLogger.d("$TAG - Selected participant: ${selectedParticipant.toLogString()}")
-        this.selectedParticipant = selectedParticipant
-    }
-
     companion object {
         const val DOUBLE_TAP_TOAST_DISPLAY_TIME = 7000L
         const val COUNT_DOWN_INTERVAL = 1000L
         const val DELAY_TO_SHOW_DOUBLE_TAP_TOAST = 500L
-        const val TAG = "OngoingCallViewModel"
     }
 
     @AssistedFactory

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
@@ -60,7 +60,6 @@ fun FullScreenTile(
     closeFullScreen: (offset: Offset) -> Unit,
     onBackButtonClicked: () -> Unit,
     setVideoPreview: (View) -> Unit,
-    requestVideoStreams: (participants: List<UICallParticipant>) -> Unit,
     clearVideoPreview: () -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: Dp = dimensions().spacing4x,
@@ -120,10 +119,6 @@ fun FullScreenTile(
                 }
             )
         }
-
-        LaunchedEffect(selectedParticipant.userId) {
-            requestVideoStreams(listOf(it))
-        }
     }
 }
 
@@ -144,7 +139,6 @@ fun PreviewFullScreenTile() = WireTheme {
         closeFullScreen = {},
         onBackButtonClicked = {},
         setVideoPreview = {},
-        requestVideoStreams = {},
         clearVideoPreview = {},
         participants = participants,
     )

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/SelectedParticipant.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/SelectedParticipant.kt
@@ -17,16 +17,10 @@
  */
 package com.wire.android.ui.calling.ongoing.fullscreen
 
-import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.user.UserId
 
 data class SelectedParticipant(
     val userId: UserId = UserId("", ""),
     val clientId: String = "",
     val isSelfUser: Boolean = false
-) {
-
-    fun toLogString(): String {
-        return "SelectedParticipant(userId=${userId.toLogString()}, clientId=${clientId.obfuscateId()}, isSelfUser=$isSelfUser)"
-    }
-}
+)

--- a/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
@@ -23,11 +23,9 @@ import com.wire.android.config.NavigationTestExtension
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.ongoing.OngoingCallViewModel
-import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallClient
-import com.wire.kalium.logic.data.call.CallQuality
 import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -172,72 +170,6 @@ class OngoingCallViewModelTest {
             }
         }
 
-    @Test
-    fun givenAUserIsSelected_whenRequestedFullScreen_thenSetTheUserAsSelected() =
-        runTest {
-            val (_, ongoingCallViewModel) = Arrangement()
-                .withCall(provideCall().copy(isCameraOn = true))
-                .withShouldShowDoubleTapToastReturning(false)
-                .withSetVideoSendState()
-                .arrange()
-
-            ongoingCallViewModel.onSelectedParticipant(selectedParticipant3)
-
-            assertEquals(selectedParticipant3, ongoingCallViewModel.selectedParticipant)
-        }
-
-    @Test
-    fun givenParticipantsList_WhenRequestingVideoStreamForFullScreenParticipant_ThenRequestItInHighQuality() =
-        runTest {
-            val expectedClients = listOf(
-                CallClient(participant1.id.toString(), participant1.clientId, false, CallQuality.LOW),
-                CallClient(participant3.id.toString(), participant3.clientId, false, CallQuality.HIGH)
-            )
-
-            val (arrangement, ongoingCallViewModel) = Arrangement()
-                .withCall(provideCall())
-                .withShouldShowDoubleTapToastReturning(false)
-                .withSetVideoSendState()
-                .withRequestVideoStreams(conversationId, expectedClients)
-                .arrange()
-
-            ongoingCallViewModel.onSelectedParticipant(selectedParticipant3)
-            ongoingCallViewModel.requestVideoStreams(participants)
-
-            coVerify(exactly = 1) {
-                arrangement.requestVideoStreams(
-                    conversationId,
-                    expectedClients
-                )
-            }
-        }
-
-    @Test
-    fun givenParticipantsList_WhenRequestingVideoStreamForAllParticipant_ThenRequestItInLowQuality() =
-        runTest {
-            val expectedClients = listOf(
-                CallClient(participant1.id.toString(), participant1.clientId, false, CallQuality.LOW),
-                CallClient(participant3.id.toString(), participant3.clientId, false, CallQuality.LOW)
-            )
-
-            val (arrangement, ongoingCallViewModel) = Arrangement()
-                .withCall(provideCall())
-                .withShouldShowDoubleTapToastReturning(false)
-                .withSetVideoSendState()
-                .withRequestVideoStreams(conversationId, expectedClients)
-                .arrange()
-
-            ongoingCallViewModel.onSelectedParticipant(SelectedParticipant())
-            ongoingCallViewModel.requestVideoStreams(participants)
-
-            coVerify(exactly = 1) {
-                arrangement.requestVideoStreams(
-                    conversationId,
-                    expectedClients
-                )
-            }
-        }
-
     private class Arrangement {
 
         @MockK
@@ -336,7 +268,6 @@ class OngoingCallViewModelTest {
             accentId = -1
         )
         val participants = listOf(participant1, participant2, participant3)
-        val selectedParticipant3 = SelectedParticipant(participant3.id, participant3.clientId, false)
     }
 
     private fun provideCall(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ coil = "2.7.0"
 commonmark = "0.24.0"
 
 # Countly
-countly = "24.7.7"
+countly = "24.4.0"
 
 # RSS
 rss-parser = "6.0.7"


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11480" title="WPB-11480" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11480</a>  [Android] Simulcast Support & Automatic Quality Adjustments
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->





This reverts commit 7cd4bd6e8.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

For safety reasons and looking for a stable version 4.10
Simulcast, we are going to be bumped out of this version.

### Causes (Optional)

Rollback the commit

### Needs release with
- https://github.com/wireapp/kalium/pull/3149

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
