### PR TITLE
fix: Crash on typing after sending mention (WPB-14897)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
@@ -300,7 +300,8 @@ class MessageCompositionHolder(
             it.copy(
                 quotedMessageId = null,
                 quotedMessage = null,
-                editMessageId = null
+                editMessageId = null,
+                selectedMentions = emptyList()
             )
         }
         onSaveDraft(messageComposition.value.toDraft(String.EMPTY))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14897" title="WPB-14897" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14897</a>  [Android] Crash on typing after sending mention
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

STR:
- open group conv
- send message with mention
- start typing a new message
Result: crash

### Causes (Optional)

After sending a message `selectedMentions` field in `MessageComposition` state is not cleared and when user start typing a new message app tries to apply old mention to the new message

### Solutions

clear `selectedMentions` after message send

