### PR TITLE
fix: not able to open some conversations [WPB-11325]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -109,6 +109,7 @@ import com.wire.android.ui.userprofile.self.dialog.LogoutOptionsDialog
 import com.wire.android.ui.userprofile.self.dialog.LogoutOptionsDialogState
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.LocalSyncStateObserver
+import com.wire.android.util.SwitchAccountObserver
 import com.wire.android.util.SyncStateObserver
 import com.wire.android.util.debug.FeatureVisibilityFlags
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
@@ -134,6 +135,9 @@ class WireActivity : AppCompatActivity() {
 
     @Inject
     lateinit var lockCodeTimeManager: Lazy<LockCodeTimeManager>
+
+    @Inject
+    lateinit var switchAccountObserver: SwitchAccountObserver
 
     private val viewModel: WireActivityViewModel by viewModels()
 
@@ -344,6 +348,19 @@ class WireActivity : AppCompatActivity() {
                     updateScreenSettingsListener
                 )
                 navigator.navController.removeOnDestinationChangedListener(currentScreenManager)
+            }
+        }
+
+        DisposableEffect(switchAccountObserver, navigator) {
+            NavigationSwitchAccountActions {
+                lifecycleScope.launch(Dispatchers.Main) {
+                    navigator.navigate(it)
+                }
+            }.let {
+                switchAccountObserver.register(it)
+                onDispose {
+                    switchAccountObserver.unregister(it)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
@@ -22,12 +22,20 @@ import android.os.Build
 import android.view.WindowManager
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import com.wire.android.util.SwitchAccountObserver
 import androidx.lifecycle.lifecycleScope
 import com.wire.android.ui.AppLockActivity
 import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
+@AndroidEntryPoint
 abstract class CallActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var switchAccountObserver: SwitchAccountObserver
+
     companion object {
         const val EXTRA_CONVERSATION_ID = "conversation_id"
         const val EXTRA_USER_ID = "user_id"
@@ -40,7 +48,7 @@ abstract class CallActivity : AppCompatActivity() {
     fun switchAccountIfNeeded(userId: String?) {
         userId?.let {
             qualifiedIdMapper.fromStringToQualifiedID(it).run {
-                callActivityViewModel.switchAccountIfNeeded(this)
+                callActivityViewModel.switchAccountIfNeeded(userId = this, actions = switchAccountObserver)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivityViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.di.ObserveScreenshotCensoringConfigUseCaseProvider
 import com.wire.android.feature.AccountSwitchUseCase
+import com.wire.android.feature.SwitchAccountActions
 import com.wire.android.feature.SwitchAccountParam
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.user.UserId
@@ -59,7 +60,7 @@ class CallActivityViewModel @Inject constructor(
             }
         }
 
-    fun switchAccountIfNeeded(userId: UserId) {
+    fun switchAccountIfNeeded(userId: UserId, actions: SwitchAccountActions) {
         viewModelScope.launch(Dispatchers.IO) {
             val shouldSwitchAccount = when (val result = currentSession()) {
                 is CurrentSessionResult.Failure.Generic -> true
@@ -67,7 +68,9 @@ class CallActivityViewModel @Inject constructor(
                 is CurrentSessionResult.Success -> result.accountInfo.userId != userId
             }
             if (shouldSwitchAccount) {
-                accountSwitch(SwitchAccountParam.SwitchToAccount(userId))
+                accountSwitch(SwitchAccountParam.SwitchToAccount(userId)).also {
+                    it.callAction(actions)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/util/SwitchAccountObserver.kt
+++ b/app/src/main/kotlin/com/wire/android/util/SwitchAccountObserver.kt
@@ -1,0 +1,56 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import com.wire.android.feature.SwitchAccountActions
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SwitchAccountObserver @Inject constructor() : SwitchAccountActions {
+    private val lock = Object()
+    private val items = mutableListOf<SwitchAccountActions>()
+
+    fun register(actions: SwitchAccountActions) {
+        synchronized(lock) {
+            items.add(actions)
+        }
+    }
+
+    fun unregister(actions: SwitchAccountActions) {
+        synchronized(lock) {
+            items.remove(actions)
+        }
+    }
+
+    override fun switchedToAnotherAccount() {
+        synchronized(lock) {
+            items.forEach {
+                it.switchedToAnotherAccount()
+            }
+        }
+    }
+
+    override fun noOtherAccountToSwitch() {
+        synchronized(lock) {
+            items.forEach {
+                it.noOtherAccountToSwitch()
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -23,6 +23,7 @@ package com.wire.android.ui
 import android.content.Intent
 import androidx.work.WorkManager
 import androidx.work.impl.OperationImpl
+import app.cash.turbine.test
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
@@ -56,6 +57,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.appVersioning.ObserveIfAppUpdateRequiredUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
@@ -88,6 +90,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
@@ -636,6 +639,50 @@ class WireActivityViewModelTest {
     }
 
     @Test
+    fun `given session changes, when observing screenshot censoring, then update screenshot censoring state`() = runTest {
+        val firstSession = AccountInfo.Valid(UserId("user1", "domain1"))
+        val secondSession = AccountInfo.Valid(UserId("user2", "domain2"))
+        val firstSessionScreenshotCensoringConfig = ObserveScreenshotCensoringConfigResult.Disabled
+        val secondSessionScreenshotCensoringConfig = ObserveScreenshotCensoringConfigResult.Enabled.ChosenByUser
+        val currentSessionFlow = MutableStateFlow(firstSession)
+        val (_, viewModel) = Arrangement()
+            .withCurrentSessionFlow(currentSessionFlow.map { CurrentSessionResult.Success(it) })
+            .withScreenshotCensoringConfigForUser(firstSession.userId, firstSessionScreenshotCensoringConfig)
+            .withScreenshotCensoringConfigForUser(secondSession.userId, secondSessionScreenshotCensoringConfig)
+            .arrange()
+        advanceUntilIdle()
+        assertEquals(false, viewModel.globalAppState.screenshotCensoringEnabled)
+
+        currentSessionFlow.emit(secondSession)
+        advanceUntilIdle()
+        assertEquals(true, viewModel.globalAppState.screenshotCensoringEnabled)
+    }
+
+    @Test
+    fun `given session changes, when observing sync state, then update sync state`() = runTest {
+        val firstSession = AccountInfo.Valid(UserId("user1", "domain1"))
+        val secondSession = AccountInfo.Valid(UserId("user2", "domain2"))
+        val firstSessionSyncState = SyncState.Live
+        val secondSessionSyncState = SyncState.SlowSync
+        val currentSessionFlow = MutableStateFlow(firstSession)
+        val (_, viewModel) = Arrangement()
+            .withCurrentSessionFlow(currentSessionFlow.map { CurrentSessionResult.Success(it) })
+            .withSyncStateForUser(firstSession.userId, firstSessionSyncState)
+            .withSyncStateForUser(secondSession.userId, secondSessionSyncState)
+            .arrange()
+        advanceUntilIdle()
+        viewModel.observeSyncFlowState.test {
+            assertEquals(firstSessionSyncState, awaitItem())
+
+            currentSessionFlow.emit(secondSession)
+            advanceUntilIdle()
+            assertEquals(secondSessionSyncState, awaitItem())
+
+            expectNoEvents()
+        }
+    }
+
+    @Test
     fun `given app theme change, when observing it, then update state with theme option`() = runTest {
         val (_, viewModel) = Arrangement()
             .withThemeOption(ThemeOption.DARK)
@@ -806,6 +853,10 @@ class WireActivityViewModelTest {
             return this
         }
 
+        fun withCurrentSessionFlow(result: Flow<CurrentSessionResult>): Arrangement = apply {
+            coEvery { currentSessionFlow() } returns result
+        }
+
         fun withDeepLinkResult(result: DeepLinkResult, isSharingIntent: Boolean = false): Arrangement {
             coEvery { deepLinkProcessor(any(), isSharingIntent) } returns result
             return this
@@ -875,6 +926,20 @@ class WireActivityViewModelTest {
 
         suspend fun withScreenshotCensoringConfig(result: ObserveScreenshotCensoringConfigResult) = apply {
             coEvery { observeScreenshotCensoringConfigUseCase() } returns flowOf(result)
+        }
+
+        suspend fun withScreenshotCensoringConfigForUser(id: UserId, result: ObserveScreenshotCensoringConfigResult) = apply {
+            val useCase = mockk<ObserveScreenshotCensoringConfigUseCase>()
+            coEvery {
+                observeScreenshotCensoringConfigUseCaseProviderFactory.create(id).observeScreenshotCensoringConfig
+            } returns useCase
+            coEvery { useCase() } returns flowOf(result)
+        }
+
+        fun withSyncStateForUser(id: UserId, result: SyncState) = apply {
+            val useCase = mockk<ObserveSyncStateUseCase>()
+            coEvery { observeSyncStateUseCaseProviderFactory.create(id).observeSyncState } returns useCase
+            coEvery { useCase() } returns flowOf(result)
         }
 
         suspend fun withThemeOption(themeOption: ThemeOption) = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11325" title="WPB-11325" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11325</a>  [Android] Can not open conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When there are 2 logged in accounts and user receives a full screen intent call for not currently selected account, then after that it's only possible to open conversations where both accounts are members of.

### Causes (Optional)

When a CallActivity is created, it checks whether it's needed to switch account (if the call is for other account), so when user receives a call from a conversation where both accounts are in, it's 50% chance that full screen intent will appear for one or another account (depends which incoming call gets handled first). CallActivity lives in another thread, so when the account is switched and there is another WireActivity in the background, state of both is unsynced and WireActivity still holds previous account from before switching.

### Solutions

Implement observer to keep both activities in sync, so when CallActivity switches account it informs WireActivity and it performs navigation to clear the back stack and recompose the home screen with switched account.
Also, functions to observe the screenshot censoring and sync state is fixed to observe account changes, previously it was taking only single first current account value so it wasn't working when account is switched.
Show incoming call as a full screen intent only for calls for current session, as if shown for another session it will switch to that session and the user won't know that he/she is receiving a call as a different account. For calls that are not for the current session it will show the notification as a heads up notification.
We should also consider showing current account name and/or avatar on CallActivity or even make it possible for the user to switch account on incoming call screen if the call can be answered by more than one account. 

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Have 2 logged in accounts, open the app, turn off the screen, receive a call for the second account and open the app again - it should be switched to that second account.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.