### PR TITLE
chore: wrong url when opening team management after migration - RC (WPB-14872)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -498,6 +498,12 @@ class UseCaseModule {
     fun provideMigrateFromPersonalToTeamUseCase(
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
-    ) =
-        coreLogic.getSessionScope(currentAccount).migrateFromPersonalToTeam
+    ) = coreLogic.getSessionScope(currentAccount).migrateFromPersonalToTeam
+
+    @ViewModelScoped
+    @Provides
+    fun provideGetTeamUrlUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ) = coreLogic.getSessionScope(currentAccount).getTeamUrlUseCase
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -118,6 +118,11 @@ fun SelfUserProfileScreen(
 ) {
     val legalHoldSubjectDialogState = rememberVisibilityState<Unit>()
 
+    LaunchedEffect(Unit) {
+        // Check if the user is able to migrate to a team account, every time the screen is shown
+        viewModelSelf.checkIfUserAbleToMigrateToTeamAccount()
+    }
+
     SelfUserProfileContent(
         state = viewModelSelf.userProfileState,
         onCloseClick = navigator::navigateBack,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -109,7 +109,6 @@ class SelfUserProfileViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             fetchSelfUser()
-            checkIfUserAbleToMigrateToTeamAccount()
             observeEstablishedCall()
             fetchIsReadOnlyAccount()
             observeLegalHoldStatus()
@@ -117,9 +116,8 @@ class SelfUserProfileViewModel @Inject constructor(
         }
     }
 
-    private suspend fun checkIfUserAbleToMigrateToTeamAccount() {
-        val isAbleToMigrateToTeamAccount = canMigrateFromPersonalToTeam() && userProfileState.teamName.isNullOrBlank()
-        userProfileState = userProfileState.copy(isAbleToMigrateToTeamAccount = isAbleToMigrateToTeamAccount)
+    suspend fun checkIfUserAbleToMigrateToTeamAccount() {
+        userProfileState = userProfileState.copy(isAbleToMigrateToTeamAccount = canMigrateFromPersonalToTeam())
     }
 
     private suspend fun fetchIsReadOnlyAccount() {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationState.kt
@@ -24,5 +24,7 @@ data class TeamMigrationState(
     val teamNameTextState: TextFieldState = TextFieldState(),
     val shouldShowMigrationLeaveDialog: Boolean = false,
     val currentStep: Int = 0,
+    val username: String = "",
+    val teamUrl: String = "",
     val migrationFailure: MigrateFromPersonalToTeamFailure? = null
 )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step4/TeamMigrationDoneStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step4/TeamMigrationDoneStepScreen.kt
@@ -65,7 +65,6 @@ fun TeamMigrationDoneStepScreen(
 ) {
     val context = LocalContext.current
 
-    val teamManagementUrl = stringResource(R.string.url_team_management)
     TeamMigrationDoneStepContent(
         onBackToWireClicked = {
             teamMigrationViewModel.sendPersonalTeamCreationFlowCompletedEvent(
@@ -79,11 +78,14 @@ fun TeamMigrationDoneStepScreen(
             )
         },
         onOpenTeamManagementClicked = {
+            val teamManagementUrl = teamMigrationViewModel.teamMigrationState.teamUrl
+
             teamMigrationViewModel.sendPersonalTeamCreationFlowCompletedEvent(
                 modalOpenTeamManagementButtonClicked = true
             )
             CustomTabsHelper.launchUrl(context, teamManagementUrl)
         },
+        username = teamMigrationViewModel.teamMigrationState.username,
         teamName = teamMigrationViewModel.teamMigrationState.teamNameTextState.text.toString()
     )
 
@@ -98,6 +100,7 @@ fun TeamMigrationDoneStepScreen(
 private fun TeamMigrationDoneStepContent(
     onBackToWireClicked: () -> Unit,
     onOpenTeamManagementClicked: () -> Unit,
+    username: String,
     teamName: String,
     modifier: Modifier = Modifier
 ) {
@@ -130,7 +133,7 @@ private fun TeamMigrationDoneStepContent(
                         bottom = dimensions().spacing56x
                     )
                     .align(alignment = Alignment.CenterHorizontally),
-                text = stringResource(R.string.personal_to_team_migration_done_step, teamName),
+                text = stringResource(R.string.personal_to_team_migration_done_step, username),
                 style = MaterialTheme.wireTypography.title01,
                 color = colorsScheme().onBackground
             )
@@ -187,6 +190,6 @@ private fun TeamMigrationDoneStepContent(
 @Composable
 private fun TeamMigrationDoneStepScreenPreview() {
     WireTheme {
-        TeamMigrationDoneStepContent({}, {}, teamName = "teamName")
+        TeamMigrationDoneStepContent({}, {}, username = "John", teamName = "teamName")
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,7 +278,6 @@
     <string name="url_why_verify_conversation" translatable="false">https://support.wire.com/hc/articles/207859815</string>
     <string name="url_how_to_add_favorites" translatable="false">https://support.wire.com/hc/articles/360002855557</string>
     <string name="url_wire_plans" translatable="false">https://wire.com/pricing</string>
-    <string name="url_team_management" translatable="false">https://teams.wire.com/</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="archive_screen_title">Archive</string>

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModelTest.kt
@@ -33,6 +33,7 @@ import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.Assertions
@@ -261,6 +262,8 @@ class TeamMigrationViewModelTest {
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
+            coEvery { getSelfUser() } returns flowOf()
+            coEvery { getTeamUrl() } returns "TeamUrl"
         }
 
         fun arrange() = this to TeamMigrationViewModel(

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModelTest.kt
@@ -22,6 +22,8 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.feature.analytics.AnonymousAnalyticsManager
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.migration.MigrateFromPersonalToTeamFailure
 import com.wire.kalium.logic.feature.user.migration.MigrateFromPersonalToTeamResult
 import com.wire.kalium.logic.feature.user.migration.MigrateFromPersonalToTeamUseCase
@@ -251,6 +253,12 @@ class TeamMigrationViewModelTest {
         @MockK
         lateinit var migrateFromPersonalToTeam: MigrateFromPersonalToTeamUseCase
 
+        @MockK
+        lateinit var getSelfUser: GetSelfUserUseCase
+
+        @MockK
+        lateinit var getTeamUrl: GetTeamUrlUseCase
+
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
         }
@@ -258,6 +266,8 @@ class TeamMigrationViewModelTest {
         fun arrange() = this to TeamMigrationViewModel(
             anonymousAnalyticsManager = anonymousAnalyticsManager,
             migrateFromPersonalToTeam = migrateFromPersonalToTeam,
+            getSelfUser = getSelfUser,
+            getTeamUrl = getTeamUrl
         ).also { viewModel ->
             viewModel.teamMigrationState.teamNameTextState.setTextAndPlaceCursorAtEnd(TEAM_NAME)
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14872" title="WPB-14872" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14872</a>  [Android] Wrong URL when opening team management after migration from button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- The user is redirected to the production team management url, instead the the one related to the current environement.
- We show team name instead of user name in last step.
- We don't hide migration banner after migration is done

### Solutions

- Get team URL from database instead of using a static link from strings.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
