### PR TITLE
fix: retain filters and simplify navigation [WPB-14518]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/HomeDestination.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/HomeDestination.kt
@@ -19,22 +19,14 @@
 package com.wire.android.navigation
 
 import androidx.annotation.DrawableRes
-import androidx.navigation.NavBackStackEntry
 import com.ramcosta.composedestinations.spec.Direction
 import com.wire.android.R
 import com.wire.android.ui.destinations.AllConversationsScreenDestination
 import com.wire.android.ui.destinations.ArchiveScreenDestination
-import com.wire.android.ui.destinations.FavoritesConversationsScreenDestination
-import com.wire.android.ui.destinations.FolderConversationsScreenDestination
-import com.wire.android.ui.destinations.GroupConversationsScreenDestination
-import com.wire.android.ui.destinations.OneOnOneConversationsScreenDestination
 import com.wire.android.ui.destinations.SettingsScreenDestination
 import com.wire.android.ui.destinations.VaultScreenDestination
 import com.wire.android.ui.destinations.WhatsNewScreenDestination
 import com.wire.android.util.ui.UIText
-import com.wire.kalium.logic.data.conversation.ConversationFilter
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 
 @Suppress("LongParameterList")
 sealed class HomeDestination(
@@ -45,53 +37,12 @@ sealed class HomeDestination(
     val withUserAvatar: Boolean = true,
     val direction: Direction
 ) {
-
-    internal fun NavBackStackEntry.baseRouteMatches(): Boolean = direction.route.getBaseRoute() == destination.route?.getBaseRoute()
-    open fun entryMatches(entry: NavBackStackEntry): Boolean = entry.baseRouteMatches()
-
     data object Conversations : HomeDestination(
         title = UIText.StringResource(R.string.conversations_screen_title),
         icon = R.drawable.ic_conversation,
         isSearchable = true,
         withNewConversationFab = true,
         direction = AllConversationsScreenDestination
-    )
-
-    data object Favorites : HomeDestination(
-        title = UIText.StringResource(R.string.label_filter_favorites),
-        icon = R.drawable.ic_conversation,
-        isSearchable = true,
-        withNewConversationFab = true,
-        direction = FavoritesConversationsScreenDestination
-    )
-
-    data class Folder(
-        val folderNavArgs: FolderNavArgs
-    ) : HomeDestination(
-        title = UIText.DynamicString(folderNavArgs.folderName),
-        icon = R.drawable.ic_conversation,
-        isSearchable = true,
-        withNewConversationFab = true,
-        direction = FolderConversationsScreenDestination(folderNavArgs)
-    ) {
-        override fun entryMatches(entry: NavBackStackEntry): Boolean =
-            entry.baseRouteMatches() && FolderConversationsScreenDestination.argsFrom(entry).folderId == folderNavArgs.folderId
-    }
-
-    data object Group : HomeDestination(
-        title = UIText.StringResource(R.string.label_filter_group),
-        icon = R.drawable.ic_conversation,
-        isSearchable = true,
-        withNewConversationFab = true,
-        direction = GroupConversationsScreenDestination
-    )
-
-    data object OneOnOne : HomeDestination(
-        title = UIText.StringResource(R.string.label_filter_one_on_one),
-        icon = R.drawable.ic_conversation,
-        isSearchable = true,
-        withNewConversationFab = true,
-        direction = OneOnOneConversationsScreenDestination
     )
 
     data object Settings : HomeDestination(
@@ -130,32 +81,11 @@ sealed class HomeDestination(
 
     companion object {
         private const val ITEM_NAME_PREFIX = "HomeNavigationItem."
-        fun values(): PersistentList<HomeDestination> =
-            persistentListOf(Conversations, Favorites, Group, OneOnOne, Settings, Vault, Archive, Support, WhatsNew)
-    }
-}
 
-fun HomeDestination.currentFilter(): ConversationFilter {
-    return when (this) {
-        HomeDestination.Conversations -> ConversationFilter.All
-        HomeDestination.Favorites -> ConversationFilter.Favorites
-        HomeDestination.Group -> ConversationFilter.Groups
-        HomeDestination.OneOnOne -> ConversationFilter.OneOnOne
-        is HomeDestination.Folder -> ConversationFilter.Folder(folderName = folderNavArgs.folderName, folderId = folderNavArgs.folderId)
-        HomeDestination.Archive,
-        HomeDestination.Settings,
-        HomeDestination.Support,
-        HomeDestination.Vault,
-        HomeDestination.WhatsNew -> ConversationFilter.All
-    }
-}
+        fun fromRoute(fullRoute: String): HomeDestination? =
+            values().find { it.direction.route.getBaseRoute() == fullRoute.getBaseRoute() }
 
-fun ConversationFilter.toDestination(): HomeDestination {
-    return when (this) {
-        ConversationFilter.All -> HomeDestination.Conversations
-        ConversationFilter.Favorites -> HomeDestination.Favorites
-        ConversationFilter.Groups -> HomeDestination.Group
-        ConversationFilter.OneOnOne -> HomeDestination.OneOnOne
-        is ConversationFilter.Folder -> HomeDestination.Folder(FolderNavArgs(folderId, folderName))
+        fun values(): Array<HomeDestination> =
+            arrayOf(Conversations, Settings, Vault, Archive, Support, WhatsNew)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivityViewModel.kt
@@ -30,7 +30,6 @@ import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -61,7 +60,7 @@ class CallActivityViewModel @Inject constructor(
         }
 
     fun switchAccountIfNeeded(userId: UserId, actions: SwitchAccountActions) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatchers.io()) {
             val shouldSwitchAccount = when (val result = currentSession()) {
                 is CurrentSessionResult.Failure.Generic -> true
                 CurrentSessionResult.Failure.SessionNotFound -> true

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/ConversationFilterState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/ConversationFilterState.kt
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.common.topappbar
+
+import android.os.Bundle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import com.wire.kalium.logic.data.conversation.ConversationFilter
+import dev.ahmedmourad.bundlizer.Bundlizer
+
+@Composable
+fun rememberConversationFilterState(): ConversationFilterState = rememberSaveable(saver = ConversationFilterState.saver()) {
+    ConversationFilterState()
+}
+
+class ConversationFilterState(initialValue: ConversationFilter = ConversationFilter.All) {
+    var filter: ConversationFilter by mutableStateOf(initialValue)
+        private set
+
+    fun changeFilter(newFilter: ConversationFilter) {
+        filter = newFilter
+    }
+
+    companion object {
+        fun saver(): Saver<ConversationFilterState, Bundle> = Saver(
+            save = {
+                Bundlizer.bundle(ConversationFilter.serializer(), it.filter)
+            },
+            restore = {
+                ConversationFilterState(Bundlizer.unbundle(ConversationFilter.serializer(), it))
+            }
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeTopBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeTopBar.kt
@@ -28,7 +28,6 @@ import com.wire.android.model.Clickable
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
 import com.wire.android.navigation.HomeDestination
-import com.wire.android.navigation.currentFilter
 import com.wire.android.ui.common.avatar.UserProfileAvatar
 import com.wire.android.ui.common.avatar.UserProfileAvatarType
 import com.wire.android.ui.common.button.WireButtonState
@@ -42,6 +41,8 @@ import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 
 @Composable
 fun HomeTopBar(
+    title: String,
+    currentFilter: ConversationFilter,
     navigationItem: HomeDestination,
     userAvatarData: UserAvatarData,
     elevation: Dp,
@@ -52,7 +53,7 @@ fun HomeTopBar(
     onOpenConversationFilter: (filter: ConversationFilter) -> Unit
 ) {
     WireCenterAlignedTopAppBar(
-        title = navigationItem.title.asString(),
+        title = title,
         onNavigationPressed = onHamburgerMenuClick,
         navigationIconType = NavigationIconType.Menu,
         actions = {
@@ -60,12 +61,12 @@ fun HomeTopBar(
                 WireTertiaryIconButton(
                     iconResource = R.drawable.ic_filter,
                     contentDescription = R.string.label_filter_conversations,
-                    state = if (navigationItem.currentFilter() == ConversationFilter.All) {
+                    state = if (currentFilter == ConversationFilter.All) {
                         WireButtonState.Default
                     } else {
                         WireButtonState.Selected
                     },
-                    onButtonClicked = { onOpenConversationFilter(navigationItem.currentFilter()) }
+                    onButtonClicked = { onOpenConversationFilter(currentFilter) }
                 )
             }
             if (navigationItem.withUserAvatar) {
@@ -100,7 +101,9 @@ fun HomeTopBar(
 fun PreviewTopBar() {
     WireTheme {
         HomeTopBar(
+            title = "Conversations",
             navigationItem = HomeDestination.Conversations,
+            currentFilter = ConversationFilter.All,
             userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
             elevation = 0.dp,
             withLegalHoldIndicator = false,
@@ -117,7 +120,9 @@ fun PreviewTopBar() {
 fun PreviewSettingsTopBarWithoutAvatar() {
     WireTheme {
         HomeTopBar(
+            title = "Settings",
             navigationItem = HomeDestination.Settings,
+            currentFilter = ConversationFilter.All,
             userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
             elevation = 0.dp,
             withLegalHoldIndicator = false,
@@ -134,7 +139,9 @@ fun PreviewSettingsTopBarWithoutAvatar() {
 fun PreviewTopBarWithNameBasedAvatar() {
     WireTheme {
         HomeTopBar(
+            title = "Conversations",
             navigationItem = HomeDestination.Conversations,
+            currentFilter = ConversationFilter.All,
             userAvatarData = UserAvatarData(
                 asset = null,
                 availabilityStatus = UserAvailabilityStatus.AVAILABLE,
@@ -155,7 +162,9 @@ fun PreviewTopBarWithNameBasedAvatar() {
 fun PreviewTopBarWithLegalHold() {
     WireTheme {
         HomeTopBar(
+            title = "Archive",
             navigationItem = HomeDestination.Archive,
+            currentFilter = ConversationFilter.All,
             userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
             elevation = 0.dp,
             withLegalHoldIndicator = true,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/AllConversationsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/AllConversationsScreen.kt
@@ -18,9 +18,9 @@
 
 package com.wire.android.ui.home.conversationslist.all
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
-import com.wire.android.navigation.FolderNavArgs
 import com.wire.android.navigation.HomeDestination
 import com.wire.android.navigation.HomeNavGraph
 import com.wire.android.navigation.WireDestination
@@ -41,72 +41,24 @@ import kotlinx.coroutines.flow.flowOf
 @Composable
 fun AllConversationsScreen(homeStateHolder: HomeStateHolder) {
     with(homeStateHolder) {
-        ConversationsScreenContent(
-            navigator = navigator,
-            searchBarState = searchBarState,
-            conversationsSource = ConversationsSource.MAIN,
-            lazyListState = lazyListStateFor(HomeDestination.Conversations),
-            emptyListContent = { ConversationsEmptyContent(filter = ConversationFilter.All) }
-        )
-    }
-}
-
-@HomeNavGraph
-@WireDestination
-@Composable
-fun FavoritesConversationsScreen(homeStateHolder: HomeStateHolder) {
-    with(homeStateHolder) {
-        ConversationsScreenContent(
-            navigator = navigator,
-            searchBarState = searchBarState,
-            conversationsSource = ConversationsSource.FAVORITES,
-            lazyListState = lazyListStateFor(HomeDestination.Favorites),
-            emptyListContent = { ConversationsEmptyContent(filter = ConversationFilter.Favorites) }
-        )
-    }
-}
-
-@HomeNavGraph
-@WireDestination(navArgsDelegate = FolderNavArgs::class)
-@Composable
-fun FolderConversationsScreen(homeStateHolder: HomeStateHolder, args: FolderNavArgs) {
-    with(homeStateHolder) {
-        ConversationsScreenContent(
-            navigator = navigator,
-            searchBarState = searchBarState,
-            conversationsSource = ConversationsSource.FOLDER(args.folderId, args.folderName),
-            emptyListContent = { ConversationsEmptyContent(filter = ConversationFilter.Folder(args.folderId, args.folderName)) }
-        )
-    }
-}
-
-@HomeNavGraph
-@WireDestination
-@Composable
-fun GroupConversationsScreen(homeStateHolder: HomeStateHolder) {
-    with(homeStateHolder) {
-        ConversationsScreenContent(
-            navigator = navigator,
-            searchBarState = searchBarState,
-            conversationsSource = ConversationsSource.GROUPS,
-            lazyListState = lazyListStateFor(HomeDestination.Group),
-            emptyListContent = { ConversationsEmptyContent(filter = ConversationFilter.Groups) }
-        )
-    }
-}
-
-@HomeNavGraph
-@WireDestination
-@Composable
-fun OneOnOneConversationsScreen(homeStateHolder: HomeStateHolder) {
-    with(homeStateHolder) {
-        ConversationsScreenContent(
-            navigator = navigator,
-            searchBarState = searchBarState,
-            conversationsSource = ConversationsSource.ONE_ON_ONE,
-            lazyListState = lazyListStateFor(HomeDestination.OneOnOne),
-            emptyListContent = { ConversationsEmptyContent(filter = ConversationFilter.OneOnOne, domain = it) }
-        )
+        Crossfade(
+            targetState = homeStateHolder.currentConversationFilter,
+            label = "Conversation filter change animation",
+        ) { filter ->
+            ConversationsScreenContent(
+                navigator = navigator,
+                searchBarState = searchBarState,
+                conversationsSource = when (filter) {
+                    is ConversationFilter.All -> ConversationsSource.MAIN
+                    is ConversationFilter.Favorites -> ConversationsSource.FAVORITES
+                    is ConversationFilter.Groups -> ConversationsSource.GROUPS
+                    is ConversationFilter.OneOnOne -> ConversationsSource.ONE_ON_ONE
+                    is ConversationFilter.Folder -> ConversationsSource.FOLDER(filter.folderId, filter.folderName)
+                },
+                lazyListState = lazyListStateFor(HomeDestination.Conversations, filter),
+                emptyListContent = { ConversationsEmptyContent(filter = ConversationFilter.All) }
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/filter/ConversationFilterSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/filter/ConversationFilterSheetContent.kt
@@ -28,7 +28,6 @@ import com.wire.kalium.logic.data.conversation.ConversationFilter
 fun ConversationFilterSheetContent(
     filterSheetState: ConversationFilterSheetState,
     onChangeFilter: (ConversationFilter) -> Unit,
-    onChangeFolder: (ConversationFilter.Folder) -> Unit,
     isBottomSheetVisible: () -> Boolean = { true }
 ) {
     when (filterSheetState.currentData.tab) {
@@ -45,7 +44,7 @@ fun ConversationFilterSheetContent(
         FilterTab.FOLDERS -> {
             ConversationFoldersSheetContent(
                 sheetData = filterSheetState.currentData,
-                onChangeFolder = onChangeFolder,
+                onChangeFolder = onChangeFilter,
                 onBackClick = {
                     filterSheetState.toFilters()
                 }
@@ -77,5 +76,5 @@ fun ConversationFilter.uiText(): UIText = when (this) {
     ConversationFilter.Favorites -> UIText.StringResource(R.string.label_filter_favorites)
     ConversationFilter.Groups -> UIText.StringResource(R.string.label_filter_group)
     ConversationFilter.OneOnOne -> UIText.StringResource(R.string.label_filter_one_on_one)
-    is ConversationFilter.Folder -> UIText.StringResource(R.string.label_filter_folders, this.folderName)
+    is ConversationFilter.Folder -> UIText.DynamicString(this.folderName)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationsSource.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationsSource.kt
@@ -22,11 +22,21 @@ import kotlinx.serialization.Serializable
 @Serializable
 sealed class ConversationsSource {
 
+    @Serializable
     data object MAIN : ConversationsSource()
+
+    @Serializable
     data object ARCHIVE : ConversationsSource()
+
+    @Serializable
     data object FAVORITES : ConversationsSource()
+
+    @Serializable
     data object GROUPS : ConversationsSource()
+
+    @Serializable
     data object ONE_ON_ONE : ConversationsSource()
 
+    @Serializable
     data class FOLDER(val folderId: String, val folderName: String) : ConversationsSource()
 }

--- a/app/src/test/kotlin/com/wire/android/ui/CallActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/CallActivityViewModelTest.kt
@@ -117,6 +117,7 @@ class CallActivityViewModelTest {
                 .arrange()
 
             viewModel.switchAccountIfNeeded(userId, arrangement.switchAccountActions)
+            advanceUntilIdle()
 
             coVerify(inverse = true) { arrangement.accountSwitch(any()) }
         }
@@ -132,6 +133,7 @@ class CallActivityViewModelTest {
             .arrange()
 
         viewModel.switchAccountIfNeeded(UserId("anotherUser", "domain"), arrangement.switchAccountActions)
+        advanceUntilIdle()
 
         coVerify(exactly = if (switchedToAnotherAccountCalled) 1 else 0) {
             arrangement.switchAccountActions.switchedToAnotherAccount()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14518" title="WPB-14518" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14518</a>  Filter not retained after navigating to another screen/Correct colors on dark mode.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The previously selected filter does not persist when the user navigates away from the conversation page, even though it is expected to remain applied until manually cleared or changed.

### Solutions

Keep the state of filters in `HomeStateHolder` so that it's retained even if navigated to a different home destination.
Simplify the navigation between different filters and folders by just using the `Crossfade` when the filter changes instead of making each filter and folder a distinct destination, so it involves reverting recent changes, but now it looks more like how it supposed to be - filter is just a parameter used within the "conversation list" screen, not that each filter is a separate screen.

### Testing

#### How to Test

Open the app, choose some filter, navigate to other home destination like settings, archive, self user profile, go back and see if the previously chosen filter is still applied.

### Attachments (Optional)


https://github.com/user-attachments/assets/e3ea19af-ea85-42db-b463-63135e4e41f4


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
