### PR TITLE
fix: add signature used by mls client (WPB-15040) 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -204,6 +204,12 @@ fun DeviceDetailsContent(
         ) {
             state.device.mlsClientIdentity?.let { identity ->
                 item {
+                    FolderHeader(
+                        name = stringResource(id = R.string.label_mls_signature, state.mlsCipherSuiteSignature.orEmpty()).uppercase(),
+                        modifier = Modifier
+                            .background(MaterialTheme.wireColorScheme.background)
+                            .fillMaxWidth()
+                    )
                     DeviceMLSSignatureItem(identity.thumbprint, screenState::copyMessage)
                     HorizontalDivider(color = MaterialTheme.wireColorScheme.background)
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.ClientType
 import com.wire.kalium.logic.data.client.DeleteClientParam
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeyType
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.client.ClientFingerprintUseCase
 import com.wire.kalium.logic.feature.client.DeleteClientResult
@@ -198,6 +199,9 @@ class DeviceDetailsViewModel @Inject constructor(
                             isCurrentDevice = result.isCurrentClient,
                             removeDeviceDialogState = RemoveDeviceDialogState.Hidden,
                             canBeRemoved = !result.isCurrentClient && isSelfClient && result.client.type != ClientType.LegalHold,
+                            mlsCipherSuiteSignature = MLSPublicKeyType.from(
+                                result.client.mlsPublicKeys?.keys?.firstOrNull().orEmpty()
+                            ).value.toString()
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/DeviceDetailsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/model/DeviceDetailsState.kt
@@ -37,5 +37,6 @@ data class DeviceDetailsState(
     val isE2EICertificateEnrollSuccess: Boolean = false,
     val isE2EICertificateEnrollError: Boolean = false,
     val isE2EIEnabled: Boolean = false,
-    val startGettingE2EICertificate: Boolean = false
+    val startGettingE2EICertificate: Boolean = false,
+    val mlsCipherSuiteSignature: String? = null,
 )


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15040" title="WPB-15040" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15040</a>  [Android] Display cipher suite on MLS device details
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


Cherry-pick of failed by action:
- https://github.com/wireapp/wire-android/pull/3740


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Displaying of the MLS signature of the client was not implemented.

### Solutions

Add the info according to specs

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Get a MLS client and in device details, you should see this info.

### Attachments (Optional)
<img src="https://github.com/user-attachments/assets/5eb18732-295b-4933-abb8-63f64b88e2c6" width="300"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
