### PR TITLE
feat: conference simulcast support (WPB-11480)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -177,6 +177,8 @@ fun OngoingCallScreen(
         clearVideoPreview = sharedCallingViewModel::clearVideoPreview,
         onCollapse = onCollapse,
         requestVideoStreams = ongoingCallViewModel::requestVideoStreams,
+        onSelectedParticipant = ongoingCallViewModel::onSelectedParticipant,
+        selectedParticipantForFullScreen = ongoingCallViewModel.selectedParticipant,
         hideDoubleTapToast = ongoingCallViewModel::hideDoubleTapToast,
         onCameraPermissionPermanentlyDenied = onCameraPermissionPermanentlyDenied,
         participants = sharedCallingViewModel.participantsState,
@@ -289,6 +291,8 @@ private fun OngoingCallContent(
     hideDoubleTapToast: () -> Unit,
     onCameraPermissionPermanentlyDenied: () -> Unit,
     requestVideoStreams: (participants: List<UICallParticipant>) -> Unit,
+    onSelectedParticipant: (selectedParticipant: SelectedParticipant) -> Unit,
+    selectedParticipantForFullScreen: SelectedParticipant,
     participants: PersistentList<UICallParticipant>,
     inPictureInPictureMode: Boolean,
     currentUserId: UserId,
@@ -303,7 +307,6 @@ private fun OngoingCallContent(
     )
 
     var shouldOpenFullScreen by remember { mutableStateOf(false) }
-    var selectedParticipantForFullScreen by remember { mutableStateOf(SelectedParticipant()) }
 
     WireBottomSheetScaffold(
         sheetDragHandle = null,
@@ -391,11 +394,14 @@ private fun OngoingCallContent(
                             selectedParticipant = selectedParticipantForFullScreen,
                             height = this@BoxWithConstraints.maxHeight - dimensions().spacing4x,
                             closeFullScreen = {
+                                onSelectedParticipant(SelectedParticipant())
                                 shouldOpenFullScreen = !shouldOpenFullScreen
                             },
                             onBackButtonClicked = {
+                                onSelectedParticipant(SelectedParticipant())
                                 shouldOpenFullScreen = !shouldOpenFullScreen
                             },
+                            requestVideoStreams = requestVideoStreams,
                             setVideoPreview = setVideoPreview,
                             clearVideoPreview = clearVideoPreview,
                             participants = participants
@@ -412,7 +418,7 @@ private fun OngoingCallContent(
                             requestVideoStreams = requestVideoStreams,
                             currentUserId = currentUserId,
                             onDoubleTap = { selectedParticipant ->
-                                selectedParticipantForFullScreen = selectedParticipant
+                                onSelectedParticipant(selectedParticipant)
                                 shouldOpenFullScreen = !shouldOpenFullScreen
                             },
                         )
@@ -580,6 +586,8 @@ fun PreviewOngoingCallContent(participants: PersistentList<UICallParticipant>) {
         participants = participants,
         inPictureInPictureMode = false,
         currentUserId = UserId("userId", "domain"),
+        onSelectedParticipant = {},
+        selectedParticipantForFullScreen = SelectedParticipant(),
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -28,8 +28,10 @@ import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.CurrentAccount
 import com.wire.android.ui.calling.model.UICallParticipant
+import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallClient
+import com.wire.kalium.logic.data.call.CallQuality
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
@@ -62,6 +64,8 @@ class OngoingCallViewModel @AssistedInject constructor(
     private var doubleTapIndicatorCountDownTimer: CountDownTimer? = null
 
     var state by mutableStateOf(OngoingCallState())
+        private set
+    var selectedParticipant by mutableStateOf(SelectedParticipant())
         private set
 
     init {
@@ -124,11 +128,23 @@ class OngoingCallViewModel @AssistedInject constructor(
                 .also {
                     if (it.isNotEmpty()) {
                         val clients: List<CallClient> = it.map { uiParticipant ->
-                            CallClient(uiParticipant.id.toString(), uiParticipant.clientId)
+                            CallClient(
+                                userId = uiParticipant.id.toString(),
+                                clientId = uiParticipant.clientId,
+                                quality = mapQualityStream(uiParticipant)
+                            )
                         }
                         requestVideoStreams(conversationId, clients)
                     }
                 }
+        }
+    }
+
+    private fun mapQualityStream(uiParticipant: UICallParticipant): CallQuality {
+        return if (uiParticipant.clientId == selectedParticipant.clientId) {
+            CallQuality.HIGH
+        } else {
+            CallQuality.LOW
         }
     }
 
@@ -137,7 +153,7 @@ class OngoingCallViewModel @AssistedInject constructor(
         doubleTapIndicatorCountDownTimer =
             object : CountDownTimer(DOUBLE_TAP_TOAST_DISPLAY_TIME, COUNT_DOWN_INTERVAL) {
                 override fun onTick(p0: Long) {
-                    appLogger.i("startDoubleTapToastDisplayCountDown: $p0")
+                    appLogger.d("$TAG - startDoubleTapToastDisplayCountDown: $p0")
                 }
 
                 override fun onFinish() {
@@ -171,10 +187,16 @@ class OngoingCallViewModel @AssistedInject constructor(
         }
     }
 
+    fun onSelectedParticipant(selectedParticipant: SelectedParticipant) {
+        appLogger.d("$TAG - Selected participant: ${selectedParticipant.toLogString()}")
+        this.selectedParticipant = selectedParticipant
+    }
+
     companion object {
         const val DOUBLE_TAP_TOAST_DISPLAY_TIME = 7000L
         const val COUNT_DOWN_INTERVAL = 1000L
         const val DELAY_TO_SHOW_DOUBLE_TAP_TOAST = 500L
+        const val TAG = "OngoingCallViewModel"
     }
 
     @AssistedFactory

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
@@ -60,6 +60,7 @@ fun FullScreenTile(
     closeFullScreen: (offset: Offset) -> Unit,
     onBackButtonClicked: () -> Unit,
     setVideoPreview: (View) -> Unit,
+    requestVideoStreams: (participants: List<UICallParticipant>) -> Unit,
     clearVideoPreview: () -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: Dp = dimensions().spacing4x,
@@ -119,6 +120,10 @@ fun FullScreenTile(
                 }
             )
         }
+
+        LaunchedEffect(selectedParticipant.userId) {
+            requestVideoStreams(listOf(it))
+        }
     }
 }
 
@@ -139,6 +144,7 @@ fun PreviewFullScreenTile() = WireTheme {
         closeFullScreen = {},
         onBackButtonClicked = {},
         setVideoPreview = {},
+        requestVideoStreams = {},
         clearVideoPreview = {},
         participants = participants,
     )

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/SelectedParticipant.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/SelectedParticipant.kt
@@ -17,10 +17,16 @@
  */
 package com.wire.android.ui.calling.ongoing.fullscreen
 
+import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.user.UserId
 
 data class SelectedParticipant(
     val userId: UserId = UserId("", ""),
     val clientId: String = "",
     val isSelfUser: Boolean = false
-)
+) {
+
+    fun toLogString(): String {
+        return "SelectedParticipant(userId=${userId.toLogString()}, clientId=${clientId.obfuscateId()}, isSelfUser=$isSelfUser)"
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
@@ -23,9 +23,11 @@ import com.wire.android.config.NavigationTestExtension
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.ongoing.OngoingCallViewModel
+import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallClient
+import com.wire.kalium.logic.data.call.CallQuality
 import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -170,6 +172,72 @@ class OngoingCallViewModelTest {
             }
         }
 
+    @Test
+    fun givenAUserIsSelected_whenRequestedFullScreen_thenSetTheUserAsSelected() =
+        runTest {
+            val (_, ongoingCallViewModel) = Arrangement()
+                .withCall(provideCall().copy(isCameraOn = true))
+                .withShouldShowDoubleTapToastReturning(false)
+                .withSetVideoSendState()
+                .arrange()
+
+            ongoingCallViewModel.onSelectedParticipant(selectedParticipant3)
+
+            assertEquals(selectedParticipant3, ongoingCallViewModel.selectedParticipant)
+        }
+
+    @Test
+    fun givenParticipantsList_WhenRequestingVideoStreamForFullScreenParticipant_ThenRequestItInHighQuality() =
+        runTest {
+            val expectedClients = listOf(
+                CallClient(participant1.id.toString(), participant1.clientId, false, CallQuality.LOW),
+                CallClient(participant3.id.toString(), participant3.clientId, false, CallQuality.HIGH)
+            )
+
+            val (arrangement, ongoingCallViewModel) = Arrangement()
+                .withCall(provideCall())
+                .withShouldShowDoubleTapToastReturning(false)
+                .withSetVideoSendState()
+                .withRequestVideoStreams(conversationId, expectedClients)
+                .arrange()
+
+            ongoingCallViewModel.onSelectedParticipant(selectedParticipant3)
+            ongoingCallViewModel.requestVideoStreams(participants)
+
+            coVerify(exactly = 1) {
+                arrangement.requestVideoStreams(
+                    conversationId,
+                    expectedClients
+                )
+            }
+        }
+
+    @Test
+    fun givenParticipantsList_WhenRequestingVideoStreamForAllParticipant_ThenRequestItInLowQuality() =
+        runTest {
+            val expectedClients = listOf(
+                CallClient(participant1.id.toString(), participant1.clientId, false, CallQuality.LOW),
+                CallClient(participant3.id.toString(), participant3.clientId, false, CallQuality.LOW)
+            )
+
+            val (arrangement, ongoingCallViewModel) = Arrangement()
+                .withCall(provideCall())
+                .withShouldShowDoubleTapToastReturning(false)
+                .withSetVideoSendState()
+                .withRequestVideoStreams(conversationId, expectedClients)
+                .arrange()
+
+            ongoingCallViewModel.onSelectedParticipant(SelectedParticipant())
+            ongoingCallViewModel.requestVideoStreams(participants)
+
+            coVerify(exactly = 1) {
+                arrangement.requestVideoStreams(
+                    conversationId,
+                    expectedClients
+                )
+            }
+        }
+
     private class Arrangement {
 
         @MockK
@@ -268,6 +336,7 @@ class OngoingCallViewModelTest {
             accentId = -1
         )
         val participants = listOf(participant1, participant2, participant3)
+        val selectedParticipant3 = SelectedParticipant(participant3.id, participant3.clientId, false)
     }
 
     private fun provideCall(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ coil = "2.7.0"
 commonmark = "0.24.0"
 
 # Countly
-countly = "24.7.7"
+countly = "24.4.0"
 
 # RSS
 rss-parser = "6.0.7"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ coil = "2.7.0"
 commonmark = "0.24.0"
 
 # Countly
-countly = "24.4.0"
+countly = "24.7.7"
 
 # RSS
 rss-parser = "6.0.7"


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11480" title="WPB-11480" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11480</a>  [Android] Simulcast Support & Automatic Quality Adjustments
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

























----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

> [!NOTE]
> Bring back the simulcast revert

### Issues

On AVS 10.x.x, we have finally supported for Simulcast (multiple quality for participants video). This is an improvement in the overall experience, and as well in performance, because when the client is with a Tile in FullScreen, we can request only that video stream, saving bandwidth. 

### Solutions

Add the code to support, this consist in simple words:

- When requesting the video streams `wcall_request_video_streams` we send a new parameter call (quality)
- ANY = 0, LOW = 1, HIGH = 2.

Also took the chance to improve some things in the code:

- Calling Logging
- JSON serializer was being created every time we requested streams, now is using a shared instance.

### Dependencies (Optional)

- https://github.com/wireapp/kalium/pull/3150

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

As of now, it is not possible, but when SFT version 5 is deployed on staging, it will be possible.
For development purposes, was 'hacked' using the SFT test server and local webapp.

### Attachments (Optional)

https://drive.google.com/file/d/18N0W4hXT3MDfL_tsD0_rJCzgDz5s4D9D/view?usp=sharing

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
