### PR TITLE
fix: harden countly sdk integration (WPB-15007)

### DIFF
--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
@@ -20,6 +20,7 @@ package com.wire.android.feature.analytics
 import android.app.Activity
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants
 import com.wire.android.feature.analytics.model.AnalyticsSettings
@@ -34,8 +35,8 @@ class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
     override fun configure(
         context: Context,
         analyticsSettings: AnalyticsSettings
-    ) {
-        if (isConfigured) return
+    ) = wrapCountlyRequest {
+        if (isConfigured) return@wrapCountlyRequest
 
         val countlyConfig = CountlyConfig(
             context,
@@ -54,24 +55,24 @@ class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
             }
         }
 
-        Countly.sharedInstance().init(countlyConfig)
-        Countly.sharedInstance().consent().giveConsent(arrayOf("apm"))
+        Countly.sharedInstance()?.init(countlyConfig)
+        Countly.sharedInstance()?.consent()?.giveConsent(arrayOf("apm"))
 
         val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
         val globalSegmentations = mapOf<String, Any>(
             AnalyticsEventConstants.APP_NAME to AnalyticsEventConstants.APP_NAME_ANDROID,
             AnalyticsEventConstants.APP_VERSION to packageInfo.versionName
         )
-        Countly.sharedInstance().views().setGlobalViewSegmentation(globalSegmentations)
+        Countly.sharedInstance()?.views()?.setGlobalViewSegmentation(globalSegmentations)
         isConfigured = true
     }
 
-    override fun onStart(activity: Activity) {
-        Countly.sharedInstance().onStart(activity)
+    override fun onStart(activity: Activity) = wrapCountlyRequest {
+        Countly.sharedInstance()?.onStart(activity)
     }
 
-    override fun onStop() {
-        Countly.sharedInstance().onStop()
+    override fun onStop() = wrapCountlyRequest {
+        Countly.sharedInstance()?.onStop()
     }
 
     /**
@@ -79,11 +80,11 @@ class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
      * Countly is doing additional operations on it.
      * See [UtilsInternalLimits.removeUnsupportedDataTypes]
      */
-    override fun sendEvent(event: AnalyticsEvent) {
-        Countly.sharedInstance().events().recordEvent(event.key, event.toSegmentation().toMutableMap())
+    override fun sendEvent(event: AnalyticsEvent) = wrapCountlyRequest {
+        Countly.sharedInstance()?.events()?.recordEvent(event.key, event.toSegmentation().toMutableMap())
     }
 
-    override fun halt() {
+    override fun halt() = wrapCountlyRequest {
         isConfigured = false
         Countly.sharedInstance().consent().removeConsentAll()
     }
@@ -93,7 +94,9 @@ class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
         isTeamMember: Boolean,
         migrationComplete: suspend () -> Unit
     ) {
-        Countly.sharedInstance().deviceId().changeWithMerge(identifier).also {
+        wrapCountlyRequest {
+            Countly.sharedInstance()?.deviceId()?.changeWithMerge(identifier)
+        }.also {
             migrationComplete()
         }
 
@@ -106,7 +109,9 @@ class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
         isTeamMember: Boolean,
         propagateIdentifier: suspend () -> Unit
     ) {
-        Countly.sharedInstance().deviceId().changeWithoutMerge(identifier)
+        wrapCountlyRequest {
+            Countly.sharedInstance()?.deviceId()?.changeWithoutMerge(identifier)
+        }
 
         setUserProfileProperties(isTeamMember = isTeamMember)
 
@@ -115,27 +120,42 @@ class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
         }
     }
 
-    private fun setUserProfileProperties(isTeamMember: Boolean) {
-        Countly.sharedInstance().userProfile().setProperty(
+    private fun setUserProfileProperties(isTeamMember: Boolean) = wrapCountlyRequest {
+        Countly.sharedInstance()?.userProfile()?.setProperty(
             AnalyticsEventConstants.TEAM_IS_TEAM,
             isTeamMember
         )
-        Countly.sharedInstance().userProfile().save()
+        Countly.sharedInstance()?.userProfile()?.save()
     }
 
     override fun isAnalyticsInitialized(): Boolean = Countly.sharedInstance().isInitialized
 
-    override fun applicationOnCreate() {
-        if (isConfigured) return
+    override fun applicationOnCreate() = wrapCountlyRequest {
+        if (isConfigured) return@wrapCountlyRequest
 
         Countly.applicationOnCreate()
     }
 
-    override fun recordView(screen: String) {
-        Countly.sharedInstance().views().startAutoStoppedView(screen)
+    override fun recordView(screen: String) = wrapCountlyRequest {
+        Countly.sharedInstance()?.views()?.startAutoStoppedView(screen)
     }
 
-    override fun stopView(screen: String) {
-        Countly.sharedInstance().views().stopViewWithName(screen)
+    override fun stopView(screen: String) = wrapCountlyRequest {
+        Countly.sharedInstance()?.views()?.stopViewWithName(screen)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun wrapCountlyRequest(block: () -> Unit) {
+        try {
+            block()
+        } catch (e: Exception) {
+            // Countly SDK throws exceptions on some cases, just log it
+            // We don't want to crash the app because of that.
+            Log.wtf(TAG, "Countly SDK request failed", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "AnonymousAnalyticsRecorderImpl"
     }
 }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15007" title="WPB-15007" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15007</a>  [Android] Countly SDK integration hardening
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


Cherry-pick of failed by action
- https://github.com/wireapp/wire-android/pull/3735

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fixes several crashes while interacting with the SDK.

### Solutions

- wrap calls to SDK and log fatal exceptions.
- Use safe (?) nullable operator and doubt completely on the SDK about possible crashes.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
