### PR TITLE
fix: non-paginated conversation list is not loading [WPB-15066]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -45,7 +45,7 @@ internal fun NavController.navigateToItem(command: NavigationCommand) {
 
     fun lastDestinationFromOtherGraph(graph: NavGraphSpec) = currentBackStack.value.lastOrNull { it.navGraph() != graph }
 
-    appLogger.d("[$TAG] -> command: ${command.destination.route.obfuscateId()}")
+    appLogger.d("[$TAG] -> command: ${command.destination.route.obfuscateId()} backStackMode:${command.backStackMode}")
     navigate(command.destination) {
         when (command.backStackMode) {
             BackStackMode.CLEAR_WHOLE, BackStackMode.CLEAR_TILL_START -> {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -214,16 +214,13 @@ class ConversationListViewModelImpl @AssistedInject constructor(
         .flowOn(dispatcher.io())
         .cachedIn(viewModelScope)
 
-    private var notPaginatedConversationListState by mutableStateOf(ConversationListState.NotPaginated())
-    override val conversationListState: ConversationListState =
-        if (usePagination) {
-            ConversationListState.Paginated(
-                conversations = conversationsPaginatedFlow,
-                domain = currentAccount.domain
-            )
-        } else {
-            notPaginatedConversationListState
+    override var conversationListState by mutableStateOf(
+        when (usePagination) {
+            true -> ConversationListState.Paginated(conversations = conversationsPaginatedFlow, domain = currentAccount.domain)
+            false -> ConversationListState.NotPaginated()
         }
+    )
+        private set
 
     init {
         if (!usePagination) {
@@ -258,7 +255,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
                     }
                     .flowOn(dispatcher.io())
                     .collect {
-                        notPaginatedConversationListState = notPaginatedConversationListState.copy(
+                        conversationListState = ConversationListState.NotPaginated(
                             isLoading = false,
                             conversations = it,
                             domain = currentAccount.domain


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15066" title="WPB-15066" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15066</a>  [Android] Conversation list not loading after login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On current 4.11 staging build, the conversation list is not loading at all after fresh install and fresh login.

### Causes (Optional)

For non-paginated state, `conversationListState` is created by using `notPaginatedConversationListState` but looks like it's using it as a value instead of using it as a state that can change and should then recompose.

### Solutions

Two separate states are not needed and can unnecessarily use resources, so merge them into a single one - for paginated just pass single value initially with the paginated flow, for non-patinated just update `conversationListState` directly.
Also, added `backStackMode` to the navigation command log so that it's more clear what the command is supposed to do.

### Testing

#### How to Test

Use a build version that doesn't have `paginated_conversation_list_enabled` enabled (currently only `internal` and `prod` have it enabled), fresh install, log in and open the app - it should load conversation list properly and not be stuck in loading state.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
