### PR TITLE
fix: countly sdk integration replace halt and bump to latest (WPB-15007)

### DIFF
--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
@@ -86,7 +86,7 @@ class AnonymousAnalyticsRecorderImpl : AnonymousAnalyticsRecorder {
 
     override fun halt() = wrapCountlyRequest {
         isConfigured = false
-        Countly.sharedInstance().halt()
+        Countly.sharedInstance()?.consent()?.removeConsentAll()
     }
 
     override suspend fun setTrackingIdentifierWithMerge(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ coil = "2.7.0"
 commonmark = "0.24.0"
 
 # Countly
-countly = "24.4.0"
+countly = "24.7.7"
 
 # RSS
 rss-parser = "6.0.7"


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15007" title="WPB-15007" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15007</a>  [Android] Countly SDK integration hardening
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After a couple of PRs addressing countly, the fixes from last week got overridden. 

### Causes (Optional)

Crash on call to halt.

### Solutions

Bring back the fix, and bump countly to latest.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Have 2 accounts with countly; one enabled, second disabled. 
First go to enabled account, then go to disabled and send app to BG

Expected:
When bringing app from "recent apps" there should no be crash, since we are not calling halt anymore, but rather:
`Countly.sharedInstance()?.consent()?.removeConsentAll()`

#### Attachments


https://github.com/user-attachments/assets/bbc15151-ad2f-4444-bff1-6f5061b3781f



----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
