### PR TITLE
feat: Add option to manage team [#WPB-14873]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersona
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
 import com.wire.kalium.logic.feature.publicuser.GetKnownUserUseCase
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
+import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
 import com.wire.kalium.logic.feature.user.DeleteAccountUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoUseCase
@@ -190,6 +191,11 @@ class UserModule {
     @Provides
     fun provideGetSelfUseCase(userScope: UserScope): GetSelfUserUseCase =
         userScope.getSelfUser
+
+    @ViewModelScoped
+    @Provides
+    fun provideGetTeamUrlUseCase(userScope: UserScope): GetTeamUrlUseCase =
+        userScope.getTeamUrl
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.defaultMinSize
@@ -43,6 +44,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -208,6 +210,7 @@ private fun SelfUserProfileContent(
     isUserInCall: () -> Boolean
 ) {
     val snackbarHostState = LocalSnackbarHostState.current
+    val uriHandler = LocalUriHandler.current
 
     state.errorMessageCode?.let { errorCode ->
         val errorMessage = mapErrorCodeToString(errorCode)
@@ -345,7 +348,13 @@ private fun SelfUserProfileContent(
 
                 Divider(color = MaterialTheme.wireColorScheme.outline)
 
-                Box(modifier = Modifier.padding(dimensions().spacing16x)) {
+                Column(
+                    modifier = Modifier.padding(dimensions().spacing16x),
+                    verticalArrangement = Arrangement.spacedBy(dimensions().spacing8x)
+                ) {
+                    if (isTeamAdminOrOwner) {
+                        ManageTeamButton(uriHandler::openUri)
+                    }
                     NewTeamButton(onAddAccountClick, isUserInCall, context)
                 }
             }
@@ -438,6 +447,22 @@ private fun CurrentSelfUserStatus(
             onStatusClicked(items[selectedIndex])
         }
     }
+}
+
+@Composable
+private fun ManageTeamButton(
+    onManageTeamClick: (String) -> Unit
+) {
+    val teamManagementLink = stringResource(R.string.url_team_management_login)
+    WireSecondaryButton(
+        modifier = Modifier
+            .testTag("Manage team"),
+        text = stringResource(R.string.user_profile_account_management),
+        onClickDescription = stringResource(R.string.content_description_self_profile_manage_team_btn),
+        onClick = {
+            onManageTeamClick(teamManagementLink)
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -352,8 +352,8 @@ private fun SelfUserProfileContent(
                     modifier = Modifier.padding(dimensions().spacing16x),
                     verticalArrangement = Arrangement.spacedBy(dimensions().spacing8x)
                 ) {
-                    if (isTeamAdminOrOwner) {
-                        ManageTeamButton(uriHandler::openUri)
+                    if (teamUrl != null) {
+                        ManageTeamButton { uriHandler.openUri(teamUrl) }
                     }
                     NewTeamButton(onAddAccountClick, isUserInCall, context)
                 }
@@ -451,15 +451,12 @@ private fun CurrentSelfUserStatus(
 
 @Composable
 private fun ManageTeamButton(
-    onManageTeamClick: (String) -> Unit
+    onManageTeamClick: () -> Unit
 ) {
-    val teamManagementLink = stringResource(R.string.url_team_management_login)
     WireSecondaryButton(
         text = stringResource(R.string.user_profile_account_management),
         onClickDescription = stringResource(R.string.content_description_self_profile_manage_team_btn),
-        onClick = {
-            onManageTeamClick(teamManagementLink)
-        }
+        onClick = onManageTeamClick
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -455,8 +455,6 @@ private fun ManageTeamButton(
 ) {
     val teamManagementLink = stringResource(R.string.url_team_management_login)
     WireSecondaryButton(
-        modifier = Modifier
-            .testTag("Manage team"),
         text = stringResource(R.string.user_profile_account_management),
         onClickDescription = stringResource(R.string.content_description_self_profile_manage_team_btn),
         onClick = {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileState.kt
@@ -34,7 +34,7 @@ data class SelfUserProfileState(
     val fullName: String = "",
     val userName: String = "",
     val teamName: String? = "", // maybe teamId is better here
-    val isTeamAdminOrOwner: Boolean = false,
+    val teamUrl: String? = null,
     val otherAccounts: List<OtherAccount> = emptyList(),
     val statusDialogData: StatusDialogData? = null, // null means no dialog to display
     val isAvatarLoading: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileState.kt
@@ -34,6 +34,7 @@ data class SelfUserProfileState(
     val fullName: String = "",
     val userName: String = "",
     val teamName: String? = "", // maybe teamId is better here
+    val isTeamAdminOrOwner: Boolean = false,
     val otherAccounts: List<OtherAccount> = emptyList(),
     val statusDialogData: StatusDialogData? = null, // null means no dialog to display
     val isAvatarLoading: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -48,6 +48,7 @@ import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
@@ -176,6 +177,7 @@ class SelfUserProfileViewModel @Inject constructor(
                             fullName = name.orEmpty(),
                             userName = handle.orEmpty(),
                             teamName = selfTeam?.name,
+                            isTeamAdminOrOwner = userType == UserType.OWNER || userType == UserType.ADMIN,
                             otherAccounts = otherAccounts,
                             avatarAsset = userProfileState.avatarAsset,
                             isAvatarLoading = false,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -55,6 +55,7 @@ import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
+import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
 import com.wire.kalium.logic.feature.team.GetUpdatedSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
@@ -99,7 +100,8 @@ class SelfUserProfileViewModel @Inject constructor(
     private val notificationManager: WireNotificationManager,
     private val globalDataStore: GlobalDataStore,
     private val qualifiedIdMapper: QualifiedIdMapper,
-    private val anonymousAnalyticsManager: AnonymousAnalyticsManager
+    private val anonymousAnalyticsManager: AnonymousAnalyticsManager,
+    private val getTeamUrl: GetTeamUrlUseCase
 ) : ViewModel() {
 
     var userProfileState by mutableStateOf(SelfUserProfileState(userId = selfUserId, isAvatarLoading = true))
@@ -177,7 +179,7 @@ class SelfUserProfileViewModel @Inject constructor(
                             fullName = name.orEmpty(),
                             userName = handle.orEmpty(),
                             teamName = selfTeam?.name,
-                            isTeamAdminOrOwner = userType == UserType.OWNER || userType == UserType.ADMIN,
+                            teamUrl = getTeamUrl().takeIf { userType == UserType.OWNER || userType == UserType.ADMIN },
                             otherAccounts = otherAccounts,
                             avatarAsset = userProfileState.avatarAsset,
                             isAvatarLoading = false,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,6 +242,7 @@
     <string name="content_description_self_profile_team">Team name, %s</string>
     <string name="content_description_self_profile_change_status">change availability status</string>
     <string name="content_description_self_profile_new_account_btn">Create a new team or personal account or log in</string>
+    <string name="content_description_self_profile_manage_team_btn">Manage team</string>
     <string name="content_description_change_picture_back_btn">Go back to your profile overview</string>
     <string name="content_description_welcome_screen_close_btn">Close new team creation and login view</string>
     <string name="content_description_login_back_btn">Go back to new team creation and login view</string>
@@ -612,6 +613,7 @@
     <string name="user_profile_status_away">Away</string>
     <string name="user_profile_status_none">None</string>
     <string name="user_profile_new_account_text">New Team or Add Account</string>
+    <string name="user_profile_account_management">Manage Team</string>
     <string name="user_profile_details_tab">Details</string>
     <string name="user_profile_devices_tab">Devices</string>
     <string name="user_profile_group_tab">Group</string>

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModelArrangement.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
+import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
 import com.wire.kalium.logic.feature.team.GetUpdatedSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
@@ -101,6 +102,9 @@ class SelfUserProfileViewModelArrangement {
     @MockK
     lateinit var canMigrateFromPersonalToTeam: CanMigrateFromPersonalToTeamUseCase
 
+    @MockK
+    lateinit var getTeamUrl: GetTeamUrlUseCase
+
     private val viewModel by lazy {
         SelfUserProfileViewModel(
             selfUserId = TestUser.SELF_USER.id,
@@ -121,7 +125,8 @@ class SelfUserProfileViewModelArrangement {
             globalDataStore = globalDataStore,
             qualifiedIdMapper = qualifiedIdMapper,
             anonymousAnalyticsManager = anonymousAnalyticsManager,
-            canMigrateFromPersonalToTeam = canMigrateFromPersonalToTeam
+            canMigrateFromPersonalToTeam = canMigrateFromPersonalToTeam,
+            getTeamUrl = getTeamUrl
         )
     }
 
@@ -136,6 +141,7 @@ class SelfUserProfileViewModelArrangement {
         coEvery { observeEstablishedCalls.invoke() } returns flowOf(emptyList())
         coEvery { observeEstablishedCalls.invoke() } returns flowOf(emptyList())
         coEvery { canMigrateFromPersonalToTeam.invoke() } returns true
+        coEvery { getTeamUrl.invoke() } returns ""
     }
 
     fun withLegalHoldStatus(result: LegalHoldStateForSelfUser) = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14873" title="WPB-14873" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14873</a>  [Android] No access to team management from application
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-14873

# What's new in this PR?

### Issues

There was no option to manage a team

### Solutions

Add button for group admins and owners to redirect to a team web page

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
