### PR TITLE
fix: tertiary selected button color [WPB-15120]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeTopBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeTopBar.kt
@@ -70,11 +70,11 @@ fun HomeTopBar(
             }
             if (navigationItem.withUserAvatar) {
                 val openLabel = stringResource(R.string.content_description_open_label)
-            val contentDescription = if (shouldShowCreateTeamUnreadIndicator) {
-                stringResource(R.string.content_description_home_profile_btn_with_notification)
-            } else {
-                stringResource(R.string.content_description_home_profile_btn)
-            }
+                val contentDescription = if (shouldShowCreateTeamUnreadIndicator) {
+                    stringResource(R.string.content_description_home_profile_btn_with_notification)
+                } else {
+                    stringResource(R.string.content_description_home_profile_btn)
+                }
                 UserProfileAvatar(
                     avatarData = userAvatarData,
                     clickable = remember {
@@ -87,7 +87,7 @@ fun HomeTopBar(
                         legalHoldIndicatorVisible = withLegalHoldIndicator
                     ),
                     shouldShowCreateTeamUnreadIndicator = shouldShowCreateTeamUnreadIndicator,
-                contentDescription = contentDescription
+                    contentDescription = contentDescription
                 )
             }
         },
@@ -102,6 +102,27 @@ fun PreviewTopBar() {
         HomeTopBar(
             navigationItem = HomeDestination.Conversations,
             userAvatarData = UserAvatarData(null, UserAvailabilityStatus.AVAILABLE),
+            elevation = 0.dp,
+            withLegalHoldIndicator = false,
+            shouldShowCreateTeamUnreadIndicator = false,
+            onHamburgerMenuClick = {},
+            onNavigateToSelfUserProfile = {},
+            onOpenConversationFilter = {}
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewTopBarWithSelectedFilter() {
+    WireTheme {
+        HomeTopBar(
+            navigationItem = HomeDestination.Group,
+            userAvatarData = UserAvatarData(
+                asset = null,
+                availabilityStatus = UserAvailabilityStatus.AVAILABLE,
+                nameBasedAvatar = NameBasedAvatar("Jon Doe", -1)
+            ),
             elevation = 0.dp,
             withLegalHoldIndicator = false,
             shouldShowCreateTeamUnreadIndicator = false,

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/button/WireTertiaryButton.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/button/WireTertiaryButton.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.ui.common.Icon
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.PreviewMultipleThemes
@@ -95,13 +96,13 @@ fun WireTertiaryButton(
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewWireTertiaryButton() {
+fun PreviewWireTertiaryButton() = WireTheme {
     WireTertiaryButton(onClick = { }, text = "text")
 }
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewWireTertiaryButtonNarrowWithIcons() {
+fun PreviewWireTertiaryButtonNarrowWithIcons() = WireTheme {
     WireTertiaryButton(
         onClick = { },
         text = "text",
@@ -113,7 +114,7 @@ fun PreviewWireTertiaryButtonNarrowWithIcons() {
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewWireTertiaryButtonNarrowOnlyIcons() {
+fun PreviewWireTertiaryButtonNarrowOnlyIcons() = WireTheme {
     WireTertiaryButton(
         onClick = { },
         leadingIcon = Icons.Filled.Search.Icon(),
@@ -124,18 +125,18 @@ fun PreviewWireTertiaryButtonNarrowOnlyIcons() {
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewWireTertiaryButtonDisabled() {
+fun PreviewWireTertiaryButtonDisabled() = WireTheme {
     WireTertiaryButton(onClick = { }, state = WireButtonState.Disabled, text = "text", fillMaxWidth = false)
 }
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewWireTertiaryButtonSelected() {
+fun PreviewWireTertiaryButtonSelected() = WireTheme {
     WireTertiaryButton(onClick = { }, state = WireButtonState.Selected, text = "text", fillMaxWidth = false)
 }
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewWireTertiaryButtonError() {
+fun PreviewWireTertiaryButtonError() = WireTheme {
     WireTertiaryButton(onClick = { }, state = WireButtonState.Error, text = "text", fillMaxWidth = false)
 }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/button/WireTertiaryButton.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/button/WireTertiaryButton.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -40,6 +39,7 @@ import com.wire.android.model.ClickBlockParams
 import com.wire.android.ui.common.Icon
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.PreviewMultipleThemes
 
 @Composable
 fun WireTertiaryButton(
@@ -93,13 +93,13 @@ fun WireTertiaryButton(
     description = description
 )
 
-@Preview(name = "Default WireSecondaryButton")
+@PreviewMultipleThemes
 @Composable
 fun PreviewWireTertiaryButton() {
     WireTertiaryButton(onClick = { }, text = "text")
 }
 
-@Preview(name = "Default narrow WireTertiaryButton with icon")
+@PreviewMultipleThemes
 @Composable
 fun PreviewWireTertiaryButtonNarrowWithIcons() {
     WireTertiaryButton(
@@ -111,7 +111,7 @@ fun PreviewWireTertiaryButtonNarrowWithIcons() {
     )
 }
 
-@Preview(name = "Default narrow WireTertiaryButton only icon")
+@PreviewMultipleThemes
 @Composable
 fun PreviewWireTertiaryButtonNarrowOnlyIcons() {
     WireTertiaryButton(
@@ -122,19 +122,19 @@ fun PreviewWireTertiaryButtonNarrowOnlyIcons() {
     )
 }
 
-@Preview(name = "Default narrow Disabled WireSecondaryButton")
+@PreviewMultipleThemes
 @Composable
 fun PreviewWireTertiaryButtonDisabled() {
     WireTertiaryButton(onClick = { }, state = WireButtonState.Disabled, text = "text", fillMaxWidth = false)
 }
 
-@Preview(name = "Selected narrow WireSecondaryButton")
+@PreviewMultipleThemes
 @Composable
 fun PreviewWireTertiaryButtonSelected() {
     WireTertiaryButton(onClick = { }, state = WireButtonState.Selected, text = "text", fillMaxWidth = false)
 }
 
-@Preview(name = "Error narrow WireSecondaryButton")
+@PreviewMultipleThemes
 @Composable
 fun PreviewWireTertiaryButtonError() {
     WireTertiaryButton(onClick = { }, state = WireButtonState.Error, text = "text", fillMaxWidth = false)

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/button/WireTertiaryIconButton.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/button/WireTertiaryIconButton.kt
@@ -31,13 +31,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.ui.common.R
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.preview.MultipleThemePreviews
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 
 @Composable
@@ -78,21 +79,57 @@ fun WireTertiaryIconButton(
     )
 }
 
-@Preview
+@MultipleThemePreviews
 @Composable
-fun PreviewWireTertiaryIconButton() {
+fun PreviewWireTertiaryIconButton() = WireTheme {
     WireTertiaryIconButton({}, loading = false, iconResource = R.drawable.ic_close, contentDescription = 0)
 }
 
-@Preview
+@MultipleThemePreviews
 @Composable
-fun PreviewWireTertiaryIconButtonLoading() {
+fun PreviewWireTertiaryIconButtonSelected() = WireTheme {
+    WireTertiaryIconButton(
+        {},
+        loading = false,
+        iconResource = R.drawable.ic_close,
+        contentDescription = 0,
+        state = WireButtonState.Selected,
+    )
+}
+
+@MultipleThemePreviews
+@Composable
+fun PreviewWireTertiaryIconButtonError() = WireTheme {
+    WireTertiaryIconButton(
+        {},
+        loading = false,
+        iconResource = R.drawable.ic_close,
+        contentDescription = 0,
+        state = WireButtonState.Error,
+    )
+}
+
+@MultipleThemePreviews
+@Composable
+fun PreviewWireTertiaryIconButtonDisabled() = WireTheme {
+    WireTertiaryIconButton(
+        {},
+        loading = false,
+        iconResource = R.drawable.ic_close,
+        contentDescription = 0,
+        state = WireButtonState.Disabled,
+    )
+}
+
+@MultipleThemePreviews
+@Composable
+fun PreviewWireTertiaryIconButtonLoading() = WireTheme {
     WireTertiaryIconButton({}, loading = true, iconResource = R.drawable.ic_close, contentDescription = 0)
 }
 
-@Preview
+@MultipleThemePreviews
 @Composable
-fun PreviewWireTertiaryIconButtonRound() {
+fun PreviewWireTertiaryIconButtonRound() = WireTheme {
     WireTertiaryIconButton(
         {},
         loading = false,

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -227,8 +227,8 @@ private val DarkWireColorScheme = WireColorScheme(
     secondaryButtonRipple = Color.White,
     tertiaryButtonEnabled = Color.Transparent, onTertiaryButtonEnabled = Color.White,
     tertiaryButtonDisabled = Color.Transparent, onTertiaryButtonDisabled = WireColorPalette.Gray60,
-    tertiaryButtonSelected = WireColorPalette.DarkBlue50, onTertiaryButtonSelected = WireColorPalette.DarkBlue500,
-    tertiaryButtonSelectedOutline = WireColorPalette.DarkBlue300,
+    tertiaryButtonSelected = WireColorPalette.DarkBlue800, onTertiaryButtonSelected = WireColorPalette.DarkBlue500,
+    tertiaryButtonSelectedOutline = WireColorPalette.DarkBlue800,
     tertiaryButtonRipple = Color.White,
 
     // strokes and shadows


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15120" title="WPB-15120" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15120</a>  Wrong tertiary button selected colors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fix for wrong tertiary button selected colors

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->

| Before | After |
| ----------- | ------------ |
|  ![wrong_colors](https://github.com/user-attachments/assets/20f7d7f5-1b45-4dc8-a691-4c78c2cc3ad1)  |  ![proper_colors](https://github.com/user-attachments/assets/f4db6d4b-636f-4fa2-a900-bf7fbc160dfc)  |



