### PR TITLE
fix: reusing PagingData crash [WPB-15055][WPB-15079][WPB-15064]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchBarState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchBarState.kt
@@ -69,8 +69,8 @@ class SearchBarState(
             },
             restore = {
                 SearchBarState(
-                    isSearchActive = it[0] as Boolean,
-                    searchQueryTextState = it[1]?.let {
+                    isSearchActive = (it.getOrNull(0) as? Boolean) ?: false,
+                    searchQueryTextState = it.getOrNull(1)?.let {
                         with(TextFieldState.Saver) {
                             restore(it)
                         }

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchBarState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchBarState.kt
@@ -80,4 +80,3 @@ class SearchBarState(
         )
     }
 }
-

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchBarState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchBarState.kt
@@ -29,11 +29,12 @@ import androidx.compose.runtime.setValue
 
 @Composable
 fun rememberSearchbarState(
+    initialIsSearchActive: Boolean = false,
     searchQueryTextState: TextFieldState = rememberTextFieldState()
 ): SearchBarState = rememberSaveable(
-    saver = SearchBarState.saver(searchQueryTextState)
+    saver = SearchBarState.saver()
 ) {
-    SearchBarState(searchQueryTextState = searchQueryTextState)
+    SearchBarState(isSearchActive = initialIsSearchActive, searchQueryTextState = searchQueryTextState)
 }
 
 class SearchBarState(
@@ -57,16 +58,26 @@ class SearchBarState(
     }
 
     companion object {
-        fun saver(searchQueryTextState: TextFieldState): Saver<SearchBarState, *> = Saver(
+        fun saver(): Saver<SearchBarState, *> = Saver(
             save = {
-                listOf(it.isSearchActive)
+                listOf(
+                    it.isSearchActive,
+                    with(TextFieldState.Saver) {
+                        save(it.searchQueryTextState)
+                    }
+                )
             },
             restore = {
                 SearchBarState(
-                    isSearchActive = it[0],
-                    searchQueryTextState = searchQueryTextState
+                    isSearchActive = it[0] as Boolean,
+                    searchQueryTextState = it[1]?.let {
+                        with(TextFieldState.Saver) {
+                            restore(it)
+                        }
+                    } ?: TextFieldState()
                 )
             }
         )
     }
 }
+

--- a/app/src/main/kotlin/com/wire/android/ui/home/archive/ArchiveScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/archive/ArchiveScreen.kt
@@ -32,7 +32,6 @@ import com.wire.android.ui.home.conversationslist.common.previewConversationFold
 import com.wire.android.ui.home.conversationslist.model.ConversationsSource
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
-import kotlinx.coroutines.flow.flowOf
 
 @HomeNavGraph
 @WireDestination
@@ -57,7 +56,7 @@ fun PreviewArchiveEmptyScreen() = WireTheme {
         searchBarState = rememberSearchbarState(),
         conversationsSource = ConversationsSource.ARCHIVE,
         emptyListContent = { ArchiveEmptyContent() },
-        conversationListViewModel = ConversationListViewModelPreview(flowOf()),
+        conversationListViewModel = ConversationListViewModelPreview(previewConversationFoldersFlow(list = listOf())),
     )
 }
 
@@ -66,10 +65,10 @@ fun PreviewArchiveEmptyScreen() = WireTheme {
 fun PreviewArchiveEmptySearchScreen() = WireTheme {
     ConversationsScreenContent(
         navigator = rememberNavigator {},
-        searchBarState = rememberSearchbarState(searchQueryTextState = TextFieldState(initialText = "er")),
+        searchBarState = rememberSearchbarState(initialIsSearchActive = true, searchQueryTextState = TextFieldState(initialText = "er")),
         conversationsSource = ConversationsSource.ARCHIVE,
         emptyListContent = { ArchiveEmptyContent() },
-        conversationListViewModel = ConversationListViewModelPreview(flowOf()),
+        conversationListViewModel = ConversationListViewModelPreview(previewConversationFoldersFlow(searchQuery = "er", list = listOf())),
     )
 }
 
@@ -78,7 +77,7 @@ fun PreviewArchiveEmptySearchScreen() = WireTheme {
 fun PreviewArchiveScreen() = WireTheme {
     ConversationsScreenContent(
         navigator = rememberNavigator {},
-        searchBarState = rememberSearchbarState(searchQueryTextState = TextFieldState(initialText = "er")),
+        searchBarState = rememberSearchbarState(initialIsSearchActive = true, searchQueryTextState = TextFieldState(initialText = "er")),
         conversationsSource = ConversationsSource.ARCHIVE,
         emptyListContent = { ArchiveEmptyContent() },
         conversationListViewModel = ConversationListViewModelPreview(previewConversationFoldersFlow(searchQuery = "er")),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import androidx.paging.insertSeparators
 import androidx.paging.map
 import com.wire.android.BuildConfig
@@ -126,7 +127,7 @@ class ConversationListViewModelPreview(
 class ConversationListViewModelImpl @AssistedInject constructor(
     @Assisted val conversationsSource: ConversationsSource,
     @Assisted private val usePagination: Boolean = BuildConfig.PAGINATED_CONVERSATION_LIST_ENABLED,
-    dispatcher: DispatcherProvider,
+    private val dispatcher: DispatcherProvider,
     private val updateConversationMutedStatus: UpdateConversationMutedStatusUseCase,
     private val getConversationsPaginated: GetConversationsFromSearchUseCase,
     private val observeConversationListDetailsWithEvents: ObserveConversationListDetailsWithEventsUseCase,
@@ -161,6 +162,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
     override val closeBottomSheet = MutableSharedFlow<Unit>()
 
     private val searchQueryFlow: MutableStateFlow<String> = MutableStateFlow("")
+    private val isSelfUserUnderLegalHoldFlow = MutableSharedFlow<Boolean>(replay = 1)
 
     private val containsNewActivitiesSection = when (conversationsSource) {
         ConversationsSource.MAIN,
@@ -174,94 +176,105 @@ class ConversationListViewModelImpl @AssistedInject constructor(
     private val conversationsPaginatedFlow: Flow<PagingData<ConversationFolderItem>> = searchQueryFlow
         .debounce { if (it.isEmpty()) 0L else DEFAULT_SEARCH_QUERY_DEBOUNCE }
         .onStart { emit("") }
+        .combine(isSelfUserUnderLegalHoldFlow, ::Pair)
         .distinctUntilChanged()
-        .flatMapLatest { searchQuery ->
+        .flatMapLatest { (searchQuery, isSelfUserUnderLegalHold) ->
             getConversationsPaginated(
                 searchQuery = searchQuery,
                 fromArchive = conversationsSource == ConversationsSource.ARCHIVE,
                 conversationFilter = conversationsSource.toFilter(),
                 onlyInteractionEnabled = false,
                 newActivitiesOnTop = containsNewActivitiesSection,
-            ).combine(observeLegalHoldStateForSelfUser()) { conversations, selfUserLegalHoldStatus ->
-                conversations.map {
-                    it.hideIndicatorForSelfUserUnderLegalHold(selfUserLegalHoldStatus)
-                }
-            }.map {
-                it.insertSeparators { before, after ->
-                    when {
-                        // do not add separators if the list shouldn't show conversations grouped into different folders
-                        !containsNewActivitiesSection -> null
+            ).map { pagingData ->
+                pagingData
+                    .map { it.hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold) }
+                    .insertSeparators { before, after ->
+                        when {
+                            // do not add separators if the list shouldn't show conversations grouped into different folders
+                            !containsNewActivitiesSection -> null
 
-                        before == null && after != null && after.hasNewActivitiesToShow ->
-                            // list starts with items with "new activities"
-                            ConversationFolder.Predefined.NewActivities
+                            before == null && after != null && after.hasNewActivitiesToShow ->
+                                // list starts with items with "new activities"
+                                ConversationFolder.Predefined.NewActivities
 
-                        before == null && after != null && !after.hasNewActivitiesToShow ->
-                            // list doesn't contain any items with "new activities"
-                            ConversationFolder.Predefined.Conversations
+                            before == null && after != null && !after.hasNewActivitiesToShow ->
+                                // list doesn't contain any items with "new activities"
+                                ConversationFolder.Predefined.Conversations
 
-                        before != null && before.hasNewActivitiesToShow && after != null && !after.hasNewActivitiesToShow ->
-                            // end of "new activities" section and beginning of "conversations" section
-                            ConversationFolder.Predefined.Conversations
+                            before != null && before.hasNewActivitiesToShow && after != null && !after.hasNewActivitiesToShow ->
+                                // end of "new activities" section and beginning of "conversations" section
+                                ConversationFolder.Predefined.Conversations
 
-                        else -> null
+                            else -> null
+                        }
                     }
-                }
             }
         }
         .flowOn(dispatcher.io())
+        .cachedIn(viewModelScope)
 
-    private var notPaginatedConversationListState by mutableStateOf(ConversationListState.NotPaginated())
-    override val conversationListState: ConversationListState
-        get() = if (usePagination) {
-            ConversationListState.Paginated(
-                conversations = conversationsPaginatedFlow,
-                domain = currentAccount.domain
-            )
-        } else {
-            notPaginatedConversationListState
+    override var conversationListState by mutableStateOf(
+        when (usePagination) {
+            true -> ConversationListState.Paginated(conversations = conversationsPaginatedFlow, domain = currentAccount.domain)
+            false -> ConversationListState.NotPaginated()
         }
+    )
+        private set
 
     init {
+        observeSelfUserLegalHoldState()
         if (!usePagination) {
-            viewModelScope.launch {
-                searchQueryFlow
-                    .debounce { if (it.isEmpty()) 0L else DEFAULT_SEARCH_QUERY_DEBOUNCE }
-                    .onStart { emit("") }
-                    .distinctUntilChanged()
-                    .flatMapLatest { searchQuery: String ->
-                        observeConversationListDetailsWithEvents(
-                            fromArchive = conversationsSource == ConversationsSource.ARCHIVE,
-                            conversationFilter = conversationsSource.toFilter()
-                        ).combine(observeLegalHoldStateForSelfUser()) { conversations, selfUserLegalHoldStatus ->
-                            conversations.map { conversationDetails ->
-                                conversationDetails.toConversationItem(
-                                    userTypeMapper = userTypeMapper,
-                                    searchQuery = searchQuery,
-                                    selfUserTeamId = observeSelfUser().firstOrNull()?.teamId
-                                ).hideIndicatorForSelfUserUnderLegalHold(selfUserLegalHoldStatus)
-                            } to searchQuery
-                        }
+            observeNonPaginatedSearchConversationList()
+        }
+    }
+
+    private fun observeSelfUserLegalHoldState() {
+        viewModelScope.launch {
+            observeLegalHoldStateForSelfUser()
+                .map { it is LegalHoldStateForSelfUser.Enabled }
+                .flowOn(dispatcher.io())
+                .collect { isSelfUserUnderLegalHoldFlow.emit(it) }
+        }
+    }
+
+    private fun observeNonPaginatedSearchConversationList() {
+        viewModelScope.launch {
+            searchQueryFlow
+                .debounce { if (it.isEmpty()) 0L else DEFAULT_SEARCH_QUERY_DEBOUNCE }
+                .onStart { emit("") }
+                .distinctUntilChanged()
+                .flatMapLatest { searchQuery: String ->
+                    observeConversationListDetailsWithEvents(
+                        fromArchive = conversationsSource == ConversationsSource.ARCHIVE,
+                        conversationFilter = conversationsSource.toFilter()
+                    ).combine(isSelfUserUnderLegalHoldFlow) { conversations, isSelfUserUnderLegalHold ->
+                        conversations.map { conversationDetails ->
+                            conversationDetails.toConversationItem(
+                                userTypeMapper = userTypeMapper,
+                                searchQuery = searchQuery,
+                                selfUserTeamId = observeSelfUser().firstOrNull()?.teamId
+                            ).hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold)
+                        } to searchQuery
                     }
-                    .map { (conversationItems, searchQuery) ->
-                        if (searchQuery.isEmpty()) {
-                            conversationItems.withFolders(source = conversationsSource).toImmutableMap()
-                        } else {
-                            searchConversation(
-                                conversationDetails = conversationItems,
-                                searchQuery = searchQuery
-                            ).withFolders(source = conversationsSource).toImmutableMap()
-                        }
+                }
+                .map { (conversationItems, searchQuery) ->
+                    if (searchQuery.isEmpty()) {
+                        conversationItems.withFolders(source = conversationsSource).toImmutableMap()
+                    } else {
+                        searchConversation(
+                            conversationDetails = conversationItems,
+                            searchQuery = searchQuery
+                        ).withFolders(source = conversationsSource).toImmutableMap()
                     }
-                    .flowOn(dispatcher.io())
-                    .collect {
-                        notPaginatedConversationListState = notPaginatedConversationListState.copy(
-                            isLoading = false,
-                            conversations = it,
-                            domain = currentAccount.domain
-                        )
-                    }
-            }
+                }
+                .flowOn(dispatcher.io())
+                .collect {
+                    conversationListState = ConversationListState.NotPaginated(
+                        isLoading = false,
+                        conversations = it,
+                        domain = currentAccount.domain
+                    )
+                }
         }
     }
 
@@ -446,11 +459,13 @@ private fun ConversationsSource.toFilter(): ConversationFilter = when (this) {
     ConversationsSource.ONE_ON_ONE -> ConversationFilter.ONE_ON_ONE
 }
 
-private fun ConversationItem.hideIndicatorForSelfUserUnderLegalHold(selfUserLegalHoldStatus: LegalHoldStateForSelfUser) =
-    // if self user is under legal hold then we shouldn't show legal hold indicator next to every conversation
-    // the indication is shown in the header of the conversation list for self user in that case and it's enough
-    when (selfUserLegalHoldStatus) {
-        is LegalHoldStateForSelfUser.Enabled -> when (this) {
+/**
+ * If self user is under legal hold then we shouldn't show legal hold indicator next to every conversation as in that case
+ * the legal hold indication is shown in the header of the conversation list for self user in that case and it's enough.
+ */
+private fun ConversationItem.hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold: Boolean) =
+    when (isSelfUserUnderLegalHold) {
+        true -> when (this) {
             is ConversationItem.ConnectionConversation -> this.copy(showLegalHoldIndicator = false)
             is ConversationItem.GroupConversation -> this.copy(showLegalHoldIndicator = false)
             is ConversationItem.PrivateConversation -> this.copy(showLegalHoldIndicator = false)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -88,7 +88,6 @@ fun ConversationsScreenContent(
     lazyListState: LazyListState = rememberLazyListState(),
     loadingListContent: @Composable (LazyListState) -> Unit = { ConversationListLoadingContent(it) },
     conversationsSource: ConversationsSource = ConversationsSource.MAIN,
-    initiallyLoaded: Boolean = LocalInspectionMode.current,
     conversationListViewModel: ConversationListViewModel = when {
         LocalInspectionMode.current -> ConversationListViewModelPreview()
         else -> hiltViewModel<ConversationListViewModelImpl, ConversationListViewModelImpl.Factory>(
@@ -189,10 +188,7 @@ fun ConversationsScreenContent(
         when (val state = conversationListViewModel.conversationListState) {
             is ConversationListState.Paginated -> {
                 val lazyPagingItems = state.conversations.collectAsLazyPagingItems()
-                var showLoading by remember { mutableStateOf(!initiallyLoaded) }
-                if (lazyPagingItems.loadState.refresh != LoadState.Loading && showLoading) {
-                    showLoading = false
-                }
+                val showLoading = lazyPagingItems.loadState.refresh == LoadState.Loading && lazyPagingItems.itemCount == 0
 
                 when {
                     // when conversation list is not yet fetched, show loading indicator

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/AllConversationsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/AllConversationsScreen.kt
@@ -33,7 +33,6 @@ import com.wire.android.ui.home.conversationslist.model.ConversationsSource
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.conversation.ConversationFilter
-import kotlinx.coroutines.flow.flowOf
 
 @HomeNavGraph(start = true)
 @WireDestination
@@ -103,7 +102,7 @@ fun PreviewAllConversationsEmptyScreen() = WireTheme {
         searchBarState = rememberSearchbarState(),
         conversationsSource = ConversationsSource.MAIN,
         emptyListContent = { ConversationsEmptyContent() },
-        conversationListViewModel = ConversationListViewModelPreview(flowOf()),
+        conversationListViewModel = ConversationListViewModelPreview(previewConversationFoldersFlow(list = listOf())),
     )
 }
 
@@ -112,10 +111,10 @@ fun PreviewAllConversationsEmptyScreen() = WireTheme {
 fun PreviewAllConversationsEmptySearchScreen() = WireTheme {
     ConversationsScreenContent(
         navigator = rememberNavigator {},
-        searchBarState = rememberSearchbarState(searchQueryTextState = TextFieldState(initialText = "er")),
+        searchBarState = rememberSearchbarState(initialIsSearchActive = true, searchQueryTextState = TextFieldState(initialText = "er")),
         conversationsSource = ConversationsSource.MAIN,
         emptyListContent = { ConversationsEmptyContent() },
-        conversationListViewModel = ConversationListViewModelPreview(flowOf()),
+        conversationListViewModel = ConversationListViewModelPreview(previewConversationFoldersFlow(searchQuery = "er", list = listOf())),
     )
 }
 
@@ -124,7 +123,7 @@ fun PreviewAllConversationsEmptySearchScreen() = WireTheme {
 fun PreviewAllConversationsSearchScreen() = WireTheme {
     ConversationsScreenContent(
         navigator = rememberNavigator {},
-        searchBarState = rememberSearchbarState(searchQueryTextState = TextFieldState(initialText = "er")),
+        searchBarState = rememberSearchbarState(initialIsSearchActive = true, searchQueryTextState = TextFieldState(initialText = "er")),
         conversationsSource = ConversationsSource.MAIN,
         emptyListContent = { ConversationsEmptyContent() },
         conversationListViewModel = ConversationListViewModelPreview(previewConversationFoldersFlow("er")),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.paging.LoadState
+import androidx.paging.LoadStates
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -234,7 +236,15 @@ fun previewConversationList(count: Int, startIndex: Int = 0, unread: Boolean = f
 fun previewConversationFoldersFlow(
     searchQuery: String = "",
     list: List<ConversationFolderItem> = previewConversationFolders(searchQuery = searchQuery)
-) = flowOf(PagingData.from(list))
+) = flowOf(PagingData.from(
+    data = list,
+    sourceLoadStates = LoadStates(
+        prepend = LoadState.NotLoading(true),
+        append = LoadState.NotLoading(true),
+        refresh = LoadState.NotLoading(true),
+    )
+)
+)
 
 fun previewConversationFolders(withFolders: Boolean = true, searchQuery: String = "", unreadCount: Int = 3, readCount: Int = 6) =
     buildList {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -236,14 +236,15 @@ fun previewConversationList(count: Int, startIndex: Int = 0, unread: Boolean = f
 fun previewConversationFoldersFlow(
     searchQuery: String = "",
     list: List<ConversationFolderItem> = previewConversationFolders(searchQuery = searchQuery)
-) = flowOf(PagingData.from(
-    data = list,
-    sourceLoadStates = LoadStates(
-        prepend = LoadState.NotLoading(true),
-        append = LoadState.NotLoading(true),
-        refresh = LoadState.NotLoading(true),
+) = flowOf(
+    PagingData.from(
+        data = list,
+        sourceLoadStates = LoadStates(
+            prepend = LoadState.NotLoading(true),
+            append = LoadState.NotLoading(true),
+            refresh = LoadState.NotLoading(true),
+        )
     )
-)
 )
 
 fun previewConversationFolders(withFolders: Boolean = true, searchQuery: String = "", unreadCount: Int = 3, readCount: Int = 6) =

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -61,6 +61,9 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -233,6 +236,77 @@ class ConversationListViewModelTest {
         coVerify(exactly = 1) { arrangement.unblockUser(userId) }
     }
 
+    @Test
+    fun `given cached PagingData, when self user legal hold changes, then should call paginated use case again`() =
+        runTest(dispatcherProvider.main()) {
+            // given
+            val conversations = listOf(
+                TestConversationItem.CONNECTION.copy(conversationId = ConversationId("conn_1", "")),
+                TestConversationItem.PRIVATE.copy(conversationId = ConversationId("private_1", "")),
+                TestConversationItem.GROUP.copy(conversationId = ConversationId("group_1", "")),
+            ).associateBy { it.conversationId }
+            val selfUserLegalHoldStateFlow = MutableSharedFlow<LegalHoldStateForSelfUser>()
+            val (arrangement, conversationListViewModel) = Arrangement(conversationsSource = ConversationsSource.MAIN)
+                .withConversationsPaginated(conversations.values.toList())
+                .withSelfUserLegalHoldStateFlow(selfUserLegalHoldStateFlow)
+                .arrange()
+            advanceUntilIdle()
+
+            (conversationListViewModel.conversationListState as ConversationListState.Paginated).conversations.test {
+                // initial legal hold state
+                selfUserLegalHoldStateFlow.emit(LegalHoldStateForSelfUser.Disabled)
+                advanceUntilIdle()
+
+                // use case is called initially
+                coVerify(exactly = 1) {
+                    arrangement.getConversationsPaginated(any(), any(), any(), any(), any())
+                }
+
+                // when legal hold state is changed
+                selfUserLegalHoldStateFlow.emit(LegalHoldStateForSelfUser.Enabled)
+                advanceUntilIdle()
+
+                // then use case should be called again (in total 2 executions) to create new PagingData
+                coVerify(exactly = 2) {
+                    arrangement.getConversationsPaginated(any(), any(), any(), any(), any())
+                }
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given cached PagingData, when observing twice, then paginated use case should not be called again`() =
+        runTest(dispatcherProvider.main()) {
+            // given
+            val conversations = listOf(
+                TestConversationItem.CONNECTION.copy(conversationId = ConversationId("conn_1", "")),
+                TestConversationItem.PRIVATE.copy(conversationId = ConversationId("private_1", "")),
+                TestConversationItem.GROUP.copy(conversationId = ConversationId("group_1", "")),
+            ).associateBy { it.conversationId }
+            val (arrangement, conversationListViewModel) = Arrangement(conversationsSource = ConversationsSource.MAIN)
+                .withConversationsPaginated(conversations.values.toList())
+                .withSelfUserLegalHoldState(LegalHoldStateForSelfUser.Disabled)
+                .arrange()
+            advanceUntilIdle()
+
+            // flow is collected first time
+            (conversationListViewModel.conversationListState as ConversationListState.Paginated).conversations.first()
+
+            // use case is called initially
+            coVerify(exactly = 1) {
+                arrangement.getConversationsPaginated(any(), any(), any(), any(), any())
+            }
+
+            // flow is collected second time
+            (conversationListViewModel.conversationListState as ConversationListState.Paginated).conversations.first()
+
+            // use case should NOT be called again, there should be still only one call
+            coVerify(exactly = 1) {
+                arrangement.getConversationsPaginated(any(), any(), any(), any(), any())
+            }
+        }
+
     inner class Arrangement(val conversationsSource: ConversationsSource = ConversationsSource.MAIN) {
         @MockK
         lateinit var updateConversationMutedStatus: UpdateConversationMutedStatusUseCase
@@ -321,8 +395,12 @@ class ConversationListViewModelTest {
             )
         }
 
-        fun withSelfUserLegalHoldState(LegalHoldStateForSelfUser: LegalHoldStateForSelfUser) = apply {
-            coEvery { observeLegalHoldStateForSelfUserUseCase() } returns flowOf(LegalHoldStateForSelfUser)
+        fun withSelfUserLegalHoldState(legalHoldStateForSelfUser: LegalHoldStateForSelfUser) = apply {
+            coEvery { observeLegalHoldStateForSelfUserUseCase() } returns flowOf(legalHoldStateForSelfUser)
+        }
+
+        fun withSelfUserLegalHoldStateFlow(legalHoldStateForSelfUserFlow: Flow<LegalHoldStateForSelfUser>) = apply {
+            coEvery { observeLegalHoldStateForSelfUserUseCase() } returns legalHoldStateForSelfUserFlow
         }
 
         fun arrange() = this to ConversationListViewModelImpl(


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15055" title="WPB-15055" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15055</a>  [Android] Crash when opening connection request from paginated list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There are crashes related to reusing `PagingData` flow when doing some actions on paginated conversation list screen, like accepting legal hold request, answering 1:1 call or opening pending connection request which can fetch user data.

### Causes (Optional)

Each action that modifies (or even puts the same exact data but just requires executing insert, update or delete query) a table that then affects paginated conversation list query, makes this query dirty and executes it again, which reloads the list. 
When using `combine`, it creates a new instance of flow, so if the `combine` is used after `PagingData` is created then if the data is changed and emitted by the flow that's combined, it will re-use the same `PagingData` and put it into a new flow, so `cachedIn` won't cache the flow properly and it will crash because `PagingData` cannot be used twice.

### Solutions

Move `combine` "above" the `PagingData` flow so that each time a new value is emitted, it will always create a new `PagingData` for the new flow and also `cachedIn` will be used correctly.
Simplify `showLoading` parameter to be a simple logical equation rather than a state. Make use of mocked `previewConversationFoldersFlow` with proper `LoadStates` to represent loaded data instead of using specific `initiallyLoaded` parameter.
Fix `rememberSearchbarState` so that it actually saves the `searchQueryTextState`.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

The crash was happening when opening pending connection request (most frequently), answering 1:1 call or accepting legal hold request, so these actions shouldn't crash the app. Also, after opening connection request or 1:1 conversation, if your or that user's data hasn't changed since the last fetch, then it shouldn't refresh the conversation list when navigating back.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/user-attachments/assets/aa1b5411-6da3-40f2-a6c7-f970b89cbac3"/> | <video width="400" src="https://github.com/user-attachments/assets/d5bb1370-e195-415b-88eb-a97585ff24b6"/> |
| <video width="400" src="https://github.com/user-attachments/assets/1c0fa88e-9d3b-42ec-aa3f-2fccc9816d7e"/> |   |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
