### PR TITLE
feat: send and receive in-call reactions [#WPB-14254]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
@@ -202,4 +202,9 @@ class CallsModule {
     @Provides
     fun provideObserveConferenceCallingEnabledUseCase(callsScope: CallsScope) =
         callsScope.observeConferenceCallingEnabled
+
+    @ViewModelScoped
+    @Provides
+    fun provideObserveInCallReactionsUseCase(callsScope: CallsScope) =
+        callsScope.observeInCallReactions
 }

--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/MessageModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/MessageModule.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.feature.asset.ObserveAssetStatusesUseCase
 import com.wire.kalium.logic.feature.asset.ObservePaginatedAssetImageMessages
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageUseCase
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCase
+import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
 import com.wire.kalium.logic.feature.message.GetNotificationsUseCase
@@ -216,4 +217,9 @@ class MessageModule {
     @Provides
     fun provideRemoveMessageDraftUseCase(messageScope: MessageScope): RemoveMessageDraftUseCase =
         messageScope.removeMessageDraftUseCase
+
+    @ViewModelScoped
+    @Provides
+    fun provideSendInCallReactionUseCase(messageScope: MessageScope): SendInCallReactionUseCase =
+        messageScope.sendInCallReactionUseCase
 }

--- a/app/src/main/kotlin/com/wire/android/mapper/UICallParticipantMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/UICallParticipantMapper.kt
@@ -21,14 +21,16 @@ package com.wire.android.mapper
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.kalium.logic.data.call.Participant
+import com.wire.kalium.logic.data.conversation.ClientId
 import javax.inject.Inject
 
 class UICallParticipantMapper @Inject constructor(
     private val userTypeMapper: UserTypeMapper,
 ) {
-    fun toUICallParticipant(participant: Participant) = UICallParticipant(
+    fun toUICallParticipant(participant: Participant, currentClientId: ClientId) = UICallParticipant(
         id = participant.id,
         clientId = participant.clientId,
+        isSelfUser = participant.clientId == currentClientId.value,
         name = participant.name,
         isMuted = participant.isMuted,
         isSpeaking = participant.isSpeaking,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/CameraButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/CameraButton.kt
@@ -20,10 +20,8 @@ package com.wire.android.ui.calling.controlbuttons
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.Dp
 import com.wire.android.R
 import com.wire.android.appLogger
-import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.permission.rememberCameraPermissionFlow
 import com.wire.android.util.ui.PreviewMultipleThemes
@@ -34,7 +32,6 @@ fun CameraButton(
     onPermissionPermanentlyDenied: () -> Unit,
     modifier: Modifier = Modifier,
     isCameraOn: Boolean = false,
-    size: Dp = dimensions().defaultCallingControlsSize,
 ) {
     val cameraPermissionCheck = rememberCameraPermissionFlow(
         onPermissionGranted = {
@@ -56,7 +53,6 @@ fun CameraButton(
             false -> R.string.content_description_calling_turn_camera_on
         },
         onClick = cameraPermissionCheck::launch,
-        size = size,
         modifier = modifier,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/HangUpOngoingButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/HangUpOngoingButton.kt
@@ -35,10 +35,11 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
-fun HangUpButton(
+fun HangUpOngoingButton(
     onHangUpButtonClicked: () -> Unit,
     modifier: Modifier = Modifier,
-    size: Dp = dimensions().defaultCallingControlsHeight,
+    width: Dp = dimensions().defaultCallingControlsWidth,
+    height: Dp = dimensions().defaultCallingControlsHeight,
     iconSize: Dp = dimensions().bigCallingHangUpButtonIconSize,
 ) {
     WirePrimaryIconButton(
@@ -46,8 +47,8 @@ fun HangUpButton(
         contentDescription = R.string.content_description_calling_hang_up_call,
         state = WireButtonState.Error,
         shape = CircleShape,
-        minSize = DpSize(size, size),
-        minClickableSize = DpSize(size, size),
+        minSize = DpSize(width, height),
+        minClickableSize = DpSize(width, height),
         iconSize = iconSize,
         onButtonClicked = onHangUpButtonClicked,
         modifier = modifier,
@@ -56,8 +57,8 @@ fun HangUpButton(
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewComposableHangUpButton() = WireTheme {
-    HangUpButton(
+fun PreviewComposableHangUpOngoingButton() = WireTheme {
+    HangUpOngoingButton(
         modifier = Modifier
             .width(MaterialTheme.wireDimensions.bigCallingControlsSize)
             .height(MaterialTheme.wireDimensions.bigCallingControlsSize),

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/InCallReactionsButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/InCallReactionsButton.kt
@@ -15,48 +15,49 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.calling.controlbuttons
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.Dp
 import com.wire.android.R
-import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
-fun CameraFlipButton(
-    onCameraFlipButtonClicked: () -> Unit,
+fun InCallReactionsButton(
+    isSelected: Boolean,
+    onInCallReactionsClick: () -> Unit,
     modifier: Modifier = Modifier,
-    isOnFrontCamera: Boolean = false,
-    size: Dp = dimensions().defaultCallingControlsSize
 ) {
     WireCallControlButton(
-        isSelected = !isOnFrontCamera,
-        iconResId = when (isOnFrontCamera) {
-            true -> R.drawable.ic_camera_flipped
-            false -> R.drawable.ic_camera_flip
+        isSelected = isSelected,
+        iconResId = when (isSelected) {
+            true -> R.drawable.ic_incall_reactions
+            false -> R.drawable.ic_incall_reactions
         },
-        contentDescription = when (isOnFrontCamera) {
-            true -> R.string.content_description_calling_flip_camera_on
-            false -> R.string.content_description_calling_flip_camera_off
+        contentDescription = when (isSelected) {
+            true -> R.string.content_description_calling_unmute_call
+            false -> R.string.content_description_calling_mute_call
         },
-        onClick = onCameraFlipButtonClicked,
-        size = size,
-        modifier = modifier,
+        onClick = onInCallReactionsClick,
+        modifier = modifier
     )
 }
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewCameraFlipButtonOn() = WireTheme {
-    CameraFlipButton(isOnFrontCamera = true, onCameraFlipButtonClicked = { })
+fun PreviewInCallReactionsButton() = WireTheme {
+    InCallReactionsButton(
+        isSelected = false,
+        onInCallReactionsClick = { }
+    )
 }
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewCameraFlipButtonOff() = WireTheme {
-    CameraFlipButton(isOnFrontCamera = false, onCameraFlipButtonClicked = { })
+fun PreviewInCallReactionsButtonSelected() = WireTheme {
+    InCallReactionsButton(
+        isSelected = true,
+        onInCallReactionsClick = { }
+    )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/MicrophoneButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/MicrophoneButton.kt
@@ -20,9 +20,7 @@ package com.wire.android.ui.calling.controlbuttons
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.Dp
 import com.wire.android.R
-import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 
@@ -31,7 +29,6 @@ fun MicrophoneButton(
     isMuted: Boolean,
     onMicrophoneButtonClicked: () -> Unit,
     modifier: Modifier = Modifier,
-    size: Dp = dimensions().defaultCallingControlsSize
 ) {
     WireCallControlButton(
         isSelected = !isMuted,
@@ -44,7 +41,6 @@ fun MicrophoneButton(
             false -> R.string.content_description_calling_mute_call
         },
         onClick = onMicrophoneButtonClicked,
-        size = size,
         modifier = modifier
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/SpeakerButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/SpeakerButton.kt
@@ -20,9 +20,7 @@ package com.wire.android.ui.calling.controlbuttons
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.Dp
 import com.wire.android.R
-import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 
@@ -31,7 +29,6 @@ fun SpeakerButton(
     isSpeakerOn: Boolean,
     onSpeakerButtonClicked: () -> Unit,
     modifier: Modifier = Modifier,
-    size: Dp = dimensions().defaultCallingControlsSize
 ) {
     WireCallControlButton(
         isSelected = isSpeakerOn,
@@ -44,7 +41,6 @@ fun SpeakerButton(
             false -> R.string.content_description_calling_turn_speaker_on
         },
         onClick = onSpeakerButtonClicked,
-        size = size,
         modifier = modifier,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/WireCallControlButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/WireCallControlButton.kt
@@ -20,14 +20,13 @@ package com.wire.android.ui.calling.controlbuttons
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import com.wire.android.ui.common.button.WireButtonState
-import com.wire.android.ui.common.button.WireSecondaryIconButton
+import com.wire.android.ui.common.button.WirePrimaryIconButton
 import com.wire.android.ui.common.button.wireSecondaryButtonColors
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
@@ -39,10 +38,11 @@ fun WireCallControlButton(
     @StringRes contentDescription: Int,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    size: Dp = dimensions().defaultCallingControlsSize,
+    width: Dp = dimensions().defaultCallingControlsWidth,
+    height: Dp = dimensions().defaultCallingControlsHeight,
     iconSize: Dp = dimensions().defaultCallingControlsIconSize
 ) {
-    WireSecondaryIconButton(
+    WirePrimaryIconButton(
         onButtonClicked = onClick,
         iconResource = iconResId,
         shape = CircleShape,
@@ -60,9 +60,9 @@ fun WireCallControlButton(
         },
         contentDescription = contentDescription,
         state = if (isSelected) WireButtonState.Selected else WireButtonState.Default,
-        minSize = DpSize(size, size),
-        minClickableSize = DpSize(size, size),
+        minSize = DpSize(width, height),
+        minClickableSize = DpSize(width, height),
         iconSize = iconSize,
-        modifier = modifier.size(size),
+        modifier = modifier,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/model/InCallReaction.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/model/InCallReaction.kt
@@ -15,24 +15,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.calling.model
 
-import com.wire.android.model.ImageAsset
-import com.wire.android.ui.home.conversationslist.model.Membership
-import com.wire.kalium.logic.data.id.QualifiedID
-
-data class UICallParticipant(
-    val id: QualifiedID,
-    val clientId: String,
-    val isSelfUser: Boolean,
-    val name: String? = null,
-    val isMuted: Boolean,
-    val isSpeaking: Boolean = false,
-    val isCameraOn: Boolean,
-    val isSharingScreen: Boolean,
-    val avatar: ImageAsset.UserAvatarAsset? = null,
-    val membership: Membership,
-    val hasEstablishedAudio: Boolean,
-    val accentId: Int
+data class InCallReaction(
+    val emoji: String,
+    val sender: ReactionSender,
 )
+
+sealed interface ReactionSender {
+    data object You : ReactionSender
+    data class Other(val name: String) : ReactionSender
+    data object Unknown : ReactionSender
+}

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -21,6 +21,10 @@ package com.wire.android.ui.calling.ongoing
 import android.content.pm.PackageManager
 import android.view.View
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -32,7 +36,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SheetValue
@@ -65,14 +68,20 @@ import com.wire.android.ui.calling.CallState
 import com.wire.android.ui.calling.ConversationName
 import com.wire.android.ui.calling.SharedCallingViewModel
 import com.wire.android.ui.calling.controlbuttons.CameraButton
-import com.wire.android.ui.calling.controlbuttons.CameraFlipButton
-import com.wire.android.ui.calling.controlbuttons.HangUpButton
+import com.wire.android.ui.calling.controlbuttons.HangUpOngoingButton
+import com.wire.android.ui.calling.controlbuttons.InCallReactionsButton
 import com.wire.android.ui.calling.controlbuttons.MicrophoneButton
 import com.wire.android.ui.calling.controlbuttons.SpeakerButton
+import com.wire.android.ui.calling.model.InCallReaction
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.ongoing.fullscreen.DoubleTapToast
 import com.wire.android.ui.calling.ongoing.fullscreen.FullScreenTile
 import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
+import com.wire.android.ui.calling.ongoing.incallreactions.AnimatableReaction
+import com.wire.android.ui.calling.ongoing.incallreactions.InCallReactionsPanel
+import com.wire.android.ui.calling.ongoing.incallreactions.InCallReactionsState
+import com.wire.android.ui.calling.ongoing.incallreactions.drawInCallReactions
+import com.wire.android.ui.calling.ongoing.incallreactions.rememberInCallReactionsState
 import com.wire.android.ui.calling.ongoing.participantsview.FloatingSelfUserTile
 import com.wire.android.ui.calling.ongoing.participantsview.VerticalCallingPager
 import com.wire.android.ui.common.ConversationVerificationIcons
@@ -85,11 +94,11 @@ import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.visbility.rememberVisibilityState
+import com.wire.android.ui.emoji.EmojiPickerBottomSheet
 import com.wire.android.ui.home.conversations.PermissionPermanentlyDeniedDialogState
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
-import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.call.CallStatus
@@ -100,6 +109,7 @@ import com.wire.kalium.logic.data.user.UserId
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.collectLatest
 import java.util.Locale
 
 @Suppress("ParameterWrapping")
@@ -118,6 +128,8 @@ fun OngoingCallScreen(
     val permissionPermanentlyDeniedDialogState =
         rememberVisibilityState<PermissionPermanentlyDeniedDialogState>()
 
+    val inCallReactionsState = rememberInCallReactionsState()
+
     val activity = LocalActivity.current
     val isPiPAvailableOnThisDevice =
         activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
@@ -133,6 +145,13 @@ fun OngoingCallScreen(
             }
         }
     }
+
+    LaunchedEffect(Unit) {
+        sharedCallingViewModel.inCallReactions.collectLatest { reaction ->
+            inCallReactionsState.runAnimation(reaction)
+        }
+    }
+
     val hangUpCall = remember {
         {
             sharedCallingViewModel.hangUpCall { activity.finishAndRemoveTask() }
@@ -167,6 +186,7 @@ fun OngoingCallScreen(
     val inPictureInPictureMode = activity.isInPictureInPictureMode
     OngoingCallContent(
         callState = sharedCallingViewModel.callState,
+        inCallReactionsState = inCallReactionsState,
         shouldShowDoubleTapToast = ongoingCallViewModel.shouldShowDoubleTapToast,
         toggleSpeaker = sharedCallingViewModel::toggleSpeaker,
         toggleMute = sharedCallingViewModel::toggleMute,
@@ -181,9 +201,10 @@ fun OngoingCallScreen(
         selectedParticipantForFullScreen = ongoingCallViewModel.selectedParticipant,
         hideDoubleTapToast = ongoingCallViewModel::hideDoubleTapToast,
         onCameraPermissionPermanentlyDenied = onCameraPermissionPermanentlyDenied,
+        onReactionClick = sharedCallingViewModel::onReactionClick,
         participants = sharedCallingViewModel.participantsState,
         inPictureInPictureMode = inPictureInPictureMode,
-        currentUserId = ongoingCallViewModel.currentUserId,
+        recentReactions = sharedCallingViewModel.recentReactions,
     )
 
     BackHandler {
@@ -279,6 +300,7 @@ private fun HandleSendingVideoFeed(
 @Composable
 private fun OngoingCallContent(
     callState: CallState,
+    inCallReactionsState: InCallReactionsState,
     shouldShowDoubleTapToast: Boolean,
     toggleSpeaker: () -> Unit,
     toggleMute: () -> Unit,
@@ -290,12 +312,13 @@ private fun OngoingCallContent(
     onCollapse: () -> Unit,
     hideDoubleTapToast: () -> Unit,
     onCameraPermissionPermanentlyDenied: () -> Unit,
+    onReactionClick: (String) -> Unit,
     requestVideoStreams: (participants: List<UICallParticipant>) -> Unit,
     onSelectedParticipant: (selectedParticipant: SelectedParticipant) -> Unit,
     selectedParticipantForFullScreen: SelectedParticipant,
     participants: PersistentList<UICallParticipant>,
+    recentReactions: Map<UserId, String>,
     inPictureInPictureMode: Boolean,
-    currentUserId: UserId,
 ) {
     val sheetInitialValue = SheetValue.PartiallyExpanded
     val sheetState = rememberStandardBottomSheetState(
@@ -307,6 +330,9 @@ private fun OngoingCallContent(
     )
 
     var shouldOpenFullScreen by remember { mutableStateOf(false) }
+
+    var showInCallReactionsPanel by remember { mutableStateOf(false) }
+    var showEmojiPicker by remember { mutableStateOf(false) }
 
     WireBottomSheetScaffold(
         sheetDragHandle = null,
@@ -336,19 +362,22 @@ private fun OngoingCallContent(
                     conversationId = callState.conversationId,
                     isMuted = callState.isMuted ?: true,
                     isCameraOn = callState.isCameraOn,
-                    isOnFrontCamera = callState.isOnFrontCamera,
                     isSpeakerOn = callState.isSpeakerOn,
+                    isShowingCallReactions = showInCallReactionsPanel,
                     toggleSpeaker = toggleSpeaker,
                     toggleMute = toggleMute,
                     onHangUpCall = hangUpCall,
                     onToggleVideo = toggleVideo,
-                    flipCamera = flipCamera,
+                    onCallReactionsClick = {
+                        showInCallReactionsPanel = !showInCallReactionsPanel
+                    },
                     onCameraPermissionPermanentlyDenied = onCameraPermissionPermanentlyDenied
                 )
             }
         },
+        sheetContainerColor = colorsScheme().background,
     ) {
-        BoxWithConstraints(
+        Column(
             modifier = Modifier
                 .padding(
                     top = it.calculateTopPadding(),
@@ -356,96 +385,135 @@ private fun OngoingCallContent(
                 )
         ) {
 
-            if (participants.isEmpty()) {
-                Column(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    WireCircularProgressIndicator(
-                        progressColor = MaterialTheme.wireColorScheme.onSurface,
-                        modifier = Modifier.align(Alignment.CenterHorizontally),
-                        size = dimensions().spacing32x
-                    )
-                    Text(
-                        text = stringResource(id = R.string.calling_screen_connecting_until_call_established),
-                        modifier = Modifier.align(Alignment.CenterHorizontally),
-                    )
-                }
-            } else {
-                Box(
-                    modifier = Modifier.fillMaxSize()
-                ) {
+            BoxWithConstraints(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .weight(1f)
+            ) {
 
-                    // if there is only one in the call, do not allow full screen
-                    if (participants.size == 1) {
-                        shouldOpenFullScreen = false
-                    }
-
-                    // if we are on full screen, and that user left the call, then we leave the full screen
-                    if (participants.find { user -> user.id == selectedParticipantForFullScreen.userId } == null) {
-                        shouldOpenFullScreen = false
-                    }
-
-                    if (shouldOpenFullScreen) {
-                        hideDoubleTapToast()
-                        FullScreenTile(
-                            callState = callState,
-                            selectedParticipant = selectedParticipantForFullScreen,
-                            height = this@BoxWithConstraints.maxHeight - dimensions().spacing4x,
-                            closeFullScreen = {
-                                onSelectedParticipant(SelectedParticipant())
-                                shouldOpenFullScreen = !shouldOpenFullScreen
-                            },
-                            onBackButtonClicked = {
-                                onSelectedParticipant(SelectedParticipant())
-                                shouldOpenFullScreen = !shouldOpenFullScreen
-                            },
-                            requestVideoStreams = requestVideoStreams,
-                            setVideoPreview = setVideoPreview,
-                            clearVideoPreview = clearVideoPreview,
-                            participants = participants
+                if (participants.isEmpty()) {
+                    Column(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        WireCircularProgressIndicator(
+                            progressColor = MaterialTheme.wireColorScheme.onSurface,
+                            modifier = Modifier.align(Alignment.CenterHorizontally),
+                            size = dimensions().spacing32x
                         )
-                    } else {
-                        VerticalCallingPager(
-                            participants = participants,
-                            isSelfUserCameraOn = callState.isCameraOn,
-                            isSelfUserMuted = callState.isMuted ?: true,
-                            isInPictureInPictureMode = inPictureInPictureMode,
-                            contentHeight = this@BoxWithConstraints.maxHeight,
-                            onSelfVideoPreviewCreated = setVideoPreview,
-                            onSelfClearVideoPreview = clearVideoPreview,
-                            requestVideoStreams = requestVideoStreams,
-                            currentUserId = currentUserId,
-                            onDoubleTap = { selectedParticipant ->
-                                onSelectedParticipant(selectedParticipant)
-                                shouldOpenFullScreen = !shouldOpenFullScreen
-                            },
-                        )
-                        DoubleTapToast(
-                            modifier = Modifier.align(Alignment.TopCenter),
-                            enabled = shouldShowDoubleTapToast,
-                            text = stringResource(id = R.string.calling_ongoing_double_tap_for_full_screen),
-                            onTap = hideDoubleTapToast
+                        Text(
+                            text = stringResource(id = R.string.calling_screen_connecting_until_call_established),
+                            modifier = Modifier.align(Alignment.CenterHorizontally),
                         )
                     }
-                    if (BuildConfig.PICTURE_IN_PICTURE_ENABLED && participants.size > 1) {
-                        val selfUser =
-                            participants.first { participant ->
-                                // API returns only id.value, without domain, till this get changed compare only id.value
-                                participant.id.equalsIgnoringBlankDomain(currentUserId)
-                            }
-                        FloatingSelfUserTile(
-                            modifier = Modifier.align(Alignment.TopEnd),
-                            contentHeight = this@BoxWithConstraints.maxHeight,
-                            contentWidth = this@BoxWithConstraints.maxWidth,
-                            participant = selfUser,
-                            onSelfUserVideoPreviewCreated = setVideoPreview,
-                            onClearSelfUserVideoPreview = clearVideoPreview
-                        )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .drawInCallReactions(state = inCallReactionsState)
+                    ) {
+
+                        // if there is only one in the call, do not allow full screen
+                        if (participants.size == 1) {
+                            shouldOpenFullScreen = false
+                        }
+
+                        // if we are on full screen, and that user left the call, then we leave the full screen
+                        if (participants.find { user -> user.id == selectedParticipantForFullScreen.userId } == null) {
+                            shouldOpenFullScreen = false
+                        }
+
+                        if (shouldOpenFullScreen) {
+                            hideDoubleTapToast()
+                            FullScreenTile(
+                                callState = callState,
+                                selectedParticipant = selectedParticipantForFullScreen,
+                                height = this@BoxWithConstraints.maxHeight - dimensions().spacing4x,
+                                closeFullScreen = {
+                                    onSelectedParticipant(SelectedParticipant())
+                                    shouldOpenFullScreen = !shouldOpenFullScreen
+                                },
+                                onBackButtonClicked = {
+                                    onSelectedParticipant(SelectedParticipant())
+                                    shouldOpenFullScreen = !shouldOpenFullScreen
+                                },
+                                requestVideoStreams = requestVideoStreams,
+                                setVideoPreview = setVideoPreview,
+                                clearVideoPreview = clearVideoPreview,
+                                participants = participants,
+                                isOnFrontCamera = callState.isOnFrontCamera,
+                                flipCamera = flipCamera,
+                            )
+                        } else {
+                            VerticalCallingPager(
+                                participants = participants,
+                                isSelfUserCameraOn = callState.isCameraOn,
+                                isSelfUserMuted = callState.isMuted ?: true,
+                                isInPictureInPictureMode = inPictureInPictureMode,
+                                isOnFrontCamera = callState.isOnFrontCamera,
+                                contentHeight = this@BoxWithConstraints.maxHeight,
+                                onSelfVideoPreviewCreated = setVideoPreview,
+                                onSelfClearVideoPreview = clearVideoPreview,
+                                requestVideoStreams = requestVideoStreams,
+                                recentReactions = recentReactions,
+                                onDoubleTap = { selectedParticipant ->
+                                    onSelectedParticipant(selectedParticipant)
+                                    shouldOpenFullScreen = !shouldOpenFullScreen
+                                },
+                                flipCamera = flipCamera,
+                            )
+                            DoubleTapToast(
+                                modifier = Modifier.align(Alignment.TopCenter),
+                                enabled = shouldShowDoubleTapToast,
+                                text = stringResource(id = R.string.calling_ongoing_double_tap_for_full_screen),
+                                onTap = hideDoubleTapToast
+                            )
+                        }
+                        if (BuildConfig.PICTURE_IN_PICTURE_ENABLED && participants.size > 1) {
+                            val selfUser = participants.first { it.isSelfUser }
+                            FloatingSelfUserTile(
+                                modifier = Modifier.align(Alignment.TopEnd),
+                                contentHeight = this@BoxWithConstraints.maxHeight,
+                                contentWidth = this@BoxWithConstraints.maxWidth,
+                                participant = selfUser,
+                                isOnFrontCamera = callState.isOnFrontCamera,
+                                onSelfUserVideoPreviewCreated = setVideoPreview,
+                                onClearSelfUserVideoPreview = clearVideoPreview,
+                                flipCamera = flipCamera,
+                            )
+                        }
                     }
                 }
             }
+
+            AnimatedContent(
+                targetState = showInCallReactionsPanel,
+                transitionSpec = {
+                    val enter = slideInVertically(initialOffsetY = { it })
+                    val exit = slideOutVertically(targetOffsetY = { it })
+                    enter.togetherWith(exit)
+                },
+                label = "InCallReactions"
+            ) { show ->
+                if (show) {
+                    InCallReactionsPanel(
+                        onReactionClick = onReactionClick,
+                        onMoreClick = { showEmojiPicker = true }
+                    )
+                }
+            }
+
+            EmojiPickerBottomSheet(
+                isVisible = showEmojiPicker,
+                onEmojiSelected = {
+                    showEmojiPicker = false
+                    onReactionClick(it)
+                },
+                onDismiss = {
+                    showEmojiPicker = false
+                },
+            )
         }
     }
 }
@@ -508,12 +576,12 @@ private fun CallingControls(
     isMuted: Boolean,
     isCameraOn: Boolean,
     isSpeakerOn: Boolean,
-    isOnFrontCamera: Boolean,
+    isShowingCallReactions: Boolean,
     toggleSpeaker: () -> Unit,
     toggleMute: () -> Unit,
     onHangUpCall: () -> Unit,
     onToggleVideo: () -> Unit,
-    flipCamera: () -> Unit,
+    onCallReactionsClick: () -> Unit,
     onCameraPermissionPermanentlyDenied: () -> Unit
 ) {
     Column(
@@ -527,7 +595,10 @@ private fun CallingControls(
                 .fillMaxWidth()
                 .height(dimensions().spacing56x)
         ) {
-            MicrophoneButton(isMuted = isMuted, onMicrophoneButtonClicked = toggleMute)
+            MicrophoneButton(
+                isMuted = isMuted,
+                onMicrophoneButtonClicked = toggleMute
+            )
             CameraButton(
                 isCameraOn = isCameraOn,
                 onPermissionPermanentlyDenied = onCameraPermissionPermanentlyDenied,
@@ -539,15 +610,12 @@ private fun CallingControls(
                 onSpeakerButtonClicked = toggleSpeaker
             )
 
-            if (isCameraOn) {
-                CameraFlipButton(
-                    isOnFrontCamera = isOnFrontCamera,
-                    onCameraFlipButtonClicked = flipCamera
-                )
-            }
+            InCallReactionsButton(
+                isSelected = isShowingCallReactions,
+                onInCallReactionsClick = onCallReactionsClick
+            )
 
-            HangUpButton(
-                modifier = Modifier.size(MaterialTheme.wireDimensions.defaultCallingControlsSize),
+            HangUpOngoingButton(
                 onHangUpButtonClicked = onHangUpCall
             )
         }
@@ -556,6 +624,7 @@ private fun CallingControls(
     }
 }
 
+@Suppress("EmptyFunctionBlock")
 @Composable
 fun PreviewOngoingCallContent(participants: PersistentList<UICallParticipant>) {
     OngoingCallContent(
@@ -571,6 +640,10 @@ fun PreviewOngoingCallContent(participants: PersistentList<UICallParticipant>) {
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
         ),
+        inCallReactionsState = object : InCallReactionsState {
+            override fun runAnimation(inCallReaction: InCallReaction) {}
+            override fun getReactions(): List<AnimatableReaction> = emptyList()
+        },
         shouldShowDoubleTapToast = false,
         toggleSpeaker = {},
         toggleMute = {},
@@ -582,12 +655,13 @@ fun PreviewOngoingCallContent(participants: PersistentList<UICallParticipant>) {
         onCollapse = {},
         hideDoubleTapToast = {},
         onCameraPermissionPermanentlyDenied = {},
+        onReactionClick = {},
         requestVideoStreams = {},
         participants = participants,
         inPictureInPictureMode = false,
-        currentUserId = UserId("userId", "domain"),
         onSelectedParticipant = {},
         selectedParticipantForFullScreen = SelectedParticipant(),
+        recentReactions = emptyMap(),
     )
 }
 
@@ -621,6 +695,7 @@ fun buildPreviewParticipantsList(count: Int = 10) = buildList {
             UICallParticipant(
                 id = QualifiedID("id_$index", ""),
                 clientId = "client_id_$index",
+                isSelfUser = false,
                 name = "Participant $index",
                 isSpeaking = index % 3 == 1,
                 isMuted = index % 3 == 2,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -47,7 +47,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel(assistedFactory = OngoingCallViewModel.Factory::class)
 class OngoingCallViewModel @AssistedInject constructor(
     @Assisted

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
@@ -62,6 +62,8 @@ fun FullScreenTile(
     setVideoPreview: (View) -> Unit,
     requestVideoStreams: (participants: List<UICallParticipant>) -> Unit,
     clearVideoPreview: () -> Unit,
+    isOnFrontCamera: Boolean,
+    flipCamera: () -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: Dp = dimensions().spacing4x,
 ) {
@@ -87,7 +89,6 @@ fun FullScreenTile(
                     .height(height)
                     .padding(contentPadding),
                 participantTitleState = it,
-                isSelfUser = selectedParticipant.isSelfUser,
                 isSelfUserCameraOn = if (selectedParticipant.isSelfUser) {
                     callState.isCameraOn
                 } else {
@@ -101,7 +102,9 @@ fun FullScreenTile(
                 shouldFillOthersVideoPreview = false,
                 isZoomingEnabled = true,
                 onSelfUserVideoPreviewCreated = setVideoPreview,
-                onClearSelfUserVideoPreview = clearVideoPreview
+                onClearSelfUserVideoPreview = clearVideoPreview,
+                isOnFrontCamera = isOnFrontCamera,
+                flipCamera = flipCamera,
             )
             LaunchedEffect(Unit) {
                 delay(200)
@@ -147,5 +150,7 @@ fun PreviewFullScreenTile() = WireTheme {
         requestVideoStreams = {},
         clearVideoPreview = {},
         participants = participants,
+        isOnFrontCamera = false,
+        flipCamera = {},
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/incallreactions/InCallReactions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/incallreactions/InCallReactions.kt
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.calling.ongoing.incallreactions
+
+@Suppress("MagicNumber")
+object InCallReactions {
+
+    /**
+     * Default in call reaction emojis
+     */
+    val defaultReactions = listOf("👍", "🎉", "❤️", "😂", "😮", "👏", "🤔", "😢", "👎")
+
+    /**
+     * Next reaction click is disabled until delay expires
+     */
+    const val reactionDelayMs = 3000L
+
+    /**
+     * Total duration for reaction animation
+     */
+    const val animationDurationMs = 3000
+
+    /**
+     * Duration for reaction fade out animation
+     */
+    const val fadeOutAnimationDuarationMs = 500
+
+    /**
+     * Delay between displaying reactions on screen
+     */
+    const val reactionsThrottleDelayMs: Long = 200
+
+    /**
+     * Duration for showing recent reaction next to user image
+     */
+    const val recentReactionShowDurationMs: Long = 6000
+}

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/incallreactions/InCallReactionsModifier.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/incallreactions/InCallReactionsModifier.kt
@@ -1,0 +1,137 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.calling.ongoing.incallreactions
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.center
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.center
+import androidx.compose.ui.unit.toSize
+import com.wire.android.R
+import com.wire.android.ui.calling.model.ReactionSender
+import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.typography
+import kotlin.math.max
+
+@Composable
+fun Modifier.drawInCallReactions(
+    state: InCallReactionsState,
+    labelTextColor: Color = Color.White,
+    labelColor: Color = Color.Black,
+    emojiBackgroundColor: Color = colorsScheme().emojiBackgroundColor,
+    emojiBackgroundSize: Dp = dimensions().inCallReactionButtonSize,
+    emojiTextStyle: TextStyle = typography().inCallReactionEmoji,
+    labelTextStyle: TextStyle = typography().label01,
+): Modifier {
+
+    val textMeasurer = rememberTextMeasurer()
+
+    val emojiBackgroundSizePx = with(LocalDensity.current) { emojiBackgroundSize.toPx() }
+    val labelTopMarginPx = with(LocalDensity.current) { dimensions().spacing12x.toPx() }
+    val labelTextPaddingPx = with(LocalDensity.current) { dimensions().spacing4x.toPx() }
+    val reactionSenderSelf = stringResource(R.string.reaction_sender_self)
+
+    return this then Modifier.drawWithContent {
+
+        drawContent()
+
+        clipRect(left = 0f, top = 0f, right = size.width, bottom = size.height) {
+
+            state.getReactions().forEach { reaction ->
+
+                val senderText = when (reaction.inCallReaction.sender) {
+                    is ReactionSender.You -> reactionSenderSelf
+                    is ReactionSender.Other -> reaction.inCallReaction.sender.name
+                    is ReactionSender.Unknown -> ""
+                }
+
+                val emojiLayoutResult = textMeasurer.measure(reaction.inCallReaction.emoji, emojiTextStyle)
+                val labelLayoutResult = textMeasurer.measure(senderText, labelTextStyle)
+
+                val emojiSize = emojiLayoutResult.size.toSize()
+                val labelSize = Size(
+                    width = labelLayoutResult.size.width + labelTextPaddingPx * 2,
+                    height = labelLayoutResult.size.height + labelTextPaddingPx * 2
+                )
+
+                val offsetVertical = size.height - size.height * reaction.verticalOffset.value
+                val offsetHorizontal = (size.width - max(emojiSize.width, labelSize.width)) * reaction.horizontalOffset
+
+                translate(
+                    top = offsetVertical + emojiSize.height,
+                    left = offsetHorizontal + (labelLayoutResult.size.width - emojiSize.width).coerceAtLeast(0f) / 2f
+                ) {
+
+                    // Draw emoji background
+                    drawRoundRect(
+                        color = emojiBackgroundColor.copy(alpha = reaction.alpha.value),
+                        topLeft = Offset(
+                            x = emojiSize.center.x - emojiBackgroundSizePx / 2,
+                            y = emojiSize.center.y - emojiBackgroundSizePx / 2,
+                        ),
+                        size = Size(emojiBackgroundSizePx, emojiBackgroundSizePx),
+                        cornerRadius = CornerRadius(20f),
+                    )
+
+                    // Draw emoji
+                    drawText(
+                        textLayoutResult = emojiLayoutResult,
+                        color = Color.Black.copy(alpha = reaction.alpha.value),
+                    )
+
+                    if (reaction.inCallReaction.sender != ReactionSender.Unknown) {
+                        // Draw label background
+                        drawRoundRect(
+                            color = labelColor.copy(alpha = reaction.alpha.value),
+                            topLeft = Offset(
+                                x = emojiSize.center.x - labelSize.center.x,
+                                y = emojiSize.height + labelTopMarginPx,
+                            ),
+                            size = labelSize,
+                            cornerRadius = CornerRadius(10f),
+                        )
+
+                        // Draw label text
+                        drawText(
+                            textLayoutResult = labelLayoutResult,
+                            color = labelTextColor.copy(alpha = reaction.alpha.value),
+                            topLeft = Offset(
+                                x = emojiSize.center.x - labelLayoutResult.size.center.x,
+                                y = emojiSize.height + labelTopMarginPx + labelTextPaddingPx
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/incallreactions/InCallReactionsPanel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/incallreactions/InCallReactionsPanel.kt
@@ -1,0 +1,170 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.calling.ongoing.incallreactions
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
+import com.wire.android.ui.calling.ongoing.incallreactions.InCallReactions.reactionDelayMs
+import com.wire.android.ui.calling.ongoing.incallreactions.InCallReactions.defaultReactions
+import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.typography
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.ui.PreviewMultipleThemes
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Composable
+fun InCallReactionsPanel(
+    onReactionClick: (String) -> Unit,
+    onMoreClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+
+    val scope = rememberCoroutineScope()
+
+    val disabledReactions = remember { mutableStateListOf<String>() }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = dimensions().spacing8x)
+            .horizontalScroll(rememberScrollState()),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(dimensions().spacing16x)
+    ) {
+
+        Spacer(modifier = Modifier.width(dimensions().spacing8x))
+
+        defaultReactions.forEach { reaction ->
+            EmojiButton(
+                isEnabled = disabledReactions.contains(reaction).not(),
+                emoji = reaction,
+                onClick = {
+                    onReactionClick(reaction)
+                    disabledReactions.add(reaction)
+                    scope.launch {
+                        delay(reactionDelayMs)
+                        disabledReactions.remove(reaction)
+                    }
+                }
+            )
+        }
+
+        Icon(
+            modifier = Modifier.clickable { onMoreClick() },
+            painter = painterResource(id = R.drawable.ic_more_emojis),
+            contentDescription = stringResource(R.string.content_description_more_emojis)
+        )
+
+        Spacer(modifier = Modifier.width(dimensions().spacing8x))
+    }
+}
+
+@Composable
+private fun EmojiButton(
+    emoji: String,
+    isEnabled: Boolean,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(dimensions().inCallReactionButtonSize)
+            .clip(RoundedCornerShape(dimensions().corner10x))
+            .clickable(isEnabled) { onClick() },
+        contentAlignment = Alignment.Center,
+    ) {
+        AnimatedVisibility(
+            visible = isEnabled,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        color = colorsScheme().secondaryButtonEnabled,
+                        shape = RoundedCornerShape(dimensions().corner10x)
+                    ),
+            )
+        }
+        Text(
+            modifier = Modifier
+                .alpha(if (isEnabled) 1f else 0.5f),
+            text = emoji,
+            fontSize = typography().inCallReactionEmoji.fontSize,
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+private fun PreviewEmojiButton() = WireTheme {
+    EmojiButton(
+        emoji = defaultReactions[0],
+        isEnabled = true,
+        onClick = {}
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+private fun PreviewEmojiButtonDisabled() = WireTheme {
+    EmojiButton(
+        emoji = defaultReactions[0],
+        isEnabled = false,
+        onClick = {}
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+private fun PreviewInCallReactionsPanel() = WireTheme {
+    InCallReactionsPanel(
+        onReactionClick = {},
+        onMoreClick = {},
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/incallreactions/InCallReactionsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/incallreactions/InCallReactionsState.kt
@@ -1,0 +1,114 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.calling.ongoing.incallreactions
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import com.wire.android.ui.calling.model.InCallReaction
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import okhttp3.internal.toImmutableList
+import kotlin.random.Random
+
+/**
+ * Keeps state for currently animated reactions
+ */
+interface InCallReactionsState {
+    fun runAnimation(inCallReaction: InCallReaction)
+    fun getReactions(): List<AnimatableReaction>
+}
+
+@Composable
+internal fun rememberInCallReactionsState(): InCallReactionsState {
+
+    val scope = rememberCoroutineScope()
+
+    return remember {
+        InCallReactionsStateImpl(
+            scope = scope,
+            mutableReactions = mutableStateListOf(),
+        )
+    }
+}
+
+private class InCallReactionsStateImpl(
+    private val scope: CoroutineScope,
+    private val mutableReactions: MutableList<AnimatableReaction>,
+) : InCallReactionsState {
+
+    /**
+     * Used by modifier to draw each animated emoji with current animation state
+     */
+    override fun getReactions(): List<AnimatableReaction> = mutableReactions.toImmutableList()
+
+    /**
+     * Adds new emoji to the list of animated emojis.
+     * Runs  animations
+     * Removes emoji from the list once animations are complete
+     */
+    override fun runAnimation(inCallReaction: InCallReaction) {
+        scope.launch(Dispatchers.Main) {
+            val animatable = AnimatableReaction(
+                inCallReaction = inCallReaction,
+                horizontalOffset = Random.nextFloat(),
+            )
+
+            mutableReactions.add(animatable)
+            runAnimations(animatable)
+            mutableReactions.remove(animatable)
+        }
+    }
+
+    /**
+     * Start transition and fade-out animations, wait for complete and return
+     */
+    private suspend fun CoroutineScope.runAnimations(reaction: AnimatableReaction) {
+        listOf(
+            launch {
+                reaction.verticalOffset.animateTo(
+                    targetValue = 1f,
+                    animationSpec = tween(durationMillis = InCallReactions.animationDurationMs, easing = LinearEasing)
+                )
+            },
+            launch {
+                reaction.alpha.animateTo(
+                    targetValue = 0.0f,
+                    animationSpec = tween(
+                        durationMillis = InCallReactions.fadeOutAnimationDuarationMs,
+                        delayMillis = InCallReactions.animationDurationMs - InCallReactions.fadeOutAnimationDuarationMs
+                    )
+                )
+            }
+        ).joinAll()
+    }
+}
+
+data class AnimatableReaction(
+    val inCallReaction: InCallReaction,
+    val verticalOffset: Animatable<Float, AnimationVector1D> = Animatable(0f),
+    val alpha: Animatable<Float, AnimationVector1D> = Animatable(1f),
+    val horizontalOffset: Float,
+)

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/FlipCameraButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/FlipCameraButton.kt
@@ -1,0 +1,66 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.calling.ongoing.participantsview
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.wire.android.R
+import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.ui.PreviewMultipleThemes
+
+@Composable
+internal fun FlipCameraButton(
+    isOnFrontCamera: Boolean,
+    modifier: Modifier = Modifier,
+    flipCamera: () -> Unit,
+) {
+    Icon(
+        modifier = modifier
+            .padding(dimensions().spacing12x)
+            .size(32.dp)
+            .background(color = colorsScheme().surface, shape = CircleShape)
+            .clip(CircleShape)
+            .clickable { flipCamera() }
+            .padding(dimensions().spacing6x),
+        painter = painterResource(R.drawable.ic_flip_camera),
+        tint = colorsScheme().onSurface,
+        contentDescription = if (isOnFrontCamera) {
+            stringResource(R.string.content_description_calling_flip_camera_on)
+        } else {
+            stringResource(R.string.content_description_calling_flip_camera_on)
+        }
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+private fun PreviewFlipCameraButton() {
+    WireTheme { FlipCameraButton(isOnFrontCamera = true) { } }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/FloatingSelfUserTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/FloatingSelfUserTile.kt
@@ -60,9 +60,11 @@ fun FloatingSelfUserTile(
     contentHeight: Dp,
     contentWidth: Dp,
     participant: UICallParticipant,
+    isOnFrontCamera: Boolean,
     onSelfUserVideoPreviewCreated: (view: View) -> Unit,
+    onClearSelfUserVideoPreview: () -> Unit,
+    flipCamera: () -> Unit,
     modifier: Modifier = Modifier,
-    onClearSelfUserVideoPreview: () -> Unit
 ) {
     var selfVideoTileHeight by remember {
         mutableStateOf(contentHeight / 4)
@@ -163,13 +165,14 @@ fun FloatingSelfUserTile(
     ) {
         ParticipantTile(
             participantTitleState = participant,
-            isSelfUser = true,
             isOnPiPMode = isOnPiPMode,
             shouldFillSelfUserCameraPreview = true,
             isSelfUserMuted = participant.isMuted,
             isSelfUserCameraOn = participant.isCameraOn,
             onSelfUserVideoPreviewCreated = onSelfUserVideoPreviewCreated,
             onClearSelfUserVideoPreview = onClearSelfUserVideoPreview,
+            isOnFrontCamera = isOnFrontCamera,
+            flipCamera = flipCamera,
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
@@ -61,12 +61,14 @@ fun VerticalCallingPager(
     isSelfUserMuted: Boolean,
     isSelfUserCameraOn: Boolean,
     isInPictureInPictureMode: Boolean,
+    isOnFrontCamera: Boolean,
     contentHeight: Dp,
-    currentUserId: UserId,
+    recentReactions: Map<UserId, String>,
     onSelfVideoPreviewCreated: (view: View) -> Unit,
     onSelfClearVideoPreview: () -> Unit,
     requestVideoStreams: (participants: List<UICallParticipant>) -> Unit,
     onDoubleTap: (selectedParticipant: SelectedParticipant) -> Unit,
+    flipCamera: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -106,7 +108,9 @@ fun VerticalCallingPager(
                             onSelfVideoPreviewCreated = onSelfVideoPreviewCreated,
                             onSelfClearVideoPreview = onSelfClearVideoPreview,
                             onDoubleTap = onDoubleTap,
-                            currentUserId = currentUserId,
+                            recentReactions = recentReactions,
+                            isOnFrontCamera = isOnFrontCamera,
+                            flipCamera = flipCamera,
                         )
                     } else {
                         GroupCallGrid(
@@ -118,8 +122,10 @@ fun VerticalCallingPager(
                             onSelfVideoPreviewCreated = onSelfVideoPreviewCreated,
                             onSelfClearVideoPreview = onSelfClearVideoPreview,
                             onDoubleTap = onDoubleTap,
-                            currentUserId = currentUserId,
                             isInPictureInPictureMode = isInPictureInPictureMode,
+                            recentReactions = recentReactions,
+                            isOnFrontCamera = isOnFrontCamera,
+                            flipCamera = flipCamera,
                         )
                     }
 
@@ -177,8 +183,10 @@ private fun PreviewVerticalCallingPager(participants: List<UICallParticipant>) {
         onSelfClearVideoPreview = {},
         requestVideoStreams = {},
         onDoubleTap = { },
+        flipCamera = { },
         isInPictureInPictureMode = false,
-        currentUserId = participants[0].id,
+        recentReactions = emptyMap(),
+        isOnFrontCamera = false,
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt
@@ -50,14 +50,16 @@ fun GroupCallGrid(
     isSelfUserMuted: Boolean,
     isSelfUserCameraOn: Boolean,
     contentHeight: Dp,
-    currentUserId: UserId,
+    isOnFrontCamera: Boolean,
     onSelfVideoPreviewCreated: (view: View) -> Unit,
     onSelfClearVideoPreview: () -> Unit,
     onDoubleTap: (selectedParticipant: SelectedParticipant) -> Unit,
+    flipCamera: () -> Unit,
+    isInPictureInPictureMode: Boolean,
+    recentReactions: Map<UserId, String>,
     modifier: Modifier = Modifier,
     contentPadding: Dp = dimensions().spacing4x,
     spacedBy: Dp = dimensions().spacing2x,
-    isInPictureInPictureMode: Boolean,
 ) {
     // We need the number of tiles rows needed to calculate their height
     val numberOfTilesRows = remember(participants.size) {
@@ -81,9 +83,6 @@ fun GroupCallGrid(
             key = { it.id.toString() + it.clientId + pageIndex },
             contentType = { getContentType(it.isCameraOn, it.isSharingScreen) }
         ) { participant ->
-            // API returns only id.value, without domain, till this get changed compare only id.value
-            val isSelfUser = participant.id.equalsIgnoringBlankDomain(currentUserId)
-
             ParticipantTile(
                 modifier = Modifier
                     .pointerInput(Unit) {
@@ -93,7 +92,7 @@ fun GroupCallGrid(
                                     SelectedParticipant(
                                         userId = participant.id,
                                         clientId = participant.clientId,
-                                        isSelfUser = isSelfUser
+                                        isSelfUser = participant.isSelfUser,
                                     )
                                 )
                             }
@@ -103,11 +102,13 @@ fun GroupCallGrid(
                     .animateItem(),
                 participantTitleState = participant,
                 isOnPiPMode = isInPictureInPictureMode,
-                isSelfUser = isSelfUser,
                 isSelfUserMuted = isSelfUserMuted,
                 isSelfUserCameraOn = isSelfUserCameraOn,
                 onSelfUserVideoPreviewCreated = onSelfVideoPreviewCreated,
-                onClearSelfUserVideoPreview = onSelfClearVideoPreview
+                onClearSelfUserVideoPreview = onSelfClearVideoPreview,
+                recentReaction = recentReactions[participant.id],
+                isOnFrontCamera = isOnFrontCamera,
+                flipCamera = flipCamera,
             )
         }
     }
@@ -139,8 +140,10 @@ private fun PreviewGroupCallGrid(participants: List<UICallParticipant>, modifier
             onSelfVideoPreviewCreated = {},
             onSelfClearVideoPreview = {},
             onDoubleTap = { },
-            currentUserId = UserId("id", "domain"),
             isInPictureInPictureMode = false,
+            recentReactions = emptyMap(),
+            isOnFrontCamera = false,
+            flipCamera = {},
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/horizentalview/CallingHorizontalView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/horizentalview/CallingHorizontalView.kt
@@ -49,10 +49,12 @@ fun CallingHorizontalView(
     isSelfUserMuted: Boolean,
     isSelfUserCameraOn: Boolean,
     contentHeight: Dp,
-    currentUserId: UserId,
     onSelfVideoPreviewCreated: (view: View) -> Unit,
     onSelfClearVideoPreview: () -> Unit,
+    recentReactions: Map<UserId, String>,
     onDoubleTap: (selectedParticipant: SelectedParticipant) -> Unit,
+    isOnFrontCamera: Boolean,
+    flipCamera: () -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: Dp = dimensions().spacing4x,
     spacedBy: Dp = dimensions().spacing2x,
@@ -69,8 +71,6 @@ fun CallingHorizontalView(
         verticalArrangement = Arrangement.spacedBy(spacedBy)
     ) {
         items(items = participants, key = { it.id.toString() + it.clientId }) { participant ->
-            // API returns only id.value, without domain, till this get changed compare only id.value
-            val isSelfUser = participant.id.equalsIgnoringBlankDomain(currentUserId)
             ParticipantTile(
                 modifier = Modifier
                     .pointerInput(Unit) {
@@ -80,7 +80,7 @@ fun CallingHorizontalView(
                                     SelectedParticipant(
                                         userId = participant.id,
                                         clientId = participant.clientId,
-                                        isSelfUser = isSelfUser
+                                        isSelfUser = participant.isSelfUser,
                                     )
                                 )
                             }
@@ -90,11 +90,13 @@ fun CallingHorizontalView(
                     .height(tileHeight)
                     .animateItem(),
                 participantTitleState = participant,
-                isSelfUser = isSelfUser,
                 isSelfUserMuted = isSelfUserMuted,
                 isSelfUserCameraOn = isSelfUserCameraOn,
                 onSelfUserVideoPreviewCreated = onSelfVideoPreviewCreated,
                 onClearSelfUserVideoPreview = onSelfClearVideoPreview,
+                recentReaction = recentReactions[participant.id],
+                isOnFrontCamera = isOnFrontCamera,
+                flipCamera = flipCamera,
             )
         }
     }
@@ -111,10 +113,12 @@ fun PreviewCallingHorizontalView(
             isSelfUserMuted = true,
             isSelfUserCameraOn = false,
             contentHeight = 800.dp,
-            currentUserId = UserId("id", "domain"),
+            recentReactions = emptyMap(),
             onSelfVideoPreviewCreated = {},
             onSelfClearVideoPreview = {},
             onDoubleTap = { },
+            isOnFrontCamera = false,
+            flipCamera = { },
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/ExpiringMap.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ExpiringMap.kt
@@ -1,0 +1,74 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Map implementation that removes entries after a delay. Not thread-safe.
+ */
+class ExpiringMap<K, V>(
+    private val scope: CoroutineScope,
+    private val expiration: Long,
+    private val delegate: MutableMap<K, V>,
+    private val currentTime: () -> Long = { System.currentTimeMillis() },
+) : MutableMap<K, V> by delegate {
+
+    private val timestamps: MutableMap<K, Long> = ConcurrentHashMap<K, Long>()
+    private var cleanupJob: Job? = null
+
+    override fun put(key: K, value: V): V? {
+        return delegate.put(key, value).also {
+            timestamps.put(key, currentTime() + expiration)
+            scheduleCleanup()
+        }
+    }
+
+    override fun remove(key: K): V? {
+        return delegate.remove(key).also {
+            timestamps.remove(key)
+            scheduleCleanup()
+        }
+    }
+
+    private fun scheduleCleanup() {
+        cleanupJob?.cancel()
+        timestamps.values.sorted().firstOrNull()?.let { nextExpiration ->
+            val delayToNext = nextExpiration - currentTime()
+            cleanupJob = scope.launch {
+                delay(delayToNext)
+                removeAllExpired()
+            }
+        }
+    }
+
+    private fun removeAllExpired() {
+        val now = currentTime()
+        timestamps.entries.onEach { (key, expiration) ->
+            if (expiration <= now) {
+                delegate.remove(key)
+            }
+        }
+        timestamps.entries.removeAll { it.value <= now }
+        scheduleCleanup()
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/util/extension/Flow.kt
+++ b/app/src/main/kotlin/com/wire/android/util/extension/Flow.kt
@@ -19,7 +19,10 @@
 package com.wire.android.util.extension
 
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.withIndex
 
 fun intervalFlow(periodMs: Long, initialDelayMs: Long = 0L, stopWhen: () -> Boolean = { false }) =
     flow {
@@ -28,4 +31,10 @@ fun intervalFlow(periodMs: Long, initialDelayMs: Long = 0L, stopWhen: () -> Bool
             emit(Unit)
             delay(periodMs)
         }
+    }
+
+fun <T> Flow<T>.withDelayAfterFirst(timeMillis: Long): Flow<T> = withIndex()
+    .map { (index, value) ->
+        if (index > 0) delay(timeMillis)
+        value
     }

--- a/app/src/main/res/drawable/ic_flip_camera.xml
+++ b/app/src/main/res/drawable/ic_flip_camera.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Wire
+  ~ Copyright (C) 2024 Wire Swiss GmbH
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see http://www.gnu.org/licenses/.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <group>
+    <clip-path
+        android:pathData="M0,0h20v20h-20z"/>
+    <path
+        android:pathData="M10,19.375C7.766,19.375 5.789,18.672 4.07,17.266C2.352,15.859 1.266,14.063 0.813,11.875H2.734C3.172,13.531 4.063,14.883 5.406,15.93C6.75,16.977 8.281,17.5 10,17.5C11.344,17.5 12.594,17.168 13.75,16.504C14.906,15.84 15.813,14.922 16.469,13.75H13.75V11.875H19.375V17.5H17.5V15.625C16.609,16.813 15.508,17.734 14.195,18.391C12.883,19.047 11.484,19.375 10,19.375ZM10,12.813C9.219,12.813 8.555,12.539 8.008,11.992C7.461,11.445 7.188,10.781 7.188,10C7.188,9.219 7.461,8.555 8.008,8.008C8.555,7.461 9.219,7.188 10,7.188C10.781,7.188 11.445,7.461 11.992,8.008C12.539,8.555 12.813,9.219 12.813,10C12.813,10.781 12.539,11.445 11.992,11.992C11.445,12.539 10.781,12.813 10,12.813ZM0.625,8.125V2.5H2.5V4.375C3.391,3.188 4.492,2.266 5.805,1.609C7.117,0.953 8.516,0.625 10,0.625C12.234,0.625 14.211,1.328 15.93,2.734C17.648,4.141 18.734,5.938 19.188,8.125H17.266C16.828,6.469 15.938,5.117 14.594,4.07C13.25,3.023 11.719,2.5 10,2.5C8.656,2.5 7.406,2.832 6.25,3.496C5.094,4.16 4.188,5.078 3.531,6.25H6.25V8.125H0.625Z"
+        android:fillColor="#000000"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_incall_reactions.xml
+++ b/app/src/main/res/drawable/ic_incall_reactions.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Wire
+  ~ Copyright (C) 2024 Wire Swiss GmbH
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see http://www.gnu.org/licenses/.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M0,10C0,15.523 4.477,20 10,20C15.523,20 20,15.523 20,10C20,4.477 15.523,0 10,0C4.477,0 0,4.477 0,10ZM18.125,10C18.125,14.487 14.487,18.125 10,18.125C5.513,18.125 1.875,14.487 1.875,10C1.875,5.513 5.513,1.875 10,1.875C14.487,1.875 18.125,5.513 18.125,10ZM3.875,11.25C4.454,14.103 6.976,16.25 10,16.25C13.024,16.25 15.546,14.103 16.125,11.25H3.875ZM5.678,12.518C5.678,12.518 10.985,12.5 14.342,12.5C14.342,12.5 14.043,13.102 13.308,13.75H6.692C6.293,13.398 5.949,12.983 5.678,12.518ZM12.5,8.75C13.19,8.75 13.75,8.19 13.75,7.5C13.75,6.81 13.19,6.25 12.5,6.25C11.81,6.25 11.25,6.81 11.25,7.5C11.25,8.19 11.81,8.75 12.5,8.75ZM8.75,7.5C8.75,8.19 8.19,8.75 7.5,8.75C6.81,8.75 6.25,8.19 6.25,7.5C6.25,6.81 6.81,6.25 7.5,6.25C8.19,6.25 8.75,6.81 8.75,7.5Z"
+      android:fillColor="#ffffff"
+      android:fillType="evenOdd"/>
+  <group>
+    <clip-path
+        android:pathData="M0,10C0,15.523 4.477,20 10,20C15.523,20 20,15.523 20,10C20,4.477 15.523,0 10,0C4.477,0 0,4.477 0,10ZM18.125,10C18.125,14.487 14.487,18.125 10,18.125C5.513,18.125 1.875,14.487 1.875,10C1.875,5.513 5.513,1.875 10,1.875C14.487,1.875 18.125,5.513 18.125,10ZM3.875,11.25C4.454,14.103 6.976,16.25 10,16.25C13.024,16.25 15.546,14.103 16.125,11.25H3.875ZM5.678,12.518C5.678,12.518 10.985,12.5 14.342,12.5C14.342,12.5 14.043,13.102 13.308,13.75H6.692C6.293,13.398 5.949,12.983 5.678,12.518ZM12.5,8.75C13.19,8.75 13.75,8.19 13.75,7.5C13.75,6.81 13.19,6.25 12.5,6.25C11.81,6.25 11.25,6.81 11.25,7.5C11.25,8.19 11.81,8.75 12.5,8.75ZM8.75,7.5C8.75,8.19 8.19,8.75 7.5,8.75C6.81,8.75 6.25,8.19 6.25,7.5C6.25,6.81 6.81,6.25 7.5,6.25C8.19,6.25 8.75,6.81 8.75,7.5Z"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,6 +162,8 @@
     <string name="content_description_calling_turn_camera_off">Turn camera off</string>
     <string name="content_description_calling_turn_speaker_on">Turn speaker on</string>
     <string name="content_description_calling_turn_speaker_off">Turn speaker off</string>
+    <string name="content_description_calling_in_call_reactions_show">Show in call reactions panel</string>
+    <string name="content_description_calling_in_call_reactions_hide">Hide in call reactions panel</string>
     <string name="content_description_show_more_options">Show more options</string>
     <string name="content_description_reply_to_messge">Reply to the message</string>
     <string name="content_description_reply_cancel">Cancel message reply</string>
@@ -1662,4 +1664,5 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="personal_to_team_migration_error_message_already_in_team">You\'ve created or joined a team with this email address on another device.</string>
     <string name="personal_to_team_migration_error_message_slow_network">Wire could not complete your team creation due to a slow internet connection.</string>
     <string name="personal_to_team_migration_error_message_unknown_error">Wire could not complete your team creation due to an unknown error.</string>
+    <string name="reaction_sender_self">You</string>
 </resources>

--- a/app/src/test/kotlin/com/wire/android/mapper/UICallParticipantMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/UICallParticipantMapperTest.kt
@@ -19,6 +19,7 @@
 package com.wire.android.mapper
 
 import com.wire.kalium.logic.data.call.Participant
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.QualifiedID
 import io.mockk.MockKAnnotations
 import kotlinx.coroutines.test.runTest
@@ -42,12 +43,37 @@ class UICallParticipantMapperTest {
             accentId = -1
         )
         // When
-        val result = mapper.toUICallParticipant(item)
+        val result = mapper.toUICallParticipant(item, ClientId("clientId"))
         // Then
         assert(
             result.id == item.id && result.clientId == item.clientId && result.name == item.name && result.isMuted == item.isMuted
                     && result.isSpeaking == item.isSpeaking && result.avatar?.userAssetId == item.avatarAssetId
-                    && result.isCameraOn == item.isCameraOn
+                    && result.isCameraOn == item.isCameraOn && result.isSelfUser == true
+        )
+    }
+
+    @Test
+    fun givenParticipant_whenMappingToUICallParticipant_thenCorrectValuesShouldBeReturnedForNonSelfUser() = runTest {
+        val (_, mapper) = Arrangement().arrange()
+        // Given
+        val item = Participant(
+            id = QualifiedID("value", "domain"),
+            clientId = "clientId",
+            name = "name",
+            isMuted = false,
+            isCameraOn = false,
+            isSpeaking = false,
+            isSharingScreen = false,
+            hasEstablishedAudio = true,
+            accentId = -1
+        )
+        // When
+        val result = mapper.toUICallParticipant(item, ClientId("otherClientId"))
+        // Then
+        assert(
+            result.id == item.id && result.clientId == item.clientId && result.name == item.name && result.isMuted == item.isMuted
+                    && result.isSpeaking == item.isSpeaking && result.avatar?.userAssetId == item.avatarAssetId
+                    && result.isCameraOn == item.isCameraOn && result.isSelfUser == false
         )
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
@@ -21,6 +21,7 @@ package com.wire.android.ui.calling
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
 import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.ui.calling.OngoingCallViewModelTest.Arrangement
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.ongoing.OngoingCallViewModel
 import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
@@ -302,6 +303,7 @@ class OngoingCallViewModelTest {
         private val participant1 = UICallParticipant(
             id = QualifiedID("value1", "domain"),
             clientId = "client-id1",
+            isSelfUser = false,
             name = "name1",
             isMuted = false,
             isSpeaking = false,
@@ -314,6 +316,7 @@ class OngoingCallViewModelTest {
         private val participant2 = UICallParticipant(
             id = QualifiedID("value2", "domain"),
             clientId = "client-id2",
+            isSelfUser = false,
             name = "name2",
             isMuted = false,
             isSpeaking = false,
@@ -326,6 +329,7 @@ class OngoingCallViewModelTest {
         private val participant3 = UICallParticipant(
             id = QualifiedID("value3", "domain"),
             clientId = "client-id3",
+            isSelfUser = false,
             name = "name3",
             isMuted = false,
             isSpeaking = false,

--- a/app/src/test/kotlin/com/wire/android/util/ExpiringMapTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/ExpiringMapTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+
+class ExpiringMapTest {
+
+    @Test
+    fun `check new item can be added map `() = runTest {
+        // given
+        val map = withTestExpiringMap()
+
+        // when
+        map.put("testKey", "testValue")
+
+        // then
+        assertEquals("testValue", map["testKey"])
+    }
+
+    @Test
+    fun `check item can be removed from map before expiration`() = runTest {
+        // given
+        val map = withTestExpiringMap()
+
+        // when
+        map.put("testKey", "testValue")
+        map.remove("testKey")
+
+        // then
+        assertEquals(null, map["testKey"])
+    }
+
+    @Test
+    fun `check item can not be obtained before expiration`() = runTest {
+        // given
+        val map = withTestExpiringMap()
+
+        // when
+        map.put("testKey", "testValue")
+        advanceTimeBy(300)
+
+        // then
+        assertEquals("testValue", map["testKey"])
+    }
+
+    @Test
+    fun `check item can not be obtained after expiration`() = runTest {
+        // given
+        val map = withTestExpiringMap()
+
+        // when
+        map.put("testKey", "testValue")
+        advanceTimeBy(301)
+
+        // then
+        assertEquals(null, map["testKey"])
+    }
+
+    @Test
+    fun `check adding item with existing key resets expiration`() = runTest {
+        // given
+        val map = withTestExpiringMap()
+
+        // when
+        map.put("testKey", "testValue")
+        advanceTimeBy(300)
+        map.put("testKey", "testValue2")
+        advanceTimeBy(300)
+
+        // then
+        assertEquals("testValue2", map["testKey"])
+    }
+
+    @Test
+    fun `check adding item with non-existing key keeps expiration for other keys`() = runTest {
+        // given
+        val map = withTestExpiringMap()
+
+        // when
+        map.put("testKey", "testValue")
+        advanceTimeBy(200)
+        map.put("testKey2", "testValue2")
+        advanceTimeBy(200)
+
+        // then
+        assertEquals(null, map["testKey"])
+    }
+
+    private fun TestScope.withTestExpiringMap(): MutableMap<String, String> = ExpiringMap<String, String>(
+        scope = this.backgroundScope,
+        expiration = 300,
+        delegate = mutableMapOf(),
+        currentTime = { currentTime }
+    )
+}

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -81,6 +81,8 @@ class WireColorScheme(
     // accents
     val groupAvatarColors: List<Color>,
     val wireAccentColors: WireAccentColors,
+
+    val emojiBackgroundColor: Color,
 ) {
     fun toColorScheme(): ColorScheme = ColorScheme(
         primary = primary, onPrimary = onPrimary,
@@ -182,6 +184,7 @@ private val LightWireColorScheme = WireColorScheme(
             Accent.Unknown -> WireColorPalette.LightBlue500
         }
     },
+    emojiBackgroundColor = Color.White,
 )
 
 // Dark WireColorScheme
@@ -257,6 +260,7 @@ private val DarkWireColorScheme = WireColorScheme(
             Accent.Unknown -> WireColorPalette.DarkBlue500
         }
     },
+    emojiBackgroundColor = Color.White,
 )
 
 @PackagePrivate

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
@@ -107,6 +107,8 @@ data class WireDimensions(
     val badgeSmallMinSize: DpSize,
     val badgeSmallMinClickableSize: DpSize,
     val onMoreOptionsButtonCornerRadius: Dp,
+    val inCallReactionButtonSize: Dp,
+    val inCallReactionRecentReactionSize: Dp,
     // Dialog
     val dialogButtonsSpacing: Dp,
     val dialogTextsSpacing: Dp,
@@ -183,6 +185,8 @@ data class WireDimensions(
     val groupButtonHeight: Dp,
     // Calling
     val defaultCallingControlsSize: Dp,
+    val defaultCallingControlsHeight: Dp,
+    val defaultCallingControlsWidth: Dp,
     val defaultCallingControlsIconSize: Dp,
     val bigCallingControlsSize: Dp,
     val bigCallingHangUpButtonIconSize: Dp,
@@ -341,11 +345,13 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     systemMessageIconLargeSize = 18.dp,
     groupButtonHeight = 82.dp,
     defaultCallingControlsSize = 56.dp,
+    defaultCallingControlsHeight = 40.dp,
+    defaultCallingControlsWidth = 56.dp,
     defaultCallingControlsIconSize = 20.dp,
     bigCallingControlsSize = 72.dp,
     bigCallingHangUpButtonIconSize = 32.dp,
     bigCallingAcceptButtonIconSize = 24.dp,
-    defaultSheetPeekHeight = 100.dp,
+    defaultSheetPeekHeight = 72.dp,
     defaultOutgoingCallSheetPeekHeight = 281.dp,
     onGoingCallUserAvatarSize = 72.dp,
     onGoingCallTileUsernameMaxWidth = 120.dp,
@@ -360,6 +366,8 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     importedMediaAssetSize = 120.dp,
     typingIndicatorHeight = 24.dp,
     legalHoldBannerMinHeight = 26.dp,
+    inCallReactionButtonSize = 48.dp,
+    inCallReactionRecentReactionSize = 32.dp,
 )
 
 private val DefaultPhoneLandscapeWireDimensions: WireDimensions = DefaultPhonePortraitWireDimensions

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireTypography.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireTypography.kt
@@ -37,7 +37,9 @@ data class WireTypography(
     val label01: TextStyle, val label02: TextStyle, val label03: TextStyle, val label04: TextStyle, val label05: TextStyle,
     val badge01: TextStyle,
     val subline01: TextStyle,
-    val code01: TextStyle
+    val code01: TextStyle,
+    val inCallReactionEmoji: TextStyle,
+    val inCallReactionRecentEmoji: TextStyle,
 ) {
     fun toTypography() = Typography(
         titleLarge = title01, titleMedium = title02, titleSmall = title03,
@@ -69,7 +71,9 @@ private val DefaultWireTypography = WireTypography(
     label05 = WireTypographyBase.Label05,
     badge01 = WireTypographyBase.Badge01,
     subline01 = WireTypographyBase.SubLine01,
-    code01 = WireTypographyBase.Code01
+    code01 = WireTypographyBase.Code01,
+    inCallReactionEmoji = WireTypographyBase.InCallEmoji,
+    inCallReactionRecentEmoji = WireTypographyBase.InCallEmojiRecent,
 )
 
 @PackagePrivate

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireTypographyBase.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireTypographyBase.kt
@@ -148,4 +148,10 @@ object WireTypographyBase {
         lineHeight = 28.13.sp,
         textAlign = TextAlign.Center
     )
+    val InCallEmoji = TextStyle(
+        fontSize = 32.sp,
+    )
+    val InCallEmojiRecent = TextStyle(
+        fontSize = 20.sp,
+    )
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14254" title="WPB-14254" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-14254</a>  [Android] In-Call Reactions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-14254
# What's new in this PR?

- Observe and display in-call reactions with animations
- Show recent reaction in participant tile
- New panel for selecting in-call reaction
- Updated style for call controls
- Camera flip button moved to participant tile

| Showing emojis | In-call reactions panel | Custom emojis | Camera flip button |
| ----------- | ------------ | ----------- | ------------ |
| ![reactions_1](https://github.com/user-attachments/assets/a1fb1dcf-d101-48a0-ae60-6bbac8fc8ba8)  | ![reactions_2](https://github.com/user-attachments/assets/4a3c4ecb-7c01-4afb-8f37-fe16fa5db2d0) | ![reactions_3](https://github.com/user-attachments/assets/eee66024-5ebd-48ff-984c-c56acbee1609) | ![reactions_4](https://github.com/user-attachments/assets/deb8079e-c6ab-41a6-bc36-34a442a49cf0)


