### PR TITLE
fix: attachments menu blends with background [WPB-15102]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
@@ -390,7 +390,7 @@ private fun UsernameTile(
     modifier: Modifier = Modifier,
 ) {
     val color =
-        if (isSpeaking) colorsScheme().primary else darkColorsScheme().surfaceContainerLowest
+        if (isSpeaking) colorsScheme().primary else darkColorsScheme().inverseOnSurface
     val nameLabelColor =
         when {
             isSpeaking -> colorsScheme().onPrimary

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -360,7 +360,9 @@ fun EnabledMessageComposer(
                             .clip(shape)
                             .drawBehind {
                                 if (!hideRipple || rippleProgress.value > 0f) {
-                                    val path = calculateOptionsPath(cornerRadiusPx, rippleProgress.value, isImeVisible, size)
+                                    val path = calculateOptionsPath(
+                                        cornerRadiusPx, rippleProgress.value, isImeVisible, size
+                                    )
                                     drawPath(
                                         path = path,
                                         color = rippleColor,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -366,13 +366,15 @@ fun EnabledMessageComposer(
                                         color = rippleColor,
                                         style = Fill
                                     )
-                                    drawPath(
-                                        path = path,
-                                        color = borderColor,
-                                        style = Stroke(
-                                            width = borderWidthPx * 2f // double to make it inner stroke, outer half is clipped anyway
+                                    if (borderWidthPx > 0f) {
+                                        drawPath(
+                                            path = path,
+                                            color = borderColor,
+                                            style = Stroke(
+                                                width = borderWidthPx * 2f // double to make it inner stroke, outer half is clipped anyway
+                                            )
                                         )
-                                    )
+                                    }
                                 }
                             }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -336,7 +336,7 @@ fun EnabledMessageComposer(
                 ) {
                     val rippleColor = colorsScheme().surfaceContainerLowest
                     val borderColor = colorsScheme().divider
-                    val borderWidthPx = dimensions().spacing1x.toPx(density)
+                    val borderWidthPx = if (isImeVisible) 0f else dimensions().spacing1x.toPx(density)
                     val cornerRadiusPx = if (isImeVisible) 0f else dimensions().corner14x.toPx(density)
                     val shape = GenericShape { size, _ ->
                         addPath(calculateOptionsPath(cornerRadiusPx, rippleProgress.value, isImeVisible, size))

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -360,22 +360,21 @@ fun EnabledMessageComposer(
                             .clip(shape)
                             .drawBehind {
                                 if (!hideRipple || rippleProgress.value > 0f) {
-                                    val path = calculateOptionsPath(
-                                        cornerRadiusPx, rippleProgress.value, isImeVisible, size
-                                    )
-                                    drawPath(
-                                        path = path,
-                                        color = rippleColor,
-                                        style = Fill
-                                    )
-                                    if (borderWidthPx > 0f) {
+                                    calculateOptionsPath(cornerRadiusPx, rippleProgress.value, isImeVisible, size).let {
                                         drawPath(
-                                            path = path,
-                                            color = borderColor,
-                                            style = Stroke(
-                                                width = borderWidthPx * 2f // double to make it inner stroke, outer half is clipped anyway
-                                            )
+                                            path = it,
+                                            color = rippleColor,
+                                            style = Fill
                                         )
+                                        if (borderWidthPx > 0f) {
+                                            drawPath(
+                                                path = it,
+                                                color = borderColor,
+                                                style = Stroke(
+                                                    width = borderWidthPx * 2f // double to make inner stroke, outer half is clipped anyway
+                                                )
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -43,7 +43,7 @@ import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.GenericShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -55,12 +55,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
@@ -326,11 +334,12 @@ fun EnabledMessageComposer(
                         showAttachments(false)
                     }
                 ) {
-                    val rippleColor = colorsScheme().surface
-                    val shape = if (isImeVisible) {
-                        RectangleShape
-                    } else {
-                        RoundedCornerShape(dimensions().corner14x)
+                    val rippleColor = colorsScheme().surfaceContainerLowest
+                    val borderColor = colorsScheme().divider
+                    val borderWidthPx = dimensions().spacing1x.toPx(density)
+                    val cornerRadiusPx = if (isImeVisible) 0f else dimensions().corner14x.toPx(density)
+                    val shape = GenericShape { size, _ ->
+                        addPath(calculateOptionsPath(cornerRadiusPx, rippleProgress.value, isImeVisible, size))
                     }
 
                     Box(
@@ -351,19 +360,17 @@ fun EnabledMessageComposer(
                             .clip(shape)
                             .drawBehind {
                                 if (!hideRipple || rippleProgress.value > 0f) {
-                                    val maxRadius = size.getDistanceToCorner(Offset(0f, 0f))
-                                    val currentRadius = maxRadius * rippleProgress.value
-
-                                    drawCircle(
+                                    val path = calculateOptionsPath(cornerRadiusPx, rippleProgress.value, isImeVisible, size)
+                                    drawPath(
+                                        path = path,
                                         color = rippleColor,
-                                        radius = currentRadius,
-                                        center = Offset(
-                                            0f,
-                                            if (isImeVisible) {
-                                                0f
-                                            } else {
-                                                size.height
-                                            }
+                                        style = Fill
+                                    )
+                                    drawPath(
+                                        path = path,
+                                        color = borderColor,
+                                        style = Stroke(
+                                            width = borderWidthPx * 2f // double to make it inner stroke, outer half is clipped anyway
                                         )
                                     )
                                 }
@@ -402,7 +409,30 @@ fun EnabledMessageComposer(
     }
 }
 
-fun Size.getDistanceToCorner(corner: Offset): Float {
+private fun Size.getDistanceToCorner(corner: Offset): Float {
     val cornerOffset = Offset(width - corner.x, height - corner.y)
     return cornerOffset.getDistance()
 }
+
+private fun calculateOptionsPath(cornerRadiusPx: Float, rippleProgress: Float, isImeVisible: Boolean, size: Size): Path {
+    val ripplePath = Path()
+    ripplePath.addOval(
+        oval = Rect(
+            center = Offset(
+                x = 0f,
+                y = if (isImeVisible) 0f else size.height
+            ),
+            radius = rippleProgress * size.getDistanceToCorner(Offset(0f, 0f))
+        )
+    )
+    val shapePath = Path()
+    shapePath.addRoundRect(
+        roundRect = RoundRect(
+            rect = size.toRect(),
+            cornerRadius = CornerRadius(cornerRadiusPx, cornerRadiusPx)
+        )
+    )
+    return ripplePath.and(shapePath)
+}
+
+private fun Dp.toPx(density: Density) = with(density) { toPx() }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -207,7 +207,7 @@ private val DarkWireColorScheme = WireColorScheme(
     surfaceVariant = WireColorPalette.Gray90, onSurfaceVariant = Color.White,
     inverseSurface = Color.White, inverseOnSurface = Color.Black,
     surfaceBright = WireColorPalette.Gray70, surfaceDim = WireColorPalette.Gray95,
-    surfaceContainerLowest = Color.Black,
+    surfaceContainerLowest = WireColorPalette.Gray100,
     surfaceContainerLow = WireColorPalette.Gray95,
     surfaceContainer = WireColorPalette.Gray90,
     surfaceContainerHigh = WireColorPalette.Gray80,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15102" title="WPB-15102" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15102</a>  [Android] File sharing overlay matches background color of conversation in dark mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Attachments menu matches the background color of the conversation screen, making it difficult to distinguish the overlay from the background.

### Solutions

Rearrange some surface colors, add border to the attachments menu in the way so that it is drawn properly even during animations.

### Testing

#### How to Test

Open attachments menu on light and dark mode.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <img width="400" src="https://github.com/user-attachments/assets/cdac72a2-8bd4-4ca7-9b4b-3346097bf16c"/> | <img width="400" src="https://github.com/user-attachments/assets/09d93dc6-40e9-4bf8-8d04-9b65c554ffbf"/> |
| <img width="400" src="https://github.com/user-attachments/assets/eaab814e-8ed4-40a4-96a5-e2f445c009c0"/> |<img width="400" src="https://github.com/user-attachments/assets/21989670-5092-4fc4-b527-c02b734ab8b0"/> | 

<video width="400" src="https://github.com/user-attachments/assets/49f69af9-a80a-4652-add5-ade71d2b9765"/>
----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
