### PR TITLE
fix: allowing empty team name when migrating [WPB-15092]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModel.kt
@@ -108,7 +108,7 @@ class TeamMigrationViewModel @Inject constructor(
     fun migrateFromPersonalToTeamAccount(onSuccess: () -> Unit) {
         viewModelScope.launch {
             migrateFromPersonalToTeam.invoke(
-                teamMigrationState.teamNameTextState.text.toString(),
+                teamMigrationState.teamNameTextState.text.trim().toString(),
             ).let { result ->
                 when (result) {
                     is MigrateFromPersonalToTeamResult.Success -> {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step2/TeamMigrationTeamNameStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step2/TeamMigrationTeamNameStepScreen.kt
@@ -129,7 +129,7 @@ private fun TeamMigrationTeamNameStepScreenContent(
                 textFieldState = teamNameTextFieldState,
             )
         }
-        val isContinueButtonEnabled = teamNameTextFieldState.text.isNotEmpty()
+        val isContinueButtonEnabled = teamNameTextFieldState.text.isNotEmpty() && teamNameTextFieldState.text.isNotBlank()
         BottomLineButtons(
             isContinueButtonEnabled = isContinueButtonEnabled,
             onContinue = onContinueButtonClicked,

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModelTest.kt
@@ -225,6 +225,22 @@ class TeamMigrationViewModelTest {
             Assertions.assertNull(viewModel.teamMigrationState.migrationFailure)
         }
 
+    @Test
+    fun `given team name with spaces at start or end, when invoking migration, then trim the name`() = runTest {
+        // given
+        val (arrangement, viewModel) = Arrangement()
+            .withMigrateFromPersonalToTeamSuccess()
+            .arrange()
+        val onSuccess = {}
+        viewModel.teamMigrationState.teamNameTextState.setTextAndPlaceCursorAtEnd(" ${Arrangement.TEAM_NAME} ")
+        // when
+        viewModel.migrateFromPersonalToTeamAccount(onSuccess)
+        // then
+        coVerify(exactly = 1) {
+            arrangement.migrateFromPersonalToTeam(Arrangement.TEAM_NAME)
+        }
+    }
+
     private class Arrangement {
 
         @MockK


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15092" title="WPB-15092" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15092</a>  [Android]User is able to create a team name consisting only of spaces.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a personal user migrates to a team account, the "Your Team" input field allows the user to enter only spaces as the team name and proceed with registration. This results in invalid or meaningless team names, which should not be permitted.

### Solutions

Modify the check for enabling "continue" button to also check whether the name is not blank.
Trim all excessive spaces at the start of end of the name.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Steps to Reproduce:
-Log in to the Android app as a personal user on the Anta BE environment.
-Start the process to migrate to a team account.
-In the Team Name Overlay, enter only spaces (e.g., " ") in the "Your Team" input field.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
