### PR TITLE
fix: adjustments for short signature names (WPB-15188)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
@@ -201,11 +201,22 @@ class DeviceDetailsViewModel @Inject constructor(
                             canBeRemoved = !result.isCurrentClient && isSelfClient && result.client.type != ClientType.LegalHold,
                             mlsCipherSuiteSignature = MLSPublicKeyType.from(
                                 result.client.mlsPublicKeys?.keys?.firstOrNull().orEmpty()
-                            ).value.toString()
+                            ).let { mapCipherSuiteSignatureToShortName(it) }
                         )
                     }
                 }
             }
+        }
+    }
+
+    private fun mapCipherSuiteSignatureToShortName(signature: MLSPublicKeyType): String {
+        return when (signature) {
+            MLSPublicKeyType.ECDSA_SECP256R1_SHA256 -> "P256"
+            MLSPublicKeyType.ECDSA_SECP384R1_SHA384 -> "P384"
+            MLSPublicKeyType.ECDSA_SECP521R1_SHA512 -> "P521"
+            MLSPublicKeyType.ED25519 -> "ED25519"
+            MLSPublicKeyType.ED448 -> "ED448"
+            is MLSPublicKeyType.Unknown -> "Unknown"
         }
     }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15188" title="WPB-15188" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15188</a>  [Android] Trim ciphersuite entry on device details
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We show now the ciphersuite entry in device details. But currently we show the full string.
We should trim it, to make it easy for the users.

### Causes (Optional)

Not previous alignment on this full vs. short name.

### Solutions

Implement following suit of what was implemented on other platforms.
I.e.:  
- https://github.com/wireapp/wire-webapp/pull/18524/files#diff-e70dcc889885ae11e48f74cfdae354706f5371cf6c2a9b28b158f4a91362386e

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Have a MLS client and see on device details the signature

### Attachments (Optional)
<img src="https://github.com/user-attachments/assets/fdf3e5ec-95c6-484b-a5b9-56cc5fb333d6" width="300" />

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
