### PR TITLE
fix: Cant see my video from other client [#WPB-12179]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
@@ -202,4 +202,8 @@ class CallsModule {
     @Provides
     fun provideObserveConferenceCallingEnabledUseCase(callsScope: CallsScope) =
         callsScope.observeConferenceCallingEnabled
+
+    @ViewModelScoped
+    @Provides
+    fun provideCurrentClientIdUseCase(callsScope: CallsScope) = callsScope.getCurrentClientIdUseCase
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallState.kt
@@ -21,6 +21,7 @@ package com.wire.android.ui.calling
 import androidx.compose.runtime.Stable
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.call.ConversationTypeForCall
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -43,5 +44,6 @@ data class CallState(
     val membership: Membership = Membership.None,
     val protocolInfo: Conversation.ProtocolInfo? = null,
     val mlsVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
-    val proteusVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+    val proteusVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+    val currentClientId: String = String.EMPTY
 )

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -183,7 +183,7 @@ fun OngoingCallScreen(
         onCameraPermissionPermanentlyDenied = onCameraPermissionPermanentlyDenied,
         participants = sharedCallingViewModel.participantsState,
         inPictureInPictureMode = inPictureInPictureMode,
-        currentUserId = ongoingCallViewModel.currentUserId,
+        currentUserId = ongoingCallViewModel.currentUserId
     )
 
     BackHandler {
@@ -417,6 +417,7 @@ private fun OngoingCallContent(
                             onSelfClearVideoPreview = clearVideoPreview,
                             requestVideoStreams = requestVideoStreams,
                             currentUserId = currentUserId,
+                            currentClientId = callState.currentClientId,
                             onDoubleTap = { selectedParticipant ->
                                 onSelectedParticipant(selectedParticipant)
                                 shouldOpenFullScreen = !shouldOpenFullScreen

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
@@ -63,6 +63,7 @@ fun VerticalCallingPager(
     isInPictureInPictureMode: Boolean,
     contentHeight: Dp,
     currentUserId: UserId,
+    currentClientId: String,
     onSelfVideoPreviewCreated: (view: View) -> Unit,
     onSelfClearVideoPreview: () -> Unit,
     requestVideoStreams: (participants: List<UICallParticipant>) -> Unit,
@@ -107,6 +108,7 @@ fun VerticalCallingPager(
                             onSelfClearVideoPreview = onSelfClearVideoPreview,
                             onDoubleTap = onDoubleTap,
                             currentUserId = currentUserId,
+                            currentClientId = currentClientId
                         )
                     } else {
                         GroupCallGrid(
@@ -119,6 +121,7 @@ fun VerticalCallingPager(
                             onSelfClearVideoPreview = onSelfClearVideoPreview,
                             onDoubleTap = onDoubleTap,
                             currentUserId = currentUserId,
+                            currentClientId = currentClientId,
                             isInPictureInPictureMode = isInPictureInPictureMode,
                         )
                     }
@@ -179,6 +182,7 @@ private fun PreviewVerticalCallingPager(participants: List<UICallParticipant>) {
         onDoubleTap = { },
         isInPictureInPictureMode = false,
         currentUserId = participants[0].id,
+        currentClientId = "clientId"
     )
 }
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-12179

# What's new in this PR?

### Issues

We were unable to see our own preview from other client

### Solutions

We were marking all our users as owners, which do not support this feature. We need to mark only one participant as owner per call on a device, to allow that we not only have to check out for the id, we also need to make sure client id match.

### Dependencies (Optional)

We need this one first https://github.com/wireapp/kalium/pull/3201

### Testing

#### How to Test

- Have two accounts A and B
- Use account A on web and android
- Use account B on either web/android
- Create group call join with all 3 instances, twice with client A and once with client B
- Start sharing screen from client A on web
- You should see client A sharing content on client A on mobile - in both PiP and non PiP modes

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
