### PR TITLE
refactor: adjust to edge-to-edge, remove deprecated APIs [WPB-14903]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/MainNavHost.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/MainNavHost.kt
@@ -21,6 +21,7 @@ package com.wire.android.navigation
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 import com.ramcosta.composedestinations.DestinationsNavHost
@@ -44,6 +45,7 @@ import com.wire.android.ui.home.newconversation.NewConversationViewModel
 fun MainNavHost(
     navigator: Navigator,
     startDestination: Route,
+    modifier: Modifier = Modifier,
 ) {
     val navHostEngine = rememberAnimatedNavHostEngine(
         rootDefaultAnimations = DefaultRootNavGraphAnimations,
@@ -55,6 +57,7 @@ fun MainNavHost(
     )
 
     DestinationsNavHost(
+        modifier = modifier,
         navGraph = WireMainNavGraph,
         engine = navHostEngine,
         startRoute = startDestination,

--- a/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
@@ -19,12 +19,12 @@ package com.wire.android.ui
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.biometric.BiometricManager
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
-import androidx.core.view.WindowCompat
 import com.wire.android.appLogger
 import com.wire.android.navigation.MainNavHost
 import com.wire.android.navigation.rememberNavigator
@@ -39,7 +39,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class AppLockActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+        enableEdgeToEdge()
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
             CompositionLocalProvider(

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -26,11 +26,14 @@ import android.os.Bundle
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -47,7 +50,6 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -163,7 +165,7 @@ class WireActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         splashScreen.setKeepOnScreenCondition { shouldKeepSplashOpen }
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+        enableEdgeToEdge()
 
         lifecycleScope.launch {
 
@@ -232,18 +234,17 @@ class WireActivity : AppCompatActivity() {
                 WireTheme {
                     Column(
                         modifier = Modifier
-                            .statusBarsPadding()
                             .semantics { testTagsAsResourceId = true }
                     ) {
                         val navigator = rememberNavigator(this@WireActivity::finish)
                         WireTopAppBar(
-                            themeOption = viewModel.globalAppState.themeOption,
                             commonTopAppBarState = commonTopAppBarViewModel.state,
                         )
                         CompositionLocalProvider(LocalNavigator provides navigator) {
                             MainNavHost(
                                 navigator = navigator,
-                                startDestination = startDestination
+                                startDestination = startDestination,
+                                modifier = Modifier.consumeWindowInsets(WindowInsets.statusBars)
                             )
                         }
 
@@ -260,11 +261,11 @@ class WireActivity : AppCompatActivity() {
 
     @Composable
     private fun WireTopAppBar(
-        themeOption: ThemeOption,
-        commonTopAppBarState: CommonTopAppBarState
+        commonTopAppBarState: CommonTopAppBarState,
+        modifier:  Modifier = Modifier,
     ) {
         CommonTopAppBar(
-            themeOption = themeOption,
+            modifier = modifier,
             commonTopAppBarState = commonTopAppBarState,
             onReturnToCallClick = { establishedCall ->
                 getOngoingCallIntent(

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -262,7 +262,7 @@ class WireActivity : AppCompatActivity() {
     @Composable
     private fun WireTopAppBar(
         commonTopAppBarState: CommonTopAppBarState,
-        modifier:  Modifier = Modifier,
+        modifier: Modifier = Modifier,
     ) {
         CommonTopAppBar(
             modifier = modifier,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/StartingCallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/StartingCallActivity.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.togetherWith
 import androidx.compose.material3.SnackbarHostState
@@ -33,7 +34,6 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
-import androidx.core.view.WindowCompat
 import com.wire.android.appLogger
 import com.wire.android.navigation.style.TransitionAnimationType
 import com.wire.android.ui.LocalActivity
@@ -87,7 +87,7 @@ class StartingCallActivity : CallActivity() {
         setUpScreenshotPreventionFlag()
         setUpCallingFlags()
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+        enableEdgeToEdge()
 
         handleNewIntent(intent)
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
@@ -26,6 +26,7 @@ import android.graphics.drawable.Icon
 import android.os.Bundle
 import android.util.Rational
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.togetherWith
 import androidx.compose.material3.SnackbarHostState
@@ -38,7 +39,6 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
-import androidx.core.view.WindowCompat
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.navigation.style.TransitionAnimationType
@@ -90,7 +90,7 @@ class OngoingCallActivity : CallActivity() {
         setUpScreenshotPreventionFlag()
         setUpCallingFlags()
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+        enableEdgeToEdge()
 
         handleNewIntent(intent)
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
@@ -20,11 +20,10 @@
 
 package com.wire.android.ui.common.topappbar
 
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColor
 import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.expandIn
-import androidx.compose.animation.shrinkOut
-import androidx.compose.foundation.background
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -32,27 +31,27 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.IntSize
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.wire.android.BuildConfig
 import com.wire.android.R
-import com.wire.android.ui.theme.ThemeOption
+import com.wire.android.ui.theme.WireColorScheme
 import com.wire.android.ui.theme.WireTheme
+import com.wire.android.ui.theme.updateSystemBarIconsAppearance
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
@@ -62,114 +61,111 @@ import com.wire.kalium.network.NetworkState
 
 @Composable
 fun CommonTopAppBar(
-    themeOption: ThemeOption,
     commonTopAppBarState: CommonTopAppBarState,
     onReturnToCallClick: (ConnectivityUIState.Call.Established) -> Unit,
     onReturnToIncomingCallClick: (ConnectivityUIState.Call.Incoming) -> Unit,
     onReturnToOutgoingCallClick: (ConnectivityUIState.Call.Outgoing) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier) {
+    val transition = updateTransition(
+        targetState = MaterialTheme.wireColorScheme to commonTopAppBarState.connectivityState.toColorType(),
+        label = "connectivity state transition"
+    )
+    val backgroundColor = transition.animateColor(label = "top app bar background color") { (colorScheme, colorType) ->
+        colorScheme.getBackgroundColor(colorType)
+    }
+    val systemBarIconsAppearance = transition.animateFloat(label = "system bar icons appearance") { (colorScheme, colorType) ->
+        if (colorScheme.getStatusBarIconsAppearance(colorType)) 1f else 0f
+    }
+
+    updateSystemBarIconsAppearance(systemBarIconsAppearance.value > 0.5f)
+
+    Column(
+        modifier = modifier
+            .drawBehind { drawRect(backgroundColor.value) }
+            .statusBarsPadding()
+    ) {
         ConnectivityStatusBar(
-            themeOption = themeOption,
             networkState = commonTopAppBarState.networkState,
             connectivityInfo = commonTopAppBarState.connectivityState,
             onReturnToCallClick = onReturnToCallClick,
             onReturnToIncomingCallClick = onReturnToIncomingCallClick,
-            onReturnToOutgoingCallClick = onReturnToOutgoingCallClick
+            onReturnToOutgoingCallClick = onReturnToOutgoingCallClick,
+            modifier = modifier,
         )
     }
 }
 
-@Composable
-fun getBackgroundColor(connectivityInfo: ConnectivityUIState): Color {
-    return when (connectivityInfo) {
-        is ConnectivityUIState.Calls -> MaterialTheme.wireColorScheme.positive
+private enum class ConnectivityStatusColorType { Calls, Connection, None }
 
-        is ConnectivityUIState.WaitingConnection,
-        ConnectivityUIState.Connecting -> MaterialTheme.wireColorScheme.primary
+private fun ConnectivityUIState.toColorType() = when (this) {
+    is ConnectivityUIState.Calls -> ConnectivityStatusColorType.Calls
+    is ConnectivityUIState.Connecting,
+    is ConnectivityUIState.WaitingConnection -> ConnectivityStatusColorType.Connection
+    is ConnectivityUIState.None -> ConnectivityStatusColorType.None
+}
 
-        ConnectivityUIState.None -> MaterialTheme.wireColorScheme.background
-    }
+private fun WireColorScheme.getBackgroundColor(statusColorType: ConnectivityStatusColorType): Color = when (statusColorType) {
+    ConnectivityStatusColorType.Calls -> positive
+    ConnectivityStatusColorType.Connection -> primary
+    ConnectivityStatusColorType.None -> background
+}
+
+private fun WireColorScheme.getStatusBarIconsAppearance(statusColorType: ConnectivityStatusColorType): Boolean = when (statusColorType) {
+    ConnectivityStatusColorType.Calls,
+    ConnectivityStatusColorType.Connection -> connectivityBarShouldUseDarkIcons
+    ConnectivityStatusColorType.None -> useDarkSystemBarIcons
 }
 
 @Composable
 private fun ConnectivityStatusBar(
-    themeOption: ThemeOption,
     connectivityInfo: ConnectivityUIState,
     networkState: NetworkState,
     onReturnToCallClick: (ConnectivityUIState.Call.Established) -> Unit,
     onReturnToIncomingCallClick: (ConnectivityUIState.Call.Incoming) -> Unit,
     onReturnToOutgoingCallClick: (ConnectivityUIState.Call.Outgoing) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    val isVisible = connectivityInfo !is ConnectivityUIState.None
-    val backgroundColor = getBackgroundColor(connectivityInfo)
-
-    if (isVisible) {
-        val darkIcons = MaterialTheme.wireColorScheme.connectivityBarShouldUseDarkIcons
-        val systemUiController = rememberSystemUiController()
-        systemUiController.setStatusBarColor(
-            color = backgroundColor,
-            darkIcons = darkIcons
-        )
-        LaunchedEffect(themeOption) {
-            systemUiController.setStatusBarColor(
-                color = backgroundColor,
-                darkIcons = darkIcons
-            )
-        }
-    } else {
-        ClearStatusBarColor()
-    }
-
-    AnimatedVisibility(
-        visible = isVisible,
-        enter = expandIn(initialSize = { fullSize -> IntSize(fullSize.width, 0) }),
-        exit = shrinkOut(targetSize = { fullSize -> IntSize(fullSize.width, 0) })
+    Column(
+        modifier = modifier
+            .animateContentSize()
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
     ) {
-        Column(
-            modifier = Modifier
-                .animateContentSize()
-                .fillMaxWidth()
-                .heightIn(min = MaterialTheme.wireDimensions.ongoingCallLabelHeight)
-                .background(backgroundColor),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
-        ) {
-            when (connectivityInfo) {
-                is ConnectivityUIState.Calls ->
-                    CallsContent(
-                        calls = connectivityInfo.calls,
-                        onReturnToCallClick = onReturnToCallClick,
-                        onReturnToIncomingCallClick = onReturnToIncomingCallClick,
-                        onReturnToOutgoingCallClick = onReturnToOutgoingCallClick
-                    )
+        when (connectivityInfo) {
+            is ConnectivityUIState.Calls ->
+                CallsContent(
+                    calls = connectivityInfo.calls,
+                    onReturnToCallClick = onReturnToCallClick,
+                    onReturnToIncomingCallClick = onReturnToIncomingCallClick,
+                    onReturnToOutgoingCallClick = onReturnToOutgoingCallClick
+                )
 
-                ConnectivityUIState.Connecting ->
+            ConnectivityUIState.Connecting ->
+                StatusLabel(
+                    R.string.connectivity_status_bar_connecting,
+                    MaterialTheme.wireColorScheme.onPrimary
+                )
+
+            is ConnectivityUIState.WaitingConnection -> {
+                val color = MaterialTheme.wireColorScheme.onPrimary
+                val waitingStatus: @Composable () -> Unit = {
                     StatusLabel(
-                        R.string.connectivity_status_bar_connecting,
-                        MaterialTheme.wireColorScheme.onPrimary
+                        stringResource = R.string.connectivity_status_bar_waiting_for_network,
+                        color
                     )
-
-                is ConnectivityUIState.WaitingConnection -> {
-                    val color = MaterialTheme.wireColorScheme.onPrimary
-                    val waitingStatus: @Composable () -> Unit = {
-                        StatusLabel(
-                            stringResource = R.string.connectivity_status_bar_waiting_for_network,
-                            color
-                        )
-                    }
-
-                    if (!BuildConfig.PRIVATE_BUILD) {
-                        waitingStatus()
-                        return@Column
-                    }
-
-                    WaitingStatusLabelInternal(connectivityInfo, networkState, waitingStatus)
                 }
 
-                ConnectivityUIState.None -> {}
+                if (!BuildConfig.PRIVATE_BUILD) {
+                    waitingStatus()
+                    return@Column
+                }
+
+                WaitingStatusLabelInternal(connectivityInfo, networkState, waitingStatus)
             }
+
+            ConnectivityUIState.None -> {}
         }
     }
 }
@@ -382,19 +378,8 @@ private fun MicrophoneIcon(
 }
 
 @Composable
-private fun ClearStatusBarColor() {
-    val backgroundColor = MaterialTheme.wireColorScheme.background
-    val darkIcons = MaterialTheme.wireColorScheme.useDarkSystemBarIcons
-
-    rememberSystemUiController().setSystemBarsColor(
-        color = backgroundColor,
-        darkIcons = darkIcons
-    )
-}
-
-@Composable
 private fun PreviewCommonTopAppBar(connectivityUIState: ConnectivityUIState) = WireTheme {
-    CommonTopAppBar(ThemeOption.SYSTEM, CommonTopAppBarState(connectivityUIState), {}, {}, {})
+    CommonTopAppBar(CommonTopAppBarState(connectivityUIState), {}, {}, {})
 }
 
 @PreviewMultipleThemes

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
@@ -115,18 +115,19 @@ class CommonTopAppBarViewModel @Inject constructor(
                             }
                         }
                     }
-                    .debounce { connectivityUIState ->
+                    .debounce { state ->
                         /**
                          * Adding some debounce here to avoid some bad UX and prevent from having blinking effect when the state changes
                          * quickly, e.g. when displaying ongoing call banner and hiding it in a short time when the user hangs up the call.
                          * Call events could take some time to be received and this function could be called when the screen is changed,
                          * so we delayed showing the banner until getting the correct calling values and for calls this debounce is bigger
                          * than for other states in order to allow for the correct handling of hanging up a call.
+                         * When state changes to None, handle it immediately, that's why we return 0L debounce time in this case.
                          */
-                        if (connectivityUIState is ConnectivityUIState.Calls && connectivityUIState.hasOngoingCall) {
-                            CONNECTIVITY_STATE_DEBOUNCE_ONGOING_CALL
-                        } else {
-                            CONNECTIVITY_STATE_DEBOUNCE_DEFAULT
+                        when {
+                            state is ConnectivityUIState.None -> 0L
+                            state is ConnectivityUIState.Calls && state.hasOngoingCall -> CONNECTIVITY_STATE_DEBOUNCE_ONGOING_CALL
+                            else -> CONNECTIVITY_STATE_DEBOUNCE_DEFAULT
                         }
                     }
                     .collectLatest { connectivityUIState ->

--- a/app/src/main/kotlin/com/wire/android/ui/emoji/HandleDraggableBottomSheetDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/emoji/HandleDraggableBottomSheetDialog.kt
@@ -16,14 +16,11 @@
 package com.wire.android.ui.emoji
 
 import android.content.Context
-import android.os.Build
-import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
-import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.annotation.LayoutRes
 import androidx.annotation.StyleRes
@@ -84,21 +81,7 @@ class HandleDraggableBottomSheetDialog : AppCompatDialog {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val window = window
-        if (window != null) {
-            if (Build.VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
-                // The status bar should always be transparent because of the window animation.
-                window.statusBarColor = 0
-
-                window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-                if (Build.VERSION.SDK_INT < VERSION_CODES.M) {
-                    // It can be transparent for API 23 and above because we will handle switching the status
-                    // bar icons to light or dark as appropriate. For API 21 and API 22 we just set the
-                    // translucent status bar.
-                    window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
-                }
-            }
-            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
-        }
+        window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
     }
 
     override fun setContentView(view: View) {
@@ -268,19 +251,6 @@ class HandleDraggableBottomSheetDialog : AppCompatDialog {
                 }
             }
             return themeId
-        }
-
-        @Deprecated("use {@link EdgeToEdgeUtils#setLightStatusBar(Window, boolean)} instead")
-        fun setLightStatusBar(view: View, isLight: Boolean) {
-            if (Build.VERSION.SDK_INT >= VERSION_CODES.M) {
-                var flags = view.systemUiVisibility
-                flags = if (isLight) {
-                    flags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-                } else {
-                    flags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
-                }
-                view.systemUiVisibility = flags
-            }
         }
     }
 }

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -23,8 +23,6 @@
      -->
     <style name="AppTheme" parent="Theme.Material3.Dark.NoActionBar">
         <item name="android:windowBackground">@color/background</item>
-        <item name="android:statusBarColor">@color/background</item>
-        <item name="android:navigationBarColor">@color/background</item>
         <item name="colorPrimary">@color/background</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -21,15 +21,11 @@
 
     <style name="AppTheme" parent="Theme.Material3.Light.NoActionBar">
         <item name="android:windowBackground">@color/background</item>
-        <item name="android:statusBarColor">@color/background</item>
-        <item name="android:navigationBarColor">@color/background</item>
         <item name="colorPrimary">@color/background</item>
     </style>
 
     <!-- This theme is only used as the splash screen -->
     <style name="AppTheme.SplashScreen" parent="Theme.SplashScreen">
-        <item name="android:statusBarColor">@color/background</item>
-        <item name="android:navigationBarColor">@color/background</item>
         <item name="android:windowLightStatusBar">@bool/is_light_theme</item>
         <item name="android:windowLightNavigationBar" tools:ignore="NewApi">@bool/is_light_theme
         </item>

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/StatusBarsHelper.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/StatusBarsHelper.kt
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.theme
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+@Composable
+fun updateSystemBarIconsAppearance(useDarkSystemBarIcons: Boolean) {
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = useDarkSystemBarIcons
+        }
+    }
+}

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/Theme.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/Theme.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalInspectionMode
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 
 @Composable
@@ -39,7 +38,6 @@ fun WireTheme(
     content: @Composable () -> Unit
 ) {
     val isPreview = LocalInspectionMode.current
-    val systemUiController = rememberSystemUiController()
     @Suppress("SpreadOperator")
     CompositionLocalProvider(
         LocalWireColors provides wireColorScheme,

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/Theme.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/Theme.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -61,9 +60,7 @@ fun WireTheme(
             typography = wireTypography.toTypography()
         ) {
             if (!isPreview) {
-                val backgroundColor = MaterialTheme.wireColorScheme.background
-                val darkIcons = MaterialTheme.wireColorScheme.useDarkSystemBarIcons
-                SideEffect { systemUiController.setSystemBarsColor(color = backgroundColor, darkIcons = darkIcons) }
+                updateSystemBarIconsAppearance(wireColorScheme.useDarkSystemBarIcons)
             }
             content()
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14903" title="WPB-14903" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14903</a>  [Android] Edge to edge replace deprecated setStatusBarColor
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In android 15 we have to adhere to new APIs for edge to edge.

### Issues

<img width="600" src="https://github.com/user-attachments/assets/caac9205-8fc4-427f-9f52-7f7c105ad7fc"/>

### Solutions

- remove deprecated calls for setting status and navigation bar colors
- update common top bar to draw color under the status bar instead
- create dedicated composable function `updateSystemBarIconsAppearance` responsible for changing this color
- remove `LaunchedEffect` when `ThemeOption` changes as `SideEffect` is created in that function already which does the job
- remove setting status bar color in `HandleDraggableBottomSheetDialog` as right now with edge-to-edge it's always transparent
- replace deprecated `setDecorFitsSystemWindows` with `enableEdgeToEdge`
- replace `AnimatedVisibility` with colors transition to make changes smoother
- replace `delay` with `debounce` when call state changes, because `delay` was just supposed to act like a `debounce`, and add smaller one also for other states to prevent blinking

### Testing

#### How to Test

Open the app and turn off network connection or start a call to change the top bar state.

### Attachments (Optional)

https://github.com/user-attachments/assets/df829b6e-d8df-42fc-b45e-1f1cbb6d7169

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
