### PR TITLE
fix: reappearing keyboard [WPB-10889]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -290,6 +290,7 @@ private fun MessageComposerTextInput(
         } else {
             isReadOnly = true
             keyboardController?.hide()
+            focusRequester.freeFocus()
         }
     }
 
@@ -312,9 +313,7 @@ private fun MessageComposerTextInput(
         modifier = modifier
             .focusRequester(focusRequester)
             .onFocusChanged { focusState ->
-                if (focusState.isFocused) {
-                    onFocusChanged(focusState.isFocused)
-                }
+                onFocusChanged(focusState.isFocused)
             }
             .onPreInterceptKeyBeforeSoftKeyboard { event ->
                 if (event.key.nativeKeyCode == android.view.KeyEvent.KEYCODE_BACK) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10889" title="WPB-10889" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10889</a>  [Android] MLS Migration opens keyboard
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When message composer input still has focus but the keyboard is closed, after making some actions, the keyboard reappears.

### Causes (Optional)

`onFocusChanged` was being called only when the input received focus, but not when focus was freed, but the logic behind that lambda in `MessageComposerStateHolder.onInputFocusedChanged` needs to be called in both cases to request or clear focus properly.

### Solutions

Cakk `onFocusChanged` in both cases, when the input gets the focus and when loses it. Also, free the focus when it's not needed anymore.

### Testing

#### How to Test

Open group conversation, click on a message input to get focus, close the keyboard, open conversation details and go back - keyboard should not reappear.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/user-attachments/assets/5521bcf4-0dc0-47f5-83a2-fd50b0c26750"/> | <video width="400" src="https://github.com/user-attachments/assets/2fdd11b8-c7ac-4476-8a51-2668e2ebe955"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
