### PR TITLE
fix: emoji picker dialog showing randomly [#WPB-6681]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/emoji/EmojiPicker.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/emoji/EmojiPicker.kt
@@ -40,6 +40,7 @@ fun EmojiPickerBottomSheet(
                     onDismiss.invoke()
                 }
                 findViewById<EmojiPickerView>(R.id.emoji_picker)?.setOnEmojiPickedListener { emojiViewItem ->
+                    dismiss()
                     onEmojiSelected(emojiViewItem.emoji)
                 }
                 findViewById<BottomSheetDragHandleView>(R.id.handle)?.let { handle ->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6681" title="WPB-6681" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6681</a>  [Android] Emoji list appears on screen unnecessaryly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-6681
----
# What's new in this PR?

### Issues
Emoji picker dialog is showing again in random places:
1. Open message reaction dialog. Open all emojis picker.
2. Select emoji.
3. Go to settings -> Give Feedback.
4. Close feedback dialog.
5. Emoji picker is shown on top of the screen and can only be dismissed by re-opening the app.

### Causes (Optional)
Emoji picker dialog is not dismissed when picking emoji and it's state is restored.

### Solutions
Dismiss dialog when emoji is selected.
