### PR TITLE
fix: answer call from notification in foreground service [WPB-9648]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/services/CallService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/CallService.kt
@@ -115,12 +115,12 @@ class CallService : Service() {
                             val userSessionScope = coreLogic.getSessionScope(userId)
                             val outgoingCallsFlow = userSessionScope.calls.observeOutgoingCall()
                             val establishedCallsFlow = userSessionScope.calls.establishedCall()
-                            val answeringCallFlow = userSessionScope.calls.observeIncomingCall(action)
+                            val callCurrentlyBeingAnsweredFlow = userSessionScope.calls.observeCallCurrentlyBeingAnswered(action)
 
                             combine(
                                 outgoingCallsFlow,
                                 establishedCallsFlow,
-                                answeringCallFlow
+                                callCurrentlyBeingAnsweredFlow
                             ) { outgoingCalls, establishedCalls, answeringCall ->
                                 val calls = outgoingCalls + establishedCalls + answeringCall
                                 calls.firstOrNull()?.let { call ->
@@ -192,7 +192,7 @@ class CallService : Service() {
         appLogger.i("$TAG: started foreground with placeholder notification")
     }
 
-    private suspend fun CallsScope.observeIncomingCall(action: Action?) = when (action) {
+    private suspend fun CallsScope.observeCallCurrentlyBeingAnswered(action: Action?) = when (action) {
         is Action.AnswerCall -> getIncomingCalls().map { it.filter { it.conversationId == action.conversationId } }
         else -> flowOf(emptyList())
     }

--- a/app/src/main/kotlin/com/wire/android/services/CallService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/CallService.kt
@@ -31,15 +31,20 @@ import com.wire.android.di.NoSession
 import com.wire.android.notification.CallNotificationData
 import com.wire.android.notification.CallNotificationManager
 import com.wire.android.notification.NotificationIds
+import com.wire.android.services.CallService.Action
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.logIfEmptyUserName
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.call.CallsScope
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold
 import dagger.hilt.android.AndroidEntryPoint
+import dev.ahmedmourad.bundlizer.Bundlizer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -50,7 +55,9 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 
@@ -90,14 +97,17 @@ class CallService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         appLogger.i("$TAG: onStartCommand")
-        val stopService = intent?.getBooleanExtra(EXTRA_STOP_SERVICE, false)
+        val action = intent?.getActionTypeExtra(EXTRA_ACTION_TYPE)
         generatePlaceholderForegroundNotification()
         serviceState.set(ServiceState.FOREGROUND)
-        if (stopService == true) {
+        if (action is Action.Stop) {
             appLogger.i("$TAG: stopSelf. Reason: stopService was called")
             stopSelf()
         } else {
             scope.launch {
+                if (action is Action.AnswerCall) {
+                    coreLogic.getSessionScope(action.userId).calls.answerCall(action.conversationId)
+                }
                 coreLogic.getGlobalScope().session.currentSessionFlow()
                     .flatMapLatest {
                         if (it is CurrentSessionResult.Success && it.accountInfo.isValid()) {
@@ -105,12 +115,14 @@ class CallService : Service() {
                             val userSessionScope = coreLogic.getSessionScope(userId)
                             val outgoingCallsFlow = userSessionScope.calls.observeOutgoingCall()
                             val establishedCallsFlow = userSessionScope.calls.establishedCall()
+                            val answeringCallFlow = userSessionScope.calls.observeIncomingCall(action)
 
                             combine(
                                 outgoingCallsFlow,
-                                establishedCallsFlow
-                            ) { outgoingCalls, establishedCalls ->
-                                val calls = outgoingCalls + establishedCalls
+                                establishedCallsFlow,
+                                answeringCallFlow
+                            ) { outgoingCalls, establishedCalls, answeringCall ->
+                                val calls = outgoingCalls + establishedCalls + answeringCall
                                 calls.firstOrNull()?.let { call ->
                                     val userName = userSessionScope.users.getSelfUser().first()
                                         .also { it.logIfEmptyUserName() }
@@ -180,22 +192,37 @@ class CallService : Service() {
         appLogger.i("$TAG: started foreground with placeholder notification")
     }
 
+    private suspend fun CallsScope.observeIncomingCall(action: Action?) = when (action) {
+        is Action.AnswerCall -> getIncomingCalls().map { it.filter { it.conversationId == action.conversationId } }
+        else -> flowOf(emptyList())
+    }
+
     companion object {
         private const val TAG = "CallService"
-        private const val EXTRA_STOP_SERVICE = "stop_service"
+        private const val EXTRA_ACTION_TYPE = "action_type"
 
-        fun newIntent(context: Context): Intent = Intent(context, CallService::class.java)
+        fun newIntent(context: Context, actionType: Action = Action.Default): Intent = Intent(context, CallService::class.java)
+            .putExtra(EXTRA_ACTION_TYPE, actionType)
 
-        fun newIntentToStop(context: Context): Intent =
-            Intent(context, CallService::class.java).apply {
-                putExtra(EXTRA_STOP_SERVICE, true)
-            }
-
-        var serviceState: AtomicReference<ServiceState> = AtomicReference(ServiceState.NOT_STARTED)
-            private set
+        val serviceState: AtomicReference<ServiceState> = AtomicReference(ServiceState.NOT_STARTED)
     }
 
     enum class ServiceState {
         NOT_STARTED, STARTED, FOREGROUND
     }
+
+    @Serializable
+    sealed class Action {
+        @Serializable
+        data object Default : Action()
+
+        @Serializable
+        data class AnswerCall(val userId: UserId, val conversationId: ConversationId) : Action()
+
+        @Serializable
+        data object Stop : Action()
+    }
 }
+
+private fun Intent.putExtra(name: String, actionType: Action): Intent = putExtra(name, Bundlizer.bundle(Action.serializer(), actionType))
+private fun Intent.getActionTypeExtra(name: String): Action? = getBundleExtra(name)?.let { Bundlizer.unbundle(Action.serializer(), it) }

--- a/app/src/main/kotlin/com/wire/android/services/CallService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/CallService.kt
@@ -225,4 +225,7 @@ class CallService : Service() {
 }
 
 private fun Intent.putExtra(name: String, actionType: Action): Intent = putExtra(name, Bundlizer.bundle(Action.serializer(), actionType))
-private fun Intent.getActionTypeExtra(name: String): Action? = getBundleExtra(name)?.let { Bundlizer.unbundle(Action.serializer(), it) }
+
+private fun Intent.getActionTypeExtra(name: String): Action? = getBundleExtra(name)?.let {
+        Bundlizer.unbundle(Action.serializer(), it)
+    }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9648" title="WPB-9648" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9648</a>  [Android] Ensure Compliance with Audio Focus Request Restrictions on Android 15
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to ensure compliance with audio focus request restrictions on Android 15:
https://developer.android.com/about/versions/15/behavior-changes-15#audio-focus

Basically, when targeting Android 15, app must be in the foreground or have foreground service working to successfully request audio focus and it’s not the case right now. 

### Solutions

AVS requests audio focus when starting/answering a call and when receiving incoming call - this one is probably just for the ringing sound and we provide the ringing sound via the notification and do not play it ourselves.
For starting or answering a call, there's one case when it may happen when the app is in the background - when answering from the incoming call notification. To make it work, answering logic is moved to the call service, so when answering from the notification, first the `CallService` is started with proper action so that the call is answered and audio focus requested after the foreground service is started.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Right now it's not yet possible to test it manually as it requires the app to target Android 15 (API 35), but after we update `target` then it shouldn't crash when doing these steps:
-open the app
-put into background
-make a call to that user from another device
-answer from the notification

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
