### PR TITLE
fix: refactoring self user fetch [#WPB-15190]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.logic.feature.publicuser.GetKnownUserUseCase
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
 import com.wire.kalium.logic.feature.user.DeleteAccountUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
@@ -190,6 +191,11 @@ class UserModule {
     @Provides
     fun provideGetSelfUseCase(userScope: UserScope): GetSelfUserUseCase =
         userScope.getSelfUser
+
+    @ViewModelScoped
+    @Provides
+    fun provideObserveSelfUseCase(userScope: UserScope): ObserveSelfUserUseCase =
+        userScope.observeSelfUser
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -350,7 +350,7 @@ class WireNotificationManager @Inject constructor(
                     } else {
                         userSessionScope.calls.getIncomingCalls()
                     }.map { calls ->
-                        userSessionScope.users.getSelfUser().first()
+                        userSessionScope.users.observeSelfUser().first()
                             .also { it.logIfEmptyUserName() }
                             .let { it.handle ?: it.name ?: "" } to calls
                     }
@@ -374,7 +374,7 @@ class WireNotificationManager @Inject constructor(
     ) {
         val selfUserNameState = coreLogic.getSessionScope(userId)
             .users
-            .getSelfUser()
+            .observeSelfUser()
             .onEach { it.logIfEmptyUserName() }
             .map { it.handle ?: it.name ?: "" }
             .distinctUntilChanged()

--- a/app/src/main/kotlin/com/wire/android/services/CallService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/CallService.kt
@@ -112,7 +112,7 @@ class CallService : Service() {
                             ) { outgoingCalls, establishedCalls ->
                                 val calls = outgoingCalls + establishedCalls
                                 calls.firstOrNull()?.let { call ->
-                                    val userName = userSessionScope.users.getSelfUser().first()
+                                    val userName = userSessionScope.users.observeSelfUser().first()
                                         .also { it.logIfEmptyUserName() }
                                         .let { it.handle ?: it.name ?: "" }
                                     Either.Right(CallNotificationData(userId, call, userName))

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -37,7 +37,7 @@ import com.wire.kalium.logic.feature.client.NeedsToRegisterClientUseCase
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
@@ -50,7 +50,7 @@ class HomeViewModel @Inject constructor(
     override val savedStateHandle: SavedStateHandle,
     private val globalDataStore: GlobalDataStore,
     private val dataStore: UserDataStore,
-    private val getSelf: GetSelfUserUseCase,
+    private val observeSelf: ObserveSelfUserUseCase,
     private val needsToRegisterClient: NeedsToRegisterClientUseCase,
     private val canMigrateFromPersonalToTeam: CanMigrateFromPersonalToTeamUseCase,
     private val observeLegalHoldStatusForSelfUser: ObserveLegalHoldStateForSelfUserUseCase,
@@ -97,15 +97,15 @@ class HomeViewModel @Inject constructor(
 
     fun checkRequirements(onRequirement: (HomeRequirement) -> Unit) {
         viewModelScope.launch {
-            val userId = getSelf().first().id
+            val selfUser = observeSelf().first()
             when {
-                shouldTriggerMigrationForUser(userId) ->
-                    onRequirement(HomeRequirement.Migration(userId))
+                shouldTriggerMigrationForUser(selfUser.id) ->
+                    onRequirement(HomeRequirement.Migration(selfUser.id))
 
                 needsToRegisterClient() -> // check if the client has been registered and open the proper screen if not
                     onRequirement(HomeRequirement.RegisterDevice)
 
-                getSelf().first().handle.isNullOrEmpty() -> // check if the user handle has been set and open the proper screen if not
+                selfUser.handle.isNullOrEmpty() -> // check if the user handle has been set and open the proper screen if not
                     onRequirement(HomeRequirement.CreateAccountUsername)
 
                 shouldDisplayWelcomeToARScreen() -> {
@@ -120,7 +120,7 @@ class HomeViewModel @Inject constructor(
 
     private fun loadUserAvatar() {
         viewModelScope.launch {
-            getSelf().collect { selfUser ->
+            observeSelf().collect { selfUser ->
                 homeState = homeState.copy(
                     userAvatarData = UserAvatarData(
                         asset = selfUser.previewPicture?.let {

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModel.kt
@@ -101,7 +101,7 @@ class ForgotLockScreenViewModel @Inject constructor(
                 is IsPasswordRequiredUseCase.Result.Success -> {
                     state.copy(
                         dialogState = ForgotLockCodeDialogState.Visible(
-                            username = getSelf().firstOrNull()?.name ?: "",
+                            username = getSelf()?.name ?: "",
                             passwordRequired = isPasswordRequiredResult.value,
                             resetDeviceEnabled = !isPasswordRequiredResult.value,
                         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/ConversationListCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/ConversationListCallViewModel.kt
@@ -43,7 +43,7 @@ import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingCallsUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveDegradedConversationNotifiedUseCase
 import com.wire.kalium.logic.feature.conversation.SetUserInformedAboutVerificationUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
@@ -70,7 +70,7 @@ class ConversationListCallViewModel @Inject constructor(
     private val setUserInformedAboutVerification: SetUserInformedAboutVerificationUseCase,
     private val observeDegradedConversationNotified: ObserveDegradedConversationNotifiedUseCase,
     private val observeConferenceCallingEnabled: ObserveConferenceCallingEnabledUseCase,
-    private val getSelf: GetSelfUserUseCase
+    private val observeSelf: ObserveSelfUserUseCase
 ) : SavedStateViewModel(savedStateHandle) {
 
     private val conversationNavArgs: ConversationNavArgs = savedStateHandle.navArgs()
@@ -110,7 +110,7 @@ class ConversationListCallViewModel @Inject constructor(
 
     private fun observeSelfTeamRole() {
         viewModelScope.launch {
-            getSelf().collectLatest { self ->
+            observeSelf().collectLatest { self ->
                 selfTeamRole.value = self.userType
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -62,7 +62,7 @@ import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.GetUpdatedSelfTeamUseCase
 import com.wire.kalium.logic.feature.team.Result
 import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import com.wire.kalium.logic.functional.getOrNull
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -91,7 +91,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
     private val observeConversationMembers: ObserveParticipantsForConversationUseCase,
     private val updateConversationAccessRole: UpdateConversationAccessRoleUseCase,
     private val getSelfTeam: GetUpdatedSelfTeamUseCase,
-    private val observerSelfUser: GetSelfUserUseCase,
+    private val observerSelfUser: ObserveSelfUserUseCase,
     private val deleteTeamConversation: DeleteTeamConversationUseCase,
     private val removeMemberFromConversation: RemoveMemberFromConversationUseCase,
     private val updateConversationMutedStatus: UpdateConversationMutedStatusUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveConversationRoleForUserUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveConversationRoleForUserUseCase.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterIsInstance
@@ -36,11 +36,11 @@ import javax.inject.Inject
 class ObserveConversationRoleForUserUseCase @Inject constructor(
     private val observeConversationMembers: ObserveConversationMembersUseCase,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
-    private val getSelfUser: GetSelfUserUseCase
+    private val observeSelfUser: ObserveSelfUserUseCase
 ) {
     suspend operator fun invoke(conversationId: ConversationId, userId: UserId): Flow<ConversationRoleData> =
         combine(
-            getSelfUser(),
+            observeSelfUser(),
             observeConversationDetails(conversationId)
                 .filterIsInstance<ObserveConversationDetailsUseCase.Result.Success>() // TODO handle StorageFailure
                 .map { it.conversationDetails },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
@@ -35,7 +35,6 @@ import com.wire.kalium.logic.feature.conversation.folder.GetFavoriteFolderUseCas
 import com.wire.kalium.logic.feature.conversation.folder.ObserveConversationsFromFolderUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -47,7 +46,7 @@ class GetConversationsFromSearchUseCase @Inject constructor(
     private val observeConversationsFromFromFolder: ObserveConversationsFromFolderUseCase,
     private val userTypeMapper: UserTypeMapper,
     private val dispatchers: DispatcherProvider,
-    private val observeSelfUser: GetSelfUserUseCase
+    private val getSelfUser: GetSelfUserUseCase
 ) {
     suspend operator fun invoke(
         searchQuery: String = "",
@@ -96,7 +95,7 @@ class GetConversationsFromSearchUseCase @Inject constructor(
                     it.toConversationItem(
                         userTypeMapper = userTypeMapper,
                         searchQuery = searchQuery,
-                        selfUserTeamId = observeSelfUser().firstOrNull()?.teamId
+                        selfUserTeamId = getSelfUser()?.teamId
                     )
                 }
             }.flowOn(dispatchers.io())

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -90,7 +90,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
@@ -150,7 +149,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
     private val observeLegalHoldStateForSelfUser: ObserveLegalHoldStateForSelfUserUseCase,
     @CurrentAccount val currentAccount: UserId,
     private val userTypeMapper: UserTypeMapper,
-    private val observeSelfUser: GetSelfUserUseCase,
+    private val getSelfUser: GetSelfUserUseCase,
     private val workManager: WorkManager
 ) : ConversationListViewModel, ViewModel() {
 
@@ -262,7 +261,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
                             conversationDetails.toConversationItem(
                                 userTypeMapper = userTypeMapper,
                                 searchQuery = searchQuery,
-                                selfUserTeamId = observeSelfUser().firstOrNull()?.teamId
+                                selfUserTeamId = getSelfUser()?.teamId
                             ).hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold)
                         } to searchQuery
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -39,7 +39,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
 import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.flow.collectLatest
@@ -52,7 +52,7 @@ import javax.inject.Inject
 @HiltViewModel
 class NewConversationViewModel @Inject constructor(
     private val createGroupConversation: CreateGroupConversationUseCase,
-    private val getSelfUser: GetSelfUserUseCase,
+    private val observeSelfUser: ObserveSelfUserUseCase,
     getDefaultProtocol: GetDefaultProtocolUseCase
 ) : ViewModel() {
 
@@ -79,7 +79,7 @@ class NewConversationViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val selfUser = getSelfUser().first()
+            val selfUser = observeSelfUser().first()
             val isSelfTeamMember = selfUser.teamId != null
             val isSelfExternalTeamMember = selfUser.userType == UserType.EXTERNAL
             newGroupState = newGroupState.copy(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModel.kt
@@ -26,7 +26,7 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
@@ -39,7 +39,7 @@ import javax.inject.Inject
 class SettingsViewModel @Inject constructor(
     private val globalDataStore: GlobalDataStore,
     private val observeIsAppLockEditable: ObserveIsAppLockEditableUseCase,
-    private val getSelf: GetSelfUserUseCase,
+    private val getSelf: ObserveSelfUserUseCase,
     private val dispatchers: DispatcherProvider,
 ) : ViewModel() {
     var state by mutableStateOf(SettingsState())

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
@@ -29,7 +29,7 @@ import com.wire.android.appLogger
 import com.wire.android.navigation.SavedStateViewModel
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.feature.team.GetUpdatedSelfTeamUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
@@ -50,7 +50,7 @@ import kotlin.properties.Delegates
 @HiltViewModel
 class MyAccountViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val getSelf: GetSelfUserUseCase,
+    private val getSelf: ObserveSelfUserUseCase,
     private val getSelfTeam: GetUpdatedSelfTeamUseCase,
     private val isSelfATeamMember: IsSelfATeamMemberUseCase,
     private val serverConfig: SelfServerConfigUseCase,
@@ -123,7 +123,7 @@ class MyAccountViewModel @Inject constructor(
         }
     }
 
-    private suspend fun fetchSelfUser() {
+    private fun fetchSelfUser() {
         viewModelScope.launch {
             val self = getSelf().flowOn(dispatchers.io()).shareIn(this, SharingStarted.WhileSubscribed(1))
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameViewModel.kt
@@ -31,7 +31,6 @@ import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.UpdateDisplayNameUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -47,7 +46,7 @@ class ChangeDisplayNameViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            getSelf().firstOrNull()?.name.orEmpty().let { currentDisplayName ->
+            getSelf()?.name.orEmpty().let { currentDisplayName ->
                 textState.setTextAndPlaceCursorAtEnd(currentDisplayName)
                 textState.textAsFlow().collectLatest {
                     displayNameState = displayNameState.copy(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/email/updateEmail/ChangeEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/email/updateEmail/ChangeEmailViewModel.kt
@@ -31,7 +31,6 @@ import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.UpdateEmailUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -48,7 +47,7 @@ class ChangeEmailViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            getSelf().firstOrNull()?.email?.let { currentEmail ->
+            getSelf()?.email?.let { currentEmail ->
                 textState.setTextAndPlaceCursorAtEnd(currentEmail)
                 textState.textAsFlow().collectLatest {
                     val isValidEmail = Patterns.EMAIL_ADDRESS.matcher(it.trim()).matches()

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/handle/ChangeHandleViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/handle/ChangeHandleViewModel.kt
@@ -34,7 +34,6 @@ import com.wire.kalium.logic.feature.user.SetUserHandleResult
 import com.wire.kalium.logic.feature.user.SetUserHandleUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -52,7 +51,7 @@ class ChangeHandleViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            getSelf().firstOrNull()?.handle.orEmpty().let { currentHandle ->
+            getSelf()?.handle.orEmpty().let { currentHandle ->
                 textState.setTextAndPlaceCursorAtEnd(currentHandle)
                 textState.textAsFlow().collectLatest { newHandle ->
                     state = when (validateHandle(newHandle.toString())) {

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
@@ -22,7 +22,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.ui.navArgs
 import com.wire.android.util.fileDateTime
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.util.DateTimeUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.first
@@ -32,7 +32,7 @@ import javax.inject.Inject
 @HiltViewModel
 class E2eiCertificateDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val observerSelfUser: GetSelfUserUseCase,
+    private val observerSelfUser: ObserveSelfUserUseCase,
 ) : ViewModel() {
     private val navArgs: E2eiCertificateDetailsScreenNavArgs =
         savedStateHandle.navArgs()

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -51,7 +51,7 @@ import com.wire.kalium.logic.data.message.SelfDeletionTimer.Companion.SELF_DELET
 import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageResult
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
@@ -74,7 +74,7 @@ import javax.inject.Inject
 @OptIn(FlowPreview::class)
 @Suppress("LongParameterList", "TooManyFunctions")
 class ImportMediaAuthenticatedViewModel @Inject constructor(
-    private val getSelf: GetSelfUserUseCase,
+    private val getSelf: ObserveSelfUserUseCase,
     private val getConversationsPaginated: GetConversationsFromSearchUseCase,
     private val handleUriAsset: HandleUriAssetUseCase,
     private val persistNewSelfDeletionTimerUseCase: PersistNewSelfDeletionTimerUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -57,7 +57,7 @@ import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserU
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
 import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
 import com.wire.kalium.logic.feature.team.GetUpdatedSelfTeamUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
 import com.wire.kalium.logic.feature.user.UpdateSelfAvailabilityStatusUseCase
@@ -84,7 +84,7 @@ import javax.inject.Inject
 class SelfUserProfileViewModel @Inject constructor(
     @CurrentAccount private val selfUserId: UserId,
     private val dataStore: UserDataStore,
-    private val getSelf: GetSelfUserUseCase,
+    private val observeSelf: ObserveSelfUserUseCase,
     private val getSelfTeam: GetUpdatedSelfTeamUseCase,
     private val canMigrateFromPersonalToTeam: CanMigrateFromPersonalToTeamUseCase,
     private val observeValidAccounts: ObserveValidAccountsUseCase,
@@ -139,7 +139,7 @@ class SelfUserProfileViewModel @Inject constructor(
 
     private fun markCreateTeamNoticeAsRead() {
         viewModelScope.launch {
-            if (getSelf().first().teamId == null && !dataStore.isCreateTeamNoticeRead().first()) {
+            if (observeSelf().first().teamId == null && !dataStore.isCreateTeamNoticeRead().first()) {
                 dataStore.setIsCreateTeamNoticeRead(true)
             }
         }
@@ -153,7 +153,7 @@ class SelfUserProfileViewModel @Inject constructor(
 
     private fun fetchSelfUser() {
         viewModelScope.launch {
-            val self = getSelf().flowOn(dispatchers.io()).shareIn(this, SharingStarted.WhileSubscribed(1))
+            val self = observeSelf().flowOn(dispatchers.io()).shareIn(this, SharingStarted.WhileSubscribed(1))
             val selfTeam = getSelfTeam().getOrNull()
             val validAccounts =
                 observeValidAccounts().flowOn(dispatchers.io()).shareIn(this, SharingStarted.WhileSubscribed(1))

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsViewModel.kt
@@ -38,7 +38,7 @@ import com.wire.kalium.logic.feature.conversation.AddServiceToConversationUseCas
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.service.GetServiceByIdUseCase
 import com.wire.kalium.logic.feature.service.ObserveIsServiceMemberUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.nullableFold
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -57,7 +57,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ServiceDetailsViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
-    private val observeSelfUser: GetSelfUserUseCase,
+    private val observeSelfUser: ObserveSelfUserUseCase,
     private val getServiceById: GetServiceByIdUseCase,
     private val observeIsServiceMember: ObserveIsServiceMemberUseCase,
     private val observeConversationRoleForUser: ObserveConversationRoleForUserUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModel.kt
@@ -25,7 +25,7 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.feature.analytics.AnonymousAnalyticsManager
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.migration.MigrateFromPersonalToTeamFailure
 import com.wire.kalium.logic.feature.user.migration.MigrateFromPersonalToTeamResult
 import com.wire.kalium.logic.feature.user.migration.MigrateFromPersonalToTeamUseCase
@@ -37,7 +37,7 @@ import javax.inject.Inject
 class TeamMigrationViewModel @Inject constructor(
     private val anonymousAnalyticsManager: AnonymousAnalyticsManager,
     private val migrateFromPersonalToTeam: MigrateFromPersonalToTeamUseCase,
-    private val getSelfUser: GetSelfUserUseCase,
+    private val observeSelfUser: ObserveSelfUserUseCase,
     private val getTeamUrl: GetTeamUrlUseCase
 ) : ViewModel() {
 
@@ -133,7 +133,7 @@ class TeamMigrationViewModel @Inject constructor(
 
     private fun setUsername() {
         viewModelScope.launch {
-            getSelfUser().collect { selfUser ->
+            observeSelfUser().collect { selfUser ->
                 selfUser.name?.let {
                     teamMigrationState = teamMigrationState.copy(username = it)
                 }

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -60,7 +60,7 @@ import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.user.E2EIRequiredResult
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.ObserveE2EIRequiredUseCase
 import com.wire.kalium.logic.feature.user.UserScope
 import com.wire.kalium.logic.sync.SyncManager
@@ -1084,7 +1084,7 @@ class WireNotificationManagerTest {
         lateinit var servicesManager: ServicesManager
 
         @MockK
-        lateinit var getSelfUser: GetSelfUserUseCase
+        lateinit var getSelfUser: ObserveSelfUserUseCase
 
         @MockK
         lateinit var currentSessionFlowUseCase: CurrentSessionFlowUseCase
@@ -1121,7 +1121,7 @@ class WireNotificationManagerTest {
             coEvery { userSessionScope.users } returns userScope
             coEvery { userSessionScope.observeE2EIRequired } returns observeE2EIRequired
             coEvery { conversationScope.markConnectionRequestAsNotified } returns markConnectionRequestAsNotified
-            coEvery { userScope.getSelfUser } returns getSelfUser
+            coEvery { userScope.observeSelfUser } returns getSelfUser
             coEvery { markConnectionRequestAsNotified(any()) } returns Unit
             coEvery { syncManager.waitUntilLive() } returns Unit
             coEvery { globalKaliumScope.getSessions } returns getSessionsUseCase
@@ -1169,7 +1169,7 @@ class WireNotificationManagerTest {
                     coEvery { markMessagesAsNotified } returns this@Arrangement.markMessagesAsNotified
                 }
                 coEvery { users } returns mockk {
-                    coEvery { getSelfUser() } returns flowOf(selfUser)
+                    coEvery { observeSelfUser() } returns flowOf(selfUser)
                 }
                 coEvery { observeE2EIRequired } returns this@Arrangement.observeE2EIRequired
             }

--- a/app/src/test/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/connection/ConnectionActionButtonViewModelTest.kt
@@ -43,7 +43,7 @@ import com.wire.kalium.logic.feature.connection.SendConnectionRequestUseCase
 import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.CreateConversationResult
 import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import io.mockk.Called
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -346,7 +346,7 @@ internal class ConnectionActionButtonHiltArrangement {
     lateinit var unblockUser: UnblockUserUseCase
 
     @MockK
-    lateinit var observeSelfUser: GetSelfUserUseCase
+    lateinit var observeSelfUser: ObserveSelfUserUseCase
 
     @MockK(relaxed = true)
     lateinit var onIgnoreSuccess: (userName: String) -> Unit

--- a/app/src/test/kotlin/com/wire/android/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/HomeViewModelTest.kt
@@ -31,7 +31,7 @@ import com.wire.kalium.logic.feature.client.NeedsToRegisterClientUseCase
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
@@ -126,7 +126,7 @@ class HomeViewModelTest {
         lateinit var dataStore: UserDataStore
 
         @MockK
-        lateinit var getSelf: GetSelfUserUseCase
+        lateinit var getSelf: ObserveSelfUserUseCase
 
         @MockK
         lateinit var needsToRegisterClient: NeedsToRegisterClientUseCase
@@ -148,7 +148,7 @@ class HomeViewModelTest {
                 savedStateHandle = savedStateHandle,
                 globalDataStore = globalDataStore,
                 dataStore = dataStore,
-                getSelf = getSelf,
+                observeSelf = getSelf,
                 needsToRegisterClient = needsToRegisterClient,
                 observeLegalHoldStatusForSelfUser = observeLegalHoldStatusForSelfUser,
                 shouldTriggerMigrationForUser = shouldTriggerMigrationForUser,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/call/ConversationListCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/call/ConversationListCallViewModelTest.kt
@@ -36,7 +36,7 @@ import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingCallsUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveDegradedConversationNotifiedUseCase
 import com.wire.kalium.logic.feature.conversation.SetUserInformedAboutVerificationUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -187,7 +187,7 @@ class ConversationListCallViewModelTest {
         lateinit var observeDegradedConversationNotifiedUseCase: ObserveDegradedConversationNotifiedUseCase
 
         @MockK
-        lateinit var getSelfUserUseCase: GetSelfUserUseCase
+        lateinit var observeSelfUserUseCase: ObserveSelfUserUseCase
 
         @MockK
         lateinit var observeConferenceCallingEnabled: ObserveConferenceCallingEnabledUseCase
@@ -205,12 +205,12 @@ class ConversationListCallViewModelTest {
             coEvery { observeParticipantsForConversation(any()) } returns flowOf()
             coEvery { setUserInformedAboutVerificationUseCase(any()) } returns Unit
             coEvery { observeDegradedConversationNotifiedUseCase(any()) } returns flowOf(false)
-            coEvery { getSelfUserUseCase() } returns flowOf()
+            coEvery { observeSelfUserUseCase() } returns flowOf()
             coEvery { observeConferenceCallingEnabled() } returns flowOf()
         }
 
         suspend fun withSelfAsAdmin() = apply {
-            coEvery { getSelfUserUseCase.invoke() } returns flowOf(TestUser.SELF_USER.copy(userType = UserType.ADMIN))
+            coEvery { observeSelfUserUseCase.invoke() } returns flowOf(TestUser.SELF_USER.copy(userType = UserType.ADMIN))
         }
 
         suspend fun withConferenceCallingEnabledResponse() = apply {
@@ -238,7 +238,7 @@ class ConversationListCallViewModelTest {
             setUserInformedAboutVerification = setUserInformedAboutVerificationUseCase,
             observeDegradedConversationNotified = observeDegradedConversationNotifiedUseCase,
             observeConferenceCallingEnabled = observeConferenceCallingEnabled,
-            getSelf = getSelfUserUseCase
+            observeSelf = observeSelfUserUseCase
         )
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -59,7 +59,7 @@ import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTim
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.GetUpdatedSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import com.wire.kalium.logic.functional.Either
 import io.mockk.MockKAnnotations
@@ -706,7 +706,7 @@ internal class GroupConversationDetailsViewModelArrangement {
     lateinit var removeMemberFromConversation: RemoveMemberFromConversationUseCase
 
     @MockK
-    lateinit var observerSelfUser: GetSelfUserUseCase
+    lateinit var observerSelfUser: ObserveSelfUserUseCase
 
     @MockK
     lateinit var observeParticipantsForConversationUseCase: ObserveParticipantsForConversationUseCase

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
@@ -182,7 +182,7 @@ class GetConversationsFromSearchUseCaseTest {
         lateinit var userTypeMapper: UserTypeMapper
 
         @MockK
-        lateinit var observeSelfUser: GetSelfUserUseCase
+        lateinit var getSelfUser: GetSelfUserUseCase
 
         val queryConfig = ConversationQueryConfig(
             searchQuery = "search",
@@ -214,7 +214,7 @@ class GetConversationsFromSearchUseCaseTest {
         }
 
         fun withSelfUser() = apply {
-            coEvery { observeSelfUser() } returns flowOf(TestUser.SELF_USER)
+            coEvery { getSelfUser() } returns TestUser.SELF_USER
         }
 
         fun arrange() = this to GetConversationsFromSearchUseCase(
@@ -223,7 +223,7 @@ class GetConversationsFromSearchUseCaseTest {
             observeConversationsFromFolderUseCase,
             userTypeMapper,
             dispatcherProvider,
-            observeSelfUser
+            getSelfUser
         )
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -347,7 +347,7 @@ class ConversationListViewModelTest {
         private lateinit var observeLegalHoldStateForSelfUserUseCase: ObserveLegalHoldStateForSelfUserUseCase
 
         @MockK
-        private lateinit var observeSelfUser: GetSelfUserUseCase
+        private lateinit var getSelfUser: GetSelfUserUseCase
 
         @MockK
         private lateinit var workManager: WorkManager
@@ -424,7 +424,7 @@ class ConversationListViewModelTest {
             observeConversationListDetailsWithEvents = observeConversationListDetailsWithEventsUseCase,
             observeLegalHoldStateForSelfUser = observeLegalHoldStateForSelfUserUseCase,
             userTypeMapper = UserTypeMapper(),
-            observeSelfUser = observeSelfUser,
+            getSelfUser = getSelfUser,
             usePagination = true,
             workManager = workManager
         )

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -35,7 +35,7 @@ import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
 import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -62,7 +62,7 @@ internal class NewConversationViewModelArrangement {
     lateinit var isMLSEnabledUseCase: IsMLSEnabledUseCase
 
     @MockK
-    lateinit var getSelfUserUseCase: GetSelfUserUseCase
+    lateinit var observeSelfUserUseCase: ObserveSelfUserUseCase
 
     @MockK(relaxed = true)
     lateinit var onGroupCreated: (ConversationId) -> Unit
@@ -172,7 +172,7 @@ internal class NewConversationViewModelArrangement {
     }
 
     fun withGetSelfUser(isTeamMember: Boolean, userType: UserType = UserType.INTERNAL) = apply {
-        coEvery { getSelfUserUseCase() } returns flowOf(SELF_USER.copy(
+        coEvery { observeSelfUserUseCase() } returns flowOf(SELF_USER.copy(
             teamId = if (isTeamMember) TeamId("teamId") else null,
             userType = userType,
         ))
@@ -184,7 +184,7 @@ internal class NewConversationViewModelArrangement {
 
     fun arrange() = this to NewConversationViewModel(
         createGroupConversation = createGroupConversation,
-        getSelfUser = getSelfUserUseCase,
+        observeSelfUser = observeSelfUserUseCase,
         getDefaultProtocol = getDefaultProtocol
     ).also {
         it.createGroupState = createGroupState

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModelTest.kt
@@ -27,7 +27,7 @@ import com.wire.android.util.newServerConfig
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.feature.team.GetUpdatedSelfTeamUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase.Result.Success
@@ -205,7 +205,7 @@ class MyAccountViewModelTest {
     private class Arrangement {
 
         @MockK
-        lateinit var getSelfUserUseCase: GetSelfUserUseCase
+        lateinit var observeSelfUserUseCase: ObserveSelfUserUseCase
 
         @MockK
         lateinit var getSelfTeamUseCase: GetUpdatedSelfTeamUseCase
@@ -231,7 +231,7 @@ class MyAccountViewModelTest {
         private val viewModel by lazy {
             MyAccountViewModel(
                 savedStateHandle,
-                getSelfUserUseCase,
+                observeSelfUserUseCase,
                 getSelfTeamUseCase,
                 isSelfATeamMember,
                 selfServerConfigUseCase,
@@ -244,7 +244,7 @@ class MyAccountViewModelTest {
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
-            coEvery { getSelfUserUseCase() } returns flowOf(TestUser.SELF_USER.copy(teamId = TeamId(TestTeam.TEAM.id)))
+            coEvery { observeSelfUserUseCase() } returns flowOf(TestUser.SELF_USER.copy(teamId = TeamId(TestTeam.TEAM.id)))
             coEvery { getSelfTeamUseCase() } returns Either.Right(TestTeam.TEAM)
             coEvery { selfServerConfigUseCase() } returns SelfServerConfigUseCase.Result.Success(newServerConfig(1))
             coEvery { isSelfATeamMember() } returns true

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameViewModelTest.kt
@@ -31,7 +31,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -147,7 +146,7 @@ class ChangeDisplayNameViewModelTest {
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
-            coEvery { getSelfUserUseCase() } returns flowOf(TestUser.SELF_USER)
+            coEvery { getSelfUserUseCase() } returns TestUser.SELF_USER
         }
 
         fun withUserSaveNameResult(result: DisplayNameUpdateResult) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/account/email/ChangeEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/account/email/ChangeEmailViewModelTest.kt
@@ -32,13 +32,12 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import okio.IOException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class)
@@ -123,7 +122,7 @@ class ChangeEmailViewModelTest {
             MockKAnnotations.init(this, relaxUnitFun = true)
             mockUri()
 
-            coEvery { self() } returns flowOf(TestUser.SELF_USER)
+            coEvery { self() } returns TestUser.SELF_USER
         }
 
         private val viewModel = ChangeEmailViewModel(

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/account/handle/ChangeHandleViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/account/handle/ChangeHandleViewModelTest.kt
@@ -34,12 +34,11 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import okio.IOException
 import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class)
@@ -159,7 +158,7 @@ class ChangeHandleViewModelTest {
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
-            coEvery { getSelf() } returns flowOf(TestUser.SELF_USER)
+            coEvery { getSelf() } returns TestUser.SELF_USER
         }
 
         private val viewModel by lazy { ChangeHandleViewModel(setHandle, validateHandle, getSelf) }

--- a/app/src/test/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModelTest.kt
@@ -30,7 +30,7 @@ import com.wire.android.ui.home.conversations.usecase.GetConversationsFromSearch
 import com.wire.android.ui.home.conversations.usecase.HandleUriAssetUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -72,7 +72,7 @@ class ImportMediaAuthenticatedViewModelTest {
     inner class Arrangement {
 
         @MockK
-        lateinit var getSelfUser: GetSelfUserUseCase
+        lateinit var getSelfUser: ObserveSelfUserUseCase
 
         @MockK
         lateinit var getConversationsPaginated: GetConversationsFromSearchUseCase

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -45,7 +45,7 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUs
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.IsOtherUserE2EIVerifiedUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import io.mockk.MockKAnnotations
@@ -78,7 +78,7 @@ internal class OtherUserProfileViewModelArrangement {
     lateinit var removeMemberFromConversationUseCase: RemoveMemberFromConversationUseCase
 
     @MockK
-    lateinit var observeSelfUser: GetSelfUserUseCase
+    lateinit var observeSelfUser: ObserveSelfUserUseCase
 
     @MockK
     lateinit var blockUser: BlockUserUseCase

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModelArrangement.kt
@@ -37,7 +37,7 @@ import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserU
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
 import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
 import com.wire.kalium.logic.feature.team.GetUpdatedSelfTeamUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
 import com.wire.kalium.logic.feature.user.UpdateSelfAvailabilityStatusUseCase
@@ -52,7 +52,7 @@ class SelfUserProfileViewModelArrangement {
     lateinit var userDataStore: UserDataStore
 
     @MockK
-    lateinit var getSelf: GetSelfUserUseCase
+    lateinit var getSelf: ObserveSelfUserUseCase
 
     @MockK
     lateinit var getSelfTeam: GetUpdatedSelfTeamUseCase
@@ -109,7 +109,7 @@ class SelfUserProfileViewModelArrangement {
         SelfUserProfileViewModel(
             selfUserId = TestUser.SELF_USER.id,
             dataStore = userDataStore,
-            getSelf = getSelf,
+            observeSelf = getSelf,
             getSelfTeam = getSelfTeam,
             observeValidAccounts = observeValidAccounts,
             updateStatus = updateStatus,

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsViewModelTest.kt
@@ -41,7 +41,7 @@ import com.wire.kalium.logic.feature.conversation.AddServiceToConversationUseCas
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.service.GetServiceByIdUseCase
 import com.wire.kalium.logic.feature.service.ObserveIsServiceMemberUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.functional.Either
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -283,7 +283,7 @@ class ServiceDetailsViewModelTest {
     private class Arrangement {
 
         @MockK
-        lateinit var observeSelfUser: GetSelfUserUseCase
+        lateinit var observeSelfUser: ObserveSelfUserUseCase
 
         @MockK
         lateinit var getServiceById: GetServiceByIdUseCase

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModelTest.kt
@@ -23,7 +23,7 @@ import com.wire.android.feature.analytics.AnonymousAnalyticsManager
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.migration.MigrateFromPersonalToTeamFailure
 import com.wire.kalium.logic.feature.user.migration.MigrateFromPersonalToTeamResult
 import com.wire.kalium.logic.feature.user.migration.MigrateFromPersonalToTeamUseCase
@@ -271,7 +271,7 @@ class TeamMigrationViewModelTest {
         lateinit var migrateFromPersonalToTeam: MigrateFromPersonalToTeamUseCase
 
         @MockK
-        lateinit var getSelfUser: GetSelfUserUseCase
+        lateinit var getSelfUser: ObserveSelfUserUseCase
 
         @MockK
         lateinit var getTeamUrl: GetTeamUrlUseCase
@@ -285,7 +285,7 @@ class TeamMigrationViewModelTest {
         fun arrange() = this to TeamMigrationViewModel(
             anonymousAnalyticsManager = anonymousAnalyticsManager,
             migrateFromPersonalToTeam = migrateFromPersonalToTeam,
-            getSelfUser = getSelfUser,
+            observeSelfUser = getSelfUser,
             getTeamUrl = getTeamUrl
         ).also { viewModel ->
             viewModel.teamMigrationState.teamNameTextState.setTextAndPlaceCursorAtEnd(TEAM_NAME)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15190" title="WPB-15190" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15190</a>  [Android] race condition in getKnownUser causes multible requests to update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-15190
----
# What's new in this PR?

Related to: https://github.com/wireapp/kalium/pull/3229

Refactoring getting / observe self user. New `GetSelfUserUseCase` use case to get self user is used where appropriate instead of observing until first value is received.