### PR TITLE
chore: show MLS client ID in debug screen for private builds [WPB-15215]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -202,12 +202,11 @@ fun DebugDataOptionsContent(
                 isEncryptedStorageEnabled = state.isEncryptedProteusStorageEnabled,
                 onEncryptedStorageEnabledChange = onEnableEncryptedProteusStorageChange
             )
-            if (BuildConfig.DEBUG) {
+            if (BuildConfig.PRIVATE_BUILD) {
                 MLSOptions(
                     keyPackagesCount = state.keyPackagesCount,
                     mlsClientId = state.mslClientId,
                     mlsErrorMessage = state.mlsErrorMessage,
-                    restartSlowSyncForRecovery = onRestartSlowSyncForRecovery,
                     onCopyText = onCopyText
                 )
             }
@@ -301,7 +300,6 @@ private fun MLSOptions(
     mlsClientId: String,
     mlsErrorMessage: String,
     onCopyText: (String) -> Unit,
-    restartSlowSyncForRecovery: () -> Unit
 ) {
     FolderHeader(stringResource(R.string.label_mls_option_title))
     Column {
@@ -310,8 +308,7 @@ private fun MLSOptions(
             text = mlsErrorMessage,
             trailingIcon = R.drawable.ic_copy,
             onIconPressed = Clickable(
-                enabled = true,
-                onClick = restartSlowSyncForRecovery
+                enabled = false
             )
         )
         SettingsItem(

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -306,10 +306,7 @@ private fun MLSOptions(
         SettingsItem(
             title = "Error Message",
             text = mlsErrorMessage,
-            trailingIcon = R.drawable.ic_copy,
-            onIconPressed = Clickable(
-                enabled = false
-            )
+            trailingIcon = null
         )
         SettingsItem(
             title = stringResource(R.string.label_key_packages_count),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15215" title="WPB-15215" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15215</a>  [Android] Bring MLS client ID back to debug settings on internal builds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

show MLS client id in private builds



### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
