### PR TITLE
fix: hide emojis panel in minimized call mode (#WPB-14254)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -417,7 +417,10 @@ private fun OngoingCallContent(
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .drawInCallReactions(state = inCallReactionsState)
+                            .drawInCallReactions(
+                                state = inCallReactionsState,
+                                enabled = !inPictureInPictureMode,
+                            )
                     ) {
 
                         // if there is only one in the call, do not allow full screen
@@ -494,7 +497,7 @@ private fun OngoingCallContent(
             }
 
             AnimatedContent(
-                targetState = showInCallReactionsPanel,
+                targetState = showInCallReactionsPanel && !inPictureInPictureMode,
                 transitionSpec = {
                     val enter = slideInVertically(initialOffsetY = { it })
                     val exit = slideOutVertically(targetOffsetY = { it })

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/incallreactions/InCallReactionsModifier.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/incallreactions/InCallReactionsModifier.kt
@@ -47,6 +47,7 @@ fun Modifier.drawInCallReactions(
     state: InCallReactionsState,
     labelTextColor: Color = Color.White,
     labelColor: Color = Color.Black,
+    enabled: Boolean = true,
     emojiBackgroundColor: Color = colorsScheme().emojiBackgroundColor,
     emojiBackgroundSize: Dp = dimensions().inCallReactionButtonSize,
     emojiTextStyle: TextStyle = typography().inCallReactionEmoji,
@@ -63,6 +64,8 @@ fun Modifier.drawInCallReactions(
     return this then Modifier.drawWithContent {
 
         drawContent()
+
+        if (!enabled) return@drawWithContent
 
         clipRect(left = 0f, top = 0f, right = size.width, bottom = size.height) {
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14254" title="WPB-14254" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-14254</a>  [Android] In-Call Reactions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

https://wearezeta.atlassian.net/browse/WPB-14254
----
### Issues
Emoji panel stays visible (partially) when call is minimized in picture-in-picture mode.
Animated emojis are shown in minimized window.

### Solutions
Hide panel and animated emojis in picture-in-picture mode
