### PR TITLE
feat: adjust new login skeleton to edge-to-edge [WPB-14337]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -205,7 +205,6 @@ dependencies {
     ksp(libs.compose.destinations.ksp)
 
     // Accompanist
-    implementation(libs.accompanist.systemUI)
     implementation(libs.accompanist.placeholder)
 
     implementation(libs.androidx.paging3)

--- a/app/src/main/kotlin/com/wire/android/ui/SplashScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/SplashScreen.kt
@@ -20,44 +20,49 @@ package com.wire.android.ui
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
-import com.wire.android.ui.theme.WireColorPalette
 import com.wire.android.ui.theme.WireTheme
+import com.wire.android.ui.theme.wireDarkColorScheme
 import com.wire.android.util.ui.PreviewMultipleThemes
-
-@Composable
-fun MainBackgroundComponent() {
-    MainBackgroundContent()
-}
 
 @SuppressLint("PackagePrivateId")
 @Composable
-private fun MainBackgroundContent() {
-    Column(modifier = Modifier.fillMaxSize()) {
+fun SplashBackgroundLayout(
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit = {},
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = MaterialTheme.wireDarkColorScheme.background), // splash is always dark
+    ) {
         val image: Painter = painterResource(id = R.drawable.bg_waves)
         Image(
             painter = image,
             contentDescription = null,
-            contentScale = ContentScale.Crop,
+            contentScale = ContentScale.FillWidth,
+            alignment = Alignment.BottomCenter,
             modifier = Modifier
                 .fillMaxWidth()
-                .background(color = WireColorPalette.Gray100)
+                .align(Alignment.BottomCenter)
         )
+        content()
     }
 }
 
 @PreviewMultipleThemes
-@Preview(showSystemUi = true)
 @Composable
 private fun PreviewSplashScreen() = WireTheme {
-    MainBackgroundContent()
+    SplashBackgroundLayout {}
 }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -74,6 +74,7 @@ import com.wire.android.navigation.rememberNavigator
 import com.wire.android.navigation.style.BackgroundStyle
 import com.wire.android.navigation.style.BackgroundType
 import com.wire.android.ui.authentication.login.LoginNavArgs
+import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
 import com.wire.android.ui.calling.getIncomingCallIntent
 import com.wire.android.ui.calling.getOutgoingCallIntent
 import com.wire.android.ui.calling.ongoing.getOngoingCallIntent
@@ -247,7 +248,7 @@ class WireActivity : AppCompatActivity() {
                         }
                     }
                     if (backgroundType == BackgroundType.Splash) {
-                        SplashBackgroundLayout()
+                        WireAuthBackgroundLayout()
                     }
                     Column(
                         modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -55,6 +56,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import com.ramcosta.composedestinations.spec.Route
 import com.wire.android.BuildConfig
 import com.wire.android.R
@@ -69,6 +71,8 @@ import com.wire.android.navigation.MainNavHost
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.rememberNavigator
+import com.wire.android.navigation.style.BackgroundStyle
+import com.wire.android.navigation.style.BackgroundType
 import com.wire.android.ui.authentication.login.LoginNavArgs
 import com.wire.android.ui.calling.getIncomingCallIntent
 import com.wire.android.ui.calling.getOutgoingCallIntent
@@ -233,13 +237,25 @@ class WireActivity : AppCompatActivity() {
                 LocalActivity provides this
             ) {
                 WireTheme {
+                    val navigator = rememberNavigator(this@WireActivity::finish)
+                    val currentBackStackEntryState = navigator.navController.currentBackStackEntryAsState()
+                    val backgroundType by remember {
+                        derivedStateOf {
+                            currentBackStackEntryState.value?.appDestination()?.style.let {
+                                (it as? BackgroundStyle)?.backgroundType() ?: BackgroundType.Default
+                            }
+                        }
+                    }
+                    if (backgroundType == BackgroundType.Splash) {
+                        SplashBackgroundLayout()
+                    }
                     Column(
                         modifier = Modifier
                             .semantics { testTagsAsResourceId = true }
                     ) {
-                        val navigator = rememberNavigator(this@WireActivity::finish)
                         WireTopAppBar(
                             commonTopAppBarState = commonTopAppBarViewModel.state,
+                            backgroundType = backgroundType,
                         )
                         CompositionLocalProvider(LocalNavigator provides navigator) {
                             MainNavHost(
@@ -263,11 +279,13 @@ class WireActivity : AppCompatActivity() {
     @Composable
     private fun WireTopAppBar(
         commonTopAppBarState: CommonTopAppBarState,
+        backgroundType: BackgroundType,
         modifier: Modifier = Modifier,
     ) {
         CommonTopAppBar(
             modifier = modifier,
             commonTopAppBarState = commonTopAppBarState,
+            backgroundType = backgroundType,
             onReturnToCallClick = { establishedCall ->
                 getOngoingCallIntent(
                     this@WireActivity,

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -247,7 +247,7 @@ class WireActivity : AppCompatActivity() {
                             }
                         }
                     }
-                    if (backgroundType == BackgroundType.Splash) {
+                    if (backgroundType == BackgroundType.Auth) {
                         WireAuthBackgroundLayout()
                     }
                     Column(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -38,7 +38,7 @@ import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
-import com.wire.android.navigation.style.SlideSplashNavigationAnimation
+import com.wire.android.navigation.style.AuthSlideNavigationAnimation
 import com.wire.android.navigation.style.TransitionAnimationType
 import com.wire.android.ui.authentication.ServerTitle
 import com.wire.android.ui.authentication.login.email.LoginEmailScreen
@@ -64,7 +64,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 @RootNavGraph
 @WireDestination(
     navArgsDelegate = LoginNavArgs::class,
-    style = SlideSplashNavigationAnimation::class,
+    style = AuthSlideNavigationAnimation::class,
 )
 @Composable
 fun LoginScreen(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/NewLoginContainer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/NewLoginContainer.kt
@@ -19,15 +19,17 @@ package com.wire.android.ui.authentication.login
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -35,10 +37,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
-import com.wire.android.ui.MainBackgroundComponent
+import com.wire.android.ui.SplashBackgroundLayout
+import com.wire.android.ui.common.bottomsheet.WireBottomSheetDefaults
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.preview.EdgeToEdgePreview
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.theme.WireTheme
@@ -62,22 +67,24 @@ private fun NewLoginContent(
     onNavigateBack: () -> Unit,
     content: @Composable () -> Unit = { }
 ) {
+    NavigationBarBackground()
     WireScaffold(
+        containerColor = Color.Transparent,
         bottomBar = {
             Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(topEnd = dimensions().spacing8x, topStart = dimensions().spacing8x))
-                    .background(colorsScheme().surface)
-                    .padding(dimensions().spacing16x)
+                    .clip(WireBottomSheetDefaults.WireBottomSheetShape)
+                    .background(WireBottomSheetDefaults.WireSheetContainerColor)
             ) {
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(dimensions().spacing16x),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     if (canNavigateBack) {
                         Icon(
-                            imageVector = Icons.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back",
                             modifier = Modifier.clickable(onClick = onNavigateBack)
                         )
@@ -97,15 +104,33 @@ private fun NewLoginContent(
                     content()
                 }
             }
-        }) { _ ->
-        Column {
-            MainBackgroundComponent()
-        }
-    }
+        }) { _ -> }
+}
+
+@Composable
+private fun NavigationBarBackground() = Box(
+    contentAlignment = Alignment.BottomCenter,
+    modifier = Modifier.fillMaxSize()
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(colorsScheme().background)
+            .navigationBarsPadding()
+    )
 }
 
 @PreviewMultipleThemes
 @Composable
 private fun PreviewNewLoginContent() = WireTheme {
-    NewLoginContent("Enter your password to log in", true, {}) { Text(text = "EMPTY") }
+    EdgeToEdgePreview(useDarkIcons = false) {
+        SplashBackgroundLayout {
+            NewLoginContent("Enter your password to log in", true, {}) {
+                Text(
+                    text = "EMPTY",
+                    modifier = Modifier.padding(dimensions().spacing24x)
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldState
@@ -80,7 +81,8 @@ fun LoginEmailScreen(
     onSuccess: (initialSyncCompleted: Boolean, isE2EIRequired: Boolean) -> Unit,
     onRemoveDeviceNeeded: () -> Unit,
     loginEmailViewModel: LoginEmailViewModel,
-    scrollState: ScrollState = rememberScrollState()
+    scrollState: ScrollState = rememberScrollState(),
+    fillMaxHeight: Boolean = true,
 ) {
     val scope = rememberCoroutineScope()
 
@@ -103,7 +105,8 @@ fun LoginEmailScreen(
         onLoginButtonClick = loginEmailViewModel::login,
         onUpdateApp = loginEmailViewModel::updateTheApp,
         forgotPasswordUrl = loginEmailViewModel.serverConfig.forgotPassword,
-        scope = scope
+        scope = scope,
+        fillMaxHeight = fillMaxHeight,
     )
 
     LaunchedEffect(loginEmailViewModel.loginState.flowState) {
@@ -129,16 +132,20 @@ private fun LoginEmailContent(
     onLoginButtonClick: () -> Unit,
     onUpdateApp: () -> Unit,
     forgotPasswordUrl: String,
-    scope: CoroutineScope
+    scope: CoroutineScope,
+    fillMaxHeight: Boolean = true,
 ) {
     Column(
-        modifier = Modifier
-            .fillMaxHeight()
+        modifier = Modifier.let {
+            if (fillMaxHeight) it.fillMaxHeight() else it.wrapContentHeight()
+        }
     ) {
 
         Column(
             modifier = Modifier
-                .weight(weight = 1f, fill = true)
+                .let {
+                    if (fillMaxHeight) it.weight(weight = 1f, fill = true) else it
+                }
                 .verticalScroll(scrollState)
                 .padding(MaterialTheme.wireDimensions.spacing16x)
                 .semantics {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/start/StartLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/start/StartLoginScreen.kt
@@ -48,20 +48,21 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.R
 import com.wire.android.config.LocalCustomUiConfigurationProvider
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
-import com.wire.android.navigation.style.PopUpNavigationAnimation
+import com.wire.android.navigation.style.PopUpSplashNavigationAnimation
+import com.wire.android.ui.SplashBackgroundLayout
 import com.wire.android.ui.authentication.login.LoginState
 import com.wire.android.ui.authentication.login.NewLoginContainer
 import com.wire.android.ui.authentication.login.email.LoginEmailState
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.preview.EdgeToEdgePreview
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.textfield.DefaultEmailNext
 import com.wire.android.ui.common.textfield.WireAutoFillType
@@ -76,7 +77,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.configuration.server.ServerConfig
 
 @WireDestination(
-    style = PopUpNavigationAnimation::class,
+    style = PopUpSplashNavigationAnimation::class,
     navArgsDelegate = StartLoginScreenNavArgs::class,
 )
 @Composable
@@ -262,18 +263,19 @@ private fun WelcomeFooter(onTermsAndConditionClick: () -> Unit, modifier: Modifi
 
 @PreviewMultipleThemes
 @Composable
-@Preview(showSystemUi = true)
-fun PreviewWelcomeScreen() {
-    WireTheme {
-        StartLoginContent(
-            isCustomBackend = false,
-            isThereActiveSession = false,
-            state = ServerConfig.DEFAULT,
-            loginEmailState = LoginEmailState(),
-            userIdentifierState = TextFieldState(),
-            onNextClicked = {},
-            navigateBack = {},
-            navigate = {}
-        )
+fun PreviewWelcomeScreen() = WireTheme {
+    EdgeToEdgePreview(useDarkIcons = false) {
+        SplashBackgroundLayout {
+            StartLoginContent(
+                isCustomBackend = false,
+                isThereActiveSession = false,
+                state = ServerConfig.DEFAULT,
+                loginEmailState = LoginEmailState(),
+                userIdentifierState = TextFieldState(),
+                onNextClicked = {},
+                navigateBack = {},
+                navigate = {}
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/start/StartLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/start/StartLoginScreen.kt
@@ -257,13 +257,12 @@ private fun WelcomeFooter(onTermsAndConditionClick: () -> Unit, modifier: Modifi
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewWelcomeScreen() = WireTheme {
+fun PreviewStartLoginScreen() = WireTheme {
     EdgeToEdgePreview(useDarkIcons = false) {
         WireAuthBackgroundLayout {
             StartLoginContent(
                 isCustomBackend = false,
                 isThereActiveSession = false,
-                state = ServerConfig.DEFAULT,
                 loginEmailState = LoginEmailState(),
                 userIdentifierState = TextFieldState(),
                 onNextClicked = {},

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/start/StartLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/start/StartLoginScreen.kt
@@ -54,7 +54,7 @@ import com.wire.android.config.LocalCustomUiConfigurationProvider
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
-import com.wire.android.navigation.style.PopUpSplashNavigationAnimation
+import com.wire.android.navigation.style.AuthPopUpNavigationAnimation
 import com.wire.android.ui.authentication.login.LoginState
 import com.wire.android.ui.authentication.login.NewLoginContainer
 import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
@@ -76,7 +76,7 @@ import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @WireDestination(
-    style = PopUpSplashNavigationAnimation::class,
+    style = AuthPopUpNavigationAnimation::class,
     navArgsDelegate = StartLoginScreenNavArgs::class,
 )
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -31,7 +31,7 @@ import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
-import com.wire.android.navigation.style.PopUpSplashNavigationAnimation
+import com.wire.android.navigation.style.AuthPopUpNavigationAnimation
 import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
 import com.wire.android.ui.common.dialogs.FeatureDisabledWithProxyDialogContent
 import com.wire.android.ui.common.dialogs.FeatureDisabledWithProxyDialogState
@@ -48,7 +48,7 @@ import kotlinx.coroutines.delay
 
 @RootNavGraph(start = true)
 @WireDestination(
-    style = PopUpSplashNavigationAnimation::class,
+    style = AuthPopUpNavigationAnimation::class,
 )
 @Composable
 fun WelcomeScreen(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -107,7 +107,7 @@ private fun WelcomeContent(
 @Composable
 fun PreviewWelcomeScreen() = WireTheme {
     EdgeToEdgePreview(useDarkIcons = false) {
-        SplashBackgroundLayout()
+        WireAuthBackgroundLayout()
         WelcomeContent(
             state = WelcomeScreenState(ServerConfig.DEFAULT),
             navigateBack = {},

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -20,21 +20,24 @@
 
 package com.wire.android.ui.authentication.welcome
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
-import com.wire.android.navigation.style.PopUpNavigationAnimation
-import com.wire.android.ui.MainBackgroundComponent
+import com.wire.android.navigation.style.PopUpSplashNavigationAnimation
+import com.wire.android.ui.SplashBackgroundLayout
 import com.wire.android.ui.common.dialogs.FeatureDisabledWithProxyDialogContent
 import com.wire.android.ui.common.dialogs.FeatureDisabledWithProxyDialogState
 import com.wire.android.ui.common.dialogs.MaxAccountsReachedDialog
 import com.wire.android.ui.common.dialogs.MaxAccountsReachedDialogState
+import com.wire.android.ui.common.preview.EdgeToEdgePreview
 import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.destinations.StartLoginScreenDestination
 import com.wire.android.ui.theme.WireTheme
@@ -45,7 +48,7 @@ import kotlinx.coroutines.delay
 
 @RootNavGraph(start = true)
 @WireDestination(
-    style = PopUpNavigationAnimation::class
+    style = PopUpSplashNavigationAnimation::class,
 )
 @Composable
 fun WelcomeScreen(
@@ -65,7 +68,6 @@ private fun WelcomeContent(
     navigateBack: () -> Unit,
     navigate: (NavigationCommand) -> Unit
 ) {
-    MainBackgroundComponent()
     val enterpriseDisabledWithProxyDialogState = rememberVisibilityState<FeatureDisabledWithProxyDialogState>()
     val createPersonalAccountDisabledWithProxyDialogState = rememberVisibilityState<FeatureDisabledWithProxyDialogState>()
     val context = LocalContext.current
@@ -81,6 +83,9 @@ private fun WelcomeContent(
         }
     )
     FeatureDisabledWithProxyDialogContent(dialogState = createPersonalAccountDisabledWithProxyDialogState)
+
+    // empty Box to keep proper bounds of the screen for transition animation to the next screen
+    Box(modifier = Modifier.fillMaxSize())
 
     with(state.startLoginDestination) {
         LaunchedEffect(this) {
@@ -101,9 +106,9 @@ private fun WelcomeContent(
 
 @PreviewMultipleThemes
 @Composable
-@Preview(showSystemUi = true)
-fun PreviewWelcomeScreen() {
-    WireTheme {
+fun PreviewWelcomeScreen() = WireTheme {
+    EdgeToEdgePreview(useDarkIcons = false) {
+        SplashBackgroundLayout()
         WelcomeContent(
             state = WelcomeScreenState(ServerConfig.DEFAULT),
             navigateBack = {},

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
@@ -100,14 +100,14 @@ fun CommonTopAppBar(
     }
 }
 
-private enum class ConnectivityStatusColorType { Calls, Connection, Splash, Default }
+private enum class ConnectivityStatusColorType { Calls, Connection, Auth, Default }
 
 private fun getColorType(connectivityState: ConnectivityUIState, backgroundType: BackgroundType) = when (connectivityState) {
     is ConnectivityUIState.Calls -> ConnectivityStatusColorType.Calls
     is ConnectivityUIState.Connecting,
     is ConnectivityUIState.WaitingConnection -> ConnectivityStatusColorType.Connection
     is ConnectivityUIState.None -> when (backgroundType) {
-        BackgroundType.Splash -> ConnectivityStatusColorType.Splash
+        BackgroundType.Auth -> ConnectivityStatusColorType.Auth
         BackgroundType.Default -> ConnectivityStatusColorType.Default
     }
 }
@@ -116,14 +116,14 @@ private fun getColorType(connectivityState: ConnectivityUIState, backgroundType:
 private fun WireColorScheme.getBackgroundColor(statusColorType: ConnectivityStatusColorType): Color = when (statusColorType) {
     ConnectivityStatusColorType.Calls -> positive
     ConnectivityStatusColorType.Connection -> primary
-    ConnectivityStatusColorType.Splash,
+    ConnectivityStatusColorType.Auth,
     ConnectivityStatusColorType.Default -> Color.Transparent
 }
 
 private fun WireColorScheme.getStatusBarUseDarkIcons(statusColorType: ConnectivityStatusColorType): Boolean = when (statusColorType) {
     ConnectivityStatusColorType.Calls,
     ConnectivityStatusColorType.Connection -> connectivityBarShouldUseDarkIcons
-    ConnectivityStatusColorType.Splash -> false // splash is always dark so use light icons
+    ConnectivityStatusColorType.Auth -> false // splash is always dark so use light icons
     ConnectivityStatusColorType.Default -> useDarkSystemBarIcons
 }
 
@@ -458,5 +458,5 @@ fun PreviewCommonTopAppBar_ConnectivityNone() =
 @Composable
 fun PreviewCommonTopAppBar_ConnectivityNone_Splash() =
     WireAuthBackgroundLayout {
-        PreviewCommonTopAppBar(ConnectivityUIState.None, BackgroundType.Splash)
+        PreviewCommonTopAppBar(ConnectivityUIState.None, BackgroundType.Auth)
     }

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.text.style.TextAlign
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.navigation.style.BackgroundType
-import com.wire.android.ui.SplashBackgroundLayout
+import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
 import com.wire.android.ui.common.preview.EdgeToEdgePreview
 import com.wire.android.ui.theme.WireColorScheme
 import com.wire.android.ui.theme.WireTheme
@@ -457,6 +457,6 @@ fun PreviewCommonTopAppBar_ConnectivityNone() =
 @PreviewMultipleThemes
 @Composable
 fun PreviewCommonTopAppBar_ConnectivityNone_Splash() =
-    SplashBackgroundLayout {
+    WireAuthBackgroundLayout {
         PreviewCommonTopAppBar(ConnectivityUIState.None, BackgroundType.Splash)
     }

--- a/core/navigation/src/main/kotlin/com/wire/android/navigation/style/BackgroundStyle.kt
+++ b/core/navigation/src/main/kotlin/com/wire/android/navigation/style/BackgroundStyle.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.navigation.style
+
+interface BackgroundStyle {
+    fun backgroundType(): BackgroundType = BackgroundType.Default
+}
+
+enum class BackgroundType {
+    Default, Splash
+}

--- a/core/navigation/src/main/kotlin/com/wire/android/navigation/style/BackgroundStyle.kt
+++ b/core/navigation/src/main/kotlin/com/wire/android/navigation/style/BackgroundStyle.kt
@@ -22,5 +22,5 @@ interface BackgroundStyle {
 }
 
 enum class BackgroundType {
-    Default, Splash
+    Default, Auth
 }

--- a/core/navigation/src/main/kotlin/com/wire/android/navigation/style/NavigationAnimationStyles.kt
+++ b/core/navigation/src/main/kotlin/com/wire/android/navigation/style/NavigationAnimationStyles.kt
@@ -28,12 +28,12 @@ object PopUpNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle 
     override fun animationType(): TransitionAnimationType = TransitionAnimationType.POP_UP
 }
 
-object SlideSplashNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle {
+object AuthSlideNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle {
     override fun animationType(): TransitionAnimationType = TransitionAnimationType.SLIDE
     override fun backgroundType(): BackgroundType  = BackgroundType.Auth
 }
 
-object PopUpSplashNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle {
+object AuthPopUpNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle {
     override fun animationType(): TransitionAnimationType = TransitionAnimationType.POP_UP
     override fun backgroundType(): BackgroundType  = BackgroundType.Auth
 }

--- a/core/navigation/src/main/kotlin/com/wire/android/navigation/style/NavigationAnimationStyles.kt
+++ b/core/navigation/src/main/kotlin/com/wire/android/navigation/style/NavigationAnimationStyles.kt
@@ -20,10 +20,20 @@ package com.wire.android.navigation.style
 
 typealias DefaultNavigationAnimation = SlideNavigationAnimation
 
-object SlideNavigationAnimation : WireDestinationStyleAnimated {
+object SlideNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle {
     override fun animationType(): TransitionAnimationType = TransitionAnimationType.SLIDE
 }
 
-object PopUpNavigationAnimation : WireDestinationStyleAnimated {
+object PopUpNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle {
     override fun animationType(): TransitionAnimationType = TransitionAnimationType.POP_UP
+}
+
+object SlideSplashNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle {
+    override fun animationType(): TransitionAnimationType = TransitionAnimationType.SLIDE
+    override fun backgroundType(): BackgroundType  = BackgroundType.Splash
+}
+
+object PopUpSplashNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle {
+    override fun animationType(): TransitionAnimationType = TransitionAnimationType.POP_UP
+    override fun backgroundType(): BackgroundType  = BackgroundType.Splash
 }

--- a/core/navigation/src/main/kotlin/com/wire/android/navigation/style/NavigationAnimationStyles.kt
+++ b/core/navigation/src/main/kotlin/com/wire/android/navigation/style/NavigationAnimationStyles.kt
@@ -30,10 +30,10 @@ object PopUpNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle 
 
 object SlideSplashNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle {
     override fun animationType(): TransitionAnimationType = TransitionAnimationType.SLIDE
-    override fun backgroundType(): BackgroundType  = BackgroundType.Splash
+    override fun backgroundType(): BackgroundType  = BackgroundType.Auth
 }
 
 object PopUpSplashNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle {
     override fun animationType(): TransitionAnimationType = TransitionAnimationType.POP_UP
-    override fun backgroundType(): BackgroundType  = BackgroundType.Splash
+    override fun backgroundType(): BackgroundType  = BackgroundType.Auth
 }

--- a/core/ui-common/build.gradle.kts
+++ b/core/ui-common/build.gradle.kts
@@ -28,8 +28,10 @@ dependencies {
     implementation(libs.compose.ui.preview)
     debugImplementation(libs.compose.ui.tooling)
 
-    implementation(libs.accompanist.systemUI)
     implementation(libs.visibilityModifiers)
+
+    // Compose Preview
+    implementation(libs.compose.edgetoedge.preview)
 
     // Image loading
     implementation(libs.coil.core)

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/preview/EdgeToEdgePreview.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/preview/EdgeToEdgePreview.kt
@@ -1,0 +1,51 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.common.preview
+
+import android.content.res.Configuration.UI_MODE_NIGHT_NO
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalConfiguration
+import de.drick.compose.edgetoedgepreviewlib.CameraCutoutMode
+import de.drick.compose.edgetoedgepreviewlib.EdgeToEdgeTemplate
+import de.drick.compose.edgetoedgepreviewlib.NavigationMode
+
+@Composable
+fun EdgeToEdgePreview(
+    useDarkIcons: Boolean,
+    content: @Composable () -> Unit,
+) {
+    // isAppearanceLightStatusBars cannot be set for previews, so we need to apply it manually
+    // TODO: remove LocalConfiguration and just pass `isDarkMode` into EdgeToEdgeTemplate after updating edgetoedgepreviewlib to 0.6.0
+    CompositionLocalProvider(
+        LocalConfiguration provides LocalConfiguration.current.apply {
+            uiMode = if (useDarkIcons) UI_MODE_NIGHT_NO else UI_MODE_NIGHT_YES
+        }
+    ) {
+        EdgeToEdgeTemplate(
+            navMode = NavigationMode.Gesture,
+            cameraCutoutMode = CameraCutoutMode.Middle,
+            isInvertedOrientation = false,
+            showInsetsBorder = false,
+            isNavigationBarVisible = true,
+            isStatusBarVisible = true,
+            content = content,
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,9 @@ compose-navigation = "2.7.7" # adjusted to work with compose-destinations "1.9.5
 compose-destinations = "1.10.2"
 screenshot = "0.0.1-alpha08"
 
+# Compose Preview
+compose-edgetoedge-preview = "0.3.0" # update after changing target sdk to 35 and androidx-core to 1.15.0
+
 # Hilt
 hilt = "2.51.1"
 hilt-composeNavigation = "1.2.0"
@@ -215,8 +218,10 @@ compose-navigation = { module = "androidx.navigation:navigation-compose", versio
 compose-destinations-core = { module = "io.github.raamcosta.compose-destinations:animations-core", version.ref = "compose-destinations" }
 compose-destinations-ksp = { module = "io.github.raamcosta.compose-destinations:ksp", version.ref = "compose-destinations" }
 
+# Compose Preview
+compose-edgetoedge-preview = { module = "de.drick.compose:edge-to-edge-preview", version.ref = "compose-edgetoedge-preview" }
+
 # Accompanist
-accompanist-systemUI = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 accompanist-placeholder = { module = "com.google.accompanist:accompanist-placeholder", version.ref = "accompanist" }
 
 # Image Loading


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14337" title="WPB-14337" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14337</a>  [Android] - Implement UI of the initial screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- added a way of creating previews with system bars that handle edge-to-edge properly
- created new styles for navigation destinations to be able to choose the background for the given screen and moved applying splash background to `WireActivity` where navigation and topbar are implemented
- added handling background colors for status and navigation bars properly when splash or default background is set for the given screen
- fixed transitions, mainly between welcome and login screen

![topbar_previews](https://github.com/user-attachments/assets/dafec33b-aca2-4c73-b254-0f6a1493f227)

https://github.com/user-attachments/assets/7e720a74-144a-40c8-9cb2-5648dfa45915

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
