### PR TITLE
fix: Send btn not shown on closed keyboard WPB-15247

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -246,16 +246,14 @@ private fun InputContent(
                     UsersTypingIndicatorForConversation(conversationId = conversationId)
                 }
             }
-            if (showOptions) {
-                if (inputType is InputType.Composing) {
-                    MessageSendActions(
-                        onSendButtonClicked = onSendButtonClicked,
-                        sendButtonEnabled = inputType.isSendButtonEnabled,
-                        selfDeletionTimer = viewModel.state(),
-                        onChangeSelfDeletionClicked = onChangeSelfDeletionClicked,
-                        modifier = Modifier.padding(end = dimensions().spacing8x)
-                    )
-                }
+            if (inputType is InputType.Composing && (showOptions || inputType.isSendButtonEnabled)) {
+                MessageSendActions(
+                    onSendButtonClicked = onSendButtonClicked,
+                    sendButtonEnabled = inputType.isSendButtonEnabled,
+                    selfDeletionTimer = viewModel.state(),
+                    onChangeSelfDeletionClicked = onChangeSelfDeletionClicked,
+                    modifier = Modifier.padding(end = dimensions().spacing8x)
+                )
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15247" title="WPB-15247" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15247</a>  [Android] Send button not shown when user closes keyboard after typing a message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Send button not shown when user closes keyboard after typing a message

### Causes (Optional)

small mistake in `if`s 

### Solutions

check if message can be sent while showing send btn and if so - show it no meter what is the state.

### Attachments (Optional)

<img width="269" alt="Screenshot 2025-01-21 at 12 43 36" src="https://github.com/user-attachments/assets/dd520351-7351-453f-b8e4-2e7669f22068" />

