### PR TITLE
fix: scrollable folders filter [WPB-15474]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/filter/ConversationFoldersSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/filter/ConversationFoldersSheetContent.kt
@@ -25,6 +25,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -59,7 +61,8 @@ fun ConversationFoldersSheetContent(
     modifier: Modifier = Modifier
 ) {
     WireMenuModalSheetContent(
-        modifier = modifier,
+        modifier = modifier
+            .verticalScroll(rememberScrollState()),
         header = MenuModalSheetHeader.Visible(
             title = stringResource(R.string.label_folders),
             customVerticalPadding = dimensions().spacing8x,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15474" title="WPB-15474" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15474</a>  [Android] When user has many folders, list is not scrollable on android
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- added scrollable modifier to folders filter to be able to scroll them when there are more folders than screen size