### PR TITLE
fix: wrong error after adding folder [WPB-15478]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/NewFolderViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/NewFolderViewModel.kt
@@ -61,23 +61,31 @@ class NewFolderViewModel @Inject constructor(
             )
                 .collect { (folders, text) ->
                     val nameExist = folders.any { it.name == text.trim() }
-                    folderNameState = folderNameState.copy(
-                        buttonEnabled = text.trim().isNotEmpty() && !nameExist && text.length <= NAME_MAX_COUNT,
-                        error = when {
-                            text.trim().isEmpty() -> FolderNameState.NameError.TextFieldError.NameEmptyError
-                            text.length > NAME_MAX_COUNT -> FolderNameState.NameError.TextFieldError.NameExceedLimitError
-                            nameExist -> FolderNameState.NameError.TextFieldError.NameAlreadyExistError
-                            else -> FolderNameState.NameError.None
-                        }
-                    )
+                    if (!folderNameState.loading) {
+                        folderNameState = folderNameState.copy(
+                            buttonEnabled = text.trim().isNotEmpty() && !nameExist && text.length <= NAME_MAX_COUNT,
+                            error = when {
+                                text.trim().isEmpty() -> FolderNameState.NameError.TextFieldError.NameEmptyError
+                                text.length > NAME_MAX_COUNT -> FolderNameState.NameError.TextFieldError.NameExceedLimitError
+                                nameExist -> FolderNameState.NameError.TextFieldError.NameAlreadyExistError
+                                else -> FolderNameState.NameError.None
+                            }
+                        )
+                    }
                 }
         }
     }
 
     fun createFolder(folderName: String) {
         viewModelScope.launch {
+            folderNameState = folderNameState.copy(
+                loading = true
+            )
             when (val result = createConversationFolder(folderName)) {
                 is CreateConversationFolderUseCase.Result.Failure -> {
+                    folderNameState = folderNameState.copy(
+                        loading = false
+                    )
                     _infoMessage.emit(
                         UIText.StringResource(
                             R.string.new_folder_failure,

--- a/app/src/test/kotlin/com/wire/android/ui/common/bottomsheet/folder/NewFolderViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/common/bottomsheet/folder/NewFolderViewModelTest.kt
@@ -157,6 +157,24 @@ class NewFolderViewModelTest {
         assertEquals(folderId, viewModel.folderNameState.folderId)
     }
 
+    @Test
+    fun `when folder creation succeeds, then state will not show NameAlreadyExistError`() = runTest {
+        val folderId = "123"
+        val (arrangement, viewModel) = Arrangement()
+            .withCreateFolderResult(CreateConversationFolderUseCase.Result.Success(folderId))
+            .arrange {}
+
+        arrangement.userFoldersChannel.send(listOf())
+        arrangement.updateTextState("NewFolder")
+
+        viewModel.createFolder("NewFolder")
+        arrangement.userFoldersChannel.send(listOf(ConversationFolder(id = folderId, name = "NewFolder", type = FolderType.USER)))
+        advanceUntilIdle()
+
+        assertEquals(FolderNameState.NameError.None, viewModel.folderNameState.error)
+        assertTrue(viewModel.folderNameState.loading)
+    }
+
     private class Arrangement {
 
         @MockK


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15478" title="WPB-15478" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15478</a>  [Android] Error shown for a split second on successful creation of new folder
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After successfully added folder there was short period of showing error that folder name already exist. It's caused because current folder list is propagating new folder before screen closes

### Solutions

Disable updating folders state by checking progress state
