### PR TITLE
fix: Blue dot at the end of progress #WPB-14575

### DIFF
--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/progress/WireLinearProgressIndicator.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/progress/WireLinearProgressIndicator.kt
@@ -39,6 +39,7 @@ fun WireLinearProgressIndicator(
         color = colorsScheme().primary,
         trackColor = colorsScheme().primaryVariant,
         modifier = modifier,
+        drawStopIndicator = {}
     )
 }
 
@@ -47,9 +48,9 @@ fun WireLinearProgressIndicator(
 fun PreviewWireLinearProgressIndicator() = WireTheme {
     Box(
         modifier = Modifier
-        .background(colorsScheme().surface)
-        .padding(dimensions().spacing16x)
+            .background(colorsScheme().surface)
+            .padding(dimensions().spacing16x)
     ) {
-        WireLinearProgressIndicator(progress = { 0.5f })
+        WireLinearProgressIndicator(progress = { 0.3f })
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14575" title="WPB-14575" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14575</a>  [Android] Blue dot displayed on restoring backup progress bar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

There is an unnecessary blue dot displayed in the restoring backup progress bar (actually on any progress bar in app).

### Causes (Optional)

`drawStopIndicator` in `LinearProgressIndicator` that we are using in `WireLinearProgressIndicator` draws this dot.

### Solutions

set `drawStopIndicator` to empty lambda, to draw nothing at the end of progress bar.
