### PR TITLE
fix: MLS with unknown signature shown for other users devices WPB-15268

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -204,8 +204,10 @@ fun DeviceDetailsContent(
         ) {
             state.device.mlsClientIdentity?.let { identity ->
                 item {
+                    val name = state.mlsCipherSuiteSignature?.let { stringResource(id = R.string.label_mls_signature, it).uppercase() }
+                        ?: stringResource(id = R.string.label_mls_no_signature_type)
                     FolderHeader(
-                        name = stringResource(id = R.string.label_mls_signature, state.mlsCipherSuiteSignature.orEmpty()).uppercase(),
+                        name = name,
                         modifier = Modifier
                             .background(MaterialTheme.wireColorScheme.background)
                             .fillMaxWidth()

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
@@ -209,14 +209,14 @@ class DeviceDetailsViewModel @Inject constructor(
         }
     }
 
-    private fun mapCipherSuiteSignatureToShortName(signature: MLSPublicKeyType): String {
+    private fun mapCipherSuiteSignatureToShortName(signature: MLSPublicKeyType): String? {
         return when (signature) {
             MLSPublicKeyType.ECDSA_SECP256R1_SHA256 -> "P256"
             MLSPublicKeyType.ECDSA_SECP384R1_SHA384 -> "P384"
             MLSPublicKeyType.ECDSA_SECP521R1_SHA512 -> "P521"
             MLSPublicKeyType.ED25519 -> "ED25519"
             MLSPublicKeyType.ED448 -> "ED448"
-            is MLSPublicKeyType.Unknown -> "Unknown"
+            is MLSPublicKeyType.Unknown -> null
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1245,6 +1245,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="label_textfield_optional_password">Password (optional)</string>
     <string name="label_proteus_details">Proteus Device Details</string>
     <string name="label_mls_signature">MLS with %1$s Signature</string>
+    <string name="label_mls_no_signature_type">MLS</string>
     <string name="label_mls_thumbprint">MLS Thumbprint</string>
     <!--create and restore backup-->
     <string name="backup_dialog_create_backup_set_password_title">Set password</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15268" title="WPB-15268" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15268</a>  [Android] MLS with unknown signature shown for other users devices
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

When we take a look at other users devices after enabling MLS for the team, it shows “MLS with Unknown Signature” above the MLS thumbprint.

### Causes (Optional)

The original issue is in CC: type of signature is unknown.

### Solutions

To not make user confused: in case of unknown signature type display just "MLS" label instead of "MLS with unknown signature"

### Attachments (Optional)

<img width="389" alt="Screenshot 2025-01-24 at 13 27 37" src="https://github.com/user-attachments/assets/3de06d20-cdde-43c4-82d2-a8921e8a48a6" />
