### PR TITLE
fix: collapse expanded text field after click on send message [WPB-14574]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -140,6 +140,7 @@ fun MessageComposer(
                         onClearMentionSearchResult()
                         clearMessage()
                         messageCompositionHolder.value.onClearDraft()
+                        messageCompositionInputStateHolder.collapseText()
                     },
                     onPingOptionClicked = onPingOptionClicked,
                     onImagesPicked = onImagesPicked,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14574" title="WPB-14574" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14574</a>  [Android] Expanded textfield should close automatically after message was sent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- hide expanded text field in message compose after sending message