### PR TITLE
feat: enterprise login, adjust style initial screen - remove footer (WPB-15520)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/WireAuthBackgroundComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/WireAuthBackgroundComponent.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.android.ui.authentication.login
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -37,7 +36,7 @@ import com.wire.android.ui.theme.wireDarkColorScheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
-fun  WireAuthBackgroundLayout(
+fun WireAuthBackgroundLayout(
     modifier: Modifier = Modifier,
     content: @Composable BoxScope.() -> Unit = {},
 ) {

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginContainer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginContainer.kt
@@ -82,7 +82,8 @@ fun NewLoginContainer(
                     content()
                 }
             }
-        }) { _ -> }
+        }
+    ) { _ -> }
 }
 
 @Composable
@@ -143,7 +144,6 @@ private fun NavigationBarBackground() = Box(
 private fun PreviewNewLoginHeader() = WireTheme {
     NewLoginHeader("Enter your password to log in", true) {}
 }
-
 
 @PreviewMultipleThemes
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
@@ -20,13 +20,10 @@
 
 package com.wire.android.ui.newauthentication.login
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardOptions
@@ -47,10 +44,8 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.R
-import com.wire.android.config.LocalCustomUiConfigurationProvider
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
@@ -70,9 +65,7 @@ import com.wire.android.ui.common.textfield.WireTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.destinations.NewLoginPasswordScreenDestination
 import com.wire.android.ui.theme.WireTheme
-import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
-import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @WireDestination(
@@ -128,7 +121,9 @@ private fun LoginContent(
                     }
             ) {
                 val error = when (loginEmailState.flowState) {
-                    is LoginState.Error.TextFieldError.InvalidValue -> stringResource(R.string.enterprise_login_error_invalid_user_identifier)
+                    is LoginState.Error.TextFieldError.InvalidValue ->
+                        stringResource(R.string.enterprise_login_error_invalid_user_identifier)
+
                     else -> null
                 }
                 EmailOrSSOCodeInput(userIdentifierState, error)
@@ -141,14 +136,6 @@ private fun LoginContent(
                             navigate(NavigationCommand(NewLoginPasswordScreenDestination(userHandle = userIdentifierState.text.toString())))
                         }
                     }
-                )
-            }
-
-            if (LocalCustomUiConfigurationProvider.current.isAccountCreationAllowed) {
-                val termsUrl = stringResource(id = R.string.url_terms_of_use_legal)
-                LoginFooter(
-                    modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.welcomeTextHorizontalPadding),
-                    onTermsAndConditionClick = { CustomTabsHelper.launchUrl(context, termsUrl) }
                 )
             }
         }
@@ -196,34 +183,6 @@ private fun EmailOrSSOCodeInput(
         modifier = Modifier.testTag("emailField"),
         testTag = "userIdentifierInput",
     )
-}
-
-@Composable
-private fun LoginFooter(onTermsAndConditionClick: () -> Unit, modifier: Modifier = Modifier) {
-    Column(modifier = modifier) {
-        Text(
-            text = stringResource(R.string.enterprise_login_title_terms_description),
-            style = MaterialTheme.wireTypography.subline01,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        Text(
-            text = stringResource(R.string.enterprise_login_title_terms_link),
-            style = MaterialTheme.wireTypography.subline01.copy(textDecoration = TextDecoration.Underline),
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = onTermsAndConditionClick,
-                    onClickLabel = stringResource(R.string.enterprise_login_title_terms_link)
-                )
-        )
-
-        Spacer(modifier = Modifier.height(MaterialTheme.wireDimensions.welcomeVerticalPadding))
-    }
 }
 
 @PreviewMultipleThemes

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
@@ -94,7 +94,6 @@ private fun LoginContent(
     navigate: (NavigationCommand) -> Unit
 ) {
     NewLoginContainer {
-        val context = LocalContext.current
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/welcome/NewWelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/welcome/NewWelcomeScreen.kt
@@ -55,9 +55,9 @@ import kotlin.time.Duration.Companion.seconds
     navArgsDelegate = LoginNavArgs::class
 )
 @Composable
-// this is a temporary solution because annotation argument "start" must be a compile-time constant
-// TODO: remove this composable as well when removing old WelcomeScreen and set start = true for NewWelcomeScreen
 fun WelcomeChooserScreen(navigator: Navigator) {
+    // this is a temporary solution because annotation argument "start" must be a compile-time constant
+    // TODO: remove this composable as well when removing old WelcomeScreen and set start = true for NewWelcomeScreen
     LaunchedEffect(Unit) {
         val destination = if (BuildConfig.ENTERPRISE_LOGIN_ENABLED) NewWelcomeScreenDestination else WelcomeScreenDestination
         navigator.navigate(NavigationCommand(destination))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -362,8 +362,6 @@
     <!-- Enterprise Login -->
     <string name="enterprise_login_welcome">Enter your email to start!</string>
     <string name="enterprise_login_title">Enter your password to log in</string>
-    <string name="enterprise_login_title_terms_description">By pressing on \"Next\", you accept Wire\'s</string>
-    <string name="enterprise_login_title_terms_link">Terms and Conditions</string>
     <string name="enterprise_login_next">Next</string>
     <string name="enterprise_login_user_identifier_label">EMAIL OR SSO CODE</string>
     <string name="enterprise_login_user_identifier_label_placeholder">Enter Email or SSO Code</string>

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/ValidateEmailOrSSOCodeUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/ValidateEmailOrSSOCodeUseCaseTest.kt
@@ -94,5 +94,4 @@ class ValidateEmailOrSSOCodeUseCaseTest {
 
         fun arrange() = this to ValidateEmailOrSSOCodeUseCase(validateEmailUseCase, validateSSOCodeUseCase)
     }
-
 }

--- a/core/navigation/src/main/kotlin/com/wire/android/navigation/style/NavigationAnimationStyles.kt
+++ b/core/navigation/src/main/kotlin/com/wire/android/navigation/style/NavigationAnimationStyles.kt
@@ -30,10 +30,10 @@ object PopUpNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle 
 
 object AuthSlideNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle {
     override fun animationType(): TransitionAnimationType = TransitionAnimationType.SLIDE
-    override fun backgroundType(): BackgroundType  = BackgroundType.Auth
+    override fun backgroundType(): BackgroundType = BackgroundType.Auth
 }
 
 object AuthPopUpNavigationAnimation : WireDestinationStyleAnimated, BackgroundStyle {
     override fun animationType(): TransitionAnimationType = TransitionAnimationType.POP_UP
-    override fun backgroundType(): BackgroundType  = BackgroundType.Auth
+    override fun backgroundType(): BackgroundType = BackgroundType.Auth
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15520" title="WPB-15520" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15520</a>  [Android] - Implement error handling for initial screens
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Adjust designs, footer was removed from the first screen.
- Fix detekt issues 

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
