### PR TITLE
fix: Audio wave mask fixes #WPB-11723

### DIFF
--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioWavesMaskHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioWavesMaskHelper.kt
@@ -46,7 +46,12 @@ class AudioWavesMaskHelper @Inject constructor(
         if (this.isEmpty()) return listOf()
 
         val divider = max() / (WAVE_MAX - 1)
-        return map { (it / divider).roundToInt() + 1 }
+
+        return if (divider == 0.0) {
+            map { 1 }
+        } else {
+            map { (it / divider).roundToInt() + 1 }
+        }
     }
 
     private fun List<Int>.averageWavesMask(): List<Double> {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioComponent.kt
@@ -105,7 +105,7 @@ fun RecordAudioComponent(
 
         val buttonModifier = Modifier
             .align(Alignment.BottomCenter)
-            .padding(bottom = dimensions().spacing20x)
+            .padding(bottom = dimensions().spacing20x, top = dimensions().spacing28x)
 
         when (viewModel.state.buttonState) {
             RecordAudioButtonState.ENABLED -> RecordAudioButtonEnabled(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11723" title="WPB-11723" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11723</a>  [Android] Playback improvement - 1 - Scroll / Duration / Speed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

After adding a new design for AudioMessages, 2 issues found out:
1. crash when recorded message has no any sound
2. when recorded message is ready to send and user could listen it: waves covered by "close" button

### Causes (Optional)

1. there is a dividing by 0, when calculating waves and equalising them.
2. just a compose issue, didn't seen before

### Solutions

1. if all the waves are 0 - do nothing for equalising them
2. just add spacing to move recorded message a bit down.

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 

| Before | After |
| ----------- | ------------ |
|  ![photo_5240078122706136187_y](https://github.com/user-attachments/assets/9365c1f1-c91d-4911-8bcb-4201767f5cf6) | ![photo_5240078122706136188_y](https://github.com/user-attachments/assets/bd90489d-22a7-4983-a933-ae3e750b81d2)  |


