### PR TITLE
fix: InCallReaction background in dark mode #WPB-15550

### DIFF
--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -260,7 +260,7 @@ private val DarkWireColorScheme = WireColorScheme(
             Accent.Unknown -> WireColorPalette.DarkBlue500
         }
     },
-    emojiBackgroundColor = Color.White,
+    emojiBackgroundColor = Color.Black,
 )
 
 @PackagePrivate


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15550" title="WPB-15550" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15550</a>  [Android] In call reactions shown in light mode when user is in dark mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

When the user has the app set to dark mode, the incall reactions are shown in light mode once a reaction is sent.
We should also show them in dark mode.

### Causes (Optional)

`emojiBackgroundColor` in dark color scheme was wrong.

### Solutions

set a correct  color to `emojiBackgroundColor`

### Attachments (Optional)

<img width="270" alt="Screenshot 2025-01-27 at 15 30 30" src="https://github.com/user-attachments/assets/4807fd20-73d6-4ed3-b712-421909adb76f" />
