### PR TITLE
fix: Wrong emojy order in message context menu #WPB-15119

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/edit/ReactionOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/ReactionOption.kt
@@ -79,7 +79,7 @@ fun ReactionOption(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
-                listOf("❤️", "👍", "😁", "🙂", "☹️", "👎").forEach { emoji ->
+                listOf("👍", "🙂", "❤️", "☹️", "👎").forEach { emoji ->
                     CompositionLocalProvider(
                         LocalMinimumInteractiveComponentSize provides Dp.Unspecified,
                     ) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15119" title="WPB-15119" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15119</a>  Emojis in the message context menu have the wrong order and selection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

In message context menu: the order and the available emojis is different to the mocks and the implementation on iOS

### Causes (Optional)

we'll never find out.

### Solutions

order it correctly.

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 

| Before | After |
| ----------- | ------------ |
|  ![photo_5240078122706136305_y](https://github.com/user-attachments/assets/788f8809-c3d9-4710-9df9-8ec205883b3d)  | ![photo_5240078122706136269_y](https://github.com/user-attachments/assets/8c288108-60cc-4887-a55a-4f437f132047)  |
