### PR TITLE
fix: disable import media during slow sync [WPB-15790]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/sync/SyncStatusViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/sync/SyncStatusViewModel.kt
@@ -1,0 +1,76 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.common.sync
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.di.ScopedArgs
+import com.wire.android.di.ViewModelScopedPreview
+import com.wire.kalium.logic.data.sync.SyncState
+import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import javax.inject.Inject
+
+@ViewModelScopedPreview
+interface SyncStatusViewModel {
+    val state: SyncStatusState
+        get() = SyncStatusState.SlowSyncCompleted
+}
+
+@HiltViewModel
+class SyncStatusViewModelImpl @Inject constructor(
+    private val observeSyncStateUseCase: ObserveSyncStateUseCase
+) : ViewModel(), SyncStatusViewModel {
+
+    override var state: SyncStatusState by mutableStateOf(SyncStatusState.Pending)
+
+    init {
+        observeSyncState()
+    }
+
+    fun observeSyncState() {
+        viewModelScope.launch {
+            observeSyncStateUseCase()
+                .collect { syncState ->
+                    state = when (syncState) {
+                        is SyncState.Failed -> SyncStatusState.Failed
+                        SyncState.GatheringPendingEvents -> SyncStatusState.SlowSyncCompleted
+                        SyncState.Live -> SyncStatusState.SlowSyncCompleted
+                        SyncState.SlowSync -> SyncStatusState.Pending
+                        SyncState.Waiting -> SyncStatusState.Pending
+                    }
+                }
+        }
+    }
+}
+
+enum class SyncStatusState {
+    Failed,
+    SlowSyncCompleted,
+    Pending
+}
+
+@Serializable
+object SyncStatusArgs : ScopedArgs {
+    override val key = "SyncStatusArgsKey"
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SelectParticipantsButtonsRow.kt
@@ -74,12 +74,14 @@ fun SendContentButton(
     onMainButtonClick: () -> Unit,
     onSelfDeletionTimerClicked: () -> Unit,
     modifier: Modifier = Modifier,
-    selfDeletionTimer: SelfDeletionTimer = SelfDeletionTimer.Disabled
+    selfDeletionTimer: SelfDeletionTimer = SelfDeletionTimer.Disabled,
+    loading: Boolean = false
 ) {
     val isSelfDeletionButtonVisible = selfDeletionTimer is SelfDeletionTimer.Enabled
     SelectParticipantsButtonsRow(
         modifier = modifier,
         showTotalSelectedItemsCount = false,
+        loading = loading,
         selectedParticipantsCount = count,
         leadingIcon = {
             Image(
@@ -119,7 +121,8 @@ fun SelectParticipantsButtonsRow(
     selectedParticipantsCount: Int = 0,
     shouldAllowNoSelectionContinue: Boolean = true,
     elevation: Dp = MaterialTheme.wireDimensions.bottomNavigationShadowElevation,
-    onMoreButtonIcon: @Composable (() -> Unit)? = null
+    onMoreButtonIcon: @Composable (() -> Unit)? = null,
+    loading: Boolean = false,
 ) {
     Surface(
         color = MaterialTheme.wireColorScheme.background,
@@ -139,6 +142,7 @@ fun SelectParticipantsButtonsRow(
             )
             val buttonText = if (showTotalSelectedItemsCount) "$mainButtonText ($countText)" else mainButtonText
             WirePrimaryButton(
+                loading = loading,
                 text = buttonText,
                 leadingIcon = leadingIcon,
                 onClick = onMainButtonClick,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15790" title="WPB-15790" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15790</a>  [Android] Client created a second conversation when sharing an image through share extension
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
- There is a race condition where sharing an image via the share extension during slow sync could send message to already migrated 1:1 conversation.

### Causes (Optional)
- The temporary inconsistency in conversation resolution led to a state where multiple 1:1 conversations were displayed across different clients.
- Eventually, the duplicate conversation was removed after a delayed sync resolution, but it caused confusion and message loss.

### Solutions
- Introduced `SyncStatusViewModel` to track the sync state and prevent sending media when slow sync is in progress.
- Disabled the send button (`loading` state) until slow sync completes, ensuring that messages are only sent to a fully resolved conversation.


### Attachments (Optional)

![Screenshot 2025-01-31 at 13 50 50](https://github.com/user-attachments/assets/881dad4b-2555-4183-acf9-e107e14a8d01)
