### PR TITLE
fix: Crash on inserting mention #WPB-15717

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -271,8 +271,7 @@ fun EnabledMessageComposer(
                         )
 
                         val mentionSearchResult = messageComposerViewState.value.mentionSearchResult
-                        if (mentionSearchResult.isNotEmpty() && inputStateHolder.isTextExpanded
-                        ) {
+                        if (mentionSearchResult.isNotEmpty() && inputStateHolder.isTextExpanded) {
                             DropDownMentionsSuggestions(
                                 currentSelectedLineIndex = currentSelectedLineIndex,
                                 cursorCoordinateY = cursorCoordinateY,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.substring
+import com.wire.android.appLogger
 import com.wire.android.ui.home.conversations.model.UIMention
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
@@ -200,6 +201,10 @@ class MessageCompositionHolder(
             userId = UserId(contact.id, contact.domain),
             handler = String.MENTION_SYMBOL + contact.name
         )
+        if (mention.start < 0 || mention.length < 2) {
+            appLogger.e("MessageCompositionHolder: Failure to add mention")
+            return
+        }
         insertMentionIntoText(mention)
         messageComposition.update {
             it.copy(

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolderTest.kt
@@ -24,7 +24,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.text.TextRange
 import com.wire.android.config.SnapshotExtension
 import com.wire.android.framework.TestConversation
+import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
+import com.wire.android.ui.home.newconversation.model.Contact
+import com.wire.kalium.logic.data.user.ConnectionState
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.Dispatchers
@@ -173,5 +176,57 @@ class MessageCompositionHolderTest {
             "_italic_",
             state.messageTextState.text.toString()
         )
+    }
+
+    @Test
+    fun `given non empty text, when adding mention, mention is added`() = runTest {
+        // given
+        val text = "@men"
+        state.messageTextState.edit {
+            replace(0, length, text)
+            selection = TextRange(start = text.length, end = text.length)
+        }
+
+        // when
+        state.addMention(
+            Contact(
+                id = "id",
+                domain = "domain",
+                name = "name",
+                handle = "men handle",
+                connectionState = ConnectionState.ACCEPTED,
+                membership = Membership.Guest
+            )
+        )
+
+        // then
+        assertEquals("@name ", state.messageTextState.text.toString())
+        assertEquals(1, state.messageComposition.value.selectedMentions.size)
+    }
+
+    @Test
+    fun `given non empty text without @ symbol, when adding mention, nothing happen`() = runTest {
+        // given
+        val text = "mann"
+        state.messageTextState.edit {
+            replace(0, length, text)
+            selection = TextRange(start = 4, end = 4)
+        }
+
+        // when
+        state.addMention(
+            Contact(
+                id = "id",
+                domain = "domain",
+                name = "name",
+                handle = "men handle",
+                connectionState = ConnectionState.ACCEPTED,
+                membership = Membership.Guest
+            )
+        )
+
+        // then
+        assertEquals(text, state.messageTextState.text.toString())
+        assertEquals(0, state.messageComposition.value.selectedMentions.size)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15717" title="WPB-15717" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15717</a>  [Android] play store crashes when inserting a mention
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

Crash in PlayStore while inserting mention. 

### Causes (Optional)

Hard to understand exact STR, but the crash happens when mentions place in text can't be found. In that case mention's position is `-1` and crash come up in `String.subSequence(0, -1)`

### Solutions

Added checking if mention position and length are good, do not add mention otherwise and added logs.

