### PR TITLE
fix: Crash on call to non-currentUser WPB-15804

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
@@ -225,21 +225,24 @@ class CallNotificationBuilder @Inject constructor(
             .setSubText(data.userName)
             .setAutoCancel(false)
             .setOngoing(true)
-            .setStyle(
-                CallStyle.forIncomingCall(
-                    person,
-                    declineCallPendingIntent(context, conversationIdString, userIdString),
-                    answerCallPendingIntent(context, conversationIdString, userIdString)
-                )
-            )
             .setVibrate(VIBRATE_PATTERN)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setContentIntent(fullScreenIncomingCallPendingIntent(context, conversationIdString, userIdString))
             .let {
                 if (asFullScreenIntent) {
                     it.setFullScreenIntent(fullScreenIncomingCallPendingIntent(context, conversationIdString, userIdString), true)
+                        .setStyle(
+                            CallStyle.forIncomingCall(
+                                person,
+                                declineCallPendingIntent(context, conversationIdString, userIdString),
+                                answerCallPendingIntent(context, conversationIdString, userIdString)
+                            )
+                        )
                 } else {
-                    it
+                    // CallStyle available only for FullScreenIntent or Services notification.
+                    // So for non-asFullScreenIntent we have show regular notification with actions.
+                    it.addAction(getDeclineCallAction(context, conversationIdString, userIdString))
+                        .addAction(getOpenIncomingCallAction(context, conversationIdString, userIdString))
                 }
             }
             .build()

--- a/app/src/main/kotlin/com/wire/android/notification/NotificationActions.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/NotificationActions.kt
@@ -19,6 +19,7 @@
 package com.wire.android.notification
 
 import android.app.Notification
+import android.app.PendingIntent
 import android.content.Context
 import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
@@ -47,3 +48,17 @@ fun getActionReply(
             .build()
     }
 }
+
+fun getOpenIncomingCallAction(context: Context, conversationId: String, userId: String) = getAction(
+    context.getString(R.string.notification_action_open_call),
+    fullScreenIncomingCallPendingIntent(context, conversationId, userId)
+)
+
+fun getDeclineCallAction(context: Context, conversationId: String, userId: String) = getAction(
+    context.getString(R.string.notification_action_decline_call),
+    declineCallPendingIntent(context, conversationId, userId)
+)
+
+private fun getAction(title: String, intent: PendingIntent) = NotificationCompat.Action
+    .Builder(null, title, intent)
+    .build()

--- a/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
@@ -51,7 +51,7 @@ fun messagePendingIntent(context: Context, conversationId: String, userId: Strin
             .appendQueryParameter(DeepLinkProcessor.USER_TO_USE_QUERY_PARAM, userId)
             .build()
     }
-    val requestCode = getRequestCode(conversationId, OPEN_MESSAGE_REQUEST_CODE_PREFIX)
+    val requestCode = getRequestCode(OPEN_MESSAGE_REQUEST_CODE_PREFIX, userId.orEmpty(), conversationId)
 
     return PendingIntent.getActivity(
         context.applicationContext,
@@ -70,7 +70,7 @@ fun otherUserProfilePendingIntent(context: Context, destinationUserId: String, u
             .appendQueryParameter(DeepLinkProcessor.USER_TO_USE_QUERY_PARAM, userId)
             .build()
     }
-    val requestCode = getRequestCode(destinationUserId, OPEN_OTHER_USER_PROFILE_CODE_PREFIX)
+    val requestCode = getRequestCode(OPEN_OTHER_USER_PROFILE_CODE_PREFIX, userId, destinationUserId)
 
     return PendingIntent.getActivity(
         context.applicationContext,
@@ -88,7 +88,7 @@ fun summaryMessagePendingIntent(context: Context): PendingIntent = openAppPendin
 
 fun replyMessagePendingIntent(context: Context, conversationId: String, userId: String?): PendingIntent = PendingIntent.getBroadcast(
     context,
-    getRequestCode(conversationId, REPLY_MESSAGE_REQUEST_CODE_PREFIX),
+    getRequestCode(REPLY_MESSAGE_REQUEST_CODE_PREFIX, userId.orEmpty(), conversationId),
     NotificationReplyReceiver.newIntent(context, conversationId, userId),
     PendingIntent.FLAG_MUTABLE
 )
@@ -109,7 +109,7 @@ fun endOngoingCallPendingIntent(context: Context, conversationId: String, userId
 
     return PendingIntent.getBroadcast(
         context.applicationContext,
-        getRequestCode(conversationId, END_ONGOING_CALL_REQUEST_CODE),
+        getRequestCode(END_ONGOING_CALL_REQUEST_CODE, userId, conversationId),
         intent,
         PendingIntent.FLAG_IMMUTABLE
     )
@@ -125,7 +125,7 @@ fun declineCallPendingIntent(context: Context, conversationId: String, userId: S
 
     return PendingIntent.getBroadcast(
         context.applicationContext,
-        getRequestCode(conversationId, DECLINE_CALL_REQUEST_CODE),
+        getRequestCode(DECLINE_CALL_REQUEST_CODE, userId, conversationId),
         intent,
         PendingIntent.FLAG_IMMUTABLE
     )
@@ -149,7 +149,7 @@ fun answerCallPendingIntent(context: Context, conversationId: String, userId: St
         )
         return PendingIntent.getBroadcast(
             context.applicationContext,
-            getRequestCode(conversationId, ANSWER_CALL_REQUEST_CODE),
+            getRequestCode(ANSWER_CALL_REQUEST_CODE, userId, conversationId),
             intent,
             PendingIntent.FLAG_IMMUTABLE
         )
@@ -174,7 +174,7 @@ fun fullScreenIncomingCallPendingIntent(context: Context, conversationId: String
 
     return PendingIntent.getActivity(
         context,
-        getRequestCode(conversationId, FULL_SCREEN_REQUEST_CODE),
+        getRequestCode(FULL_SCREEN_REQUEST_CODE, userId, conversationId),
         intent,
         PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
     )
@@ -227,7 +227,7 @@ fun playPauseAudioPendingIntent(context: Context): PendingIntent {
 
     return PendingIntent.getBroadcast(
         context.applicationContext,
-        getRequestCode("", PLAY_PAUSE_AUDIO_REQUEST_CODE),
+        getRequestCode(PLAY_PAUSE_AUDIO_REQUEST_CODE),
         intent,
         PendingIntent.FLAG_IMMUTABLE
     )
@@ -238,7 +238,7 @@ fun stopAudioPendingIntent(context: Context): PendingIntent {
 
     return PendingIntent.getBroadcast(
         context.applicationContext,
-        getRequestCode("", STOP_AUDIO_REQUEST_CODE),
+        getRequestCode(STOP_AUDIO_REQUEST_CODE),
         intent,
         PendingIntent.FLAG_IMMUTABLE
     )
@@ -258,4 +258,5 @@ private const val OPEN_MESSAGE_REQUEST_CODE_PREFIX = "open_message_"
 private const val OPEN_OTHER_USER_PROFILE_CODE_PREFIX = "open_other_user_profile_"
 private const val REPLY_MESSAGE_REQUEST_CODE_PREFIX = "reply_"
 
-private fun getRequestCode(conversationId: String, prefix: String): Int = (prefix + conversationId).hashCode()
+private fun getRequestCode(prefix: String, userId: String = "", conversationId: String = ""): Int =
+    (prefix + userId + conversationId).hashCode()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -966,6 +966,8 @@
     <string name="notification_action_reply">Reply</string>
     <string name="notification_receiver_name">You</string>
     <string name="label_type_a_message">Type a message</string>
+    <string name="notification_action_open_call">Open Call</string>
+    <string name="notification_action_decline_call">Decline</string>
     <string name="notification_incoming_call_content">Calling…</string>
     <string name="notification_ongoing_call_content">Ongoing call…</string>
     <string name="notification_group_call_content">%s calling...</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15804" title="WPB-15804" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15804</a>  [Android] App crashing on oncoming group call if 2 users are logged in and in the same group conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

1. Crash receiving a call to non-currentUser
STR:
- login on 2 users at 1 device
- call into user that is not "current"
result: crash `CallStyle notifications must either be for a foreground Service or use a fullScreenIntent.`

2. wrong call ended on click `Decline` in notification
STR: 
- login on 2 users at 1 device
- add both users to the same group
- call in that group from some other user
- receive 2 notifications about calling
- decline call for current user
result: cal declined for non-currentUser

### Causes (Optional)

1. For distinguish and do not auto-switching account when the call comes to non-currentUser we made notification for that users regular, not `FullScreenIntent`. But the problem that we can't use CallStyle for the notification in that case.
2. `requestCode` for the `PendingIntent` for actions in notification are the same for the same conversation but different users: while creating request code only conversationId is taken into consideration. As result: 2 notifications for 2 users but for the same conversation (in group call, or message in group) have actions with the same PendingIntents.

### Solutions

1. Remove `CallStyle` for not-FullScreenIntent notifications and add regular Actions for open a call Or decline it.
2. Update creating `requestCode` for the `PendingIntent` to take userId into consideration.
