### PR TITLE
feat: deeplink parameter to select login flow [WPB-15982]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityDialogs.kt
@@ -57,6 +57,7 @@ import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dialogs.CustomServerDetailsDialog
 import com.wire.android.ui.common.dialogs.CustomServerDetailsDialogState
+import com.wire.android.ui.common.dialogs.CustomServerDialogState
 import com.wire.android.ui.common.dialogs.CustomServerNoNetworkDialog
 import com.wire.android.ui.common.dialogs.CustomServerNoNetworkDialogState
 import com.wire.android.ui.common.dialogs.MaxAccountAllowedDialogContent
@@ -69,6 +70,7 @@ import com.wire.android.ui.joinConversation.JoinConversationViaDeepLinkDialog
 import com.wire.android.ui.joinConversation.JoinConversationViaInviteLinkError
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.deeplink.LoginType
 import com.wire.android.util.deviceDateTimeFormat
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
@@ -242,23 +244,27 @@ fun JoinConversationDialog(
 
 @Composable
 fun CustomBackendDialog(
-    globalAppState: GlobalAppState,
+    state: CustomServerDialogState?,
     onDismiss: () -> Unit,
-    onConfirm: () -> Unit,
-    onTryAgain: (String) -> Unit
+    onConfirm: (LoginType) -> Unit,
+    onTryAgain: (String, LoginType) -> Unit
 ) {
-    when (globalAppState.customBackendDialog) {
+    when (state) {
         is CustomServerDetailsDialogState -> {
             CustomServerDetailsDialog(
-                serverLinks = globalAppState.customBackendDialog.serverLinks,
+                serverLinks = state.serverLinks,
                 onDismiss = onDismiss,
-                onConfirm = onConfirm
+                onConfirm = {
+                    onConfirm(state.loginType)
+                }
             )
         }
 
         is CustomServerNoNetworkDialogState -> {
             CustomServerNoNetworkDialog(
-                onTryAgain = { onTryAgain(globalAppState.customBackendDialog.customServerUrl) },
+                onTryAgain = {
+                    onTryAgain(state.customServerUrl, state.loginType)
+                },
                 onDismiss = onDismiss
             )
         }
@@ -577,14 +583,10 @@ fun PreviewJoinConversationDialogError() {
 fun PreviewCustomBackendDialog() {
     WireTheme {
         CustomBackendDialog(
-            GlobalAppState(
-                customBackendDialog = CustomServerDetailsDialogState(
-                    ServerConfig.STAGING
-                )
-            ),
-            {},
-            {},
-            {}
+            state = CustomServerDetailsDialogState(ServerConfig.STAGING),
+            onDismiss = {},
+            onConfirm = {},
+            onTryAgain = { _, _ -> },
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomServerDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomServerDialog.kt
@@ -45,6 +45,7 @@ import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.wireDialogPropertiesBuilder
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.deeplink.LoginType
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.configuration.server.ServerConfig
 
@@ -165,9 +166,14 @@ private fun CustomServerPropertyInfo(
     }
 }
 
-sealed class CustomServerDialogState
+sealed interface CustomServerDialogState {
+    val loginType: LoginType
+}
 
-data class CustomServerDetailsDialogState(val serverLinks: ServerConfig.Links) : CustomServerDialogState()
+data class CustomServerDetailsDialogState(
+    val serverLinks: ServerConfig.Links,
+    override val loginType: LoginType = LoginType.Default,
+) : CustomServerDialogState
 
 @PreviewMultipleThemes
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomServerNoNetworkDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/CustomServerNoNetworkDialog.kt
@@ -25,6 +25,7 @@ import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.deeplink.LoginType
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
@@ -55,7 +56,10 @@ internal fun CustomServerNoNetworkDialog(
     )
 }
 
-data class CustomServerNoNetworkDialogState(val customServerUrl: String) : CustomServerDialogState()
+data class CustomServerNoNetworkDialogState(
+    val customServerUrl: String,
+    override val loginType: LoginType = LoginType.Default,
+) : CustomServerDialogState
 
 @PreviewMultipleThemes
 @Composable

--- a/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
@@ -41,7 +41,7 @@ import javax.inject.Singleton
 
 sealed class DeepLinkResult {
     data object Unknown : DeepLinkResult()
-    data class CustomServerConfig(val url: String) : DeepLinkResult()
+    data class CustomServerConfig(val url: String, val loginType: LoginType = LoginType.Default) : DeepLinkResult()
 
     @Serializable
     sealed class SSOLogin : DeepLinkResult() {
@@ -211,7 +211,8 @@ class DeepLinkProcessor @Inject constructor(
 
     private fun getCustomServerConfigDeepLinkResult(uri: Uri) =
         uri.getQueryParameter(SERVER_CONFIG_PARAM)?.let {
-            DeepLinkResult.CustomServerConfig(it)
+            val loginType = LoginType.getByName(uri.getQueryParameter(SERVER_CONFIG_LOGIN_TYPE_PARAM) ?: LoginType.Default.name)
+            DeepLinkResult.CustomServerConfig(it, loginType)
         } ?: DeepLinkResult.Unknown
 
     private fun getSSOLoginDeepLinkResult(uri: Uri): DeepLinkResult {
@@ -246,6 +247,7 @@ class DeepLinkProcessor @Inject constructor(
         const val E2EI_DEEPLINK_OAUTH_REDIRECT_PATH = "oauth2redirect"
         const val ACCESS_DEEPLINK_HOST = "access"
         const val SERVER_CONFIG_PARAM = "config"
+        const val SERVER_CONFIG_LOGIN_TYPE_PARAM = "login-type"
         const val SSO_LOGIN_DEEPLINK_HOST = "sso-login"
         const val SSO_LOGIN_FAILURE = "failure"
         const val SSO_LOGIN_SUCCESS = "success"
@@ -311,4 +313,12 @@ enum class SwitchAccountStatus {
     NoNeeded,
     FailedDueToCall,
     FailedDueToUnknownError
+}
+
+enum class LoginType {
+    Default, Old, New;
+
+    companion object {
+        fun getByName(value: String) = entries.firstOrNull { it.name.lowercase() == value.lowercase() } ?: Default
+    }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -113,7 +113,7 @@ class WireActivityViewModelTest {
             .withSomeCurrentSession()
             .arrange()
 
-        viewModel.handleDeepLink(null, {}, {}, {}, {}, {}, {}, {})
+        viewModel.handleDeepLink(null, {}, {}, {}, {}, {}, {}, {}, {})
 
         assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
     }
@@ -124,7 +124,7 @@ class WireActivityViewModelTest {
             .withNoCurrentSession()
             .arrange()
 
-        viewModel.handleDeepLink(null, {}, {}, {}, {}, {}, {}, {})
+        viewModel.handleDeepLink(null, {}, {}, {}, {}, {}, {}, {}, {})
 
         assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
     }
@@ -138,7 +138,7 @@ class WireActivityViewModelTest {
             .withNoOngoingCall()
             .arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
+        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
         coVerify(exactly = 1) { arrangement.deepLinkProcessor.invoke(any(), any()) }
         verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
     }
@@ -154,7 +154,7 @@ class WireActivityViewModelTest {
                 .withNoOngoingCall()
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
 
             assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
@@ -172,7 +172,7 @@ class WireActivityViewModelTest {
                 .withNoOngoingCall()
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
 
             assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
@@ -189,7 +189,7 @@ class WireActivityViewModelTest {
                 .withNoOngoingCall()
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
 
             assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
@@ -209,7 +209,7 @@ class WireActivityViewModelTest {
                 .withNoOngoingCall()
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
 
             assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
@@ -230,7 +230,7 @@ class WireActivityViewModelTest {
                 .withOngoingCall()
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, {}, {}, {}, arrangement.onCannotLoginDuringACall)
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, {}, {}, {}, arrangement.onCannotLoginDuringACall, {})
 
             verify(exactly = 1) { arrangement.onCannotLoginDuringACall() }
         }
@@ -245,7 +245,7 @@ class WireActivityViewModelTest {
                 .withCurrentScreen(MutableStateFlow<CurrentScreen>(CurrentScreen.Home))
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
 
             assertEquals(InitialAppState.NOT_MIGRATED, viewModel.initialAppState())
             verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
@@ -261,7 +261,7 @@ class WireActivityViewModelTest {
             .withNoOngoingCall()
             .arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
+        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
 
         assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
         verify(exactly = 1) { arrangement.onDeepLinkResult(ssoLogin) }
@@ -276,7 +276,7 @@ class WireActivityViewModelTest {
             .withNoOngoingCall()
             .arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
+        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
 
         assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
         verify(exactly = 1) { arrangement.onDeepLinkResult(ssoLogin) }
@@ -291,7 +291,7 @@ class WireActivityViewModelTest {
                 .withDeepLinkResult(result)
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, arrangement.onDeepLinkResult, {}, {}, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
 
             assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
@@ -306,7 +306,7 @@ class WireActivityViewModelTest {
                 .withDeepLinkResult(result)
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, arrangement.onDeepLinkResult, {}, {}, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
 
             assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
@@ -321,7 +321,7 @@ class WireActivityViewModelTest {
                 .withDeepLinkResult(result)
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {}, {})
 
             assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
@@ -335,7 +335,7 @@ class WireActivityViewModelTest {
             .withDeepLinkResult(result)
             .arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
+        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
 
         assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
         verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
@@ -351,7 +351,7 @@ class WireActivityViewModelTest {
                 .withDeepLinkResult(result)
                 .arrange()
 
-            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, {}, arrangement.onDeepLinkResult, {}, {})
+            viewModel.handleDeepLink(mockedIntent(), {}, {}, {}, {}, arrangement.onDeepLinkResult, {}, {}, {})
 
             assertEquals(InitialAppState.LOGGED_IN, viewModel.initialAppState())
             verify(exactly = 1) { arrangement.onDeepLinkResult(result) }
@@ -365,7 +365,7 @@ class WireActivityViewModelTest {
             .withDeepLinkResult(result)
             .arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
+        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
 
         assertEquals(InitialAppState.NOT_LOGGED_IN, viewModel.initialAppState())
         verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
@@ -377,7 +377,7 @@ class WireActivityViewModelTest {
             .withSomeCurrentSession()
             .arrange()
 
-        viewModel.handleDeepLink(null, {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
+        viewModel.handleDeepLink(null, {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
 
         verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
     }
@@ -413,7 +413,7 @@ class WireActivityViewModelTest {
             )
             .arrange()
 
-        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {})
+        viewModel.handleDeepLink(mockedIntent(), {}, {}, arrangement.onDeepLinkResult, {}, {}, {}, {}, {})
 
         viewModel.globalAppState.conversationJoinedDialog `should be equal to` JoinConversationViaCodeState.Show(
             conversationName,
@@ -454,12 +454,35 @@ class WireActivityViewModelTest {
             onMigrationLogin = {},
             onOpenOtherUserProfile = {},
             onAuthorizationNeeded = {},
-            onCannotLoginDuringACall = {}
+            onCannotLoginDuringACall = {},
+            onUnknown = {},
         )
 
         viewModel.globalAppState.conversationJoinedDialog `should be equal to` null
         verify(exactly = 0) { arrangement.onDeepLinkResult(any()) }
         verify(exactly = 1) { arrangement.onOpenConversation(DeepLinkResult.OpenConversation(conversationId, false)) }
+    }
+
+    @Test
+    fun `given Intent with Unknown deep link, when handling deep links, then onUnknown is called `() = runTest {
+        val result = DeepLinkResult.Unknown
+        val (arrangement, viewModel) = Arrangement()
+            .withDeepLinkResult(result)
+            .arrange()
+
+        viewModel.handleDeepLink(
+            intent = mockedIntent(),
+            onIsSharingIntent = {},
+            onOpenConversation = {},
+            onSSOLogin = {},
+            onMigrationLogin = {},
+            onOpenOtherUserProfile = {},
+            onAuthorizationNeeded = {},
+            onCannotLoginDuringACall = {},
+            onUnknown = arrangement.onUnknown
+        )
+
+        verify(exactly = 1) { arrangement.onUnknown() }
     }
 
     @Test
@@ -853,6 +876,9 @@ class WireActivityViewModelTest {
 
         @MockK(relaxed = true)
         lateinit var onOpenConversation: (DeepLinkResult.OpenConversation) -> Unit
+
+        @MockK(relaxed = true)
+        lateinit var onUnknown: () -> Unit
 
         private val viewModel by lazy {
             WireActivityViewModel(


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15982" title="WPB-15982" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15982</a>  [Android] Add deeplink parameter for automation to select old vs new login flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We need to provide a way for QA automation to be able to test both old and new login flows as we will be maintaining both for some time.
During the meeting, the option was chosen to solve this by adding a parameter to the custom backend deeplink that will allow to enforce specific login flow.

Parameter `login-type` can be one of:
- `new`
- `old`
- `default` - login flow type ultimately will be decided by looking at the API version, currently by checking the feature flag (now the new flow is enabled only for the `dev` build variant)

and can be added to the custom backend deeplink like so:

`wire://access/?config=https://staging-nginz-https.zinfra.io/deeplink.json&login-type=old`

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Click on the deeplink with `login-type` parameter.
You can use adb command:
`adb shell 'am start -W -a android.intent.action.VIEW -d "wire://access/?config=https://staging-nginz-https.zinfra.io/deeplink.json&login-type=old"'`
or just create a simple html file with links like so:
`<a href="wire://access/?config=https://staging-nginz-https.zinfra.io/deeplink.json&login-type=old"">Staging old login</a>`

### Attachments (Optional)

https://github.com/user-attachments/assets/35d1b48c-5bca-45af-9c00-b9eaee8d5694

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
