### PR TITLE
fix: Call stuck connecting state (WPB-15575)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.feature.call.usecase.EndCallOnConversationChangeUse
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.FlipToBackCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.FlipToFrontCameraUseCase
-import com.wire.kalium.logic.feature.call.usecase.GetAllCallsWithSortedParticipantsUseCase
+import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveOutgoingCallUseCase
@@ -58,7 +58,7 @@ class CallsModule {
 
     @ViewModelScoped
     @Provides
-    fun provideGetIncomingCallsUseCase(callsScope: CallsScope) =
+    fun provideGetIncomingCallsUseCase(callsScope: CallsScope): GetIncomingCallsUseCase =
         callsScope.getIncomingCalls
 
     @ViewModelScoped
@@ -90,12 +90,6 @@ class CallsModule {
     @Provides
     fun provideAcceptCallUseCase(callsScope: CallsScope) =
         callsScope.answerCall
-
-    @ViewModelScoped
-    @Provides
-    fun provideObserveCallByConversationIdUseCase(
-        callsScope: CallsScope
-    ): GetAllCallsWithSortedParticipantsUseCase = callsScope.allCallsWithSortedParticipants
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -125,7 +125,7 @@ class SharedCallingViewModel @AssistedInject constructor(
 
     init {
         viewModelScope.launch {
-            val allCallsSharedFlow = observeEstablishedCallWithSortedParticipants(conversationId)
+            val allCallsSharedFlow = observeEstablishedCallWithSortedParticipants()
                 .flowOn(dispatchers.default()).shareIn(this, started = SharingStarted.Lazily)
 
             launch {

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -73,7 +73,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 class SharedCallingViewModelTest {
 
     @MockK
-    private lateinit var establishedCall: ObserveEstablishedCallWithSortedParticipantsUseCase
+    private lateinit var observeEstablishedCall: ObserveEstablishedCallWithSortedParticipantsUseCase
 
     @MockK
     private lateinit var endCall: EndCallUseCase
@@ -141,7 +141,7 @@ class SharedCallingViewModelTest {
     @BeforeEach
     fun setup() {
         MockKAnnotations.init(this)
-        coEvery { establishedCall.invoke(any()) } returns callFlow
+        coEvery { observeEstablishedCall.invoke() } returns callFlow
         coEvery { observeConversationDetails.invoke(any()) } returns emptyFlow()
         coEvery { observeSpeaker.invoke() } returns emptyFlow()
         coEvery { observeInCallReactionsUseCase(any()) } returns reactionsFlow
@@ -150,7 +150,7 @@ class SharedCallingViewModelTest {
         sharedCallingViewModel = SharedCallingViewModel(
             conversationId = conversationId,
             conversationDetails = observeConversationDetails,
-            observeEstablishedCallWithSortedParticipants = establishedCall,
+            observeEstablishedCallWithSortedParticipants = observeEstablishedCall,
             endCall = endCall,
             muteCall = muteCall,
             flipToFrontCamera = flipToFrontCamera,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15575" title="WPB-15575" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15575</a>  [Android] Prolonged "Connecting" on device A mode when call is answered on device B
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App stuck on connecting screen when users joins a call or when he kills the app and open it again during a call

### Solutions

fixed in kalium https://github.com/wireapp/kalium/pull/3282

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
