### PR TITLE
feat: Disable Performance tracking #WPB-15791

### DIFF
--- a/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
+++ b/core/analytics-enabled/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsRecorderImpl.kt
@@ -57,14 +57,9 @@ class AnonymousAnalyticsRecorderImpl(
             crashes.apply {
                 enableCrashReporting()
             }
-            apm.apply {
-                enableAppStartTimeTracking()
-                enableForegroundBackgroundTracking()
-            }
         }
 
         Countly.sharedInstance()?.init(countlyConfig)
-        Countly.sharedInstance()?.consent()?.giveConsent(arrayOf("apm"))
 
         val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
         val globalSegmentations = mapOf<String, Any>(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15791" title="WPB-15791" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15791</a>  [Android] Disable Performance tracking
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

Due to to the high consumption of data points (reports send) the performance tracking (Application Performance Monitoring; APM) should be removed. In addition, Countly will discontinue this feature in the future.

### Solutions


- App open loading time is no longer tracked
- Time in foreground is no longer tracked
- Time in background is no longer tracked
- The client does not send Countly APM reports
