### PR TITLE
fix: disable folders options for archived conversation [WPB-15888]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
@@ -146,7 +146,7 @@ internal fun ConversationMainSheetContent(
                     }
                 }
             }
-            if (moveConversationToFolder != null) {
+            if (moveConversationToFolder != null && !conversationSheetContent.isArchived) {
                 add {
                     MenuBottomSheetItem(
                         leading = {
@@ -168,7 +168,7 @@ internal fun ConversationMainSheetContent(
                     )
                 }
             }
-            if (conversationSheetContent.folder != null) {
+            if (conversationSheetContent.folder != null && !conversationSheetContent.isArchived) {
                 add {
                     MenuBottomSheetItem(
                         leading = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15888" title="WPB-15888" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15888</a>  [Android] It should not be possible to move a conversation to folder from archive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- disabled folders options for archived conversation