### PR TITLE
fix: add conversation to folder after its creation [WPB-15892]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/ConversationFoldersNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/ConversationFoldersNavArgs.kt
@@ -29,3 +29,9 @@ data class ConversationFoldersNavArgs(
 
 @Parcelize
 data class ConversationFoldersNavBackArgs(val message: String) : Parcelable
+
+@Parcelize
+data class NewConversationFolderNavBackArgs(
+    val folderName: String,
+    val folderId: String
+) : Parcelable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/ConversationFoldersScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/ConversationFoldersScreen.kt
@@ -59,6 +59,7 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.typography
 import com.wire.android.ui.destinations.NewConversationFolderScreenDestination
 import com.wire.kalium.logic.data.conversation.ConversationFolder
+import com.wire.kalium.logic.data.conversation.FolderType
 
 @RootNavGraph
 @WireDestination(
@@ -70,7 +71,7 @@ fun ConversationFoldersScreen(
     args: ConversationFoldersNavArgs,
     navigator: Navigator,
     resultNavigator: ResultBackNavigator<ConversationFoldersNavBackArgs>,
-    resultRecipient: ResultRecipient<NewConversationFolderScreenDestination, String>,
+    resultRecipient: ResultRecipient<NewConversationFolderScreenDestination, NewConversationFolderNavBackArgs>,
     foldersViewModel: ConversationFoldersVM =
         hiltViewModel<ConversationFoldersVMImpl, ConversationFoldersVMImpl.Factory>(
             creationCallback = { it.create(ConversationFoldersStateArgs(args.currentFolderId)) }
@@ -104,7 +105,13 @@ fun ConversationFoldersScreen(
         when (it) {
             NavResult.Canceled -> {}
             is NavResult.Value -> {
-                foldersViewModel.onFolderSelected(it.value)
+                moveToFolderVM.moveConversationToFolder(
+                    ConversationFolder(
+                        it.value.folderId,
+                        it.value.folderName,
+                        FolderType.USER
+                    )
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/NewConversationFolderScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/NewConversationFolderScreen.kt
@@ -66,13 +66,18 @@ import com.wire.android.util.ui.SnackBarMessageHandler
 @Composable
 fun NewConversationFolderScreen(
     navigator: Navigator,
-    resultNavigator: ResultBackNavigator<String>,
+    resultNavigator: ResultBackNavigator<NewConversationFolderNavBackArgs>,
     viewModel: NewFolderViewModel = hiltViewModel()
 ) {
 
     LaunchedEffect(viewModel.folderNameState.folderId) {
         if (viewModel.folderNameState.folderId != null) {
-            resultNavigator.navigateBack(viewModel.folderNameState.folderId!!)
+            resultNavigator.navigateBack(
+                NewConversationFolderNavBackArgs(
+                    viewModel.textState.text.toString(),
+                    viewModel.folderNameState.folderId!!
+                )
+            )
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15892" title="WPB-15892" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15892</a>  [Android] It should not be possible to create empty folders
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Changed flow of adding new folder to after creation move conversation to newly created folder to not have empty folders