### PR TITLE
fix: FileSharing menu - no gaps #WPB-15276

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -39,7 +39,6 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.isImeVisible
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.GenericShape

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -384,7 +384,7 @@ fun EnabledMessageComposer(
                     offset = if (isImeVisible) {
                         IntOffset(0, 0)
                     } else {
-                        with(density) { IntOffset(0, -dimensions().spacing64x.toPx().roundToInt()) }
+                        with(density) { IntOffset(0, -dimensions().spacing48x.toPx().roundToInt()) }
                     },
                     onDismissRequest = {
                         hideRipple = true
@@ -403,13 +403,6 @@ fun EnabledMessageComposer(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(inputStateHolder.calculateOptionsMenuHeight(additionalOptionStateHolder.additionalOptionsSubMenuState))
-                            .padding(
-                                horizontal = if (isImeVisible) {
-                                    dimensions().spacing0x
-                                } else {
-                                    dimensions().spacing8x
-                                }
-                            )
                             .background(
                                 color = Color.Transparent,
                                 shape = shape
@@ -489,7 +482,8 @@ private fun calculateOptionsPath(cornerRadiusPx: Float, rippleProgress: Float, i
     shapePath.addRoundRect(
         roundRect = RoundRect(
             rect = size.toRect(),
-            cornerRadius = CornerRadius(cornerRadiusPx, cornerRadiusPx)
+            topRight = CornerRadius(cornerRadiusPx, cornerRadiusPx),
+            topLeft = CornerRadius(cornerRadiusPx, cornerRadiusPx)
         )
     )
     return ripplePath.and(shapePath)

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -30,8 +30,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.KeyboardActionHandler
+import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -258,13 +258,15 @@ private fun InputContent(
                     UsersTypingIndicatorForConversation(conversationId = conversationId)
                 }
             }
-            MessageSendActions(
-                onSendButtonClicked = onSendButtonClicked,
-                sendButtonEnabled = canSendMessage,
-                selfDeletionTimer = viewModel.state(),
-                onChangeSelfDeletionClicked = onChangeSelfDeletionClicked,
-                modifier = Modifier.padding(end = dimensions().spacing8x)
-            )
+            if (canSendMessage || showOptions) {
+                MessageSendActions(
+                    onSendButtonClicked = onSendButtonClicked,
+                    sendButtonEnabled = canSendMessage,
+                    selfDeletionTimer = viewModel.state(),
+                    onChangeSelfDeletionClicked = onChangeSelfDeletionClicked,
+                    modifier = Modifier.padding(end = dimensions().spacing8x)
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15276" title="WPB-15276" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15276</a>  [Android] File sharing menu should not have a gaps
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

- There should be no gap between the additional options menu and the text input field or on the left and right side of the menu.
- Send message btn should not be visible when the keyboard is closed and there is no text to send. (this is out of the scope of task, but i found that regression, so just fixed it)


### Attachments (Optional)

<img width="285" alt="Screenshot 2025-02-07 at 17 47 57" src="https://github.com/user-attachments/assets/dfc61c38-604d-44ba-8ca1-1fef34c7edcd" />
