### PR TITLE
fix: samsung keyboard not respecting enter to send [WPB-15994]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -222,14 +222,18 @@ fun EnabledMessageComposer(
                                         (messageCompositionInputStateHolder.inputType as InputType.Composing).isSendButtonEnabled
                             }
                         }
-                        val keyboardOptions =
+                        val keyboardOptions by remember {
+                            derivedStateOf {
                                 if (messageComposerViewState.value.enterToSend) {
                                     KeyboardOptions.Companion.MessageComposerEnterToSend
                                 } else {
                                     KeyboardOptions.Companion.MessageComposerDefault
                                 }
+                            }
+                        }
 
-                        val keyboardActionHandler =
+                        val keyboardActionHandler by remember {
+                            derivedStateOf {
                                 KeyboardActionHandler {
                                     if (canSendMessage) {
                                         onSendButtonClicked()
@@ -237,6 +241,8 @@ fun EnabledMessageComposer(
                                         Unit
                                     }
                                 }
+                            }
+                        }
 
                         ActiveMessageComposerInput(
                             conversationId = conversationId,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -71,7 +71,6 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
-import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -81,7 +80,6 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
-import com.wire.android.appLogger
 import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
 import com.wire.android.ui.common.bottombar.bottomNavigationBarHeight
 import com.wire.android.ui.common.colorsScheme

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalContext
@@ -81,6 +82,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
+import com.wire.android.appLogger
 import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
 import com.wire.android.ui.common.bottombar.bottomNavigationBarHeight
 import com.wire.android.ui.common.colorsScheme
@@ -223,18 +225,14 @@ fun EnabledMessageComposer(
                                         (messageCompositionInputStateHolder.inputType as InputType.Composing).isSendButtonEnabled
                             }
                         }
-                        val keyboardOptions by remember {
-                            derivedStateOf {
+                        val keyboardOptions =
                                 if (messageComposerViewState.value.enterToSend) {
                                     KeyboardOptions.Companion.MessageComposerEnterToSend
                                 } else {
                                     KeyboardOptions.Companion.MessageComposerDefault
                                 }
-                            }
-                        }
 
-                        val keyboardActionHandler by remember {
-                            derivedStateOf {
+                        val keyboardActionHandler =
                                 KeyboardActionHandler {
                                     if (canSendMessage) {
                                         onSendButtonClicked()
@@ -242,8 +240,6 @@ fun EnabledMessageComposer(
                                         Unit
                                     }
                                 }
-                            }
-                        }
 
                         ActiveMessageComposerInput(
                             conversationId = conversationId,
@@ -309,9 +305,9 @@ fun EnabledMessageComposer(
                                         }
                                     }
                                 )
-                                .onPreviewKeyEvent { keyEvent ->
+                                .onKeyEvent { keyEvent ->
                                     if (keyEvent.type != KeyEventType.KeyDown) {
-                                        return@onPreviewKeyEvent false
+                                        return@onKeyEvent false
                                     }
                                     if (keyEvent.isShiftPressed && keyEvent.key == Key.Enter) {
                                         messageComposerStateHolder.messageCompositionInputStateHolder.messageTextState.edit {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1697,7 +1697,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="new_folder_error_name_exceeded_limit_error">Minimum of 1 and maximum of 64 characters</string>
     <string name="new_folder_failure">“%1$s” folder could not be added</string>
     <string name="press_enter_to_send_title">Press Enter to send</string>
-    <string name="press_enter_to_send_text">If this is on, messages can be sent with the Enter key on the Keyboard</string>
+    <string name="press_enter_to_send_text">When this is on, you can send messages with the Enter key on your keyboard.</string>
     <string name="custimization_options_header_title">Options</string>
 
 </resources>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15994" title="WPB-15994" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15994</a>  [Android]"Press Enter to send" setting not working as expected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

to send is disabled clicking enter on a Samsung or Microsoft keyboards will send the message regardless 

### Causes (Optional)

those keyboards are executing the code inside `onPreviewKeyEvent` even though in its docs it mentions that it is only for hardware keyboards

### Solutions

replacing `onPreviewKeyEvent` with `onKeyEvent` seems to work fine

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
