### PR TITLE
feat: login type selector [WPB-16058]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/AccountSwitchUseCase.kt
@@ -18,7 +18,6 @@
 
 package com.wire.android.feature
 
-import com.wire.android.BuildConfig
 import com.wire.android.appLogger
 import com.wire.android.di.ApplicationScope
 import com.wire.android.navigation.BackStackMode
@@ -194,11 +193,11 @@ interface SwitchAccountActions {
     fun noOtherAccountToSwitch()
 }
 
-class NavigationSwitchAccountActions(val navigate: (NavigationCommand) -> Unit) : SwitchAccountActions {
+class NavigationSwitchAccountActions(val navigate: (NavigationCommand) -> Unit, val canUseNewLogin: () -> Boolean) : SwitchAccountActions {
     override fun switchedToAnotherAccount() = navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
     override fun noOtherAccountToSwitch() = navigate(
         NavigationCommand(
-            if (BuildConfig.ENTERPRISE_LOGIN_ENABLED) NewLoginScreenDestination() else WelcomeScreenDestination(),
+            if (canUseNewLogin()) NewLoginScreenDestination() else WelcomeScreenDestination(),
             BackStackMode.CLEAR_WHOLE
         )
     )

--- a/app/src/main/kotlin/com/wire/android/navigation/LoginTypeSelector.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/LoginTypeSelector.kt
@@ -1,0 +1,54 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.navigation
+
+import com.wire.android.config.DefaultServerConfig
+import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.feature.auth.LoginContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LoginTypeSelector @Inject constructor(
+    dispatcherProvider: DispatcherProvider,
+    @KaliumCoreLogic private val coreLogic: CoreLogic,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.default())
+    private val loginContextForDefaultServerConfigStateFlow: StateFlow<LoginContext> = runBlocking {
+        // it needs to be initialised before navigation is setup
+        loginContextFlow(DefaultServerConfig).stateIn(scope, SharingStarted.Eagerly, loginContextFlow(DefaultServerConfig).first())
+    }
+    private suspend fun loginContextFlow(serverLinks: ServerConfig.Links) = coreLogic.getGlobalScope().observeLoginContext(serverLinks)
+
+    suspend fun canUseNewLogin(serverLinks: ServerConfig.Links?) = when {
+        serverLinks != null -> loginContextFlow(serverLinks).first() == LoginContext.EnterpriseLogin
+        else -> canUseNewLogin()
+    }
+
+    fun canUseNewLogin() = loginContextForDefaultServerConfigStateFlow.value == LoginContext.EnterpriseLogin
+}

--- a/app/src/main/kotlin/com/wire/android/navigation/MainNavHost.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/MainNavHost.kt
@@ -48,7 +48,7 @@ import com.wire.android.ui.home.newconversation.NewConversationViewModel
 @Composable
 fun MainNavHost(
     navigator: Navigator,
-    loginTypeSelector: LoginTypeSelector,
+    loginTypeSelector: LoginTypeSelector?,
     startDestination: Route,
     modifier: Modifier = Modifier,
 ) {
@@ -71,8 +71,8 @@ fun MainNavHost(
             // 👇 To make Navigator available to all destinations as a non-navigation parameter
             dependency(navigator)
 
-            // 👇 To make LoginTypeSelector available to all destinations as a non-navigation parameter
-            dependency(loginTypeSelector)
+            // 👇 To make LoginTypeSelector available to all destinations as a non-navigation parameter if provided
+            if (loginTypeSelector != null) dependency(loginTypeSelector)
 
             // 👇 To tie NewConversationViewModel to nested NewConversationNavGraph, making it shared between all screens that belong to it
             dependency(NavGraphs.newConversation) {

--- a/app/src/main/kotlin/com/wire/android/navigation/MainNavHost.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/MainNavHost.kt
@@ -48,6 +48,7 @@ import com.wire.android.ui.home.newconversation.NewConversationViewModel
 @Composable
 fun MainNavHost(
     navigator: Navigator,
+    loginTypeSelector: LoginTypeSelector,
     startDestination: Route,
     modifier: Modifier = Modifier,
 ) {
@@ -69,6 +70,9 @@ fun MainNavHost(
         dependenciesContainerBuilder = {
             // 👇 To make Navigator available to all destinations as a non-navigation parameter
             dependency(navigator)
+
+            // 👇 To make LoginTypeSelector available to all destinations as a non-navigation parameter
+            dependency(loginTypeSelector)
 
             // 👇 To tie NewConversationViewModel to nested NewConversationNavGraph, making it shared between all screens that belong to it
             dependency(NavGraphs.newConversation) {

--- a/app/src/main/kotlin/com/wire/android/navigation/Navigator.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/Navigator.kt
@@ -18,7 +18,6 @@
 package com.wire.android.navigation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavHostController
@@ -68,5 +67,3 @@ fun rememberNavigator(
     }
     return remember(finish, isAllowedToNavigate, navController) { Navigator(finish, navController, isAllowedToNavigate) }
 }
-
-val LocalNavigator = compositionLocalOf<Navigator> { error("No Navigator provided") }

--- a/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import com.wire.android.appLogger
-import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.MainNavHost
 import com.wire.android.navigation.rememberNavigator
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
@@ -35,13 +34,9 @@ import com.wire.android.ui.destinations.EnterLockCodeScreenDestination
 import com.wire.android.ui.destinations.SetLockCodeScreenDestination
 import com.wire.android.ui.theme.WireTheme
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class AppLockActivity : AppCompatActivity() {
-
-    @Inject
-    lateinit var loginTypeSelector: LoginTypeSelector
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -74,7 +69,7 @@ class AppLockActivity : AppCompatActivity() {
 
                     MainNavHost(
                         navigator = navigator,
-                        loginTypeSelector = loginTypeSelector,
+                        loginTypeSelector = null, // LoginTypeSelector is not needed for destinations in AppLockActivity
                         startDestination = startDestination
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import com.wire.android.appLogger
+import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.MainNavHost
 import com.wire.android.navigation.rememberNavigator
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
@@ -34,9 +35,14 @@ import com.wire.android.ui.destinations.EnterLockCodeScreenDestination
 import com.wire.android.ui.destinations.SetLockCodeScreenDestination
 import com.wire.android.ui.theme.WireTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class AppLockActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var loginTypeSelector: LoginTypeSelector
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -68,6 +74,7 @@ class AppLockActivity : AppCompatActivity() {
 
                     MainNavHost(
                         navigator = navigator,
+                        loginTypeSelector = loginTypeSelector,
                         startDestination = startDestination
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -185,6 +185,9 @@ class WireActivity : AppCompatActivity() {
             appLogger.i("$TAG legal hold requested status")
             legalHoldRequestedViewModel.observeLegalHoldRequest()
 
+            appLogger.i("$TAG init login type selector")
+            loginTypeSelector.init()
+
             appLogger.i("$TAG start destination")
             val startDestination = when (viewModel.initialAppState()) {
                 InitialAppState.NOT_MIGRATED -> MigrationScreenDestination

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -711,22 +711,20 @@ class WireActivity : AppCompatActivity() {
             viewModel.handleDeepLink(
                 intent = intent,
                 onOpenConversation = {
-                    runOnUiThread {
-                        if (it.switchedAccount) {
-                            navigate(
-                                NavigationCommand(
-                                    HomeScreenDestination,
-                                    BackStackMode.CLEAR_WHOLE
-                                )
-                            )
-                        }
+                    if (it.switchedAccount) {
                         navigate(
                             NavigationCommand(
-                                ConversationScreenDestination(it.conversationId),
-                                BackStackMode.UPDATE_EXISTED
+                                HomeScreenDestination,
+                                BackStackMode.CLEAR_WHOLE
                             )
                         )
                     }
+                    navigate(
+                        NavigationCommand(
+                            ConversationScreenDestination(it.conversationId),
+                            BackStackMode.UPDATE_EXISTED
+                        )
+                    )
                 },
                 onIsSharingIntent = {
                     navigate(

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -66,7 +66,7 @@ import com.wire.android.config.LocalCustomUiConfigurationProvider
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.feature.NavigationSwitchAccountActions
 import com.wire.android.navigation.BackStackMode
-import com.wire.android.navigation.LocalNavigator
+import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.MainNavHost
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
@@ -128,11 +128,10 @@ import com.wire.android.util.deeplink.LoginType
 import dagger.Lazy
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicBoolean
@@ -152,17 +151,19 @@ class WireActivity : AppCompatActivity() {
     @Inject
     lateinit var switchAccountObserver: SwitchAccountObserver
 
+    @Inject
+    lateinit var loginTypeSelector: LoginTypeSelector
+
     private val viewModel: WireActivityViewModel by viewModels()
     private val featureFlagNotificationViewModel: FeatureFlagNotificationViewModel by viewModels()
     private val commonTopAppBarViewModel: CommonTopAppBarViewModel by viewModels()
     private val legalHoldRequestedViewModel: LegalHoldRequestedViewModel by viewModels()
     private val legalHoldDeactivatedViewModel: LegalHoldDeactivatedViewModel by viewModels()
 
-    val navigationCommands: MutableSharedFlow<NavigationCommand> = MutableSharedFlow()
+    private val newIntents = Channel<Pair<Intent, Bundle?>>(1) // keep the latest new intent
 
     // This flag is used to keep the splash screen open until the first screen is drawn.
     private var shouldKeepSplashOpen = true
-    private var isNavigationCollecting = false
     private val isWelcomeEmptyStartDestination = AtomicBoolean(false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -188,22 +189,22 @@ class WireActivity : AppCompatActivity() {
             appLogger.i("$TAG start destination")
             val startDestination = when (viewModel.initialAppState()) {
                 InitialAppState.NOT_MIGRATED -> MigrationScreenDestination
-                InitialAppState.NOT_LOGGED_IN -> when {
-                    BuildConfig.ENTERPRISE_LOGIN_ENABLED -> NewWelcomeEmptyStartScreenDestination.also {
+                InitialAppState.NOT_LOGGED_IN -> when (loginTypeSelector.canUseNewLogin()) {
+                    true -> NewWelcomeEmptyStartScreenDestination.also {
                         isWelcomeEmptyStartDestination.set(true)
                     }
-                    else -> WelcomeScreenDestination
+                    false -> WelcomeScreenDestination
                 }
                 InitialAppState.ENROLL_E2EI -> E2EIEnrollmentScreenDestination
                 InitialAppState.LOGGED_IN -> HomeScreenDestination
             }
             appLogger.i("$TAG composable content")
+            setComposableContent(startDestination)
 
-            setComposableContent(startDestination) {
-                appLogger.i("$TAG splash hide")
-                shouldKeepSplashOpen = false
-                handleDeepLink(intent, savedInstanceState)
-            }
+            appLogger.i("$TAG splash hide")
+            shouldKeepSplashOpen = false
+
+            handleNewIntent(intent, savedInstanceState)
         }
     }
 
@@ -214,26 +215,16 @@ class WireActivity : AppCompatActivity() {
             handleSynchronizeExternalData(intent)
             return
         }
-
         setIntent(intent)
-        if (isNavigationCollecting) {
-            /*
-             * - When true then navigationCommands is subscribed and can handle navigation commands right away.
-             * - When false then navigationCommands needs to be subscribed again to be able to receive and handle navigation commands.
-             *
-             * Activity intent is updated anyway using setIntent(intent) so that we always keep the latest intent received, so when
-             * isNavigationCollecting is false then we handle it after navigationCommands is subscribed again and onComplete called again.
-             * We make sure to handle particular intent only once thanks to the flag HANDLED_DEEPLINK_FLAG put into the handled intent.
-             */
-            handleDeepLink(intent)
-        }
+        handleNewIntent(intent)
+    }
+
+    private fun handleNewIntent(intent: Intent, savedInstanceState: Bundle? = null) = lifecycleScope.launch {
+        newIntents.send(intent to savedInstanceState)
     }
 
     @Suppress("LongMethod")
-    private fun setComposableContent(
-        startDestination: Route,
-        onComplete: () -> Unit
-    ) {
+    private fun setComposableContent(startDestination: Route) {
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
 
@@ -281,17 +272,16 @@ class WireActivity : AppCompatActivity() {
                             commonTopAppBarState = commonTopAppBarViewModel.state,
                             backgroundType = backgroundType,
                         )
-                        CompositionLocalProvider(LocalNavigator provides navigator) {
-                            MainNavHost(
-                                navigator = navigator,
-                                startDestination = startDestination,
-                                modifier = Modifier.consumeWindowInsets(WindowInsets.statusBars)
-                            )
-                        }
+                        MainNavHost(
+                            navigator = navigator,
+                            loginTypeSelector = loginTypeSelector,
+                            startDestination = startDestination,
+                            modifier = Modifier.consumeWindowInsets(WindowInsets.statusBars)
+                        )
 
                         // This setup needs to be done after the navigation graph is created, because building the graph takes some time,
                         // and if any NavigationCommand is executed before the graph is fully built, it will cause a NullPointerException.
-                        SetUpNavigation(navigator, onComplete)
+                        SetUpNavigation(navigator)
                         HandleScreenshotCensoring()
                         HandleDialogs(navigator::navigate)
                     }
@@ -354,26 +344,17 @@ class WireActivity : AppCompatActivity() {
     }
 
     @Composable
-    private fun SetUpNavigation(
-        navigator: Navigator,
-        onComplete: () -> Unit,
-    ) {
+    private fun SetUpNavigation(navigator: Navigator) {
         val currentKeyboardController by rememberUpdatedState(LocalSoftwareKeyboardController.current)
         val currentNavigator by rememberUpdatedState(navigator)
         LaunchedEffect(Unit) {
             lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    navigationCommands
-                        .onSubscription {
-                            isNavigationCollecting = true
-                            onComplete()
-                        }
-                        .onCompletion {
-                            isNavigationCollecting = false
-                        }
-                        .collectLatest {
+                    newIntents
+                        .consumeAsFlow()
+                        .collectLatest { (intent, savedInstanceState) ->
                             currentKeyboardController?.hide()
-                            currentNavigator.navigate(it)
+                            handleDeepLink(currentNavigator, intent, savedInstanceState)
                         }
                 }
             }
@@ -396,11 +377,14 @@ class WireActivity : AppCompatActivity() {
         }
 
         DisposableEffect(switchAccountObserver, navigator) {
-            NavigationSwitchAccountActions {
-                lifecycleScope.launch(Dispatchers.Main) {
-                    navigator.navigate(it)
-                }
-            }.let {
+            NavigationSwitchAccountActions(
+                {
+                    lifecycleScope.launch(Dispatchers.Main) {
+                        navigator.navigate(it)
+                    }
+                },
+                loginTypeSelector::canUseNewLogin
+            ).let {
                 switchAccountObserver.register(it)
                 onDispose {
                     switchAccountObserver.unregister(it)
@@ -499,7 +483,7 @@ class WireActivity : AppCompatActivity() {
                     logout = {
                         viewModel.doHardLogout(
                             { UserDataStore(context, it) },
-                            NavigationSwitchAccountActions(navigate)
+                            NavigationSwitchAccountActions(navigate, loginTypeSelector::canUseNewLogin)
                         )
                         logoutOptionsDialogState.dismiss()
                     }
@@ -570,24 +554,28 @@ class WireActivity : AppCompatActivity() {
                     },
                     onConfirm = { loginType ->
                         viewModel.customBackendDialogProceedButtonClicked { serverLinks ->
-                            navigate(
-                                NavigationCommand(
-                                    destination = when (loginType) {
-                                        LoginType.New -> NewLoginPasswordScreenDestination(customServerConfig = serverLinks)
-                                        LoginType.Old -> WelcomeScreenDestination(customServerConfig = serverLinks)
-                                        LoginType.Default -> when {
-                                            // TODO: for now we use feature flag, but it should decide by checking API version
-                                            BuildConfig.ENTERPRISE_LOGIN_ENABLED -> NewLoginPasswordScreenDestination(customServerConfig = serverLinks)
-                                            else -> WelcomeScreenDestination(customServerConfig = serverLinks)
-                                        }
-                                    },
-                                    // if "welcome empty start" screen then switch "start" screen to proper one
-                                    backStackMode = when (isWelcomeEmptyStartDestination.getAndSet(false)) {
-                                        true -> BackStackMode.CLEAR_WHOLE
-                                        else -> BackStackMode.UPDATE_EXISTED
+                            lifecycleScope.launch {
+                                val destination = when (loginType) {
+                                    LoginType.New -> NewLoginPasswordScreenDestination(customServerConfig = serverLinks)
+                                    LoginType.Old -> WelcomeScreenDestination(customServerConfig = serverLinks)
+                                    LoginType.Default -> when (loginTypeSelector.canUseNewLogin(serverLinks)) {
+                                        true -> NewLoginPasswordScreenDestination(customServerConfig = serverLinks)
+                                        false -> WelcomeScreenDestination(customServerConfig = serverLinks)
                                     }
-                                )
-                            )
+                                }
+                                withContext(Dispatchers.Main) {
+                                    navigate(
+                                        NavigationCommand(
+                                            destination = destination,
+                                            // if "welcome empty start" screen then switch "start" screen to proper one
+                                            backStackMode = when (isWelcomeEmptyStartDestination.getAndSet(false)) {
+                                                true -> BackStackMode.CLEAR_WHOLE
+                                                else -> BackStackMode.UPDATE_EXISTED
+                                            }
+                                        )
+                                    )
+                                }
+                            }
                         }
                     },
                     onTryAgain = viewModel::onCustomServerConfig
@@ -602,14 +590,14 @@ class WireActivity : AppCompatActivity() {
                 )
                 AccountLoggedOutDialog(
                     viewModel.globalAppState.blockUserUI
-                ) { viewModel.tryToSwitchAccount(NavigationSwitchAccountActions(navigate)) }
+                ) { viewModel.tryToSwitchAccount(NavigationSwitchAccountActions(navigate, loginTypeSelector::canUseNewLogin)) }
                 NewClientDialog(
                     viewModel.globalAppState.newClientDialog,
                     { navigate(NavigationCommand(SelfDevicesScreenDestination)) },
                     {
                         viewModel.switchAccount(
                             userId = it,
-                            actions = NavigationSwitchAccountActions(navigate),
+                            actions = NavigationSwitchAccountActions(navigate, loginTypeSelector::canUseNewLogin),
                             onComplete = { navigate(NavigationCommand(SelfDevicesScreenDestination)) })
                     },
                     viewModel::dismissNewClientsDialog
@@ -700,12 +688,13 @@ class WireActivity : AppCompatActivity() {
      * This method is responsible for handling deep links from given intent
      */
     private fun handleDeepLink(
+        navigator: Navigator,
         intent: Intent?,
         savedInstanceState: Bundle? = null
     ) {
         val navigate: (NavigationCommand) -> Unit = {
-            lifecycleScope.launch {
-                navigationCommands.emit(it)
+            runOnUiThread {
+                navigator.navigate(it)
             }
         }
         val originalIntent = savedInstanceState.getOriginalIntent()
@@ -717,7 +706,7 @@ class WireActivity : AppCompatActivity() {
         ) {
             if (isWelcomeEmptyStartDestination.getAndSet(false)) {
                 // no deep link to handle so if "welcome empty start" screen then switch "start" screen to login by navigating to it
-                navigate(NavigationCommand(NewLoginScreenDestination(), BackStackMode.CLEAR_WHOLE))
+                navigator.navigate(NavigationCommand(NewLoginScreenDestination(), BackStackMode.CLEAR_WHOLE))
             }
             return
         } else {
@@ -778,9 +767,9 @@ class WireActivity : AppCompatActivity() {
                 onMigrationLogin = {
                     navigate(
                         NavigationCommand(
-                            when {
-                                BuildConfig.ENTERPRISE_LOGIN_ENABLED -> NewLoginScreenDestination(userHandle = it.userHandle)
-                                else -> LoginScreenDestination(userHandle = it.userHandle)
+                            when (loginTypeSelector.canUseNewLogin()) {
+                                true -> NewLoginScreenDestination(userHandle = it.userHandle)
+                                false -> LoginScreenDestination(userHandle = it.userHandle)
                             },
                             // if "welcome empty start" screen then switch "start" screen to proper one
                             when (isWelcomeEmptyStartDestination.getAndSet(false)) {
@@ -809,8 +798,9 @@ class WireActivity : AppCompatActivity() {
                 onSSOLogin = {
                     navigate(
                         NavigationCommand(
-                            when {
-                                BuildConfig.ENTERPRISE_LOGIN_ENABLED -> NewLoginScreenDestination(ssoLoginResult = it)
+                            when (navigator.navController.currentBackStackEntry?.appDestination()?.route?.getBaseRoute()) {
+                                // if SSO login started from new login screen then go back to the new login flow
+                                NewLoginScreenDestination.route.getBaseRoute() -> NewLoginScreenDestination(ssoLoginResult = it)
                                 else -> LoginScreenDestination(ssoLoginResult = it)
                             },
                             // if needs to log in and "welcome empty start" screen then switch "start" screen to login

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -131,6 +131,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -160,7 +161,7 @@ class WireActivity : AppCompatActivity() {
     private val legalHoldRequestedViewModel: LegalHoldRequestedViewModel by viewModels()
     private val legalHoldDeactivatedViewModel: LegalHoldDeactivatedViewModel by viewModels()
 
-    private val newIntents = Channel<Pair<Intent, Bundle?>>(1) // keep the latest new intent
+    private val newIntents = Channel<Pair<Intent, Bundle?>>(Channel.BUFFERED) // keep new intents until subscribed but do not replay them
 
     // This flag is used to keep the splash screen open until the first screen is drawn.
     private var shouldKeepSplashOpen = true
@@ -352,6 +353,7 @@ class WireActivity : AppCompatActivity() {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     newIntents
                         .consumeAsFlow()
+                        .distinctUntilChanged()
                         .collectLatest { (intent, savedInstanceState) ->
                             currentKeyboardController?.hide()
                             handleDeepLink(currentNavigator, intent, savedInstanceState)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -359,11 +359,9 @@ class WireActivityViewModel @Inject constructor(
     fun customBackendDialogProceedButtonClicked(onProceed: (ServerConfig.Links) -> Unit) {
         val backendDialogState = globalAppState.customBackendDialog
         if (backendDialogState is CustomServerDetailsDialogState) {
-            viewModelScope.launch {
-                dismissCustomBackendDialog()
-                if (checkNumberOfSessions()) {
-                    onProceed(backendDialogState.serverLinks)
-                }
+            dismissCustomBackendDialog()
+            if (checkNumberOfSessions()) {
+                onProceed(backendDialogState.serverLinks)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt
@@ -40,6 +40,7 @@ import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.R
 import com.wire.android.feature.NavigationSwitchAccountActions
 import com.wire.android.navigation.BackStackMode
+import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
@@ -76,6 +77,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 @Composable
 fun RegisterDeviceScreen(
     navigator: Navigator,
+    loginTypeSelector: LoginTypeSelector,
     viewModel: RegisterDeviceViewModel = hiltViewModel(),
     clearSessionViewModel: ClearSessionViewModel = hiltViewModel(),
 ) {
@@ -101,7 +103,11 @@ fun RegisterDeviceScreen(
                 onContinuePressed = viewModel::onContinue,
                 onErrorDismiss = viewModel::onErrorDismiss,
                 onBackButtonClicked = clearSessionViewModel::onBackButtonClicked,
-                onCancelLoginClicked = { clearSessionViewModel.onCancelLoginClicked(NavigationSwitchAccountActions(navigator::navigate)) },
+                onCancelLoginClicked = {
+                    clearSessionViewModel.onCancelLoginClicked(
+                        NavigationSwitchAccountActions(navigator::navigate, loginTypeSelector::canUseNewLogin)
+                    )
+                },
                 onProceedLoginClicked = clearSessionViewModel::onProceedLoginClicked
             )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceScreen.kt
@@ -39,6 +39,7 @@ import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.R
 import com.wire.android.feature.NavigationSwitchAccountActions
 import com.wire.android.navigation.BackStackMode
+import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
@@ -73,6 +74,7 @@ import com.wire.kalium.logic.data.conversation.ClientId
 @Composable
 fun RemoveDeviceScreen(
     navigator: Navigator,
+    loginTypeSelector: LoginTypeSelector,
     viewModel: RemoveDeviceViewModel = hiltViewModel(),
     clearSessionViewModel: ClearSessionViewModel = hiltViewModel(),
 ) {
@@ -95,7 +97,11 @@ fun RemoveDeviceScreen(
         onDialogDismiss = viewModel::onDialogDismissed,
         onErrorDialogDismiss = viewModel::clearDeleteClientError,
         onBackButtonClicked = clearSessionViewModel::onBackButtonClicked,
-        onCancelLoginClicked = { clearSessionViewModel.onCancelLoginClicked(NavigationSwitchAccountActions(navigator::navigate)) },
+        onCancelLoginClicked = {
+            clearSessionViewModel.onCancelLoginClicked(
+                NavigationSwitchAccountActions(navigator::navigate, loginTypeSelector::canUseNewLogin)
+            )
+        },
         onProceedLoginClicked = clearSessionViewModel::onProceedLoginClicked
     )
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOScreen.kt
@@ -82,7 +82,6 @@ fun LoginSSOScreen(
             loginSSOViewModel.clearLoginErrors()
             onRemoveDeviceNeeded()
         },
-        // TODO: replace with retrieved ServerConfig from sso login
         onLoginButtonClick = loginSSOViewModel::login,
         ssoLoginResult = ssoLoginResult,
         onCustomServerDialogDismiss = loginSSOViewModel::onCustomServerDialogDismiss,

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
@@ -36,6 +36,7 @@ import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.R
 import com.wire.android.feature.NavigationSwitchAccountActions
 import com.wire.android.navigation.BackStackMode
+import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
@@ -72,6 +73,7 @@ import com.wire.kalium.logic.functional.Either
 @Composable
 fun E2EIEnrollmentScreen(
     navigator: Navigator,
+    loginTypeSelector: LoginTypeSelector,
     viewModel: E2EIEnrollmentViewModel = hiltViewModel(),
 ) {
     val state = viewModel.state
@@ -95,7 +97,9 @@ fun E2EIEnrollmentScreen(
             )
         },
         onBackButtonClicked = viewModel::onBackButtonClicked,
-        onCancelEnrollmentClicked = { viewModel.onCancelEnrollmentClicked(NavigationSwitchAccountActions(navigator::navigate)) },
+        onCancelEnrollmentClicked = {
+            viewModel.onCancelEnrollmentClicked(NavigationSwitchAccountActions(navigator::navigate, loginTypeSelector::canUseNewLogin))
+        },
         onProceedEnrollmentClicked = viewModel::onProceedEnrollmentClicked
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
@@ -47,9 +47,9 @@ import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextAlign
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.RootNavGraph
-import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.navigation.BackStackMode
+import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
@@ -74,11 +74,12 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 @Composable
 fun ForgotLockCodeScreen(
     navigator: Navigator,
+    loginTypeSelector: LoginTypeSelector,
     viewModel: ForgotLockScreenViewModel = hiltViewModel(),
 ) {
     with(viewModel.state) {
         LaunchedEffect(completed) {
-            val destination = if (BuildConfig.ENTERPRISE_LOGIN_ENABLED) NewLoginScreenDestination() else WelcomeScreenDestination()
+            val destination = if (loginTypeSelector.canUseNewLogin()) NewLoginScreenDestination() else WelcomeScreenDestination()
             if (completed) navigator.navigate(NavigationCommand(destination, BackStackMode.CLEAR_WHOLE))
         }
         ForgotLockCodeScreenContent(

--- a/app/src/main/kotlin/com/wire/android/ui/migration/MigrationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/migration/MigrationScreen.kt
@@ -29,10 +29,10 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.RootNavGraph
-import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.migration.MigrationData
 import com.wire.android.navigation.BackStackMode
+import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
@@ -54,6 +54,7 @@ import com.wire.android.util.ui.stringWithStyledArgs
 @Composable
 fun MigrationScreen(
     navigator: Navigator,
+    loginTypeSelector: LoginTypeSelector,
     viewModel: MigrationViewModel = hiltViewModel()
 ) {
 
@@ -61,7 +62,7 @@ fun MigrationScreen(
         is MigrationState.LoginRequired -> navigator.navigate(
             NavigationCommand(
                 when {
-                    BuildConfig.ENTERPRISE_LOGIN_ENABLED -> NewLoginScreenDestination(userHandle = state.userHandle)
+                    loginTypeSelector.canUseNewLogin() -> NewLoginScreenDestination(userHandle = state.userHandle)
                     else -> LoginScreenDestination(userHandle = state.userHandle)
                 },
                 BackStackMode.CLEAR_WHOLE
@@ -72,7 +73,7 @@ fun MigrationScreen(
             NavigationCommand(
                 when {
                     state.currentSessionAvailable -> HomeScreenDestination
-                    BuildConfig.ENTERPRISE_LOGIN_ENABLED -> NewLoginScreenDestination()
+                    loginTypeSelector.canUseNewLogin() -> NewLoginScreenDestination()
                     else -> WelcomeScreenDestination()
                 },
                 BackStackMode.CLEAR_WHOLE

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/welcome/NewWelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/welcome/NewWelcomeScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import com.ramcosta.composedestinations.annotation.RootNavGraph
-import com.wire.android.BuildConfig
+import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
@@ -37,11 +37,12 @@ import com.wire.android.ui.destinations.WelcomeScreenDestination
 @RootNavGraph(start = true)
 @WireDestination
 @Composable
-fun WelcomeChooserScreen(navigator: Navigator) {
-    // this is a temporary solution because annotation argument "start" must be a compile-time constant
-    // TODO: remove this composable as well when removing old WelcomeScreen and set start = true for NewWelcomeScreen
+fun WelcomeChooserScreen(
+    navigator: Navigator,
+    loginTypeSelector: LoginTypeSelector,
+) {
     LaunchedEffect(Unit) {
-        val destination = if (BuildConfig.ENTERPRISE_LOGIN_ENABLED) NewLoginScreenDestination() else WelcomeScreenDestination()
+        val destination = if (loginTypeSelector.canUseNewLogin()) NewLoginScreenDestination() else WelcomeScreenDestination()
         navigator.navigate(NavigationCommand(destination))
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -58,13 +58,13 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ramcosta.composedestinations.annotation.RootNavGraph
-import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.model.ImageAsset
 import com.wire.android.model.SnackBarMessage
 import com.wire.android.model.UserAvatarData
 import com.wire.android.navigation.BackStackMode
+import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
@@ -124,6 +124,7 @@ import okio.Path.Companion.toPath
 @Composable
 fun ImportMediaScreen(
     navigator: Navigator,
+    loginTypeSelector: LoginTypeSelector,
     featureFlagNotificationViewModel: FeatureFlagNotificationViewModel = hiltViewModel(),
 ) {
     when (val fileSharingRestrictedState = featureFlagNotificationViewModel.featureFlagState.isFileSharingState) {
@@ -138,7 +139,7 @@ fun ImportMediaScreen(
                 fileSharingRestrictedState = fileSharingRestrictedState,
                 navigateBack = navigator.finish,
                 openWireAction = {
-                    val destination = if (BuildConfig.ENTERPRISE_LOGIN_ENABLED) NewLoginScreenDestination() else WelcomeScreenDestination()
+                    val destination = if (loginTypeSelector.canUseNewLogin()) NewLoginScreenDestination() else WelcomeScreenDestination()
                     navigator.navigate(NavigationCommand(destination, BackStackMode.CLEAR_WHOLE))
                 }
             )

--- a/app/src/test/kotlin/com/wire/android/navigation/LoginTypeSelectorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/navigation/LoginTypeSelectorTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.navigation
+
+import com.wire.android.config.DefaultServerConfig
+import com.wire.android.config.TestDispatcherProvider
+import com.wire.android.util.newServerConfig
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.feature.auth.LoginContext
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+
+class LoginTypeSelectorTest {
+    private val dispatcherProvider = TestDispatcherProvider()
+
+    @Test
+    fun `given default config with enterprise context, then can use new login`() =
+        runTest(dispatcherProvider.main()) {
+            val (_, loginTypeSelector) = Arrangement()
+                .withContextFlowForConfig(DefaultServerConfig, flowOf(LoginContext.EnterpriseLogin))
+                .arrange()
+            val result = loginTypeSelector.canUseNewLogin()
+            assertEquals(true, result)
+        }
+
+    @Test
+    fun `given custom config with enterprise context, then can use new login`() =
+        runTest(dispatcherProvider.main()) {
+            val config = newServerConfig(1)
+            val (_, loginTypeSelector) = Arrangement()
+                .withContextFlowForConfig(DefaultServerConfig, flowOf(LoginContext.FallbackLogin))
+                .withContextFlowForConfig(config.links, flowOf(LoginContext.EnterpriseLogin))
+                .arrange()
+            val result = loginTypeSelector.canUseNewLogin(config.links)
+            assertEquals(true, result)
+        }
+
+    @Test
+    fun `given default config with fallback context, then cannot use new login`() =
+        runTest(dispatcherProvider.main()) {
+            val (_, loginTypeSelector) = Arrangement()
+                .withContextFlowForConfig(DefaultServerConfig, flowOf(LoginContext.FallbackLogin))
+                .arrange()
+            val result = loginTypeSelector.canUseNewLogin()
+            assertEquals(false, result)
+        }
+
+    @Test
+    fun `given custom config with fallback context, then cannot use new login`() =
+        runTest(dispatcherProvider.main()) {
+            val config = newServerConfig(1)
+            val (_, loginTypeSelector) = Arrangement()
+                .withContextFlowForConfig(DefaultServerConfig, flowOf(LoginContext.EnterpriseLogin))
+                .withContextFlowForConfig(config.links, flowOf(LoginContext.FallbackLogin))
+                .arrange()
+            val result = loginTypeSelector.canUseNewLogin(config.links)
+            assertEquals(false, result)
+        }
+
+    @Test
+    fun `given default config with fallback context, when context changes to enterprise, then can use new login after it changes`() =
+        runTest(dispatcherProvider.main()) {
+            val contextFlow = MutableStateFlow<LoginContext>(LoginContext.FallbackLogin)
+            val (_, loginTypeSelector) = Arrangement()
+                .withContextFlowForConfig(DefaultServerConfig, contextFlow)
+                .arrange()
+            val resultBeforeChange = loginTypeSelector.canUseNewLogin()
+            assertEquals(false, resultBeforeChange)
+            contextFlow.value = LoginContext.EnterpriseLogin
+            val resultAfterChange = loginTypeSelector.canUseNewLogin()
+            assertEquals(true, resultAfterChange)
+        }
+
+    @Test
+    fun `given custom config with fallback context, when context changes to enterprise, then can use new login after it changes`() =
+        runTest(dispatcherProvider.main()) {
+            val config = newServerConfig(1)
+            val contextFlow = MutableStateFlow<LoginContext>(LoginContext.FallbackLogin)
+            val (_, loginTypeSelector) = Arrangement()
+                .withContextFlowForConfig(DefaultServerConfig, flowOf(LoginContext.FallbackLogin))
+                .withContextFlowForConfig(config.links, contextFlow)
+                .arrange()
+            val resultBeforeChange = loginTypeSelector.canUseNewLogin(config.links)
+            assertEquals(false, resultBeforeChange)
+            contextFlow.value = LoginContext.EnterpriseLogin
+            val resultAfterChange = loginTypeSelector.canUseNewLogin(config.links)
+            assertEquals(true, resultAfterChange)
+        }
+
+    inner class Arrangement {
+        @MockK
+        lateinit var coreLogic: CoreLogic
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        fun arrange() = this to LoginTypeSelector(dispatcherProvider, coreLogic)
+
+        fun withContextFlowForConfig(config: ServerConfig.Links, contextFlow: Flow<LoginContext>) = apply {
+            coEvery { coreLogic.getGlobalScope().observeLoginContext(config) } returns contextFlow
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -105,7 +105,6 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
 
     PICTURE_IN_PICTURE_ENABLED("picture_in_picture_enabled", ConfigType.BOOLEAN),
     PAGINATED_CONVERSATION_LIST_ENABLED("paginated_conversation_list_enabled", ConfigType.BOOLEAN),
-    ENTERPRISE_LOGIN_ENABLED("enterprise_login_enabled", ConfigType.BOOLEAN),
 
     /**
      * Anonymous Analytics

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/Theme.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/Theme.kt
@@ -47,10 +47,7 @@ fun WireTheme(
         // we need to provide our default content color dependent on the current colorScheme, otherwise it's Color.Black
         LocalContentColor provides wireColorScheme.onBackground,
         *if (isPreview) {
-            arrayOf(
-                LocalSnackbarHostState provides remember { SnackbarHostState() },
-//                LocalNavigator provides rememberNavigator {} // todo, uncomment when we have navigation module, ignore since is prevonly
-            )
+            arrayOf(LocalSnackbarHostState provides remember { SnackbarHostState() })
         } else emptyArray(),
     ) {
         MaterialTheme(

--- a/default.json
+++ b/default.json
@@ -34,8 +34,7 @@
             "analytics_enabled": false,
             "picture_in_picture_enabled": true,
             "analytics_app_key": "8ffae535f1836ed5f58fd5c8a11c00eca07c5438",
-            "analytics_server_url": "https://countly.wire.com/",
-            "enterprise_login_enabled": true
+            "analytics_server_url": "https://countly.wire.com/"
         },
         "staging": {
             "application_id": "com.waz.zclient.dev",
@@ -143,6 +142,5 @@
     "limit_team_members_fetch_during_slow_sync": 2000,
     "picture_in_picture_enabled": false,
     "paginated_conversation_list_enabled": false,
-    "enterprise_login_enabled": false,
     "should_display_release_notes": true
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16058" title="WPB-16058" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16058</a>  [Android] Create login flow selector
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- implemented `LoginTypeSelector` depending on common API version for the given server config
- `LoginTypeSelector` is available for all screen destinations as a non-navigation parameter and it's used whenever the login flow needs to be opened, it can take specific custom server config to select proper login flow for it or can use build's default config if not passed any
- to make it easier and faster to use (since default config is primarily used), for default config there's a `StateFlow`, for other custom ones it needs to run a suspend fun to get that info
- simplified the way of handling new intents, used `Channel` with built-in buffering without replaying instead of trying to achieve it using `SharedFlow` and moved deeplink handling to be closer to the navigation to be able to select proper destination
- removed `LocalNavigator` as it was not used anywhere and was partly commented out
- removed `ENTERPRISE_LOGIN_ENABLED` feature config flag as it's not needed anymore - from now on select login flow based on API or enforce specific one by adding a `login-type` parameter to the custom backend deeplink

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/3287

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Open deep link with custom backend that supports API v8, for instance `dev` build to support development builds and `anta` backend which supports development v8.

### Attachments (Optional)

https://github.com/user-attachments/assets/5ee50ca5-7179-4183-8905-16e7b3e3c6eb

`anta` supports development v8 so new login flow for `anta`, fallback to old flow for others.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
