### PR TITLE
feat: Migrate to Team analytics update WPB-16050

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -26,8 +26,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.datastore.UserDataStore
-import com.wire.android.feature.analytics.AnonymousAnalyticsManager
-import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.migration.userDatabase.ShouldTriggerMigrationForUserUserCase
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.model.NameBasedAvatar
@@ -55,8 +53,7 @@ class HomeViewModel @Inject constructor(
     private val needsToRegisterClient: NeedsToRegisterClientUseCase,
     private val canMigrateFromPersonalToTeam: CanMigrateFromPersonalToTeamUseCase,
     private val observeLegalHoldStatusForSelfUser: ObserveLegalHoldStateForSelfUserUseCase,
-    private val shouldTriggerMigrationForUser: ShouldTriggerMigrationForUserUserCase,
-    private val analyticsManager: AnonymousAnalyticsManager,
+    private val shouldTriggerMigrationForUser: ShouldTriggerMigrationForUserUserCase
 ) : SavedStateViewModel(savedStateHandle) {
 
     @VisibleForTesting
@@ -140,13 +137,5 @@ class HomeViewModel @Inject constructor(
             globalDataStore.setWelcomeScreenPresented()
             homeState = homeState.copy(shouldDisplayWelcomeMessage = false)
         }
-    }
-
-    fun sendOpenProfileEvent() {
-        analyticsManager.sendEvent(
-            AnalyticsEvent.UserProfileOpened(
-                isMigrationDotActive = homeState.shouldShowCreateTeamUnreadIndicator
-            )
-        )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -163,7 +163,6 @@ fun SelfUserProfileScreen(
             )
         },
         onCreateAccount = {
-            viewModelSelf.sendPersonalToTeamMigrationEvent()
             navigator.navigate(NavigationCommand(TeamMigrationScreenDestination))
         },
         onAccountDetailsClick = { navigator.navigate(NavigationCommand(MyAccountScreenDestination)) },

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -39,6 +39,7 @@ import com.wire.android.notification.WireNotificationManager
 import com.wire.android.ui.legalhold.banner.LegalHoldUIState
 import com.wire.android.ui.userprofile.self.dialog.StatusDialogData
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.toQualifiedID
@@ -61,7 +62,6 @@ import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
 import com.wire.kalium.logic.feature.user.UpdateSelfAvailabilityStatusUseCase
-import com.wire.kalium.common.functional.getOrNull
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -321,14 +321,6 @@ class SelfUserProfileViewModel @Inject constructor(
         anonymousAnalyticsManager.sendEvent(
             AnalyticsEvent.QrCode.Click(
                 isTeam = !userProfileState.teamName.isNullOrBlank()
-            )
-        )
-    }
-
-    fun sendPersonalToTeamMigrationEvent() {
-        anonymousAnalyticsManager.sendEvent(
-            AnalyticsEvent.PersonalTeamMigration.ClickedPersonalTeamMigrationCta(
-                createTeamButtonClicked = true
             )
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationScreen.kt
@@ -113,7 +113,6 @@ fun TeamMigrationScreen(
                 if (navController.currentDestination?.route == NavGraphs.personalToTeamMigration.destinations.last().route) {
                     navigator.navigateBack()
                 } else {
-                    teamMigrationViewModel.sendPersonalToTeamMigrationDismissed()
                     teamMigrationViewModel.showMigrationLeaveDialog()
                 }
             }
@@ -139,17 +138,9 @@ fun TeamMigrationScreen(
 
     if (teamMigrationViewModel.teamMigrationState.shouldShowMigrationLeaveDialog) {
         ConfirmMigrationLeaveDialog(
-            onContinue = {
-                teamMigrationViewModel.sendPersonalTeamCreationFlowCanceledEvent(
-                    modalContinueClicked = true
-                )
-                teamMigrationViewModel.hideMigrationLeaveDialog()
-            }
+            onContinue = teamMigrationViewModel::hideMigrationLeaveDialog
         ) {
             teamMigrationViewModel.hideMigrationLeaveDialog()
-            teamMigrationViewModel.sendPersonalTeamCreationFlowCanceledEvent(
-                modalLeaveClicked = true
-            )
             navigator.navigateBack()
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationScreen.kt
@@ -55,10 +55,6 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.preview.MultipleThemePreviews
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.userprofile.teammigration.common.ConfirmMigrationLeaveDialog
-import com.wire.android.ui.userprofile.teammigration.step1.TEAM_MIGRATION_TEAM_PLAN_STEP
-import com.wire.android.ui.userprofile.teammigration.step2.TEAM_MIGRATION_TEAM_NAME_STEP
-import com.wire.android.ui.userprofile.teammigration.step3.TEAM_MIGRATION_CONFIRMATION_STEP
-import com.wire.android.ui.userprofile.teammigration.step4.TEAM_MIGRATION_DONE_STEP
 
 @OptIn(ExperimentalMaterialNavigationApi::class, ExperimentalAnimationApi::class)
 @WireDestination(style = PopUpNavigationAnimation::class)
@@ -99,10 +95,18 @@ fun TeamMigrationScreen(
             .background(color = colorsScheme().surface)
     ) {
         val closeIconContentDescription = when (teamMigrationViewModel.teamMigrationState.currentStep) {
-            TEAM_MIGRATION_TEAM_PLAN_STEP -> stringResource(R.string.personal_to_team_migration_close_team_account_content_description)
-            TEAM_MIGRATION_TEAM_NAME_STEP -> stringResource(R.string.personal_to_team_migration_close_team_name_content_description)
-            TEAM_MIGRATION_CONFIRMATION_STEP -> stringResource(R.string.personal_to_team_migration_close_confirmation_content_description)
-            TEAM_MIGRATION_DONE_STEP -> stringResource(R.string.personal_to_team_migration_close_team_created_content_description)
+            TeamMigrationViewModel.TEAM_MIGRATION_TEAM_PLAN_STEP ->
+                stringResource(R.string.personal_to_team_migration_close_team_account_content_description)
+
+            TeamMigrationViewModel.TEAM_MIGRATION_TEAM_NAME_STEP ->
+                stringResource(R.string.personal_to_team_migration_close_team_name_content_description)
+
+            TeamMigrationViewModel.TEAM_MIGRATION_CONFIRMATION_STEP ->
+                stringResource(R.string.personal_to_team_migration_close_confirmation_content_description)
+
+            TeamMigrationViewModel.TEAM_MIGRATION_DONE_STEP ->
+                stringResource(R.string.personal_to_team_migration_close_team_created_content_description)
+
             else -> stringResource(R.string.personal_to_team_migration_close_icon_content_description)
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationState.kt
@@ -28,5 +28,5 @@ data class TeamMigrationState(
     val username: String = "",
     val teamUrl: String = "",
     val migrationFailure: MigrateFromPersonalToTeamFailure? = null,
-    val isMigrationDotActive : Boolean = false
+    val isMigrationDotActive: Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationState.kt
@@ -27,5 +27,6 @@ data class TeamMigrationState(
     val currentStep: Int = 0,
     val username: String = "",
     val teamUrl: String = "",
-    val migrationFailure: MigrateFromPersonalToTeamFailure? = null
+    val migrationFailure: MigrateFromPersonalToTeamFailure? = null,
+    val isMigrationDotActive : Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModel.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.datastore.UserDataStore
 import com.wire.android.feature.analytics.AnonymousAnalyticsManager
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
@@ -38,6 +39,7 @@ class TeamMigrationViewModel @Inject constructor(
     private val anonymousAnalyticsManager: AnonymousAnalyticsManager,
     private val migrateFromPersonalToTeam: MigrateFromPersonalToTeamUseCase,
     private val observeSelfUser: ObserveSelfUserUseCase,
+    private val dataStore: UserDataStore,
     private val getTeamUrl: GetTeamUrlUseCase
 ) : ViewModel() {
 
@@ -47,6 +49,7 @@ class TeamMigrationViewModel @Inject constructor(
     init {
         setUsername()
         setTeamUrl()
+        observeMigrationDotActive()
     }
 
     fun showMigrationLeaveDialog() {
@@ -57,50 +60,9 @@ class TeamMigrationViewModel @Inject constructor(
         teamMigrationState = teamMigrationState.copy(shouldShowMigrationLeaveDialog = false)
     }
 
-    fun sendPersonalToTeamMigrationDismissed() {
-        anonymousAnalyticsManager.sendEvent(
-            AnalyticsEvent.PersonalTeamMigration.ClickedPersonalTeamMigrationCta(
-                dismissCreateTeamButtonClicked = true
-            )
-        )
-    }
-
-    fun sendPersonalTeamCreationFlowStartedEvent(step: Int) {
-        anonymousAnalyticsManager.sendEvent(
-            AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowStarted(
-                step = step
-            )
-        )
-    }
-
     fun setCurrentStep(step: Int) {
         teamMigrationState = teamMigrationState.copy(currentStep = step)
-    }
-
-    fun sendPersonalTeamCreationFlowCanceledEvent(
-        modalLeaveClicked: Boolean? = null,
-        modalContinueClicked: Boolean? = null
-    ) {
-        anonymousAnalyticsManager.sendEvent(
-            AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowCanceled(
-                teamName = teamMigrationState.teamNameTextState.text.toString(),
-                modalLeaveClicked = modalLeaveClicked,
-                modalContinueClicked = modalContinueClicked
-            )
-        )
-    }
-
-    fun sendPersonalTeamCreationFlowCompletedEvent(
-        modalOpenTeamManagementButtonClicked: Boolean? = null,
-        backToWireButtonClicked: Boolean? = null
-    ) {
-        anonymousAnalyticsManager.sendEvent(
-            AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowCompleted(
-                teamName = teamMigrationState.teamNameTextState.text.toString(),
-                modalOpenTeamManagementButtonClicked = modalOpenTeamManagementButtonClicked,
-                backToWireButtonClicked = backToWireButtonClicked
-            )
-        )
+        sendPersonalTeamCreationFlowStepEvent(step)
     }
 
     fun setIsMigratingState(isMigrating: Boolean) {
@@ -147,5 +109,29 @@ class TeamMigrationViewModel @Inject constructor(
         viewModelScope.launch {
             teamMigrationState = teamMigrationState.copy(teamUrl = getTeamUrl())
         }
+    }
+
+    private fun observeMigrationDotActive() {
+        viewModelScope.launch {
+            dataStore.isCreateTeamNoticeRead().collect { isRead ->
+                teamMigrationState = teamMigrationState.copy(
+                    isMigrationDotActive = !isRead
+                )
+            }
+        }
+    }
+
+    private fun sendPersonalTeamCreationFlowStepEvent(step: Int) {
+        val event = when (step) {
+            1 -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowTeamPlan(
+                isMigrationDotActive = teamMigrationState.isMigrationDotActive
+            )
+
+            2 -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowTeamName
+            3 -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowConfirm
+            4 -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowCompleted
+            else -> null
+        }
+        event?.let { anonymousAnalyticsManager.sendEvent(event) }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModel.kt
@@ -123,15 +123,22 @@ class TeamMigrationViewModel @Inject constructor(
 
     private fun sendPersonalTeamCreationFlowStepEvent(step: Int) {
         val event = when (step) {
-            1 -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowTeamPlan(
+            TEAM_MIGRATION_TEAM_PLAN_STEP -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowTeamPlan(
                 isMigrationDotActive = teamMigrationState.isMigrationDotActive
             )
 
-            2 -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowTeamName
-            3 -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowConfirm
-            4 -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowCompleted
+            TEAM_MIGRATION_TEAM_NAME_STEP -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowTeamName
+            TEAM_MIGRATION_CONFIRMATION_STEP -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowConfirm
+            TEAM_MIGRATION_DONE_STEP -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowCompleted
             else -> null
         }
         event?.let { anonymousAnalyticsManager.sendEvent(event) }
+    }
+
+    companion object {
+        const val TEAM_MIGRATION_TEAM_PLAN_STEP = 1
+        const val TEAM_MIGRATION_TEAM_NAME_STEP = 2
+        const val TEAM_MIGRATION_CONFIRMATION_STEP = 3
+        const val TEAM_MIGRATION_DONE_STEP = 4
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step1/TeamMigrationTeamPlanStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step1/TeamMigrationTeamPlanStepScreen.kt
@@ -77,7 +77,6 @@ fun TeamMigrationTeamPlanStepScreen(
     )
 
     LaunchedEffect(Unit) {
-        teamMigrationViewModel.sendPersonalTeamCreationFlowStartedEvent(TEAM_MIGRATION_TEAM_PLAN_STEP)
         teamMigrationViewModel.setCurrentStep(TEAM_MIGRATION_TEAM_PLAN_STEP)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step1/TeamMigrationTeamPlanStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step1/TeamMigrationTeamPlanStepScreen.kt
@@ -59,8 +59,6 @@ import com.wire.android.ui.userprofile.teammigration.common.BottomLineButtons
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.PreviewMultipleThemes
 
-const val TEAM_MIGRATION_TEAM_PLAN_STEP = 1
-
 @PersonalToTeamMigrationNavGraph(start = true)
 @WireDestination(
     style = SlideNavigationAnimation::class
@@ -77,7 +75,7 @@ fun TeamMigrationTeamPlanStepScreen(
     )
 
     LaunchedEffect(Unit) {
-        teamMigrationViewModel.setCurrentStep(TEAM_MIGRATION_TEAM_PLAN_STEP)
+        teamMigrationViewModel.setCurrentStep(TeamMigrationViewModel.TEAM_MIGRATION_TEAM_PLAN_STEP)
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step2/TeamMigrationTeamNameStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step2/TeamMigrationTeamNameStepScreen.kt
@@ -70,7 +70,6 @@ fun TeamMigrationTeamNameStepScreen(
         teamNameTextFieldState = teamMigrationViewModel.teamMigrationState.teamNameTextState
     )
     LaunchedEffect(Unit) {
-        teamMigrationViewModel.sendPersonalTeamCreationFlowStartedEvent(TEAM_MIGRATION_TEAM_NAME_STEP)
         teamMigrationViewModel.setCurrentStep(TEAM_MIGRATION_TEAM_NAME_STEP)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step2/TeamMigrationTeamNameStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step2/TeamMigrationTeamNameStepScreen.kt
@@ -49,8 +49,6 @@ import com.wire.android.ui.userprofile.teammigration.TeamMigrationViewModel
 import com.wire.android.ui.userprofile.teammigration.common.BottomLineButtons
 import com.wire.android.util.ui.PreviewMultipleThemes
 
-const val TEAM_MIGRATION_TEAM_NAME_STEP = 2
-
 @PersonalToTeamMigrationNavGraph
 @WireDestination(
     style = SlideNavigationAnimation::class
@@ -70,7 +68,7 @@ fun TeamMigrationTeamNameStepScreen(
         teamNameTextFieldState = teamMigrationViewModel.teamMigrationState.teamNameTextState
     )
     LaunchedEffect(Unit) {
-        teamMigrationViewModel.setCurrentStep(TEAM_MIGRATION_TEAM_NAME_STEP)
+        teamMigrationViewModel.setCurrentStep(TeamMigrationViewModel.TEAM_MIGRATION_TEAM_NAME_STEP)
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step3/TeamMigrationConfirmationStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step3/TeamMigrationConfirmationStepScreen.kt
@@ -64,8 +64,6 @@ import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.feature.user.migration.MigrateFromPersonalToTeamFailure
 
-const val TEAM_MIGRATION_CONFIRMATION_STEP = 3
-
 @PersonalToTeamMigrationNavGraph
 @WireDestination(
     style = SlideNavigationAnimation::class
@@ -109,7 +107,7 @@ fun TeamMigrationConfirmationStepScreen(
     )
 
     LaunchedEffect(Unit) {
-        teamMigrationViewModel.setCurrentStep(TEAM_MIGRATION_CONFIRMATION_STEP)
+        teamMigrationViewModel.setCurrentStep(TeamMigrationViewModel.TEAM_MIGRATION_CONFIRMATION_STEP)
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step3/TeamMigrationConfirmationStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step3/TeamMigrationConfirmationStepScreen.kt
@@ -109,7 +109,6 @@ fun TeamMigrationConfirmationStepScreen(
     )
 
     LaunchedEffect(Unit) {
-        teamMigrationViewModel.sendPersonalTeamCreationFlowStartedEvent(TEAM_MIGRATION_CONFIRMATION_STEP)
         teamMigrationViewModel.setCurrentStep(TEAM_MIGRATION_CONFIRMATION_STEP)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step4/TeamMigrationDoneStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step4/TeamMigrationDoneStepScreen.kt
@@ -67,9 +67,6 @@ fun TeamMigrationDoneStepScreen(
 
     TeamMigrationDoneStepContent(
         onBackToWireClicked = {
-            teamMigrationViewModel.sendPersonalTeamCreationFlowCompletedEvent(
-                backToWireButtonClicked = true
-            )
             navigator.navigate(
                 NavigationCommand(
                     HomeScreenDestination,
@@ -79,10 +76,6 @@ fun TeamMigrationDoneStepScreen(
         },
         onOpenTeamManagementClicked = {
             val teamManagementUrl = teamMigrationViewModel.teamMigrationState.teamUrl
-
-            teamMigrationViewModel.sendPersonalTeamCreationFlowCompletedEvent(
-                modalOpenTeamManagementButtonClicked = true
-            )
             CustomTabsHelper.launchUrl(context, teamManagementUrl)
         },
         username = teamMigrationViewModel.teamMigrationState.username,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step4/TeamMigrationDoneStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step4/TeamMigrationDoneStepScreen.kt
@@ -52,8 +52,6 @@ import com.wire.android.ui.userprofile.teammigration.common.BulletList
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.PreviewMultipleThemes
 
-const val TEAM_MIGRATION_DONE_STEP = 4
-
 @PersonalToTeamMigrationNavGraph
 @WireDestination(
     style = SlideNavigationAnimation::class
@@ -83,7 +81,7 @@ fun TeamMigrationDoneStepScreen(
     )
 
     LaunchedEffect(Unit) {
-        teamMigrationViewModel.setCurrentStep(TEAM_MIGRATION_DONE_STEP)
+        teamMigrationViewModel.setCurrentStep(TeamMigrationViewModel.TEAM_MIGRATION_DONE_STEP)
     }
 
     BackHandler { }

--- a/app/src/test/kotlin/com/wire/android/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/HomeViewModelTest.kt
@@ -21,8 +21,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.datastore.UserDataStore
-import com.wire.android.feature.analytics.AnonymousAnalyticsManager
-import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.framework.TestUser
 import com.wire.android.migration.userDatabase.ShouldTriggerMigrationForUserUserCase
 import com.wire.kalium.logic.data.user.SelfUser
@@ -36,7 +34,6 @@ import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
-import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -97,24 +94,6 @@ class HomeViewModelTest {
             assertEquals(true, viewModel.homeState.shouldDisplayLegalHoldIndicator)
         }
 
-    @Test
-    fun `given open profile event, when sendOpenProfileEvent is called, then send the event with the unread indicator value`() =
-        runTest {
-            val (arrangement, viewModel) = Arrangement()
-                .withLegalHoldStatus(flowOf(LegalHoldStateForSelfUser.Enabled))
-                .arrange()
-
-            viewModel.sendOpenProfileEvent()
-
-            verify(exactly = 1) {
-                arrangement.analyticsManager.sendEvent(
-                    AnalyticsEvent.UserProfileOpened(
-                        isMigrationDotActive = viewModel.homeState.shouldShowCreateTeamUnreadIndicator
-                    )
-                )
-            }
-        }
-
     internal class Arrangement {
 
         @MockK
@@ -142,9 +121,6 @@ class HomeViewModelTest {
         lateinit var shouldTriggerMigrationForUser: ShouldTriggerMigrationForUserUserCase
 
         @MockK
-        lateinit var analyticsManager: AnonymousAnalyticsManager
-
-        @MockK
         lateinit var canMigrateFromPersonalToTeam: CanMigrateFromPersonalToTeamUseCase
 
         private val viewModel by lazy {
@@ -156,7 +132,6 @@ class HomeViewModelTest {
                 needsToRegisterClient = needsToRegisterClient,
                 observeLegalHoldStatusForSelfUser = observeLegalHoldStatusForSelfUser,
                 shouldTriggerMigrationForUser = shouldTriggerMigrationForUser,
-                analyticsManager = analyticsManager,
                 canMigrateFromPersonalToTeam = canMigrateFromPersonalToTeam,
                 getSelfUser = getSelf,
             )

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModelTest.kt
@@ -19,10 +19,8 @@ package com.wire.android.ui.userprofile.self
 
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
-import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.ui.legalhold.banner.LegalHoldUIState
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
-import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
@@ -63,23 +61,5 @@ class SelfUserProfileViewModelTest {
                 .arrange()
             // then
             assertEquals(LegalHoldUIState.None, viewModel.userProfileState.legalHoldStatus)
-        }
-
-    @Test
-    fun `given a createTeamButtonClicked event, when sendPersonalToTeamMigrationEvent is called, then the event is sent`() =
-        runTest {
-            val (arrangement, viewModel) = SelfUserProfileViewModelArrangement()
-                .withLegalHoldStatus(LegalHoldStateForSelfUser.Disabled)
-                .arrange()
-
-            viewModel.sendPersonalToTeamMigrationEvent()
-
-            verify(exactly = 1) {
-                arrangement.anonymousAnalyticsManager.sendEvent(
-                    AnalyticsEvent.PersonalTeamMigration.ClickedPersonalTeamMigrationCta(
-                        createTeamButtonClicked = true
-                    )
-                )
-            }
         }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModelTest.kt
@@ -19,6 +19,7 @@ package com.wire.android.ui.userprofile.teammigration
 
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.datastore.UserDataStore
 import com.wire.android.feature.analytics.AnonymousAnalyticsManager
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.kalium.common.error.NetworkFailure
@@ -66,112 +67,20 @@ class TeamMigrationViewModelTest {
         }
 
     @Test
-    fun `given close modal event, when sendPersonalToTeamMigrationDismissed is called, then send the event`() =
-        runTest {
-            val (arrangement, viewModel) = Arrangement()
-                .arrange()
-
-            viewModel.sendPersonalToTeamMigrationDismissed()
-
-            verify(exactly = 1) {
-                arrangement.anonymousAnalyticsManager.sendEvent(
-                    AnalyticsEvent.PersonalTeamMigration.ClickedPersonalTeamMigrationCta(
-                        dismissCreateTeamButtonClicked = true
-                    )
-                )
-            }
-        }
-
-    @Test
-    fun `given the step of migration flow, when sendPersonalTeamCreationFlowStartedEvent is called, then send the event`() =
+    fun `given the step of migration flow, when setCurrentStep is called, then update currentStep and send the event`() =
         runTest {
             val step = 2
             val (arrangement, viewModel) = Arrangement()
                 .arrange()
 
-            viewModel.sendPersonalTeamCreationFlowStartedEvent(2)
+            viewModel.setCurrentStep(step)
 
             verify(exactly = 1) {
                 arrangement.anonymousAnalyticsManager.sendEvent(
-                    AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowStarted(
-                        step = step
-                    )
+                    AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowTeamName
                 )
             }
-        }
-
-    @Test
-    fun `given modalLeaveClicked event, when sendPersonalTeamCreationFlowCanceledEvent is called, then send the event`() =
-        runTest {
-            val (arrangement, viewModel) = Arrangement()
-                .arrange()
-
-            viewModel.sendPersonalTeamCreationFlowCanceledEvent(modalLeaveClicked = true)
-
-            verify(exactly = 1) {
-                arrangement.anonymousAnalyticsManager.sendEvent(
-                    AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowCanceled(
-                        teamName = viewModel.teamMigrationState.teamNameTextState.text.toString(),
-                        modalLeaveClicked = true
-                    )
-                )
-            }
-        }
-
-    @Test
-    fun `given modalContinueClicked event, when sendPersonalTeamCreationFlowCanceledEvent is called, then send the event`() =
-        runTest {
-            val (arrangement, viewModel) = Arrangement()
-                .arrange()
-
-            viewModel.sendPersonalTeamCreationFlowCanceledEvent(modalContinueClicked = true)
-
-            verify(exactly = 1) {
-                arrangement.anonymousAnalyticsManager.sendEvent(
-                    AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowCanceled(
-                        teamName = viewModel.teamMigrationState.teamNameTextState.text.toString(),
-                        modalContinueClicked = true
-                    )
-                )
-            }
-        }
-
-    @Test
-    fun `given modalOpenTeamManagementButtonClicked event, when sendPersonalTeamCreationFlowCompletedEvent is called, then send the event`() =
-        runTest {
-            val (arrangement, viewModel) = Arrangement()
-                .arrange()
-
-            viewModel.sendPersonalTeamCreationFlowCompletedEvent(
-                modalOpenTeamManagementButtonClicked = true
-            )
-
-            verify(exactly = 1) {
-                arrangement.anonymousAnalyticsManager.sendEvent(
-                    AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowCompleted(
-                        teamName = viewModel.teamMigrationState.teamNameTextState.text.toString(),
-                        modalOpenTeamManagementButtonClicked = true
-                    )
-                )
-            }
-        }
-
-    @Test
-    fun `given backToWireButtonClicked event, when sendPersonalTeamCreationFlowCompletedEvent is called, then send the event`() =
-        runTest {
-            val (arrangement, viewModel) = Arrangement()
-                .arrange()
-
-            viewModel.sendPersonalTeamCreationFlowCompletedEvent(backToWireButtonClicked = true)
-
-            verify(exactly = 1) {
-                arrangement.anonymousAnalyticsManager.sendEvent(
-                    AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowCompleted(
-                        teamName = viewModel.teamMigrationState.teamNameTextState.text.toString(),
-                        backToWireButtonClicked = true
-                    )
-                )
-            }
+            assertEquals(step, viewModel.teamMigrationState.currentStep)
         }
 
     @Test
@@ -278,16 +187,21 @@ class TeamMigrationViewModelTest {
         @MockK
         lateinit var getTeamUrl: GetTeamUrlUseCase
 
+        @MockK
+        lateinit var dataStore: UserDataStore
+
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
             coEvery { getSelfUser() } returns flowOf()
             coEvery { getTeamUrl() } returns "TeamUrl"
+            coEvery { dataStore.isCreateTeamNoticeRead() } returns flowOf(false)
         }
 
         fun arrange() = this to TeamMigrationViewModel(
             anonymousAnalyticsManager = anonymousAnalyticsManager,
             migrateFromPersonalToTeam = migrateFromPersonalToTeam,
             observeSelfUser = getSelfUser,
+            dataStore = dataStore,
             getTeamUrl = getTeamUrl
         ).also { viewModel ->
             viewModel.teamMigrationState.teamNameTextState.setTextAndPlaceCursorAtEnd(TEAM_NAME)

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/model/AnalyticsEvent.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/model/AnalyticsEvent.kt
@@ -30,7 +30,6 @@ import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CALLING_
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CALLING_ENDED_CONVERSATION_SIZE
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CALLING_ENDED_CONVERSATION_TYPE
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CALLING_ENDED_END_REASON
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.IS_TEAM_MEMBER
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CALLING_ENDED_UNIQUE_SCREEN_SHARE
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CALLING_QUALITY_REVIEW_IGNORE_REASON
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CALLING_QUALITY_REVIEW_IGNORE_REASON_KEY
@@ -39,24 +38,16 @@ import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CALLING_
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CALLING_QUALITY_REVIEW_LABEL_KEY
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CALLING_QUALITY_REVIEW_LABEL_NOT_DISPLAYED
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CALLING_QUALITY_REVIEW_SCORE_KEY
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CLICKED_CREATE_TEAM
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CLICKED_DISMISS_CTA
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CLICKED_PERSONAL_MIGRATION_CTA_EVENT
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.CONTRIBUTED_LOCATION
+import com.wire.android.feature.analytics.model.AnalyticsEventConstants.IS_TEAM_MEMBER
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.MESSAGE_ACTION_KEY
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.MIGRATION_DOT_ACTIVE
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.MODAL_BACK_TO_WIRE_CLICKED
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.MODAL_CONTINUE_CLICKED
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.MODAL_LEAVE_CLICKED
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.MODAL_OPEN_TEAM_MANAGEMENT_CLICKED
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.MODAL_TEAM_NAME
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.PERSONAL_TEAM_CREATION_FLOW_CANCELLED
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.PERSONAL_TEAM_CREATION_FLOW_COMPLETED
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.PERSONAL_TEAM_CREATION_FLOW_STARTED_EVENT
+import com.wire.android.feature.analytics.model.AnalyticsEventConstants.PERSONAL_TO_TEAM_FLOW_COMPLETED_EVENT
+import com.wire.android.feature.analytics.model.AnalyticsEventConstants.PERSONAL_TO_TEAM_FLOW_CONFIRM_EVENT
+import com.wire.android.feature.analytics.model.AnalyticsEventConstants.PERSONAL_TO_TEAM_FLOW_TEAM_NAME_EVENT
+import com.wire.android.feature.analytics.model.AnalyticsEventConstants.PERSONAL_TO_TEAM_FLOW_TEAM_PLAN_EVENT
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.QR_CODE_SEGMENTATION_USER_TYPE_PERSONAL
 import com.wire.android.feature.analytics.model.AnalyticsEventConstants.QR_CODE_SEGMENTATION_USER_TYPE_TEAM
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.STEP_MODAL_CREATE_TEAM
-import com.wire.android.feature.analytics.model.AnalyticsEventConstants.USER_PROFILE_OPENED
 import com.wire.kalium.logic.data.call.RecentlyEndedCallMetadata
 import com.wire.kalium.logic.data.conversation.Conversation
 
@@ -308,92 +299,29 @@ interface AnalyticsEvent {
         }
     }
 
-    data class UserProfileOpened(
-        val isMigrationDotActive: Boolean
-    ) : AnalyticsEvent {
-        override val key: String = USER_PROFILE_OPENED
-
-        override fun toSegmentation(): Map<String, Any> {
-            return mapOf(
-                MIGRATION_DOT_ACTIVE to isMigrationDotActive
-            )
-        }
-    }
-
     sealed interface PersonalTeamMigration : AnalyticsEvent {
-
-        data class ClickedPersonalTeamMigrationCta(
-            val createTeamButtonClicked: Boolean? = null,
-            val dismissCreateTeamButtonClicked: Boolean? = null
+        data class PersonalTeamCreationFlowTeamPlan(
+            val isMigrationDotActive: Boolean
         ) : AnalyticsEvent {
-            override val key: String = CLICKED_PERSONAL_MIGRATION_CTA_EVENT
-
-            override fun toSegmentation(): Map<String, Any> {
-                val segmentations = mutableMapOf<String, Any>()
-                createTeamButtonClicked?.let {
-                    segmentations.put(CLICKED_CREATE_TEAM, it)
-                }
-                dismissCreateTeamButtonClicked?.let {
-                    segmentations.put(CLICKED_DISMISS_CTA, it)
-                }
-                return segmentations
-            }
-        }
-
-        data class PersonalTeamCreationFlowStarted(
-            val step: Int
-        ) : AnalyticsEvent {
-            override val key: String = PERSONAL_TEAM_CREATION_FLOW_STARTED_EVENT
+            override val key: String = PERSONAL_TO_TEAM_FLOW_TEAM_PLAN_EVENT
 
             override fun toSegmentation(): Map<String, Any> {
                 return mapOf(
-                    STEP_MODAL_CREATE_TEAM to step
+                    MIGRATION_DOT_ACTIVE to isMigrationDotActive
                 )
             }
         }
 
-        data class PersonalTeamCreationFlowCanceled(
-            val teamName: String?,
-            val modalLeaveClicked: Boolean? = null,
-            val modalContinueClicked: Boolean? = null
-        ) : AnalyticsEvent {
-            override val key: String = PERSONAL_TEAM_CREATION_FLOW_CANCELLED
-
-            override fun toSegmentation(): Map<String, Any> {
-                val segmentations = mutableMapOf<String, Any>()
-                modalLeaveClicked?.let {
-                    segmentations.put(MODAL_LEAVE_CLICKED, it)
-                }
-                modalContinueClicked?.let {
-                    segmentations.put(MODAL_CONTINUE_CLICKED, it)
-                }
-                teamName?.let {
-                    segmentations.put(MODAL_TEAM_NAME, it)
-                }
-                return segmentations
-            }
+        data object PersonalTeamCreationFlowTeamName : AnalyticsEvent {
+            override val key: String = PERSONAL_TO_TEAM_FLOW_TEAM_NAME_EVENT
         }
 
-        data class PersonalTeamCreationFlowCompleted(
-            val teamName: String? = null,
-            val modalOpenTeamManagementButtonClicked: Boolean? = null,
-            val backToWireButtonClicked: Boolean? = null
-        ) : AnalyticsEvent {
-            override val key: String = PERSONAL_TEAM_CREATION_FLOW_COMPLETED
+        data object PersonalTeamCreationFlowConfirm : AnalyticsEvent {
+            override val key: String = PERSONAL_TO_TEAM_FLOW_CONFIRM_EVENT
+        }
 
-            override fun toSegmentation(): Map<String, Any> {
-                val segmentations = mutableMapOf<String, Any>()
-                teamName?.let {
-                    segmentations.put(MODAL_TEAM_NAME, it)
-                }
-                modalOpenTeamManagementButtonClicked?.let {
-                    segmentations.put(MODAL_OPEN_TEAM_MANAGEMENT_CLICKED, it)
-                }
-                backToWireButtonClicked?.let {
-                    segmentations.put(MODAL_BACK_TO_WIRE_CLICKED, it)
-                }
-                return segmentations
-            }
+        data object PersonalTeamCreationFlowCompleted : AnalyticsEvent {
+            override val key: String = PERSONAL_TO_TEAM_FLOW_COMPLETED_EVENT
         }
     }
 }
@@ -479,24 +407,11 @@ object AnalyticsEventConstants {
     const val QR_CODE_SEGMENTATION_USER_TYPE_TEAM = "team"
 
     /**
-     * user profile
-     */
-    const val USER_PROFILE_OPENED = "ui.clicked-profile"
-
-    /**
      * Personal to team migration
      */
-    const val CLICKED_PERSONAL_MIGRATION_CTA_EVENT = "ui.clicked-personal-migration-cta"
-    const val PERSONAL_TEAM_CREATION_FLOW_STARTED_EVENT = "user.personal-team-creation-flow-started"
-    const val PERSONAL_TEAM_CREATION_FLOW_CANCELLED = "user.personal-team-creation-flow-cancelled"
-    const val PERSONAL_TEAM_CREATION_FLOW_COMPLETED = "user.personal-team-creation-flow-completed"
+    const val PERSONAL_TO_TEAM_FLOW_TEAM_PLAN_EVENT = "user.personal-to-team-flow-team-plan-1"
+    const val PERSONAL_TO_TEAM_FLOW_TEAM_NAME_EVENT = "user.personal-to-team-flow-team-name-2"
+    const val PERSONAL_TO_TEAM_FLOW_CONFIRM_EVENT = "user.personal-to-team-flow-confirm-3"
+    const val PERSONAL_TO_TEAM_FLOW_COMPLETED_EVENT = "user.personal-to-team-flow-completed-4"
     const val MIGRATION_DOT_ACTIVE = "migration_dot_active"
-    const val CLICKED_CREATE_TEAM = "clicked_create_team"
-    const val CLICKED_DISMISS_CTA = "clicked_dismiss_cta"
-    const val STEP_MODAL_CREATE_TEAM = "step_modalcreateteam"
-    const val MODAL_TEAM_NAME = "modal_team-name"
-    const val MODAL_CONTINUE_CLICKED = "modal_continue-clicked"
-    const val MODAL_LEAVE_CLICKED = "modal_leave-clicked"
-    const val MODAL_BACK_TO_WIRE_CLICKED = "modal_back-to-wire-clicked"
-    const val MODAL_OPEN_TEAM_MANAGEMENT_CLICKED = "modal_open-tm-clicked"
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16050" title="WPB-16050" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16050</a>  [Android] Modification of personal-to-teams events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

Updates in migrate from Personal to Team account.
remove events: 
- `ui.clicked-profile`
- `ui.clicked-personal-migration-cta`
- `user.personal-team-creation-flow-started`
- `user.personal-team-creation-flow-stopped`
- `user.personal-team-creation-flow-cancelled`
- `user.personal-team-creation-flow-completed`

add events: 
- `user.personal-to-team-flow-team-plan-1` (with parameter `migration_dot_active`)
- `user.personal-to-team-flow-team-name-2`
- `user.personal-to-team-flow-confirm-3`
- `user.personal-to-team-flow-completed-4`