### PR TITLE
fix: CallControlButtons shape #WPB-16054

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/WireCallControlButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/WireCallControlButton.kt
@@ -42,11 +42,10 @@ fun WireCallControlButton(
     height: Dp = dimensions().defaultCallingControlsHeight,
     iconSize: Dp = dimensions().defaultCallingControlsIconSize
 ) {
-    val shape = CircleShape
     WireSecondaryIconButton(
         onButtonClicked = onClick,
         iconResource = iconResId,
-        shape = shape,
+        shape = CircleShape,
         colors = with(colorsScheme()) {
             wireSecondaryButtonColors().copy(
                 selected = inverseSurface,
@@ -64,6 +63,6 @@ fun WireCallControlButton(
         minSize = DpSize(width, height),
         minClickableSize = DpSize(width, height),
         iconSize = iconSize,
-        modifier = modifier
+        modifier = modifier,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/WireCallControlButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/WireCallControlButton.kt
@@ -20,20 +20,16 @@ package com.wire.android.ui.calling.controlbuttons
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.foundation.border
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.dp
 import com.wire.android.ui.common.button.WireButtonState
-import com.wire.android.ui.common.button.WirePrimaryIconButton
+import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.button.wireSecondaryButtonColors
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.theme.wireColorScheme
 
 @Composable
 fun WireCallControlButton(
@@ -47,7 +43,7 @@ fun WireCallControlButton(
     iconSize: Dp = dimensions().defaultCallingControlsIconSize
 ) {
     val shape = CircleShape
-    WirePrimaryIconButton(
+    WireSecondaryIconButton(
         onButtonClicked = onClick,
         iconResource = iconResId,
         shape = shape,
@@ -58,7 +54,7 @@ fun WireCallControlButton(
                 onSelected = inverseOnSurface,
                 selectedRipple = inverseOnSurface,
                 enabled = secondaryButtonEnabled,
-                enabledOutline = secondaryButtonEnabledOutline,
+                enabledOutline = secondaryButtonDisabledOutline,
                 onEnabled = onSecondaryButtonEnabled,
                 enabledRipple = secondaryButtonRipple,
             )
@@ -68,6 +64,6 @@ fun WireCallControlButton(
         minSize = DpSize(width, height),
         minClickableSize = DpSize(width, height),
         iconSize = iconSize,
-        modifier = modifier.border(width = 1.dp, color = MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline, shape = shape)
+        modifier = modifier
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/WireCallControlButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/WireCallControlButton.kt
@@ -20,16 +20,20 @@ package com.wire.android.ui.calling.controlbuttons
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.foundation.border
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryIconButton
 import com.wire.android.ui.common.button.wireSecondaryButtonColors
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireColorScheme
 
 @Composable
 fun WireCallControlButton(
@@ -42,10 +46,11 @@ fun WireCallControlButton(
     height: Dp = dimensions().defaultCallingControlsHeight,
     iconSize: Dp = dimensions().defaultCallingControlsIconSize
 ) {
+    val shape = CircleShape
     WirePrimaryIconButton(
         onButtonClicked = onClick,
         iconResource = iconResId,
-        shape = CircleShape,
+        shape = shape,
         colors = with(colorsScheme()) {
             wireSecondaryButtonColors().copy(
                 selected = inverseSurface,
@@ -63,6 +68,6 @@ fun WireCallControlButton(
         minSize = DpSize(width, height),
         minClickableSize = DpSize(width, height),
         iconSize = iconSize,
-        modifier = modifier,
+        modifier = modifier.border(width = 1.dp, color = MaterialTheme.wireColorScheme.secondaryButtonDisabledOutline, shape = shape)
     )
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16054" title="WPB-16054" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-16054</a>  [Android] UI Missing Calling Button Shape
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

The calling buttons (camera, speaker, and mic) are missing their intended round shape on the preview screen in version 

### Causes (Optional)

missed it somewhere :) 

### Solutions

add a borders for buttons

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 

| Before | After |
| ----------- | ------------ |
|  ![photo_5303385085950684910_y](https://github.com/user-attachments/assets/11e109b8-7f59-473e-afb4-a3a635ba00da) | ![photo_5303385085950684859_y](https://github.com/user-attachments/assets/bfbfbce3-9057-4982-bb0a-92fba3b9db10)  |
| ![photo_5303385085950684911_y](https://github.com/user-attachments/assets/a748dbf1-383f-4d02-9663-6171d4f739f1)  |  ![photo_5303385085950684860_y](https://github.com/user-attachments/assets/bff5cf51-2b19-464e-8d9d-68cbdd9fca33) |

