### PR TITLE
chore(logging): guarantee app metadata in log files [WPB-8645]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/debug/UserDebugViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/UserDebugViewModel.kt
@@ -69,13 +69,13 @@ class UserDebugViewModel
     fun setLoggingEnabledState(isEnabled: Boolean) {
         viewModelScope.launch {
             globalDataStore.setLoggingEnabled(isEnabled)
-        }
-        if (isEnabled) {
-            logFileWriter.start()
-            CoreLogger.setLoggingLevel(level = KaliumLogLevel.VERBOSE)
-        } else {
-            logFileWriter.stop()
-            CoreLogger.setLoggingLevel(level = KaliumLogLevel.DISABLED)
+            if (isEnabled) {
+                logFileWriter.start()
+                CoreLogger.setLoggingLevel(level = KaliumLogLevel.VERBOSE)
+            } else {
+                logFileWriter.stop()
+                CoreLogger.setLoggingLevel(level = KaliumLogLevel.DISABLED)
+            }
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8645" title="WPB-8645" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-8645</a>  [Android] Infrastructure code and developer experience
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Most of the times, we don't get basic app information when reading the log files.

### Causes

We launch an async coroutine that will initialise the `LogFileWriter`, and _immediately_ log basic app information, like App version, OS version, Phone model, Commit hash, etc.

### Solutions

Make it so that `LogFileWriter.start()` _suspends_ until it actually starts. Then we can start printing basic information.

This is done by waiting for the first log lines to come before completing the `LogFileWriter.start`.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
