### PR TITLE
feat: use entered email for old flow when new is not supported [WPB-16058]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -75,6 +75,7 @@ import com.wire.android.navigation.startDestination
 import com.wire.android.navigation.style.BackgroundStyle
 import com.wire.android.navigation.style.BackgroundType
 import com.wire.android.ui.authentication.login.LoginPasswordPath
+import com.wire.android.ui.authentication.login.PreFilledUserIdentifierType
 import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
 import com.wire.android.ui.calling.getIncomingCallIntent
 import com.wire.android.ui.calling.getOutgoingCallIntent
@@ -769,8 +770,8 @@ class WireActivity : AppCompatActivity() {
                     navigate(
                         NavigationCommand(
                             when (loginTypeSelector.canUseNewLogin()) {
-                                true -> NewLoginScreenDestination(userHandle = it.userHandle)
-                                false -> LoginScreenDestination(userHandle = it.userHandle)
+                                true -> NewLoginScreenDestination(userHandle = PreFilledUserIdentifierType.PreFilled(it.userHandle))
+                                false -> LoginScreenDestination(userHandle = PreFilledUserIdentifierType.PreFilled(it.userHandle))
                             },
                             // if "welcome empty start" screen then switch "start" screen to proper one
                             when (navigator.shouldReplaceWelcomeLoginStartDestination()) {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginNavArgs.kt
@@ -21,11 +21,25 @@ import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import kotlinx.serialization.Serializable
 
+@Serializable
 data class LoginNavArgs(
-    val userHandle: String? = null,
+    val userHandle: PreFilledUserIdentifierType = PreFilledUserIdentifierType.None,
     val ssoLoginResult: DeepLinkResult.SSOLogin? = null,
     val loginPasswordPath: LoginPasswordPath? = null,
 )
+
+@Serializable
+sealed interface PreFilledUserIdentifierType {
+    @Serializable
+    data object None : PreFilledUserIdentifierType
+    @Serializable
+    data class PreFilled(val userIdentifier: String, val editable: Boolean = false) : PreFilledUserIdentifierType
+
+    val userIdentifierEditable: Boolean get() = when (this) {
+        is PreFilled -> this.editable
+        is None -> true
+    }
+}
 
 @Serializable
 data class LoginPasswordPath(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginNavArgs.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class LoginNavArgs(
-    val userHandle: PreFilledUserIdentifierType = PreFilledUserIdentifierType.None,
+    val userHandle: PreFilledUserIdentifierType.PreFilled? = null,
     val ssoLoginResult: DeepLinkResult.SSOLogin? = null,
     val loginPasswordPath: LoginPasswordPath? = null,
 )

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -95,10 +95,5 @@ fun AddAuthenticatedUserUseCase.Result.Failure.toLoginError(): LoginState.Error 
     AddAuthenticatedUserUseCase.Result.Failure.UserAlreadyExists -> LoginState.Error.DialogError.UserAlreadyExists
 }
 
-sealed interface PreFilledUserIdentifierType {
-    data object None : PreFilledUserIdentifierType
-    data class PreFilled(val userIdentifier: String) : PreFilledUserIdentifierType
-}
-
 val ServerConfig.Links.isProxyEnabled get() = this.apiProxy != null
 val ServerConfig.Links.isProxyAuthRequired get() = apiProxy?.needsAuthentication ?: false

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -74,7 +74,7 @@ class LoginEmailViewModel @Inject constructor(
     coreLogic
 ) {
     val loginNavArgs: LoginNavArgs = savedStateHandle.navArgs()
-    private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle
+    private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle ?: PreFilledUserIdentifierType.None
 
     val userIdentifierTextState: TextFieldState = TextFieldState()
     val passwordTextState: TextFieldState = TextFieldState()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -74,15 +74,13 @@ class LoginEmailViewModel @Inject constructor(
     coreLogic
 ) {
     val loginNavArgs: LoginNavArgs = savedStateHandle.navArgs()
-    private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle.let {
-        if (it.isNullOrEmpty()) PreFilledUserIdentifierType.None else PreFilledUserIdentifierType.PreFilled(it)
-    }
+    private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle
 
     val userIdentifierTextState: TextFieldState = TextFieldState()
     val passwordTextState: TextFieldState = TextFieldState()
     val proxyIdentifierTextState: TextFieldState = TextFieldState()
     val proxyPasswordTextState: TextFieldState = TextFieldState()
-    var loginState by mutableStateOf(LoginEmailState(preFilledUserIdentifier is PreFilledUserIdentifierType.None))
+    var loginState by mutableStateOf(LoginEmailState(preFilledUserIdentifier.userIdentifierEditable))
 
     val secondFactorVerificationCodeTextState: TextFieldState = TextFieldState()
     var secondFactorVerificationCodeState by mutableStateOf(VerificationCodeState())

--- a/app/src/main/kotlin/com/wire/android/ui/migration/MigrationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/migration/MigrationScreen.kt
@@ -36,6 +36,7 @@ import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
+import com.wire.android.ui.authentication.login.PreFilledUserIdentifierType
 import com.wire.android.ui.common.SettingUpWireScreenContent
 import com.wire.android.ui.common.SettingUpWireScreenType
 import com.wire.android.ui.destinations.HomeScreenDestination
@@ -62,8 +63,10 @@ fun MigrationScreen(
         is MigrationState.LoginRequired -> navigator.navigate(
             NavigationCommand(
                 when {
-                    loginTypeSelector.canUseNewLogin() -> NewLoginScreenDestination(userHandle = state.userHandle)
-                    else -> LoginScreenDestination(userHandle = state.userHandle)
+                    loginTypeSelector.canUseNewLogin() ->
+                        NewLoginScreenDestination(userHandle = PreFilledUserIdentifierType.PreFilled(state.userHandle))
+                    else ->
+                        LoginScreenDestination(userHandle = PreFilledUserIdentifierType.PreFilled(state.userHandle))
                 },
                 BackStackMode.CLEAR_WHOLE
             )

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginAction.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginAction.kt
@@ -22,7 +22,7 @@ import com.wire.android.ui.authentication.login.sso.SSOUrlConfig
 import com.wire.kalium.logic.configuration.server.ServerConfig
 
 sealed interface NewLoginAction {
-    data object EnterpriseLoginNotSupported : NewLoginAction
+    data class EnterpriseLoginNotSupported(val userIdentifier: String) : NewLoginAction
     data class EmailPassword(val userIdentifier: String, val loginPasswordPath: LoginPasswordPath) : NewLoginAction
     data class CustomConfig(val userIdentifier: String, val customServerConfig: ServerConfig.Links) : NewLoginAction
     data class SSO(val url: String, val config: SSOUrlConfig) : NewLoginAction

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
@@ -58,6 +58,7 @@ import com.wire.android.ui.authentication.login.LoginErrorDialog
 import com.wire.android.ui.authentication.login.LoginNavArgs
 import com.wire.android.ui.authentication.login.LoginPasswordPath
 import com.wire.android.ui.authentication.login.NewLoginNavGraph
+import com.wire.android.ui.authentication.login.PreFilledUserIdentifierType
 import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
 import com.wire.android.ui.authentication.login.sso.SSOUrlConfigHolder
 import com.wire.android.ui.authentication.login.toLoginDialogErrorData
@@ -76,6 +77,7 @@ import com.wire.android.ui.common.typography
 import com.wire.android.ui.destinations.E2EIEnrollmentScreenDestination
 import com.wire.android.ui.destinations.HomeScreenDestination
 import com.wire.android.ui.destinations.InitialSyncScreenDestination
+import com.wire.android.ui.destinations.LoginScreenDestination
 import com.wire.android.ui.destinations.NewLoginPasswordScreenDestination
 import com.wire.android.ui.destinations.NewLoginScreenDestination
 import com.wire.android.ui.destinations.RemoveDeviceScreenDestination
@@ -103,7 +105,7 @@ fun NewLoginScreen(
         when (newLoginAction) {
             is NewLoginAction.EmailPassword -> {
                 val loginNavArgs = LoginNavArgs(
-                    userHandle = newLoginAction.userIdentifier,
+                    userHandle = PreFilledUserIdentifierType.PreFilled(newLoginAction.userIdentifier),
                     loginPasswordPath = newLoginAction.loginPasswordPath
                 )
                 navigator.navigate(NavigationCommand(NewLoginPasswordScreenDestination(loginNavArgs)))
@@ -111,7 +113,7 @@ fun NewLoginScreen(
 
             is NewLoginAction.CustomConfig -> {
                 val loginNavArgs = LoginNavArgs(
-                    userHandle = newLoginAction.userIdentifier,
+                    userHandle = PreFilledUserIdentifierType.PreFilled(newLoginAction.userIdentifier),
                     loginPasswordPath = LoginPasswordPath(customServerConfig = newLoginAction.customServerConfig)
                 )
                 navigator.navigate(NavigationCommand(NewLoginScreenDestination(loginNavArgs), BackStackMode.CLEAR_WHOLE))
@@ -134,7 +136,12 @@ fun NewLoginScreen(
             }
 
             is NewLoginAction.EnterpriseLoginNotSupported -> {
-                navigator.navigate(NavigationCommand(WelcomeScreenDestination(viewModel.serverConfig)))
+                navigator.navigate(NavigationCommand(WelcomeScreenDestination(viewModel.serverConfig), BackStackMode.CLEAR_WHOLE))
+                val loginNavArgs = LoginNavArgs(
+                    userHandle = PreFilledUserIdentifierType.PreFilled(userIdentifier = newLoginAction.userIdentifier, editable = true),
+                    loginPasswordPath = LoginPasswordPath(viewModel.serverConfig),
+                )
+                navigator.navigate(NavigationCommand(LoginScreenDestination(loginNavArgs)))
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -98,7 +98,7 @@ class NewLoginViewModel(
     )
 
     private val loginNavArgs: LoginNavArgs = savedStateHandle.navArgs()
-    private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle
+    private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle ?: PreFilledUserIdentifierType.None
     var serverConfig: ServerConfig.Links by mutableStateOf(loginNavArgs.loginPasswordPath?.customServerConfig.orDefault())
         private set
 

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -98,9 +98,7 @@ class NewLoginViewModel(
     )
 
     private val loginNavArgs: LoginNavArgs = savedStateHandle.navArgs()
-    private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle.let {
-        if (it.isNullOrEmpty()) PreFilledUserIdentifierType.None else PreFilledUserIdentifierType.PreFilled(it)
-    }
+    private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle
     var serverConfig: ServerConfig.Links by mutableStateOf(loginNavArgs.loginPasswordPath?.customServerConfig.orDefault())
         private set
 
@@ -163,7 +161,8 @@ class NewLoginViewModel(
                     }
 
                     is EnterpriseLoginResult.Failure.NotSupported ->  withContext(dispatchers.main()) {
-                        action(NewLoginAction.EnterpriseLoginNotSupported)
+                        action(NewLoginAction.EnterpriseLoginNotSupported(email))
+                        updateLoginFlowState(NewLoginFlowState.Default)
                     }
 
                     is EnterpriseLoginResult.Success -> {
@@ -250,6 +249,7 @@ class NewLoginViewModel(
                     withContext(dispatchers.main()) {
                         updateLoginFlowState(NewLoginFlowState.Default)
                         action(NewLoginAction.SSO(requestUrl, SSOUrlConfig(serverConfig, ssoCode)))
+                        updateLoginFlowState(NewLoginFlowState.Default)
                     }
                 }
             )
@@ -275,16 +275,23 @@ class NewLoginViewModel(
                             loginExtension.registerClient(storedUserId, null).let { result ->
                                 withContext(dispatchers.main()) {
                                     when (result) {
-                                        is RegisterClientResult.Success -> when (loginExtension.isInitialSyncCompleted(storedUserId)) {
-                                            true -> action(NewLoginAction.Success(NewLoginAction.Success.NextStep.None))
-                                            false -> action(NewLoginAction.Success(NewLoginAction.Success.NextStep.InitialSync))
+                                        is RegisterClientResult.Success -> {
+                                            when (loginExtension.isInitialSyncCompleted(storedUserId)) {
+                                                true -> action(NewLoginAction.Success(NewLoginAction.Success.NextStep.None))
+                                                false -> action(NewLoginAction.Success(NewLoginAction.Success.NextStep.InitialSync))
+                                            }
+                                            updateLoginFlowState(NewLoginFlowState.Default)
                                         }
 
-                                        is RegisterClientResult.E2EICertificateRequired ->
+                                        is RegisterClientResult.E2EICertificateRequired -> {
                                             action(NewLoginAction.Success(NewLoginAction.Success.NextStep.E2EIEnrollment))
+                                            updateLoginFlowState(NewLoginFlowState.Default)
+                                        }
 
-                                        is RegisterClientResult.Failure.TooManyClients ->
+                                        is RegisterClientResult.Failure.TooManyClients -> {
                                             action(NewLoginAction.Success(NewLoginAction.Success.NextStep.TooManyDevices))
+                                            updateLoginFlowState(NewLoginFlowState.Default)
+                                        }
 
                                         is RegisterClientResult.Failure.Generic ->
                                             updateLoginFlowState(NewLoginFlowState.Error.DialogError.GenericError(result.genericFailure))

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/password/NewLoginPasswordScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/password/NewLoginPasswordScreen.kt
@@ -54,6 +54,7 @@ import com.wire.android.ui.authentication.login.LoginErrorDialog
 import com.wire.android.ui.authentication.login.LoginNavArgs
 import com.wire.android.ui.authentication.login.LoginState
 import com.wire.android.ui.authentication.login.NewLoginNavGraph
+import com.wire.android.ui.authentication.login.PreFilledUserIdentifierType
 import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
 import com.wire.android.ui.authentication.login.email.ForgotPasswordLabel
 import com.wire.android.ui.authentication.login.email.LoginButton
@@ -104,7 +105,7 @@ fun NewLoginPasswordScreen(
         if (loginEmailViewModel.secondFactorVerificationCodeState.isCodeInputNecessary) {
             val verificationCodeNavArgs = LoginNavArgs(
                 loginPasswordPath = navArgs.loginPasswordPath,
-                userHandle = loginEmailViewModel.userIdentifierTextState.text.toString()
+                userHandle = PreFilledUserIdentifierType.PreFilled(loginEmailViewModel.userIdentifierTextState.text.toString())
             )
             navigator.navigate(NavigationCommand(NewLoginVerificationCodeScreenDestination(verificationCodeNavArgs)))
         }

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -384,7 +384,7 @@ class NewLoginViewModelTest {
     fun `given not supported failure, when enterprise login, then call EnterpriseLoginNotSupported action`() =
         testEnterpriseLoginActions(
             result = EnterpriseLoginResult.Failure.NotSupported,
-            expected = NewLoginAction.EnterpriseLoginNotSupported,
+            expected = NewLoginAction.EnterpriseLoginNotSupported(email),
         )
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16058" title="WPB-16058" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16058</a>  [Android] Create login flow selector
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Pass email when navigating to the old login flow when the app uses server config that doesn't support v8 so that the user won't have to enter it twice. It's done by returning email in `EnterpriseLoginNotSupported` action and then passing it as a navigation parameter. `LoginNavArgs.userHandle` was changed to become `PreFilledUserIdentifierType.PreFilled` and a new field `editable` was added to that class so that it can be decided when navigating whether email field should be enabled for editing or pre-filled without the option to edit it.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Use the deep link to switch backend to the one that doesn't yet support enterprise login and v8 (staging for instance) and with the `login-type=new` parameter. It should make it so that when you try to log in, the app will return `EnterpriseLoginNotSupported` because it's not supported on this backend yet, so it should navigate to the old flow with email field already filled in but also able to be edited.

### Attachments (Optional)

https://github.com/user-attachments/assets/8e160cba-938a-4268-ab55-c32c782cb107

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
