### PR TITLE
chore(channel): handle new Channel conversation type from Kalium [WPB-15865]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/migration/MigrationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/migration/MigrationMapper.kt
@@ -156,10 +156,11 @@ class MigrationMapper @Inject constructor() {
     }
 
     private fun mapConversationType(type: Int): Type? = when (type) {
-        0 -> Type.GROUP
-        1 -> Type.SELF
-        2 -> Type.ONE_ON_ONE
-        3, 4 -> Type.CONNECTION_PENDING
+        // There were no channels in the old app. So 0 -> Regular
+        0 -> Type.Group.Regular
+        1 -> Type.Self
+        2 -> Type.OneOnOne
+        3, 4 -> Type.ConnectionPending
         else -> null
     }
 

--- a/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
@@ -297,7 +297,7 @@ class CallNotificationBuilder @Inject constructor(
     // Notifications content
     private fun getNotificationBody(data: CallNotificationData) =
         when (data.conversationType) {
-            Conversation.Type.GROUP -> {
+            is Conversation.Type.Group -> {
                 val name = data.callerName ?: context.getString(R.string.notification_call_default_caller_name)
                 (data.callerTeamName?.let { "$name @$it" } ?: name)
                     .let { context.getString(R.string.notification_group_call_content, it) }
@@ -308,7 +308,7 @@ class CallNotificationBuilder @Inject constructor(
 
     fun getNotificationTitle(data: CallNotificationData): String =
         when (data.conversationType) {
-            Conversation.Type.GROUP -> data.conversationName ?: context.getString(R.string.notification_call_default_group_name)
+            is Conversation.Type.Group -> data.conversationName ?: context.getString(R.string.notification_call_default_group_name)
             else -> {
                 val name = data.callerName ?: context.getString(R.string.notification_call_default_caller_name)
                 data.callerTeamName?.let { "$name @$it" } ?: name

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -199,7 +199,7 @@ class SharedCallingViewModel @AssistedInject constructor(
                 callStatus = call.status,
                 callerName = call.callerName,
                 isCameraOn = call.isCameraOn,
-                isCbrEnabled = call.isCbrEnabled && call.conversationType == Conversation.Type.ONE_ON_ONE
+                isCbrEnabled = call.isCbrEnabled && call.conversationType == Conversation.Type.OneOnOne
             )
         }
     }
@@ -213,7 +213,7 @@ class SharedCallingViewModel @AssistedInject constructor(
                 isMuted = call.isMuted,
                 callStatus = call.status,
                 isCameraOn = call.isCameraOn,
-                isCbrEnabled = call.isCbrEnabled && call.conversationType == Conversation.Type.ONE_ON_ONE,
+                isCbrEnabled = call.isCbrEnabled && call.conversationType == Conversation.Type.OneOnOne,
                 callerName = call.callerName,
             )
             participantsState = call.participants.map {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
@@ -32,7 +32,7 @@ data class ConversationInfoViewState(
     val conversationDetailsData: ConversationDetailsData = ConversationDetailsData.None(null),
     val conversationAvatar: ConversationAvatar = ConversationAvatar.None,
     val hasUserPermissionToEdit: Boolean = false,
-    val conversationType: Conversation.Type = Conversation.Type.ONE_ON_ONE,
+    val conversationType: Conversation.Type = Conversation.Type.OneOnOne,
     val protocolInfo: Conversation.ProtocolInfo? = null,
     val mlsVerificationStatus: Conversation.VerificationStatus? = null,
     val proteusVerificationStatus: Conversation.VerificationStatus? = null,

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversation.kt
@@ -36,7 +36,7 @@ object TestConversation {
     val ONE_ON_ONE = Conversation(
         ID.copy(value = "1O1 ID"),
         "ONE_ON_ONE Name",
-        Conversation.Type.ONE_ON_ONE,
+        Conversation.Type.OneOnOne,
         TestTeam.TEAM_ID,
         ProtocolInfo.Proteus,
         MutedConversationStatus.AllAllowed,
@@ -59,7 +59,7 @@ object TestConversation {
     val SELF = Conversation(
         ID.copy(value = "SELF ID"),
         "SELF Name",
-        Conversation.Type.SELF,
+        Conversation.Type.Self,
         TestTeam.TEAM_ID,
         ProtocolInfo.Proteus,
         MutedConversationStatus.AllAllowed,
@@ -83,7 +83,7 @@ object TestConversation {
     fun GROUP(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
         ID,
         "GROUP Name",
-        Conversation.Type.GROUP,
+        Conversation.Type.Group.Regular,
         TestTeam.TEAM_ID,
         protocolInfo,
         MutedConversationStatus.AllAllowed,
@@ -107,7 +107,7 @@ object TestConversation {
     fun one_on_one(convId: ConversationId) = Conversation(
         convId,
         "ONE_ON_ONE Name",
-        Conversation.Type.ONE_ON_ONE,
+        Conversation.Type.OneOnOne,
         TestTeam.TEAM_ID,
         ProtocolInfo.Proteus,
         MutedConversationStatus.AllAllowed,
@@ -138,7 +138,7 @@ object TestConversation {
     val CONVERSATION = Conversation(
         ConversationId("conv_id", "domain"),
         "ONE_ON_ONE Name",
-        Conversation.Type.ONE_ON_ONE,
+        Conversation.Type.OneOnOne,
         TestTeam.TEAM_ID,
         ProtocolInfo.Proteus,
         MutedConversationStatus.AllAllowed,

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversationDetails.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversationDetails.kt
@@ -43,7 +43,7 @@ object TestConversationDetails {
         UserType.EXTERNAL,
     )
 
-    val GROUP = ConversationDetails.Group(
+    val GROUP = ConversationDetails.Group.Regular(
         TestConversation.ONE_ON_ONE,
         isSelfUserMember = true,
         selfRole = Conversation.Member.Role.Member

--- a/app/src/test/kotlin/com/wire/android/notification/CallNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/CallNotificationManagerTest.kt
@@ -436,7 +436,7 @@ class CallNotificationManagerTest {
             isCbrEnabled = false,
             maxParticipants = 0,
             conversationName = "ONE_ON_ONE Name",
-            conversationType = Conversation.Type.ONE_ON_ONE,
+            conversationType = Conversation.Type.OneOnOne,
             callerName = "otherUsername",
             callerTeamName = "team_1"
         )

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -1266,7 +1266,7 @@ class WireNotificationManagerTest {
             isCameraOn = false,
             maxParticipants = 0,
             conversationName = "ONE_ON_ONE Name",
-            conversationType = Conversation.Type.ONE_ON_ONE,
+            conversationType = Conversation.Type.OneOnOne,
             callerName = "otherUsername",
             callerTeamName = "team_1",
             isCbrEnabled = false

--- a/app/src/test/kotlin/com/wire/android/ui/CallFeedbackViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/CallFeedbackViewModelTest.kt
@@ -202,7 +202,7 @@ class CallFeedbackViewModelTest {
                 callVideoEnabled = false
             ),
             conversationDetails = RecentlyEndedCallMetadata.ConversationDetails(
-                conversationType = Conversation.Type.ONE_ON_ONE,
+                conversationType = Conversation.Type.OneOnOne,
                 conversationSize = 5,
                 conversationGuests = 2,
                 conversationGuestsPro = 1

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -970,7 +970,7 @@ class WireActivityViewModelTest {
             isCbrEnabled = false,
             callerId = UserId("caller", "domain"),
             conversationName = "ONE_ON_ONE Name",
-            conversationType = Conversation.Type.ONE_ON_ONE,
+            conversationType = Conversation.Type.OneOnOne,
             callerName = "otherUsername",
             callerTeamName = "team1"
         )
@@ -989,7 +989,7 @@ class WireActivityViewModelTest {
                 callVideoEnabled = false
             ),
             conversationDetails = RecentlyEndedCallMetadata.ConversationDetails(
-                conversationType = Conversation.Type.ONE_ON_ONE,
+                conversationType = Conversation.Type.OneOnOne,
                 conversationSize = 5,
                 conversationGuests = 2,
                 conversationGuestsPro = 1

--- a/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
@@ -357,7 +357,7 @@ class OngoingCallViewModelTest {
         isCameraOn = false,
         maxParticipants = 0,
         conversationName = "ONE_ON_ONE Name",
-        conversationType = Conversation.Type.ONE_ON_ONE,
+        conversationType = Conversation.Type.OneOnOne,
         callerName = "otherUsername",
         callerTeamName = "team_1",
         isCbrEnabled = false

--- a/app/src/test/kotlin/com/wire/android/ui/calling/incoming/IncomingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/incoming/IncomingCallViewModelTest.kt
@@ -261,7 +261,7 @@ class IncomingCallViewModelTest {
             isCameraOn = false,
             maxParticipants = 0,
             conversationName = "ONE_ON_ONE Name",
-            conversationType = Conversation.Type.ONE_ON_ONE,
+            conversationType = Conversation.Type.OneOnOne,
             callerName = "otherUsername",
             callerTeamName = "team_1",
             isCbrEnabled = false

--- a/app/src/test/kotlin/com/wire/android/ui/calling/outgoing/OutgoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/outgoing/OutgoingCallViewModelTest.kt
@@ -181,7 +181,7 @@ class OutgoingCallViewModelTest {
             isCbrEnabled = false,
             maxParticipants = 0,
             conversationName = "ONE_ON_ONE Name",
-            conversationType = Conversation.Type.ONE_ON_ONE,
+            conversationType = Conversation.Type.OneOnOne,
             callerName = "otherUsername",
             callerTeamName = "team_1"
         )

--- a/app/src/test/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModelTest.kt
@@ -406,7 +406,7 @@ class CommonTopAppBarViewModelTest {
             false,
             UserId("caller", "domain"),
             "ONE_ON_ONE Name",
-            Conversation.Type.ONE_ON_ONE,
+            Conversation.Type.OneOnOne,
             "otherUsername",
             "team1"
         )

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelArrangement.kt
@@ -220,7 +220,7 @@ internal fun withMockConversationDetailsOneOnOne(
 internal fun mockConversationDetailsGroup(
     conversationName: String,
     mockedConversationId: ConversationId = ConversationId("someId", "someDomain")
-) = ConversationDetails.Group(
+) = ConversationDetails.Group.Regular(
     conversation = TestConversation.GROUP()
         .copy(name = conversationName, id = mockedConversationId),
     hasOngoingCall = false,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -661,11 +661,11 @@ class GroupConversationDetailsViewModelTest {
 
     companion object {
         val dummyConversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-        val testGroup = ConversationDetails.Group(
+        val testGroup = ConversationDetails.Group.Regular(
             Conversation(
                 id = dummyConversationId,
                 name = "Conv Name",
-                type = Conversation.Type.ONE_ON_ONE,
+                type = Conversation.Type.OneOnOne,
                 teamId = TeamId("team_id"),
                 protocol = Conversation.ProtocolInfo.Proteus,
                 mutedStatus = MutedConversationStatus.AllAllowed,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationCallListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationCallListViewModelTest.kt
@@ -167,7 +167,7 @@ class ConversationCallListViewModelTest {
             isCbrEnabled = false,
             callerId = QualifiedID("some_id", "some_domain"),
             conversationName = "some_name",
-            conversationType = Conversation.Type.GROUP,
+            conversationType = Conversation.Type.Group.Regular,
             callerName = "some_name",
             callerTeamName = "some_team_name"
         )

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -283,7 +283,7 @@ class MediaGalleryViewModelTest {
             conversation = Conversation(
                 id = mockedConversationId,
                 name = mockedConversationTitle,
-                type = Conversation.Type.ONE_ON_ONE,
+                type = Conversation.Type.OneOnOne,
                 teamId = null,
                 protocol = Conversation.ProtocolInfo.Proteus,
                 mutedStatus = AllAllowed,

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
@@ -454,7 +454,7 @@ class RecordAudioViewModelTest {
                 isCbrEnabled = false,
                 maxParticipants = 0,
                 conversationName = "ONE_ON_ONE Name",
-                conversationType = Conversation.Type.ONE_ON_ONE,
+                conversationType = Conversation.Type.OneOnOne,
                 callerName = "otherUsername",
                 callerTeamName = "team_1"
             )

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -76,7 +76,7 @@ internal class NewConversationViewModelArrangement {
         val CONVERSATION = Conversation(
             id = CONVERSATION_ID,
             name = null,
-            type = Conversation.Type.ONE_ON_ONE,
+            type = Conversation.Type.OneOnOne,
             teamId = null,
             protocol = Conversation.ProtocolInfo.Proteus,
             mutedStatus = MutedConversationStatus.AllAllowed,

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -267,7 +267,7 @@ class OtherUserProfileScreenViewModelTest {
         val CONVERSATION = Conversation(
             id = CONVERSATION_ID,
             name = "some_name",
-            type = Conversation.Type.ONE_ON_ONE,
+            type = Conversation.Type.OneOnOne,
             teamId = null,
             protocol = Conversation.ProtocolInfo.Proteus,
             mutedStatus = MutedConversationStatus.AllAllowed,

--- a/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
@@ -372,7 +372,7 @@ class DeepLinkProcessorTest {
             isCbrEnabled = false,
             callerId = UserId("caller", "domain"),
             conversationName = "ONE_ON_ONE Name",
-            conversationType = Conversation.Type.ONE_ON_ONE,
+            conversationType = Conversation.Type.OneOnOne,
             callerName = "otherUsername",
             callerTeamName = "team1"
         )

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/model/AnalyticsEvent.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/model/AnalyticsEvent.kt
@@ -212,8 +212,9 @@ interface AnalyticsEvent {
 
         private fun RecentlyEndedCallMetadata.toConversationType(): String {
             return when (conversationDetails.conversationType) {
-                Conversation.Type.ONE_ON_ONE -> "one_to_one"
-                Conversation.Type.GROUP -> "group"
+                Conversation.Type.OneOnOne -> "one_to_one"
+                Conversation.Type.Group.Regular -> "group"
+                Conversation.Type.Group.Channel -> "channel"
                 else -> throw IllegalStateException("Call should not happen for ${conversationDetails.conversationType}")
             }
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15865" title="WPB-15865" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-15865</a>  [Android] Show channels in conversation list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Kalium had some breaking changes regarding the introduction of Channels.

### Solutions

Fix breaking changes as Kalium is introducing a new Conversation Type. For now, no logic should change within the Android app. Regular groups and Channels are treated equally, as new Channel features are still to be developed.

### Dependencies


Needs releases with:

- https://github.com/wireapp/kalium/pull/3321

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
