### PR TITLE
fix: disable in-call reactions while connecting [WPB-16372]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/InCallReactionsButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/InCallReactionsButton.kt
@@ -28,8 +28,10 @@ fun InCallReactionsButton(
     isSelected: Boolean,
     onInCallReactionsClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
 ) {
     WireCallControlButton(
+        isEnabled = isEnabled,
         isSelected = isSelected,
         iconResId = when (isSelected) {
             true -> R.drawable.ic_incall_reactions
@@ -58,6 +60,16 @@ fun PreviewInCallReactionsButton() = WireTheme {
 fun PreviewInCallReactionsButtonSelected() = WireTheme {
     InCallReactionsButton(
         isSelected = true,
+        onInCallReactionsClick = { }
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewInCallReactionsButtonDisabled() = WireTheme {
+    InCallReactionsButton(
+        isSelected = false,
+        isEnabled = false,
         onInCallReactionsClick = { }
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/WireCallControlButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/WireCallControlButton.kt
@@ -25,11 +25,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
+import com.wire.android.R
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.button.wireSecondaryButtonColors
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
 fun WireCallControlButton(
@@ -38,6 +41,7 @@ fun WireCallControlButton(
     @StringRes contentDescription: Int,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
     width: Dp = dimensions().defaultCallingControlsWidth,
     height: Dp = dimensions().defaultCallingControlsHeight,
     iconSize: Dp = dimensions().defaultCallingControlsIconSize
@@ -59,10 +63,48 @@ fun WireCallControlButton(
             )
         },
         contentDescription = contentDescription,
-        state = if (isSelected) WireButtonState.Selected else WireButtonState.Default,
+        state = when {
+            !isEnabled -> WireButtonState.Disabled
+            isSelected -> WireButtonState.Selected
+            else -> WireButtonState.Default
+        },
         minSize = DpSize(width, height),
         minClickableSize = DpSize(width, height),
         iconSize = iconSize,
         modifier = modifier,
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewWireCallControlButton() = WireTheme {
+    WireCallControlButton(
+        isSelected = false,
+        iconResId = R.drawable.ic_camera_off,
+        contentDescription = 0,
+        onClick = { }
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewWireCallControlButtonSelected() = WireTheme {
+    WireCallControlButton(
+        isSelected = true,
+        iconResId = R.drawable.ic_camera_on,
+        contentDescription = 0,
+        onClick = { }
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewWireCallControlButtonDisabled() = WireTheme {
+    WireCallControlButton(
+        isSelected = false,
+        isEnabled = false,
+        iconResId = R.drawable.ic_camera_on,
+        contentDescription = 0,
+        onClick = { }
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -335,6 +335,7 @@ private fun OngoingCallContent(
 
     var showInCallReactionsPanel by remember { mutableStateOf(false) }
     var showEmojiPicker by remember { mutableStateOf(false) }
+    val isConnecting = participants.isEmpty()
 
     WireBottomSheetScaffold(
         sheetDragHandle = null,
@@ -366,6 +367,7 @@ private fun OngoingCallContent(
                     isCameraOn = callState.isCameraOn,
                     isSpeakerOn = callState.isSpeakerOn,
                     isShowingCallReactions = showInCallReactionsPanel,
+                    isConnecting = isConnecting,
                     toggleSpeaker = toggleSpeaker,
                     toggleMute = toggleMute,
                     onHangUpCall = hangUpCall,
@@ -393,7 +395,7 @@ private fun OngoingCallContent(
                     .weight(1f)
             ) {
 
-                if (participants.isEmpty()) {
+                if (isConnecting) {
                     Column(
                         modifier = Modifier.fillMaxSize(),
                         verticalArrangement = Arrangement.Center,
@@ -572,6 +574,7 @@ private fun CallingControls(
     isCameraOn: Boolean,
     isSpeakerOn: Boolean,
     isShowingCallReactions: Boolean,
+    isConnecting: Boolean,
     toggleSpeaker: () -> Unit,
     toggleMute: () -> Unit,
     onHangUpCall: () -> Unit,
@@ -607,6 +610,7 @@ private fun CallingControls(
 
             InCallReactionsButton(
                 isSelected = isShowingCallReactions,
+                isEnabled = !isConnecting,
                 onInCallReactionsClick = onCallReactionsClick
             )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16372" title="WPB-16372" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16372</a>  [Android] In-call Reactions can be sent while user is still in a connecting state
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The user is able to send in-call reactions while still in the "Connecting" state, despite not having joined the call yet.

### Solutions

Disable in-call reactions button while in the "Connecting" state.

### Testing

#### How to Test

Join the call and try to click in-call reactions button while in the "Connecting" state.

### Attachments (Optional)

<img width="644" alt="image" src="https://github.com/user-attachments/assets/098beeec-37d2-4188-b93d-886ab3536e61" />

https://github.com/user-attachments/assets/88bf96d0-c4f3-4e4a-99f0-66a103e1f88e

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.