### PR TITLE
fix: crashes on audio message playback [WPB-16195]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioMessageViewModel.kt
@@ -1,0 +1,128 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.media.audiomessage
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.di.ScopedArgs
+import com.wire.android.di.ViewModelScopedPreview
+import com.wire.android.di.scopedArgs
+import com.wire.kalium.logic.data.id.ConversationId
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import javax.inject.Inject
+
+@ViewModelScopedPreview
+interface AudioMessageViewModel {
+    val state: AudioMessageState get() = AudioMessageState()
+    fun playAudio() {}
+    fun changeAudioPosition(position: Float) {}
+    fun changeAudioSpeed(audioSpeed: AudioSpeed) {}
+}
+
+@HiltViewModel
+class AudioMessageViewModelImpl @Inject constructor(
+    private val audioMessagePlayer: ConversationAudioMessagePlayer,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel(), AudioMessageViewModel {
+
+    private val args: AudioMessageArgs = savedStateHandle.scopedArgs()
+
+    override var state: AudioMessageState by mutableStateOf(AudioMessageState())
+        private set
+
+    init {
+        observeAudioState()
+        observeAudioSpeed()
+        initWavesMask()
+    }
+
+    private fun observeAudioState() {
+        viewModelScope.launch {
+            audioMessagePlayer.observableAudioMessagesState
+                .mapNotNull {
+                    it[ConversationAudioMessagePlayer.MessageIdWrapper(args.conversationId, args.messageId)]
+                }
+                .distinctUntilChanged()
+                .collectLatest {
+                    state = state.copy(audioState = it)
+                }
+        }
+    }
+
+    private fun observeAudioSpeed() {
+        viewModelScope.launch {
+            audioMessagePlayer.audioSpeed
+                .distinctUntilChanged()
+                .collectLatest {
+                    state = state.copy(audioSpeed = it)
+                }
+        }
+    }
+
+    private fun initWavesMask() {
+        viewModelScope.launch {
+            audioMessagePlayer.fetchWavesMask(args.conversationId, args.messageId)
+        }
+    }
+
+    override fun playAudio() {
+        viewModelScope.launch {
+            audioMessagePlayer.playAudio(args.conversationId, args.messageId)
+        }
+    }
+
+    override fun changeAudioPosition(position: Float) {
+        viewModelScope.launch {
+            audioMessagePlayer.setPosition(args.conversationId, args.messageId, position.toInt())
+        }
+    }
+
+    override fun changeAudioSpeed(audioSpeed: AudioSpeed) {
+        viewModelScope.launch {
+            audioMessagePlayer.setSpeed(audioSpeed)
+        }
+    }
+}
+
+@Serializable
+data class AudioMessageArgs(
+    val conversationId: ConversationId,
+    val messageId: String
+) : ScopedArgs {
+    override val key = "$ARGS_KEY:$conversationId:$messageId"
+
+    companion object {
+        const val ARGS_KEY = "AudioMessageArgsKey"
+    }
+}
+
+@Stable
+data class AudioMessageState(
+    val audioSpeed: AudioSpeed = AudioSpeed.NORMAL,
+    val audioState: AudioState = AudioState.DEFAULT,
+)

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayer.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayer.kt
@@ -450,7 +450,9 @@ class ConversationAudioMessagePlayer
                     .also {
                         getAssetMessageDeferredMap[key] = it
                     }
-            } else deferredResult
+            } else {
+                deferredResult
+            }
         }.await()
     }
 

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayer.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayer.kt
@@ -21,12 +21,10 @@ import android.content.Context
 import android.media.MediaPlayer
 import android.media.MediaPlayer.SEEK_CLOSEST_SYNC
 import android.net.Uri
-import androidx.annotation.VisibleForTesting
 import com.wire.android.R
 import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.services.ServicesManager
-import com.wire.android.util.ExpiringMap
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.extension.intervalFlow
 import com.wire.android.util.ui.UIText
@@ -75,13 +73,9 @@ class ConversationAudioMessagePlayer
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     @ApplicationScope private val scope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
-    currentTime: () -> Long = { System.currentTimeMillis() },
 ) {
-    companion object {
-        private const val UPDATE_POSITION_INTERVAL_IN_MS = 1000L
-
-        @VisibleForTesting
-        internal const val GET_ASSET_MESSAGE_CACHE_EXPIRATION_MS = 5 * 60_000L // 5 minutes
+    private companion object {
+        const val UPDATE_POSITION_INTERVAL_IN_MS = 1000L
     }
 
     init {
@@ -425,12 +419,7 @@ class ConversationAudioMessagePlayer
     }
 
     private val getAssetMessageMutex = Mutex()
-    private val getAssetMessageDeferredMap = ExpiringMap<GetAssetMessageKey, Deferred<MessageAssetResult>>(
-        scope = scope,
-        expiration = GET_ASSET_MESSAGE_CACHE_EXPIRATION_MS,
-        delegate = mutableMapOf(),
-        currentTime = currentTime,
-    )
+    private val getAssetMessageDeferredMap = mutableMapOf<GetAssetMessageKey, Deferred<MessageAssetResult>>()
 
     private suspend fun getAssetMessage(
         userId: UserId,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -92,7 +92,6 @@ import com.wire.android.feature.sketch.destinations.DrawingCanvasScreenDestinati
 import com.wire.android.feature.sketch.model.DrawingCanvasNavArgs
 import com.wire.android.feature.sketch.model.DrawingCanvasNavBackArgs
 import com.wire.android.mapper.MessageDateTimeGroup
-import com.wire.android.media.audiomessage.AudioSpeed
 import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.model.SnackBarMessage
 import com.wire.android.navigation.BackStackMode
@@ -144,7 +143,6 @@ import com.wire.android.ui.home.conversations.info.ConversationDetailsData
 import com.wire.android.ui.home.conversations.info.ConversationInfoViewModel
 import com.wire.android.ui.home.conversations.info.ConversationInfoViewState
 import com.wire.android.ui.home.conversations.media.preview.ImagesPreviewNavBackArgs
-import com.wire.android.ui.home.conversations.messages.AudioMessagesState
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewState
 import com.wire.android.ui.home.conversations.messages.draft.MessageDraftViewModel
@@ -549,9 +547,6 @@ fun ConversationScreen(
         onReactionClick = { messageId, emoji ->
             conversationMessagesViewModel.toggleReaction(messageId, emoji)
         },
-        onAudioClick = conversationMessagesViewModel::audioClick,
-        onChangeAudioPosition = conversationMessagesViewModel::changeAudioPosition,
-        onChangeAudioSpeed = conversationMessagesViewModel::changeAudioSpeed,
         onResetSessionClick = conversationMessagesViewModel::onResetSession,
         onUpdateConversationReadDate = messageComposerViewModel::updateConversationReadDate,
         onDropDownClick = {
@@ -844,9 +839,6 @@ private fun ConversationScreen(
     onPingOptionClicked: () -> Unit,
     onImagesPicked: (List<Uri>) -> Unit,
     onDeleteMessage: (String, Boolean) -> Unit,
-    onAudioClick: (String) -> Unit,
-    onChangeAudioPosition: (String, Int) -> Unit,
-    onChangeAudioSpeed: (AudioSpeed) -> Unit,
     onAssetItemClicked: (String) -> Unit,
     onImageFullScreenMode: (UIMessage.Regular, Boolean) -> Unit,
     onStartCall: () -> Unit,
@@ -928,7 +920,7 @@ private fun ConversationScreen(
                     ConversationScreenContent(
                         conversationId = conversationInfoViewState.conversationId,
                         bottomSheetVisible = bottomSheetVisible,
-                        audioMessagesState = conversationMessagesViewState.audioMessagesState,
+                        playingAudioMessage = conversationMessagesViewState.playingAudioMessage,
                         assetStatuses = conversationMessagesViewState.assetStatuses,
                         lastUnreadMessageInstant = conversationMessagesViewState.firstUnreadInstant,
                         unreadEventCount = conversationMessagesViewState.firstUnreadEventIndex,
@@ -940,9 +932,6 @@ private fun ConversationScreen(
                         onPingOptionClicked = onPingOptionClicked,
                         onImagesPicked = onImagesPicked,
                         onAssetItemClicked = onAssetItemClicked,
-                        onAudioItemClicked = onAudioClick,
-                        onChangeAudioPosition = onChangeAudioPosition,
-                        onChangeAudioSpeed = onChangeAudioSpeed,
                         onImageFullScreenMode = onImageFullScreenMode,
                         onReactionClicked = onReactionClick,
                         onResetSessionClicked = onResetSessionClick,
@@ -1009,7 +998,7 @@ private fun ConversationScreenContent(
     bottomSheetVisible: Boolean,
     lastUnreadMessageInstant: Instant?,
     unreadEventCount: Int,
-    audioMessagesState: AudioMessagesState,
+    playingAudioMessage: PlayingAudioMessage,
     assetStatuses: PersistentMap<String, MessageAssetStatus>,
     selectedMessageId: String?,
     messageComposerStateHolder: MessageComposerStateHolder,
@@ -1018,9 +1007,6 @@ private fun ConversationScreenContent(
     onPingOptionClicked: () -> Unit,
     onImagesPicked: (List<Uri>) -> Unit,
     onAssetItemClicked: (String) -> Unit,
-    onAudioItemClicked: (String) -> Unit,
-    onChangeAudioPosition: (String, Int) -> Unit,
-    onChangeAudioSpeed: (AudioSpeed) -> Unit,
     onImageFullScreenMode: (UIMessage.Regular, Boolean) -> Unit,
     onReactionClicked: (String, String) -> Unit,
     onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit,
@@ -1058,7 +1044,7 @@ private fun ConversationScreenContent(
                 lazyPagingMessages = lazyPagingMessages,
                 lazyListState = lazyListState,
                 lastUnreadMessageInstant = lastUnreadMessageInstant,
-                audioMessagesState = audioMessagesState,
+                playingAudioMessage = playingAudioMessage,
                 assetStatuses = assetStatuses,
                 onUpdateConversationReadDate = onUpdateConversationReadDate,
                 clickActions = MessageClickActions.Content(
@@ -1066,9 +1052,6 @@ private fun ConversationScreenContent(
                     onProfileClicked = onOpenProfile,
                     onReactionClicked = onReactionClicked,
                     onAssetClicked = onAssetItemClicked,
-                    onPlayAudioClicked = onAudioItemClicked,
-                    onAudioPositionChanged = onChangeAudioPosition,
-                    onAudioSpeedChange = onChangeAudioSpeed,
                     onImageClicked = onImageFullScreenMode,
                     onLinkClicked = onLinkClick,
                     onReplyClicked = onNavigateToReplyOriginalMessage,
@@ -1137,7 +1120,7 @@ fun MessageList(
     lazyPagingMessages: LazyPagingItems<UIMessage>,
     lazyListState: LazyListState,
     lastUnreadMessageInstant: Instant?,
-    audioMessagesState: AudioMessagesState,
+    playingAudioMessage: PlayingAudioMessage,
     assetStatuses: PersistentMap<String, MessageAssetStatus>,
     onUpdateConversationReadDate: (String) -> Unit,
     onSwipedToReply: (UIMessage.Regular) -> Unit,
@@ -1251,8 +1234,6 @@ fun MessageList(
                         conversationDetailsData = conversationDetailsData,
                         showAuthor = showAuthor,
                         useSmallBottomPadding = useSmallBottomPadding,
-                        audioState = audioMessagesState.audioStates[message.header.messageId],
-                        audioSpeed = audioMessagesState.audioSpeed,
                         assetStatus = assetStatuses[message.header.messageId]?.transferStatus,
                         clickActions = clickActions,
                         swipableMessageConfiguration = swipableConfiguration,
@@ -1278,7 +1259,7 @@ fun MessageList(
             JumpToPlayingAudioButton(
                 lazyListState = lazyListState,
                 lazyPagingMessages = lazyPagingMessages,
-                playingAudiMessage = audioMessagesState.playingAudiMessage
+                playingAudioMessage = playingAudioMessage
             )
             JumpToLastMessageButton(lazyListState = lazyListState)
         }
@@ -1417,14 +1398,14 @@ fun JumpToLastMessageButton(
 @Composable
 fun BoxScope.JumpToPlayingAudioButton(
     lazyListState: LazyListState,
-    playingAudiMessage: PlayingAudioMessage,
+    playingAudioMessage: PlayingAudioMessage,
     lazyPagingMessages: LazyPagingItems<UIMessage>,
     modifier: Modifier = Modifier,
     coroutineScope: CoroutineScope = rememberCoroutineScope()
 ) {
-    if (playingAudiMessage is PlayingAudioMessage.Some && playingAudiMessage.state.isPlaying()) {
+    if (playingAudioMessage is PlayingAudioMessage.Some && playingAudioMessage.state.isPlaying()) {
         val indexOfPlayedMessage = lazyPagingMessages.itemSnapshotList
-            .indexOfFirst { playingAudiMessage.messageId == it?.header?.messageId }
+            .indexOfFirst { playingAudioMessage.messageId == it?.header?.messageId }
 
         if (indexOfPlayedMessage < 0) return
 
@@ -1456,7 +1437,7 @@ fun BoxScope.JumpToPlayingAudioButton(
                 modifier = Modifier
                     .padding(horizontal = dimensions().spacing8x)
                     .weight(1f, fill = false),
-                text = playingAudiMessage.authorName.asString(),
+                text = playingAudioMessage.authorName.asString(),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 color = colorsScheme().onPrimaryButtonEnabled,
@@ -1464,7 +1445,7 @@ fun BoxScope.JumpToPlayingAudioButton(
             )
             Text(
                 modifier = Modifier,
-                text = DateAndTimeParsers.audioMessageTime(playingAudiMessage.state.currentPositionInMs.toLong()),
+                text = DateAndTimeParsers.audioMessageTime(playingAudioMessage.state.currentPositionInMs.toLong()),
                 color = colorsScheme().onPrimaryButtonEnabled,
                 style = MaterialTheme.wireTypography.label03,
             )
@@ -1518,8 +1499,6 @@ fun PreviewConversationScreen() = WireTheme {
         onStartCall = { },
         onJoinCall = { },
         onReactionClick = { _, _ -> },
-        onChangeAudioPosition = { _, _ -> },
-        onAudioClick = { },
         onResetSessionClick = { _, _ -> },
         onUpdateConversationReadDate = { },
         onDropDownClick = { },
@@ -1542,6 +1521,5 @@ fun PreviewConversationScreen() = WireTheme {
         onLinkClick = { _ -> },
         openDrawingCanvas = {},
         onImagesPicked = {},
-        onChangeAudioSpeed = {}
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
@@ -69,7 +69,6 @@ import com.wire.android.ui.home.conversations.DownloadedAssetDialog
 import com.wire.android.ui.home.conversations.PermissionPermanentlyDeniedDialogState
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
 import com.wire.android.ui.home.conversations.edit.assetOptionsMenuItems
-import com.wire.android.ui.home.conversations.messages.AudioMessagesState
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
@@ -116,9 +115,6 @@ fun ConversationMediaScreen(
             )
         },
         onAssetItemClicked = conversationMessagesViewModel::downloadOrFetchAssetAndShowDialog,
-        audioMessagesState = conversationMessagesViewModel.conversationViewState.audioMessagesState,
-        onPlayAudioItemClicked = conversationMessagesViewModel::audioClick,
-        onAudioItemPositionChanged = conversationMessagesViewModel::changeAudioPosition,
         onOpenAssetOptions = remember { onOpenAssetOptions },
     )
 
@@ -167,11 +163,8 @@ fun ConversationMediaScreen(
 @Composable
 private fun Content(
     state: ConversationAssetMessagesViewState,
-    audioMessagesState: AudioMessagesState = AudioMessagesState(),
     initialPage: ConversationMediaScreenTabItem = ConversationMediaScreenTabItem.PICTURES,
     onImageFullScreenMode: (conversationId: ConversationId, messageId: String, isSelfAsset: Boolean) -> Unit = { _, _, _ -> },
-    onPlayAudioItemClicked: (String) -> Unit = {},
-    onAudioItemPositionChanged: (String, Int) -> Unit = { _, _ -> },
     onAssetItemClicked: (String) -> Unit = {},
     onOpenAssetOptions: (messageId: String, isMyMessage: Boolean) -> Unit = { _, _ -> },
     onNavigationPressed: () -> Unit = {},
@@ -222,10 +215,7 @@ private fun Content(
 
                     ConversationMediaScreenTabItem.FILES -> FileAssetsContent(
                         groupedAssetMessageList = state.assetMessages,
-                        audioMessagesState = audioMessagesState,
                         assetStatuses = state.assetStatuses,
-                        onPlayAudioItemClicked = onPlayAudioItemClicked,
-                        onAudioItemPositionChanged = onAudioItemPositionChanged,
                         onAssetItemClicked = onAssetItemClicked,
                         onItemLongClicked = onOpenAssetOptions
                     )
@@ -297,13 +287,12 @@ fun PreviewConversationMediaScreenImagesContent() = WireTheme {
 @PreviewMultipleThemes
 @Composable
 fun PreviewConversationMediaScreenFilesContent() = WireTheme {
-    val (flowOfAssets, assetStatuses, audioStatuses) = mockAssets()
+    val (flowOfAssets, assetStatuses) = mockAssets()
     Content(
         state = ConversationAssetMessagesViewState(
             assetMessages = flowOfAssets,
             assetStatuses = assetStatuses,
         ),
-        audioMessagesState = audioStatuses,
         initialPage = ConversationMediaScreenTabItem.FILES,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -24,11 +24,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import androidx.paging.PagingData
-import androidx.paging.map
 import com.wire.android.R
 import com.wire.android.appLogger
-import com.wire.android.media.audiomessage.AudioSpeed
 import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
 import com.wire.android.model.SnackBarMessage
 import com.wire.android.navigation.SavedStateViewModel
@@ -48,6 +45,7 @@ import com.wire.android.util.FileManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.startFileShareIntent
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
 import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -67,7 +65,6 @@ import com.wire.kalium.logic.feature.message.GetSearchedConversationMessagePosit
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionResult
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
-import com.wire.kalium.common.functional.onFailure
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.CoroutineScope
@@ -78,10 +75,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -186,19 +181,11 @@ class ConversationMessagesViewModel @Inject constructor(
     }
 
     private fun observeAudioPlayerState() {
-        val observableAudioMessagesState = audioMessagePlayer.observableAudioMessagesState
-            .map { audioMessageStates -> audioMessageStates.mapKeys { it.key.messageId } }
-//            .shareIn(viewModelScope, SharingStarted.Eagerly)
-
         viewModelScope.launch {
-            combine(
-                observableAudioMessagesState,
-                audioMessagePlayer.audioSpeed,
-                audioMessagePlayer.playingAudioMessageFlow
-            ) { audioMessageStates, audioSpeed, playingAudiMessage ->
-                AudioMessagesState(audioMessageStates.toPersistentMap(), audioSpeed, playingAudiMessage)
-            }
-                .collectLatest { conversationViewState = conversationViewState.copy(audioMessagesState = it) }
+            audioMessagePlayer.playingAudioMessageFlow
+                .collectLatest {
+                    conversationViewState = conversationViewState.copy(playingAudioMessage = it)
+                }
         }
     }
 
@@ -227,7 +214,6 @@ class ConversationMessagesViewModel @Inject constructor(
         }
 
         val paginatedMessagesFlow = getMessageForConversation(conversationId, lastReadIndex)
-            .fetchAudioWavesMaskIfNeeded()
             .flowOn(dispatchers.io())
 
         conversationViewState = conversationViewState.copy(
@@ -398,24 +384,6 @@ class ConversationMessagesViewModel @Inject constructor(
             deleteMessageDialogsState = newValue(it)
         }
 
-    fun audioClick(messageId: String) {
-        viewModelScope.launch {
-            audioMessagePlayer.playAudio(conversationId, messageId)
-        }
-    }
-
-    fun changeAudioPosition(messageId: String, position: Int) {
-        viewModelScope.launch {
-            audioMessagePlayer.setPosition(conversationId, messageId, position)
-        }
-    }
-
-    fun changeAudioSpeed(audioSpeed: AudioSpeed) {
-        viewModelScope.launch {
-            audioMessagePlayer.setSpeed(audioSpeed)
-        }
-    }
-
     fun updateImageOnFullscreenMode(message: UIMessage.Regular?) {
         lastImageMessageShownOnGallery = message
     }
@@ -451,19 +419,6 @@ class ConversationMessagesViewModel @Inject constructor(
                         conversationId = conversationId
                     )
                 )
-            }
-        }
-
-    // checking all the new messages if it's an AudioMessage and fetch WavesMask for it if so
-    private fun Flow<PagingData<UIMessage>>.fetchAudioWavesMaskIfNeeded(): Flow<PagingData<UIMessage>> =
-        map {
-            it.map { message ->
-                if (message.messageContent is UIMessageContent.AudioAssetMessage) {
-                    viewModelScope.launch {
-                        audioMessagePlayer.fetchWavesMask(conversationId, message.header.messageId)
-                    }
-                }
-                message
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewState.kt
@@ -19,8 +19,6 @@
 package com.wire.android.ui.home.conversations.messages
 
 import androidx.paging.PagingData
-import com.wire.android.media.audiomessage.AudioSpeed
-import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.UIMessage
@@ -36,18 +34,12 @@ data class ConversationMessagesViewState(
     val firstUnreadInstant: Instant? = null,
     val firstUnreadEventIndex: Int = 0,
     val downloadedAssetDialogState: DownloadedAssetDialogVisibilityState = DownloadedAssetDialogVisibilityState.Hidden,
-    val audioMessagesState: AudioMessagesState = AudioMessagesState(),
+    val playingAudioMessage: PlayingAudioMessage = PlayingAudioMessage.None,
     val assetStatuses: PersistentMap<String, MessageAssetStatus> = persistentMapOf(),
     val searchedMessageId: String? = null
 )
 
-data class AudioMessagesState(
-    val audioStates: PersistentMap<String, AudioState> = persistentMapOf(),
-    val audioSpeed: AudioSpeed = AudioSpeed.NORMAL,
-    val playingAudiMessage: PlayingAudioMessage = PlayingAudioMessage.None
-)
-
 sealed class DownloadedAssetDialogVisibilityState {
-    object Hidden : DownloadedAssetDialogVisibilityState()
+    data object Hidden : DownloadedAssetDialogVisibilityState()
     data class Displayed(val assetData: AssetBundle, val messageId: String) : DownloadedAssetDialogVisibilityState()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageClickActions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageClickActions.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.android.ui.home.conversations.messages.item
 
-import com.wire.android.media.audiomessage.AudioSpeed
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
@@ -28,9 +27,6 @@ sealed class MessageClickActions {
     open val onProfileClicked: (String) -> Unit = {}
     open val onReactionClicked: (String, String) -> Unit = { _, _ -> }
     open val onAssetClicked: (String) -> Unit = {}
-    open val onPlayAudioClicked: (String) -> Unit = {}
-    open val onAudioPositionChanged: (String, Int) -> Unit = { _, _ -> }
-    open val onAudioSpeedChange: (AudioSpeed) -> Unit = { _ -> }
     open val onImageClicked: (UIMessage.Regular, Boolean) -> Unit = { _, _ -> }
     open val onLinkClicked: (String) -> Unit = {}
     open val onReplyClicked: (UIMessage.Regular) -> Unit = {}
@@ -48,9 +44,6 @@ sealed class MessageClickActions {
         override val onProfileClicked: (String) -> Unit = {},
         override val onReactionClicked: (String, String) -> Unit = { _, _ -> },
         override val onAssetClicked: (String) -> Unit = {},
-        override val onPlayAudioClicked: (String) -> Unit = {},
-        override val onAudioPositionChanged: (String, Int) -> Unit = { _, _ -> },
-        override val onAudioSpeedChange: (AudioSpeed) -> Unit = { _ -> },
         override val onImageClicked: (UIMessage.Regular, Boolean) -> Unit = { _, _ -> },
         override val onLinkClicked: (String) -> Unit = {},
         override val onReplyClicked: (UIMessage.Regular) -> Unit = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContainerItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContainerItem.kt
@@ -21,8 +21,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.wire.android.media.audiomessage.AudioSpeed
-import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper
 import com.wire.android.ui.home.conversations.info.ConversationDetailsData
@@ -42,8 +40,6 @@ fun MessageContainerItem(
     searchQuery: String = "",
     showAuthor: Boolean = true,
     useSmallBottomPadding: Boolean = false,
-    audioState: AudioState? = null,
-    audioSpeed: AudioSpeed = AudioSpeed.NORMAL,
     assetStatus: AssetTransferStatus? = null,
     shouldDisplayMessageStatus: Boolean = true,
     shouldDisplayFooter: Boolean = true,
@@ -86,8 +82,6 @@ fun MessageContainerItem(
                 conversationDetailsData = conversationDetailsData,
                 clickActions = clickActions,
                 showAuthor = showAuthor,
-                audioState = audioState,
-                audioSpeed = audioSpeed,
                 assetStatus = assetStatus,
                 swipableMessageConfiguration = swipableMessageConfiguration,
                 failureInteractionAvailable = failureInteractionAvailable,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
@@ -10,8 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
-import com.wire.android.media.audiomessage.AudioSpeed
-import com.wire.android.media.audiomessage.AudioState
+import com.wire.android.media.audiomessage.AudioMessageArgs
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.HorizontalSpace
@@ -41,13 +40,8 @@ internal fun UIMessage.Regular.MessageContentAndStatus(
     message: UIMessage.Regular,
     assetStatus: AssetTransferStatus?,
     searchQuery: String,
-    audioState: AudioState?,
-    audioSpeed: AudioSpeed,
     onAssetClicked: (String) -> Unit,
     onImageClicked: (UIMessage.Regular, Boolean) -> Unit,
-    onAudioClicked: (String) -> Unit,
-    onAudioPositionChanged: (String, Int) -> Unit,
-    onAudioSpeedChange: (AudioSpeed) -> Unit,
     onProfileClicked: (String) -> Unit,
     onLinkClicked: (String) -> Unit,
     onReplyClicked: (UIMessage.Regular) -> Unit,
@@ -75,14 +69,9 @@ internal fun UIMessage.Regular.MessageContentAndStatus(
                 message = message,
                 messageContent = messageContent,
                 searchQuery = searchQuery,
-                audioState = audioState,
-                audioSpeed = audioSpeed,
                 assetStatus = assetStatus,
-                onAudioClick = onAudioClicked,
-                onChangeAudioPosition = onAudioPositionChanged,
                 onAssetClick = onAssetClickable,
                 onImageClick = onImageClickable,
-                onAudioSpeedChange = onAudioSpeedChange,
                 onOpenProfile = onProfileClicked,
                 onLinkClick = onLinkClicked,
                 onReplyClick = onReplyClickable,
@@ -109,14 +98,9 @@ private fun MessageContent(
     message: UIMessage.Regular,
     messageContent: UIMessageContent.Regular?,
     searchQuery: String,
-    audioState: AudioState?,
-    audioSpeed: AudioSpeed,
     assetStatus: AssetTransferStatus?,
     onAssetClick: Clickable,
     onImageClick: Clickable,
-    onAudioClick: (String) -> Unit,
-    onChangeAudioPosition: (String, Int) -> Unit,
-    onAudioSpeedChange: (AudioSpeed) -> Unit,
     onOpenProfile: (String) -> Unit,
     onLinkClick: (String) -> Unit,
     onReplyClick: Clickable,
@@ -230,23 +214,9 @@ private fun MessageContent(
 
         is UIMessageContent.AudioAssetMessage -> {
             Column {
-                val audioMessageState: AudioState = audioState ?: AudioState.DEFAULT
-
-                val totalTimeInMs = remember(audioMessageState.totalTimeInMs) {
-                    audioMessageState.sanitizeTotalTime(messageContent.audioMessageDurationInMs.toInt())
-                }
-
                 AudioMessage(
-                    audioMediaPlayingState = audioMessageState.audioMediaPlayingState,
-                    totalTimeInMs = totalTimeInMs,
-                    currentPositionInMs = audioMessageState.currentPositionInMs,
-                    audioSpeed = audioSpeed,
-                    waveMask = audioMessageState.wavesMask,
-                    onPlayButtonClick = { onAudioClick(message.header.messageId) },
-                    onSliderPositionChange = { position ->
-                        onChangeAudioPosition(message.header.messageId, position.toInt())
-                    },
-                    onAudioSpeedChange = { onAudioSpeedChange(audioSpeed.toggle()) }
+                    audioMessageArgs = AudioMessageArgs(message.conversationId, message.header.messageId),
+                    audioMessageDurationInMs = messageContent.audioMessageDurationInMs,
                 )
                 PartialDeliveryInformation(messageContent.deliveryStatus)
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
@@ -41,8 +41,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
-import com.wire.android.media.audiomessage.AudioSpeed
-import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.ui.common.LegalHoldIndicator
 import com.wire.android.ui.common.StatusBox
 import com.wire.android.ui.common.UserBadge
@@ -73,8 +71,6 @@ fun RegularMessageItem(
     clickActions: MessageClickActions,
     message: UIMessage.Regular,
     conversationDetailsData: ConversationDetailsData,
-    audioState: AudioState?,
-    audioSpeed: AudioSpeed,
     modifier: Modifier = Modifier,
     searchQuery: String = "",
     showAuthor: Boolean = true,
@@ -150,16 +146,11 @@ fun RegularMessageItem(
                             onAssetClicked = clickActions.onAssetClicked,
                             onImageClicked = clickActions.onImageClicked,
                             searchQuery = searchQuery,
-                            audioState = audioState,
-                            audioSpeed = audioSpeed,
-                            onAudioClicked = clickActions.onPlayAudioClicked,
-                            onAudioPositionChanged = clickActions.onAudioPositionChanged,
                             onProfileClicked = clickActions.onProfileClicked,
                             onLinkClicked = clickActions.onLinkClicked,
                             shouldDisplayMessageStatus = shouldDisplayMessageStatus,
                             conversationDetailsData = conversationDetailsData,
                             onReplyClicked = clickActions.onReplyClicked,
-                            onAudioSpeedChange = clickActions.onAudioSpeedChange
                         )
                         if (shouldDisplayFooter) {
                             VerticalSpace.x4()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -51,7 +51,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
+import com.wire.android.di.hiltViewModelScoped
 import com.wire.android.media.audiomessage.AudioMediaPlayingState
+import com.wire.android.media.audiomessage.AudioMessageArgs
+import com.wire.android.media.audiomessage.AudioMessageViewModel
+import com.wire.android.media.audiomessage.AudioMessageViewModelImpl
 import com.wire.android.media.audiomessage.AudioSpeed
 import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.model.Clickable
@@ -75,6 +79,32 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
 fun AudioMessage(
+    audioMessageArgs: AudioMessageArgs,
+    audioMessageDurationInMs: Long,
+    modifier: Modifier = Modifier,
+    viewModel: AudioMessageViewModel =
+        hiltViewModelScoped<AudioMessageViewModelImpl, AudioMessageViewModel, AudioMessageArgs>(audioMessageArgs),
+) {
+    val totalTimeInMs = remember(viewModel.state.audioState.totalTimeInMs, audioMessageDurationInMs) {
+        viewModel.state.audioState.sanitizeTotalTime(audioMessageDurationInMs.toInt())
+    }
+    AudioMessage(
+        audioMediaPlayingState = viewModel.state.audioState.audioMediaPlayingState,
+        totalTimeInMs = totalTimeInMs,
+        currentPositionInMs = viewModel.state.audioState.currentPositionInMs,
+        audioSpeed = viewModel.state.audioSpeed,
+        waveMask = viewModel.state.audioState.wavesMask,
+        onPlayButtonClick = viewModel::playAudio,
+        onSliderPositionChange = viewModel::changeAudioPosition,
+        onAudioSpeedChange = {
+            viewModel.changeAudioSpeed(viewModel.state.audioSpeed.toggle())
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun AudioMessage(
     audioMediaPlayingState: AudioMediaPlayingState,
     totalTimeInMs: AudioState.TotalTimeInMs,
     currentPositionInMs: Int,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesResultsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesResultsScreen.kt
@@ -60,7 +60,6 @@ fun SearchConversationMessagesResultsScreen(
                         message = message,
                         conversationDetailsData = ConversationDetailsData.None(null),
                         searchQuery = searchQuery,
-                        audioState = null,
                         clickActions = MessageClickActions.FullItem(
                             onFullMessageLongClicked = null,
                             onFullMessageClicked = onMessageClick,

--- a/app/src/test/kotlin/com/wire/android/media/audiomessage/AudioMessageViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/media/audiomessage/AudioMessageViewModelTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.media.audiomessage
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.ScopedArgsTestExtension
+import com.wire.android.di.scopedArgs
+import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer.MessageIdWrapper
+import com.wire.kalium.logic.data.id.ConversationId
+import io.mockk.MockKAnnotations
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(CoroutineTestExtension::class)
+@ExtendWith(ScopedArgsTestExtension::class)
+class AudioMessageViewModelTest {
+
+    @Test
+    fun `given audio state is updated with waves mask, when observing, then update the state properly`() = runTest {
+        val audioState = AudioState.DEFAULT.copy(audioMediaPlayingState = AudioMediaPlayingState.Fetching)
+        val audioMessageFlow = MutableStateFlow<Map<MessageIdWrapper, AudioState>>(emptyMap())
+        val (arrangement, viewModel) = Arrangement()
+            .withAudioMessageStateFlow(audioMessageFlow)
+            .arrange()
+        val messageIdWrapper = arrangement.audioMessageArgs.toMessageIdWrapper()
+
+        // state not yet added to the flow
+        assertEquals(AudioState.DEFAULT, viewModel.state.audioState)
+
+        // add the state to the flow but waves mask is not yet fetched
+        audioMessageFlow.value = mapOf(messageIdWrapper to audioState)
+        advanceUntilIdle()
+        assertEquals(audioState, viewModel.state.audioState)
+
+        // waves mask fetched
+        val wavesMask = listOf(1, 2, 3)
+        val audioStateWithWavesMask = audioState.copy(wavesMask = wavesMask)
+        audioMessageFlow.value = mapOf(messageIdWrapper to audioStateWithWavesMask)
+        advanceUntilIdle()
+        assertEquals(audioStateWithWavesMask, viewModel.state.audioState)
+    }
+
+    @Test
+    fun `given audio speed is updated, when observing, then update the state properly`() = runTest {
+        val audioSpeedFlow = MutableStateFlow(AudioSpeed.NORMAL)
+        val (arrangement, viewModel) = Arrangement()
+            .withAudioSpeedFlow(audioSpeedFlow)
+            .arrange()
+
+        // speed not changed yet
+        assertEquals(AudioSpeed.NORMAL, viewModel.state.audioSpeed)
+
+        // speed changed
+        audioSpeedFlow.value = AudioSpeed.FAST
+        advanceUntilIdle()
+        assertEquals(AudioSpeed.FAST, viewModel.state.audioSpeed)
+    }
+
+    @Test
+    fun `given audio message, when initializing, then fetch waves mask only once`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .arrange()
+        val (conversationId, messageId) = arrangement.audioMessageArgs
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            arrangement.audioMessagePlayer.fetchWavesMask(conversationId, messageId)
+        }
+    }
+
+    @Test
+    fun `given audio message, when play audio executed, then call proper action`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .arrange()
+        val (conversationId, messageId) = arrangement.audioMessageArgs
+        advanceUntilIdle()
+
+        viewModel.playAudio()
+
+        coVerify(exactly = 1) {
+            arrangement.audioMessagePlayer.playAudio(conversationId, messageId)
+        }
+    }
+
+    @Test
+    fun `given audio message, when audio position changed, then call proper action`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .arrange()
+        val (conversationId, messageId) = arrangement.audioMessageArgs
+        val position = 10f
+        advanceUntilIdle()
+
+        viewModel.changeAudioPosition(position)
+
+        coVerify(exactly = 1) {
+            arrangement.audioMessagePlayer.setPosition(conversationId, messageId, position.toInt())
+        }
+    }
+
+    @Test
+    fun `given audio message, when audio speed changed, then call proper action`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .arrange()
+        val audioSpeed = AudioSpeed.FAST
+        advanceUntilIdle()
+
+        viewModel.changeAudioSpeed(audioSpeed)
+
+        coVerify(exactly = 1) {
+            arrangement.audioMessagePlayer.setSpeed(audioSpeed)
+        }
+    }
+
+    inner class Arrangement {
+
+        @MockK
+        lateinit var audioMessagePlayer: ConversationAudioMessagePlayer
+
+        @MockK
+        lateinit var savedStateHandle: SavedStateHandle
+
+        val audioMessageArgs = AudioMessageArgs(ConversationId("convId", "domain"), "msgId")
+
+        init {
+            MockKAnnotations.init(this, relaxed = true)
+            every { savedStateHandle.scopedArgs<AudioMessageArgs>() } returns audioMessageArgs
+        }
+
+        fun withAudioMessageStateFlow(flow: Flow<Map<MessageIdWrapper, AudioState>>) = apply {
+            every { audioMessagePlayer.observableAudioMessagesState } returns flow
+        }
+
+        fun withAudioSpeedFlow(flow: Flow<AudioSpeed>) = apply {
+            every { audioMessagePlayer.audioSpeed } returns flow
+        }
+
+        fun arrange() = this to AudioMessageViewModelImpl(audioMessagePlayer, savedStateHandle)
+    }
+}
+
+private fun AudioMessageArgs.toMessageIdWrapper() = MessageIdWrapper(conversationId, messageId)

--- a/app/src/test/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayerTest.kt
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.android.media
+package com.wire.android.media.audiomessage
 
 import android.content.Context
 import android.media.MediaPlayer
@@ -23,12 +23,6 @@ import android.media.PlaybackParams
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import com.wire.android.framework.FakeKaliumFileSystem
-import com.wire.android.media.audiomessage.AudioFocusHelper
-import com.wire.android.media.audiomessage.AudioMediaPlayingState
-import com.wire.android.media.audiomessage.AudioSpeed
-import com.wire.android.media.audiomessage.AudioState
-import com.wire.android.media.audiomessage.AudioWavesMaskHelper
-import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
 import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer.MessageIdWrapper
 import com.wire.android.services.ServicesManager
 import com.wire.kalium.logic.CoreLogic

--- a/app/src/test/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayerTest.kt
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2024 Wire Swiss GmbH
+ * Copyright (C) 2025 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,9 +22,11 @@ import android.media.MediaPlayer
 import android.media.PlaybackParams
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
+import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.FakeKaliumFileSystem
 import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer.MessageIdWrapper
 import com.wire.android.services.ServicesManager
+import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.id.ConversationId
@@ -38,21 +40,21 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import okio.Path
 import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.Test
 
+private val dispatchers: DispatcherProvider = TestDispatcherProvider()
+
 @Suppress("LongMethod")
 class ConversationAudioMessagePlayerTest {
 
     @Test
-    fun givenTheSuccessFullAssetFetch_whenPlayingAudioForFirstTime_thenEmitStatesAsExpected() = runTest {
+    fun givenTheSuccessfulAssetFetch_whenPlayingAudioForFirstTime_thenEmitStatesAsExpected() = runTest(dispatchers.default()) {
         val (arrangement, conversationAudioMessagePlayer) = Arrangement()
             .withAudioMediaPlayerReturningTotalTime(1000)
-            .withSuccessFullAssetFetch()
+            .withSuccessfulAssetFetch()
             .withCurrentSession()
             .arrange()
 
@@ -67,7 +69,6 @@ class ConversationAudioMessagePlayerTest {
                 conversationId,
                 testAudioMessageId
             )
-            this@runTest.advanceUntilIdle()
 
             awaitAndAssertStateUpdate { state ->
                 val currentState = state[messageIdWrapper]
@@ -114,88 +115,87 @@ class ConversationAudioMessagePlayerTest {
     }
 
     @Test
-    fun givenTheSuccessFullAssetFetch_whenPlayingTheSameMessageIdTwiceSequentially_thenEmitStatesAsExpected() = runTest {
-        val (arrangement, conversationAudioMessagePlayer) = Arrangement()
-            .withSuccessFullAssetFetch()
-            .withCurrentSession()
-            .withAudioMediaPlayerReturningTotalTime(1000)
-            .withMediaPlayerPlaying()
-            .arrange()
+    fun givenTheSuccessfulAssetFetch_whenPlayingTheSameMessageIdTwiceSequentially_thenEmitStatesAsExpected() =
+        runTest(dispatchers.default()) {
+            val (arrangement, conversationAudioMessagePlayer) = Arrangement()
+                .withSuccessfulAssetFetch()
+                .withCurrentSession()
+                .withAudioMediaPlayerReturningTotalTime(1000)
+                .withMediaPlayerPlaying()
+                .arrange()
 
-        val testAudioMessageId = "some-dummy-message-id"
-        val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-        val messageIdWrapper = MessageIdWrapper(conversationId, testAudioMessageId)
+            val testAudioMessageId = "some-dummy-message-id"
+            val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
+            val messageIdWrapper = MessageIdWrapper(conversationId, testAudioMessageId)
 
-        conversationAudioMessagePlayer.observableAudioMessagesState.test {
-            // skip first emit from onStart
-            awaitItem()
-            // playing first time
-            conversationAudioMessagePlayer.playAudio(
-                conversationId,
-                testAudioMessageId
-            )
-            advanceUntilIdle()
+            conversationAudioMessagePlayer.observableAudioMessagesState.test {
+                // skip first emit from onStart
+                awaitItem()
+                // playing first time
+                conversationAudioMessagePlayer.playAudio(
+                    conversationId,
+                    testAudioMessageId
+                )
 
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
-                assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Fetching)
-            }
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
-                assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.SuccessfulFetching)
-            }
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
-                assertEquals(currentState!!.wavesMask, Arrangement.WAVES_MASK)
-            }
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
-                assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Playing)
-            }
-            awaitItem() // currentPosition update
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
+                awaitAndAssertStateUpdate { state ->
+                    val currentState = state[messageIdWrapper]
+                    assert(currentState != null)
+                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Fetching)
+                }
+                awaitAndAssertStateUpdate { state ->
+                    val currentState = state[messageIdWrapper]
+                    assert(currentState != null)
+                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.SuccessfulFetching)
+                }
+                awaitAndAssertStateUpdate { state ->
+                    val currentState = state[messageIdWrapper]
+                    assert(currentState != null)
+                    assertEquals(currentState!!.wavesMask, Arrangement.WAVES_MASK)
+                }
+                awaitAndAssertStateUpdate { state ->
+                    val currentState = state[messageIdWrapper]
+                    assert(currentState != null)
+                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Playing)
+                }
+                awaitItem() // currentPosition update
+                awaitAndAssertStateUpdate { state ->
+                    val currentState = state[messageIdWrapper]
+                    assert(currentState != null)
 
-                val totalTime = currentState!!.totalTimeInMs
-                assert(totalTime is AudioState.TotalTimeInMs.Known)
-                assert((totalTime as AudioState.TotalTimeInMs.Known).value == 1000)
+                    val totalTime = currentState!!.totalTimeInMs
+                    assert(totalTime is AudioState.TotalTimeInMs.Known)
+                    assert((totalTime as AudioState.TotalTimeInMs.Known).value == 1000)
+                }
+
+                // playing second time
+                conversationAudioMessagePlayer.playAudio(
+                    conversationId,
+                    testAudioMessageId
+                )
+                awaitAndAssertStateUpdate { state ->
+                    val currentState = state[messageIdWrapper]
+                    assert(currentState != null)
+                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Paused)
+                }
+
+                cancelAndIgnoreRemainingEvents()
             }
 
-            // playing second time
-            conversationAudioMessagePlayer.playAudio(
-                conversationId,
-                testAudioMessageId
-            )
-            advanceUntilIdle()
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
-                assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Paused)
-            }
+            with(arrangement) {
+                verify(exactly = 1) { mediaPlayer.prepare() }
+                verify(exactly = 1) { mediaPlayer.setDataSource(any(), any()) }
+                verify(exactly = 1) { mediaPlayer.start() }
+                verify(exactly = 1) { mediaPlayer.pause() }
 
-            cancelAndIgnoreRemainingEvents()
+                verify(exactly = 0) { mediaPlayer.seekTo(any()) }
+            }
         }
-
-        with(arrangement) {
-            verify(exactly = 1) { mediaPlayer.prepare() }
-            verify(exactly = 1) { mediaPlayer.setDataSource(any(), any()) }
-            verify(exactly = 1) { mediaPlayer.start() }
-            verify(exactly = 1) { mediaPlayer.pause() }
-
-            verify(exactly = 0) { mediaPlayer.seekTo(any()) }
-        }
-    }
 
     @Test
-    fun givenTheSuccessFullAssetFetch_whenPlayingDifferentAudioAfterFirstOneIsPlayed_thenEmitStatesAsExpected() =
-        runTest {
+    fun givenTheSuccessfulAssetFetch_whenPlayingDifferentAudioAfterFirstOneIsPlayed_thenEmitStatesAsExpected() =
+        runTest(dispatchers.default()) {
             val (arrangement, conversationAudioMessagePlayer) = Arrangement()
-                .withSuccessFullAssetFetch()
+                .withSuccessfulAssetFetch()
                 .withCurrentSession()
                 .withAudioMediaPlayerReturningTotalTime(1000)
                 .arrange()
@@ -214,7 +214,6 @@ class ConversationAudioMessagePlayerTest {
                     conversationId,
                     firstAudioMessageId
                 )
-                this@runTest.advanceUntilIdle()
 
                 awaitAndAssertStateUpdate { state ->
                     val currentState = state[firstAudioMessageIdWrapper]
@@ -296,10 +295,10 @@ class ConversationAudioMessagePlayerTest {
         }
 
     @Test
-    fun givenTheSuccessFullAssetFetch_whenPlayingDifferentAudioAfterFirstOneIsPlayedAndSecondResumed_thenEmitStatesAsExpected() =
-        runTest {
+    fun givenTheSuccessfulAssetFetch_whenPlayingDifferentAudioAfterFirstOneIsPlayedAndSecondResumed_thenEmitStatesAsExpected() =
+        runTest(dispatchers.default()) {
             val (arrangement, conversationAudioMessagePlayer) = Arrangement()
-                .withSuccessFullAssetFetch()
+                .withSuccessfulAssetFetch()
                 .withCurrentSession()
                 .withAudioMediaPlayerReturningTotalTime(1000)
                 .arrange()
@@ -318,7 +317,6 @@ class ConversationAudioMessagePlayerTest {
                     conversationId,
                     firstAudioMessageId
                 )
-                this@runTest.advanceUntilIdle()
 
                 awaitAndAssertStateUpdate { state ->
                     val currentState = state[firstAudioMessageIdWrapper]
@@ -354,7 +352,6 @@ class ConversationAudioMessagePlayerTest {
                     ConversationId("some-dummy-value", "some.dummy.domain"),
                     secondAudioMessageId
                 )
-                this@runTest.advanceUntilIdle()
 
                 awaitAndAssertStateUpdate { state ->
                     val currentState = state[firstAudioMessageIdWrapper]
@@ -403,7 +400,6 @@ class ConversationAudioMessagePlayerTest {
                     ConversationId("some-dummy-value", "some.dummy.domain"),
                     firstAudioMessageId
                 )
-                this@runTest.advanceUntilIdle()
                 awaitAndAssertStateUpdate { state ->
                     val currentState = state[secondAudioMessageIdWrapper]
                     assert(currentState != null)
@@ -456,10 +452,10 @@ class ConversationAudioMessagePlayerTest {
         }
 
     @Test
-    fun givenTheSuccessFullAssetFetch_whenPlayingDifferentAudioAfterFirstOneIsPlayedAndSecondStoppedAndResume_thenEmitStatesAsExpected() =
-        runTest {
+    fun givenTheSuccessfulAssetFetch_whenPlayingDifferentAudioAfterFirstOneIsPlayedAndSecondStoppedAndResume_thenEmitStatesAsExpected() =
+        runTest(dispatchers.default()) {
             val (arrangement, conversationAudioMessagePlayer) = Arrangement()
-                .withSuccessFullAssetFetch()
+                .withSuccessfulAssetFetch()
                 .withCurrentSession()
                 .withAudioMediaPlayerReturningTotalTime(1000)
                 .withMediaPlayerPlaying()
@@ -477,7 +473,6 @@ class ConversationAudioMessagePlayerTest {
                     conversationId,
                     testAudioMessageId
                 )
-                this@runTest.advanceUntilIdle()
 
                 awaitAndAssertStateUpdate { state ->
                     val currentState = state[messageIdWrapper]
@@ -513,7 +508,6 @@ class ConversationAudioMessagePlayerTest {
                     conversationId,
                     testAudioMessageId
                 )
-                this@runTest.advanceUntilIdle()
                 awaitAndAssertStateUpdate { state ->
                     val currentState = state[messageIdWrapper]
                     assert(currentState != null)
@@ -528,7 +522,6 @@ class ConversationAudioMessagePlayerTest {
                     conversationId,
                     testAudioMessageId
                 )
-                this@runTest.advanceUntilIdle()
                 awaitAndAssertStateUpdate { state ->
                     val currentState = state[messageIdWrapper]
                     assert(currentState != null)
@@ -549,10 +542,10 @@ class ConversationAudioMessagePlayerTest {
         }
 
     @Test
-    fun givenTheSuccessFullAssetFetch_whenAudioSpeedChanged_thenMediaPlayerParamsWereUpdated() = runTest {
+    fun givenTheSuccessfulAssetFetch_whenAudioSpeedChanged_thenMediaPlayerParamsWereUpdated() = runTest(dispatchers.default()) {
         val params = PlaybackParams()
         val (arrangement, conversationAudioMessagePlayer) = Arrangement()
-            .withSuccessFullAssetFetch()
+            .withSuccessfulAssetFetch()
             .withCurrentSession()
             .withAudioMediaPlayerReturningParams(params)
             .arrange()
@@ -565,10 +558,10 @@ class ConversationAudioMessagePlayerTest {
     }
 
     @Test
-    fun givenPlayingAudioMessage_whenStopAudioCalled_thenServiceStoppedAndAudioFocusAbandoned() = runTest {
+    fun givenPlayingAudioMessage_whenStopAudioCalled_thenServiceStoppedAndAudioFocusAbandoned() = runTest(dispatchers.default()) {
         val (arrangement, conversationAudioMessagePlayer) = Arrangement()
             .withAudioMediaPlayerReturningTotalTime(1000)
-            .withSuccessFullAssetFetch()
+            .withSuccessfulAssetFetch()
             .withCurrentSession()
             .arrange()
 
@@ -582,7 +575,6 @@ class ConversationAudioMessagePlayerTest {
                 conversationId,
                 testAudioMessageId
             )
-            this@runTest.advanceUntilIdle()
 
             conversationAudioMessagePlayer.forceToStopCurrentAudioMessage()
 
@@ -623,7 +615,7 @@ class Arrangement {
     @MockK
     lateinit var audioFocusHelper: AudioFocusHelper
 
-    private val testScope = CoroutineScope(UnconfinedTestDispatcher())
+    private val testScope: CoroutineScope = CoroutineScope(dispatchers.default())
 
     private val conversationAudioMessagePlayer by lazy {
         ConversationAudioMessagePlayer(
@@ -633,7 +625,8 @@ class Arrangement {
             { servicesManager },
             audioFocusHelper,
             coreLogic,
-            testScope
+            testScope,
+            dispatchers,
         )
     }
 
@@ -658,7 +651,7 @@ class Arrangement {
         )
     }
 
-    fun withSuccessFullAssetFetch() = apply {
+    fun withSuccessfulAssetFetch() = apply {
         coEvery {
             coreLogic.getSessionScope(any()).messages.getAssetMessage.invoke(any<ConversationId>(), any<String>())
         } returns CompletableDeferred(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -20,19 +20,16 @@ package com.wire.android.ui.home.conversations.messages
 
 import androidx.paging.PagingData
 import androidx.paging.map
-import androidx.paging.testing.asSnapshot
 import app.cash.turbine.test
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
 import com.wire.android.framework.TestMessage
 import com.wire.android.framework.TestMessage.GENERIC_ASSET_CONTENT
 import com.wire.android.media.audiomessage.AudioMediaPlayingState
-import com.wire.android.media.audiomessage.AudioSpeed
 import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer.MessageIdWrapper
 import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
-import com.wire.android.ui.home.conversations.composer.mockUIAudioMessage
 import com.wire.android.ui.home.conversations.composer.mockUITextMessage
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
@@ -43,10 +40,8 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
 import io.mockk.coVerify
 import io.mockk.verify
-import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
@@ -311,27 +306,6 @@ class ConversationMessagesViewModelTest {
         }
 
     @Test
-    fun `given the AudioMessage in list, when getting paging flow, then fetching the waveMask for AudioMessage is called`() = runTest {
-        // Given
-        val firstMessage = mockUITextMessage(id = "firstId")
-        val secondMessage = mockUIAudioMessage(id = "secondId")
-        val pagingData = PagingData.from(listOf(firstMessage, secondMessage))
-
-        val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
-            .withSuccessfulViewModelInit()
-            .withPaginatedMessagesReturning(pagingData)
-            .arrange()
-
-        val job = launch { viewModel.conversationViewState.messages.asSnapshot() }
-        job.start()
-        advanceUntilIdle()
-
-        coVerify(exactly = 1) { arrangement.conversationAudioMessagePlayer.fetchWavesMask(any(), any()) }
-
-        job.cancel()
-    }
-
-    @Test
     fun `given an message ID, when some Audio is played, then state contains it`() = runTest {
         val message = TestMessage.ASSET_MESSAGE
         val audioState = AudioState.DEFAULT.copy(
@@ -339,20 +313,15 @@ class ConversationMessagesViewModelTest {
             totalTimeInMs = AudioState.TotalTimeInMs.Known(10000),
             currentPositionInMs = 300
         )
-        val playingAudiMessage = PlayingAudioMessage.Some(
+        val playingAudioMessage = PlayingAudioMessage.Some(
             conversationId = message.conversationId,
             messageId = message.id,
             authorName = UIText.DynamicString("some name"),
             state = AudioState.DEFAULT.copy(currentPositionInMs = audioState.currentPositionInMs)
         )
-        val expectedAudioMessagesState = AudioMessagesState(
-            audioStates = persistentMapOf(message.id to audioState),
-            audioSpeed = AudioSpeed.NORMAL,
-            playingAudiMessage = playingAudiMessage
-        )
         val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
             .withSuccessfulViewModelInit()
-            .withPlayingAudioMessageFlow(flowOf(playingAudiMessage))
+            .withPlayingAudioMessageFlow(flowOf(playingAudioMessage))
             .withObservableAudioMessagesState(
                 flowOf(
                     mapOf(
@@ -365,7 +334,7 @@ class ConversationMessagesViewModelTest {
 
         advanceUntilIdle()
 
-        assertEquals(expectedAudioMessagesState, viewModel.conversationViewState.audioMessagesState)
+        assertEquals(playingAudioMessage, viewModel.conversationViewState.playingAudioMessage)
     }
 
     @Test
@@ -376,11 +345,6 @@ class ConversationMessagesViewModelTest {
             totalTimeInMs = AudioState.TotalTimeInMs.Known(10000),
             currentPositionInMs = 300
         )
-        val expectedAudioMessagesState = AudioMessagesState(
-            audioStates = persistentMapOf(message.id to audioState),
-            audioSpeed = AudioSpeed.NORMAL,
-            playingAudiMessage = PlayingAudioMessage.None
-        )
         val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
             .withSuccessfulViewModelInit()
             .withPlayingAudioMessageFlow(flowOf(PlayingAudioMessage.None))
@@ -389,6 +353,6 @@ class ConversationMessagesViewModelTest {
 
         advanceUntilIdle()
 
-        assertEquals(expectedAudioMessagesState, viewModel.conversationViewState.audioMessagesState)
+        assertEquals(PlayingAudioMessage.None, viewModel.conversationViewState.playingAudioMessage)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16195" title="WPB-16195" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16195</a>  [Android]Audio not available or app crashes on playback
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app crashes as soon as the user taps the play button on audio message.

### Causes (Optional)

Race condition when fetching audio asset file - it can be executed multiple times at once as it's also called to fetch waves mask and then asset file can be overwritten and broken (created but empty for instance) resulting in a crash when trying to play empty file. 
The "fetch waves mask" action can also be called multiple times for each message as it's called every time paging data is updated. The whole map of audio states is propagated through all composables all way down from the screen to the `AudioMessage` item and it's not stable so it can be also prone to more unneeded recompositions. 
`ConversationAudioMessagePlayer` dropping and losing some of the crucial states emitted because of `DROP_OLDEST` and for instance making the audio message be played without any indication on the screen.

### Solutions

Secured `getAssetMessage` by keeping the deferred until it's completed so that each execution during that time will reuse the same deferred and it won't be called multiple times at the same time - no issues with overwriting the file and no unnecessary requests.
Created dedicated scoped `AudioMessageViewModel` which handles the state for the given message and executes calls to play the audio associated with that message, change the audio speed or fetch waves mask for that audio so that it happens only once and is kept in the view model. Thanks to that, a map with all audio states doesn't need to be passed all the way to the `AudioMessage` but instead it uses state from injected scoped `AudioMessageViewModel`.
Replaced `DROP_OLDEST` with `SUSPEND` in `ConversationAudioMessagePlayer` to not lose any state updates.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Receive audio messages and try to play them.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.