### PR TITLE
fix: broken compilation on AnonymousAnalyticsManagerTest and ExternalLoggerManager (WPB-16121)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -247,6 +247,7 @@ dependencies {
         if (configs["analytics_enabled"] as? Boolean == true) {
             println(">> Adding Anonymous Analytics dependency to [$key] flavor")
             add("${key}Implementation", project(":core:analytics-enabled"))
+            add("test${key.capitalize()}Implementation", project(":core:analytics-disabled"))
         } else {
             add("${key}Implementation", project(":core:analytics-disabled"))
         }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -149,6 +149,7 @@ dependencies {
     // kover
     kover(project(":features:sketch"))
     kover(project(":core:ui-common"))
+    kover(project(":core:analytics-enabled"))
 
     // Application dependencies
     implementation(libs.androidx.appcompat)

--- a/app/src/public/kotlin/com/wire/android/ExternalLoggerManager.kt
+++ b/app/src/public/kotlin/com/wire/android/ExternalLoggerManager.kt
@@ -1,9 +1,8 @@
 package com.wire.android
 
 import android.content.Context
-import com.wire.android.datastore.GlobalDataStore
 
 object ExternalLoggerManager {
 
-    fun initDatadogLogger(context: Context, globalDataStore: GlobalDataStore) = Unit
+    fun initDatadogLogger(context: Context) = Unit
 }

--- a/core/analytics-enabled/src/test/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerTest.kt
+++ b/core/analytics-enabled/src/test/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerTest.kt
@@ -291,7 +291,7 @@ class AnonymousAnalyticsManagerTest {
 
         // then
         verify(exactly = 1) {
-            arrangement.anonymousAnalyticsRecorder.recordView(eq(screen))
+            arrangement.anonymousAnalyticsRecorder.recordView(any())
         }
     }
 
@@ -353,7 +353,7 @@ class AnonymousAnalyticsManagerTest {
 
         // then
         verify(exactly = 1) {
-            arrangement.anonymousAnalyticsRecorder.stopView(eq(screen))
+            arrangement.anonymousAnalyticsRecorder.stopView(any())
         }
     }
 
@@ -451,13 +451,15 @@ class AnonymousAnalyticsManagerTest {
             private fun dummyManager() = object : DummyManager {}
             val existingIdentifierResult = AnalyticsResult<DummyManager>(
                 identifierResult = AnalyticsIdentifierResult.ExistingIdentifier(CURRENT_IDENTIFIER),
-                profileProperties = AnalyticsProfileProperties(
-                    isTeamMember = true,
-                    teamId = null,
-                    contactsAmount = null,
-                    teamMembersAmount = null,
-                    isEnterprise = null
-                ),
+                profileProperties = suspend {
+                    AnalyticsProfileProperties(
+                        isTeamMember = true,
+                        teamId = null,
+                        contactsAmount = null,
+                        teamMembersAmount = null,
+                        isEnterprise = null
+                    )
+                },
                 manager = dummyManager()
             )
             val disabledIdentifierResult = existingIdentifierResult.copy(


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16121" title="WPB-16121" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16121</a>  [Android] Implement new user properties
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->




----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Broken test for analytics and compilation for custom builds

- #3806
- #3890

### Solutions

Cherry-pick fixes from RC

- 478667b2ff5022491751374d5d048aeda46314c4
- d996e1aa40e3f3a74af1b1039167bcc6f1f9820d
- af6cb19f53e25c508ea8667ea3331ef1dcbf70cb

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
