### PR TITLE
feat(channels): distinguish channels in conversation list [WPB-15865]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
@@ -62,6 +62,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             ),
             hasOnGoingCall = conversationDetails.hasOngoingCall && conversationDetails.isSelfUserMember,
             isFromTheSameTeam = conversationDetails.conversation.teamId == selfUserTeamId,
+            isChannel = conversationDetails is Group.Channel,
             isSelfUserMember = conversationDetails.isSelfUserMember,
             teamId = conversationDetails.conversation.teamId,
             selfMemberRole = conversationDetails.selfRole,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -177,7 +177,11 @@ private fun GeneralConversationItem(
                                     selectOnRadioGroup()
                                 })
                             }
-                            GroupConversationAvatar(conversation.conversationId)
+                            if (isChannel) {
+                                ChannelConversationAvatar(conversationId)
+                            } else {
+                                GroupConversationAvatar(conversationId)
+                            }
                         }
                     },
                     title = {
@@ -395,6 +399,37 @@ fun PreviewGroupConversationItemWithUnreadCount() = WireTheme {
             teamId = null,
             isArchived = false,
             isFromTheSameTeam = false,
+            isChannel = false,
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            isFavorite = false,
+            folder = null,
+            playingAudio = null
+        ),
+        modifier = Modifier,
+        isSelectableItem = false,
+        isChecked = false,
+        {}, {}, {}, {}, {}, {},
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewChannelGroupConversationItemWithUnreadCount() = WireTheme {
+    ConversationItemFactory(
+        conversation = ConversationItem.GroupConversation(
+            "groupName looooooooooooooooooooooooooooooooooooong",
+            conversationId = QualifiedID("value", "domain"),
+            mutedStatus = MutedConversationStatus.AllAllowed,
+            lastMessageContent = UILastMessageContent.TextMessage(
+                MessageBody(UIText.DynamicString("Very looooooooooong messageeeeeeeeeeeeeee"))
+            ),
+            badgeEventType = BadgeEventType.UnreadMessage(100),
+            selfMemberRole = null,
+            teamId = null,
+            isArchived = false,
+            isFromTheSameTeam = false,
+            isChannel = true,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
@@ -424,6 +459,7 @@ fun PreviewGroupConversationItemWithNoBadges() = WireTheme {
             teamId = null,
             isArchived = false,
             isFromTheSameTeam = false,
+            isChannel = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
@@ -455,6 +491,7 @@ fun PreviewGroupConversationItemWithLastDeletedMessage() = WireTheme {
             teamId = null,
             isArchived = false,
             isFromTheSameTeam = false,
+            isChannel = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
@@ -484,6 +521,7 @@ fun PreviewGroupConversationItemWithMutedBadgeAndUnreadMentionBadge() = WireThem
             teamId = null,
             isArchived = false,
             isFromTheSameTeam = false,
+            isChannel = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
@@ -514,6 +552,7 @@ fun PreviewGroupConversationItemWithOngoingCall() = WireTheme {
             hasOnGoingCall = true,
             isArchived = false,
             isFromTheSameTeam = false,
+            isChannel = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
@@ -629,6 +668,7 @@ fun PreviewPrivateConversationItemWithPlayingAudio() = WireTheme {
             teamId = null,
             isArchived = false,
             isFromTheSameTeam = false,
+            isChannel = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -212,6 +212,7 @@ fun previewConversationList(count: Int, startIndex: Int = 0, unread: Boolean = f
                     hasOnGoingCall = false,
                     isArchived = false,
                     isFromTheSameTeam = false,
+                    isChannel = false,
                     mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
                     proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
                     searchQuery = searchQuery,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -57,6 +57,7 @@ sealed class ConversationItem : ConversationFolderItem {
         val hasOnGoingCall: Boolean = false,
         val selfMemberRole: Conversation.Member.Role?,
         val isFromTheSameTeam: Boolean,
+        val isChannel: Boolean,
         val isSelfUserMember: Boolean = true,
         override val conversationId: ConversationId,
         override val mutedStatus: MutedConversationStatus,

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversationItem.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversationItem.kt
@@ -61,6 +61,7 @@ object TestConversationItem {
         badgeEventType = BadgeEventType.UnreadMessage(100),
         selfMemberRole = null,
         isFromTheSameTeam = false,
+        isChannel = false,
         teamId = null,
         isArchived = false,
         mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15865" title="WPB-15865" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-15865</a>  [Android] Show channels in conversation list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Channels are properly displayed in Conversation List, with the correct icon.

Introduced the `isChannel` attribute to distinguish channel conversations across data models and UI components **for the conversation list**. Updated `ConversationMapper` and related UI logic to handle channel-specific behavior, including rendering appropriate avatars. Added previews to validate the new functionality in different states.

### Testing

Not added, as it only changes UI.

### Attachments

| Dark Theme | Light Theme |
| ----------- | ------------ |
|  ![Screenshot_20250319-114953](https://github.com/user-attachments/assets/9b3ca403-9856-410f-a886-e75fa28dcd92) | ![Screenshot_20250319-115046](https://github.com/user-attachments/assets/13e7db81-8a85-498d-9d1b-4bba44fa3961) |

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
