### PR TITLE
fix: handle 2fa on RegisterDeviceScreen [WPB-16573]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/AuthenticationModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/AuthenticationModule.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.di.accountScoped
+
+import com.wire.android.di.CurrentAccount
+import com.wire.android.di.KaliumCoreLogic
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.auth.AuthenticationScope
+import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerificationCodeUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+
+@Module
+@InstallIn(ViewModelComponent::class)
+class AuthenticationModule {
+
+    @Provides
+    @ViewModelScoped
+    fun provideAuthenticationScope(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): AuthenticationScope = coreLogic.getSessionScope(currentAccount).authenticationScope
+
+    @ViewModelScoped
+    @Provides
+    fun provideRequest2FACodeUseCase(authenticationScope: AuthenticationScope): RequestSecondFactorVerificationCodeUseCase =
+        authenticationScope.requestSecondFactorVerificationCode
+}

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt
@@ -19,9 +19,12 @@
 package com.wire.android.ui.authentication.devices.register
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
@@ -44,6 +47,7 @@ import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.WireDestination
 import com.wire.android.navigation.style.PopUpNavigationAnimation
+import com.wire.android.navigation.style.TransitionAnimationType
 import com.wire.android.ui.authentication.devices.common.ClearSessionState
 import com.wire.android.ui.authentication.devices.common.ClearSessionViewModel
 import com.wire.android.ui.common.button.WireButtonState
@@ -94,16 +98,30 @@ fun RegisterDeviceScreen(
 
         is RegisterDeviceFlowState.TooManyDevices -> navigator.navigate(NavigationCommand(RemoveDeviceScreenDestination))
         else ->
-            RegisterDeviceContent(
-                state = viewModel.state,
-                passwordTextState = viewModel.passwordTextState,
-                clearSessionState = clearSessionViewModel.state,
-                onContinuePressed = viewModel::onContinue,
-                onErrorDismiss = viewModel::onErrorDismiss,
-                onBackButtonClicked = clearSessionViewModel::onBackButtonClicked,
-                onCancelLoginClicked = { clearSessionViewModel.onCancelLoginClicked(NavigationSwitchAccountActions(navigator::navigate)) },
-                onProceedLoginClicked = clearSessionViewModel::onProceedLoginClicked
-            )
+            AnimatedContent(
+                targetState = viewModel.secondFactorVerificationCodeState.isCodeInputNecessary,
+                transitionSpec = {
+                    TransitionAnimationType.SLIDE.enterTransition.togetherWith(TransitionAnimationType.SLIDE.exitTransition)
+                },
+                modifier = Modifier.fillMaxSize()
+            ) { isCodeInputNecessary ->
+                if (isCodeInputNecessary) {
+                    RegisterDeviceVerificationCodeScreen(viewModel)
+                } else {
+                    RegisterDeviceContent(
+                        state = viewModel.state,
+                        passwordTextState = viewModel.passwordTextState,
+                        clearSessionState = clearSessionViewModel.state,
+                        onContinuePressed = viewModel::onContinue,
+                        onErrorDismiss = viewModel::onErrorDismiss,
+                        onBackButtonClicked = clearSessionViewModel::onBackButtonClicked,
+                        onCancelLoginClicked = {
+                            clearSessionViewModel.onCancelLoginClicked(NavigationSwitchAccountActions(navigator::navigate))
+                        },
+                        onProceedLoginClicked = clearSessionViewModel::onProceedLoginClicked
+                    )
+                }
+            }
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceVerificationCodeScreen.kt
@@ -16,31 +16,32 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.android.ui.authentication.login.email
+package com.wire.android.ui.authentication.devices.register
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.wire.android.ui.authentication.login.LoginState
+import com.wire.android.ui.authentication.devices.register.RegisterDeviceFlowState
+import com.wire.android.ui.authentication.devices.register.RegisterDeviceViewModel
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeScreenContent
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeState
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
-fun LoginEmailVerificationCodeScreen(
-    viewModel: LoginEmailViewModel = hiltViewModel()
+fun RegisterDeviceVerificationCodeScreen(
+    viewModel: RegisterDeviceViewModel = hiltViewModel()
 ) = VerificationCodeScreenContent(
     viewModel.secondFactorVerificationCodeTextState,
     viewModel.secondFactorVerificationCodeState,
-    viewModel.loginState.flowState is LoginState.Loading,
+    viewModel.state.flowState is RegisterDeviceFlowState.Loading,
     viewModel::onCodeResend,
     viewModel::onCodeVerificationBackPress
 )
 
 @PreviewMultipleThemes
 @Composable
-internal fun LoginEmailVerificationCodeScreenPreview() = WireTheme {
+internal fun RegisterDeviceVerificationCodeScreenPreview() = WireTheme {
     VerificationCodeScreenContent(
         verificationCodeTextState = TextFieldState(),
         verificationCodeState = VerificationCodeState(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceVerificationCodeScreen.kt
@@ -21,8 +21,6 @@ package com.wire.android.ui.authentication.devices.register
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.wire.android.ui.authentication.devices.register.RegisterDeviceFlowState
-import com.wire.android.ui.authentication.devices.register.RegisterDeviceViewModel
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeScreenContent
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeState
 import com.wire.android.ui.theme.WireTheme

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
@@ -105,10 +105,10 @@ class RegisterDeviceViewModel @Inject constructor(
                 capabilities = null,
                 modelPostfix = if (BuildConfig.PRIVATE_BUILD) " [${BuildConfig.FLAVOR}_${BuildConfig.BUILD_TYPE}]" else null
             )
-        ).handle(secondFactorVerificationCode != null)
+        ).handle(secondFactorVerificationCode.isNullOrEmpty())
     }
 
-    private suspend fun RegisterClientResult.handle(userEntered2FA: Boolean) {
+    private suspend fun RegisterClientResult.handle(empty2FACodeInput: Boolean) {
         when (this) {
             is RegisterClientResult.Failure.TooManyClients -> updateFlowState(RegisterDeviceFlowState.TooManyDevices)
 
@@ -136,7 +136,7 @@ class RegisterDeviceViewModel @Inject constructor(
                     continueEnabled = true,
                     flowState = RegisterDeviceFlowState.Default
                 )
-                if (userEntered2FA) {
+                if (empty2FACodeInput) {
                     // code not yet entered so invalid code was the one reused from last login so just request a new one
                     request2FACode()
                 } else {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
@@ -19,6 +19,7 @@
 package com.wire.android.ui.authentication.devices.register
 
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -26,10 +27,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.BuildConfig
 import com.wire.android.datastore.UserDataStore
+import com.wire.android.ui.authentication.verificationcode.VerificationCodeState
 import com.wire.android.ui.common.textfield.textAsFlow
+import com.wire.kalium.logic.data.auth.verification.VerifiableAction
+import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerificationCodeUseCase
 import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.client.RegisterClientUseCase
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
@@ -44,10 +49,16 @@ class RegisterDeviceViewModel @Inject constructor(
     private val registerClientUseCase: GetOrRegisterClientUseCase,
     private val isPasswordRequired: IsPasswordRequiredUseCase,
     private val userDataStore: UserDataStore,
+    private val getSelfUser: GetSelfUserUseCase,
+    private val requestSecondFactorVerificationCodeUseCase: RequestSecondFactorVerificationCodeUseCase,
 ) : ViewModel() {
 
     val passwordTextState: TextFieldState = TextFieldState()
     var state: RegisterDeviceState by mutableStateOf(RegisterDeviceState())
+        private set
+
+    val secondFactorVerificationCodeTextState: TextFieldState = TextFieldState()
+    var secondFactorVerificationCodeState: VerificationCodeState by mutableStateOf(VerificationCodeState())
         private set
 
     init {
@@ -71,21 +82,31 @@ class RegisterDeviceViewModel @Inject constructor(
                 state = state.copy(flowState = RegisterDeviceFlowState.Default, continueEnabled = it.isNotEmpty())
             }
         }
+        viewModelScope.launch {
+            secondFactorVerificationCodeTextState.textAsFlow().collectLatest {
+                secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(isCurrentCodeInvalid = false)
+                if (it.length == VerificationCodeState.DEFAULT_VERIFICATION_CODE_LENGTH) {
+                    registerClient(passwordTextState.text.toString(), it.toString())
+                }
+            }
+        }
     }
 
     fun onErrorDismiss() {
         updateFlowState(RegisterDeviceFlowState.Default)
     }
 
-    private suspend fun registerClient(password: String?) {
+    private suspend fun registerClient(password: String?, secondFactorVerificationCode: String? = null) {
         state = state.copy(flowState = RegisterDeviceFlowState.Loading, continueEnabled = false)
-        when (val registerDeviceResult = registerClientUseCase(
+        val registerDeviceResult = registerClientUseCase(
             RegisterClientUseCase.RegisterClientParam(
                 password = password,
+                secondFactorVerificationCode = secondFactorVerificationCode,
                 capabilities = null,
                 modelPostfix = if (BuildConfig.PRIVATE_BUILD) " [${BuildConfig.FLAVOR}_${BuildConfig.BUILD_TYPE}]" else null
             )
-        )) {
+        )
+        when (registerDeviceResult) {
             is RegisterClientResult.Failure.TooManyClients ->
                 updateFlowState(RegisterDeviceFlowState.TooManyDevices)
 
@@ -108,6 +129,26 @@ class RegisterDeviceViewModel @Inject constructor(
                     )
                 )
 
+            is RegisterClientResult.Failure.InvalidCredentials.Missing2FA -> request2FACode()
+
+            is RegisterClientResult.Failure.InvalidCredentials.Invalid2FA -> {
+                state = state.copy(
+                    continueEnabled = true,
+                    flowState = RegisterDeviceFlowState.Default
+                )
+                when (secondFactorVerificationCode.isNullOrEmpty()) {
+                     true -> { // code not yet entered so invalid code was the one reused from last login so just request a new one
+                        request2FACode()
+                    }
+                    false -> { // invalid code was the one already entered so show invalid code error
+                        secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(
+                            isCodeInputNecessary = true,
+                            isCurrentCodeInvalid = true,
+                        )
+                    }
+                }
+            }
+
             is RegisterClientResult.Failure.Generic -> state = state.copy(
                 continueEnabled = true,
                 flowState = RegisterDeviceFlowState.Error.GenericError(registerDeviceResult.genericFailure)
@@ -126,6 +167,44 @@ class RegisterDeviceViewModel @Inject constructor(
     fun onContinue() {
         viewModelScope.launch {
             registerClient(passwordTextState.text.toString())
+        }
+    }
+
+    fun onCodeResend() {
+        viewModelScope.launch {
+            request2FACode()
+        }
+    }
+
+    fun onCodeVerificationBackPress() {
+        secondFactorVerificationCodeTextState.clearText()
+        secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(
+            isCodeInputNecessary = false,
+            emailUsed = "",
+        )
+    }
+
+    private suspend fun request2FACode() {
+        getSelfUser()?.email?.let { email ->
+            requestSecondFactorVerificationCodeUseCase(
+                email = email,
+                verifiableAction = VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION
+            ).let { result ->
+                when (result) {
+                    is RequestSecondFactorVerificationCodeUseCase.Result.Success,
+                    is RequestSecondFactorVerificationCodeUseCase.Result.Failure.TooManyRequests -> {
+                        secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(
+                            isCodeInputNecessary = true,
+                            emailUsed = email,
+                        )
+                        updateFlowState(RegisterDeviceFlowState.Default)
+                    }
+
+                    is RequestSecondFactorVerificationCodeUseCase.Result.Failure.Generic -> {
+                        updateFlowState(RegisterDeviceFlowState.Error.GenericError(result.cause))
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeScreenContent.kt
@@ -41,7 +41,6 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 
-
 @Composable
 fun VerificationCodeScreenContent(
     verificationCodeTextState: TextFieldState,
@@ -94,9 +93,11 @@ private fun MainContent(
         style = typography().body01,
         textAlign = TextAlign.Start
     )
-    Spacer(modifier = Modifier
+    Spacer(
+        modifier = Modifier
         .height(dimensions().spacing8x)
-        .weight(1f))
+        .weight(1f)
+    )
     VerificationCode(
         codeLength = codeState.codeLength,
         codeState = codeTextState,
@@ -104,9 +105,11 @@ private fun MainContent(
         isCurrentCodeInvalid = codeState.isCurrentCodeInvalid,
         onResendCode = onResendCode,
     )
-    Spacer(modifier = Modifier
+    Spacer(
+        modifier = Modifier
         .height(dimensions().spacing8x)
-        .weight(1f))
+        .weight(1f)
+    )
 }
 
 @PreviewMultipleThemes

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeScreenContent.kt
@@ -1,0 +1,126 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.authentication.verificationcode
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import com.wire.android.R
+import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.scaffold.WireScaffold
+import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.common.typography
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.ui.PreviewMultipleThemes
+import com.wire.android.util.ui.UIText
+
+
+@Composable
+fun VerificationCodeScreenContent(
+    verificationCodeTextState: TextFieldState,
+    verificationCodeState: VerificationCodeState,
+    isLoading: Boolean,
+    onCodeResend: () -> Unit,
+    onBackPressed: () -> Unit,
+) {
+    BackHandler { onBackPressed() }
+    WireScaffold(
+        topBar = {
+            WireCenterAlignedTopAppBar(
+                elevation = dimensions().spacing0x,
+                title = stringResource(id = R.string.second_factor_authentication_title),
+                navigationIconType = null,
+            )
+        }
+    ) { internalPadding ->
+        MainContent(
+            codeTextState = verificationCodeTextState,
+            codeState = verificationCodeState,
+            isLoading = isLoading,
+            onResendCode = onCodeResend,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(internalPadding)
+                .padding(dimensions().spacing16x)
+        )
+    }
+}
+
+@Composable
+private fun MainContent(
+    codeTextState: TextFieldState,
+    codeState: VerificationCodeState,
+    isLoading: Boolean,
+    onResendCode: () -> Unit,
+    modifier: Modifier = Modifier
+) = Column(
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.Center,
+    modifier = modifier
+) {
+    Text(
+        text = UIText.StringResource(
+            R.string.second_factor_authentication_instructions_label,
+            codeState.emailUsed
+        ).asString(),
+        color = colorsScheme().onBackground,
+        style = typography().body01,
+        textAlign = TextAlign.Start
+    )
+    Spacer(modifier = Modifier
+        .height(dimensions().spacing8x)
+        .weight(1f))
+    VerificationCode(
+        codeLength = codeState.codeLength,
+        codeState = codeTextState,
+        isLoading = isLoading,
+        isCurrentCodeInvalid = codeState.isCurrentCodeInvalid,
+        onResendCode = onResendCode,
+    )
+    Spacer(modifier = Modifier
+        .height(dimensions().spacing8x)
+        .weight(1f))
+}
+
+@PreviewMultipleThemes
+@Composable
+internal fun VerificationCodeScreenPreview() = WireTheme {
+    VerificationCodeScreenContent(
+        verificationCodeTextState = TextFieldState(),
+        verificationCodeState = VerificationCodeState(
+            codeLength = 6,
+            isCurrentCodeInvalid = false,
+            emailUsed = ""
+        ),
+        isLoading = false,
+        onCodeResend = {},
+        onBackPressed = {},
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeState.kt
@@ -38,7 +38,7 @@ sealed class HomeRequirement {
     data class Migration(val userId: UserId) : HomeRequirement()
     data object RegisterDevice : HomeRequirement()
     data object CreateAccountUsername : HomeRequirement()
-    data object InitialSync: HomeRequirement()
+    data object InitialSync : HomeRequirement()
 
     fun navigate(navigate: (NavigationCommand) -> Unit) = when (this) {
         is Migration -> navigate(NavigationCommand(MigrationScreenDestination(this.userId), BackStackMode.CLEAR_WHOLE))

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeState.kt
@@ -22,6 +22,7 @@ import com.wire.android.model.UserAvatarData
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.ui.destinations.CreateAccountUsernameScreenDestination
+import com.wire.android.ui.destinations.InitialSyncScreenDestination
 import com.wire.android.ui.destinations.MigrationScreenDestination
 import com.wire.android.ui.destinations.RegisterDeviceScreenDestination
 import com.wire.kalium.logic.data.user.UserId
@@ -37,12 +38,12 @@ sealed class HomeRequirement {
     data class Migration(val userId: UserId) : HomeRequirement()
     data object RegisterDevice : HomeRequirement()
     data object CreateAccountUsername : HomeRequirement()
-    data object None : HomeRequirement()
+    data object InitialSync: HomeRequirement()
 
     fun navigate(navigate: (NavigationCommand) -> Unit) = when (this) {
         is Migration -> navigate(NavigationCommand(MigrationScreenDestination(this.userId), BackStackMode.CLEAR_WHOLE))
         is RegisterDevice -> navigate(NavigationCommand(RegisterDeviceScreenDestination, BackStackMode.CLEAR_WHOLE))
         is CreateAccountUsername -> navigate(NavigationCommand(CreateAccountUsernameScreenDestination, BackStackMode.CLEAR_WHOLE))
-        is None -> null
+        is InitialSync -> navigate(NavigationCommand(InitialSyncScreenDestination, BackStackMode.CLEAR_WHOLE))
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -31,6 +31,7 @@ import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
 import com.wire.android.navigation.SavedStateViewModel
+import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.feature.client.NeedsToRegisterClientUseCase
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
@@ -38,8 +39,11 @@ import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersona
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -49,7 +53,6 @@ class HomeViewModel @Inject constructor(
     override val savedStateHandle: SavedStateHandle,
     private val globalDataStore: GlobalDataStore,
     private val dataStore: UserDataStore,
-    private val getSelfUser: GetSelfUserUseCase,
     private val observeSelf: ObserveSelfUserUseCase,
     private val needsToRegisterClient: NeedsToRegisterClientUseCase,
     private val canMigrateFromPersonalToTeam: CanMigrateFromPersonalToTeamUseCase,
@@ -61,10 +64,29 @@ class HomeViewModel @Inject constructor(
     var homeState by mutableStateOf(HomeState())
         private set
 
+    private val selfUserFlow = MutableSharedFlow<SelfUser?>(replay = 1)
+
     init {
-        loadUserAvatar()
+        observeSelfUser()
         observeLegalHoldStatus()
         observeCreateTeamIndicator()
+    }
+
+    private fun observeSelfUser() {
+        viewModelScope.launch {
+            observeSelf().collectLatest { selfUser ->
+                selfUserFlow.emit(selfUser)
+                homeState = homeState.copy(
+                    userAvatarData = UserAvatarData(
+                        asset = selfUser.previewPicture?.let {
+                            UserAvatarAsset(it)
+                        },
+                        availabilityStatus = selfUser.availabilityStatus,
+                        nameBasedAvatar = NameBasedAvatar(selfUser.name, selfUser.accentId)
+                    )
+                )
+            }
+        }
     }
 
     private fun observeLegalHoldStatus() {
@@ -96,7 +118,7 @@ class HomeViewModel @Inject constructor(
 
     fun checkRequirements(onRequirement: (HomeRequirement) -> Unit) {
         viewModelScope.launch {
-            val selfUser = getSelfUser() ?: return@launch
+            val selfUser = selfUserFlow.firstOrNull() ?: return@launch
             when {
                 shouldTriggerMigrationForUser(selfUser.id) -> // check if the user needs to be migrated from scala app
                     onRequirement(HomeRequirement.Migration(selfUser.id))
@@ -119,22 +141,6 @@ class HomeViewModel @Inject constructor(
 
     private suspend fun shouldDisplayWelcomeToARScreen() =
         globalDataStore.isMigrationCompleted() && !globalDataStore.isWelcomeScreenPresented()
-
-    private fun loadUserAvatar() {
-        viewModelScope.launch {
-            observeSelf().collect { selfUser ->
-                homeState = homeState.copy(
-                    userAvatarData = UserAvatarData(
-                        asset = selfUser.previewPicture?.let {
-                            UserAvatarAsset(it)
-                        },
-                        availabilityStatus = selfUser.availabilityStatus,
-                        nameBasedAvatar = NameBasedAvatar(selfUser.name, selfUser.accentId)
-                    )
-                )
-            }
-        }
-    }
 
     fun dismissWelcomeMessage() {
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -36,11 +36,9 @@ import com.wire.kalium.logic.feature.client.NeedsToRegisterClientUseCase
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
@@ -20,7 +20,6 @@ package com.wire.android.ui.authentication.devices.register
 
 import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
-import com.wire.android.assertIs
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.SnapshotExtension
 import com.wire.android.config.mockUri
@@ -31,7 +30,6 @@ import com.wire.android.util.EMPTY
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.data.auth.verification.VerifiableAction
 import com.wire.kalium.logic.data.user.SelfUser
-import com.wire.kalium.logic.feature.auth.AuthenticationResult
 import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerificationCodeUseCase
 import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
@@ -50,7 +48,6 @@ import org.amshove.kluent.internal.assertEquals
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.extension.ExtendWith

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
@@ -18,16 +18,24 @@
 
 package com.wire.android.ui.authentication.devices.register
 
+import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.wire.android.assertIs
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.SnapshotExtension
 import com.wire.android.config.mockUri
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.framework.TestClient
+import com.wire.android.framework.TestUser
 import com.wire.android.util.EMPTY
 import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.logic.data.auth.verification.VerifiableAction
+import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.feature.auth.AuthenticationResult
+import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerificationCodeUseCase
 import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -38,50 +46,30 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.extension.ExtendWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class)
 class RegisterDeviceViewModelTest {
 
-    @MockK
-    private lateinit var registerClientUseCase: GetOrRegisterClientUseCase
-
-    @MockK
-    private lateinit var isPasswordRequiredUseCase: IsPasswordRequiredUseCase
-
-    @MockK
-    lateinit var userDataStore: UserDataStore
-
-    private lateinit var registerDeviceViewModel: RegisterDeviceViewModel
-
-    @BeforeEach
-    fun setup() {
-        MockKAnnotations.init(this)
-        mockUri()
-        coEvery { isPasswordRequiredUseCase() } returns IsPasswordRequiredUseCase.Result.Success(true)
-        every { userDataStore.initialSyncCompleted } returns flowOf(true)
-        registerDeviceViewModel = RegisterDeviceViewModel(
-            registerClientUseCase,
-            isPasswordRequiredUseCase,
-            userDataStore
-        )
-    }
-
     @Test
     fun `given empty string, when entering the password to register, then button is disabled`() = runTest {
+        val (arrangement, registerDeviceViewModel) = Arrangement().arrange()
         registerDeviceViewModel.passwordTextState.setTextAndPlaceCursorAtEnd(String.EMPTY)
         registerDeviceViewModel.state.continueEnabled shouldBeEqualTo false
         registerDeviceViewModel.state.flowState shouldBeInstanceOf RegisterDeviceFlowState.Default::class
     }
 
     @Test
-    fun `given non-empty string, when entering the password to register, then button is disabled`() {
+    fun `given non-empty string, when entering the password to register, then button is disabled`() = runTest {
+        val (arrangement, registerDeviceViewModel) = Arrangement().arrange()
         registerDeviceViewModel.passwordTextState.setTextAndPlaceCursorAtEnd("abc")
         registerDeviceViewModel.state.continueEnabled shouldBeEqualTo true
         registerDeviceViewModel.state.flowState shouldBeInstanceOf RegisterDeviceFlowState.Default::class
@@ -90,18 +78,16 @@ class RegisterDeviceViewModelTest {
     @Test
     fun `given button is clicked, when request returns Success, then navigateToHomeScreen is called`() = runTest {
         val password = "abc"
-        coEvery {
-            registerClientUseCase(
-                any()
-            )
-        } returns RegisterClientResult.Success(CLIENT)
-
+        val (arrangement, registerDeviceViewModel) = Arrangement()
+            .withRegisterClientReturning(RegisterClientResult.Success(CLIENT))
+            .arrange()
         registerDeviceViewModel.passwordTextState.setTextAndPlaceCursorAtEnd(password)
 
         registerDeviceViewModel.onContinue()
         advanceUntilIdle()
+
         coVerify(exactly = 1) {
-            registerClientUseCase(any())
+            arrangement.registerClientUseCase(any())
         }
         registerDeviceViewModel.state.flowState shouldBeInstanceOf RegisterDeviceFlowState.Success::class
     }
@@ -109,36 +95,38 @@ class RegisterDeviceViewModelTest {
     @Test
     fun `given button is clicked, when request returns TooManyClients Error, then navigateToRemoveDevicesScreen is called`() = runTest {
         val password = "abc"
-        coEvery {
-            registerClientUseCase(any())
-        } returns RegisterClientResult.Failure.TooManyClients
+        val (arrangement, registerDeviceViewModel) = Arrangement()
+            .withRegisterClientReturning(RegisterClientResult.Failure.TooManyClients)
+            .arrange()
         registerDeviceViewModel.passwordTextState.setTextAndPlaceCursorAtEnd(password)
 
         registerDeviceViewModel.onContinue()
         advanceUntilIdle()
+
         coVerify(exactly = 1) {
-            registerClientUseCase(any())
+            arrangement.registerClientUseCase(any())
         }
         registerDeviceViewModel.state.flowState shouldBeInstanceOf RegisterDeviceFlowState.TooManyDevices::class
     }
 
     @Test
     fun `given button is clicked, when password is invalid, then UsernameInvalidError is passed`() = runTest {
-        coEvery {
-            registerClientUseCase(any())
-        } returns RegisterClientResult.Failure.InvalidCredentials.InvalidPassword
+        val (arrangement, registerDeviceViewModel) = Arrangement()
+            .withRegisterClientReturning(RegisterClientResult.Failure.InvalidCredentials.InvalidPassword)
+            .arrange()
 
         registerDeviceViewModel.onContinue()
         advanceUntilIdle()
-        registerDeviceViewModel.state.flowState shouldBeInstanceOf RegisterDeviceFlowState.Error::class
+
         registerDeviceViewModel.state.flowState shouldBeInstanceOf RegisterDeviceFlowState.Error::class
     }
 
     @Test
     fun `given button is clicked, when request returns Generic error, then GenericError is passed`() = runTest {
         val networkFailure = NetworkFailure.NoNetworkConnection(null)
-        coEvery { registerClientUseCase(any()) } returns
-                RegisterClientResult.Failure.Generic(networkFailure)
+        val (arrangement, registerDeviceViewModel) = Arrangement()
+            .withRegisterClientReturning(RegisterClientResult.Failure.Generic(networkFailure))
+            .arrange()
 
         registerDeviceViewModel.onContinue()
         advanceUntilIdle()
@@ -151,17 +139,199 @@ class RegisterDeviceViewModelTest {
     @Test
     fun `given dialog is dismissed, when state error is DialogError, then hide error`() = runTest {
         val networkFailure = NetworkFailure.NoNetworkConnection(null)
-        coEvery { registerClientUseCase(any()) } returns
-                RegisterClientResult.Failure.Generic(networkFailure)
+        val (arrangement, registerDeviceViewModel) = Arrangement()
+            .withRegisterClientReturning(RegisterClientResult.Failure.Generic(networkFailure))
+            .arrange()
 
         registerDeviceViewModel.onContinue()
         advanceUntilIdle()
+
         registerDeviceViewModel.state.flowState shouldBeInstanceOf RegisterDeviceFlowState.Error.GenericError::class
         registerDeviceViewModel.onErrorDismiss()
         registerDeviceViewModel.state.flowState shouldBe RegisterDeviceFlowState.Default
     }
 
+    @Test
+    fun `given missing 2fa, when registering, then request 2fa code`() = runTest {
+        val email = "user@email.com"
+        val (arrangement, registerDeviceViewModel) = Arrangement()
+            .withRegisterClientReturning(RegisterClientResult.Failure.InvalidCredentials.Missing2FA)
+            .withGetSelfReturning(SELF_USER.copy(email = email))
+            .withRequestSecondFactorVerificationCodeReturning(RequestSecondFactorVerificationCodeUseCase.Result.Success)
+            .arrange()
+
+        registerDeviceViewModel.onContinue()
+        advanceUntilIdle()
+
+        assertEquals(true, registerDeviceViewModel.secondFactorVerificationCodeState.isCodeInputNecessary)
+        coVerify(exactly = 1) {
+            arrangement.requestSecondFactorVerificationCodeUseCase(email, VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION)
+        }
+    }
+
+    @Test
+    fun `given invalid 2fa, when registering with reused code, then request 2fa code and do not show invalid code`() = runTest {
+        val email = "user@email.com"
+        val (arrangement, registerDeviceViewModel) = Arrangement()
+            .withRegisterClientReturning(RegisterClientResult.Failure.InvalidCredentials.Invalid2FA)
+            .withGetSelfReturning(SELF_USER.copy(email = email))
+            .withRequestSecondFactorVerificationCodeReturning(RequestSecondFactorVerificationCodeUseCase.Result.Success)
+            .arrange()
+        registerDeviceViewModel.secondFactorVerificationCodeTextState.clearText() // no code yet entered
+
+        registerDeviceViewModel.onContinue()
+        advanceUntilIdle()
+
+        assertEquals(true, registerDeviceViewModel.secondFactorVerificationCodeState.isCodeInputNecessary)
+        assertEquals(false, registerDeviceViewModel.secondFactorVerificationCodeState.isCurrentCodeInvalid)
+        coVerify(exactly = 1) {
+            arrangement.requestSecondFactorVerificationCodeUseCase(email, VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION)
+        }
+    }
+
+    @Test
+    fun `given invalid 2fa, when registering with entered code by user, then request 2fa code and show invalid code`() = runTest {
+        val email = "user@email.com"
+        val (arrangement, registerDeviceViewModel) = Arrangement()
+            .withRegisterClientReturning(RegisterClientResult.Failure.InvalidCredentials.Invalid2FA)
+            .withGetSelfReturning(SELF_USER.copy(email = email))
+            .withRequestSecondFactorVerificationCodeReturning(RequestSecondFactorVerificationCodeUseCase.Result.Success)
+            .arrange()
+        registerDeviceViewModel.secondFactorVerificationCodeTextState.setTextAndPlaceCursorAtEnd("123456") // code entered by user
+
+        registerDeviceViewModel.onContinue()
+        advanceUntilIdle()
+
+        assertEquals(true, registerDeviceViewModel.secondFactorVerificationCodeState.isCodeInputNecessary)
+        assertEquals(true, registerDeviceViewModel.secondFactorVerificationCodeState.isCurrentCodeInvalid)
+        coVerify(exactly = 1) {
+            arrangement.requestSecondFactorVerificationCodeUseCase(email, VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION)
+        }
+    }
+
+    @Test
+    fun `given success, when requesting 2fa code, then require code input`() = runTest {
+        val email = "user@email.com"
+        val (arrangement, registerDeviceViewModel) = Arrangement()
+            .withRegisterClientReturning(RegisterClientResult.Failure.InvalidCredentials.Invalid2FA)
+            .withGetSelfReturning(SELF_USER.copy(email = email))
+            .withRequestSecondFactorVerificationCodeReturning(RequestSecondFactorVerificationCodeUseCase.Result.Success)
+            .arrange()
+
+        registerDeviceViewModel.onContinue()
+        advanceUntilIdle()
+
+        assertEquals(true, registerDeviceViewModel.secondFactorVerificationCodeState.isCodeInputNecessary)
+    }
+
+    @Test
+    fun `given too many requests failure, when requesting 2fa code, then require code input`() = runTest {
+        val email = "user@email.com"
+        val (arrangement, registerDeviceViewModel) = Arrangement()
+            .withRegisterClientReturning(RegisterClientResult.Failure.InvalidCredentials.Invalid2FA)
+            .withGetSelfReturning(SELF_USER.copy(email = email))
+            .withRequestSecondFactorVerificationCodeReturning(RequestSecondFactorVerificationCodeUseCase.Result.Failure.TooManyRequests)
+            .arrange()
+
+        registerDeviceViewModel.onContinue()
+        advanceUntilIdle()
+
+        assertEquals(true, registerDeviceViewModel.secondFactorVerificationCodeState.isCodeInputNecessary)
+    }
+
+    @Test
+    fun `given other failure, when requesting 2fa code, then show error and do not require code input`() = runTest {
+        val email = "user@email.com"
+        val failure = NetworkFailure.NoNetworkConnection(null)
+        val (arrangement, registerDeviceViewModel) = Arrangement()
+            .withRegisterClientReturning(RegisterClientResult.Failure.InvalidCredentials.Invalid2FA)
+            .withGetSelfReturning(SELF_USER.copy(email = email))
+            .withRequestSecondFactorVerificationCodeReturning(RequestSecondFactorVerificationCodeUseCase.Result.Failure.Generic(failure))
+            .arrange()
+
+        registerDeviceViewModel.onContinue()
+        advanceUntilIdle()
+
+        assertEquals(false, registerDeviceViewModel.secondFactorVerificationCodeState.isCodeInputNecessary)
+        assertInstanceOf<RegisterDeviceFlowState.Error.GenericError>(registerDeviceViewModel.state.flowState).let {
+            assertEquals(failure, it.coreFailure)
+        }
+    }
+
+    @Test
+    fun `given 2fa code fully entered, when requesting 2fa code, then execute registration with given code`() = runTest {
+        val email = "user@email.com"
+        val (arrangement, registerDeviceViewModel) = Arrangement()
+            .withRegisterClientReturning(RegisterClientResult.Failure.InvalidCredentials.Missing2FA)
+            .withGetSelfReturning(SELF_USER.copy(email = email))
+            .withRequestSecondFactorVerificationCodeReturning(RequestSecondFactorVerificationCodeUseCase.Result.Success)
+            .arrange()
+        registerDeviceViewModel.onContinue()
+        advanceUntilIdle()
+
+        registerDeviceViewModel.secondFactorVerificationCodeTextState.setTextAndPlaceCursorAtEnd("12345") // not fully entered
+        advanceUntilIdle()
+        coVerify(exactly = 0) {
+            arrangement.registerClientUseCase(match { it.secondFactorVerificationCode == "12345" })
+        }
+
+        registerDeviceViewModel.secondFactorVerificationCodeTextState.setTextAndPlaceCursorAtEnd("123456") // fully entered
+        advanceUntilIdle()
+        coVerify(exactly = 1) {
+            arrangement.registerClientUseCase(match { it.secondFactorVerificationCode == "123456" })
+        }
+    }
+
+    inner class Arrangement {
+
+        @MockK
+        internal lateinit var registerClientUseCase: GetOrRegisterClientUseCase
+
+        @MockK
+        internal lateinit var isPasswordRequiredUseCase: IsPasswordRequiredUseCase
+
+        @MockK
+        internal lateinit var getSelfUserUseCase: GetSelfUserUseCase
+
+        @MockK
+        internal lateinit var requestSecondFactorVerificationCodeUseCase: RequestSecondFactorVerificationCodeUseCase
+
+        @MockK
+        internal lateinit var userDataStore: UserDataStore
+
+        init {
+            MockKAnnotations.init(this)
+            mockUri()
+            coEvery { isPasswordRequiredUseCase() } returns IsPasswordRequiredUseCase.Result.Success(true)
+            every { userDataStore.initialSyncCompleted } returns flowOf(true)
+            coEvery { getSelfUserUseCase() } returns SELF_USER
+        }
+
+        fun arrange() = this to RegisterDeviceViewModel(
+            registerClientUseCase,
+            isPasswordRequiredUseCase,
+            userDataStore,
+            getSelfUserUseCase,
+            requestSecondFactorVerificationCodeUseCase,
+        )
+
+        fun withRegisterClientReturning(result: RegisterClientResult) = apply {
+            coEvery { registerClientUseCase(any()) } returns result
+        }
+
+        fun withGetSelfReturning(result: SelfUser) = apply {
+            coEvery { getSelfUserUseCase() } returns result
+        }
+
+        fun withRequestSecondFactorVerificationCodeReturning(result: RequestSecondFactorVerificationCodeUseCase.Result) = apply {
+            coEvery {
+                requestSecondFactorVerificationCodeUseCase(any(), any())
+            } returns result
+        }
+    }
+
     companion object {
         val CLIENT = TestClient.CLIENT
+        val SELF_USER = TestUser.SELF_USER
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/HomeViewModelTest.kt
@@ -201,6 +201,9 @@ class HomeViewModelTest {
         lateinit var observeSelfUser: ObserveSelfUserUseCase
 
         @MockK
+        lateinit var getSelf: GetSelfUserUseCase
+
+        @MockK
         lateinit var needsToRegisterClient: NeedsToRegisterClientUseCase
 
         @MockK

--- a/app/src/test/kotlin/com/wire/android/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/HomeViewModelTest.kt
@@ -29,7 +29,6 @@ import com.wire.kalium.logic.feature.client.NeedsToRegisterClientUseCase
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -199,9 +198,6 @@ class HomeViewModelTest {
 
         @MockK
         lateinit var observeSelfUser: ObserveSelfUserUseCase
-
-        @MockK
-        lateinit var getSelf: GetSelfUserUseCase
 
         @MockK
         lateinit var needsToRegisterClient: NeedsToRegisterClientUseCase


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16573" title="WPB-16573" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16573</a>  [Android] Invalid information alert received although login is valid
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`RegisterDeviceScreen`, which is kind of a fallback flow when the device hasn't been registered successfully during account creation or login, has been missing a logic of handling 2FA codes when registering a client so in that case user hasn't been able to register device properly resulting in not being able to use the app properly.

### Solutions

Implemented handling 2FA code also on that screen, similarly to the way it's handled during the login - first the code that is persisted from the last login is used and if that returns `Invalid2FA` then new code is requested and the user needs to enter it to complete the registration flow.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

It's hard to reproduce manually as it can happen for instance when login is completed but device registration request that's executed right after it fails because of a crash for instance.

### Attachments (Optional)

https://github.com/user-attachments/assets/824eed0a-d975-4a7e-8597-d0647e9ebddc

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
