### PR TITLE
fix: new login path 4 - invalid sso code [WPB-16673] [WPB-16674]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtension.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtension.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.feature.auth.sso.FetchSSOSettingsUseCase
 import com.wire.kalium.logic.feature.auth.sso.SSOInitiateLoginResult
 import com.wire.kalium.logic.feature.auth.sso.SSOInitiateLoginUseCase
 import com.wire.kalium.logic.feature.auth.sso.SSOLoginSessionResult
+import com.wire.kalium.logic.feature.auth.sso.ValidateSSOCodeUseCase.Companion.SSO_CODE_WIRE_PREFIX
 
 class LoginSSOViewModelExtension(
     private val addAuthenticatedUser: AddAuthenticatedUserUseCase,
@@ -72,12 +73,7 @@ class LoginSSOViewModelExtension(
             authScope.ssoLoginScope.fetchSSOSettings().also {
                 when (it) {
                     is FetchSSOSettingsUseCase.Result.Failure -> onFetchSSOSettingsFailure(it)
-                    is FetchSSOSettingsUseCase.Result.Success -> {
-                        val ssoCodeWithPrefix = it.defaultSSOCode?.let { ssoCode ->
-                            if (ssoCode.startsWith("wire-")) ssoCode else "wire-$ssoCode"
-                        }
-                        onSuccess(ssoCodeWithPrefix)
-                    }
+                    is FetchSSOSettingsUseCase.Result.Success -> onSuccess(it.defaultSSOCode?.ssoCodeWithPrefix())
                 }
             }
         }
@@ -116,3 +112,6 @@ class LoginSSOViewModelExtension(
         }
     }
 }
+
+fun String.ssoCodeWithPrefix() = if (this.startsWith(SSO_CODE_WIRE_PREFIX)) this else "$SSO_CODE_WIRE_PREFIX$this"
+

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtension.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtension.kt
@@ -114,4 +114,3 @@ class LoginSSOViewModelExtension(
 }
 
 fun String.ssoCodeWithPrefix() = if (this.startsWith(SSO_CODE_WIRE_PREFIX)) this else "$SSO_CODE_WIRE_PREFIX$this"
-

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -39,6 +39,7 @@ import com.wire.android.ui.authentication.login.PreFilledUserIdentifierType
 import com.wire.android.ui.authentication.login.email.LoginEmailViewModel.Companion.USER_IDENTIFIER_SAVED_STATE_KEY
 import com.wire.android.ui.authentication.login.sso.LoginSSOViewModelExtension
 import com.wire.android.ui.authentication.login.sso.SSOUrlConfig
+import com.wire.android.ui.authentication.login.sso.ssoCodeWithPrefix
 import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.ui.navArgs
 import com.wire.android.util.EMPTY
@@ -168,7 +169,7 @@ class NewLoginViewModel(
                     is EnterpriseLoginResult.Success -> {
                         when (val loginRedirectPath = loginFlowResult.loginRedirectPath) {
                             is LoginRedirectPath.SSO -> {
-                                initiateSSO(serverConfig, loginRedirectPath.ssoCode, action)
+                                initiateSSO(serverConfig, loginRedirectPath.ssoCode.ssoCodeWithPrefix(), action)
                             }
 
                             is LoginRedirectPath.CustomBackend -> withContext(dispatchers.main()) {

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScop
 import com.wire.kalium.logic.feature.auth.sso.FetchSSOSettingsUseCase
 import com.wire.kalium.logic.feature.auth.sso.SSOInitiateLoginResult
 import com.wire.kalium.logic.feature.auth.sso.SSOLoginSessionResult
+import com.wire.kalium.logic.feature.auth.sso.ValidateSSOCodeUseCase.Companion.SSO_CODE_WIRE_PREFIX
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -110,7 +111,7 @@ class NewLoginViewModelTest {
     @Test
     fun `given success, when initiating SSO, then call SSO action with url`() = runTest(dispatchers.main()) {
         val redirectUrl = "https://redirect.url"
-        val config = SSOUrlConfig(newServerConfig(1).links, "sso-code")
+        val config = SSOUrlConfig(newServerConfig(1).links, SSO_CODE_WITH_PREFIX)
         val (arrangement, sut) = Arrangement()
             .withEmailOrSSOCodeValidatorReturning(ValidateEmailOrSSOCodeUseCase.Result.ValidSSOCode)
             .withInitiateSSOSuccess(redirectUrl, config.serverConfig)
@@ -132,7 +133,7 @@ class NewLoginViewModelTest {
             .withInitiateSSOFailure(SSOInitiateLoginResult.Failure.InvalidCode)
             .arrange()
 
-        sut.initiateSSO(serverConfig, "sso-code", arrangement.action)
+        sut.initiateSSO(serverConfig, SSO_CODE_WITH_PREFIX, arrangement.action)
         advanceUntilIdle()
 
         verify(exactly = 0) {
@@ -149,7 +150,7 @@ class NewLoginViewModelTest {
             .withInitiateSSOAuthScopeFailure(AutoVersionAuthScopeUseCase.Result.Failure.UnknownServerVersion)
             .arrange()
 
-        sut.initiateSSO(serverConfig, "sso-code", arrangement.action)
+        sut.initiateSSO(serverConfig, SSO_CODE_WITH_PREFIX, arrangement.action)
         advanceUntilIdle()
 
         verify(exactly = 0) {
@@ -161,7 +162,7 @@ class NewLoginViewModelTest {
     @Test
     fun `given default SSO code, when confirming custom config dialog, then initiate SSO with that code`() = runTest(dispatchers.main()) {
         val serverConfig = newServerConfig(1).links
-        val ssoCode = "sso-code"
+        val ssoCode = SSO_CODE_WITH_PREFIX
         val (arrangement, sut) = Arrangement()
             .withFetchDefaultSSOCodeSuccess(ssoCode)
             .arrange()
@@ -235,7 +236,7 @@ class NewLoginViewModelTest {
     @Test
     fun `given SSO session established, when handling SSO result, then register client`() = runTest(dispatchers.main()) {
         val ssoDeepLinkResult = DeepLinkResult.SSOLogin.Success("cookie", "server-config-id")
-        val config = SSOUrlConfig(newServerConfig(1).links, "sso-code")
+        val config = SSOUrlConfig(newServerConfig(1).links, SSO_CODE_WITH_PREFIX)
         val userId = UserId("user-id", "domain")
         val (arrangement, sut) = Arrangement()
             .withEstablishSSOSessionSuccess(userId)
@@ -254,7 +255,7 @@ class NewLoginViewModelTest {
     @Test
     fun `given auth scope failure, when handling SSO result, then update error state`() = runTest(dispatchers.main()) {
         val ssoDeepLinkResult = DeepLinkResult.SSOLogin.Success("cookie", "server-config-id")
-        val config = SSOUrlConfig(newServerConfig(1).links, "sso-code")
+        val config = SSOUrlConfig(newServerConfig(1).links, SSO_CODE_WITH_PREFIX)
         val (arrangement, sut) = Arrangement()
             .withEstablishSSOSessionAuthScopeFailure(AutoVersionAuthScopeUseCase.Result.Failure.UnknownServerVersion)
             .arrange()
@@ -271,7 +272,7 @@ class NewLoginViewModelTest {
     @Test
     fun `given SSO login failure, when handling SSO result, then update error state`() = runTest(dispatchers.main()) {
         val ssoDeepLinkResult = DeepLinkResult.SSOLogin.Success("cookie", "server-config-id")
-        val config = SSOUrlConfig(newServerConfig(1).links, "sso-code")
+        val config = SSOUrlConfig(newServerConfig(1).links, SSO_CODE_WITH_PREFIX)
         val (arrangement, sut) = Arrangement()
             .withEstablishSSOSessionLoginFailure(SSOLoginSessionResult.Failure.InvalidCookie)
             .arrange()
@@ -288,7 +289,7 @@ class NewLoginViewModelTest {
     @Test
     fun `given add user failure, when handling SSO result, then update error state`() = runTest(dispatchers.main()) {
         val ssoDeepLinkResult = DeepLinkResult.SSOLogin.Success("cookie", "server-config-id")
-        val config = SSOUrlConfig(newServerConfig(1).links, "sso-code")
+        val config = SSOUrlConfig(newServerConfig(1).links, SSO_CODE_WITH_PREFIX)
         val (arrangement, sut) = Arrangement()
             .withEstablishSSOSessionAddUserFailure(AddAuthenticatedUserUseCase.Result.Failure.UserAlreadyExists)
             .arrange()
@@ -308,7 +309,7 @@ class NewLoginViewModelTest {
         isInitialSyncCompleted: Boolean = true,
     ) = runTest(dispatchers.main()) {
         val ssoDeepLinkResult = DeepLinkResult.SSOLogin.Success("cookie", "server-config-id")
-        val config = SSOUrlConfig(newServerConfig(1).links, "sso-code")
+        val config = SSOUrlConfig(newServerConfig(1).links, SSO_CODE_WITH_PREFIX)
         val userId = UserId("user-id", "domain")
         val (arrangement, sut) = Arrangement()
             .withEstablishSSOSessionSuccess(userId)
@@ -355,7 +356,7 @@ class NewLoginViewModelTest {
     @Test
     fun `given register client other failure, when handling SSO result, then update error state`() = runTest(dispatchers.main()) {
         val ssoDeepLinkResult = DeepLinkResult.SSOLogin.Success("cookie", "server-config-id")
-        val config = SSOUrlConfig(newServerConfig(1).links, "sso-code")
+        val config = SSOUrlConfig(newServerConfig(1).links, SSO_CODE_WITH_PREFIX)
         val failure = CoreFailure.Unknown(RuntimeException("Error!"))
         val (arrangement, sut) = Arrangement()
             .withEstablishSSOSessionSuccess(UserId("user-id", "domain"))
@@ -392,7 +393,7 @@ class NewLoginViewModelTest {
 
     @Test
     fun `given custom config passed, when handling SSO result, then use custom config`() =
-        testCustomConfigWhenHandlingSSOResult(SSOUrlConfig(newServerConfig(2).links, "sso-code"))
+        testCustomConfigWhenHandlingSSOResult(SSOUrlConfig(newServerConfig(2).links, SSO_CODE_WITH_PREFIX))
 
     @Test
     fun `given no custom config passed, when handling SSO result, then use default config`() =
@@ -401,7 +402,7 @@ class NewLoginViewModelTest {
     @Test
     fun `given SSO result failure, when handling SSO result, then update error state`() = runTest(dispatchers.main()) {
         val ssoDeepLinkResult = DeepLinkResult.SSOLogin.Failure(SSOFailureCodes.NotFound)
-        val config = SSOUrlConfig(newServerConfig(2).links, "sso-code")
+        val config = SSOUrlConfig(newServerConfig(2).links, SSO_CODE_WITH_PREFIX)
         val failure = CoreFailure.Unknown(RuntimeException("Error!"))
         val (arrangement, sut) = Arrangement()
             .withEstablishSSOSessionSuccess(UserId("user-id", "domain"))
@@ -467,8 +468,8 @@ class NewLoginViewModelTest {
         )
 
     @Test
-    fun `given SSO path, when enterprise login, then initiate SSO with given SSO code`() = runTest(dispatchers.main()) {
-        val ssoCode = "sso-code"
+    fun `given SSO path & code with prefix, when enterprise login, then initiate SSO with given SSO code`() = runTest(dispatchers.main()) {
+        val ssoCode = SSO_CODE_WITH_PREFIX
         val (arrangement, sut) = Arrangement()
             .withAuthenticationScopeSuccess()
             .withGetLoginFlowForDomainReturning(EnterpriseLoginResult.Success(LoginRedirectPath.SSO(ssoCode)))
@@ -484,6 +485,27 @@ class NewLoginViewModelTest {
             arrangement.loginSSOViewModelExtension.initiateSSO(any(), ssoCode, any(), any(), any())
         }
     }
+
+    @Test
+    fun `given SSO path & code without prefix, when enterprise login, then initiate SSO with given SSO code with prefix`() =
+        runTest(dispatchers.main()) {
+            val ssoCodeWithoutPrefix = SSO_CODE_WITHOUT_PREFIX
+            val ssoCodeWithPrefix = SSO_CODE_WITH_PREFIX
+            val (arrangement, sut) = Arrangement()
+                .withAuthenticationScopeSuccess()
+                .withGetLoginFlowForDomainReturning(EnterpriseLoginResult.Success(LoginRedirectPath.SSO(ssoCodeWithoutPrefix)))
+                .arrange()
+    
+            sut.getEnterpriseLoginFlow(email, arrangement.action)
+            advanceUntilIdle()
+    
+            verify(exactly = 0) {
+                arrangement.action(any())
+            }
+            coVerify(exactly = 1) {
+                arrangement.loginSSOViewModelExtension.initiateSSO(any(), ssoCodeWithPrefix, any(), any(), any())
+            }
+        }
 
     @Test
     fun `given custom backend path, when enterprise login, then update custom backend state`() = runTest(dispatchers.main()) {
@@ -713,5 +735,10 @@ class NewLoginViewModelTest {
             loginSSOViewModelExtension,
             dispatchers
         )
+    }
+    
+    companion object {
+        private const val SSO_CODE_WITHOUT_PREFIX: String = "fd994b20-b9af-11ec-ae36-00163e9b33ca"
+        private const val SSO_CODE_WITH_PREFIX: String = "$SSO_CODE_WIRE_PREFIX$SSO_CODE_WITHOUT_PREFIX"
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -495,10 +495,10 @@ class NewLoginViewModelTest {
                 .withAuthenticationScopeSuccess()
                 .withGetLoginFlowForDomainReturning(EnterpriseLoginResult.Success(LoginRedirectPath.SSO(ssoCodeWithoutPrefix)))
                 .arrange()
-    
+
             sut.getEnterpriseLoginFlow(email, arrangement.action)
             advanceUntilIdle()
-    
+
             verify(exactly = 0) {
                 arrangement.action(any())
             }
@@ -736,7 +736,7 @@ class NewLoginViewModelTest {
             dispatchers
         )
     }
-    
+
     companion object {
         private const val SSO_CODE_WITHOUT_PREFIX: String = "fd994b20-b9af-11ec-ae36-00163e9b33ca"
         private const val SSO_CODE_WITH_PREFIX: String = "$SSO_CODE_WIRE_PREFIX$SSO_CODE_WITHOUT_PREFIX"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16673" title="WPB-16673" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16673</a>  [Android]Any sso user is not working and logs says "get domain registration: {"path":"SSO"} 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When attempting to log in, entering an email associated with a claimed domain that uses SSO (Path 4), the app returns error "Invalid email or SSO code".

### Causes (Optional)

SSO code returned from the enterprise login request is missing the `wire-` prefix.

### Solutions

Implement logic of adding this prefix if it's missing before initiating the SSO.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Enter email associated with a claimed domain that uses SSO (for instance `user1@sso.ios.wire.com`: `Aqa123456!`)

### Attachments (Optional)

https://github.com/user-attachments/assets/f17dfb9f-1666-447d-8933-5a8a96815261

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
