### PR TITLE
fix: analytics should be disabled for c-builds (WPB-16675)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import customization.ConfigurationFileImporter
+import customization.Customization.isCustomizationEnabled
 import customization.NormalizedFlavorSettings
 
 /*
@@ -242,13 +243,15 @@ dependencies {
 
     // Anonymous Analytics
     val flavors = getFlavorsSettings()
+    val isCustomBuild = isCustomizationEnabled()
     flavors.flavorMap.entries.forEach { (key, configs) ->
-        if (configs["analytics_enabled"] as? Boolean == true) {
-            println(">> Adding Anonymous Analytics dependency to [$key] flavor")
+        if (configs["analytics_enabled"] as? Boolean == false || isCustomBuild) {
+            println(">> Dependency Anonymous Analytics is disabled for [$key] flavor")
+            add("${key}Implementation", project(":core:analytics-disabled"))
+        } else {
+            println(">> Dependency Anonymous Analytics is enabled for [$key] flavor")
             add("${key}Implementation", project(":core:analytics-enabled"))
             add("test${key.capitalize()}Implementation", project(":core:analytics-disabled"))
-        } else {
-            add("${key}Implementation", project(":core:analytics-disabled"))
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -245,13 +245,13 @@ dependencies {
     val flavors = getFlavorsSettings()
     val isCustomBuild = isCustomizationEnabled()
     flavors.flavorMap.entries.forEach { (key, configs) ->
-        if (configs["analytics_enabled"] as? Boolean == false || isCustomBuild) {
-            println(">> Dependency Anonymous Analytics is disabled for [$key] flavor")
-            add("${key}Implementation", project(":core:analytics-disabled"))
-        } else {
+        if (configs["analytics_enabled"] as? Boolean == true && !isCustomBuild) {
             println(">> Dependency Anonymous Analytics is enabled for [$key] flavor")
             add("${key}Implementation", project(":core:analytics-enabled"))
             add("test${key.capitalize()}Implementation", project(":core:analytics-disabled"))
+        } else {
+            println(">> Dependency Anonymous Analytics is disabled for [$key] flavor")
+            add("${key}Implementation", project(":core:analytics-disabled"))
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
@@ -59,7 +59,17 @@ class LocationPickerHelper @Inject constructor(
                 leadingMessage = "GetLocation",
                 jsonStringKeyValues = mapOf("isUsingGms" to false)
             )
-            val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+            val locationManager = try {
+                context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+            } catch (e: Exception) {
+                appLogger.e(
+                    message = "Failed to get location manager",
+                    throwable = e
+                )
+                onError()
+                return
+            }
+
             locationManager.getLastKnownLocation(LocationManager.FUSED_PROVIDER).let { lastLocation ->
                 if (
                     lastLocation != null

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerHelper.kt
@@ -42,6 +42,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
+@Suppress("TooGenericExceptionCaught")
 @SuppressLint("MissingPermission")
 class LocationPickerHelper @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -126,7 +127,6 @@ class LocationPickerHelper @Inject constructor(
         timeoutJob.start()
     }
 
-    @Suppress("TooGenericExceptionCaught")
     internal fun isLocationServicesEnabled(): Boolean {
         return try {
             val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager

--- a/buildSrc/src/main/kotlin/customization/Customization.kt
+++ b/buildSrc/src/main/kotlin/customization/Customization.kt
@@ -97,8 +97,7 @@ object Customization {
     fun getBuildtimeConfiguration(
         rootDir: File
     ): BuildTimeConfiguration {
-        val isCustomFromGit = readCustomizationProperty(CustomizationGitProperty.CUSTOM_REPOSITORY) != null
-        return if (isCustomFromGit) {
+        return if (isCustomizationEnabled()) {
             val customFile = getCustomisationFileFromGitProperties(rootDir)
             getBuildtimeConfiguration(rootDir, CustomizationOption.FromFile(customFile))
         } else {
@@ -232,6 +231,8 @@ object Customization {
          */
         data class FromFile(val customJsonFile: File) : CustomizationOption()
     }
+
+    fun isCustomizationEnabled(): Boolean = readCustomizationProperty(CustomizationGitProperty.CUSTOM_REPOSITORY) != null
 
     private fun readCustomizationProperty(property: CustomizationGitProperty): String? =
         System.getenv(property.variableName) ?: properties.getProperty(property.variableName)


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16675" title="WPB-16675" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16675</a>  [Android] C app is crashing when sending messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Crash while performing actions in the app for custom builds.

```
Process: com.wire.android.xxxxx, PID: 22097
com.goterl.resourceloader.ResourceLoaderException: lateinit property coroutineScope has not been initialized
	at com.wire.android.feature.analytics.AnonymousAnalyticsManagerImpl.sendEvent(Unknown Source:8)
	at com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel.handleAssetContributionEvent(Unknown Source:47)
                                                                            access$handleAssetContributionEvent
	at com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel$sendAttachment$1$1.invokeSuspend(Unknown Source:335)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(Unknown Source:8)
	at kotlinx.coroutines.DispatchedTask.run(Unknown Source:98)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(Unknown Source:81)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Unknown Source:2)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(Unknown Source:92)
                                                            executeTask
                                                            runWorker
                                                            run
	Suppressed: pi.e: [z0{Cancelling}@28484bb, Dispatchers.Main.immediate]
```

### Causes (Optional)

Analytics dependency was added before resolving custom builds config

### Solutions

Consider if we are building a custom app to just disable the analytics. This might be tweaked later if we need to.


### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

N/A

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
