### PR TITLE
fix: cancel login operation when going back [WPB-16670]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -28,6 +28,7 @@ import com.ramcosta.composedestinations.navigation.navigate
 import com.ramcosta.composedestinations.spec.DestinationSpec
 import com.ramcosta.composedestinations.spec.Direction
 import com.ramcosta.composedestinations.spec.NavGraphSpec
+import com.ramcosta.composedestinations.utils.findDestination
 import com.ramcosta.composedestinations.utils.navGraph
 import com.ramcosta.composedestinations.utils.route
 import com.wire.android.appLogger
@@ -99,7 +100,7 @@ private fun NavOptionsBuilder.popUpTo(
 }
 
 internal fun NavDestination.toDestination(): DestinationSpec<*>? =
-    this.route?.let { currentRoute -> WireMainNavGraph.destinationsByRoute[currentRoute] }
+    this.route?.let { currentRoute -> WireMainNavGraph.findDestination(currentRoute) }
 
 fun String.getBaseRoute(): String =
     this.indexOfAny(listOf("?", "/")).let {

--- a/app/src/main/kotlin/com/wire/android/navigation/Navigator.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/Navigator.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavHostController
+import com.ramcosta.composedestinations.utils.findDestination
 
 class Navigator(
     val finish: () -> Unit,
@@ -63,7 +64,7 @@ fun rememberNavigator(
     finish: () -> Unit,
 ): Navigator {
     val navController = rememberTrackingAnimatedNavController {
-        WireMainNavGraph.destinationsByRoute[it]?.let { it::class.simpleName } // there is a proguard rule for Routes
+        WireMainNavGraph.findDestination(it)?.let { it::class.simpleName } // there is a proguard rule for Routes
     }
     return remember(finish, isAllowedToNavigate, navController) { Navigator(finish, navController, isAllowedToNavigate) }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginState.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.common.error.CoreFailure
 sealed class LoginState {
     data object Default : LoginState()
     data object Loading : LoginState()
+    data object Canceled : LoginState()
     data class Success(val initialSyncCompleted: Boolean, val isE2EIRequired: Boolean) : LoginState()
     sealed class Error : LoginState() {
         sealed class TextFieldError : Error() {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -148,8 +148,11 @@ class LoginEmailViewModel @Inject constructor(
         updateEmailFlowState(LoginState.Loading)
         viewModelScope.launch {
             val previousSessionUserId = coreLogic.getGlobalScope().session.currentSession().let {
-                if (it is CurrentSessionResult.Success && it.accountInfo.isValid()) it.accountInfo.userId
-                else null
+                if (it is CurrentSessionResult.Success && it.accountInfo.isValid()) {
+                    it.accountInfo.userId
+                } else {
+                    null
+                }
             }
             startLoginJob().let {
                 loginJobData.value = LoginJobData(it, previousSessionUserId)

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentViewModel.kt
@@ -22,18 +22,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.appLogger
-import com.wire.android.feature.AccountSwitchUseCase
-import com.wire.android.feature.SwitchAccountActions
-import com.wire.android.feature.SwitchAccountParam
 import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.logic.feature.client.FinalizeMLSClientAfterE2EIEnrollment
-import com.wire.kalium.logic.feature.e2ei.usecase.E2EIEnrollmentResult
-import com.wire.kalium.logic.feature.session.CurrentSessionResult
-import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
-import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.fold
+import com.wire.kalium.logic.feature.client.FinalizeMLSClientAfterE2EIEnrollment
+import com.wire.kalium.logic.feature.e2ei.usecase.E2EIEnrollmentResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -44,56 +37,18 @@ data class E2EIEnrollmentState(
     val isLoading: Boolean = false,
     val isCertificateEnrollError: Boolean = false,
     val isCertificateEnrollSuccess: Boolean = false,
-    val showCancelLoginDialog: Boolean = false,
     val startGettingE2EICertificate: Boolean = false
 )
 
 @HiltViewModel
 class E2EIEnrollmentViewModel @Inject constructor(
     private val finalizeMLSClientAfterE2EIEnrollment: FinalizeMLSClientAfterE2EIEnrollment,
-    private val currentSession: CurrentSessionUseCase,
-    private val deleteSession: DeleteSessionUseCase,
-    private val switchAccount: AccountSwitchUseCase
 ) : ViewModel() {
     var state by mutableStateOf(E2EIEnrollmentState())
 
     fun finalizeMLSClient() {
         viewModelScope.launch {
             finalizeMLSClientAfterE2EIEnrollment.invoke()
-        }
-    }
-
-    fun onBackButtonClicked() {
-        state = state.copy(showCancelLoginDialog = true)
-    }
-
-    fun onProceedEnrollmentClicked() {
-        state = state.copy(showCancelLoginDialog = false)
-    }
-
-    fun onCancelEnrollmentClicked(switchAccountActions: SwitchAccountActions) {
-        state = state.copy(showCancelLoginDialog = false)
-        viewModelScope.launch {
-            currentSession().let {
-                when (it) {
-                    is CurrentSessionResult.Success -> {
-                        deleteSession(it.accountInfo.userId)
-                    }
-
-                    is CurrentSessionResult.Failure.Generic -> {
-                        appLogger.e("failed to delete session")
-                    }
-
-                    CurrentSessionResult.Failure.SessionNotFound -> {
-                        appLogger.e("session not found")
-                    }
-                }
-            }
-        }.invokeOnCompletion {
-            viewModelScope.launch {
-                switchAccount(SwitchAccountParam.TryToSwitchToNextAccount)
-                    .callAction(switchAccountActions)
-            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/password/NewLoginPasswordScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/password/NewLoginPasswordScreen.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.ui.newauthentication.login.password
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -123,9 +124,13 @@ fun NewLoginPasswordScreen(
             navigator.navigate(NavigationCommand(CreateTeamAccountOverviewScreenDestination(loginEmailViewModel.serverConfig)))
         },
         canNavigateBack = navigator.navController.previousBackStackEntry != null, // if there is a previous screen to navigate back to
-        navigateBack = navigator::navigateBack,
+        navigateBack = loginEmailViewModel::cancelLogin,
         isCloudAccountCreationPossible = navArgs.loginPasswordPath?.isCloudAccountCreationPossible ?: true,
     )
+
+    BackHandler {
+        loginEmailViewModel.cancelLogin()
+    }
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -328,6 +333,10 @@ fun LoginStateNavigationAndDialogs(viewModel: LoginEmailViewModel, navigator: Na
             is LoginState.Error.TooManyDevicesError -> {
                 viewModel.clearLoginErrors()
                 navigator.navigate(NavigationCommand(RemoveDeviceScreenDestination, BackStackMode.CLEAR_WHOLE))
+            }
+
+            is LoginState.Canceled -> {
+                navigator.navigateBack()
             }
 
             else -> {

--- a/app/src/test/kotlin/com/wire/android/config/NavigationTestExtension.kt
+++ b/app/src/test/kotlin/com/wire/android/config/NavigationTestExtension.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.android.config
 
+import com.ramcosta.composedestinations.utils.allDestinations
 import com.wire.android.navigation.WireMainNavGraph
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -44,11 +45,11 @@ import org.junit.jupiter.api.extension.ExtensionContext
 class NavigationTestExtension : BeforeEachCallback, AfterEachCallback {
     override fun beforeEach(context: ExtensionContext?) {
         mockkStatic("com.wire.android.ui.NavArgsGettersKt")
-        WireMainNavGraph.destinations.forEach { mockkObject(it) }
+        WireMainNavGraph.allDestinations.forEach { mockkObject(it) }
     }
 
     override fun afterEach(context: ExtensionContext?) {
         unmockkStatic("com.wire.android.ui.NavArgsGettersKt")
-        WireMainNavGraph.destinations.forEach { unmockkObject(it) }
+        WireMainNavGraph.allDestinations.forEach { unmockkObject(it) }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/devices/common/ClearSessionViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/devices/common/ClearSessionViewModelTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.authentication.devices.common
+
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.feature.AccountSwitchUseCase
+import com.wire.android.feature.SwitchAccountActions
+import com.wire.android.feature.SwitchAccountParam
+import com.wire.android.feature.SwitchAccountResult
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.logic.data.auth.AccountInfo
+import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.auth.LogoutUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
+import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(CoroutineTestExtension::class)
+class ClearSessionViewModelTest {
+
+    @Test
+    fun `given cancel login dialog not shown, when back button clicked, then show cancel login dialog`() = runTest {
+        // given
+        val (_, viewModel) = Arrangement().arrange()
+        viewModel.state.showCancelLoginDialog shouldBe false
+        // when
+        viewModel.onBackButtonClicked()
+        // then
+        viewModel.state.showCancelLoginDialog shouldBe true
+    }
+
+    @Test
+    fun `given cancel login dialog shown, when proceed login clicked, then hide cancel login dialog`() = runTest {
+        // given
+        val (_, viewModel) = Arrangement().arrange()
+        viewModel.onBackButtonClicked() // to show dialog
+        viewModel.state.showCancelLoginDialog shouldBe true
+        // when
+        viewModel.onProceedLoginClicked()
+        // then
+        viewModel.state.showCancelLoginDialog shouldBe false
+    }
+
+    @Test
+    fun `given cancel login dialog shown, when cancel login clicked, then hide cancel login dialog`() = runTest {
+        // given
+        val currentSession = AccountInfo.Valid(UserId("userId", "domain"))
+        val (arrangement, viewModel) = Arrangement()
+            .withCurrentSessionReturning(CurrentSessionResult.Success(currentSession))
+            .arrange()
+        viewModel.onBackButtonClicked() // to show dialog
+        viewModel.state.showCancelLoginDialog shouldBe true
+        // when
+        viewModel.onCancelLoginClicked(arrangement.switchAccountActions)
+        advanceUntilIdle()
+        // then
+        viewModel.state.showCancelLoginDialog shouldBe false
+    }
+
+    @Test
+    fun `given valid session, when cancel login clicked, then call proper actions`() = runTest {
+        // given
+        val currentSession = AccountInfo.Valid(UserId("userId", "domain"))
+        val (arrangement, viewModel) = Arrangement()
+            .withCurrentSessionReturning(CurrentSessionResult.Success(currentSession))
+            .withDeleteSessionReturning(DeleteSessionUseCase.Result.Success)
+            .withSwitchAccountReturning(SwitchAccountResult.SwitchedToAnotherAccount)
+            .arrange()
+        // when
+        viewModel.onCancelLoginClicked(arrangement.switchAccountActions)
+        advanceUntilIdle()
+        // then
+        coVerify(exactly = 1) {
+            arrangement.logout(LogoutReason.SELF_HARD_LOGOUT, true)
+            arrangement.deleteSession(currentSession.userId)
+            arrangement.switchAccount(SwitchAccountParam.TryToSwitchToNextAccount)
+            arrangement.switchAccountActions.switchedToAnotherAccount()
+        }
+    }
+
+    @Test
+    fun `given no valid session, when canceling, then do not logout or delete session but do switch account`() = runTest {
+        // given
+        val (arrangement, viewModel) = Arrangement()
+            .withCurrentSessionReturning(CurrentSessionResult.Failure.SessionNotFound)
+            .withSwitchAccountReturning(SwitchAccountResult.SwitchedToAnotherAccount)
+            .arrange()
+        // when
+        viewModel.onCancelLoginClicked(arrangement.switchAccountActions)
+        advanceUntilIdle()
+        // then
+        coVerify(exactly = 0) {
+            arrangement.logout(LogoutReason.SELF_HARD_LOGOUT, true)
+            arrangement.deleteSession(any())
+        }
+        coVerify(exactly = 1) {
+            arrangement.switchAccount(SwitchAccountParam.TryToSwitchToNextAccount)
+            arrangement.switchAccountActions.switchedToAnotherAccount()
+        }
+    }
+
+    @Test
+    fun `given no valid session and delete session fails, when canceling, then still do switch account`() = runTest {
+        // given
+        val (arrangement, viewModel) = Arrangement()
+            .withCurrentSessionReturning(CurrentSessionResult.Failure.SessionNotFound)
+            .withDeleteSessionReturning(DeleteSessionUseCase.Result.Failure(StorageFailure.DataNotFound))
+            .withSwitchAccountReturning(SwitchAccountResult.SwitchedToAnotherAccount)
+            .arrange()
+        viewModel.onBackButtonClicked() // to show dialog
+        viewModel.state.showCancelLoginDialog shouldBe true
+        // when
+        viewModel.onCancelLoginClicked(arrangement.switchAccountActions)
+        advanceUntilIdle()
+        // then
+        coVerify(exactly = 0) {
+            arrangement.logout(LogoutReason.SELF_HARD_LOGOUT, true)
+            arrangement.deleteSession(any())
+        }
+        coVerify(exactly = 1) {
+            arrangement.switchAccount(SwitchAccountParam.TryToSwitchToNextAccount)
+            arrangement.switchAccountActions.switchedToAnotherAccount()
+        }
+    }
+
+    inner class Arrangement {
+
+        @MockK
+        lateinit var currentSession: CurrentSessionUseCase
+
+        @MockK
+        lateinit var deleteSession: DeleteSessionUseCase
+
+        @MockK
+        lateinit var logout: LogoutUseCase
+
+        @MockK
+        lateinit var switchAccount: AccountSwitchUseCase
+
+        @MockK
+        lateinit var switchAccountActions: SwitchAccountActions
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+            withCurrentSessionReturning(CurrentSessionResult.Success(AccountInfo.Valid(UserId("userId", "domain"))))
+            withDeleteSessionReturning(DeleteSessionUseCase.Result.Success)
+            withSwitchAccountReturning(SwitchAccountResult.SwitchedToAnotherAccount)
+        }
+
+        fun arrange() = this to ClearSessionViewModel(currentSession, deleteSession, switchAccount, logout)
+
+        fun withCurrentSessionReturning(result: CurrentSessionResult) = apply {
+            coEvery { currentSession() } returns result
+        }
+
+        fun withDeleteSessionReturning(result: DeleteSessionUseCase.Result) = apply {
+            coEvery { deleteSession(any()) } returns result
+        }
+
+        fun withSwitchAccountReturning(result: SwitchAccountResult) = apply {
+            coEvery { switchAccount(any()) } returns result
+        }
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16670" title="WPB-16670" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16670</a>  [Android] Back arrow on login screen does not cancel login operation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On the login screen, when a user enters their login credentials and taps the "Next" button, the login process begins. However, if the user taps the back arrow in the top left corner while the page is still loading, the UI navigates back to the previous screen, but the login process continues in the background. If the app is later restarted, the user is found to be logged in, indicating that the login was completed despite the UI navigation.

### Solutions

Keep the login operation job and cancel it when user decides to go back. After that, some clean-up is required, depending on how far the login process went, but it may be required to remove self user's email, clean the db, close the user's scope to cancel all ongoing user processes and delete the session so that it looks like the account was never logged in. To achieve that, the easiest way is to perform hard logout and then remove the session - this way we are sure it makes all required actions. After that also it's required to switch back to the previous account so the previous account's id is kept during the login process.
Some of it also applies to other existing screens like remove device - when user goes back then the app needs to logout the user, but the actual logout was never executed, just the session was being removed, so there was some data being left, so to unify these processes logout was added also to `ClearSessionViewModel` and this view model was used on `E2EIEnrollmentScreen` - previously the same logic was duplicated on `E2EIEnrollmentViewModel`, now it uses `ClearSessionViewModel` as well to make it easier to maintain.
Fixed some other small issue as well that started to be more noticeable here after creating dedicated subgraphs for login flows - screens belonging to subgraphs were not included when logging screen name properly or deciding whether connection top bar should be visible or not that started. That was because `.destinationsByRoute` and `.destinations` only return screens from particular graph not including subgraphs, so it was replaced with `.findDestination` and `.allDestinations` to have all screens covered.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Login and navigate back during the login process. 
Close the app and open again to check if it still not logged in. 
Try to log in again using the same credentials to check that there are no unwanted data left over from the previous attempt.

### Attachments (Optional)

https://github.com/user-attachments/assets/6ef754ca-58ff-4553-b1c5-53f2c16fa8a0

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
