### PR TITLE
fix: keep showing user email after handling SSO url [WPB-14340]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/SSOUrlConfigHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/SSOUrlConfigHolder.kt
@@ -43,4 +43,4 @@ class SSOUrlConfigHolderImpl(private val savedStateHandle: SavedStateHandle) : S
 private const val SSO_URL_CONFIG_KEY: String = "sso-url-config"
 
 @Serializable
-data class SSOUrlConfig(val serverConfig: ServerConfig.Links, val ssoCode: String = "")
+data class SSOUrlConfig(val serverConfig: ServerConfig.Links, val userIdentifier: String = "")

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -249,7 +249,7 @@ class NewLoginViewModel(
                 onSuccess = { requestUrl, serverConfig ->
                     withContext(dispatchers.main()) {
                         updateLoginFlowState(NewLoginFlowState.Default)
-                        action(NewLoginAction.SSO(requestUrl, SSOUrlConfig(serverConfig, ssoCode)))
+                        action(NewLoginAction.SSO(requestUrl, SSOUrlConfig(serverConfig, userIdentifierTextState.text.toString())))
                         updateLoginFlowState(NewLoginFlowState.Default)
                     }
                 }
@@ -260,7 +260,7 @@ class NewLoginViewModel(
         updateLoginFlowState(NewLoginFlowState.Loading)
         if (config != null) {
             serverConfig = config.serverConfig
-            userIdentifierTextState.setTextAndPlaceCursorAtEnd(config.ssoCode)
+            userIdentifierTextState.setTextAndPlaceCursorAtEnd(config.userIdentifier)
         }
         when (ssoLoginResult) {
             is DeepLinkResult.SSOLogin.Success -> {

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -117,7 +117,7 @@ class NewLoginViewModelTest {
             .withInitiateSSOSuccess(redirectUrl, config.serverConfig)
             .arrange()
 
-        sut.initiateSSO(config.serverConfig, config.ssoCode, arrangement.action)
+        sut.initiateSSO(config.serverConfig, config.userIdentifier, arrangement.action)
         advanceUntilIdle()
 
         verify(exactly = 1) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14340" title="WPB-14340" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14340</a>  [Android] - Implement UI paths 4 & 7
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When logging in using email of cloud user with SSO and claimed domain, after opening SSO url and handling returning deep link, the input field text is changed from email to SSO code that the app got from the backend and used for this user.

### Solutions

Instead of keeping SSO code, keep the user identifier input text so that when opening the app again, the input stays the same and doesn't confuse the user.

### Testing

#### How to Test

Enter email of cloud user with SSO and claimed domain and login.

### Attachments (Optional)

https://github.com/user-attachments/assets/69a0961d-2eb0-4b35-abab-46d73ced427c

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
