### PR TITLE
fix: crash when recording audio after playing previous one [WPB-16687]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioFocusHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioFocusHelper.kt
@@ -79,7 +79,7 @@ class AudioFocusHelper @Inject constructor(private val audioManager: AudioManage
      * Abandon the exclusive audio focus.
      */
     fun abandonExclusive() {
-        audioManager.abandonAudioFocusRequest(focusRequest)
+        audioManager.abandonAudioFocusRequest(exclusiveFocusRequest)
     }
 
     fun setListener(onPauseCurrentAudio: () -> Unit, onResumeCurrentAudio: () -> Unit) {

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayer.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayer.kt
@@ -211,21 +211,25 @@ class RecordAudioMessagePlayer @Inject constructor(
     }
 
     private suspend fun resumeAudio() {
-        audioMediaPlayer.start()
-        audioMessageStateUpdate.emit(
-            RecordAudioMediaPlayerStateUpdate.RecordAudioMediaPlayingStateUpdate(
-                audioMediaPlayingState = AudioMediaPlayingState.Playing
+        if (currentAudioFile != null) {
+            audioMediaPlayer.start()
+            audioMessageStateUpdate.emit(
+                RecordAudioMediaPlayerStateUpdate.RecordAudioMediaPlayingStateUpdate(
+                    audioMediaPlayingState = AudioMediaPlayingState.Playing
+                )
             )
-        )
+        }
     }
 
     private suspend fun pause() {
-        audioMediaPlayer.pause()
-        audioMessageStateUpdate.emit(
-            RecordAudioMediaPlayerStateUpdate.RecordAudioMediaPlayingStateUpdate(
-                AudioMediaPlayingState.Paused
+        if (currentAudioFile != null) {
+            audioMediaPlayer.pause()
+            audioMessageStateUpdate.emit(
+                RecordAudioMediaPlayerStateUpdate.RecordAudioMediaPlayingStateUpdate(
+                    AudioMediaPlayingState.Paused
+                )
             )
-        )
+        }
     }
 
     suspend fun stop() {
@@ -239,6 +243,7 @@ class RecordAudioMessagePlayer @Inject constructor(
     }
 
     fun close() {
+        audioFocusHelper.abandon()
         audioMediaPlayer.release()
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -268,7 +268,6 @@ class RecordAudioViewModel @Inject constructor(
             state.originalOutputFile?.toPath()?.deleteIfExists()
             state.effectsOutputFile?.toPath()?.deleteIfExists()
             recordAudioMessagePlayer.stop()
-            recordAudioMessagePlayer.close()
             state = state.copy(
                 buttonState = RecordAudioButtonState.ENABLED,
                 discardDialogState = RecordAudioDialogState.Hidden,
@@ -285,7 +284,6 @@ class RecordAudioViewModel @Inject constructor(
     ) {
         viewModelScope.launch {
             recordAudioMessagePlayer.stop()
-            recordAudioMessagePlayer.close()
 
             val outputFile = state.originalOutputFile
             val effectsFile = state.effectsOutputFile


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16687" title="WPB-16687" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16687</a>  [Android] App crashes when second audio is recorded after playing the first before sending
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app crashes when attempting to send an audio recording for the second time because the user played the 1st recording before sending it. 

### Causes (Optional)

- `MediaPlayer` being released after closing or sending a message so it cannot be reused again
- audio focus not being abandoned correctly and receiving audiofocus loss when trying to record again
- trying to pause audio when there is no audio being played and `MediaPlayer` is not initialised

### Solutions

- do not release `MediaPlayer` after sending or closing, it can be reused then (the same instance is persisted as long as the view model exists)
- abandon focus when closing the recording
- fix `abandonExclusive` function to abandon `exclusiveFocusRequest` and not regular `focusRequest`
- check if there is any current audio set before trying to pause or resume

### Testing

#### How to Test

Steps to Reproduce:
-record an audio message.
-play the recording before sending it.
-send the audio message.
-attempt to make another audio recording.
-observe that the app crashes.

Actual Result:
the app crashes when attempting to make a second audio recording because the user played the 1st recording before sending.

Expected Result:
users should be able to record, play and send multiple audio messages without the app crashing.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
