### PR TITLE
fix: too many devices response crashing new login flow [WPB-16833]

### DIFF
--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -405,6 +405,7 @@ class LoginEmailViewModelTest {
             .withGetOrRegisterClientReturning(RegisterClientResult.Failure.TooManyClients)
             .withInitialSyncCompletedReturning(true)
             .withDeleteSessionReturning(DeleteSessionUseCase.Result.Success)
+            .withUpdateCurrentSessionReturning(UpdateCurrentSessionUseCase.Result.Success)
             .arrange()
 
         loginViewModel.userIdentifierTextState.setTextAndPlaceCursorAtEnd(email)
@@ -495,6 +496,7 @@ class LoginEmailViewModelTest {
             .withValidateEmailReturning(true)
             .withPersistEmailReturning(PersistSelfUserEmailResult.Failure(failure))
             .withDeleteSessionReturning(DeleteSessionUseCase.Result.Success)
+            .withUpdateCurrentSessionReturning(UpdateCurrentSessionUseCase.Result.Success)
             .arrange()
 
         loginViewModel.userIdentifierTextState.setTextAndPlaceCursorAtEnd(email)
@@ -671,6 +673,59 @@ class LoginEmailViewModelTest {
         coVerify(exactly = 1) { // verify that the second login job has been started
             arrangement.loginUseCase(any(), any(), any(), any(), any())
             arrangement.addAuthenticatedUserUseCase(any(), any(), eq(authToken2), any())
+        }
+    }
+
+    @Test
+    fun `given too many clients failure, when registering client, then do not revert new session`() = runTest {
+        // given
+        val previousUserId = UserId("previousUserId", "domain")
+        val newUserId = UserId("newUserId", "domain")
+        val authToken = AUTH_TOKEN.copy(userId = newUserId)
+        val (arrangement, viewModel) = Arrangement()
+            .withDeleteSessionReturning(DeleteSessionUseCase.Result.Success)
+            .withUpdateCurrentSessionReturning(UpdateCurrentSessionUseCase.Result.Success)
+            .withCurrentSessionReturning(CurrentSessionResult.Success(AccountInfo.Valid(previousUserId)))
+            .withLoginReturning(AuthenticationResult.Success(authToken, SSO_ID, SERVER_CONFIG.id, null))
+            .withAddAuthenticatedUserReturning(AddAuthenticatedUserUseCase.Result.Success(newUserId))
+            .withValidateEmailReturning(true)
+            .withPersistEmailReturning(PersistSelfUserEmailResult.Success)
+            .withGetOrRegisterClientReturning(RegisterClientResult.Failure.TooManyClients)
+            .arrange()
+        // when
+        viewModel.login()
+        advanceUntilIdle()
+        // then
+        coVerify(exactly = 0) {
+            arrangement.logoutUseCase(LogoutReason.SELF_HARD_LOGOUT, true)
+            arrangement.deleteSessionUseCase(newUserId)
+            arrangement.updateCurrentSessionUseCase(previousUserId)
+        }
+    }
+    @Test
+    fun `given other failure than too many clients, when registering client, then revert new session`() = runTest {
+        // given
+        val previousUserId = UserId("previousUserId", "domain")
+        val newUserId = UserId("newUserId", "domain")
+        val authToken = AUTH_TOKEN.copy(userId = newUserId)
+        val (arrangement, viewModel) = Arrangement()
+            .withDeleteSessionReturning(DeleteSessionUseCase.Result.Success)
+            .withUpdateCurrentSessionReturning(UpdateCurrentSessionUseCase.Result.Success)
+            .withCurrentSessionReturning(CurrentSessionResult.Success(AccountInfo.Valid(previousUserId)))
+            .withLoginReturning(AuthenticationResult.Success(authToken, SSO_ID, SERVER_CONFIG.id, null))
+            .withAddAuthenticatedUserReturning(AddAuthenticatedUserUseCase.Result.Success(newUserId))
+            .withValidateEmailReturning(true)
+            .withPersistEmailReturning(PersistSelfUserEmailResult.Success)
+            .withGetOrRegisterClientReturning(RegisterClientResult.Failure.Generic(CoreFailure.Unknown(null)))
+            .arrange()
+        // when
+        viewModel.login()
+        advanceUntilIdle()
+        // then
+        coVerify(exactly = 1) {
+            arrangement.logoutUseCase(LogoutReason.SELF_HARD_LOGOUT, true)
+            arrangement.deleteSessionUseCase(newUserId)
+            arrangement.updateCurrentSessionUseCase(previousUserId)
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -702,6 +702,7 @@ class LoginEmailViewModelTest {
             arrangement.updateCurrentSessionUseCase(previousUserId)
         }
     }
+
     @Test
     fun `given other failure than too many clients, when registering client, then revert new session`() = runTest {
         // given


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16833" title="WPB-16833" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16833</a>  [Android]App crashes on second user login and previous user becomes inaccessible
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The Wire Android app crashes when registering client returns "too many devices" error. After that, the previously logged-in user is no longer accessible.

### Causes (Optional)

When client registration fails, it reverts new session by removing it but without updating current session to previous one after that, so the app doesn't have any current session anymore, that's why it requires login even if there was another account logged in.

### Solutions

Do not revert new session if the client registration fails with "too many devices" error as it should keep newly logged in session and navigate to `RemoveDeviceScreen`, so in that case navigate to that screen, otherwise, if it's any other failure, only then revert new session and do that not only by deleting new session but also update current session afterwards (to previous one or null if there was no other account logged in).

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Log in using account that already has as many clients registered as it can be (so 7). The app should not crash when logging in and should navigate to the screen where you can remove one of your devices. 

### Attachments (Optional)

https://github.com/user-attachments/assets/dc1cf3b0-f63c-41e1-903b-0d497e54c5b0

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.