### PR TITLE
feat(channels): show or hide channel creation as needed [WPB-16634]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/ChannelsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/ChannelsModule.kt
@@ -22,6 +22,7 @@ import com.wire.android.di.KaliumCoreLogic
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.channels.ChannelsScope
+import com.wire.kalium.logic.feature.channels.ObserveChannelsCreationPermissionUseCase
 import com.wire.kalium.logic.feature.conversation.channel.UpdateChannelAddPermissionUseCase
 import dagger.Module
 import dagger.Provides
@@ -44,4 +45,9 @@ class ChannelsModule {
     @Provides
     fun provideUpdateChannelAddPermission(channelsScope: ChannelsScope): UpdateChannelAddPermissionUseCase =
         channelsScope.updateChannelAddPermission
+
+    @ViewModelScoped
+    @Provides
+    fun provideChannelCreationPermissionUseCase(channelsScope: ChannelsScope): ObserveChannelsCreationPermissionUseCase =
+        channelsScope.observeChannelsCreationPermissionUseCase
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupMetadataState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupMetadataState.kt
@@ -32,6 +32,7 @@ data class GroupMetadataState(
     val animatedGroupNameError: Boolean = false,
     val continueEnabled: Boolean = false,
     val isLoading: Boolean = false,
+    val isChannelCreationPossible: Boolean = false,
     val isChannel: Boolean = true,
     val error: NewGroupError = NewGroupError.None,
     val mode: GroupNameMode = GroupNameMode.CREATION,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchUsersAndServicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchUsersAndServicesScreen.kt
@@ -78,7 +78,7 @@ fun SearchUsersAndServicesScreen(
     screenType: SearchPeopleScreenType,
     modifier: Modifier = Modifier,
     isSelfTeamMember: Boolean = false,
-    isChannelsAllowed: Boolean = true,
+    isUserAllowedToCreateChannels: Boolean = true,
     isGroupSubmitVisible: Boolean = true,
     isServicesAllowed: Boolean = false,
     initialPage: SearchPeopleTabItem = SearchPeopleTabItem.PEOPLE,
@@ -201,7 +201,7 @@ fun SearchUsersAndServicesScreen(
                     SearchPeopleScreenType.NEW_CONVERSATION -> {
                         CreateRegularGroupOrChannelButtons(
                             isSelfTeamMember = isSelfTeamMember,
-                            shouldShowChannelButton = isChannelsAllowed,
+                            shouldShowChannelButton = isUserAllowedToCreateChannels,
                             onCreateNewRegularGroup = onCreateNewGroup,
                             onCreateNewChannel = onCreateNewChannel
                         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/NewConversationSearchPeopleScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/NewConversationSearchPeopleScreen.kt
@@ -50,6 +50,7 @@ fun NewConversationSearchPeopleScreen(
     SearchUsersAndServicesScreen(
         searchTitle = stringResource(id = R.string.label_new_conversation),
         isSelfTeamMember = isSelfTeamMember,
+        isUserAllowedToCreateChannels = newConversationViewModel.newGroupState.isChannelCreationPossible,
         onOpenUserProfile = { contact ->
             OtherUserProfileScreenDestination(QualifiedID(contact.id, contact.domain))
                 .let { navigator.navigate(NavigationCommand(it)) }

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -36,13 +36,16 @@ import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.feature.channels.ChannelCreationPermission
 import io.mockk.coVerify
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.fail
 import org.amshove.kluent.internal.assertEquals
+import org.amshove.kluent.internal.assertFalse
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -321,5 +324,27 @@ class NewConversationViewModelTest {
 
         // Then
         assertEquals(false, isInvoked)
+    }
+
+    @Test
+    fun `given user is allowed to create channel, when initializing viewModel, then state should reflect that`() = runTest {
+        // Given
+        val (_, viewModel) = NewConversationViewModelArrangement()
+            .withGetSelfUser(isTeamMember = true)
+            .withChannelCreationPermissionReturning(flowOf(ChannelCreationPermission.Allowed(false)))
+            .arrange()
+
+        assertTrue(viewModel.newGroupState.isChannelCreationPossible)
+    }
+
+    @Test
+    fun `given user is NOT allowed to create channel, when initializing viewModel, then state should reflect that`() = runTest {
+        // Given
+        val (_, viewModel) = NewConversationViewModelArrangement()
+            .withGetSelfUser(isTeamMember = true)
+            .withChannelCreationPermissionReturning(flowOf(ChannelCreationPermission.Forbidden))
+            .arrange()
+
+        assertFalse(viewModel.newGroupState.isChannelCreationPossible)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16634" title="WPB-16634" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-16634</a>  [Android] Enable/disable Channnel creation based on team settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We need to show and hide the `Create new Channel` button depending on whether the user is allowed to create a channel or not.

Use the UseCase in Kalium to figure it out. Observe its value in the `NewConversationViewModel` and update the state accordingly.

This value is bubbled up to the UI and it shows the button only if necessary.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
