### PR TITLE
feat(channels): display channel avatar within conversation top app bar [WPB-15857]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -52,13 +52,16 @@ import com.wire.android.ui.common.LegalHoldIndicator
 import com.wire.android.ui.common.avatar.UserProfileAvatar
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.preview.MultipleThemePreviews
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.topappbar.NavigationIconButton
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.home.conversations.info.ConversationAvatar
 import com.wire.android.ui.home.conversations.info.ConversationDetailsData
 import com.wire.android.ui.home.conversations.info.ConversationInfoViewState
+import com.wire.android.ui.home.conversationslist.common.ChannelConversationAvatar
 import com.wire.android.ui.home.conversationslist.common.GroupConversationAvatar
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
@@ -202,8 +205,16 @@ private fun Avatar(
     conversationInfoViewState: ConversationInfoViewState
 ) {
     when (conversationAvatar) {
-        is ConversationAvatar.Group ->
+        is ConversationAvatar.Group.Regular ->
             GroupConversationAvatar(
+                conversationId = conversationAvatar.conversationId,
+                size = dimensions().avatarConversationTopBarSize,
+                cornerRadius = dimensions().groupAvatarConversationTopBarCornerRadius,
+                padding = dimensions().avatarConversationTopBarClickablePadding,
+            )
+
+        is ConversationAvatar.Group.Channel ->
+            ChannelConversationAvatar(
                 conversationId = conversationAvatar.conversationId,
                 size = dimensions().avatarConversationTopBarSize,
                 cornerRadius = dimensions().groupAvatarConversationTopBarCornerRadius,
@@ -335,7 +346,7 @@ fun PreviewConversationScreenTopAppBarLongTitleWithSearchAndOngoingCall() {
     )
 }
 
-@Preview("Topbar with a short  conversation title")
+@Preview("Topbar with a short conversation title")
 @Composable
 fun PreviewConversationScreenTopAppBarShortTitle() {
     val conversationId = QualifiedID("", "")
@@ -344,7 +355,7 @@ fun PreviewConversationScreenTopAppBarShortTitle() {
             conversationId = ConversationId("value", "domain"),
             conversationName = UIText.DynamicString("Short title"),
             conversationDetailsData = ConversationDetailsData.Group(null, conversationId),
-            conversationAvatar = ConversationAvatar.Group(conversationId)
+            conversationAvatar = ConversationAvatar.Group.Regular(conversationId)
         ),
         onBackButtonClick = {},
         onDropDownClick = {},
@@ -359,7 +370,32 @@ fun PreviewConversationScreenTopAppBarShortTitle() {
     )
 }
 
-@Preview("Topbar with a short  conversation title and join group call")
+@MultipleThemePreviews
+@Preview("Topbar with a short conversation title for a channel")
+@Composable
+fun PreviewConversationScreenTopAppBarShortTitleChannel() = WireTheme {
+    val conversationId = QualifiedID("", "")
+    ConversationScreenTopAppBarContent(
+        ConversationInfoViewState(
+            conversationId = ConversationId("value", "domain"),
+            conversationName = UIText.DynamicString("Short title"),
+            conversationDetailsData = ConversationDetailsData.Group(null, conversationId),
+            conversationAvatar = ConversationAvatar.Group.Channel(conversationId)
+        ),
+        onBackButtonClick = {},
+        onDropDownClick = {},
+        isDropDownEnabled = true,
+        onSearchButtonClick = {},
+        onPhoneButtonClick = {},
+        hasOngoingCall = false,
+        onJoinCallButtonClick = {},
+        onAudioPermissionPermanentlyDenied = {},
+        isInteractionEnabled = true,
+        isSearchEnabled = false
+    )
+}
+
+@Preview("Topbar with a short conversation title and join group call")
 @Composable
 fun PreviewConversationScreenTopAppBarShortTitleWithOngoingCall() {
     val conversationId = QualifiedID("", "")
@@ -368,7 +404,7 @@ fun PreviewConversationScreenTopAppBarShortTitleWithOngoingCall() {
             conversationId = ConversationId("value", "domain"),
             conversationName = UIText.DynamicString("Short title"),
             conversationDetailsData = ConversationDetailsData.Group(null, conversationId),
-            conversationAvatar = ConversationAvatar.Group(conversationId)
+            conversationAvatar = ConversationAvatar.Group.Regular(conversationId)
         ),
         onBackButtonClick = {},
         onDropDownClick = {},
@@ -392,7 +428,7 @@ fun PreviewConversationScreenTopAppBarShortTitleWithVerified() {
             conversationId = ConversationId("value", "domain"),
             conversationName = UIText.DynamicString("Short title"),
             conversationDetailsData = ConversationDetailsData.Group(null, conversationId),
-            conversationAvatar = ConversationAvatar.Group(conversationId),
+            conversationAvatar = ConversationAvatar.Group.Regular(conversationId),
             protocolInfo = Conversation.ProtocolInfo.Proteus,
             proteusVerificationStatus = Conversation.VerificationStatus.VERIFIED,
             mlsVerificationStatus = Conversation.VerificationStatus.VERIFIED
@@ -419,7 +455,7 @@ fun PreviewConversationScreenTopAppBarShortTitleWithLegalHold() {
             conversationId = ConversationId("value", "domain"),
             conversationName = UIText.DynamicString("Short title"),
             conversationDetailsData = ConversationDetailsData.Group(null, conversationId),
-            conversationAvatar = ConversationAvatar.Group(conversationId),
+            conversationAvatar = ConversationAvatar.Group.Regular(conversationId),
             protocolInfo = Conversation.ProtocolInfo.Proteus,
             legalHoldStatus = Conversation.LegalHoldStatus.ENABLED,
         ),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -157,7 +157,8 @@ class ConversationInfoViewModel @Inject constructor(
                     conversationDetails.otherUser.availabilityStatus
                 )
 
-            is ConversationDetails.Group -> ConversationAvatar.Group(conversationDetails.conversation.id)
+            is ConversationDetails.Group.Regular -> ConversationAvatar.Group.Regular(conversationDetails.conversation.id)
+            is ConversationDetails.Group.Channel -> ConversationAvatar.Group.Channel(conversationDetails.conversation.id)
             else -> ConversationAvatar.None
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
@@ -57,8 +57,13 @@ sealed class ConversationDetailsData(open val conversationProtocol: Conversation
     ) : ConversationDetailsData(conversationProtocol)
 }
 
-sealed class ConversationAvatar {
-    data object None : ConversationAvatar()
-    data class OneOne(val avatarAsset: ImageAsset.UserAvatarAsset?, val status: UserAvailabilityStatus) : ConversationAvatar()
-    data class Group(val conversationId: QualifiedID) : ConversationAvatar()
+sealed interface ConversationAvatar {
+    data object None : ConversationAvatar
+    data class OneOne(val avatarAsset: ImageAsset.UserAvatarAsset?, val status: UserAvailabilityStatus) : ConversationAvatar
+    sealed interface Group : ConversationAvatar {
+        val conversationId: QualifiedID
+
+        data class Regular(override val conversationId: QualifiedID) : Group
+        data class Channel(override val conversationId: QualifiedID) : Group
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15857" title="WPB-15857" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15857</a>  [Android] Add Channel avatars
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Introduced `Regular` and `Channel` subtypes within `ConversationAvatar.Group` to differentiate between regular groups and channel conversations. Updated UI previews and logic to reflect these changes, ensuring proper rendering of distinct avatars for both types in the top app bar.

### Attachments

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/43fb26c1-c9ca-47e7-a51a-043904ce275d" />

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
