### PR TITLE
test: speed up tests [WPB-8645]

### DIFF
--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.auth.LogoutCallbackManager
 import com.wire.kalium.logic.feature.call.CallsScope
+import com.wire.kalium.logic.feature.call.usecase.EndCallOnConversationChangeUseCase
 import com.wire.kalium.logic.feature.message.MessageScope
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
@@ -188,6 +189,9 @@ class GlobalObserversManagerTest {
         lateinit var callsScope: CallsScope
 
         @MockK
+        lateinit var endCallOnConversationChangeUseCase: EndCallOnConversationChangeUseCase
+
+        @MockK
         lateinit var userSessionScope: UserSessionScope
 
         @MockK
@@ -213,6 +217,8 @@ class GlobalObserversManagerTest {
             every { notificationChannelsManager.createUserNotificationChannels(any()) } returns Unit
             every { coreLogic.getGlobalScope().logoutCallbackManager } returns logoutCallbackManager
             every { coreLogic.getSessionScope(any()) } returns userSessionScope
+            every { callsScope.endCallOnConversationChange } returns endCallOnConversationChangeUseCase
+            coEvery { endCallOnConversationChangeUseCase.invoke() } returns Unit
             every { userSessionScope.calls } returns callsScope
             every { userSessionScope.messages } returns messageScope
             coEvery { messageScope.deleteEphemeralMessageEndDate() } returns Unit

--- a/app/src/test/kotlin/com/wire/android/config/NavigationTestExtension.kt
+++ b/app/src/test/kotlin/com/wire/android/config/NavigationTestExtension.kt
@@ -17,11 +17,7 @@
  */
 package com.wire.android.config
 
-import com.ramcosta.composedestinations.utils.allDestinations
-import com.wire.android.navigation.WireMainNavGraph
-import io.mockk.mockkObject
 import io.mockk.mockkStatic
-import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
@@ -45,11 +41,9 @@ import org.junit.jupiter.api.extension.ExtensionContext
 class NavigationTestExtension : BeforeEachCallback, AfterEachCallback {
     override fun beforeEach(context: ExtensionContext?) {
         mockkStatic("com.wire.android.ui.NavArgsGettersKt")
-        WireMainNavGraph.allDestinations.forEach { mockkObject(it) }
     }
 
     override fun afterEach(context: ExtensionContext?) {
         unmockkStatic("com.wire.android.ui.NavArgsGettersKt")
-        WireMainNavGraph.allDestinations.forEach { unmockkObject(it) }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
@@ -19,9 +19,7 @@
 package com.wire.android.ui.calling
 
 import com.wire.android.config.CoroutineTestExtension
-import com.wire.android.config.NavigationTestExtension
 import com.wire.android.datastore.GlobalDataStore
-import com.wire.android.ui.calling.OngoingCallViewModelTest.Arrangement
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.ongoing.OngoingCallViewModel
 import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
@@ -50,7 +48,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(NavigationTestExtension::class)
 @ExtendWith(CoroutineTestExtension::class)
 class OngoingCallViewModelTest {
 

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -133,6 +133,8 @@ class SharedCallingViewModelTest {
         UICallParticipantMapper(userTypeMapper)
     }
 
+    private val dispatcherProvider = TestDispatcherProvider()
+
     private lateinit var sharedCallingViewModel: SharedCallingViewModel
 
     val reactionsFlow = MutableSharedFlow<InCallReactionMessage>()
@@ -167,13 +169,13 @@ class SharedCallingViewModelTest {
             observeInCallReactionsUseCase = observeInCallReactionsUseCase,
             sendInCallReactionUseCase = sendInCallReactionUseCase,
             getCurrentClientId = getCurrentClientId,
-            dispatchers = TestDispatcherProvider()
+            dispatchers = dispatcherProvider
         )
     }
 
     @Test
     fun `given isMuted value is null, when toggling microphone, then do not update microphone state`() =
-        runTest {
+        runTest(dispatcherProvider.main()) {
             sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isMuted = null)
             coEvery { muteCall(conversationId) } returns Unit
 
@@ -183,7 +185,7 @@ class SharedCallingViewModelTest {
         }
 
     @Test
-    fun `given an un-muted call, when toggling microphone, then mute the call`() = runTest {
+    fun `given an un-muted call, when toggling microphone, then mute the call`() = runTest(dispatcherProvider.main()) {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isMuted = false)
         coEvery { muteCall(conversationId) } returns Unit
 
@@ -195,7 +197,7 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun `given a muted call, when toggling microphone, then un-mute the call`() = runTest {
+    fun `given a muted call, when toggling microphone, then un-mute the call`() = runTest(dispatcherProvider.main()) {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isMuted = true)
         coEvery { unMuteCall(any()) } returns Unit
 
@@ -208,7 +210,7 @@ class SharedCallingViewModelTest {
 
     @Test
     fun `given user on a preview screen, when muting microphone, then mute the call with false param`() =
-        runTest {
+        runTest(dispatcherProvider.main()) {
             sharedCallingViewModel.callState =
                 sharedCallingViewModel.callState.copy(isMuted = false)
             coEvery { muteCall(conversationId, false) } returns Unit
@@ -222,7 +224,7 @@ class SharedCallingViewModelTest {
 
     @Test
     fun `given user on a preview screen, when un-muting microphone, then un-mute the call with false param`() =
-        runTest {
+        runTest(dispatcherProvider.main()) {
             sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isMuted = true)
             coEvery { unMuteCall(conversationId, false) } returns Unit
 
@@ -234,7 +236,7 @@ class SharedCallingViewModelTest {
         }
 
     @Test
-    fun `given front facing camera, when flipping it, then switch to back camera`() = runTest {
+    fun `given front facing camera, when flipping it, then switch to back camera`() = runTest(dispatcherProvider.main()) {
         sharedCallingViewModel.callState =
             sharedCallingViewModel.callState.copy(isOnFrontCamera = true)
         coEvery { flipToBackCamera(conversationId) } returns Unit
@@ -247,7 +249,7 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun `given back facing camera, when flipping it, then switch to front camera`() = runTest {
+    fun `given back facing camera, when flipping it, then switch to front camera`() = runTest(dispatcherProvider.main()) {
         sharedCallingViewModel.callState =
             sharedCallingViewModel.callState.copy(isOnFrontCamera = false)
         coEvery { flipToFrontCamera(conversationId) } returns Unit
@@ -260,7 +262,7 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun `given camera is turned on, when toggling video, then turn off video`() = runTest {
+    fun `given camera is turned on, when toggling video, then turn off video`() = runTest(dispatcherProvider.main()) {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isCameraOn = true)
         coEvery { updateVideoState(any(), any()) } returns Unit
 
@@ -272,7 +274,7 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun `given camera is turned off, when toggling video, then turn on video`() = runTest {
+    fun `given camera is turned off, when toggling video, then turn on video`() = runTest(dispatcherProvider.main()) {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isCameraOn = false)
         coEvery { updateVideoState(any(), any()) } returns Unit
 
@@ -284,7 +286,7 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun `given an active call, when the user ends call, then invoke endCall useCase`() = runTest {
+    fun `given an active call, when the user ends call, then invoke endCall useCase`() = runTest(dispatcherProvider.main()) {
         coEvery { endCall(any()) } returns Unit
         coEvery { muteCall(any(), false) } returns Unit
         every { callRinger.stop() } returns Unit
@@ -299,7 +301,7 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun `given an active call, when the user ends call, then reset call config`() = runTest {
+    fun `given an active call, when the user ends call, then reset call config`() = runTest(dispatcherProvider.main()) {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(
             isCameraOn = true,
             isSpeakerOn = true
@@ -325,7 +327,7 @@ class SharedCallingViewModelTest {
 
     @Test
     fun `given a call, when setVideoPreview is called, then set the video preview`() =
-        runTest {
+        runTest(dispatcherProvider.main()) {
             coEvery { setVideoPreview(any(), any()) } returns Unit
 
             sharedCallingViewModel.setVideoPreview(view)
@@ -335,7 +337,7 @@ class SharedCallingViewModelTest {
         }
 
     @Test
-    fun `given a call, when clearVideoPreview is called, then clear view`() = runTest {
+    fun `given a call, when clearVideoPreview is called, then clear view`() = runTest(dispatcherProvider.main()) {
         coEvery { setVideoPreview(any(), any()) } returns Unit
 
         sharedCallingViewModel.clearVideoPreview()
@@ -345,7 +347,7 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsReceived_ThenNewEmojiIsEmitted() = runTest {
+    fun givenAnOngoingCall_WhenInCallReactionIsReceived_ThenNewEmojiIsEmitted() = runTest(dispatcherProvider.main()) {
 
         sharedCallingViewModel.inCallReactions.test {
 
@@ -364,7 +366,7 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsReceived_ThenNewRecentReactionEmitted() = runTest {
+    fun givenAnOngoingCall_WhenInCallReactionIsReceived_ThenNewRecentReactionEmitted() = runTest(dispatcherProvider.main()) {
 
         // when
         reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍")))
@@ -376,7 +378,7 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun givenAnOngoingCall_WhenNewInCallReactionIsReceived_ThenRecentReactionUpdated() = runTest {
+    fun givenAnOngoingCall_WhenNewInCallReactionIsReceived_ThenRecentReactionUpdated() = runTest(dispatcherProvider.main()) {
 
         // when
         reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍", "🎉")))
@@ -388,7 +390,7 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenReactionMessageIsSent() = runTest {
+    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenReactionMessageIsSent() = runTest(dispatcherProvider.main()) {
 
         // given
         coEvery { sendInCallReactionUseCase(conversationId, any()) } returns Either.Right(Unit)
@@ -403,7 +405,7 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenNewEmojiIsEmitted() = runTest {
+    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenNewEmojiIsEmitted() = runTest(dispatcherProvider.main()) {
 
         // given
         coEvery { sendInCallReactionUseCase(conversationId, any()) } returns Either.Right(Unit)
@@ -421,7 +423,7 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun givenAnOngoingCall_WhenInCallReactionSentFails_ThenNoEmojiIsEmitted() = runTest {
+    fun givenAnOngoingCall_WhenInCallReactionSentFails_ThenNoEmojiIsEmitted() = runTest(dispatcherProvider.main()) {
         // given
         coEvery { sendInCallReactionUseCase(conversationId, any()) } returns
                 Either.Left(NetworkFailure.NoNetworkConnection(IllegalStateException()))

--- a/app/src/test/kotlin/com/wire/android/ui/calling/outgoing/OutgoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/outgoing/OutgoingCallViewModelTest.kt
@@ -19,7 +19,6 @@
 package com.wire.android.ui.calling.outgoing
 
 import com.wire.android.config.CoroutineTestExtension
-import com.wire.android.config.NavigationTestExtension
 import com.wire.android.media.CallRinger
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallStatus
@@ -45,7 +44,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(NavigationTestExtension::class)
 @ExtendWith(CoroutineTestExtension::class)
 class OutgoingCallViewModelTest {
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8645" title="WPB-8645" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-8645</a>  [Android] Infrastructure code and developer experience
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Tests are sloooooooooooow.

### Causes

It seems that `mockkStatic` and `mockkObject` are _very_ expensive methods to call. And we're calling them a lot in `NavigationTestExtension`.

![image](https://github.com/user-attachments/assets/32dea5ce-4ffc-4ceb-a21b-b307e6338a04)

![image](https://github.com/user-attachments/assets/a034dfd1-6cb5-42ce-ba3a-57aadfe8cb6c)

### Solutions

Removed the  `NavigationTestExtension` from test classes where it was unnecessary. 

Simplify `NavigationTestExtension` so it doesn't do unnecessary `mockkObject` calls, which is expensive. The `mockkObject` calls were there just to allow doing `Destination.argsFrom`, which we aren't using in tests anyway :)

Change `SharedCallingViewModelTest` to use the same `TestDispatcher` used in `runTest`, so delays are skipped during tests.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
