### PR TITLE
chore(channels): adapt text to suit both regular groups and channels [WPB-16636]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -321,7 +321,7 @@ fun MessagePreview.uiLastMessageContent(): UILastMessageContent {
             val ephemeralContent = (content as MessagePreviewContent.Ephemeral)
             if (ephemeralContent.isGroupConversation) {
                 UILastMessageContent.TextMessage(
-                    MessageBody(UIText.StringResource(R.string.ephemeral_group_event_message))
+                    MessageBody(UIText.StringResource(R.string.ephemeral_group_channel_event_message))
                 )
             } else {
                 UILastMessageContent.TextMessage(

--- a/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
@@ -300,7 +300,7 @@ class CallNotificationBuilder @Inject constructor(
             is Conversation.Type.Group -> {
                 val name = data.callerName ?: context.getString(R.string.notification_call_default_caller_name)
                 (data.callerTeamName?.let { "$name @$it" } ?: name)
-                    .let { context.getString(R.string.notification_group_call_content, it) }
+                    .let { context.getString(R.string.notification_group_channel_call_content, it) }
             }
 
             else -> context.getString(R.string.notification_incoming_call_content)

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
@@ -287,7 +287,7 @@ internal fun ConversationMainSheetContent(
                             )
                         },
                         itemProvidedColor = MaterialTheme.colorScheme.error,
-                        title = stringResource(R.string.label_leave_group),
+                        title = stringResource(R.string.label_leave_conversation),
                         onItemClick = {
                             leaveGroup(
                                 LeaveGroupDialogState(
@@ -308,7 +308,7 @@ internal fun ConversationMainSheetContent(
                                 contentDescription = null
                             )
                         },
-                        title = stringResource(R.string.label_delete_group_locally),
+                        title = stringResource(R.string.label_delete_conversation_locally),
                         itemProvidedColor = MaterialTheme.colorScheme.error,
                         onItemClick = {
                             deleteGroupLocally(
@@ -330,7 +330,7 @@ internal fun ConversationMainSheetContent(
                                 contentDescription = null,
                             )
                         },
-                        title = stringResource(R.string.label_delete_group),
+                        title = stringResource(R.string.label_delete_conversation),
                         itemProvidedColor = MaterialTheme.colorScheme.error,
                         onItemClick = {
                             deleteGroup(

--- a/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupConversationNameComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/groupname/GroupConversationNameComponent.kt
@@ -18,7 +18,6 @@
 
 package com.wire.android.ui.common.groupname
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
@@ -138,7 +137,7 @@ fun GroupNameScreen(
                             }
                             WireTextField(
                                 textState = newGroupNameTextState,
-                                placeholderText = stringResource(R.string.group_name_placeholder),
+                                placeholderText = stringResource(R.string.conversation_name_placeholder),
                                 labelText = stringResource(labelText).uppercase(),
                                 state = computeGroupMetadataState(newGroupState.isChannel, error),
                                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text, imeAction = ImeAction.Done),

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeSnackBarMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeSnackBarMessage.kt
@@ -25,23 +25,11 @@ import com.wire.android.util.ui.UIText
 sealed class HomeSnackBarMessage(override val uiText: UIText) : SnackBarMessage {
 
     data class ClearConversationContentSuccess(val isGroup: Boolean) : HomeSnackBarMessage(
-        UIText.StringResource(
-            if (isGroup) {
-                R.string.group_content_deleted
-            } else {
-                R.string.conversation_content_deleted
-            }
-        )
+        UIText.StringResource(R.string.conversation_content_deleted)
     )
 
     data class ClearConversationContentFailure(val isGroup: Boolean) : HomeSnackBarMessage(
-        UIText.StringResource(
-            if (isGroup) {
-                R.string.group_content_delete_failure
-            } else {
-                R.string.conversation_content_delete_failure
-            }
-        )
+        UIText.StringResource(R.string.conversation_content_delete_failure)
     )
 
     class SuccessConnectionIgnoreRequest(val userName: String) :
@@ -55,20 +43,20 @@ sealed class HomeSnackBarMessage(override val uiText: UIText) : SnackBarMessage 
     data object UnblockingUserOperationError : HomeSnackBarMessage(UIText.StringResource(R.string.error_unblocking_user))
     data class DeletedConversationGroupSuccess(val groupName: String) : HomeSnackBarMessage(
         UIText.StringResource(
-            R.string.conversation_group_removed_success,
+            R.string.conversation_removed_success,
             groupName
         )
     )
     data class DeleteConversationGroupLocallySuccess(val groupName: String) : HomeSnackBarMessage(
         UIText.StringResource(
-            R.string.conversation_group_removed_locally_success,
+            R.string.conversation_removed_locally_success,
             groupName
         )
     )
 
-    data object DeleteConversationGroupError : HomeSnackBarMessage(UIText.StringResource(R.string.delete_group_conversation_error))
-    data object LeftConversationSuccess : HomeSnackBarMessage(UIText.StringResource(R.string.left_conversation_group_success))
-    data object LeaveConversationError : HomeSnackBarMessage(UIText.StringResource(R.string.leave_group_conversation_error))
+    data object DeleteConversationGroupError : HomeSnackBarMessage(UIText.StringResource(R.string.delete_conversation_conversation_error))
+    data object LeftConversationSuccess : HomeSnackBarMessage(UIText.StringResource(R.string.left_conversation_success))
+    data object LeaveConversationError : HomeSnackBarMessage(UIText.StringResource(R.string.leave_conversation_error))
     data class UpdateArchivingStatusSuccess(val isArchiving: Boolean) : HomeSnackBarMessage(
         UIText.StringResource(
             if (isArchiving) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -471,7 +471,7 @@ private fun GroupConversationDetailsContent(
                             if (shouldShowAddParticipantsButton) {
                                 Box(modifier = Modifier.padding(MaterialTheme.wireDimensions.spacing16x)) {
                                     WirePrimaryButton(
-                                        text = stringResource(R.string.conversation_details_group_participants_add),
+                                        text = stringResource(R.string.conversation_details_conversation_participants_add),
                                         onClick = onAddParticipantsPressed,
                                     )
                                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsTopBarCollapsing.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsTopBarCollapsing.kt
@@ -92,8 +92,11 @@ fun GroupConversationDetailsTopBarCollapsing(
             ) {
                 Text(
                     text = title.ifBlank {
-                        if (isLoading) ""
-                        else UIText.StringResource(R.string.group_unavailable_label).asString()
+                        if (isLoading) {
+                            ""
+                        } else {
+                            UIText.StringResource(R.string.conversation_unavailable_label).asString()
+                        }
                     },
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -290,7 +290,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
                         ConversationDeletionLocallyStatus.SUCCEEDED -> onSuccess()
 
                         ConversationDeletionLocallyStatus.FAILED ->
-                            onFailure(UIText.StringResource(R.string.delete_group_conversation_error))
+                            onFailure(UIText.StringResource(R.string.delete_conversation_conversation_error))
 
                         ConversationDeletionLocallyStatus.RUNNING,
                         ConversationDeletionLocallyStatus.IDLE -> {
@@ -471,9 +471,9 @@ class GroupConversationDetailsViewModel @Inject constructor(
         )
 
         if (clearContentResult is ClearConversationContentUseCase.Result.Failure) {
-            onMessage(UIText.StringResource(R.string.group_content_delete_failure))
+            onMessage(UIText.StringResource(R.string.conversation_content_delete_failure))
         } else {
-            onMessage(UIText.StringResource(R.string.group_content_deleted))
+            onMessage(UIText.StringResource(R.string.conversation_content_deleted))
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/menu/DeleteConversationGroupDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/menu/DeleteConversationGroupDialog.kt
@@ -37,8 +37,8 @@ internal fun DeleteConversationGroupDialog(
 ) {
     VisibilityState(dialogState) {
         WireDialog(
-            title = stringResource(id = R.string.delete_group_conversation_dialog_title, it.conversationName),
-            text = stringResource(id = R.string.delete_group_conversation_dialog_description),
+            title = stringResource(id = R.string.delete_conversation_conversation_dialog_title, it.conversationName),
+            text = stringResource(id = R.string.delete_conversation_conversation_dialog_description),
             buttonsHorizontalAlignment = true,
             onDismiss = dialogState::dismiss,
             dismissButtonProperties = WireDialogButtonProperties(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/menu/DeleteConversationGroupLocallyDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/menu/DeleteConversationGroupLocallyDialog.kt
@@ -36,8 +36,8 @@ internal fun DeleteConversationGroupLocallyDialog(
 ) {
     VisibilityState(dialogState) {
         WireDialog(
-            title = stringResource(id = R.string.delete_group_locally_conversation_dialog_title, it.conversationName),
-            text = stringResource(id = R.string.delete_group_locally_conversation_dialog_description),
+            title = stringResource(id = R.string.delete_conversation_locally_conversation_dialog_title, it.conversationName),
+            text = stringResource(id = R.string.delete_conversation_locally_conversation_dialog_description),
             buttonsHorizontalAlignment = true,
             onDismiss = dialogState::dismiss,
             dismissButtonProperties = WireDialogButtonProperties(
@@ -47,7 +47,7 @@ internal fun DeleteConversationGroupLocallyDialog(
             ),
             optionButton1Properties = WireDialogButtonProperties(
                 onClick = { onDeleteGroupLocally(it) },
-                text = stringResource(id = R.string.delete_group_locally_delete_for_me_label),
+                text = stringResource(id = R.string.delete_conversation_locally_delete_for_me_label),
                 type = WireDialogButtonType.Primary,
                 state = if (isLoading) {
                     WireButtonState.Disabled

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/menu/LeaveConversationGroupDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/menu/LeaveConversationGroupDialog.kt
@@ -42,8 +42,8 @@ internal fun LeaveConversationGroupDialog(
 ) {
     VisibilityState(dialogState) { state ->
         WireDialog(
-            title = stringResource(id = R.string.leave_group_conversation_dialog_title, state.conversationName),
-            text = stringResource(id = R.string.leave_group_conversation_dialog_description),
+            title = stringResource(id = R.string.leave_conversation_dialog_title, state.conversationName),
+            text = stringResource(id = R.string.leave_conversation_dialog_description),
             buttonsHorizontalAlignment = true,
             onDismiss = dialogState::dismiss,
             dismissButtonProperties = WireDialogButtonProperties(
@@ -64,7 +64,7 @@ internal fun LeaveConversationGroupDialog(
             )
         ) {
             WireLabelledCheckbox(
-                label = stringResource(R.string.leave_group_conversation_dialog_delete_fully_check),
+                label = stringResource(R.string.leave_conversation_dialog_delete_fully_check),
                 checked = state.shouldDelete,
                 onCheckClicked = remember { { dialogState.show(state.copy(shouldDelete = it)) } },
                 horizontalArrangement = Arrangement.Center,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationAllParticipantsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationAllParticipantsScreen.kt
@@ -84,7 +84,7 @@ private fun GroupConversationAllParticipantsContent(
         topBar = {
             WireCenterAlignedTopAppBar(
                 elevation = lazyListState.rememberTopBarElevationState().value,
-                title = stringResource(R.string.conversation_details_group_participants_title),
+                title = stringResource(R.string.conversation_details_participants_title),
                 navigationIconType = NavigationIconType.Back(),
                 onNavigationPressed = onBackPressed
             ) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
@@ -34,12 +34,12 @@ fun LazyListScope.participantsFoldersWithElements(
     onRowItemClicked: (UIParticipant) -> Unit
 ) {
     folderWithElements(
-        header = context.getString(R.string.conversation_details_group_admins, state.data.allAdminsCount),
+        header = context.getString(R.string.conversation_details_conversation_admins, state.data.allAdminsCount),
         items = state.data.admins,
         onRowItemClicked = onRowItemClicked
     )
     folderWithElements(
-        header = context.getString(R.string.conversation_details_group_members, state.data.allParticipantsCount),
+        header = context.getString(R.string.conversation_details_conversation_members, state.data.allParticipantsCount),
         items = state.data.participants,
         onRowItemClicked = onRowItemClicked
     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchUsersAndServicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchUsersAndServicesScreen.kt
@@ -124,7 +124,7 @@ fun SearchUsersAndServicesScreen(
                                 NavigationIconType.Close(R.string.content_description_new_conversation_close_btn)
 
                             SearchPeopleScreenType.NEW_GROUP_CONVERSATION ->
-                                NavigationIconType.Back(R.string.content_description_new_group_conversation_back_btn)
+                                NavigationIconType.Back(R.string.content_description_new_conversation_back_btn)
                         },
                         onNavigationPressed = onClose
                     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
@@ -47,9 +47,9 @@ fun CreateGroupErrorDialog(
         ) to null
 
         is CreateGroupState.Error.ConflictedBackends -> DialogErrorStrings(
-            title = stringResource(id = R.string.group_can_not_be_created_title),
+            title = stringResource(id = R.string.conversation_can_not_be_created_title),
             message = stringResource(
-                    id = R.string.group_can_not_be_created_federation_conflict_description,
+                    id = R.string.conversation_can_not_be_created_federation_conflict_description,
                     error.domains.dropLast(1).joinToString(", "),
                     error.domains.last()
                 ),
@@ -69,7 +69,7 @@ fun CreateGroupErrorDialog(
             onClick = if (error.isConflictedBackends) onAccept else onDismiss,
             text = stringResource(
                 id = if (error.isConflictedBackends) {
-                    R.string.group_can_not_be_created_edit_participiant_list
+                    R.string.conversation_can_not_be_created_edit_participant_list
                 } else {
                     R.string.label_ok
                 }
@@ -79,7 +79,7 @@ fun CreateGroupErrorDialog(
         optionButton2Properties = if (error.isConflictedBackends) {
             WireDialogButtonProperties(
                 onClick = onCancel,
-                text = stringResource(R.string.group_can_not_be_created_discard_group_creation),
+                text = stringResource(R.string.conversation_can_not_be_created_discard_creation),
                 type = WireDialogButtonType.Secondary,
             )
         } else {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroup.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroup.kt
@@ -67,7 +67,7 @@ fun OtherUserProfileGroup(
         item(key = "user_group_name") {
             UserGroupDetailsInformation(
                 title = context.resources.stringWithStyledArgs(
-                    R.string.user_profile_group_member,
+                    R.string.user_profile_conversation_member,
                     MaterialTheme.wireTypography.body01,
                     MaterialTheme.wireTypography.body02,
                     MaterialTheme.wireColorScheme.onBackground,
@@ -89,7 +89,7 @@ fun OtherUserProfileGroup(
         }
         item(key = "user_group_role") {
             UserRoleInformation(
-                label = stringResource(id = R.string.user_profile_group_role),
+                label = stringResource(id = R.string.user_profile_conversation_role),
                 value = AnnotatedString(state.groupState!!.role.name.asString()),
                 isSelfAdmin = state.groupState.isSelfAdmin,
                 openChangeRoleBottomSheet = openChangeRoleBottomSheet,
@@ -116,7 +116,7 @@ private fun UserGroupDetailsInformation(
             Spacer(modifier = Modifier.height(dimensions().spacing16x))
             if (isSelfAdmin) {
                 WireButton(
-                    text = stringResource(id = R.string.user_profile_group_remove_button),
+                    text = stringResource(id = R.string.user_profile_conversation_remove_button),
                     minSize = MaterialTheme.wireDimensions.buttonSmallMinSize,
                     minClickableSize = MaterialTheme.wireDimensions.buttonMinClickableSize,
                     fillMaxWidth = false,
@@ -174,8 +174,8 @@ fun EditButton(onEditClicked: () -> Unit, modifier: Modifier = Modifier) {
 
 val Member.Role.name
     get() = when (this) {
-        Member.Role.Admin -> UIText.StringResource(R.string.group_role_admin)
-        Member.Role.Member -> UIText.StringResource(R.string.group_role_member)
+        Member.Role.Admin -> UIText.StringResource(R.string.conversation_role_admin)
+        Member.Role.Member -> UIText.StringResource(R.string.conversation_role_member)
         is Member.Role.Unknown -> UIText.DynamicString(name)
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -653,7 +653,7 @@ fun ContentFooter(
 }
 
 enum class OtherUserProfileTabItem(@StringRes val titleResId: Int) : TabItem {
-    GROUP(R.string.user_profile_group_tab),
+    GROUP(R.string.user_profile_conversation_tab),
     DETAILS(R.string.user_profile_details_tab),
     DEVICES(R.string.user_profile_devices_tab);
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/bottomsheet/EditGroupRoleBottomSheet.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/bottomsheet/EditGroupRoleBottomSheet.kt
@@ -39,7 +39,7 @@ fun EditGroupRoleBottomSheet(
     closeChangeRoleBottomSheet: () -> Unit
 ) {
     WireMenuModalSheetContent(
-        header = MenuModalSheetHeader.Visible(title = stringResource(R.string.user_profile_role_in_group, groupState.groupName)),
+        header = MenuModalSheetHeader.Visible(title = stringResource(R.string.user_profile_role_in_conversation, groupState.groupName)),
         menuItems = listOf(
             { EditGroupRoleItem(Member.Role.Admin, groupState.role, changeMemberRole, closeChangeRoleBottomSheet) },
             { EditGroupRoleItem(Member.Role.Member, groupState.role, changeMemberRole, closeChangeRoleBottomSheet) }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -61,7 +61,6 @@
     <string name="content_description_unarchive">إزالة من الأرشيف</string>
     <string name="content_description_block_the_user">حظر</string>
     <string name="content_description_unblock_the_user">إلغاء حظر</string>
-    <string name="content_description_leave_the_group">غادر المجموعة</string>
     <string name="content_description_conversation_phone_icon">بدء مكالمة صوتية</string>
     <string name="content_description_empty"></string>
     <!-- Non translatable strings-->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -97,14 +97,11 @@
     <string name="content_description_unarchive">Reaktivieren</string>
     <string name="content_description_block_the_user">Blockieren</string>
     <string name="content_description_unblock_the_user">Freigeben</string>
-    <string name="content_description_leave_the_group">Gruppe verlassen</string>
-    <string name="content_description_delete_the_group">Gruppe löschen</string>
     <string name="content_description_conversation_phone_icon">Audioanruf starten</string>
     <string name="content_description_welcome_wire_logo">Wire</string>
     <string name="content_description_conversation_mention_someone">Jemanden erwähnen</string>
     <string name="content_description_conversation_back_btn">Zurück zur Unterhaltungsliste</string>
     <string name="content_description_conversation_open_details_label">Unterhaltungsdetails öffnen</string>
-    <string name="content_description_new_conversation">Nach Personen suchen oder eine neue Gruppe erstellen</string>
     <string name="content_description_send_button">Senden</string>
     <string name="content_description_timed_message_button">Selbstlöschende Nachrichten, Taste</string>
     <string name="content_description_menu_button">Hauptnavigation</string>
@@ -181,7 +178,7 @@
     <string name="content_description_close_dropdown">Dropdown schließen</string>
     <string name="content_description_open_notification_settings_label">Benachrichtigungseinstellungen öffnen</string>
     <string name="content_description_new_conversation_close_btn">Ansicht neue Unterhaltung schließen</string>
-    <string name="content_description_new_group_conversation_back_btn">Zurück zur Ansicht neue Unterhaltung</string>
+    <string name="content_description_new_conversation_back_btn">Zurück zur Ansicht neue Unterhaltung</string>
     <string name="content_description_new_conversation_name_back_btn">Zurück zur Ansicht neue Unterhaltung</string>
     <string name="content_description_new_group_name_field">Gruppen-Name eingeben</string>
     <string name="content_description_new_channel_name_field">Gruppen-Name eingeben</string>
@@ -439,7 +436,7 @@
     <string name="new_group_description">Bis zu 500 Personen können an einer Gruppenunterhaltung teilnehmen.</string>
     <string name="group_name_title">Gruppenname</string>
     <string name="channel_name_title">Channel-Name</string>
-    <string name="group_name_placeholder">Namen eingeben</string>
+    <string name="conversation_name_placeholder">Namen eingeben</string>
     <string name="group_name_description">Geben Sie dieser Gruppe einen aussagekräftigen Namen.</string>
     <string name="channel_name_description">Geben Sie diesem Channel einen aussagekräftigen Namen.</string>
     <string name="protocol">Protokoll</string>
@@ -451,10 +448,7 @@
     <string name="empty_channel_name_error">Bitte geben Sie einen Channel-Namen ein</string>
     <string name="regular_group_name_exceeded_limit_error">Gruppenname darf 64 Zeichen nicht überschreiten</string>
     <string name="channel_name_exceeded_limit_error">Channel-Name darf 64 Zeichen nicht überschreiten</string>
-    <string name="group_can_not_be_created_title">Gruppe kann nicht erstellt werden</string>
-    <string name="group_can_not_be_created_federation_conflict_description">Personen der Backends %1$s und %2$s können nicht derselben Gruppenunterhaltung beitreten.\n\nUm die Gruppe zu erstellen, entfernen Sie die betroffenen Teilnehmer.</string>
-    <string name="group_can_not_be_created_edit_participiant_list">Teilnehmerliste bearbeiten</string>
-    <string name="group_can_not_be_created_discard_group_creation">Gruppenerstellung verwerfen</string>
+    <string name="conversation_can_not_be_created_edit_participant_list">Teilnehmerliste bearbeiten</string>
     <string name="asset_message_tap_to_download_text">Zum Herunterladen tippen</string>
     <string name="asset_message_upload_in_progress_text">Hochladen…</string>
     <string name="asset_message_download_in_progress_text">Herunterladen…</string>
@@ -473,23 +467,16 @@
     <string name="label_add_participants">Teilnehmer hinzufügen</string>
     <string name="username_unavailable_label">Name nicht verfügbar</string>
     <string name="temporary_user_label">%s hat die Unterhaltung verlassen</string>
-    <string name="group_unavailable_label">Gruppenname nicht verfügbar</string>
     <string name="conversation_details_title">Unterhaltungsdetails</string>
     <string name="conversation_details_options_tab">OPTIONEN</string>
     <string name="conversation_details_participants_tab">TEILNEHMER</string>
     <string name="conversation_details_options_group_name">GRUPPENNAME</string>
-    <string name="conversation_details_group_admins">GRUPPEN-ADMINS (%d)</string>
-    <string name="conversation_details_group_members">GRUPPEN-MITGLIEDER (%d)</string>
-    <string name="conversation_details_participants_info">Diese Gruppe hat %s Teilnehmer.\nBis zu 500 Personen können an einer Gruppenunterhaltung teilnehmen.</string>
     <string name="conversation_details_participants_count">%s Teilnehmer</string>
     <string name="conversation_details_show_all_participants">Alle Teilnehmer anzeigen (%d)</string>
-    <string name="conversation_details_group_participants_title">Teilnehmer</string>
-    <string name="conversation_details_group_participants_add">Teilnehmer hinzufügen</string>
     <string name="conversation_participant_you_label">(Sie)</string>
     <string name="conversation_details_is_classified">SICHERHEITSNIVEAU: VS-NfD</string>
     <string name="conversation_details_is_not_classified">SICHERHEITSNIVEAU: NICHT EINGESTUFT</string>
     <string name="conversation_options_self_deleting_messages_label">Selbstlöschende Nachrichten</string>
-    <string name="conversation_options_self_deleting_messages_description">Wenn diese Option aktiviert ist, verschwinden alle Nachrichten in dieser Gruppe nach einer bestimmten Zeit.</string>
     <string name="conversation_options_guests_label">Gäste</string>
     <string name="conversation_details_guest_description">Wenn diese Option aktiviert ist, können Personen außerhalb des Teams an dieser Unterhaltung teilnehmen</string>
     <string name="conversation_options_guest_description">Aktivieren Sie diese Option, um die Unterhaltung für Personen außerhalb Ihres Teams zu öffnen – auch wenn diese Wire nicht nutzen.</string>
@@ -501,15 +488,6 @@
     <string name="disable_guest_dialog_text">Aktuelle Gäste werden aus der Unterhaltung entfernt. Neue Gäste können nicht hinzugefügt werden.</string>
     <string name="disable_services_dialog_title">Zugang zu Diensten deaktivieren?</string>
     <string name="disable_services_dialog_text">Aktuelle Dienste werden aus der Unterhaltung entfernt. Neue Dienste können nicht hinzugefügt werden.</string>
-    <string name="leave_group_conversation_menu_item">Gruppe verlassen…</string>
-    <string name="leave_group_conversation_dialog_title">\"%s\" verlassen?</string>
-    <string name="leave_group_conversation_dialog_description">Sie können dann auf keinem Gerät mehr Nachrichten in dieser Gruppe senden oder lesen.</string>
-    <string name="delete_group_conversation_menu_item">Gruppe löschen…</string>
-    <string name="delete_group_conversation_dialog_title">\"%s\" entfernen?</string>
-    <string name="delete_group_conversation_dialog_description">Die Gruppe wird auf allen Geräten aus der Liste Ihrer Unterhaltungen entfernt. Sie können dann nicht mehr auf die Gruppe und ihren Inhalt zugreifen.</string>
-    <string name="delete_group_locally_conversation_dialog_title">Gruppe \"%s\" für mich löschen?</string>
-    <string name="delete_group_locally_conversation_dialog_description">Sie können dann nicht mehr auf die Gruppe und ihren Inhalt zugreifen. Es gibt keine Möglichkeit, sie wiederherzustellen.</string>
-    <string name="delete_group_locally_delete_for_me_label">Für mich löschen</string>
     <!-- Import/Export External Media -->
     <string name="import_media_content_title">Mit Wire teilen</string>
     <string name="import_media_searchbar_title">Nach Unterhaltung suchen</string>
@@ -556,13 +534,9 @@
     <string name="user_profile_account_management">Team verwalten</string>
     <string name="user_profile_details_tab">Details</string>
     <string name="user_profile_devices_tab">Geräte</string>
-    <string name="user_profile_group_tab">Gruppe</string>
-    <string name="user_profile_group_member">Mitglied der Gruppe ”%s”</string>
-    <string name="user_profile_group_role">ROLLE</string>
-    <string name="user_profile_role_in_group">Benutzerrolle in ”%s”</string>
+    <string name="user_profile_role_in_conversation">Benutzerrolle in ”%s”</string>
     <string name="user_profile_role_change_error">Beim Ändern der Rolle ist ein Fehler aufgetreten. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut</string>
     <string name="user_profile_unblock_user">Benutzer freigeben</string>
-    <string name="user_profile_group_remove_button">Aus Gruppe entfernen</string>
     <string name="user_profile_logging_out_progress">Abmelden...</string>
     <string name="user_profile_qr_code">QR-Code öffnen</string>
     <string name="user_profile_qr_code_title">Profil teilen</string>
@@ -575,9 +549,8 @@
     <!-- Remove Conversation Member Dialog -->
     <string name="dialog_remove_conversation_member_title">Aus Gruppe entfernen?</string>
     <string name="dialog_remove_conversation_member_description">%1$s (@%2$s) wird in dieser Unterhaltung keine Nachrichten senden oder empfangen können.</string>
-    <string name="dialog_remove_conversation_member_error">Beim Entfernen des Teilnehmers aus der Gruppe ist ein Fehler aufgetreten</string>
-    <string name="group_role_admin">Admin</string>
-    <string name="group_role_member">Mitglied</string>
+    <string name="conversation_role_admin">Admin</string>
+    <string name="conversation_role_member">Mitglied</string>
     <!-- Logout Wipe Data Dialog -->
     <string name="dialog_logout_wipe_data_title">Daten löschen?</string>
     <string name="dialog_logout_wipe_data_checkbox">Ihre persönlichen Daten und Unterhaltungen vollständig von diesem Gerät entfernen</string>
@@ -604,9 +577,6 @@
     <string name="label_clear_content">Verlauf löschen…</string>
     <string name="label_block">Blockieren</string>
     <string name="label_unblock">Freigeben</string>
-    <string name="label_leave_group">Gruppe verlassen</string>
-    <string name="label_delete_group_locally">Gruppe für mich löschen</string>
-    <string name="label_delete_group">Gruppe löschen</string>
     <!-- Conversation filter BottomSheet -->
     <string name="label_filter_conversations">Unterhaltungen filtern</string>
     <string name="label_filter_favorites">Favoriten</string>
@@ -696,14 +666,10 @@
     <string name="label_system_message_conversation_started_by_self">**Sie** haben die Unterhaltung begonnen</string>
     <string name="label_system_message_conversation_started_by_other">%1$s hat die Unterhaltung begonnen</string>
     <string name="label_system_message_conversation_started_with_members">Mit %1$s</string>
-    <string name="label_system_message_conversation_failed_add_members_summary">%1$s **Teilnehmer** konnten der Gruppe nicht hinzugefügt werden.</string>
-    <string name="label_system_message_conversation_failed_add_many_members_details">%1$s konnten der Gruppe nicht hinzugefügt werden.</string>
-    <string name="label_system_message_conversation_failed_add_one_member_details">%1$s konnte der Gruppe nicht hinzugefügt werden.</string>
     <string name="label_system_message_conversation_degraded_mls">Diese Unterhaltung ist nicht mehr überprüft, da mindestens ein Teilnehmer ein neues Gerät verwendet oder ein ungültiges Zertifikat hat.</string>
     <string name="label_system_message_conversation_degraded_proteus">Diese Unterhaltung ist nicht mehr überprüft, da mindestens ein Teilnehmer ein neues Gerät verwendet oder ein ungültiges Zertifikat hat.</string>
     <string name="label_system_message_conversation_verified_mls">Alle Geräte sind überprüft (Ende-zu-Ende-Identität)</string>
     <string name="label_system_message_conversation_verified_proteus">Alle Fingerabdrücke sind überprüft (Proteus)</string>
-    <string name="label_system_message_conversation_started_sensitive_information">Kommunikation in Wire ist immer Ende-zu-Ende verschlüsselt. Alles, was Sie in dieser Unterhaltung senden und empfangen, ist nur für Sie und andere Gruppenteilnehmer zugänglich.\n**Bitte seien Sie dennoch vorsichtig, mit wem Sie vertrauliche Informationen teilen.**</string>
     <string name="label_conversations_details_verified_proteus">Überprüft (Proteus)</string>
     <string name="label_conversations_details_verified_mls">Überprüft (Ende-zu-Ende-Identität)</string>
     <!-- Last messages -->
@@ -785,7 +751,7 @@
         <item quantity="other">%1$d Nachrichten</item>
     </plurals>
     <string name="ephemeral_one_to_one_event_message">"Hat eine Nachricht gesendet"</string>
-    <string name="ephemeral_group_event_message">"Jemand hat eine Nachricht gesendet"</string>
+    <string name="ephemeral_group_channel_event_message">"Jemand hat eine Nachricht gesendet"</string>
     <!--Typing Indicator-->
     <plurals name="typing_indicator_event_message">
         <item quantity="one">%s schreibt</item>
@@ -843,13 +809,13 @@
     <string name="conversation_on_file_downloaded">Die Datei %s wurde im Download-Ordner gespeichert</string>
     <string name="error_blocking_user">Benutzer konnte nicht blockiert werden</string>
     <string name="blocking_user_success">%s blockiert</string>
-    <string name="conversation_group_removed_success">“%s” entfernt</string>
-    <string name="conversation_group_removed_locally_success">“%s” für mich gelöscht</string>
-    <string name="leave_group_conversation_error">Beim Verlassen der Unterhaltung ist ein Fehler aufgetreten</string>
-    <string name="joined_conversation_group_success">Sie sind der Unterhaltung beigetreten.</string>
-    <string name="left_conversation_group_success">Sie haben die Unterhaltung verlassen.</string>
+    <string name="conversation_removed_success">“%s” entfernt</string>
+    <string name="conversation_removed_locally_success">“%s” für mich gelöscht</string>
+    <string name="leave_conversation_error">Beim Verlassen der Unterhaltung ist ein Fehler aufgetreten</string>
+    <string name="joined_conversation_success">Sie sind der Unterhaltung beigetreten.</string>
+    <string name="left_conversation_success">Sie haben die Unterhaltung verlassen.</string>
     <string name="error_unblocking_user">Benutzer konnte nicht freigegeben werden</string>
-    <string name="delete_group_conversation_error">Beim Löschen der Unterhaltung ist ein Fehler aufgetreten</string>
+    <string name="delete_conversation_conversation_error">Beim Löschen der Unterhaltung ist ein Fehler aufgetreten</string>
     <string name="error_limit_number_assets_imported_exceeded">Sie können nur bis zu 20 Dateien gleichzeitig senden</string>
     <!-- Archiving -->
     <string name="success_archiving_conversation">Unterhaltung wurde archiviert</string>
@@ -879,13 +845,12 @@
     <string name="notification_reply">Antwort: %1$s</string>
     <string name="notification_not_supported_issue">Funktion nicht unterstützt</string>
     <string name="notification_connection_request">Möchte Sie als Kontakt hinzufügen</string>
-    <string name="notification_conversation_deleted">Hat die Gruppe gelöscht</string>
     <string name="notification_action_reply">Antworten</string>
     <string name="notification_receiver_name">Sie</string>
     <string name="label_type_a_message">Eine Nachricht schreiben</string>
     <string name="notification_incoming_call_content">Ruft an…</string>
     <string name="notification_ongoing_call_content">Aktiver Anruf…</string>
-    <string name="notification_group_call_content">%s ruft an...</string>
+    <string name="notification_group_channel_call_content">%s ruft an...</string>
     <string name="notification_call_default_caller_name">Jemand</string>
     <string name="notification_call_default_group_name">Eingehender Gruppenanruf</string>
     <string name="notification_audio_message_body">Audionachricht</string>
@@ -973,7 +938,7 @@
         Admin und geben diesen Code an: \n%d
     </string>
     <string name="asset_download_dialog_default_title">Datei herunterladen</string>
-    <string name="empty_group_label">Unterhaltung ohne Namen</string>
+    <string name="empty_conversation_label">Unterhaltung ohne Namen</string>
     <string name="label_show_more">Mehr anzeigen</string>
     <!--prohibited asset messages -->
     <string name="prohibited_images_message">Empfang von Bildern ist verboten</string>
@@ -993,19 +958,12 @@
     <string name="allow_services_regular_group_description">Öffnen Sie diese Unterhaltung für Dienste. Diese Einstellung kann später jederzeit geändert werden.</string>
     <string name="allow_services_channel_description">Öffnen Sie diese Unterhaltung für Personen außerhalb Ihres Teams oder für Dienste. Diese Einstellung kann später jederzeit geändert werden.</string>
     <string name="service_details_label">Dienst</string>
-    <string name="service_details_add_service_label">Zur Gruppe hinzufügen</string>
-    <string name="service_details_remove_service_label">Aus Gruppe entfernen</string>
-    <string name="service_remove_success">Dienst aus Gruppe entfernt</string>
-    <string name="service_remove_error">Dienst kann nicht aus Gruppe entfernt werden</string>
-    <string name="service_add_success">Dienst zur Gruppe hinzugefügt</string>
-    <string name="service_add_error">Dienst kann nicht zur Gruppe hinzugefügt werden</string>
     <string name="service_no_information_available_title">Keine Informationen verfügbar</string>
     <string name="service_no_information_available_subtitle">Versuchen Sie es erneut oder wenden Sie sich an Ihren Team-Admin</string>
     <string name="read_receipts">Lesebestätigungen</string>
     <string name="read_receipts_regular_group_description">Wenn diese Option aktiviert ist, können Sender sehen, wenn ihre Nachrichten gelesen werden.</string>
     <string name="read_receipts_channel_description">Wenn diese Option aktiviert ist, können Sender sehen, wenn ihre Nachrichten in diesem Channel gelesen werden.</string>
     <string name="disable_guests_dialog_title">Gäste nicht zulassen?</string>
-    <string name="disable_guests_dialog_description">Gäste, die Sie im vorherigen Schritt ausgewählt haben, sind nicht Teil der Gruppe, wenn Sie den Gastzugang nicht erlauben.</string>
     <string name="disable_guests_dialog_button">Keine Gäste zulassen</string>
     <!--block user dialog -->
     <string name="block_user_dialog_title">Benutzer blockieren?</string>
@@ -1189,9 +1147,7 @@ Bei Gruppenunterhaltungen kann der Gruppen-Admin diese Einstellung überschreibe
     <string name="backup_dialog_restore_wrong_user_error_message">Der Gesprächsverlauf eines anderen Kontos kann nicht wiederhergestellt werden.</string>
     <string name="backup_dialog_restore_general_error_title">Es ist ein Fehler aufgetreten</string>
     <string name="backup_dialog_restore_general_error_message">Ihr Gesprächsverlauf konnte nicht wiederhergestellt werden. Bitte versuchen Sie es erneut oder kontaktieren Sie Wire Support.</string>
-    <string name="group_content_deleted">Gesprächsverlauf gelöscht</string>
     <string name="conversation_content_deleted">Gesprächsverlauf gelöscht</string>
-    <string name="group_content_delete_failure">Gesprächsverlauf konnte nicht gelöscht werden</string>
     <string name="conversation_content_delete_failure">Gesprächsverlauf konnte nicht gelöscht werden</string>
     <string name="group_label">Gruppe</string>
     <string name="conversation_label">Unterhaltung</string>
@@ -1232,13 +1188,10 @@ Bei Gruppenunterhaltungen kann der Gruppen-Admin diese Einstellung überschreibe
     <string name="join_conversation_dialog_message">Sie wurden zu dieser Unterhaltung eingeladen.\n\n%1$s</string>
     <string name="join_conversation_dialog_button">Beitreten</string>
     <string name="join_conversation_via_deeplink_error_title">Sie konnten der Unterhaltung nicht beitreten</string>
-    <string name="join_conversation_via_deeplink_error_link_expired">Der Link zu dieser Gruppenunterhaltung ist abgelaufen oder nicht mehr gültig.</string>
     <string name="join_conversation_via_deeplink_error_max_number_of_participent">Die maximale Teilnehmeranzahl in dieser Unterhaltung wurde erreicht.</string>
-    <string name="join_conversation_via_deeplink_error_general">Aufgrund eines Fehlers konnten Sie nicht zur Gruppenunterhaltung hinzugefügt werden.</string>
     <!-- edit self-deleting messages -->
     <string name="self_deleting_messages_title">Selbstlöschende Nachrichten</string>
     <string name="self_deleting_messages_option">Löschen von Nachrichten erzwingen</string>
-    <string name="self_deleting_messages_option_description">Wenn diese Option aktiviert ist, verschwinden alle Nachrichten in dieser Gruppe nach einer bestimmten Zeit. Dies gilt für alle Teilnehmer der Gruppe.</string>
     <string name="self_deleting_messages_folder_timer">Timer</string>
     <!-- visit link -->
     <string name="label_visit_link_title">Link öffnen</string>
@@ -1265,8 +1218,6 @@ Bei Gruppenunterhaltungen kann der Gruppen-Admin diese Einstellung überschreibe
     <string name="title_device_key_fingerprint">SCHLÜSSEL-FINGERABDRUCK</string>
     <string name="label_client_key_fingerprint_not_available">NICHT VERFÜGBAR</string>
     <string name="guest_room_link_copied">Link in Zwischenablage kopiert</string>
-    <string name="guest_room_link_enabled">Erstellen von Gäste-Links ist nun für alle Gruppen-Admins aktiviert</string>
-    <string name="guest_room_link_disabled">Erstellen von Gäste-Links ist nun für alle Gruppen-Admins deaktiviert</string>
     <!-- New Device dialog -->
     <string name="new_device_dialog_current_user_title">Ihr Benutzerkonto wurde verwendet</string>
     <string name="new_device_dialog_message_defice_info">%1$s\nVon: %2$s \n</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -91,8 +91,6 @@
     <string name="content_description_move_to_archive">Mover a archivo</string>
     <string name="content_description_block_the_user">Bloquear</string>
     <string name="content_description_unblock_the_user">Desbloquear</string>
-    <string name="content_description_leave_the_group">Abandonar el grupo</string>
-    <string name="content_description_delete_the_group">Eliminar el grupo</string>
     <string name="content_description_conversation_phone_icon">Iniciar una llamada</string>
     <string name="content_description_welcome_wire_logo">Logo de Wire</string>
     <string name="content_description_conversation_enable_rich_text_mode">Bot&#243;n de modo de texto enriquecido</string>
@@ -332,7 +330,7 @@ Un mensaje eliminado no puede ser restaurado.</string>
     <string name="new_group_title">Nuevo Grupo</string>
     <string name="new_group_description">Hasta 500 personas pueden unirse a una conversaci&#243;n grupal.</string>
     <string name="group_name_title">Nombre del grupo</string>
-    <string name="group_name_placeholder">Introduce un nombre</string>
+    <string name="conversation_name_placeholder">Introduce un nombre</string>
     <string name="group_name_description">Asigna un nombre significativo a este grupo.</string>
     <string name="protocol">Protocolo</string>
     <string name="cipher_suite">Suite de Cifrado</string>
@@ -354,18 +352,13 @@ Un mensaje eliminado no puede ser restaurado.</string>
     <string name="conversation_details_options_tab">OPCIONES</string>
     <string name="conversation_details_participants_tab">PARTICIPANTES</string>
     <string name="conversation_details_options_group_name">NOMBRE DEL GRUPO</string>
-    <string name="conversation_details_group_admins">ADMIINS DEL GRUPO (%d)</string>
-    <string name="conversation_details_group_members">MIEMBROS DEL GRUPO (%d)</string>
     <string name="conversation_details_participants_info">Este grupo tiene %s participantes.
 Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="conversation_details_show_all_participants">Mostrar todos los participantes (%d)</string>
-    <string name="conversation_details_group_participants_title">Participantes del grupo</string>
-    <string name="conversation_details_group_participants_add">A&#241;adir participantes</string>
     <string name="conversation_participant_you_label">(Tú)</string>
     <string name="conversation_details_is_classified">NIVEL DE SEGURIDAD: VS-NfD</string>
     <string name="conversation_details_is_not_classified">NIVEL DE SEGURIDAD: NO CLASIFICADO</string>
     <string name="conversation_options_self_deleting_messages_label">Mensajes con auto-borrado</string>
-    <string name="conversation_options_self_deleting_messages_description">Cuando esté activado, todos los mensajes de este grupo desaparecerán después de un cierto tiempo.</string>
     <string name="conversation_options_guests_label">Invitados</string>
     <string name="conversation_details_guest_description">Cuando est&#225; activo, personas fuera de su equipo pueden unirse a esta conversaci&#243;n.</string>
     <string name="conversation_options_guest_description">Active esta opci&#243;n para abrir esta conversaci&#243;n a personas fuera de su equipo, incluso si no tienen Wire.</string>
@@ -377,12 +370,6 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="disable_guest_dialog_text">Los invitados actuales ser&#225;n eliminados de la conversaci&#243;n. No se permitir&#225;n nuevos invitados.</string>
     <string name="disable_services_dialog_title">&#191;Desea desactivar el acceso a servicios?</string>
     <string name="disable_services_dialog_text">Los servicios actuales ser&#225;n eliminados de la conversaci&#243;n. No se permitir&#225;n nuevos servicios.</string>
-    <string name="leave_group_conversation_menu_item">Abandonar grupo...</string>
-    <string name="leave_group_conversation_dialog_title">&#191;Abandonar \"%s\"?</string>
-    <string name="leave_group_conversation_dialog_description">Ya no podr&#225; enviar ni leer mensajes en este grupo en ning&#250;n dispositivo.</string>
-    <string name="delete_group_conversation_menu_item">Eliminar grupo...</string>
-    <string name="delete_group_conversation_dialog_title">Eliminar \"%s\"?</string>
-    <string name="delete_group_conversation_dialog_description">El grupo ser&#225; eliminado de su lista de conversaciones en todos los dispositivos. Ya no podr&#225; acceder al grupo y su contenido.</string>
     <!-- Import/Export External Media -->
     <string name="import_media_content_title">Compartir con Wire</string>
     <string name="import_media_searchbar_title">Buscar conversaci&#243;n</string>
@@ -418,20 +405,15 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="user_profile_status_none">Ninguno</string>
     <string name="user_profile_details_tab">Detalles</string>
     <string name="user_profile_devices_tab">Dispositivos</string>
-    <string name="user_profile_group_tab">Grupo</string>
-    <string name="user_profile_group_member">Miembro del grupo &#8221;%s&#8221;</string>
-    <string name="user_profile_group_role">ROL</string>
-    <string name="user_profile_role_in_group">Rol en &#8221;%s&#8221;</string>
+    <string name="user_profile_role_in_conversation">Rol en &#8221;%s&#8221;</string>
     <string name="user_profile_role_change_error">Ocurri&#243; un error al intentar cambiar el rol. Por favor, verifica tu conexi&#243;n a internet e intenta de nuevo.</string>
     <string name="user_profile_unblock_user">Desbloquear usuario</string>
-    <string name="user_profile_group_remove_button">Eliminar del grupo</string>
     <string name="user_profile_logging_out_progress">Cerrando sesión...</string>
     <!-- Remove Conversation Member Dialog -->
     <string name="dialog_remove_conversation_member_title">&#191;Eliminar del grupo?</string>
     <string name="dialog_remove_conversation_member_description">%1$s (@%2$s) no podr&#225; enviar ni recibir mensajes en esta conversaci&#243;n.</string>
-    <string name="dialog_remove_conversation_member_error">Ocurri&#243; un error al eliminar al participante del grupo.</string>
-    <string name="group_role_admin">Administrador</string>
-    <string name="group_role_member">Miembro</string>
+    <string name="conversation_role_admin">Administrador</string>
+    <string name="conversation_role_member">Miembro</string>
     <!-- Logout Wipe Data Dialog -->
     <string name="dialog_logout_wipe_data_title">&#191;Borrar datos?</string>
     <string name="dialog_logout_wipe_data_checkbox">Eliminar toda tu informaci&#243;n personal y conversaciones en este dispositivo.</string>
@@ -452,8 +434,6 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="label_clear_content">Borrar contenido...</string>
     <string name="label_block">Bloquear</string>
     <string name="label_unblock">Desbloquear</string>
-    <string name="label_leave_group">Dejar conversaci&#243;n en grupo</string>
-    <string name="label_delete_group">Eliminar grupo</string>
     <!-- Conversation filter BottomSheet -->
     <!-- Muting options BottomSheet -->
     <string name="muting_option_all_allowed_title">Todo</string>
@@ -520,8 +500,6 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="label_system_message_conversation_history_lost">No has usado este dispositivo por un tiempo. Es posible que algunos mensajes no aparezcan aqu&#237;.</string>
     <string name="label_system_message_receipt_mode_on">encendido</string>
     <string name="label_system_message_receipt_mode_off">apagado</string>
-    <string name="label_system_message_conversation_failed_add_many_members_details">%1$s no pudieron ser añadidos a la conversación.</string>
-    <string name="label_system_message_conversation_failed_add_one_member_details">%1$s no pudo ser añadido a la conversación.</string>
     <!-- Last messages -->
     <plurals name="last_message_self_added_users">
         <item quantity="one">Has añadido a 1 persona a la conversación</item>
@@ -589,7 +567,7 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
         <item quantity="other">%1$d mensajes</item>
     </plurals>
     <string name="ephemeral_one_to_one_event_message">"Envió un mensaje"</string>
-    <string name="ephemeral_group_event_message">"Alguien envió un mensaje"</string>
+    <string name="ephemeral_group_channel_event_message">"Alguien envió un mensaje"</string>
     <!--Typing Indicator-->
     <plurals name="typing_indicator_event_message">
         <item quantity="one">%s está escribiendo</item>
@@ -630,12 +608,12 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="conversation_on_file_downloaded">El archivo %s se guard&#243; correctamente en la carpeta de descargas.</string>
     <string name="error_blocking_user">No se pudo bloquear al usuario.</string>
     <string name="blocking_user_success">%s bloqueado.</string>
-    <string name="conversation_group_removed_success">\"%s\" eliminado.</string>
-    <string name="leave_group_conversation_error">Ocurri&#243; un error al salir de la conversaci&#243;n.</string>
-    <string name="joined_conversation_group_success">Te uniste a la conversaci&#243;n.</string>
-    <string name="left_conversation_group_success">Saliste de la conversaci&#243;n.</string>
+    <string name="conversation_removed_success">\"%s\" eliminado.</string>
+    <string name="leave_conversation_error">Ocurri&#243; un error al salir de la conversaci&#243;n.</string>
+    <string name="joined_conversation_success">Te uniste a la conversaci&#243;n.</string>
+    <string name="left_conversation_success">Saliste de la conversaci&#243;n.</string>
     <string name="error_unblocking_user">No se pudo desbloquear al usuario.</string>
-    <string name="delete_group_conversation_error">Ocurri&#243; un error al eliminar la conversaci&#243;n.</string>
+    <string name="delete_conversation_conversation_error">Ocurri&#243; un error al eliminar la conversaci&#243;n.</string>
     <string name="error_limit_number_assets_imported_exceeded">Solo puedes enviar hasta 20 archivos a la vez.</string>
     <!-- Archiving -->
     <!-- Favorite -->
@@ -653,13 +631,12 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="notification_reply">Responder: %1$s</string>
     <string name="notification_not_supported_issue">Funci&#243;n no compatible.</string>
     <string name="notification_connection_request">Quiere conectarse.</string>
-    <string name="notification_conversation_deleted">Elimin&#243; el grupo.</string>
     <string name="notification_action_reply">Responder</string>
     <string name="notification_receiver_name">T&#250;</string>
     <string name="label_type_a_message">Escribe un mensaje</string>
     <string name="notification_incoming_call_content">Llamando...</string>
     <string name="notification_ongoing_call_content">Llamada en curso...</string>
-    <string name="notification_group_call_content">%s llama...</string>
+    <string name="notification_group_channel_call_content">%s llama...</string>
     <string name="notification_call_default_caller_name">Alguien</string>
     <string name="notification_call_default_group_name">Llamada en grupo entrante</string>
     <!-- Calling-->
@@ -719,7 +696,7 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="sso_error_dialog_message">Por favor, int&#233;ntelo de nuevo. Si esto no ayuda, p&#243;ngase en contacto con su administrador y proporcione este c&#243;digo:
 %d</string>
     <string name="asset_download_dialog_default_title">Descargar archivo</string>
-    <string name="empty_group_label">Conversaci&#243;n sin nombre</string>
+    <string name="empty_conversation_label">Conversaci&#243;n sin nombre</string>
     <string name="label_show_more">Mostrar m&#225;s</string>
     <!--prohibited asset messages -->
     <string name="prohibited_images_message">No se permiten recibir im&#225;genes</string>
@@ -737,17 +714,10 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="allow_guest_switch_description">Abra esta conversaci&#243;n a personas fuera de su equipo. Siempre puede cambiarlo m&#225;s tarde.</string>
     <string name="allow_services">Permitir servicios</string>
     <string name="service_details_label">Servicio</string>
-    <string name="service_details_add_service_label">Añadir al grupo</string>
-    <string name="service_details_remove_service_label">Eliminar del grupo</string>
-    <string name="service_remove_success">Servicio eliminado del grupo</string>
-    <string name="service_remove_error">No se pudo eliminar el servicio del grupo</string>
-    <string name="service_add_success">Servicio añadido al grupo</string>
-    <string name="service_add_error">No se pudo añadir el servicio al grupo</string>
     <string name="service_no_information_available_title">Ninguna información disponible</string>
     <string name="service_no_information_available_subtitle">Inténtalo de nuevo o contacta con el administrador de tu equipo</string>
     <string name="read_receipts">Recibos de lectura</string>
     <string name="disable_guests_dialog_title">&#191;No permitir invitados?</string>
-    <string name="disable_guests_dialog_description">Los invitados que seleccion&#243; en el paso anterior no formar&#225;n parte del grupo si no permite el acceso de invitados.</string>
     <string name="disable_guests_dialog_button">No permitir invitados</string>
     <!--block user dialog -->
     <string name="block_user_dialog_title">&#191;Bloquear usuario?</string>
@@ -846,9 +816,7 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="backup_dialog_restore_wrong_user_error_message">No puedes restaurar un historial desde una cuenta diferente.</string>
     <string name="backup_dialog_restore_general_error_title">Algo sali&#243; mal</string>
     <string name="backup_dialog_restore_general_error_message">No se pudo restaurar tu historial. Por favor, int&#233;ntalo de nuevo o contacta al soporte de Wire.</string>
-    <string name="group_content_deleted">El contenido del grupo fue eliminado</string>
     <string name="conversation_content_deleted">El contenido de la conversaci&#243;n fue eliminado</string>
-    <string name="group_content_delete_failure">No se pudo eliminar el contenido del grupo</string>
     <string name="conversation_content_delete_failure">No se pudo eliminar el contenido de la conversaci&#243;n</string>
     <string name="group_label">grupo</string>
     <string name="conversation_label">conversaci&#243;n</string>
@@ -885,13 +853,10 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
 %1$s</string>
     <string name="join_conversation_dialog_button">Unirse</string>
     <string name="join_conversation_via_deeplink_error_title">No se pudo unirse a la conversaci&#243;n</string>
-    <string name="join_conversation_via_deeplink_error_link_expired">El enlace a esta conversaci&#243;n grupal ha expirado o la conversaci&#243;n se ha configurado como privada.</string>
     <string name="join_conversation_via_deeplink_error_max_number_of_participent">Se ha alcanzado el n&#250;mero m&#225;ximo de participantes en esta conversaci&#243;n.</string>
-    <string name="join_conversation_via_deeplink_error_general">Debido a un error, no se pudo agregar a la conversaci&#243;n grupal.</string>
     <!-- edit self-deleting messages -->
     <string name="self_deleting_messages_title">Mensajes con auto-borrado</string>
     <string name="self_deleting_messages_option">Forzar auto-borrado de mensajes</string>
-    <string name="self_deleting_messages_option_description">Cuando esté activado, todos los mensajes de este grupo desaparecerán después de un cierto tiempo. Esto se aplica a todos los participantes del grupo.</string>
     <string name="self_deleting_messages_folder_timer">Contador</string>
     <!-- visit link -->
     <!-- invalid link -->
@@ -910,8 +875,6 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="title_device_key_fingerprint">HU&#201;LLA DIGITAL DE LA LLAVE DEL DISPOSITIVO</string>
     <string name="label_client_key_fingerprint_not_available">NO DISPONIBLE</string>
     <string name="guest_room_link_copied">Enlace copiado al portapapeles</string>
-    <string name="guest_room_link_enabled">La generación de enlaces de invitado ahora está activada para todos los administradores del grupo</string>
-    <string name="guest_room_link_disabled">La generación de enlaces de invitado ahora está desactivada para todos los administradores del grupo</string>
     <!-- New Device dialog -->
     <string name="new_device_dialog_current_user_title">Su cuenta se utiliz&#243; en</string>
     <string name="new_device_dialog_current_user_btn">Administrar dispositivos</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -73,8 +73,6 @@
     <string name="content_description_move_to_archive">Teisalda arhiivi</string>
     <string name="content_description_block_the_user">Blokeeri</string>
     <string name="content_description_unblock_the_user">Tühista blokeering</string>
-    <string name="content_description_leave_the_group">Lahku grupist</string>
-    <string name="content_description_delete_the_group">Kustuta grupp</string>
     <string name="content_description_conversation_phone_icon">Alusta häälkõnet</string>
     <string name="content_description_send_button">Saada</string>
     <string name="content_description_remove_devices_screen_device_item_icon">Seadme üksus</string>
@@ -280,7 +278,7 @@
     <!-- Search Contact-->
     <!-- Snackbar messages -->
     <string name="blocking_user_success">%s blokeeritud</string>
-    <string name="conversation_group_removed_success">“%s” eemaldatud</string>
+    <string name="conversation_removed_success">“%s” eemaldatud</string>
     <!-- Archiving -->
     <!-- Favorite -->
     <!-- Animation label -->
@@ -296,13 +294,12 @@
     <string name="notification_reply">Vastus: %1$s</string>
     <string name="notification_not_supported_issue">Funktsioon pole toetatud</string>
     <string name="notification_connection_request">Soovib ühenduda</string>
-    <string name="notification_conversation_deleted">Kustutas grupi</string>
     <string name="notification_action_reply">Vasta</string>
     <string name="notification_receiver_name">Sina</string>
     <string name="label_type_a_message">Sisesta sõnum</string>
     <string name="notification_incoming_call_content">Helistab…</string>
     <string name="notification_ongoing_call_content">Käimasolev kõne…</string>
-    <string name="notification_group_call_content">%s helistab...</string>
+    <string name="notification_group_channel_call_content">%s helistab...</string>
     <string name="notification_call_default_caller_name">Keegi</string>
     <string name="notification_call_default_group_name">Sissetulev grupikõne</string>
     <!-- Calling-->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -93,8 +93,6 @@
     <string name="content_description_unarchive">Restaurer</string>
     <string name="content_description_block_the_user">Bloquer</string>
     <string name="content_description_unblock_the_user">Débloquer</string>
-    <string name="content_description_leave_the_group">Quitter le groupe</string>
-    <string name="content_description_delete_the_group">Supprimer le groupe</string>
     <string name="content_description_conversation_phone_icon">Passer un appel audio</string>
     <string name="content_description_welcome_wire_logo">Wire</string>
     <string name="content_description_conversation_search_icon">Icône de Recherche</string>
@@ -370,15 +368,14 @@
     <string name="new_group_title">Nouveau groupe</string>
     <string name="new_group_description">Jusqu\'à 500 personnes peuvent rejoindre une conversation de groupe.</string>
     <string name="group_name_title">Nom du groupe</string>
-    <string name="group_name_placeholder">Entrez un nom</string>
+    <string name="conversation_name_placeholder">Entrez un nom</string>
     <string name="group_name_description">Donnez un nom évocateur au groupe.</string>
     <string name="protocol">Protocole</string>
     <string name="mls">MLS</string>
     <string name="cipher_suite">Suite cryptographique</string>
     <string name="last_key_material_update_label">Dernière mise à jour de la clé matérielle</string>
     <string name="group_state_label">État du groupe</string>
-    <string name="group_can_not_be_created_edit_participiant_list">Modifier la liste des participants</string>
-    <string name="group_can_not_be_created_discard_group_creation">Annuler la création du groupe</string>
+    <string name="conversation_can_not_be_created_edit_participant_list">Modifier la liste des participants</string>
     <string name="asset_message_tap_to_download_text">Appuyer ici pour lancer le téléchargement</string>
     <string name="asset_message_upload_in_progress_text">Envoi en cours…</string>
     <string name="asset_message_download_in_progress_text">Téléchargement en cours…</string>
@@ -396,23 +393,16 @@
     <string name="member_name_you_label_lowercase">vous</string>
     <string name="label_add_participants">Ajouter des participants</string>
     <string name="username_unavailable_label">Le nom n’est pas disponible</string>
-    <string name="group_unavailable_label">Nom de groupe non disponible</string>
     <string name="conversation_details_title">Détails de la conversation</string>
     <string name="conversation_details_options_tab">OPTIONS</string>
     <string name="conversation_details_participants_tab">PARTICIPANTS</string>
     <string name="conversation_details_options_group_name">NOM DU GROUPE</string>
-    <string name="conversation_details_group_admins">ADMINISTRATEUR DU GROUPE (%d)</string>
-    <string name="conversation_details_group_members">MEMBRES DU GROUPE (%d)</string>
-    <string name="conversation_details_participants_info">Ce groupe a %s participants. \nJusqu\'à 500 personnes peuvent rejoindre un groupe de conversations.</string>
     <string name="conversation_details_participants_count">%s participants</string>
     <string name="conversation_details_show_all_participants">Afficher tous les participants (%d)</string>
-    <string name="conversation_details_group_participants_title">Participants au groupe</string>
-    <string name="conversation_details_group_participants_add">Ajouter des participants</string>
     <string name="conversation_participant_you_label">(Vous)</string>
     <string name="conversation_details_is_classified">NIVEAU DE SÉCURITÉ : VS-NfD</string>
     <string name="conversation_details_is_not_classified">NIVEAU DE SÉCURITÉ : INCLASSIFIÉ</string>
     <string name="conversation_options_self_deleting_messages_label">Messages éphémères</string>
-    <string name="conversation_options_self_deleting_messages_description">Lorsque cette option est activée, tous les messages de ce groupe disparaîtront après un certain temps.</string>
     <string name="conversation_options_guests_label">Invités</string>
     <string name="conversation_details_guest_description">Lorsque cela est activé, des personnes extérieures à votre équipe peuvent rejoindre cette conversation</string>
     <string name="conversation_options_guest_description">Activez cette option pour ouvrir cette conversation à des personnes en dehors de votre équipe, même si elles n\'ont pas de Wire.</string>
@@ -424,12 +414,6 @@
     <string name="disable_guest_dialog_text">Tous les invités seront retirés de la conversation. Il ne sera plus possible d\'ajouter de nouveaux invités.</string>
     <string name="disable_services_dialog_title">Désactiver l\'accès aux services ?</string>
     <string name="disable_services_dialog_text">Tous les services seront retirés de la conversation. Il ne sera plus possible d\'ajouter de nouveaux services.</string>
-    <string name="leave_group_conversation_menu_item">Quitter le groupe…</string>
-    <string name="leave_group_conversation_dialog_title">Quitter «%s»?</string>
-    <string name="leave_group_conversation_dialog_description">Vous ne serez alors plus en mesure d\'envoyer ou de lire des messages dans ce groupe sur aucun appareil.</string>
-    <string name="delete_group_conversation_menu_item">Supprimer le groupe…</string>
-    <string name="delete_group_conversation_dialog_title">Supprimer «%s»?</string>
-    <string name="delete_group_conversation_dialog_description">Le groupe sera supprimé de votre liste de conversations sur tous les appareils. Vous ne pourrez plus accéder au groupe et à son contenu.</string>
     <!-- Import/Export External Media -->
     <string name="import_media_content_title">Partager avec Wire</string>
     <string name="import_media_searchbar_title">Rechercher des conversations</string>
@@ -473,20 +457,15 @@
     <string name="user_profile_status_none">Aucune</string>
     <string name="user_profile_details_tab">Informations</string>
     <string name="user_profile_devices_tab">Appareils</string>
-    <string name="user_profile_group_tab">Groupe</string>
-    <string name="user_profile_group_member">Membre du groupe «%s»</string>
-    <string name="user_profile_group_role">RÔLE</string>
-    <string name="user_profile_role_in_group">Rôle dans «%s»</string>
+    <string name="user_profile_role_in_conversation">Rôle dans «%s»</string>
     <string name="user_profile_role_change_error">Il y a eu une erreur en essayant de modifier le rôle. Veuillez vérifier votre connexion internet et réessayer</string>
     <string name="user_profile_unblock_user">Débloquer l\'utilisateur</string>
-    <string name="user_profile_group_remove_button">Supprimer du groupe</string>
     <string name="user_profile_logging_out_progress">Déconnexion...</string>
     <!-- Remove Conversation Member Dialog -->
     <string name="dialog_remove_conversation_member_title">Supprimer du groupe ?</string>
     <string name="dialog_remove_conversation_member_description">%1$s (@%2$s) ne pourra ni envoyer ni recevoir de message dans cette conversation.</string>
-    <string name="dialog_remove_conversation_member_error">Une erreur s\'est produite lors de la suppression du participant du groupe</string>
-    <string name="group_role_admin">Administrateur</string>
-    <string name="group_role_member">Membre</string>
+    <string name="conversation_role_admin">Administrateur</string>
+    <string name="conversation_role_member">Membre</string>
     <!-- Logout Wipe Data Dialog -->
     <string name="dialog_logout_wipe_data_title">Supprimer les données ?</string>
     <string name="dialog_logout_wipe_data_checkbox">Supprime toutes vos informations personnelles et conversations de cet appareil</string>
@@ -508,8 +487,6 @@
     <string name="label_clear_content">Effacer le contenu…</string>
     <string name="label_block">Bloquer</string>
     <string name="label_unblock">Débloquer</string>
-    <string name="label_leave_group">Quitter le groupe</string>
-    <string name="label_delete_group">Supprimer le groupe</string>
     <!-- Conversation filter BottomSheet -->
     <!-- Muting options BottomSheet -->
     <string name="muting_option_all_allowed_title">Toutes</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -91,8 +91,6 @@
     <string name="content_description_unarchive">Ukloni iz arhive</string>
     <string name="content_description_block_the_user">Blokiraj</string>
     <string name="content_description_unblock_the_user">Odblokiraj</string>
-    <string name="content_description_leave_the_group">Napusti grupu</string>
-    <string name="content_description_delete_the_group">Izbriši grupu</string>
     <string name="content_description_conversation_phone_icon">Pokreni audio poziv</string>
     <string name="content_description_welcome_wire_logo">Wire</string>
     <string name="content_description_conversation_search_icon">Ikona pretraživanja</string>
@@ -361,13 +359,12 @@
     <string name="new_group_title">Nova Grupa</string>
     <string name="new_group_description">Grupnom razgovoru može se pridružiti do 500 ljudi.</string>
     <string name="group_name_title">Naziv grupe</string>
-    <string name="group_name_placeholder">Unesite naziv</string>
+    <string name="conversation_name_placeholder">Unesite naziv</string>
     <string name="group_name_description">Dajte ovoj grupi smislen naziv.</string>
     <string name="protocol">Protokol</string>
     <string name="mls">MLS</string>
     <string name="cipher_suite">Cipher Suite</string>
-    <string name="group_can_not_be_created_edit_participiant_list">Uredite Popis Sudionika</string>
-    <string name="group_can_not_be_created_discard_group_creation">Odbaci Stvaranje Grupe</string>
+    <string name="conversation_can_not_be_created_edit_participant_list">Uredite Popis Sudionika</string>
     <string name="asset_message_tap_to_download_text">Dodirni za preuzimanje</string>
     <string name="asset_message_upload_in_progress_text">Učitavanje…</string>
     <string name="asset_message_download_in_progress_text">Preuzimanje…</string>
@@ -382,21 +379,13 @@
     <string name="member_name_you_label_lowercase">ti</string>
     <string name="label_add_participants">Dodaj sudionike</string>
     <string name="username_unavailable_label">Ime nije dostupno</string>
-    <string name="group_unavailable_label">Ime grupe nije dostupno</string>
     <string name="conversation_details_title">Detalji razgovora</string>
     <string name="conversation_details_options_tab">OPCIJE</string>
     <string name="conversation_details_participants_tab">SUDIONICI</string>
     <string name="conversation_details_options_group_name">NAZIV GRUPE</string>
-    <string name="conversation_details_group_admins">ADMINISTRATORI GRUPE (%d)</string>
-    <string name="conversation_details_group_members">ČLANOVI GRUPE (%d)</string>
-    <string name="conversation_details_participants_info">Ova grupa ima %s sudionika.\nGrupnom razgovoru može se pridružiti do 500 ljudi.</string>
-    <string name="conversation_details_group_participants_add">Dodaj sudionike</string>
     <string name="conversation_participant_you_label">(Vi)</string>
     <string name="conversation_options_guests_label">Gosti</string>
     <string name="conversation_options_guest_not_editable_description">Ne možete onemogućiti opciju gosta u ovom razgovoru jer ju je kreirao netko iz drugog tima.</string>
-    <string name="leave_group_conversation_menu_item">Napusti grupu…</string>
-    <string name="leave_group_conversation_dialog_title">Napusti “%s”?</string>
-    <string name="delete_group_conversation_menu_item">Obriši Grupu…</string>
     <!-- Import/Export External Media -->
     <string name="import_media_send_button_title">Pošalji</string>
     <!--Read receipts -->
@@ -414,15 +403,12 @@
     <string name="user_profile_status_none">Ništa</string>
     <string name="user_profile_details_tab">Detalji</string>
     <string name="user_profile_devices_tab">Uređaji</string>
-    <string name="user_profile_group_tab">Grupa</string>
-    <string name="user_profile_group_member">Član grupe ”%s”</string>
     <string name="user_profile_unblock_user">Odblokiraj korisnika</string>
-    <string name="user_profile_group_remove_button">Ukloni iz grupe</string>
     <string name="user_profile_logging_out_progress">Odjava...</string>
     <!-- Remove Conversation Member Dialog -->
     <string name="dialog_remove_conversation_member_title">Ukloni iz grupe?</string>
-    <string name="group_role_admin">Admin</string>
-    <string name="group_role_member">Član</string>
+    <string name="conversation_role_admin">Admin</string>
+    <string name="conversation_role_member">Član</string>
     <!-- Logout Wipe Data Dialog -->
     <string name="dialog_logout_wipe_data_title">Obriši podatke?</string>
     <string name="dialog_logout_wipe_data_checkbox">Izbriši sve osobne informacije i razgovore na ovom uređaju</string>
@@ -434,8 +420,6 @@
     <string name="label_move_to_archive">Premjesti u Arhivu</string>
     <string name="label_block">Blokiraj</string>
     <string name="label_unblock">Odblokiraj</string>
-    <string name="label_leave_group">Napusti grupu</string>
-    <string name="label_delete_group">Obriši Grupu</string>
     <!-- Conversation filter BottomSheet -->
     <!-- Muting options BottomSheet -->
     <string name="muting_option_all_allowed_title">Sve</string>
@@ -478,8 +462,8 @@
     <string name="error_server_miscommunication_message">Molimo pokušajte ponovno</string>
     <string name="error_socket_title">Nevažeća informacija</string>
     <string name="error_conversation_deleting_message">Poruka se ne može izbrisati</string>
-    <string name="left_conversation_group_success">Napustili ste razgovor.</string>
-    <string name="delete_group_conversation_error">Došlo je do pogreške prilikom brisanja razgovora</string>
+    <string name="left_conversation_success">Napustili ste razgovor.</string>
+    <string name="delete_conversation_conversation_error">Došlo je do pogreške prilikom brisanja razgovora</string>
     <string name="error_limit_number_assets_imported_exceeded">Možete poslati najviše 20 datoteka odjednom</string>
     <!-- Archiving -->
     <string name="dialog_archive_conversation_option">Arhiviraj</string>
@@ -497,7 +481,7 @@
     <string name="notification_receiver_name">Vi</string>
     <string name="label_type_a_message">Napiši poruku</string>
     <string name="notification_ongoing_call_content">Poziv u tijeku…</string>
-    <string name="notification_group_call_content">%s zove...</string>
+    <string name="notification_group_channel_call_content">%s zove...</string>
     <string name="notification_call_default_caller_name">Netko</string>
     <!-- Calling-->
     <string name="calling_button_label_microphone">Mikrofon</string>
@@ -531,15 +515,13 @@
     <string name="media_gallery_on_image_downloaded">Spremi u Download mapu</string>
     <!--sso dialog-->
     <string name="asset_download_dialog_default_title">Preuzmite datoteku</string>
-    <string name="empty_group_label">Neimenovani razgovor</string>
+    <string name="empty_conversation_label">Neimenovani razgovor</string>
     <string name="label_show_more">Prikaži više</string>
     <!--prohibited asset messages -->
     <!--wire dropdown-->
     <string name="wire_dropdown_placeholder">Izaberi stavku</string>
     <string name="change">Promijeni</string>
     <string name="allow_guests">Dopustite goste</string>
-    <string name="service_details_add_service_label">Dodaj u grupu</string>
-    <string name="service_details_remove_service_label">Ukloni iz grupe</string>
     <!--block user dialog -->
     <string name="block_user_dialog_confirm_button">Blokiraj</string>
     <!--Settings -->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -100,8 +100,6 @@
     <string name="content_description_unarchive">Archiválás visszavonása</string>
     <string name="content_description_block_the_user">Tiltás</string>
     <string name="content_description_unblock_the_user">Tiltás feloldása</string>
-    <string name="content_description_leave_the_group">Kilépés a csoportból</string>
-    <string name="content_description_delete_the_group">Csoport törlése</string>
     <string name="content_description_conversation_phone_icon">Hívás indítása</string>
     <string name="content_description_welcome_wire_logo">Wire</string>
     <string name="content_description_conversation_search_icon">Keresés ikon</string>
@@ -116,7 +114,6 @@
     <string name="content_description_conversation_mention_someone">Valaki megemlítése</string>
     <string name="content_description_conversation_back_btn">Vissza a beszélgetések listájához</string>
     <string name="content_description_conversation_open_details_label">beszélgetés részleteinek megnyitása</string>
-    <string name="content_description_new_conversation">Személyek keresése vagy új csoport létrehozása</string>
     <string name="content_description_back_button">Vissza gomb</string>
     <string name="content_description_send_button">Küldés</string>
     <string name="content_description_timed_message_button">Önmegsemmisítő üzenetek gomb</string>
@@ -223,7 +220,7 @@
     <string name="content_description_close_dropdown">lenyíló elem összecsukása</string>
     <string name="content_description_open_notification_settings_label">értesítési beállítások megnyitása</string>
     <string name="content_description_new_conversation_close_btn">Az új beszélgetés lap bezárása</string>
-    <string name="content_description_new_group_conversation_back_btn">Vissza az új beszélgetés lapra</string>
+    <string name="content_description_new_conversation_back_btn">Vissza az új beszélgetés lapra</string>
     <string name="content_description_new_conversation_name_back_btn">Vissza az új beszélgetés lapra</string>
     <string name="content_description_new_conversation_options_heading">Beszélgetés beállításai</string>
     <string name="content_description_pending_connection_badge">kapcsolatkérelem jóváhagyása függőben</string>
@@ -468,17 +465,14 @@
     <string name="new_group_title">Új csoport</string>
     <string name="new_group_description">Akár 500 személy csatlakozhat egy csoportos beszélgetéshez.</string>
     <string name="group_name_title">Csoportnév</string>
-    <string name="group_name_placeholder">Adjon meg egy nevet</string>
+    <string name="conversation_name_placeholder">Adjon meg egy nevet</string>
     <string name="group_name_description">Adjon a csoportnak egy kifejező nevet.</string>
     <string name="protocol">Protokoll</string>
     <string name="mls">MLS</string>
     <string name="cipher_suite">Titkosítási csomag</string>
     <string name="last_key_material_update_label">Legutóbbi kulcskészlet-frissítés</string>
     <string name="group_state_label">Csoport állapota</string>
-    <string name="group_can_not_be_created_title">A csoportot nem lehet létrehozni</string>
-    <string name="group_can_not_be_created_federation_conflict_description">Felhasználók a(z) %1$s és a(z) %2$s kiszolgálóról nem csatlakoztathatók egyazon csoportos beszélgetésbe.\n\nA csoport létrehozásához távolítsa el az érintett résztvevőket.</string>
-    <string name="group_can_not_be_created_edit_participiant_list">Résztvevők listájának szerkesztése</string>
-    <string name="group_can_not_be_created_discard_group_creation">Csoport létrehozásának elvetése</string>
+    <string name="conversation_can_not_be_created_edit_participant_list">Résztvevők listájának szerkesztése</string>
     <string name="asset_message_tap_to_download_text">Érintse meg a letöltéshez</string>
     <string name="asset_message_upload_in_progress_text">Feltöltés…</string>
     <string name="asset_message_download_in_progress_text">Letöltés…</string>
@@ -497,23 +491,16 @@
     <string name="label_add_participants">Résztvevők hozzáadása</string>
     <string name="username_unavailable_label">A név nem elérhető</string>
     <string name="temporary_user_label">%s kilépett</string>
-    <string name="group_unavailable_label">A csoportnév nem elérhető</string>
     <string name="conversation_details_title">Beszélgetés részletei</string>
     <string name="conversation_details_options_tab">LEHETŐSÉGEK</string>
     <string name="conversation_details_participants_tab">RÉSZTVEVŐK</string>
     <string name="conversation_details_options_group_name">CSOPORT NEVE</string>
-    <string name="conversation_details_group_admins">CSOPORTADMINISZTRÁTOROK (%d)</string>
-    <string name="conversation_details_group_members">CSOPORTTAGOK (%d)</string>
-    <string name="conversation_details_participants_info">A csoportnak %s résztvevője van.\nAkár 500 fő is csatlakozhat egy csoportos beszélgetéshez.</string>
     <string name="conversation_details_participants_count">%s résztvevő</string>
     <string name="conversation_details_show_all_participants">Mutassa az összes résztvevőt (%d)</string>
-    <string name="conversation_details_group_participants_title">Csoport résztvevői</string>
-    <string name="conversation_details_group_participants_add">Résztvevők hozzáadása</string>
     <string name="conversation_participant_you_label">(Ön)</string>
     <string name="conversation_details_is_classified">BIZTONSÁGI SZINT: VS-NfD</string>
     <string name="conversation_details_is_not_classified">BIZTONSÁGI SZINT: NYÍLT</string>
     <string name="conversation_options_self_deleting_messages_label">Önmegsemmisítő üzenetek</string>
-    <string name="conversation_options_self_deleting_messages_description">Ha ez aktív, ebben a csoportban minden üzenet el fog tűnni bizonyos idő elteltével.</string>
     <string name="conversation_options_guests_label">Vendégek</string>
     <string name="conversation_details_guest_description">Ha ez aktív, csapatodon kívüli emberek is csatlakozhatnak ehhez a beszélgetéshez</string>
     <string name="conversation_options_guest_description">Aktiválja ezt az opciót, hogy csapatán kívüli személyek is csatlakozhassanak a beszélgetéshez, még ha nincs is Wire-ük.</string>
@@ -525,16 +512,6 @@
     <string name="disable_guest_dialog_text">A jelenlegi vendégek el lesznek távolítva a beszélgetésből. Új vendégek sem csatlakozhatnak.</string>
     <string name="disable_services_dialog_title">Kikapcsolja a szolgáltatások hozzáférését?</string>
     <string name="disable_services_dialog_text">A jelenlegi szolgáltatások el lesznek távolítva a beszélgetésből. Új szolgáltatások sem lesznek engedélyezve.</string>
-    <string name="leave_group_conversation_menu_item">Kilépés a csoportból…</string>
-    <string name="leave_group_conversation_dialog_title">Kilép “%s” beszélgetésből?</string>
-    <string name="leave_group_conversation_dialog_description">A továbbiakban nem tud üzeneteket küldeni vagy fogadni ebben a csoportban egyik eszközön sem.</string>
-    <string name="leave_group_conversation_dialog_delete_fully_check">A csoport és annak tartalma törlése nálam és az összes eszközömön</string>
-    <string name="delete_group_conversation_menu_item">Csoport törlése…</string>
-    <string name="delete_group_conversation_dialog_title">Eltávolítja “%s” beszélgetést?</string>
-    <string name="delete_group_conversation_dialog_description">Ez a csoport eltávolításra kerül a beszélgetések közül minden eszközön. Többé nem lesz hozzáférése a csoporthoz és annak tartalmához.</string>
-    <string name="delete_group_locally_conversation_dialog_title">Legyen \"%s\" csoport törölve nálam?</string>
-    <string name="delete_group_locally_conversation_dialog_description">Nem fog tudni hozzáférni a csoporthoz és annak tartalmához. Nincs lehetőség a visszaállításra.</string>
-    <string name="delete_group_locally_delete_for_me_label">Törlés nálam</string>
     <!-- Import/Export External Media -->
     <string name="import_media_content_title">Megosztás Wire-rel</string>
     <string name="import_media_searchbar_title">Beszélgetés keresése</string>
@@ -581,13 +558,9 @@
     <string name="user_profile_account_management">Csapat kezelése</string>
     <string name="user_profile_details_tab">Részletek</string>
     <string name="user_profile_devices_tab">Eszközök</string>
-    <string name="user_profile_group_tab">Csoport</string>
-    <string name="user_profile_group_member">A(z) ”%s” csoport tagja</string>
-    <string name="user_profile_group_role">SZEREP</string>
-    <string name="user_profile_role_in_group">Szerep ”%s” csoportban</string>
+    <string name="user_profile_role_in_conversation">Szerep ”%s” csoportban</string>
     <string name="user_profile_role_change_error">Hiba lépett fel szerepcsere közben. Ellenőrizze internetkapcsolatát, és próbálja újra</string>
     <string name="user_profile_unblock_user">Felhasználótiltás feloldása</string>
-    <string name="user_profile_group_remove_button">Eltávolítás a csoportból</string>
     <string name="user_profile_logging_out_progress">Kijelentkezés...</string>
     <string name="user_profile_qr_code">QR-kód megnyitása</string>
     <string name="user_profile_qr_code_title">Profil megosztása</string>
@@ -600,9 +573,8 @@
     <!-- Remove Conversation Member Dialog -->
     <string name="dialog_remove_conversation_member_title">Eltávolítja a csoportból?</string>
     <string name="dialog_remove_conversation_member_description">%1$s (@%2$s) ezután nem fog tudni üzenetet küldeni és fogadni ebben a beszélgetésben.</string>
-    <string name="dialog_remove_conversation_member_error">Hiba történt a résztvevő csoportból történő eltávolítása során</string>
-    <string name="group_role_admin">Admin</string>
-    <string name="group_role_member">Tag</string>
+    <string name="conversation_role_admin">Admin</string>
+    <string name="conversation_role_member">Tag</string>
     <!-- Logout Wipe Data Dialog -->
     <string name="dialog_logout_wipe_data_title">Adatok törlése?</string>
     <string name="dialog_logout_wipe_data_checkbox">Törölje az összes személyes adatát és beszélgetését erről az eszközről</string>
@@ -630,9 +602,6 @@
     <string name="label_clear_content">Tartalom törlése…</string>
     <string name="label_block">Tiltás</string>
     <string name="label_unblock">Tiltás feloldása</string>
-    <string name="label_leave_group">Kilépés a csoportból</string>
-    <string name="label_delete_group_locally">Csoport törlése nálam</string>
-    <string name="label_delete_group">Csoport törlése</string>
     <!-- Conversation filter BottomSheet -->
     <string name="label_filter_conversations">Beszélgetések szűrése</string>
     <string name="label_filter_all">Az összes beszélgetés</string>
@@ -730,14 +699,10 @@
     <string name="label_system_message_conversation_started_by_self">**Ön** indította a beszélgetést</string>
     <string name="label_system_message_conversation_started_by_other">%1$s indította a beszélgetést</string>
     <string name="label_system_message_conversation_started_with_members">%1$s résztvevővel</string>
-    <string name="label_system_message_conversation_failed_add_members_summary">%1$s **résztvevőket** nem sikerült hozzáadni a csoporthoz.</string>
-    <string name="label_system_message_conversation_failed_add_many_members_details">%1$s nem sikerült hozzáadni a csoporthoz.</string>
-    <string name="label_system_message_conversation_failed_add_one_member_details">%1$s nem sikerült hozzáadni a csoporthoz.</string>
     <string name="label_system_message_conversation_degraded_mls">Ez a beszélgetés nem ellenőrzött többé, mivel legalább egy résztvevő új eszközt kezdett használni, vagy érvénytelen tanúsítvánnyal rendelkezik.</string>
     <string name="label_system_message_conversation_degraded_proteus">Ez a beszélgetés nem ellenőrzött többé, mivel legalább egy résztvevő új eszközt kezdett használni, vagy érvénytelen tanúsítvánnyal rendelkezik.</string>
     <string name="label_system_message_conversation_verified_mls">Minden eszköz ellenőrzött (végpontok közötti azonosítás)</string>
     <string name="label_system_message_conversation_verified_proteus">Minden ujjlenyomat ellenőrizve (Proteus)</string>
-    <string name="label_system_message_conversation_started_sensitive_information">A Wire-ben a kommunikáció mindig titkos a végpontok között. Minden, amit küld és fogad ebben a beszélgetésben, csak az Ön és a csoport résztvevői számára hozzáférhető.\n**Továbbra is legyen körültekintő, kivel oszt meg érzékeny információkat.**</string>
     <string name="label_conversations_details_verified_proteus">Ellenőrzött (Proteus)</string>
     <string name="label_conversations_details_verified_mls">Ellenőrzött (végpontok közötti azonosítás)</string>
     <!-- Last messages -->
@@ -819,7 +784,7 @@
         <item quantity="other">%1$d üzenet</item>
     </plurals>
     <string name="ephemeral_one_to_one_event_message">"Üzenetet küldött"</string>
-    <string name="ephemeral_group_event_message">"Valaki egy üzenetet küldött"</string>
+    <string name="ephemeral_group_channel_event_message">"Valaki egy üzenetet küldött"</string>
     <!--Typing Indicator-->
     <plurals name="typing_indicator_event_message">
         <item quantity="one">%s gépel</item>
@@ -878,13 +843,13 @@
     <string name="conversation_on_file_downloaded">A(z) %s fájl mentése a Letöltések mappába sikerült</string>
     <string name="error_blocking_user">A felhasználót nem sikerült letiltani</string>
     <string name="blocking_user_success">%s letiltva</string>
-    <string name="conversation_group_removed_success">“%s” eltávolítva</string>
-    <string name="conversation_group_removed_locally_success">\"%s\" törölve nálam</string>
-    <string name="leave_group_conversation_error">Hiba történt a beszélgetésből kilépés során</string>
-    <string name="joined_conversation_group_success">Ön csatlakozott a beszélgetéshez.</string>
-    <string name="left_conversation_group_success">Ön kilépett a beszélgetésből.</string>
+    <string name="conversation_removed_success">“%s” eltávolítva</string>
+    <string name="conversation_removed_locally_success">\"%s\" törölve nálam</string>
+    <string name="leave_conversation_error">Hiba történt a beszélgetésből kilépés során</string>
+    <string name="joined_conversation_success">Ön csatlakozott a beszélgetéshez.</string>
+    <string name="left_conversation_success">Ön kilépett a beszélgetésből.</string>
     <string name="error_unblocking_user">A felhasználó tiltását nem sikerült feloldani</string>
-    <string name="delete_group_conversation_error">Hiba történt a beszélgetés törlése során</string>
+    <string name="delete_conversation_conversation_error">Hiba történt a beszélgetés törlése során</string>
     <string name="error_limit_number_assets_imported_exceeded">Egyszerre legfeljebb 20 fájlt küldhet</string>
     <!-- Archiving -->
     <string name="success_archiving_conversation">A beszélgetés archiválva lett</string>
@@ -914,7 +879,6 @@
     <string name="notification_reply">Válasz: %1$s</string>
     <string name="notification_not_supported_issue">Nem támogatott funkció</string>
     <string name="notification_connection_request">Szeretne csatlakozni</string>
-    <string name="notification_conversation_deleted">Törölte a csoportot</string>
     <string name="notification_action_reply">Válasz</string>
     <string name="notification_receiver_name">Ön</string>
     <string name="label_type_a_message">Írjon üzenetet</string>
@@ -922,7 +886,7 @@
     <string name="notification_action_decline_call">Elutasítás</string>
     <string name="notification_incoming_call_content">Hívás…</string>
     <string name="notification_ongoing_call_content">Folyamatban lévő hívás…</string>
-    <string name="notification_group_call_content">%s hívja...</string>
+    <string name="notification_group_channel_call_content">%s hívja...</string>
     <string name="notification_call_default_caller_name">Valaki</string>
     <string name="notification_call_default_group_name">Bejövő csoportos hívás</string>
     <string name="notification_outgoing_call_tap_to_return">Koppintásra visszatér a híváshoz - Hívás...</string>
@@ -1011,7 +975,7 @@
         rendszergazdával, és adja át ezt a kódot:\n%d\"
     </string>
     <string name="asset_download_dialog_default_title">Fájl letöltése</string>
-    <string name="empty_group_label">Név nélküli beszélgetés</string>
+    <string name="empty_conversation_label">Név nélküli beszélgetés</string>
     <string name="label_show_more">Mutasson többet</string>
     <!--prohibited asset messages -->
     <string name="prohibited_images_message">Képek fogadása tilos</string>
@@ -1029,17 +993,10 @@
     <string name="allow_guest_switch_description">Megnyitja a beszélgetést a csapatán kívüli személyek számára is. Ezt később bármikor megváltoztathatja.</string>
     <string name="allow_services">Szolgáltatások engedélyezése</string>
     <string name="service_details_label">Szolgáltatás</string>
-    <string name="service_details_add_service_label">Hozzáadás a csoporthoz</string>
-    <string name="service_details_remove_service_label">Eltávolítás a csoportból</string>
-    <string name="service_remove_success">A szolgáltatás eltávolítva a csoportból</string>
-    <string name="service_remove_error">A szolgáltatást nem sikerült eltávolítani a csoportból</string>
-    <string name="service_add_success">Szolgáltatás hozzáadva a csoporthoz</string>
-    <string name="service_add_error">A szolgáltatást nem sikerült hozzáadni a csoporthoz</string>
     <string name="service_no_information_available_title">Nincs elérhető információ</string>
     <string name="service_no_information_available_subtitle">Próbálja újra, vagy forduljon a csapatadminisztrátorhoz</string>
     <string name="read_receipts">Olvasási visszaigazolások</string>
     <string name="disable_guests_dialog_title">Vendégek ne legyenek engedélyezve?</string>
-    <string name="disable_guests_dialog_description">Az előző lépésben kijelölt vendégek nem lesznek részesei a csoportnak, ha nem engedélyezi a vendég hozzáférést.</string>
     <string name="disable_guests_dialog_button">Vendégek nem engedélyezettek</string>
     <!--block user dialog -->
     <string name="block_user_dialog_title">Letiltja a felhasználót?</string>
@@ -1232,9 +1189,7 @@ Ez a beállítás az összes beszélgetésre érvényes ezen az eszközön.</str
     <string name="backup_dialog_restore_wrong_user_error_message">Nem állíthatja vissza egy másik fiók előzményeit.</string>
     <string name="backup_dialog_restore_general_error_title">Valami hiba történt</string>
     <string name="backup_dialog_restore_general_error_message">Az előzményeit nem sikerült visszaállítani. Próbálja újra, vagy forduljon a Wire ügyfélszolgálatához.</string>
-    <string name="group_content_deleted">A csoport tartalma törölve</string>
     <string name="conversation_content_deleted">A beszélgetés tartalma törölve</string>
-    <string name="group_content_delete_failure">A csoport tartalmát nem sikerült törölni</string>
     <string name="conversation_content_delete_failure">A beszélgetés tartalmát nem sikerült törölni</string>
     <string name="group_label">csoport</string>
     <string name="conversation_label">beszélgetés</string>
@@ -1275,13 +1230,10 @@ Ez a beállítás az összes beszélgetésre érvényes ezen az eszközön.</str
     <string name="join_conversation_dialog_message">Meghívták egy beszélgetésbe.\n\n%1$s</string>
     <string name="join_conversation_dialog_button">Csatlakozás</string>
     <string name="join_conversation_via_deeplink_error_title">Nem tud beszélgetéshez csatlakozni</string>
-    <string name="join_conversation_via_deeplink_error_link_expired">A csoportos beszélgetésre mutató link lejárt, vagy a beszélgetés privátra lett állítva.</string>
     <string name="join_conversation_via_deeplink_error_max_number_of_participent">A beszélgetésben résztvevők száma elérte a maximumot.</string>
-    <string name="join_conversation_via_deeplink_error_general">Egy hiba miatt nem tudott csatlakozni a csoportos beszélgetéshez.</string>
     <!-- edit self-deleting messages -->
     <string name="self_deleting_messages_title">Önmegsemmisítő üzenetek</string>
     <string name="self_deleting_messages_option">Üzenet törlésének kényszerítése</string>
-    <string name="self_deleting_messages_option_description">Ha ez aktív, ebben a csoportban minden üzenet el fog tűnni bizonyos idő után. Ez minden résztvevőre érvényes.</string>
     <string name="self_deleting_messages_folder_timer">Időzítő</string>
     <!-- visit link -->
     <string name="label_visit_link_title">Hivatkozás megnyitása</string>
@@ -1308,8 +1260,6 @@ Ez a beállítás az összes beszélgetésre érvényes ezen az eszközön.</str
     <string name="title_device_key_fingerprint">ESZKÖZ KULCS UJJLENYOMAT</string>
     <string name="label_client_key_fingerprint_not_available">NEM ELÉRHETŐ</string>
     <string name="guest_room_link_copied">A hivatkozás a vágólapra másolva</string>
-    <string name="guest_room_link_enabled">Hivatkozások létrehozása mostantól engedélyezett minden csoportadminisztrátornak</string>
-    <string name="guest_room_link_disabled">Hivatkozások létrehozása mostantól tiltott minden csoportadminisztrátornak</string>
     <!-- New Device dialog -->
     <string name="new_device_dialog_current_user_title">Fiókja legutóbbi használata:</string>
     <string name="new_device_dialog_message_defice_info">%1$s\nErről: %2$s \n</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -96,8 +96,6 @@
     <string name="content_description_unarchive">Disarchivia</string>
     <string name="content_description_block_the_user">Blocca</string>
     <string name="content_description_unblock_the_user">Sblocca</string>
-    <string name="content_description_leave_the_group">Abbandona il gruppo</string>
-    <string name="content_description_delete_the_group">Elimina il gruppo</string>
     <string name="content_description_conversation_phone_icon">Avvia chiamata audio</string>
     <string name="content_description_welcome_wire_logo">Wire</string>
     <string name="content_description_conversation_search_icon">Icona di ricerca</string>
@@ -373,15 +371,14 @@ Un messaggio eliminato non pu&#242; essere ripristinato.</string>
     <string name="new_group_title">Nuovo Gruppo</string>
     <string name="new_group_description">Fino a 500 persone possono unirsi a una conversazione di gruppo.</string>
     <string name="group_name_title">Nome del Gruppo</string>
-    <string name="group_name_placeholder">Inserisci un nome</string>
+    <string name="conversation_name_placeholder">Inserisci un nome</string>
     <string name="group_name_description">Dai a questo gruppo un nome significativo.</string>
     <string name="protocol">Protocollo</string>
     <string name="mls">MLS</string>
     <string name="cipher_suite">Suite di Crittografia</string>
     <string name="last_key_material_update_label">Ultimo Aggiornamento del Materiale Chiave</string>
     <string name="group_state_label">Stato del gruppo</string>
-    <string name="group_can_not_be_created_edit_participiant_list">Modifica l\'elenco dei partecipanti</string>
-    <string name="group_can_not_be_created_discard_group_creation">Scarta la creazione del gruppo</string>
+    <string name="conversation_can_not_be_created_edit_participant_list">Modifica l\'elenco dei partecipanti</string>
     <string name="asset_message_tap_to_download_text">Tocca per scaricare</string>
     <string name="asset_message_upload_in_progress_text">Caricamento in corso...</string>
     <string name="asset_message_download_in_progress_text">Download in corso...</string>
@@ -397,24 +394,18 @@ Un messaggio eliminato non pu&#242; essere ripristinato.</string>
     <string name="member_name_you_label_lowercase">tu</string>
     <string name="label_add_participants">Aggiungi partecipanti</string>
     <string name="username_unavailable_label">Nome non disponibile</string>
-    <string name="group_unavailable_label">Nome del gruppo non disponibile</string>
     <string name="conversation_details_title">Dettagli della conversazione</string>
     <string name="conversation_details_options_tab">OPZIONI</string>
     <string name="conversation_details_participants_tab">PARTICIPANTI</string>
     <string name="conversation_details_options_group_name">NOME DEL GRUPPO</string>
-    <string name="conversation_details_group_admins">AMMINISTRATORI DI GRUPPO (%d)</string>
-    <string name="conversation_details_group_members">MEMBRI DEL GRUPPO (%d)</string>
     <string name="conversation_details_participants_info">Questo gruppo ha %s partecipanti.
 Fino a 500 persone possono unirsi a una conversazione di gruppo.</string>
     <string name="conversation_details_participants_count">%s partecipanti</string>
     <string name="conversation_details_show_all_participants">Mostra tutti i partecipanti (%d)</string>
-    <string name="conversation_details_group_participants_title">Partecipanti del gruppo</string>
-    <string name="conversation_details_group_participants_add">Aggiungi partecipanti</string>
     <string name="conversation_participant_you_label">(Tu)</string>
     <string name="conversation_details_is_classified">LIVELLO DI SICUREZZA: VS-NfD</string>
     <string name="conversation_details_is_not_classified">Livello di sicurezza: NON CLASSIFICATO. </string>
     <string name="conversation_options_self_deleting_messages_label">Autodistruzione dei messaggi</string>
-    <string name="conversation_options_self_deleting_messages_description">Quando attivo, tutti i messaggi in questo gruppo scompariranno dopo un certo periodo di tempo.</string>
     <string name="conversation_options_guests_label">Ospiti</string>
     <string name="conversation_details_guest_description">Con questa opzione ATTIVA, persone al di fuori del tuo team possono unirsi a questa conversazione.</string>
     <string name="conversation_options_guest_description">Attiva questa opzione per aprire questa conversazione a persone al di fuori del tuo team, anche se non hanno Wire.</string>
@@ -426,12 +417,6 @@ Fino a 500 persone possono unirsi a una conversazione di gruppo.</string>
     <string name="disable_guest_dialog_text">Gli ospiti attuali verranno rimossi dalla conversazione. Non verranno autorizzati nuovi ospiti.</string>
     <string name="disable_services_dialog_title">Disattivare l\'accesso ai servizi?</string>
     <string name="disable_services_dialog_text">I servizi attuali verranno rimossi dalla conversazione. Non verranno autorizzati nuovi servizi.</string>
-    <string name="leave_group_conversation_menu_item">Abbandona gruppo...</string>
-    <string name="leave_group_conversation_dialog_title">Abbandonare &#8220;%s&#8221;?</string>
-    <string name="leave_group_conversation_dialog_description">Non potrai pi&#249; inviare o leggere messaggi in questo gruppo su nessun dispositivo.</string>
-    <string name="delete_group_conversation_menu_item">Elimina gruppo...</string>
-    <string name="delete_group_conversation_dialog_title">Rimuovere &#8220;%s&#8221;?</string>
-    <string name="delete_group_conversation_dialog_description">Il gruppo verr&#224; rimosso dalla tua lista di conversazioni su tutti i dispositivi. Non potrai pi&#249; accedere al gruppo e al suo contenuto.</string>
     <!-- Import/Export External Media -->
     <string name="import_media_content_title">Condividi con Wire</string>
     <string name="import_media_searchbar_title">Ricerca conversazione</string>
@@ -467,20 +452,15 @@ Fino a 500 persone possono unirsi a una conversazione di gruppo.</string>
     <string name="user_profile_status_none">Nessuno</string>
     <string name="user_profile_details_tab">Dettagli</string>
     <string name="user_profile_devices_tab">Dispositivi</string>
-    <string name="user_profile_group_tab">Gruppo</string>
-    <string name="user_profile_group_member">Member of the group &#8221;%s&#8221;</string>
-    <string name="user_profile_group_role">RUOLO</string>
-    <string name="user_profile_role_in_group">Role in &#8221;%s&#8221;</string>
+    <string name="user_profile_role_in_conversation">Role in &#8221;%s&#8221;</string>
     <string name="user_profile_role_change_error">Si è verificato un errore provando a modificare il ruolo. Sei pregato di controllare la tua connessione a Internet e di riprovare</string>
     <string name="user_profile_unblock_user">Sblocca Utente</string>
-    <string name="user_profile_group_remove_button">Rimuovi dal gruppo</string>
     <string name="user_profile_logging_out_progress">Disconnessione...</string>
     <!-- Remove Conversation Member Dialog -->
     <string name="dialog_remove_conversation_member_title">Rimuovere dal gruppo?</string>
     <string name="dialog_remove_conversation_member_description">%1$s (@%2$s) non potrà inviare o ricevere i messaggi in questa conversazione.</string>
-    <string name="dialog_remove_conversation_member_error">Si è verificato un errore rimuovendo il partecipante dal gruppo</string>
-    <string name="group_role_admin">Amministratore</string>
-    <string name="group_role_member">Membro</string>
+    <string name="conversation_role_admin">Amministratore</string>
+    <string name="conversation_role_member">Membro</string>
     <!-- Logout Wipe Data Dialog -->
     <string name="dialog_logout_wipe_data_title">Cancellare i dati?</string>
     <string name="dialog_logout_wipe_data_checkbox">Eliminare tutte le tue informazioni personali e conversazioni su questo dispositivo</string>
@@ -502,8 +482,6 @@ Fino a 500 persone possono unirsi a una conversazione di gruppo.</string>
     <string name="label_clear_content">Cancella contenuto...</string>
     <string name="label_block">Blocca</string>
     <string name="label_unblock">Sblocca</string>
-    <string name="label_leave_group">Lascia il gruppo</string>
-    <string name="label_delete_group">Elimina il gruppo</string>
     <!-- Conversation filter BottomSheet -->
     <!-- Muting options BottomSheet -->
     <string name="muting_option_all_allowed_title">Tutto</string>
@@ -586,14 +564,10 @@ Fino a 500 persone possono unirsi a una conversazione di gruppo.</string>
     <string name="label_system_message_conversation_started_by_self">**Hai** avviato la conversazione</string>
     <string name="label_system_message_conversation_started_by_other">%1$s ha avviato la conversazione</string>
     <string name="label_system_message_conversation_started_with_members">Con %1$s</string>
-    <string name="label_system_message_conversation_failed_add_members_summary">Impossibile aggiungere %1$s **partecipanti** al gruppo.</string>
-    <string name="label_system_message_conversation_failed_add_many_members_details">Impossibile aggiungere %1$s al gruppo.</string>
-    <string name="label_system_message_conversation_failed_add_one_member_details">Impossibile aggiungere %1$s al gruppo.</string>
     <string name="label_system_message_conversation_degraded_mls">Questa conversazione non è più verificata, poiché almeno un partecipante ha iniziato a utilizzare un nuovo dispositivo, o dispone di un certificato non valido.</string>
     <string name="label_system_message_conversation_degraded_proteus">Questa conversazione non è più verificata, poiché almeno un partecipante ha iniziato a utilizzare un nuovo dispositivo, o dispone di un certificato non valido.</string>
     <string name="label_system_message_conversation_verified_mls">Tutti i dispositivi sono verificati (identità end-to-end)</string>
     <string name="label_system_message_conversation_verified_proteus">Tutte le impronte digitali sono verificate (Proteus)</string>
-    <string name="label_system_message_conversation_started_sensitive_information">La comunicazione su Wire è sempre crittografata end-to-end. Tutto ciò che invii e ricevi in questa conversazione è accessibile soltanto a te e agli altri partecipanti del gruppo.\n**Ti preghiamo di prestare comunque attenzione a con chi condividi le informazioni sensibili.**</string>
     <string name="label_conversations_details_verified_proteus">Verificata (Proteus)</string>
     <string name="label_conversations_details_verified_mls">Verificata (Identità end-to-end)</string>
     <!-- Last messages -->
@@ -671,7 +645,7 @@ Fino a 500 persone possono unirsi a una conversazione di gruppo.</string>
         <item quantity="other">%1$d messaggi</item>
     </plurals>
     <string name="ephemeral_one_to_one_event_message">"Ha inviato un messaggio"</string>
-    <string name="ephemeral_group_event_message">"Qualcuno ha inviato un messaggio"</string>
+    <string name="ephemeral_group_channel_event_message">"Qualcuno ha inviato un messaggio"</string>
     <!--Typing Indicator-->
     <plurals name="typing_indicator_event_message">
         <item quantity="one">%s sta scrivendo</item>
@@ -724,12 +698,12 @@ Fino a 500 persone possono unirsi a una conversazione di gruppo.</string>
     <string name="conversation_on_file_downloaded">Il file %s &#232; stato salvato con successo nella cartella Download</string>
     <string name="error_blocking_user">Impossibile bloccare l\'utente.</string>
     <string name="blocking_user_success">%s bloccato.</string>
-    <string name="conversation_group_removed_success">\"%s\" rimosso.</string>
-    <string name="leave_group_conversation_error">Si &#232; verificato un errore durante la rimozione dalla conversazione.</string>
-    <string name="joined_conversation_group_success">Ora fai parte della conversazione.</string>
-    <string name="left_conversation_group_success">Hai abbandonato la conversazione.</string>
+    <string name="conversation_removed_success">\"%s\" rimosso.</string>
+    <string name="leave_conversation_error">Si &#232; verificato un errore durante la rimozione dalla conversazione.</string>
+    <string name="joined_conversation_success">Ora fai parte della conversazione.</string>
+    <string name="left_conversation_success">Hai abbandonato la conversazione.</string>
     <string name="error_unblocking_user">Impossibile sbloccare l\'utente.</string>
-    <string name="delete_group_conversation_error">Si &#232; verificato un errore durante la cancellazione della conversazione.</string>
+    <string name="delete_conversation_conversation_error">Si &#232; verificato un errore durante la cancellazione della conversazione.</string>
     <string name="error_limit_number_assets_imported_exceeded">&#200; possibile inviare fino a 20 file alla volta.</string>
     <!-- Archiving -->
     <string name="success_archiving_conversation">Conversazione archiviata</string>
@@ -754,13 +728,12 @@ Fino a 500 persone possono unirsi a una conversazione di gruppo.</string>
     <string name="notification_reply">Risposta: %1$s</string>
     <string name="notification_not_supported_issue">Funzione non supportata.</string>
     <string name="notification_connection_request">Vuole connettersi.</string>
-    <string name="notification_conversation_deleted">Hai eliminato il gruppo</string>
     <string name="notification_action_reply">Rispondi</string>
     <string name="notification_receiver_name">Tu</string>
     <string name="label_type_a_message">Scrivi un messaggio</string>
     <string name="notification_incoming_call_content">Chiamata in arrivo...</string>
     <string name="notification_ongoing_call_content">Chiamata in corso...</string>
-    <string name="notification_group_call_content">%s sta chiamando...</string>
+    <string name="notification_group_channel_call_content">%s sta chiamando...</string>
     <string name="notification_call_default_caller_name">Qualcuno</string>
     <string name="notification_call_default_group_name">Chiamata di gruppo in entrata</string>
     <!-- Calling-->
@@ -828,7 +801,7 @@ Rispondendo qui, verr&#224; riagganciata l\'altra chiamata.</string>
     <string name="sso_error_dialog_title">Impossibile effettuare l\'accesso con SSO</string>
     <string name="sso_error_dialog_message">Riprova. Se il problema persiste, contatta l\'amministratore e fornisci questo codice:\n%d</string>
     <string name="asset_download_dialog_default_title">Scarica file</string>
-    <string name="empty_group_label">Conversazione senza nome</string>
+    <string name="empty_conversation_label">Conversazione senza nome</string>
     <string name="label_show_more">Mostra altro</string>
     <!--prohibited asset messages -->
     <string name="prohibited_images_message">Ricevere immagini è vietato</string>
@@ -846,17 +819,10 @@ Rispondendo qui, verr&#224; riagganciata l\'altra chiamata.</string>
     <string name="allow_guest_switch_description">Apri questa conversazione a persone esterne al tuo team. Puoi sempre cambiarla successivamente.</string>
     <string name="allow_services">Consenti servizi</string>
     <string name="service_details_label">Servizio</string>
-    <string name="service_details_add_service_label">Aggiungi Al Gruppo</string>
-    <string name="service_details_remove_service_label">Rimuovi Dal Gruppo</string>
-    <string name="service_remove_success">Servizio rimosso dal gruppo</string>
-    <string name="service_remove_error">Impossibile rimuovere il servizio dal gruppo</string>
-    <string name="service_add_success">Servizio aggiunto al gruppo</string>
-    <string name="service_add_error">Impossibile aggiungere il servizio al gruppo</string>
     <string name="service_no_information_available_title">Nessuna informazione disponibile</string>
     <string name="service_no_information_available_subtitle">Riprova o contatta l\'amministratore del tuo team</string>
     <string name="read_receipts">Ricevute di lettura</string>
     <string name="disable_guests_dialog_title">Non consentire ospiti?</string>
-    <string name="disable_guests_dialog_description">Gli ospiti selezionati nel passaggio precedente non faranno parte del gruppo se non consenti l\'accesso agli ospiti.</string>
     <string name="disable_guests_dialog_button">Non consentire ospiti</string>
     <!--block user dialog -->
     <string name="block_user_dialog_title">Bloccare l\'utente?</string>
@@ -1024,9 +990,7 @@ Rispondendo qui, verr&#224; riagganciata l\'altra chiamata.</string>
     <string name="backup_dialog_restore_wrong_user_error_message">Non puoi ripristinare la cronologia di un altro account.</string>
     <string name="backup_dialog_restore_general_error_title">Qualcosa &#232; andato storto</string>
     <string name="backup_dialog_restore_general_error_message">Impossibile ripristinare lo storico. Riprova o contatta il supporto tecnico di Wire.</string>
-    <string name="group_content_deleted">Il contenuto del gruppo &#232; stato eliminato.</string>
     <string name="conversation_content_deleted">Il contenuto della conversazione &#232; stato eliminato.</string>
-    <string name="group_content_delete_failure">Impossibile eliminare il contenuto del gruppo.</string>
     <string name="conversation_content_delete_failure">Impossibile eliminare il contenuto della conversazione.</string>
     <string name="group_label">gruppo</string>
     <string name="conversation_label">conversazione</string>
@@ -1062,13 +1026,10 @@ Rispondendo qui, verr&#224; riagganciata l\'altra chiamata.</string>
     <string name="join_conversation_dialog_message">Sei stato invitato ad una conversazione.\n\n%1$s</string>
     <string name="join_conversation_dialog_button">Unisciti</string>
     <string name="join_conversation_via_deeplink_error_title">Impossibile unirsi alla conversazione</string>
-    <string name="join_conversation_via_deeplink_error_link_expired">Il link per questa conversazione di gruppo &#232; scaduto o la conversazione &#232; stata impostata come privata.</string>
     <string name="join_conversation_via_deeplink_error_max_number_of_participent">Il numero massimo di partecipanti in questa conversazione &#232; stato raggiunto.</string>
-    <string name="join_conversation_via_deeplink_error_general">A causa di un errore non sei stato aggiunto alla conversazione di gruppo.</string>
     <!-- edit self-deleting messages -->
     <string name="self_deleting_messages_title">Autodistruzione Messaggi</string>
     <string name="self_deleting_messages_option">Forza eliminazione dei messaggi</string>
-    <string name="self_deleting_messages_option_description">Quando è attivo, tutti i messaggi in questo gruppo scompariranno dopo un certo periodo di tempo. Ciò si applica a tutti i partecipanti del gruppo.</string>
     <string name="self_deleting_messages_folder_timer">Timer</string>
     <!-- visit link -->
     <string name="label_visit_link_title">Visita il link</string>
@@ -1091,8 +1052,6 @@ Rispondendo qui, verr&#224; riagganciata l\'altra chiamata.</string>
     <string name="title_device_key_fingerprint">IMPRONTA CHIAVE DISPOSITIVO</string>
     <string name="label_client_key_fingerprint_not_available">NON DISPONIBILE</string>
     <string name="guest_room_link_copied">Link copiato negli appunti</string>
-    <string name="guest_room_link_enabled">La generazione di link ospiti &#232; ora abilitata per tutti gli amministratori di gruppo</string>
-    <string name="guest_room_link_disabled">La generazione di link ospiti &#232; stata disabilitata per tutti gli amministratori di gruppo</string>
     <!-- New Device dialog -->
     <string name="new_device_dialog_current_user_title">Il tuo account &#232; stato utilizzato su</string>
     <string name="new_device_dialog_message_defice_info">%1$s\Da: %2$s \n</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -95,8 +95,6 @@
     <string name="content_description_unarchive">アーカイブを解除</string>
     <string name="content_description_block_the_user">ブロック</string>
     <string name="content_description_unblock_the_user">ブロック解除</string>
-    <string name="content_description_leave_the_group">グループから退出</string>
-    <string name="content_description_delete_the_group">グループを削除</string>
     <string name="content_description_conversation_phone_icon">音声通話を開始</string>
     <string name="content_description_welcome_wire_logo">Wire</string>
     <string name="content_description_conversation_search_icon">検索アイコン</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -73,8 +73,6 @@
     <string name="content_description_move_to_archive">Przenie&#347; do archiwum</string>
     <string name="content_description_block_the_user">Zablokuj u&#380;ytkownika</string>
     <string name="content_description_unblock_the_user">Odblokuj u&#380;ytkownika</string>
-    <string name="content_description_leave_the_group">Opu&#347;&#263; grup&#281;</string>
-    <string name="content_description_delete_the_group">Usu&#324; grup&#281;</string>
     <string name="content_description_conversation_phone_icon">Rozmowa g&#322;osowa</string>
     <string name="content_description_conversation_enable_rich_text_mode">W&#322;&#261;cz tryb bogatego tekstu</string>
     <string name="content_description_conversation_send_emoticon">Wy&#347;lij emotikon&#281;</string>
@@ -309,7 +307,7 @@ Usuni&#281;ta wiadomo&#347;&#263; nie mo&#380;e zosta&#263; przywr&#243;cona.</s
     <string name="new_group_title">Nowa grupa</string>
     <string name="new_group_description">Do grupy mo&#380;e do&#322;&#261;czy&#263; do 500 os&#243;b.</string>
     <string name="group_name_title">Nazwa grupy</string>
-    <string name="group_name_placeholder">Wprowad&#378; nazw&#281;</string>
+    <string name="conversation_name_placeholder">Wprowad&#378; nazw&#281;</string>
     <string name="group_name_description">Przypisz tej grupie znacz&#261;c&#261; nazw&#281;.</string>
     <string name="protocol">Protok&#243;&#322;</string>
     <string name="cipher_suite">Pakiet Szyfr&#243;w</string>
@@ -331,13 +329,9 @@ Usuni&#281;ta wiadomo&#347;&#263; nie mo&#380;e zosta&#263; przywr&#243;cona.</s
     <string name="conversation_details_options_tab">OPCJE</string>
     <string name="conversation_details_participants_tab">UCZESTNICY</string>
     <string name="conversation_details_options_group_name">NAZWA GRUPY</string>
-    <string name="conversation_details_group_admins">ADMINISTRATORZY GRUPY (%d)</string>
-    <string name="conversation_details_group_members">UCZESTNICY GRUPY (%d)</string>
     <string name="conversation_details_participants_info">Ta grupa ma %s uczestnik&#243;w.
 Do grupy mo&#380;e do&#322;&#261;czy&#263; maksymalnie 500 os&#243;b.</string>
     <string name="conversation_details_show_all_participants">Poka&#380; wszystkich uczestnik&#243;w (%d)</string>
-    <string name="conversation_details_group_participants_title">Uczestnicy grupy</string>
-    <string name="conversation_details_group_participants_add">Dodaj uczestnik&#243;w</string>
     <string name="conversation_participant_you_label">(Ty)</string>
     <string name="conversation_details_is_classified">POZIOM BEZPIECZE&#323;STWA: VS-NfD</string>
     <string name="conversation_details_is_not_classified">POZIOM BEZPIECZE&#323;STWA: Nieutajnione</string>
@@ -352,12 +346,6 @@ Do grupy mo&#380;e do&#322;&#261;czy&#263; maksymalnie 500 os&#243;b.</string>
     <string name="disable_guest_dialog_text">Obecni go&#347;cie zostan&#261; usuni&#281;ci z konwersacji. Nowi go&#347;cie nie zostan&#261; dopuszczeni.</string>
     <string name="disable_services_dialog_title">Wy&#322;&#261;czy&#263; dost&#281;p us&#322;ug?</string>
     <string name="disable_services_dialog_text">Obecne us&#322;ugi zostan&#261; usuni&#281;te z konwersacji. Nowe us&#322;ugi nie zostan&#261; dopuszczone.</string>
-    <string name="leave_group_conversation_menu_item">Opu&#347;&#263; grup&#281;...</string>
-    <string name="leave_group_conversation_dialog_title">Opu&#347;ci&#263; &#8222;%s&#8221;?</string>
-    <string name="leave_group_conversation_dialog_description">Nie b&#281;dzie mo&#380;na ju&#380; wysy&#322;a&#263; ani odczytywa&#263; wiadomo&#347;ci w tej grupie na &#380;adnym urz&#261;dzeniu.</string>
-    <string name="delete_group_conversation_menu_item">Usu&#324; grup&#281;...</string>
-    <string name="delete_group_conversation_dialog_title">Usun&#261;&#263; &#8222;%s&#8221;?</string>
-    <string name="delete_group_conversation_dialog_description">Grupa zostanie usuni&#281;ta z Twojej listy konwersacji na wszystkich urz&#261;dzeniach. Nie b&#281;dzie mo&#380;na ju&#380; uzyska&#263; dost&#281;pu do grupy i jej zawarto&#347;ci.</string>
     <!-- Import/Export External Media -->
     <string name="import_media_content_title">Udost&#281;pnij w Wire</string>
     <string name="import_media_searchbar_title">Wyszukaj konwersacj&#281;</string>
@@ -392,19 +380,14 @@ Do grupy mo&#380;e do&#322;&#261;czy&#263; maksymalnie 500 os&#243;b.</string>
     <string name="user_profile_status_none">Brak</string>
     <string name="user_profile_details_tab">Szczeg&#243;&#322;y</string>
     <string name="user_profile_devices_tab">Urz&#261;dzenia</string>
-    <string name="user_profile_group_tab">Grupa</string>
-    <string name="user_profile_group_member">Cz&#322;onek grupy \"%s\"</string>
-    <string name="user_profile_group_role">Rola</string>
-    <string name="user_profile_role_in_group">Rola w \"%s\"</string>
+    <string name="user_profile_role_in_conversation">Rola w \"%s\"</string>
     <string name="user_profile_role_change_error">Wyst&#261;pi&#322; b&#322;&#261;d podczas zmiany roli. Sprawd&#378; swoje po&#322;&#261;czenie internetowe i spr&#243;buj ponownie.</string>
     <string name="user_profile_unblock_user">Odblokuj u&#380;ytkownika</string>
-    <string name="user_profile_group_remove_button">Usu&#324; z grupy</string>
     <!-- Remove Conversation Member Dialog -->
     <string name="dialog_remove_conversation_member_title">Usun&#261;&#263; z grupy?</string>
     <string name="dialog_remove_conversation_member_description">%1$s (@%2$s) nie b&#281;dzie m&#243;g&#322; wysy&#322;a&#263; ani odbiera&#263; wiadomo&#347;ci w tej rozmowie.</string>
-    <string name="dialog_remove_conversation_member_error">Wyst&#261;pi&#322; b&#322;&#261;d podczas usuwania uczestnika z grupy</string>
-    <string name="group_role_admin">Administrator</string>
-    <string name="group_role_member">Cz&#322;onek</string>
+    <string name="conversation_role_admin">Administrator</string>
+    <string name="conversation_role_member">Cz&#322;onek</string>
     <!-- Logout Wipe Data Dialog -->
     <string name="dialog_logout_wipe_data_title">Wyczy&#347;ci&#263; dane?</string>
     <string name="dialog_logout_wipe_data_checkbox">Usu&#324; wszystkie twoje informacje osobiste i rozmowy na tym urz&#261;dzeniu</string>
@@ -425,8 +408,6 @@ Do grupy mo&#380;e do&#322;&#261;czy&#263; maksymalnie 500 os&#243;b.</string>
     <string name="label_clear_content">Wyczy&#347;&#263; tre&#347;&#263;...</string>
     <string name="label_block">Zablokuj</string>
     <string name="label_unblock">Odblokuj</string>
-    <string name="label_leave_group">Opu&#347;&#263; grup&#281;</string>
-    <string name="label_delete_group">Usu&#324; grup&#281;</string>
     <!-- Conversation filter BottomSheet -->
     <!-- Muting options BottomSheet -->
     <string name="muting_option_all_allowed_title">Wszystko</string>
@@ -607,12 +588,12 @@ Do grupy mo&#380;e do&#322;&#261;czy&#263; maksymalnie 500 os&#243;b.</string>
     <string name="conversation_on_file_downloaded">Plik %s zosta&#322; pomy&#347;lnie zapisany w folderze Pobrane.</string>
     <string name="error_blocking_user">Nie mo&#380;na zablokowa&#263; u&#380;ytkownika.</string>
     <string name="blocking_user_success">%s zosta&#322; zablokowany.</string>
-    <string name="conversation_group_removed_success">\"%s\" zosta&#322; usuni&#281;ty.</string>
-    <string name="leave_group_conversation_error">Wyst&#261;pi&#322; b&#322;&#261;d podczas opuszczania rozmowy.</string>
-    <string name="joined_conversation_group_success">Do&#322;&#261;czy&#322;e&#347; do rozmowy.</string>
-    <string name="left_conversation_group_success">Opu&#347;ci&#322;e&#347; rozmow&#281;.</string>
+    <string name="conversation_removed_success">\"%s\" zosta&#322; usuni&#281;ty.</string>
+    <string name="leave_conversation_error">Wyst&#261;pi&#322; b&#322;&#261;d podczas opuszczania rozmowy.</string>
+    <string name="joined_conversation_success">Do&#322;&#261;czy&#322;e&#347; do rozmowy.</string>
+    <string name="left_conversation_success">Opu&#347;ci&#322;e&#347; rozmow&#281;.</string>
     <string name="error_unblocking_user">Nie mo&#380;na odblokowa&#263; u&#380;ytkownika.</string>
-    <string name="delete_group_conversation_error">Wyst&#261;pi&#322; b&#322;&#261;d podczas usuwania rozmowy.</string>
+    <string name="delete_conversation_conversation_error">Wyst&#261;pi&#322; b&#322;&#261;d podczas usuwania rozmowy.</string>
     <string name="error_limit_number_assets_imported_exceeded">Mo&#380;esz przes&#322;a&#263; jednocze&#347;nie maksymalnie 20 plik&#243;w</string>
     <!-- Archiving -->
     <!-- Favorite -->
@@ -629,13 +610,12 @@ Do grupy mo&#380;e do&#322;&#261;czy&#263; maksymalnie 500 os&#243;b.</string>
     <string name="notification_reply">Odpowied&#378;: %1$s</string>
     <string name="notification_not_supported_issue">Funkcjonalno&#347;&#263; niedost&#281;pna</string>
     <string name="notification_connection_request">Chce si&#281; po&#322;&#261;czy&#263;</string>
-    <string name="notification_conversation_deleted">Usuni&#281;to grup&#281;</string>
     <string name="notification_action_reply">Odpowiedz</string>
     <string name="notification_receiver_name">Ty</string>
     <string name="label_type_a_message">Napisz wiadomo&#347;&#263;</string>
     <string name="notification_incoming_call_content">Dzwoni...</string>
     <string name="notification_ongoing_call_content">Trwa po&#322;&#261;czenie...</string>
-    <string name="notification_group_call_content">%s dzwoni...</string>
+    <string name="notification_group_channel_call_content">%s dzwoni...</string>
     <string name="notification_call_default_caller_name">Kto&#347;</string>
     <string name="notification_call_default_group_name">Po&#322;&#261;czenie grupowe przychodz&#261;ce</string>
     <!-- Calling-->
@@ -694,7 +674,7 @@ Do&#322;&#261;czenie do tego po&#322;&#261;czenia spowoduje zako&#324;czenie tam
     <string name="sso_error_dialog_message">Spr&#243;buj ponownie. Je&#347;li to nie pomo&#380;e, skontaktuj si&#281; z administratorem i podaj ten kod:
 %d</string>
     <string name="asset_download_dialog_default_title">Pobierz plik</string>
-    <string name="empty_group_label">Konwersacja bez nazwy</string>
+    <string name="empty_conversation_label">Konwersacja bez nazwy</string>
     <string name="label_show_more">Poka&#380; wi&#281;cej</string>
     <!--prohibited asset messages -->
     <string name="prohibited_images_message">Otrzymywanie obraz&#243;w jest zabronione</string>
@@ -713,7 +693,6 @@ Do&#322;&#261;czenie do tego po&#322;&#261;czenia spowoduje zako&#324;czenie tam
     <string name="allow_services">Zezw&#243;l na serwisy</string>
     <string name="read_receipts">Potwierdzenia odczytu</string>
     <string name="disable_guests_dialog_title">Nie zezwalaj na go&#347;ci?</string>
-    <string name="disable_guests_dialog_description">Go&#347;cie, kt&#243;rych wybra&#322;e&#347; w poprzednim kroku, nie b&#281;d&#261; cz&#281;&#347;ci&#261; tej grupy, je&#347;li nie zezwolisz na dost&#281;p dla go&#347;ci.</string>
     <string name="disable_guests_dialog_button">Nie zezwalaj na go&#347;ci</string>
     <!--block user dialog -->
     <string name="block_user_dialog_title">Zablokowa&#263; u&#380;ytkownika?</string>
@@ -810,9 +789,7 @@ Do&#322;&#261;czenie do tego po&#322;&#261;czenia spowoduje zako&#324;czenie tam
     <string name="backup_dialog_restore_wrong_user_error_message">Nie mo&#380;na przywr&#243;ci&#263; historii z innego konta.</string>
     <string name="backup_dialog_restore_general_error_title">Wyst&#261;pi&#322; problem</string>
     <string name="backup_dialog_restore_general_error_message">Nie uda&#322;o si&#281; przywr&#243;ci&#263; historii. Spr&#243;buj ponownie lub skontaktuj si&#281; z pomoc&#261; techniczn&#261; Wire.</string>
-    <string name="group_content_deleted">Zawarto&#347;&#263; grupy zosta&#322;a usuni&#281;ta</string>
     <string name="conversation_content_deleted">Zawarto&#347;&#263; rozmowy zosta&#322;a usuni&#281;ta</string>
-    <string name="group_content_delete_failure">Nie uda&#322;o si&#281; usun&#261;&#263; zawarto&#347;ci grupy</string>
     <string name="conversation_content_delete_failure">Nie uda&#322;o si&#281; usun&#261;&#263; zawarto&#347;ci rozmowy</string>
     <string name="group_label">Grupa</string>
     <string name="conversation_label">Konwersacja</string>
@@ -845,9 +822,7 @@ Prosimy u&#380;y&#263; zarz&#261;dzania zespo&#322;ami (%1$s) na tym &#347;rodow
     <string name="join_conversation_dialog_message">Zosta&#322;e&#347; zaproszony do rozmowy.\n\n%1$s</string>
     <string name="join_conversation_dialog_button">Do&#322;&#261;cz</string>
     <string name="join_conversation_via_deeplink_error_title">Nie mo&#380;na do&#322;&#261;czy&#263; do rozmowy</string>
-    <string name="join_conversation_via_deeplink_error_link_expired">Link do tej grupowej rozmowy wygas&#322; lub rozmowa zosta&#322;a ustawiona na prywatn&#261;.</string>
     <string name="join_conversation_via_deeplink_error_max_number_of_participent">Osi&#261;gni&#281;to maksymaln&#261; liczb&#281; uczestnik&#243;w tej rozmowy.</string>
-    <string name="join_conversation_via_deeplink_error_general">Z powodu b&#322;&#281;du nie mo&#380;esz zosta&#263; dodany do grupowej rozmowy.</string>
     <!-- edit self-deleting messages -->
     <!-- visit link -->
     <!-- invalid link -->
@@ -863,8 +838,6 @@ Prosimy u&#380;y&#263; zarz&#261;dzania zespo&#322;ami (%1$s) na tym &#347;rodow
     <string name="revoke_guest__room_link_dialog_title">Wycofa&#263; link dla go&#347;ci?</string>
     <string name="title_device_key_fingerprint">ODCISK KLUCZA URZ&#260;DZENIA</string>
     <string name="label_client_key_fingerprint_not_available">NIEDOST&#280;PNY</string>
-    <string name="guest_room_link_enabled">Generowanie link&#243;w dla go&#347;ci jest teraz w&#322;&#261;czone dla wszystkich administrator&#243;w grupy</string>
-    <string name="guest_room_link_disabled">Generowanie link&#243;w dla go&#347;ci jest teraz wy&#322;&#261;czone dla wszystkich administrator&#243;w grupy</string>
     <!-- New Device dialog -->
     <string name="new_device_dialog_current_user_title">Twoje konto zosta&#322;o u&#380;yte na</string>
     <string name="new_device_dialog_current_user_btn">Zarz&#261;dzaj urz&#261;dzeniami</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -93,8 +93,6 @@
     <string name="content_description_unarchive">Desarquivar</string>
     <string name="content_description_block_the_user">Bloquear</string>
     <string name="content_description_unblock_the_user">Desbloquear</string>
-    <string name="content_description_leave_the_group">Sair do grupo</string>
-    <string name="content_description_delete_the_group">Excluir o grupo</string>
     <string name="content_description_conversation_phone_icon">Iniciar chamada de áudio</string>
     <string name="content_description_welcome_wire_logo">Wire</string>
     <string name="content_description_conversation_enable_rich_text_mode">Habilitar modo de texto avançado</string>
@@ -365,14 +363,13 @@ Uma mensagem excluída não pode ser restaurada.</string>
     <string name="new_group_title">Novo Grupo</string>
     <string name="new_group_description">Até 500 pessoas podem participar de uma conversa.</string>
     <string name="group_name_title">Nome do Grupo</string>
-    <string name="group_name_placeholder">Digite um nome</string>
+    <string name="conversation_name_placeholder">Digite um nome</string>
     <string name="group_name_description">Dê um nome ao grupo.</string>
     <string name="protocol">Protocolo</string>
     <string name="mls">MLS</string>
     <string name="last_key_material_update_label">Última atualização de material criptográfico</string>
     <string name="group_state_label">Estado do Grupo</string>
-    <string name="group_can_not_be_created_edit_participiant_list">Editar lista de participantes</string>
-    <string name="group_can_not_be_created_discard_group_creation">Descartar criação de grupo</string>
+    <string name="conversation_can_not_be_created_edit_participant_list">Editar lista de participantes</string>
     <string name="asset_message_tap_to_download_text">Toque para baixar</string>
     <string name="asset_message_upload_in_progress_text">Fazendo upload…</string>
     <string name="asset_message_download_in_progress_text">Baixando…</string>
@@ -391,18 +388,13 @@ Uma mensagem excluída não pode ser restaurada.</string>
     <string name="conversation_details_options_tab">OPÇÕES</string>
     <string name="conversation_details_participants_tab">PARTICIPANTES</string>
     <string name="conversation_details_options_group_name">NOME DO GRUPO</string>
-    <string name="conversation_details_group_admins">ADMINISTRADORES DO GRUPO (%d)</string>
-    <string name="conversation_details_group_members">MEMBROS DO GRUPO (%d)</string>
     <string name="conversation_details_participants_info">Este grupo tem %s participantes.
 Até 500 pessoas podem participar de uma conversa em grupo.</string>
     <string name="conversation_details_show_all_participants">Mostrar todos os participantes (%d)</string>
-    <string name="conversation_details_group_participants_title">Participantes do Grupo</string>
-    <string name="conversation_details_group_participants_add">Adicionar participantes</string>
     <string name="conversation_participant_you_label">(Você)</string>
     <string name="conversation_details_is_classified">NÍVEL DE SEGURANÇA: VS-NfD</string>
     <string name="conversation_details_is_not_classified">DETALHES DA CONVERSA: NÍVEL DE SEGURANÇA: NÃO CONFIDENCIAL</string>
     <string name="conversation_options_self_deleting_messages_label">Mensagens auto-destrutivas</string>
-    <string name="conversation_options_self_deleting_messages_description">Quando isso estiver ativado, tosas as mensagens neste grupo desaparecerão depois de um certo tempo.</string>
     <string name="conversation_options_guests_label">Convidados</string>
     <string name="conversation_details_guest_description">Quando isso está LIGADO, pessoas de fora do seu time podem se juntar a essa conversa</string>
     <string name="conversation_options_guest_description">Ative essa opção para abrir essa conversa para pessoas fora do seu time, mesmo que elas não tenham o Wire.</string>
@@ -414,12 +406,6 @@ Até 500 pessoas podem participar de uma conversa em grupo.</string>
     <string name="disable_guest_dialog_text">Os convidados atuais serão removidos da conversa. Novos convidados não serão permitidos.</string>
     <string name="disable_services_dialog_title">Desativar acesso de serviços?</string>
     <string name="disable_services_dialog_text">Os serviços atuais serão removidos da conversa. Novos serviços não serão permitidos.</string>
-    <string name="leave_group_conversation_menu_item">Sair do Grupo…</string>
-    <string name="leave_group_conversation_dialog_title">Sair de \"%s\"?</string>
-    <string name="leave_group_conversation_dialog_description">Você não poderá mais enviar ou ler mensagens nesse grupo em nenhum dispositivo.</string>
-    <string name="delete_group_conversation_menu_item">Deletar Grupo…</string>
-    <string name="delete_group_conversation_dialog_title">Remover \"%s\"?</string>
-    <string name="delete_group_conversation_dialog_description">O grupo será removido da sua lista de conversas em todos os dispositivos. Você não poderá mais acessar o grupo e seu conteúdo.</string>
     <!-- Import/Export External Media -->
     <string name="import_media_content_title">Compartilhar com o Wire</string>
     <string name="import_media_searchbar_title">Buscar conversa</string>
@@ -455,20 +441,15 @@ Até 500 pessoas podem participar de uma conversa em grupo.</string>
     <string name="user_profile_status_none">Nenhum</string>
     <string name="user_profile_details_tab">Detalhes</string>
     <string name="user_profile_devices_tab">Dispositivos</string>
-    <string name="user_profile_group_tab">Grupo</string>
-    <string name="user_profile_group_member">Membro do grupo \"%s\"</string>
-    <string name="user_profile_group_role">FUNÇÃO</string>
-    <string name="user_profile_role_in_group">Função em \"%s\"</string>
+    <string name="user_profile_role_in_conversation">Função em \"%s\"</string>
     <string name="user_profile_role_change_error">Houve um erro ao tentar alterar a função. Por favor, verifique sua conexão com a internet e tente novamente</string>
     <string name="user_profile_unblock_user">Desbloquear usuário</string>
-    <string name="user_profile_group_remove_button">Remover do grupo</string>
     <string name="user_profile_logging_out_progress">Saindo...</string>
     <!-- Remove Conversation Member Dialog -->
     <string name="dialog_remove_conversation_member_title">Remover do grupo?</string>
     <string name="dialog_remove_conversation_member_description">%1$s (@%2$s) não poderá enviar nem receber mensagens nesta conversa.</string>
-    <string name="dialog_remove_conversation_member_error">Houve um erro ao remover o participante do grupo</string>
-    <string name="group_role_admin">Administrador</string>
-    <string name="group_role_member">Membro</string>
+    <string name="conversation_role_admin">Administrador</string>
+    <string name="conversation_role_member">Membro</string>
     <!-- Logout Wipe Data Dialog -->
     <string name="dialog_logout_wipe_data_title">Limpar Dados?</string>
     <string name="dialog_logout_wipe_data_checkbox">Excluir todas as suas informações pessoais e conversas deste dispositivo</string>
@@ -490,8 +471,6 @@ Até 500 pessoas podem participar de uma conversa em grupo.</string>
     <string name="label_clear_content">Limpar Conteúdo…</string>
     <string name="label_block">Bloquear</string>
     <string name="label_unblock">Desbloquear</string>
-    <string name="label_leave_group">Sair do Grupo</string>
-    <string name="label_delete_group">Excluir Grupo</string>
     <!-- Conversation filter BottomSheet -->
     <!-- Muting options BottomSheet -->
     <string name="muting_option_all_allowed_title">Tudo</string>
@@ -623,7 +602,7 @@ Até 500 pessoas podem participar de uma conversa em grupo.</string>
         <item quantity="other">%1$d mensagens</item>
     </plurals>
     <string name="ephemeral_one_to_one_event_message">"Enviou uma mensagem"</string>
-    <string name="ephemeral_group_event_message">"Alguém enviou uma mensagem"</string>
+    <string name="ephemeral_group_channel_event_message">"Alguém enviou uma mensagem"</string>
     <!--Typing Indicator-->
     <!-- Search Messages -->
     <string name="label_search_button">Procurar</string>
@@ -669,12 +648,12 @@ Até 500 pessoas podem participar de uma conversa em grupo.</string>
     <string name="conversation_on_file_downloaded">O arquivo %s foi salvo com sucesso na pasta Downloads.</string>
     <string name="error_blocking_user">O usuário não pôde ser bloqueado.</string>
     <string name="blocking_user_success">%s bloqueado.</string>
-    <string name="conversation_group_removed_success">\"%s\" removido.</string>
-    <string name="leave_group_conversation_error">Ocorreu um erro ao sair da conversa.</string>
-    <string name="joined_conversation_group_success">Você entrou na conversa.</string>
-    <string name="left_conversation_group_success">Você saiu da conversa.</string>
+    <string name="conversation_removed_success">\"%s\" removido.</string>
+    <string name="leave_conversation_error">Ocorreu um erro ao sair da conversa.</string>
+    <string name="joined_conversation_success">Você entrou na conversa.</string>
+    <string name="left_conversation_success">Você saiu da conversa.</string>
     <string name="error_unblocking_user">O usuário não pôde ser desbloqueado.</string>
-    <string name="delete_group_conversation_error">Ocorreu um erro ao excluir a conversa.</string>
+    <string name="delete_conversation_conversation_error">Ocorreu um erro ao excluir a conversa.</string>
     <string name="error_limit_number_assets_imported_exceeded">Você só pode enviar até 20 arquivos de uma vez.</string>
     <!-- Archiving -->
     <string name="success_archiving_conversation">Conversa arquivada</string>
@@ -693,13 +672,12 @@ Até 500 pessoas podem participar de uma conversa em grupo.</string>
     <string name="notification_reply">Resposta: %1$s</string>
     <string name="notification_not_supported_issue">Recurso não suportado</string>
     <string name="notification_connection_request">Deseja conectar-se</string>
-    <string name="notification_conversation_deleted">O grupo foi deletado</string>
     <string name="notification_action_reply">Responder</string>
     <string name="notification_receiver_name">Você</string>
     <string name="label_type_a_message">Digite uma mensagem</string>
     <string name="notification_incoming_call_content">Chamando…</string>
     <string name="notification_ongoing_call_content">Chamada em andamento…</string>
-    <string name="notification_group_call_content">%s está chamando…</string>
+    <string name="notification_group_channel_call_content">%s está chamando…</string>
     <string name="notification_call_default_caller_name">Alguém</string>
     <string name="notification_call_default_group_name">Chamada em Grupo Recebida</string>
     <!-- Calling-->
@@ -761,7 +739,7 @@ Até 500 pessoas podem participar de uma conversa em grupo.</string>
     <string name="sso_error_dialog_title">Não foi possível fazer login com SSO</string>
     <string name="sso_error_dialog_message">Por favor tente novamente. Se isso não resolver, contate um administrador e forneça este código:\n%d\"</string>
     <string name="asset_download_dialog_default_title">Baixar arquivo</string>
-    <string name="empty_group_label">Conversa sem nome</string>
+    <string name="empty_conversation_label">Conversa sem nome</string>
     <string name="label_show_more">Mostrar Mais</string>
     <!--prohibited asset messages -->
     <string name="prohibited_images_message">O recebimento de imagens está desabilitado</string>
@@ -779,17 +757,10 @@ Até 500 pessoas podem participar de uma conversa em grupo.</string>
     <string name="allow_guest_switch_description">Abrir esta conversa para pessoas fora do seu time. Você pode sempre alterar isso depois.</string>
     <string name="allow_services">Permitir serviços</string>
     <string name="service_details_label">Serviço</string>
-    <string name="service_details_add_service_label">Adicionar ao grupo</string>
-    <string name="service_details_remove_service_label">Remover do grupo</string>
-    <string name="service_remove_success">Serviço removido do grupo</string>
-    <string name="service_remove_error">Não é possível remover o serviço do grupo</string>
-    <string name="service_add_success">Serviço adicionado ao grupo</string>
-    <string name="service_add_error">Não é possível adicionar o serviço ao grupo</string>
     <string name="service_no_information_available_title">Nenhuma informação disponível</string>
     <string name="service_no_information_available_subtitle">Tente novamente ou entre em contato com o administrador da sua equipe</string>
     <string name="read_receipts">Confirmações de leitura</string>
     <string name="disable_guests_dialog_title">Desabilitar Convidados?</string>
-    <string name="disable_guests_dialog_description">Os convidados selecionados anteriormente não farão parte do grupo se não for permitido o acessso.</string>
     <string name="disable_guests_dialog_button">Desabilitar Convidados</string>
     <!--block user dialog -->
     <string name="block_user_dialog_title">Bloquear usuário?</string>
@@ -907,9 +878,7 @@ Até 500 pessoas podem participar de uma conversa em grupo.</string>
     <string name="backup_dialog_restore_wrong_user_error_message">Não é possível restaurar o histórico de outra conta.</string>
     <string name="backup_dialog_restore_general_error_title">Algo deu errado</string>
     <string name="backup_dialog_restore_general_error_message">Não foi possível restaurar seu histórico. Por favor, tente novamente ou entre em contato com o suporte ao cliente do Wire.</string>
-    <string name="group_content_deleted">Conteúdo do grupo foi excluído</string>
     <string name="conversation_content_deleted">Conteúdo da conversa foi excluído</string>
-    <string name="group_content_delete_failure">Não foi possível excluir o conteúdo do grupo</string>
     <string name="conversation_content_delete_failure">Não foi possível excluir o conteúdo da conversa</string>
     <string name="group_label">grupo</string>
     <string name="conversation_label">conversa</string>
@@ -948,13 +917,10 @@ Por favor, use o gerenciamento de equipe (%1$s) neste backend.</string>
 %1$s</string>
     <string name="join_conversation_dialog_button">Entrar</string>
     <string name="join_conversation_via_deeplink_error_title">Não foi possível entrar na conversa</string>
-    <string name="join_conversation_via_deeplink_error_link_expired">O link para esta conversa expirou ou a conversa foi definida como privada.</string>
     <string name="join_conversation_via_deeplink_error_max_number_of_participent">O número máximo de participantes nesta conversa foi atingido.</string>
-    <string name="join_conversation_via_deeplink_error_general">Devido a um erro, você não pôde ser adicionado à conversa em grupo.</string>
     <!-- edit self-deleting messages -->
     <string name="self_deleting_messages_title">Mensagens autodestrutivas</string>
     <string name="self_deleting_messages_option">Forçar exclusão de mensagens</string>
-    <string name="self_deleting_messages_option_description">Quando isto estiver ativado, todas as mensagens neste grupo desaparecerão após um certo tempo. Isto se aplica a todos os participantes do grupo.</string>
     <string name="self_deleting_messages_folder_timer">Temporizador</string>
     <!-- visit link -->
     <string name="label_visit_link_title">Visitar Link</string>
@@ -976,8 +942,6 @@ Por favor, use o gerenciamento de equipe (%1$s) neste backend.</string>
     <string name="title_device_key_fingerprint">IDENTIFICAÇÃO DO DISPOSITIVO</string>
     <string name="label_client_key_fingerprint_not_available">NÃO DISPONÍVEL</string>
     <string name="guest_room_link_copied">Link copiado para a área de transferência</string>
-    <string name="guest_room_link_enabled">A geração de links de convidado agora está habilitada para todos os administradores de grupo</string>
-    <string name="guest_room_link_disabled">A geração de links de convidado agora está desabilitada para todos os administradores de grupo</string>
     <!-- New Device dialog -->
     <string name="new_device_dialog_current_user_title">Sua conta foi usada em</string>
     <string name="new_device_dialog_current_user_btn">Gerenciar dispositivos</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -102,8 +102,6 @@
     <string name="content_description_unarchive">Разархивировать</string>
     <string name="content_description_block_the_user">Заблокировать</string>
     <string name="content_description_unblock_the_user">Разблокировать</string>
-    <string name="content_description_leave_the_group">Покинуть группу</string>
-    <string name="content_description_delete_the_group">Удалить группу</string>
     <string name="content_description_conversation_phone_icon">Начать звонок</string>
     <string name="content_description_welcome_wire_logo">Wire</string>
     <string name="content_description_conversation_search_icon">Значок поиска</string>
@@ -118,7 +116,6 @@
     <string name="content_description_conversation_mention_someone">Упомянуть кого-нибудь</string>
     <string name="content_description_conversation_back_btn">Вернуться к списку бесед</string>
     <string name="content_description_conversation_open_details_label">открыть информацию о беседе</string>
-    <string name="content_description_new_conversation">Поиск друзей или создание новой группы</string>
     <string name="content_description_back_button">Кнопка назад</string>
     <string name="content_description_send_button">Отправить</string>
     <string name="content_description_timed_message_button">Самоудаляющиеся сообщения, кнопка</string>
@@ -226,7 +223,7 @@
     <string name="content_description_close_dropdown">закрыть раскрывающийся список</string>
     <string name="content_description_open_notification_settings_label">открыть настройки уведомлений</string>
     <string name="content_description_new_conversation_close_btn">Закрыть просмотр новой беседы</string>
-    <string name="content_description_new_group_conversation_back_btn">Вернуться к просмотру новой беседы</string>
+    <string name="content_description_new_conversation_back_btn">Вернуться к просмотру новой беседы</string>
     <string name="content_description_new_conversation_name_back_btn">Вернуться к просмотру новой беседы</string>
     <string name="content_description_new_group_name_field">Введите имя группы</string>
     <string name="content_description_new_channel_name_field">Введите название канала</string>
@@ -486,7 +483,7 @@
     <string name="new_group_description">К групповой беседе могут присоединиться до 500 участников.</string>
     <string name="group_name_title">Название группы</string>
     <string name="channel_name_title">Название канала</string>
-    <string name="group_name_placeholder">Введите название</string>
+    <string name="conversation_name_placeholder">Введите название</string>
     <string name="group_name_description">Дайте этой группе осмысленное название.</string>
     <string name="channel_name_description">Дайте этому каналу осмысленное название.</string>
     <string name="protocol">Протокол</string>
@@ -498,10 +495,7 @@
     <string name="empty_channel_name_error">Пожалуйста, введите название канала</string>
     <string name="regular_group_name_exceeded_limit_error">Название группы не должно превышать 64 символа</string>
     <string name="channel_name_exceeded_limit_error">Название канала не должно превышать 64 символа</string>
-    <string name="group_can_not_be_created_title">Невозможно создать группу</string>
-    <string name="group_can_not_be_created_federation_conflict_description">Пользователи бэкэндов %1$s и %2$s не могут присоединиться к одной групповой беседе.\n\nДля создания группы удалите затронутых участников.</string>
-    <string name="group_can_not_be_created_edit_participiant_list">Изменить список участников</string>
-    <string name="group_can_not_be_created_discard_group_creation">Отменить создание группы</string>
+    <string name="conversation_can_not_be_created_edit_participant_list">Изменить список участников</string>
     <string name="asset_message_tap_to_download_text">Нажмите для загрузки</string>
     <string name="asset_message_upload_in_progress_text">Отправка…</string>
     <string name="asset_message_download_in_progress_text">Загрузка…</string>
@@ -520,23 +514,16 @@
     <string name="label_add_participants">Добавить участников</string>
     <string name="username_unavailable_label">Имя недоступно</string>
     <string name="temporary_user_label">%s покинул(-а)</string>
-    <string name="group_unavailable_label">Название группы недоступно</string>
     <string name="conversation_details_title">Информация о беседе</string>
     <string name="conversation_details_options_tab">ПАРАМЕТРЫ</string>
     <string name="conversation_details_participants_tab">УЧАСТНИКИ</string>
     <string name="conversation_details_options_group_name">НАЗВАНИЕ ГРУППЫ</string>
-    <string name="conversation_details_group_admins">АДМИНИСТРАТОРЫ ГРУППЫ (%d)</string>
-    <string name="conversation_details_group_members">УЧАСТНИКИ ГРУППЫ (%d)</string>
-    <string name="conversation_details_participants_info">В этой группе %s участника(-ов).\nК групповой беседе могут присоединиться до 500 человек.</string>
     <string name="conversation_details_participants_count">%s участников</string>
     <string name="conversation_details_show_all_participants">Показать всех участников (%d)</string>
-    <string name="conversation_details_group_participants_title">Участники группы</string>
-    <string name="conversation_details_group_participants_add">Добавить участников</string>
     <string name="conversation_participant_you_label">(Вы)</string>
     <string name="conversation_details_is_classified">УРОВЕНЬ БЕЗОПАСНОСТИ: VS-NfD</string>
     <string name="conversation_details_is_not_classified">УРОВЕНЬ БЕЗОПАСНОСТИ: НЕКЛАССИФИЦИРОВАН</string>
     <string name="conversation_options_self_deleting_messages_label">Самоудаляющиеся сообщения</string>
-    <string name="conversation_options_self_deleting_messages_description">Если этот параметр включен, все сообщения в этой группе будут исчезать через определенное время.</string>
     <string name="conversation_options_guests_label">Гости</string>
     <string name="conversation_details_guest_description">Когда эта опция включена, к беседе могут присоединиться пользователи, не входящие в вашу команду</string>
     <string name="conversation_options_guest_description">Включите эту опцию, чтобы открыть эту беседу для пользователей не из вашей команды, даже если у них нет Wire.</string>
@@ -548,16 +535,6 @@
     <string name="disable_guest_dialog_text">Текущие гости будут удалены из беседы. Новые гости допущены не будут.</string>
     <string name="disable_services_dialog_title">Отключить доступ сервисов?</string>
     <string name="disable_services_dialog_text">Текущие сервисы будут удалены из беседы. Новые сервисы допущены не будут.</string>
-    <string name="leave_group_conversation_menu_item">Покинуть группу…</string>
-    <string name="leave_group_conversation_dialog_title">Покинуть “%s”?</string>
-    <string name="leave_group_conversation_dialog_description">Вы больше не сможете отправлять и читать сообщения в этой группе ни на одном устройстве.</string>
-    <string name="leave_group_conversation_dialog_delete_fully_check">Удалить группу и ее контент у меня на всех моих устройствах</string>
-    <string name="delete_group_conversation_menu_item">Удалить группу…</string>
-    <string name="delete_group_conversation_dialog_title">Удалить “%s”?</string>
-    <string name="delete_group_conversation_dialog_description">Группа будет удалена из списка бесед на всех устройствах. Вы больше не сможете получить доступ к группе и ее контенту.</string>
-    <string name="delete_group_locally_conversation_dialog_title">Удалить себя из группы \"%s\"?</string>
-    <string name="delete_group_locally_conversation_dialog_description">Вы не сможете получить доступ к группе и ее содержимому. Восстановить ее невозможно.</string>
-    <string name="delete_group_locally_delete_for_me_label">Удалить себя</string>
     <!-- Import/Export External Media -->
     <string name="import_media_content_title">Поделиться с Wire</string>
     <string name="import_media_searchbar_title">Поиск по беседе</string>
@@ -606,13 +583,9 @@
     <string name="user_profile_account_management">Управлять командой</string>
     <string name="user_profile_details_tab">Подробности</string>
     <string name="user_profile_devices_tab">Устройства</string>
-    <string name="user_profile_group_tab">Группа</string>
-    <string name="user_profile_group_member">Участник группы \"%s\"</string>
-    <string name="user_profile_group_role">РОЛЬ</string>
-    <string name="user_profile_role_in_group">Роль в ”%s”</string>
+    <string name="user_profile_role_in_conversation">Роль в ”%s”</string>
     <string name="user_profile_role_change_error">При попытке изменить роль возникла ошибка. Проверьте, пожалуйста, подключение к интернету и повторите попытку</string>
     <string name="user_profile_unblock_user">Разблокировать пользователя</string>
-    <string name="user_profile_group_remove_button">Удалить из группы</string>
     <string name="user_profile_logging_out_progress">Выход...</string>
     <string name="user_profile_qr_code">Открыть QR-код</string>
     <string name="user_profile_qr_code_title">Поделиться профилем</string>
@@ -625,9 +598,8 @@
     <!-- Remove Conversation Member Dialog -->
     <string name="dialog_remove_conversation_member_title">Удалить из группы?</string>
     <string name="dialog_remove_conversation_member_description">%1$s (@%2$s) не сможет отправлять или получать сообщения в этой беседе.</string>
-    <string name="dialog_remove_conversation_member_error">При удалении участника из группы произошла ошибка</string>
-    <string name="group_role_admin">Администратор</string>
-    <string name="group_role_member">Участник</string>
+    <string name="conversation_role_admin">Администратор</string>
+    <string name="conversation_role_member">Участник</string>
     <!-- Logout Wipe Data Dialog -->
     <string name="dialog_logout_wipe_data_title">Удалить данные?</string>
     <string name="dialog_logout_wipe_data_checkbox">Удалить всю личную информацию и беседы на этом устройстве</string>
@@ -655,9 +627,6 @@
     <string name="label_clear_content">Очистить контент…</string>
     <string name="label_block">Заблокировать</string>
     <string name="label_unblock">Разблокировать</string>
-    <string name="label_leave_group">Покинуть группу</string>
-    <string name="label_delete_group_locally">Удалить себя из группы</string>
-    <string name="label_delete_group">Удалить группу</string>
     <!-- Conversation filter BottomSheet -->
     <string name="label_filter_conversations">Отфильтровать беседы</string>
     <string name="label_filter_all">Все беседы</string>
@@ -758,14 +727,10 @@
     <string name="label_system_message_conversation_started_by_self">**Вы** начали беседу</string>
     <string name="label_system_message_conversation_started_by_other">%1$s начал(-а) беседу</string>
     <string name="label_system_message_conversation_started_with_members">С %1$s</string>
-    <string name="label_system_message_conversation_failed_add_members_summary">Не удалось добавить в группу %1$s **участников**.</string>
-    <string name="label_system_message_conversation_failed_add_many_members_details">Не удалось добавить %1$s в группу.</string>
-    <string name="label_system_message_conversation_failed_add_one_member_details">Не удалось добавить %1$s в группу.</string>
     <string name="label_system_message_conversation_degraded_mls">Эта беседа больше не является верифицированной, поскольку по крайней мере один из участников начал использовать новое устройство или имеет недействительный сертификат.</string>
     <string name="label_system_message_conversation_degraded_proteus">Эта беседа больше не является верифицированной, поскольку по крайней мере один из участников начал использовать новое устройство или имеет недействительный сертификат.</string>
     <string name="label_system_message_conversation_verified_mls">Все устройства верифицированы (сквозная идентификация)</string>
     <string name="label_system_message_conversation_verified_proteus">Все отпечатки верифицированы (Proteus)</string>
-    <string name="label_system_message_conversation_started_sensitive_information">Общение в Wire всегда ведется с использованием сквозного шифрования. Все, что вы отправляете и получаете в этой беседе, доступно только вам и другим участникам группы.\n**Пожалуйста, будьте осторожны с теми, кому вы сообщаете конфиденциальную информацию.**</string>
     <string name="label_conversations_details_verified_proteus">Верифицировано (Proteus)</string>
     <string name="label_conversations_details_verified_mls">Верифицировано (сквозная идентификация)</string>
     <!-- Last messages -->
@@ -871,7 +836,7 @@
         <item quantity="other">%1$d сообщения</item>
     </plurals>
     <string name="ephemeral_one_to_one_event_message">"Отправил(-а) сообщение"</string>
-    <string name="ephemeral_group_event_message">"Кто-то прислал сообщение"</string>
+    <string name="ephemeral_group_channel_event_message">"Кто-то прислал сообщение"</string>
     <!--Typing Indicator-->
     <plurals name="typing_indicator_event_message">
         <item quantity="one">%s печатает</item>
@@ -933,13 +898,13 @@
     <string name="conversation_on_file_downloaded">Файл %s был успешно сохранен в папку Загрузки</string>
     <string name="error_blocking_user">Пользователь не может быть заблокирован</string>
     <string name="blocking_user_success">%s заблокирован</string>
-    <string name="conversation_group_removed_success">“%s” удален</string>
-    <string name="conversation_group_removed_locally_success">Удалили себя из \"%s\"</string>
-    <string name="leave_group_conversation_error">При выходе из беседы произошла ошибка</string>
-    <string name="joined_conversation_group_success">Вы присоединились к беседе.</string>
-    <string name="left_conversation_group_success">Вы покинули беседу.</string>
+    <string name="conversation_removed_success">“%s” удален</string>
+    <string name="conversation_removed_locally_success">Удалили себя из \"%s\"</string>
+    <string name="leave_conversation_error">При выходе из беседы произошла ошибка</string>
+    <string name="joined_conversation_success">Вы присоединились к беседе.</string>
+    <string name="left_conversation_success">Вы покинули беседу.</string>
     <string name="error_unblocking_user">Пользователь не может быть разблокирован</string>
-    <string name="delete_group_conversation_error">При удалении беседы произошла ошибка</string>
+    <string name="delete_conversation_conversation_error">При удалении беседы произошла ошибка</string>
     <string name="error_limit_number_assets_imported_exceeded">Одновременно можно отправить не более 20 файлов</string>
     <!-- Archiving -->
     <string name="success_archiving_conversation">Беседа архивирована</string>
@@ -969,7 +934,6 @@
     <string name="notification_reply">Ответ: %1$s</string>
     <string name="notification_not_supported_issue">Функция не поддерживается</string>
     <string name="notification_connection_request">Хочет подключиться</string>
-    <string name="notification_conversation_deleted">Удалил группу</string>
     <string name="notification_action_reply">Ответить</string>
     <string name="notification_receiver_name">Вы</string>
     <string name="label_type_a_message">Введите сообщение</string>
@@ -977,7 +941,7 @@
     <string name="notification_action_decline_call">Отклонить</string>
     <string name="notification_incoming_call_content">Вызов…</string>
     <string name="notification_ongoing_call_content">Исходящий вызов…</string>
-    <string name="notification_group_call_content">%s вызывает...</string>
+    <string name="notification_group_channel_call_content">%s вызывает...</string>
     <string name="notification_call_default_caller_name">Кто-то</string>
     <string name="notification_call_default_group_name">Входящий групповой вызов</string>
     <string name="notification_outgoing_call_tap_to_return">Нажмите, чтобы вернуться к вызову - Вызов...</string>
@@ -1066,7 +1030,7 @@
         администратором и сообщите этот код:\n%d\"
     </string>
     <string name="asset_download_dialog_default_title">Загрузить файл</string>
-    <string name="empty_group_label">Безымянная беседа</string>
+    <string name="empty_conversation_label">Безымянная беседа</string>
     <string name="label_show_more">Развернуть</string>
     <!--prohibited asset messages -->
     <string name="prohibited_images_message">Получение изображений запрещено</string>
@@ -1086,19 +1050,12 @@
     <string name="allow_services_regular_group_description">Открыть эту беседу для сервисов. Вы всегда сможете изменить это позже.</string>
     <string name="allow_services_channel_description">Откройте эту беседу для людей, не из вашей команды или сервисов. Вы всегда сможете изменить это позже.</string>
     <string name="service_details_label">Сервис</string>
-    <string name="service_details_add_service_label">Добавить в группу</string>
-    <string name="service_details_remove_service_label">Удалить из группы</string>
-    <string name="service_remove_success">Сервис удален из группы</string>
-    <string name="service_remove_error">Не удалось удалить сервис из группы</string>
-    <string name="service_add_success">Сервис добавлен в группу</string>
-    <string name="service_add_error">Не удалось добавить сервис в группу</string>
     <string name="service_no_information_available_title">Информация недоступна</string>
     <string name="service_no_information_available_subtitle">Попробуйте еще раз или свяжитесь с администратором группы</string>
     <string name="read_receipts">Отчеты о прочтении</string>
     <string name="read_receipts_regular_group_description">При включении ваши собеседники смогут видеть когда было прочитано их сообщение.</string>
     <string name="read_receipts_channel_description">При включении ваши собеседники смогут видеть когда было прочитано их сообщение в этом канале.</string>
     <string name="disable_guests_dialog_title">Не разрешать гостей?</string>
-    <string name="disable_guests_dialog_description">Гости, выбранные на предыдущем этапе, не смогут войти в группу, если не разрешить гостевой доступ.</string>
     <string name="disable_guests_dialog_button">Не разрешать гостей</string>
     <!--block user dialog -->
     <string name="block_user_dialog_title">Заблокировать пользователя?</string>
@@ -1294,9 +1251,7 @@
     <string name="backup_dialog_restore_wrong_user_error_message">Вы не можете восстановить историю из другой учетной записи.</string>
     <string name="backup_dialog_restore_general_error_title">Что-то пошло не так</string>
     <string name="backup_dialog_restore_general_error_message">Ваша история не может быть восстановлена. Пожалуйста, попробуйте еще раз или обратитесь в службу поддержки Wire.</string>
-    <string name="group_content_deleted">Контент группы был удален</string>
     <string name="conversation_content_deleted">Контент беседы был удален</string>
-    <string name="group_content_delete_failure">Не удалось удалить контент группы</string>
     <string name="conversation_content_delete_failure">Не удалось удалить контент беседы</string>
     <string name="group_label">группы</string>
     <string name="conversation_label">беседа</string>
@@ -1337,13 +1292,10 @@
     <string name="join_conversation_dialog_message">Вас пригласили в беседу.\n\n%1$s</string>
     <string name="join_conversation_dialog_button">Присоединиться</string>
     <string name="join_conversation_via_deeplink_error_title">Невозможно присоединиться к беседе</string>
-    <string name="join_conversation_via_deeplink_error_link_expired">Срок действия ссылки на эту групповую беседу истек или беседа стала приватной.</string>
     <string name="join_conversation_via_deeplink_error_max_number_of_participent">Достигнуто максимальное количество участников в этой беседе.</string>
-    <string name="join_conversation_via_deeplink_error_general">Из-за ошибки вы не можете быть добавлены в групповую беседу.</string>
     <!-- edit self-deleting messages -->
     <string name="self_deleting_messages_title">Самоудаляющиеся сообщения</string>
     <string name="self_deleting_messages_option">Принудительное удаление сообщений</string>
-    <string name="self_deleting_messages_option_description">При включении этой опции все сообщения в данной группе будут исчезать через определенное время. Это относится ко всем участникам группы.</string>
     <string name="self_deleting_messages_folder_timer">Таймер</string>
     <!-- visit link -->
     <string name="label_visit_link_title">Перейти по ссылке</string>
@@ -1370,8 +1322,6 @@
     <string name="title_device_key_fingerprint">ОТПЕЧАТОК КЛЮЧА УСТРОЙСТВА</string>
     <string name="label_client_key_fingerprint_not_available">НЕДОСТУПНО</string>
     <string name="guest_room_link_copied">Ссылка скопирована в буфер обмена</string>
-    <string name="guest_room_link_enabled">Генерация гостевых ссылок теперь включена для всех администраторов групп</string>
-    <string name="guest_room_link_disabled">Генерация гостевых ссылок теперь отключена для всех администраторов групп</string>
     <!-- New Device dialog -->
     <string name="new_device_dialog_current_user_title">Ваш аккаунт использовался на</string>
     <string name="new_device_dialog_message_defice_info">%1$s\nОт: %2$s \n</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -97,8 +97,6 @@
     <string name="content_description_unarchive">අසංරක්‍ෂණය</string>
     <string name="content_description_block_the_user">අවහිර කරන්න</string>
     <string name="content_description_unblock_the_user">අනවහිර</string>
-    <string name="content_description_leave_the_group">සමූහය හැරයන්න</string>
-    <string name="content_description_delete_the_group">සමූහය මකන්න</string>
     <string name="content_description_conversation_phone_icon">ශ්‍රව්‍ය ඇමතුමක් අරඹන්න</string>
     <string name="content_description_welcome_wire_logo">වයර්</string>
     <string name="content_description_conversation_search_icon">සොයන්න නිරූපකය</string>
@@ -372,14 +370,13 @@
     <string name="new_group_title">නව සමූහය</string>
     <string name="new_group_description">සමූහ සංවාදයකට {{count}} දෙනෙකුට එක්විය හැකිය.</string>
     <string name="group_name_title">සමූහයේ නම</string>
-    <string name="group_name_placeholder">නමක් යොදන්න</string>
+    <string name="conversation_name_placeholder">නමක් යොදන්න</string>
     <string name="group_name_description">මෙම කණ්ඩායමට අර්ථවත් නමක් දෙන්න.</string>
     <string name="protocol">කෙටුම්පත</string>
     <string name="mls">MLS</string>
     <string name="cipher_suite">කේතාංකන කට්ටලය</string>
     <string name="group_state_label">සමූහයේ තත්‍වය</string>
-    <string name="group_can_not_be_created_edit_participiant_list">සහභාගීන් සංස්කරණය</string>
-    <string name="group_can_not_be_created_discard_group_creation">සමූහය සෑදීම ඉවතලන්න</string>
+    <string name="conversation_can_not_be_created_edit_participant_list">සහභාගීන් සංස්කරණය</string>
     <string name="asset_message_tap_to_download_text">බාගැනීමට ඔබන්න</string>
     <string name="asset_message_upload_in_progress_text">උඩුගත වෙමින්…</string>
     <string name="asset_message_download_in_progress_text">බාගත වෙමින්…</string>
@@ -395,23 +392,16 @@
     <string name="member_name_you_label_lowercase">ඔබ</string>
     <string name="label_add_participants">සහභාගීන් යොදන්න</string>
     <string name="username_unavailable_label">නම නොතිබේ</string>
-    <string name="group_unavailable_label">සමූහයේ නම නොතිබේ</string>
     <string name="conversation_details_title">සංවාදයේ විස්තර</string>
     <string name="conversation_details_options_tab">විකල්ප</string>
     <string name="conversation_details_participants_tab">සහභාගීන්</string>
     <string name="conversation_details_options_group_name">සමූහයේ නම</string>
-    <string name="conversation_details_group_admins">සමූහයේ පරිපාලකයින් (%d)</string>
-    <string name="conversation_details_group_members">සමූහයේ සාමාජිකයින් (%d)</string>
-    <string name="conversation_details_participants_info">මෙම සමූහයේ සහභාගීන් %s දෙනෙක් සිටියි.\nසමූහ සංවාදයකට 500 දෙනෙකුට එක් වීමට හැකිය.</string>
     <string name="conversation_details_participants_count">සහභාගීන් %s</string>
     <string name="conversation_details_show_all_participants">සියළු සහභාගීන් පෙන්වන්න (%d)</string>
-    <string name="conversation_details_group_participants_title">සමූහයේ සහභාගීන්</string>
-    <string name="conversation_details_group_participants_add">සහභාගීන් යොදන්න</string>
     <string name="conversation_participant_you_label">(ඔබ)</string>
     <string name="conversation_details_is_classified">ආරක්‍ෂණ මට්ටම: VS-NfD</string>
     <string name="conversation_details_is_not_classified">ආරක්‍ෂණ මට්ටම: වර්ගීකෘත නොවේ</string>
     <string name="conversation_options_self_deleting_messages_label">ඉබේ මැකෙන පණිවිඩ</string>
-    <string name="conversation_options_self_deleting_messages_description">මෙය සක්‍රිය විට, මෙම සමූහයේ ඇති සියලුම පණිවිඩ නිශ්චිත කාලයකට පසු අතුරුදහන් වනු ඇත.</string>
     <string name="conversation_options_guests_label">අමුත්තන්</string>
     <string name="conversation_details_guest_description">මෙය සක්‍රිය නම්, මෙම සංවාදයට කණ්ඩායමෙන් පිටත අයට එක් වීමට හැකිය</string>
     <string name="conversation_options_guest_description">ඔබගේ කණ්ඩායමෙන් පිටත පුද්ගලයින්ට මෙම සංවාදය විවෘත කිරීමට මෙම විකල්පය සක්‍රිය කරන්න. වයර් නැති අයට ද උපකාරී වේ.</string>
@@ -423,12 +413,6 @@
     <string name="disable_guest_dialog_text">වත්මන් අමුත්තන් සංවාදයෙන් ඉවත් කරනු ලැබේ. නව අමුත්තන්ට ඉඩ නොදෙනු ඇත.</string>
     <string name="disable_services_dialog_title">සේවා ප්‍රවේශය අබල කරන්නද?</string>
     <string name="disable_services_dialog_text">වත්මන් සේවා සංවාදයෙන් ඉවත් කෙරේ. නව සේවා සඳහා ඉඩ නොදෙනු ඇත.</string>
-    <string name="leave_group_conversation_menu_item">සමූහය හැරයන්න…</string>
-    <string name="leave_group_conversation_dialog_title">“%s” හැරයනවාද?</string>
-    <string name="leave_group_conversation_dialog_description">ඔබට තවදුරටත් මෙම සමූහයට කිසිදු උපාංගයකින් පණිවිඩ යැවීමට හෝ කියවීමට නොහැකි වනු ඇත.</string>
-    <string name="delete_group_conversation_menu_item">සමූහය මකන්න…</string>
-    <string name="delete_group_conversation_dialog_title">“%s” ඉවත් කරන්නද?</string>
-    <string name="delete_group_conversation_dialog_description">සියලුම උපාංගවල ඔබගේ සංවාද ලැයිස්තුවෙන් සමූහය ඉවත් කරනු ලැබේ. ඔබට තවදුරටත් සමූහයට සහ එහි අන්තර්ගතයට ප්‍රවේශ වීමට නොහැකි වනු ඇත.</string>
     <!-- Import/Export External Media -->
     <string name="import_media_content_title">වයර් සමඟ බෙදාගන්න</string>
     <string name="import_media_searchbar_title">සංවාදයක් සොයන්න</string>
@@ -472,20 +456,15 @@
     <string name="user_profile_status_none">කිසිවක් නැත</string>
     <string name="user_profile_details_tab">විස්තර</string>
     <string name="user_profile_devices_tab">උපාංග</string>
-    <string name="user_profile_group_tab">සමූහය</string>
-    <string name="user_profile_group_member">”%s” සමූහයේ සාමාජිකයෙකි</string>
-    <string name="user_profile_group_role">භූමිකාව</string>
-    <string name="user_profile_role_in_group">”%s” හි භූමිකාව</string>
+    <string name="user_profile_role_in_conversation">”%s” හි භූමිකාව</string>
     <string name="user_profile_role_change_error">භූමිකාව වෙනස් කිරීමට තැත් කිරීමේ දී දෝෂයක් සිදු විය. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය පරීක්‍ෂා කර නැවත උත්සාහ කරන්න</string>
     <string name="user_profile_unblock_user">අනවහිර කරන්න</string>
-    <string name="user_profile_group_remove_button">සමූහයෙන් ඉවත් කරන්න</string>
     <string name="user_profile_logging_out_progress">නික්මෙමින්...</string>
     <!-- Remove Conversation Member Dialog -->
     <string name="dialog_remove_conversation_member_title">සමූහයෙන් ඉවත් කරන්නද?</string>
     <string name="dialog_remove_conversation_member_description">%1$s (@%2$s) හට මෙම සංවාදයට පණිවිඩ යැවීමට හෝ ලැබීමට නොහැකි වනු ඇත.</string>
-    <string name="dialog_remove_conversation_member_error">සහභාගියා සමූහයෙන් ඉවත් කිරීමේ දී දෝෂයක් සිදු විය</string>
-    <string name="group_role_admin">පරිපාලක</string>
-    <string name="group_role_member">සාමාජික</string>
+    <string name="conversation_role_admin">පරිපාලක</string>
+    <string name="conversation_role_member">සාමාජික</string>
     <!-- Logout Wipe Data Dialog -->
     <string name="dialog_logout_wipe_data_title">දත්ත මකන්නද?</string>
     <string name="dialog_logout_wipe_data_checkbox">මෙම උපාංගයේ ඔබගේ සියළුම පෞද්. තොරතුරු හා සංවාද මකන්න</string>
@@ -507,8 +486,6 @@
     <string name="label_clear_content">අන්තර්ගතය මකන්න…</string>
     <string name="label_block">අවහිර කරන්න</string>
     <string name="label_unblock">අනවහිර</string>
-    <string name="label_leave_group">සමූහය හැරයන්න</string>
-    <string name="label_delete_group">සමූහය මකන්න</string>
     <!-- Conversation filter BottomSheet -->
     <!-- Muting options BottomSheet -->
     <string name="muting_option_all_allowed_title">සියල්ල</string>
@@ -588,14 +565,10 @@
     <string name="label_system_message_conversation_started_by_self">**ඔබ** සංවාදය ආරම්භ කළා</string>
     <string name="label_system_message_conversation_started_by_other">%1$s සංවාදය ආරම්භ කළා</string>
     <string name="label_system_message_conversation_started_with_members">%1$s සමග</string>
-    <string name="label_system_message_conversation_failed_add_members_summary">**සහභාගීන්** %1$s ක් සමූහයට එක් කිරීමට නොහැකි විය.</string>
-    <string name="label_system_message_conversation_failed_add_many_members_details">%1$s දෙනෙක් සමූහයට එක් කිරීමට නොහැකි විය.</string>
-    <string name="label_system_message_conversation_failed_add_one_member_details">%1$s දෙනෙක් සමූහයට එක් කිරීමට නොහැකි විය.</string>
     <string name="label_system_message_conversation_degraded_mls">අවම වශයෙන් එක් සහභාගියෙක් නව උපාංගයක් භාවිතා කරන නිසා හෝ වලංගු නොවන සහතිකයක් තිබෙන බැවින් සංවාදය තවදුරටත් සත්‍යාපිත නොවේ.</string>
     <string name="label_system_message_conversation_degraded_proteus">අවම වශයෙන් එක් සහභාගියෙක් නව උපාංගයක් භාවිතා කරන නිසා හෝ වලංගු නොවන සහතිකයක් තිබෙන බැවින් සංවාදය තවදුරටත් සත්‍යාපිත නොවේ.</string>
     <string name="label_system_message_conversation_verified_mls">සියලු උපාංග සත්‍යාපිතයි (අන්ත අනන්‍යතාව)</string>
     <string name="label_system_message_conversation_verified_proteus">සියලු ඇඟිලි සටහන් සත්‍යාපිතයි (ප්‍රෝටියස්)</string>
-    <string name="label_system_message_conversation_started_sensitive_information">වයර් සන්නිවේදනය සෑම විටම අන්ත සංකේතිතයි. මෙම සංවාදයේ ඔබ යවන සහ ලැබෙන සෑම දෙයක්ම ඔබට සහ වෙනත් සමූහ සහභාගීන්ට පමණක් ප්‍රවේශ වීමට හැකිය.\n**ඔබ සංවේදී තොරතුරු බෙදාගන්නේ කවුරුන් සමඟ දැයි තවදුරටත් සැලකිලිමත් වන්න.**</string>
     <string name="label_conversations_details_verified_proteus">සත්‍යාපිතයි (ප්‍රෝටියස්)</string>
     <string name="label_conversations_details_verified_mls">සත්‍යාපිතයි (අන්ත අනන්‍යතාව)</string>
     <!-- Last messages -->
@@ -673,7 +646,7 @@
         <item quantity="other">පණිවිඩ %1$d</item>
     </plurals>
     <string name="ephemeral_one_to_one_event_message">"පණිවිඩයක් එවා ඇත"</string>
-    <string name="ephemeral_group_event_message">"යමෙක් පණිවිඩයක් එවා ඇත"</string>
+    <string name="ephemeral_group_channel_event_message">"යමෙක් පණිවිඩයක් එවා ඇත"</string>
     <!--Typing Indicator-->
     <plurals name="typing_indicator_event_message">
         <item quantity="one">%s ලියමින්</item>
@@ -728,12 +701,12 @@
     <string name="conversation_on_file_downloaded">බාගැනීමේ බහාලුමට %s ගොනුව සාර්ථකව සුරැකිණි</string>
     <string name="error_blocking_user">පරිශ්‍රීලකයා අවහිර කිරීමට නොහැකි විය</string>
     <string name="blocking_user_success">%s අවහිර කෙරිණි</string>
-    <string name="conversation_group_removed_success">“%s” ඉවත් කෙරිණි</string>
-    <string name="leave_group_conversation_error">සංවාදය හැරයන විට දෝෂයක් සිදු විය</string>
-    <string name="joined_conversation_group_success">ඔබ සංවාදයට එක්වුණා.</string>
-    <string name="left_conversation_group_success">ඔබ සංවාදය හැරගියා.</string>
+    <string name="conversation_removed_success">“%s” ඉවත් කෙරිණි</string>
+    <string name="leave_conversation_error">සංවාදය හැරයන විට දෝෂයක් සිදු විය</string>
+    <string name="joined_conversation_success">ඔබ සංවාදයට එක්වුණා.</string>
+    <string name="left_conversation_success">ඔබ සංවාදය හැරගියා.</string>
     <string name="error_unblocking_user">පරිශ්‍රීලකයා අනවහිර කිරීමට නොහැකි විය</string>
-    <string name="delete_group_conversation_error">සංවාදය මකන විට දෝෂයක් සිදු විය</string>
+    <string name="delete_conversation_conversation_error">සංවාදය මකන විට දෝෂයක් සිදු විය</string>
     <string name="error_limit_number_assets_imported_exceeded">එකවර ගොනු 20 ක් පමණක් යැවීමට හැකිය</string>
     <!-- Archiving -->
     <string name="success_archiving_conversation">සංවාදය සංරක්‍ෂණය කර ඇත</string>
@@ -759,13 +732,12 @@
     <string name="notification_reply">පිළිතුර: %1$s</string>
     <string name="notification_not_supported_issue">විශේෂාංගයට සහාය නොදක්වයි</string>
     <string name="notification_connection_request">සබැඳීමට වුවමනාය</string>
-    <string name="notification_conversation_deleted">සමූහය මකාදමා ඇත</string>
     <string name="notification_action_reply">පිළිතුර</string>
     <string name="notification_receiver_name">ඔබ</string>
     <string name="label_type_a_message">පණිවිඩයක් ලියන්න</string>
     <string name="notification_incoming_call_content">අමතමින්…</string>
     <string name="notification_ongoing_call_content">පවතින ඇමතුම…</string>
-    <string name="notification_group_call_content">%s අමතමින්...</string>
+    <string name="notification_group_channel_call_content">%s අමතමින්...</string>
     <string name="notification_call_default_caller_name">යමෙක්</string>
     <string name="notification_call_default_group_name">ලැබෙන සමූහ ඇමතුම</string>
     <string name="notification_outgoing_call_tap_to_return">ඇමතුමට යාමට ඔබන්න - අමතමින්...</string>
@@ -838,7 +810,7 @@
         පරිපාලක අමතා මෙම කේතය දෙන්න:\n%d\"
     </string>
     <string name="asset_download_dialog_default_title">ගොනුව බාගන්න</string>
-    <string name="empty_group_label">නම් කොකළ සංවාදය</string>
+    <string name="empty_conversation_label">නම් කොකළ සංවාදය</string>
     <string name="label_show_more">තව පෙන්වන්න</string>
     <!--prohibited asset messages -->
     <string name="prohibited_images_message">රූප ලැබීම වළක්වා ඇත</string>
@@ -856,17 +828,10 @@
     <string name="allow_guest_switch_description">ඔබගේ කණ්ඩායමෙන් පිටත පුද්ගලයින්ට මෙම සංවාදය විවෘත කරන්න. මෙය පසුව වෙනස් කිරීමට හැකිය.</string>
     <string name="allow_services">සේවාවලට ඉඩදෙන්න</string>
     <string name="service_details_label">සේවාව</string>
-    <string name="service_details_add_service_label">සමූහයට දමන්න</string>
-    <string name="service_details_remove_service_label">සමූහයෙන් ඉවත් කරන්න</string>
-    <string name="service_remove_success">සේවාව සමූහයෙන් ඉවත් කෙරිණි</string>
-    <string name="service_remove_error">සමූහයෙන් සේවාව ඉවත් කිරීමට නොහැකිය</string>
-    <string name="service_add_success">සේවාව සමූහයට එක් කෙරිණි</string>
-    <string name="service_add_error">සමූහයට සේවාව එක් කිරීමට නොහැකිය</string>
     <string name="service_no_information_available_title">තොරතුරු නොතිබේ</string>
     <string name="service_no_information_available_subtitle">නැවත උත්සාහ කරන්න හෝ කණ්ඩායමේ පරිපාලකයා අමතන්න</string>
     <string name="read_receipts">කියවූ බවට ලදුපත්</string>
     <string name="disable_guests_dialog_title">අමුත්තන්ට ඉඩ නොදේ ද?</string>
-    <string name="disable_guests_dialog_description">ඔබ අමුත්තන්ට ප්‍රවේශය නොදෙන්නේ නම්, ඔබ කලින් පියවරේ දී තෝරාගත් අමුත්තන් සමූහයේ කොටසක් නොවනු ඇත.</string>
     <string name="disable_guests_dialog_button">අමුත්තන්ට ඉඩ නොදෙන්න</string>
     <!--block user dialog -->
     <string name="block_user_dialog_title">අවහිර කරන්න ද?</string>
@@ -1034,9 +999,7 @@
     <string name="backup_dialog_restore_wrong_user_error_message">වෙනත් ගිණුමකින් ඉතිහාසය ප්‍රත්‍යර්පණයට සහාය නොදක්වයි.</string>
     <string name="backup_dialog_restore_general_error_title">යමක් වැරදී ඇත</string>
     <string name="backup_dialog_restore_general_error_message">ඔබගේ ඉතිහාසය ප්‍රත්‍යර්පණයට නොහැකි විය. කරුණාකර නැවත උත්සාහ කරන්න හෝ වයර් පාරිභෝගික සේවාව අමතන්න.</string>
-    <string name="group_content_deleted">සමූහයේ අන්තර්ගතය මකාදමා ඇත</string>
     <string name="conversation_content_deleted">සංවාදයේ අන්තර්ගතය මකාදමා ඇත</string>
-    <string name="group_content_delete_failure">සමූහයේ අන්තර්ගතය මැකීමට නොහැකි විය</string>
     <string name="conversation_content_delete_failure">සංවාදයේ අන්තර්ගතය මැකීමට නොහැකි විය</string>
     <string name="group_label">සමුහය</string>
     <string name="conversation_label">සංවාදය</string>
@@ -1071,13 +1034,10 @@
     <string name="join_conversation_dialog_message">ඔබට සංවාදයකට ආරාධනා කර ඇත.\n\n%1$s</string>
     <string name="join_conversation_dialog_button">එක්වන්න</string>
     <string name="join_conversation_via_deeplink_error_title">සංවාදයට එක්වීමට නොහැකිය</string>
-    <string name="join_conversation_via_deeplink_error_link_expired">මෙම සමූහ සංවාදයේ සබැඳිය කල් ඉකුත් වී හෝ සංවාදය පෞද්ගලික ලෙස සකසා ඇත.</string>
     <string name="join_conversation_via_deeplink_error_max_number_of_participent">මෙම සංවාදයේ උපරිම සහභාගීන් ගණනට ළඟා වී ඇත.</string>
-    <string name="join_conversation_via_deeplink_error_general">දෝෂයක් හේතුවෙන් ඔබව සමූහ සංවාදයට එක් කිරීමට නොහැකි විය.</string>
     <!-- edit self-deleting messages -->
     <string name="self_deleting_messages_title">ඉබේ මැකෙන පණිවිඩ</string>
     <string name="self_deleting_messages_option">බලෙන් පණිවිඩය මකන්න</string>
-    <string name="self_deleting_messages_option_description">මෙය සක්‍රිය විට, මෙම සමූහයේ ඇති සියලුම පණිවිඩ නිශ්චිත කාලයකට පසු අතුරුදහන් වනු ඇත. මෙය සමූහයේ සියලුම සහභාගීන්ටට අදාළ වේ.</string>
     <string name="self_deleting_messages_folder_timer">මුහුර්තකය</string>
     <!-- visit link -->
     <string name="label_visit_link_title">සබැඳිය බලන්න</string>
@@ -1100,8 +1060,6 @@
     <string name="title_device_key_fingerprint">උපාංගයේ යතුරේ ඇඟිලි සටහන</string>
     <string name="label_client_key_fingerprint_not_available">නොතිබේ</string>
     <string name="guest_room_link_copied">සබැඳිය පසුරු පුවරුවට පිටපත් විය</string>
-    <string name="guest_room_link_enabled">සමූහයේ සියළුම පරිපාලකයින් සඳහා ආගන්තුක සබැඳි උත්පාදනය සබලයි</string>
-    <string name="guest_room_link_disabled">සමූහයේ සියළුම පරිපාලකයින් සඳහා ආගන්තුක සබැඳි උත්පාදනය අබලයි</string>
     <!-- New Device dialog -->
     <string name="new_device_dialog_current_user_title">මෙදින ගිණුම භාවිතා කර ඇත:</string>
     <string name="new_device_dialog_message_defice_info">%1$s\nවෙතින්: %2$s \n</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -85,12 +85,9 @@
     <string name="content_description_move_to_archive">Flytta till arkiv</string>
     <string name="content_description_block_the_user">Blockera</string>
     <string name="content_description_unblock_the_user">Avblockera</string>
-    <string name="content_description_leave_the_group">Lämna gruppen</string>
-    <string name="content_description_delete_the_group">Ta bort gruppen</string>
     <string name="content_description_conversation_phone_icon">Starta ljudsamtal</string>
     <string name="content_description_welcome_wire_logo">Wire</string>
     <string name="content_description_conversation_mention_someone">Nämn någon</string>
-    <string name="content_description_new_conversation">Sök efter personer eller skapa ny grupp</string>
     <string name="content_description_back_button">Bakåt-knapp</string>
     <string name="content_description_send_button">Skicka</string>
     <string name="content_description_timed_message_button">Självraderande meddelanden, knapp</string>
@@ -274,10 +271,10 @@
     <string name="new_group_title">Ny grupp</string>
     <string name="new_group_description">Upp till 500 personer kan ansluta till en grupp-konversation.</string>
     <string name="group_name_title">Gruppnamn</string>
-    <string name="group_name_placeholder">Ange ett namn</string>
+    <string name="conversation_name_placeholder">Ange ett namn</string>
     <string name="group_name_description">Ge den här gruppen ett meningsfullt namn.</string>
     <string name="protocol">Protokoll</string>
-    <string name="group_can_not_be_created_edit_participiant_list">Redigera deltagarlista</string>
+    <string name="conversation_can_not_be_created_edit_participant_list">Redigera deltagarlista</string>
     <string name="asset_message_tap_to_download_text">Tryck för att hämta</string>
     <string name="asset_message_upload_in_progress_text">Laddar upp…</string>
     <string name="asset_message_download_in_progress_text">Hämtar…</string>
@@ -288,16 +285,11 @@
     <string name="conversation_details_options_tab">ALTERNATIV</string>
     <string name="conversation_details_participants_tab">DELTAGARE</string>
     <string name="conversation_details_options_group_name">GRUPPNAMN</string>
-    <string name="conversation_details_group_members">GRUPPMEDLEMMAR (%d)</string>
     <string name="conversation_details_participants_count">%s deltagare</string>
     <string name="conversation_details_show_all_participants">Visa alla deltagare (%d)</string>
-    <string name="conversation_details_group_participants_title">Gruppdeltagare</string>
-    <string name="conversation_details_group_participants_add">Lägg till deltagare</string>
     <string name="conversation_participant_you_label">(Du)</string>
     <string name="conversation_options_guests_label">Gäster</string>
     <string name="conversation_options_services_label">Tjänster</string>
-    <string name="leave_group_conversation_menu_item">Lämna grupp…</string>
-    <string name="delete_group_conversation_menu_item">Radera grupp…</string>
     <!-- Import/Export External Media -->
     <string name="import_media_content_title">Dela med Wire</string>
     <string name="import_media_searchbar_title">Sök efter konversation</string>
@@ -335,11 +327,8 @@
     <string name="user_profile_status_none">Ingen</string>
     <string name="user_profile_details_tab">Detaljer</string>
     <string name="user_profile_devices_tab">Enheter</string>
-    <string name="user_profile_group_tab">Grupp</string>
-    <string name="user_profile_group_role">ROLL</string>
-    <string name="user_profile_role_in_group">Roll i \"%s\"</string>
+    <string name="user_profile_role_in_conversation">Roll i \"%s\"</string>
     <string name="user_profile_unblock_user">Avblockera användare</string>
-    <string name="user_profile_group_remove_button">Ta bort från gruppen</string>
     <string name="user_profile_logging_out_progress">Loggar ut...</string>
     <string name="user_profile_qr_code">Öppna QR-kod</string>
     <string name="user_profile_qr_code_title">Dela profil</string>
@@ -347,9 +336,8 @@
     <string name="user_profile_qr_code_share_image_link">Dela QR-kod</string>
     <!-- Remove Conversation Member Dialog -->
     <string name="dialog_remove_conversation_member_title">Ta bort från gruppen?</string>
-    <string name="dialog_remove_conversation_member_error">Det uppstod ett fel när deltagaren skulle tas bort från gruppen</string>
-    <string name="group_role_admin">Administratör</string>
-    <string name="group_role_member">Medlem</string>
+    <string name="conversation_role_admin">Administratör</string>
+    <string name="conversation_role_member">Medlem</string>
     <!-- Logout Wipe Data Dialog -->
     <string name="dialog_logout_wipe_data_title">Rensa data?</string>
     <string name="dialog_logout_wipe_data_checkbox">Ta bort all din personliga information och konversationer i den här enheten</string>
@@ -362,8 +350,6 @@
     <string name="label_move_to_archive">Flytta till Arkiv</string>
     <string name="label_clear_content">Rensa innehåll…</string>
     <string name="label_block">Blockera</string>
-    <string name="label_leave_group">Lämna grupp</string>
-    <string name="label_delete_group">Radera grupp</string>
     <!-- Conversation filter BottomSheet -->
     <string name="label_filter_conversations">Filtrera konversationer</string>
     <string name="label_filter_all">Alla konversationer</string>
@@ -444,7 +430,7 @@
     <string name="error_server_miscommunication_message">Försök igen</string>
     <string name="error_no_network_title">Väntar på nätverk</string>
     <string name="error_no_network_message">Kontrollera din internetanslutning och försök igen</string>
-    <string name="left_conversation_group_success">Du har lämnat konversationen.</string>
+    <string name="left_conversation_success">Du har lämnat konversationen.</string>
     <!-- Archiving -->
     <!-- Favorite -->
     <!-- Animation label -->
@@ -459,7 +445,7 @@
     <string name="notification_receiver_name">Du</string>
     <string name="label_type_a_message">Skriv ett meddelande</string>
     <string name="notification_incoming_call_content">Ringer…</string>
-    <string name="notification_group_call_content">%s ringer...</string>
+    <string name="notification_group_channel_call_content">%s ringer...</string>
     <!-- Calling-->
     <string name="calling_button_label_microphone">Mikrofon</string>
     <string name="calling_button_label_camera">Kamera</string>
@@ -486,7 +472,6 @@
     <string name="change">Ändra</string>
     <string name="allow_guests">Tillåt gäster</string>
     <string name="service_details_label">Tjänst</string>
-    <string name="service_details_add_service_label">Lägg till i grupp</string>
     <string name="read_receipts">Läskvitton</string>
     <!--block user dialog -->
     <string name="block_user_dialog_body">%1$s kommer inte att kunna kontakta dig eller lägga till dig i gruppkonversationer. De kommer inte att meddelas om detta.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -98,8 +98,6 @@
     <string name="content_description_unarchive">Arşivden Çıkar</string>
     <string name="content_description_block_the_user">Engelle</string>
     <string name="content_description_unblock_the_user">Engeli kaldır</string>
-    <string name="content_description_leave_the_group">Gruptan ayrıl</string>
-    <string name="content_description_delete_the_group">Grubu sil</string>
     <string name="content_description_conversation_phone_icon">Sesli aramayı başlat</string>
     <string name="content_description_welcome_wire_logo">Wire</string>
     <string name="content_description_conversation_search_icon">Arama simgesi</string>
@@ -240,8 +238,6 @@ Yedek dosyayı korumak için güçlü bir şifre seçin.</string>
     <string name="conversation_details_options_tab">SEÇENEKLER</string>
     <string name="conversation_details_participants_tab">KATILIMCILAR</string>
     <string name="conversation_details_participants_count">katılımcılar %s</string>
-    <string name="conversation_details_group_participants_title">\n**Lütfen yinede önemli bilgi paylaşırken dikkatli olun.**</string>
-    <string name="conversation_options_self_deleting_messages_description">Bu açık olduğunda, bu gruptaki tüm mesajlar belirli bir süre sonra kaybolacaktır.</string>
     <string name="conversation_options_guests_label">Misafirler</string>
     <string name="conversation_options_services_label">Servisler</string>
     <string name="conversation_options_services_description">Bu görüşmeyi hizmetlere açmak için bu seçeneği AÇIK konumuna getirin.</string>
@@ -264,7 +260,6 @@ Yedek dosyayı korumak için güçlü bir şifre seçin.</string>
     <!--Conversation-->
     <!-- System messages -->
     <string name="label_system_message_conversation_history_lost">YOU HAVEN\'T USED THIS DEVICE FOR A WHILE. SOME MESSAGES MAY NOT APPEAR HERE.</string>
-    <string name="label_system_message_conversation_started_sensitive_information">Wire\'daki iletişim her zaman uçtan uca şifrelenir. Bu görüşmede gönderdiğiniz ve aldığınız her şeye yalnızca siz ve diğer grup katılımcıları erişebilir.</string>
     <!-- Last messages -->
     <string name="last_message_other_user_joined_conversation">sohbete katıldı.</string>
     <!-- Unread Events -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -79,8 +79,6 @@
     <string name="content_description_unarchive">Розархівувати</string>
     <string name="content_description_block_the_user">Заблокувати</string>
     <string name="content_description_unblock_the_user">Розблокувати</string>
-    <string name="content_description_leave_the_group">Покинути групу</string>
-    <string name="content_description_delete_the_group">Видалити групу</string>
     <string name="content_description_welcome_wire_logo">Wire</string>
     <string name="content_description_conversation_mention_someone">Згадати когось</string>
     <string name="content_description_send_button">Надіслати</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,8 +109,8 @@
     <string name="content_description_unarchive">Unarchive</string>
     <string name="content_description_block_the_user">Block</string>
     <string name="content_description_unblock_the_user">Unblock</string>
-    <string name="content_description_leave_the_group">Leave the group</string>
-    <string name="content_description_delete_the_group">Delete the group</string>
+    <string name="content_description_leave_the_conversation">Leave the conversation</string>
+    <string name="content_description_delete_the_conversation">Delete the conversation</string>
     <string name="content_description_conversation_phone_icon">Start audio call</string>
     <string name="content_description_welcome_wire_logo">Wire</string>
     <string name="content_description_conversation_search_icon">Search icon</string>
@@ -125,7 +125,7 @@
     <string name="content_description_conversation_mention_someone">Mention someone</string>
     <string name="content_description_conversation_back_btn">Go back to conversation list</string>
     <string name="content_description_conversation_open_details_label">open conversation details</string>
-    <string name="content_description_new_conversation">Search for people or create a new group</string>
+    <string name="content_description_new_conversation">Search for people or create a new conversation</string>
     <string name="content_description_back_button">Back button</string>
     <string name="content_description_send_button">Send</string>
     <string name="content_description_timed_message_button">Self-deleting messages, button</string>
@@ -233,7 +233,7 @@
     <string name="content_description_close_dropdown">close dropdown</string>
     <string name="content_description_open_notification_settings_label">open notification settings</string>
     <string name="content_description_new_conversation_close_btn">Close new conversation view</string>
-    <string name="content_description_new_group_conversation_back_btn">Go back to new conversation view</string>
+    <string name="content_description_new_conversation_back_btn">Go back to new conversation view</string>
     <string name="content_description_new_conversation_name_back_btn">Go back to new conversation view</string>
     <string name="content_description_new_group_name_field">Type group name</string>
     <string name="content_description_new_channel_name_field">Type channel name</string>
@@ -544,7 +544,7 @@
     <string name="new_group_description">Up to 500 people can join a group conversation.</string>
     <string name="group_name_title">Group Name</string>
     <string name="channel_name_title">Channel Name</string>
-    <string name="group_name_placeholder">Enter a name</string>
+    <string name="conversation_name_placeholder">Enter a name</string>
     <string name="group_name_description">Give this group a meaningful name.</string>
     <string name="channel_name_description">Give this channel a meaningful name.</string>
     <string name="protocol">Protocol</string>
@@ -556,10 +556,10 @@
     <string name="empty_channel_name_error">Please enter a channel name</string>
     <string name="regular_group_name_exceeded_limit_error">Group name should not exceed 64 characters</string>
     <string name="channel_name_exceeded_limit_error">Channel name should not exceed 64 characters</string>
-    <string name="group_can_not_be_created_title">Group can\'t be created</string>
-    <string name="group_can_not_be_created_federation_conflict_description">People from backends %1$s and %2$s can\'t join the same group conversation.\n\nTo create the group, remove affected participants.</string>
-    <string name="group_can_not_be_created_edit_participiant_list">Edit Participants List</string>
-    <string name="group_can_not_be_created_discard_group_creation">Discard Group Creation</string>
+    <string name="conversation_can_not_be_created_title">Conversation can\'t be created</string>
+    <string name="conversation_can_not_be_created_federation_conflict_description">People from backends %1$s and %2$s can\'t join the same conversation.\n\nTo create the conversation, remove affected participants.</string>
+    <string name="conversation_can_not_be_created_edit_participant_list">Edit Participants List</string>
+    <string name="conversation_can_not_be_created_discard_creation">Discard Conversation Creation</string>
     <string name="asset_message_tap_to_download_text">Tap to download</string>
     <string name="asset_message_upload_in_progress_text">Uploading…</string>
     <string name="asset_message_download_in_progress_text">Downloading…</string>
@@ -578,23 +578,23 @@
     <string name="label_add_participants">Add Participants</string>
     <string name="username_unavailable_label">Name not available</string>
     <string name="temporary_user_label">%s left</string>
-    <string name="group_unavailable_label">Group name not available</string>
+    <string name="conversation_unavailable_label">Conversation name not available</string>
     <string name="conversation_details_title">Conversation Details</string>
     <string name="conversation_details_options_tab">OPTIONS</string>
     <string name="conversation_details_participants_tab">PARTICIPANTS</string>
     <string name="conversation_details_options_group_name">GROUP NAME</string>
-    <string name="conversation_details_group_admins">GROUP ADMINS (%d)</string>
-    <string name="conversation_details_group_members">GROUP MEMBERS (%d)</string>
-    <string name="conversation_details_participants_info">This group has %s participants.\nUp to 500 people can join a group conversation.</string>
+    <string name="conversation_details_conversation_admins">CONVERSATION ADMINS (%d)</string>
+    <string name="conversation_details_conversation_members">CONVERSATION MEMBERS (%d)</string>
+    <string name="conversation_details_participants_info">This conversation has %s participants.\nUp to 500 people can join a conversation.</string>
     <string name="conversation_details_participants_count">%s participants</string>
     <string name="conversation_details_show_all_participants">Show all participants (%d)</string>
-    <string name="conversation_details_group_participants_title">Group Participants</string>
-    <string name="conversation_details_group_participants_add">Add participants</string>
+    <string name="conversation_details_participants_title">Conversation Participants</string>
+    <string name="conversation_details_conversation_participants_add">Add participants</string>
     <string name="conversation_participant_you_label">(You)</string>
     <string name="conversation_details_is_classified">SECURITY LEVEL: VS-NfD</string>
     <string name="conversation_details_is_not_classified">SECURITY LEVEL: UNCLASSIFIED</string>
     <string name="conversation_options_self_deleting_messages_label">Self-deleting messages</string>
-    <string name="conversation_options_self_deleting_messages_description">When this is on, all messages in this group will disappear after a certain time.</string>
+    <string name="conversation_options_self_deleting_messages_description">When this is on, all messages in this conversation will disappear after a certain time.</string>
     <string name="conversation_options_guests_label">Guests</string>
     <string name="conversation_details_guest_description">When this is ON, people from outside your team can join this conversation</string>
     <string name="conversation_options_guest_description">Turn this option ON to open this conversation to people outside your team, even if they don\'t have Wire.</string>
@@ -606,16 +606,16 @@
     <string name="disable_guest_dialog_text">Current guests will be removed from the conversation. New guests will not be allowed.</string>
     <string name="disable_services_dialog_title">Disable services access?</string>
     <string name="disable_services_dialog_text">Current services will be removed from the conversation. New services will not be allowed.</string>
-    <string name="leave_group_conversation_menu_item">Leave Group…</string>
-    <string name="leave_group_conversation_dialog_title">Leave “%s”?</string>
-    <string name="leave_group_conversation_dialog_description">You will then no longer be able to send or read messages in this group on any device.</string>
-    <string name="leave_group_conversation_dialog_delete_fully_check">Delete the group and its content for me on all my devices</string>
-    <string name="delete_group_conversation_menu_item">Delete Group…</string>
-    <string name="delete_group_conversation_dialog_title">Remove “%s”?</string>
-    <string name="delete_group_conversation_dialog_description">The group will be removed from your conversations list on all devices. You will no longer be able to access the group and its content.</string>
-    <string name="delete_group_locally_conversation_dialog_title">Delete “%s” group for me?</string>
-    <string name="delete_group_locally_conversation_dialog_description">You won’t be able to access the group and its content. There is no option to restore it.</string>
-    <string name="delete_group_locally_delete_for_me_label">Delete for Me</string>
+    <string name="leave_conversation_menu_item">Leave Conversation…</string>
+    <string name="leave_conversation_dialog_title">Leave “%s”?</string>
+    <string name="leave_conversation_dialog_description">You will then no longer be able to send or read messages in this conversation on any device.</string>
+    <string name="leave_conversation_dialog_delete_fully_check">Delete the conversation and its content for me on all my devices</string>
+    <string name="delete_conversation_conversation_menu_item">Delete Conversation…</string>
+    <string name="delete_conversation_conversation_dialog_title">Remove “%s”?</string>
+    <string name="delete_conversation_conversation_dialog_description">The conversation will be removed from your conversations list on all devices. You will no longer be able to access the conversation and its content.</string>
+    <string name="delete_conversation_locally_conversation_dialog_title">Delete “%s” conversation for me?</string>
+    <string name="delete_conversation_locally_conversation_dialog_description">You won’t be able to access the conversation and its content. There is no option to restore it.</string>
+    <string name="delete_conversation_locally_delete_for_me_label">Delete for Me</string>
     <!-- Import/Export External Media -->
     <string name="import_media_content_title">Share With Wire</string>
     <string name="import_media_searchbar_title">Search for conversation</string>
@@ -666,13 +666,13 @@
     <string name="user_profile_account_management">Manage Team</string>
     <string name="user_profile_details_tab">Details</string>
     <string name="user_profile_devices_tab">Devices</string>
-    <string name="user_profile_group_tab">Group</string>
-    <string name="user_profile_group_member">Member of the group ”%s”</string>
-    <string name="user_profile_group_role">ROLE</string>
-    <string name="user_profile_role_in_group">Role in ”%s”</string>
+    <string name="user_profile_conversation_tab">Conversation</string>
+    <string name="user_profile_conversation_member">Member of the conversation ”%s”</string>
+    <string name="user_profile_conversation_role">ROLE</string>
+    <string name="user_profile_role_in_conversation">Role in ”%s”</string>
     <string name="user_profile_role_change_error">There was an error trying to change the role. Please check your internet connection and try again</string>
     <string name="user_profile_unblock_user">Unblock User</string>
-    <string name="user_profile_group_remove_button">Remove from group</string>
+    <string name="user_profile_conversation_remove_button">Remove from conversation</string>
     <string name="user_profile_logging_out_progress">Logging out...</string>
     <string name="user_profile_qr_code">Open QR Code</string>
     <string name="user_profile_qr_code_title">Share Profile</string>
@@ -683,11 +683,11 @@
     <string name="user_profile_create_team_card_button">Create a Team</string>
     <string name="user_profile_create_team_description_card">Explore extra features for free with the same level of security.</string>
     <!-- Remove Conversation Member Dialog -->
-    <string name="dialog_remove_conversation_member_title">Remove from group?</string>
+    <string name="dialog_remove_conversation_member_title">Remove from conversation?</string>
     <string name="dialog_remove_conversation_member_description">%1$s (@%2$s) will not be able to send or receive messages in this conversation.</string>
-    <string name="dialog_remove_conversation_member_error">There was an error while removing the participant from the group</string>
-    <string name="group_role_admin">Admin</string>
-    <string name="group_role_member">Member</string>
+    <string name="dialog_remove_conversation_member_error">There was an error while removing the participant from the conversatrion</string>
+    <string name="conversation_role_admin">Admin</string>
+    <string name="conversation_role_member">Member</string>
     <!-- Logout Wipe Data Dialog -->
     <string name="dialog_logout_wipe_data_title">Clear Data?</string>
     <string name="dialog_logout_wipe_data_checkbox">Delete all your personal information and conversations on this device</string>
@@ -715,9 +715,9 @@
     <string name="label_clear_content">Clear Content…</string>
     <string name="label_block">Block</string>
     <string name="label_unblock">Unblock</string>
-    <string name="label_leave_group">Leave Group</string>
-    <string name="label_delete_group_locally">Delete Group For Me</string>
-    <string name="label_delete_group">Delete Group</string>
+    <string name="label_leave_conversation">Leave Conversation</string>
+    <string name="label_delete_conversation_locally">Delete Conversation For Me</string>
+    <string name="label_delete_conversation">Delete Conversation</string>
     <!-- Conversation filter BottomSheet -->
     <string name="label_filter_conversations">Filter Conversations</string>
     <string name="label_filter_all">All Conversations</string>
@@ -815,14 +815,14 @@
     <string name="label_system_message_conversation_started_by_self">**You** started the conversation</string>
     <string name="label_system_message_conversation_started_by_other">%1$s started the conversation</string>
     <string name="label_system_message_conversation_started_with_members">With %1$s</string>
-    <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the group.</string>
-    <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the group.</string>
-    <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the group.</string>
+    <string name="label_system_message_conversation_failed_add_members_summary">%1$s **participants** could not be added to the conversation.</string>
+    <string name="label_system_message_conversation_failed_add_many_members_details">%1$s could not be added to the conversation.</string>
+    <string name="label_system_message_conversation_failed_add_one_member_details">%1$s could not be added to the conversation.</string>
     <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as at least one participant started using a new device or has an invalid certificate.</string>
     <string name="label_system_message_conversation_degraded_proteus">This conversation is no longer verified, as at least one participant started using a new device or has an invalid certificate.</string>
     <string name="label_system_message_conversation_verified_mls">All devices are verified (end-to-end identity)</string>
     <string name="label_system_message_conversation_verified_proteus">All fingerprints are verified (Proteus)</string>
-    <string name="label_system_message_conversation_started_sensitive_information">Communication in Wire is always end-to-end encrypted. Everything you send and receive in this conversation is only accessible to you and other group participants.\n**Please still be careful with who you share sensitive information.**</string>
+    <string name="label_system_message_conversation_started_sensitive_information">Communication in Wire is always end-to-end encrypted. Everything you send and receive in this conversation is only accessible to you and other conversation participants.\n**Please still be careful with who you share sensitive information.**</string>
     <string name="label_conversations_details_verified_proteus">Verified (Proteus)</string>
     <string name="label_conversations_details_verified_mls">Verified (End-to-end Identity)</string>
     <!-- Last messages -->
@@ -904,7 +904,7 @@
         <item quantity="other">%1$d messages</item>
     </plurals>
     <string name="ephemeral_one_to_one_event_message">"Sent a message"</string>
-    <string name="ephemeral_group_event_message">"Someone sent a message"</string>
+    <string name="ephemeral_group_channel_event_message">"Someone sent a message"</string>
     <!--Typing Indicator-->
     <plurals name="typing_indicator_event_message">
         <item quantity="one">%s is typing</item>
@@ -975,13 +975,13 @@
     <string name="conversation_on_file_downloaded">The file %s was saved successfully to the Downloads folder</string>
     <string name="error_blocking_user">User could not be blocked</string>
     <string name="blocking_user_success">%s blocked</string>
-    <string name="conversation_group_removed_success">“%s” removed</string>
-    <string name="conversation_group_removed_locally_success">“%s” deleted for me</string>
-    <string name="leave_group_conversation_error">There was an error while leaving conversation</string>
-    <string name="joined_conversation_group_success">You joined the conversation.</string>
-    <string name="left_conversation_group_success">You left the conversation.</string>
+    <string name="conversation_removed_success">“%s” removed</string>
+    <string name="conversation_removed_locally_success">“%s” deleted for me</string>
+    <string name="leave_conversation_error">There was an error while leaving conversation</string>
+    <string name="joined_conversation_success">You joined the conversation.</string>
+    <string name="left_conversation_success">You left the conversation.</string>
     <string name="error_unblocking_user">User could not be unblocked</string>
-    <string name="delete_group_conversation_error">There was an error while deleting conversation</string>
+    <string name="delete_conversation_conversation_error">There was an error while deleting conversation</string>
     <string name="error_limit_number_assets_imported_exceeded">You can only send up to 20 files at once</string>
     <!-- Archiving -->
     <string name="success_archiving_conversation">Conversation was archived</string>
@@ -1014,7 +1014,7 @@
     <string name="notification_reply">Reply: %1$s</string>
     <string name="notification_not_supported_issue">Feature not supported</string>
     <string name="notification_connection_request">Wants to connect</string>
-    <string name="notification_conversation_deleted">Deleted the group</string>
+    <string name="notification_conversation_deleted">Deleted the conversation</string>
     <string name="notification_action_reply">Reply</string>
     <string name="notification_receiver_name">You</string>
     <string name="label_type_a_message">Type a message</string>
@@ -1022,7 +1022,7 @@
     <string name="notification_action_decline_call">Decline</string>
     <string name="notification_incoming_call_content">Calling…</string>
     <string name="notification_ongoing_call_content">Ongoing call…</string>
-    <string name="notification_group_call_content">%s calling...</string>
+    <string name="notification_group_channel_call_content">%s calling...</string>
     <string name="notification_call_default_caller_name">Someone</string>
     <string name="notification_call_default_group_name">Incoming group call</string>
     <string name="notification_outgoing_call_tap_to_return">Tap to return to call - Calling...</string>
@@ -1111,7 +1111,7 @@
         admin and provide this code:\n%d"
     </string>
     <string name="asset_download_dialog_default_title">Download file</string>
-    <string name="empty_group_label">Unnamed conversation</string>
+    <string name="empty_conversation_label">Unnamed conversation</string>
     <string name="label_show_more">Show More</string>
     <!--prohibited asset messages -->
     <string name="prohibited_images_message">Receiving images is prohibited</string>
@@ -1131,19 +1131,19 @@
     <string name="allow_services_regular_group_description">Open this conversation to services. You can always change it later.</string>
     <string name="allow_services_channel_description">Open this conversation to people outside your team or services. You can always change it later.</string>
     <string name="service_details_label">Service</string>
-    <string name="service_details_add_service_label">Add To Group</string>
-    <string name="service_details_remove_service_label">Remove From Group</string>
-    <string name="service_remove_success">Service removed from group</string>
-    <string name="service_remove_error">Unable to remove service from group</string>
-    <string name="service_add_success">Service added to group</string>
-    <string name="service_add_error">Unable to add service to group</string>
+    <string name="service_details_add_service_label">Add To Conversation</string>
+    <string name="service_details_remove_service_label">Remove From Conversation</string>
+    <string name="service_remove_success">Service removed from conversation</string>
+    <string name="service_remove_error">Unable to remove service from conversation</string>
+    <string name="service_add_success">Service added to conversation</string>
+    <string name="service_add_error">Unable to add service to conversation</string>
     <string name="service_no_information_available_title">No information available</string>
     <string name="service_no_information_available_subtitle">Try again or reach out to your team admin</string>
     <string name="read_receipts">Read receipts</string>
     <string name="read_receipts_regular_group_description">When this is on, people can see when their messages in this conversation are read.</string>
     <string name="read_receipts_channel_description">When this is on, people can see when their messages in this channel are read.</string>
     <string name="disable_guests_dialog_title">Not Allow Guests?</string>
-    <string name="disable_guests_dialog_description">Guests you selected in the previous step won\'t be part of the group if you do not allow guest access.</string>
+    <string name="disable_guests_dialog_description">Guests you selected in the previous step won\'t be part of the conversation if you do not allow guest access.</string>
     <string name="disable_guests_dialog_button">Not Allow Guests</string>
     <!--block user dialog -->
     <string name="block_user_dialog_title">Block user?</string>
@@ -1340,9 +1340,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="backup_dialog_restore_wrong_user_error_message">You cannot restore history from a different account.</string>
     <string name="backup_dialog_restore_general_error_title">Something Went Wrong</string>
     <string name="backup_dialog_restore_general_error_message">Your history could not be restored. Please try again or contact the Wire customer support.</string>
-    <string name="group_content_deleted">Group content was deleted</string>
     <string name="conversation_content_deleted">Conversation content was deleted</string>
-    <string name="group_content_delete_failure">Group content could not be deleted</string>
     <string name="conversation_content_delete_failure">Conversation content could not be deleted</string>
     <string name="group_label">group</string>
     <string name="conversation_label">conversation</string>
@@ -1389,13 +1387,13 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="join_conversation_dialog_message">You have been invited to a conversation.\n\n%1$s</string>
     <string name="join_conversation_dialog_button">Join</string>
     <string name="join_conversation_via_deeplink_error_title">Unable to join conversation</string>
-    <string name="join_conversation_via_deeplink_error_link_expired">The link to this group conversation expired or the conversation was set to private.</string>
+    <string name="join_conversation_via_deeplink_error_link_expired">The link to this conversation expired or the conversation was set to private.</string>
     <string name="join_conversation_via_deeplink_error_max_number_of_participent">The maximum number of participants in this conversation has been reached.</string>
-    <string name="join_conversation_via_deeplink_error_general">Due to an error you could not be added to the group conversation.</string>
+    <string name="join_conversation_via_deeplink_error_general">Due to an error you could not be added to the conversation.</string>
     <!-- edit self-deleting messages -->
     <string name="self_deleting_messages_title">Self-deleting Messages</string>
     <string name="self_deleting_messages_option">Enforce message deletion</string>
-    <string name="self_deleting_messages_option_description">When this is on, all messages in this group will disappear after a certain time. This applies to all group participants.</string>
+    <string name="self_deleting_messages_option_description">When this is on, all messages in this conversation will disappear after a certain time. This applies to all participants.</string>
     <string name="self_deleting_messages_folder_timer">Timer</string>
     <!-- visit link -->
     <string name="label_visit_link_title">Visit Link</string>
@@ -1422,8 +1420,8 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="title_device_key_fingerprint">DEVICE KEY FINGERPRINT</string>
     <string name="label_client_key_fingerprint_not_available">NOT AVAILABLE</string>
     <string name="guest_room_link_copied">Link copied to clipboard</string>
-    <string name="guest_room_link_enabled">Generating guest links is now enabled for all group admins</string>
-    <string name="guest_room_link_disabled">Generating guest links is now disabled for all group admins</string>
+    <string name="guest_room_link_enabled">Generating guest links is now enabled for all conversation admins</string>
+    <string name="guest_room_link_disabled">Generating guest links is now disabled for all conversation admins</string>
     <!-- New Device dialog -->
     <string name="new_device_dialog_current_user_title">Your account was used on</string>
     <string name="new_device_dialog_message_defice_info">%1$s\nFrom: %2$s \n</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16636" title="WPB-16636" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-16636</a>  [Android] Channel details screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We have many texts that say "Group" and they could be reused for channels.

### Solutions

Just replace "Group" with "Conversation" for most of the texts.
Some are still unique to each, but most of the logic and the text description still can be reused like that.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
