### PR TITLE
fix(channels): properly show channel promotion button [WPB-16979]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchUsersAndServicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchUsersAndServicesScreen.kt
@@ -77,8 +77,8 @@ fun SearchUsersAndServicesScreen(
     onClose: () -> Unit,
     screenType: SearchPeopleScreenType,
     modifier: Modifier = Modifier,
-    isSelfTeamMember: Boolean = false,
-    isUserAllowedToCreateChannels: Boolean = true,
+    shouldShowChannelPromotion: Boolean,
+    isUserAllowedToCreateChannels: Boolean,
     isGroupSubmitVisible: Boolean = true,
     isServicesAllowed: Boolean = false,
     initialPage: SearchPeopleTabItem = SearchPeopleTabItem.PEOPLE,
@@ -200,8 +200,8 @@ fun SearchUsersAndServicesScreen(
                 when (screenType) {
                     SearchPeopleScreenType.NEW_CONVERSATION -> {
                         CreateRegularGroupOrChannelButtons(
-                            isSelfTeamMember = isSelfTeamMember,
-                            shouldShowChannelButton = isUserAllowedToCreateChannels,
+                            shouldShowChannelPromotion = shouldShowChannelPromotion,
+                            isUserAllowedToCreateChannels = isUserAllowedToCreateChannels,
                             onCreateNewRegularGroup = onCreateNewGroup,
                             onCreateNewChannel = onCreateNewChannel
                         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/adddembertoconversation/AddMembersSearchScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/adddembertoconversation/AddMembersSearchScreen.kt
@@ -65,5 +65,7 @@ fun AddMembersSearchScreen(
         screenType = SearchPeopleScreenType.CONVERSATION_DETAILS,
         selectedContacts = addMembersToConversationViewModel.newGroupState.selectedContacts,
         isServicesAllowed = navArgs.isServicesAllowed,
+        isUserAllowedToCreateChannels = false,
+        shouldShowChannelPromotion = false,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateRegularGroupOrChannelButtons.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateRegularGroupOrChannelButtons.kt
@@ -43,8 +43,8 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
 fun CreateRegularGroupOrChannelButtons(
-    isSelfTeamMember: Boolean,
-    shouldShowChannelButton: Boolean,
+    shouldShowChannelPromotion: Boolean,
+    isUserAllowedToCreateChannels: Boolean,
     onCreateNewRegularGroup: () -> Unit,
     onCreateNewChannel: () -> Unit,
     modifier: Modifier = Modifier,
@@ -59,7 +59,7 @@ fun CreateRegularGroupOrChannelButtons(
             modifier = modifier
                 .padding(dimensions().spacing16x)
         ) {
-            if (shouldShowChannelButton) {
+            if (isUserAllowedToCreateChannels || shouldShowChannelPromotion) {
                 WirePrimaryButton(
                     text = stringResource(R.string.label_create_new_channel),
                     onClick = onCreateNewChannel,
@@ -73,7 +73,7 @@ fun CreateRegularGroupOrChannelButtons(
                         )
                     },
                     trailingIcon = {
-                        if (!isSelfTeamMember) {
+                        if (shouldShowChannelPromotion) {
                             Image(
                                 painter = painterResource(id = R.drawable.ic_upgrade),
                                 contentDescription = null,
@@ -106,11 +106,24 @@ fun CreateRegularGroupOrChannelButtons(
 
 @PreviewMultipleThemes
 @Composable
+fun PreviewCreateRegularGroupOrChannelButtonsWithPromotion() {
+    WireTheme {
+        CreateRegularGroupOrChannelButtons(
+            shouldShowChannelPromotion = true,
+            isUserAllowedToCreateChannels = true,
+            onCreateNewRegularGroup = { },
+            onCreateNewChannel = { }
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
 fun PreviewCreateRegularGroupOrChannelButtons() {
     WireTheme {
         CreateRegularGroupOrChannelButtons(
-            isSelfTeamMember = false,
-            shouldShowChannelButton = true,
+            shouldShowChannelPromotion = false,
+            isUserAllowedToCreateChannels = true,
             onCreateNewRegularGroup = { },
             onCreateNewChannel = { }
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupsearch/NewGroupConversationSearchPeopleScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupsearch/NewGroupConversationSearchPeopleScreen.kt
@@ -51,7 +51,8 @@ fun NewGroupConversationSearchPeopleScreen(
             OtherUserProfileScreenDestination(QualifiedID(contact.id, contact.domain))
                 .let { navigator.navigate(NavigationCommand(it)) }
         },
-        isSelfTeamMember = isSelfTeamMember,
+        shouldShowChannelPromotion = !isSelfTeamMember,
+        isUserAllowedToCreateChannels = false,
         onContactChecked = newConversationViewModel::updateSelectedContacts,
         onContinue = { navigator.navigate(NavigationCommand(NewGroupNameScreenDestination)) },
         isGroupSubmitVisible = newConversationViewModel.newGroupState.isGroupCreatingAllowed == true,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/NewConversationSearchPeopleScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/NewConversationSearchPeopleScreen.kt
@@ -46,10 +46,11 @@ fun NewConversationSearchPeopleScreen(
     newConversationViewModel: NewConversationViewModel,
 ) {
     val isSelfTeamMember = newConversationViewModel.newGroupState.isSelfTeamMember ?: false
+    val shouldShowChannelPromotion = !isSelfTeamMember
     val showCreateTeamDialog = remember { mutableStateOf(false) }
     SearchUsersAndServicesScreen(
         searchTitle = stringResource(id = R.string.label_new_conversation),
-        isSelfTeamMember = isSelfTeamMember,
+        shouldShowChannelPromotion = shouldShowChannelPromotion,
         isUserAllowedToCreateChannels = newConversationViewModel.newGroupState.isChannelCreationPossible,
         onOpenUserProfile = { contact ->
             OtherUserProfileScreenDestination(QualifiedID(contact.id, contact.domain))
@@ -61,7 +62,7 @@ fun NewConversationSearchPeopleScreen(
             navigator.navigate(NavigationCommand(NewGroupConversationSearchPeopleScreenDestination))
         },
         onCreateNewChannel = {
-            if (isSelfTeamMember) {
+            if (shouldShowChannelPromotion) {
                 newConversationViewModel.setIsChannel(true)
                 navigator.navigate(NavigationCommand(NewGroupConversationSearchPeopleScreenDestination))
             } else {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16979" title="WPB-16979" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16979</a>  [Android]Channel upgrade button is not available for personal user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Channel promotion / upgrade button not appearing for personal users.

### Causes

I f'ed up and hid the button unless the user is allowed to create channels.

### Solutions

Replaced `isSelfTeamMember` and `shouldShowChannelButton` with `shouldShowChannelPromotion` and `isUserAllowedToCreateChannels` for better clarity. 

Adjusted the logic for displaying channel promotion and creation buttons across multiple screens to align with requirements. 

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
