### PR TITLE
feat(channels): hide access settings from members (WPB-16954)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -204,6 +204,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
                         isServicesAllowed = groupDetails.conversation.isServicesAllowed() && !isMLSTeam && !isMLSConversation,
                         isUpdatingNameAllowed = isSelfAnAdmin && !isSelfExternalMember,
                         isUpdatingGuestAllowed = isSelfAnAdmin && isSelfInOwnerTeam,
+                        isUpdatingChannelAccessAllowed = isSelfAnAdmin && isSelfInOwnerTeam,
                         isUpdatingServicesAllowed = isSelfAnAdmin && !isMLSTeam && !isMLSConversation,
                         isUpdatingReadReceiptAllowed = isSelfAnAdmin && groupDetails.conversation.isTeamGroup(),
                         isUpdatingSelfDeletingAllowed = isSelfAnAdmin,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -120,11 +120,11 @@ fun GroupConversationSettings(
                     GroupConversationOptionsItem(
                         title = stringResource(R.string.channel_access_label),
                         subtitle = stringResource(id = R.string.channel_access_short_description),
-                        arrowType = ArrowType.TITLE_ALIGNED,
+                        arrowType = if (state.isUpdatingChannelAccessAllowed) ArrowType.TITLE_ALIGNED else ArrowType.NONE,
                         arrowLabel = stringResource(state.channelAccessType!!.label),
                         arrowLabelColor = colorsScheme().onBackground,
                         onClick = onChannelAccessItemClicked,
-                        isClickable = true,
+                        isClickable = state.isUpdatingChannelAccessAllowed,
                     )
                 }
             }
@@ -384,6 +384,7 @@ fun PreviewAdminTeamGroupConversationOptions() = WireTheme {
             areAccessOptionsAvailable = true,
             isUpdatingNameAllowed = true,
             isUpdatingGuestAllowed = true,
+            isUpdatingChannelAccessAllowed = true,
             isUpdatingServicesAllowed = true,
             isUpdatingSelfDeletingAllowed = true,
             isUpdatingReadReceiptAllowed = true,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
@@ -51,6 +51,7 @@ data class GroupConversationOptionsState(
     val isUpdatingServicesAllowed: Boolean = false,
     val isUpdatingSelfDeletingAllowed: Boolean = false,
     val isUpdatingReadReceiptAllowed: Boolean = false,
+    val isUpdatingChannelAccessAllowed: Boolean = false,
     val shouldShowAddParticipantsButtonForChannel: Boolean = false,
     val changeGuestOptionConfirmationRequired: Boolean = false,
     val changeServiceOptionConfirmationRequired: Boolean = false,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16954" title="WPB-16954" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16954</a>  [Android]Access section for setting add-permission is visible to members
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Access section for setting add-permission is visible to members

### Causes (Optional)

Not implemented

### Solutions

Make access section clickable for admins only

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
