### PR TITLE
fix(channels): display icon lock on private channels [WPB-16931]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
@@ -49,8 +49,8 @@ fun ConversationDetailsWithEvents.toConversationItem(
     selfUserTeamId: TeamId?,
     playingAudioMessage: PlayingAudioMessage
 ): ConversationItem = when (val conversationDetails = this.conversationDetails) {
-    is Group -> {
-        ConversationItem.GroupConversation(
+    is Group.Regular -> {
+        ConversationItem.Group.Regular(
             groupName = conversationDetails.conversation.name.orEmpty(),
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
@@ -62,7 +62,6 @@ fun ConversationDetailsWithEvents.toConversationItem(
             ),
             hasOnGoingCall = conversationDetails.hasOngoingCall && conversationDetails.isSelfUserMember,
             isFromTheSameTeam = conversationDetails.conversation.teamId == selfUserTeamId,
-            isChannel = conversationDetails is Group.Channel,
             isSelfUserMember = conversationDetails.isSelfUserMember,
             teamId = conversationDetails.conversation.teamId,
             selfMemberRole = conversationDetails.selfRole,
@@ -74,6 +73,34 @@ fun ConversationDetailsWithEvents.toConversationItem(
             isFavorite = conversationDetails.isFavorite,
             folder = conversationDetails.folder,
             playingAudio = getPlayingAudioInConversation(playingAudioMessage, conversationDetails)
+        )
+    }
+
+    is Group.Channel -> {
+        ConversationItem.Group.Channel(
+            groupName = conversationDetails.conversation.name.orEmpty(),
+            conversationId = conversationDetails.conversation.id,
+            mutedStatus = conversationDetails.conversation.mutedStatus,
+            showLegalHoldIndicator = conversationDetails.conversation.legalHoldStatus.showLegalHoldIndicator(),
+            lastMessageContent = lastMessage.toUIPreview(unreadEventCount),
+            badgeEventType = parseConversationEventType(
+                mutedStatus = conversationDetails.conversation.mutedStatus,
+                unreadEventCount = unreadEventCount
+            ),
+            hasOnGoingCall = conversationDetails.hasOngoingCall && conversationDetails.isSelfUserMember,
+            isFromTheSameTeam = conversationDetails.conversation.teamId == selfUserTeamId,
+            isSelfUserMember = conversationDetails.isSelfUserMember,
+            teamId = conversationDetails.conversation.teamId,
+            selfMemberRole = conversationDetails.selfRole,
+            isArchived = conversationDetails.conversation.archived,
+            mlsVerificationStatus = conversationDetails.conversation.mlsVerificationStatus,
+            proteusVerificationStatus = conversationDetails.conversation.proteusVerificationStatus,
+            hasNewActivitiesToShow = hasNewActivitiesToShow,
+            searchQuery = searchQuery,
+            isFavorite = conversationDetails.isFavorite,
+            folder = conversationDetails.folder,
+            playingAudio = getPlayingAudioInConversation(playingAudioMessage, conversationDetails),
+            isPrivate = conversationDetails.access == Group.Channel.ChannelAccess.PRIVATE
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/PreviewWireModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/PreviewWireModalSheetLayout.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.Composable
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.preview.MultipleThemePreviews
 import com.wire.android.ui.edit.ReactionOption
-import com.wire.android.ui.home.conversationslist.common.GroupConversationAvatar
+import com.wire.android.ui.home.conversationslist.common.RegularGroupConversationAvatar
 import com.wire.kalium.logic.data.id.ConversationId
 
 @MultipleThemePreviews
@@ -40,7 +40,7 @@ fun PreviewMenuModalSheetContentWithHeader() {
         header = MenuModalSheetHeader.Visible(
             "Title",
             {
-                GroupConversationAvatar(
+                RegularGroupConversationAvatar(
                     conversationId = ConversationId("value", "domain")
                 )
             },

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContent.kt
@@ -117,6 +117,7 @@ sealed interface ConversationTypeDetail {
         data class Channel(
             override val conversationId: ConversationId,
             override val isFromTheSameTeam: Boolean,
+            val isPrivate: Boolean
         ) : Group
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetState.kt
@@ -63,16 +63,17 @@ fun rememberConversationSheetState(
     isConversationDeletionLocallyRunning: Boolean
 ): ConversationSheetState {
     val conversationSheetContent: ConversationSheetContent = when (conversationItem) {
-        is ConversationItem.GroupConversation -> {
+        is ConversationItem.Group -> {
             with(conversationItem) {
                 ConversationSheetContent(
                     conversationId = conversationId,
                     title = groupName.ifEmpty { stringResource(id = R.string.member_name_deleted_label) },
                     mutingConversationState = mutedStatus,
-                    conversationTypeDetail = if (isChannel) {
+                    conversationTypeDetail = if (conversationItem is ConversationItem.Group.Channel) {
                         ConversationTypeDetail.Group.Channel(
                             conversationId = conversationId,
-                            isFromTheSameTeam = isFromTheSameTeam
+                            isFromTheSameTeam = isFromTheSameTeam,
+                            isPrivate = conversationItem.isPrivate,
                         )
                     } else {
                         ConversationTypeDetail.Group.Regular(

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/HomeSheetContent.kt
@@ -43,7 +43,7 @@ import com.wire.android.ui.common.dialogs.UnblockUserDialogState
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.folder.ConversationFoldersNavArgs
 import com.wire.android.ui.home.conversationslist.common.ChannelConversationAvatar
-import com.wire.android.ui.home.conversationslist.common.GroupConversationAvatar
+import com.wire.android.ui.home.conversationslist.common.RegularGroupConversationAvatar
 import com.wire.android.ui.home.conversationslist.model.BlockingState
 import com.wire.android.ui.home.conversationslist.model.DialogState
 import com.wire.android.ui.home.conversationslist.model.GroupDialogState
@@ -339,10 +339,10 @@ private fun ConversationLeadingIcon(
 ) {
     when (val typeDetail = conversationSheetContent.conversationTypeDetail) {
         is ConversationTypeDetail.Group.Channel ->
-            ChannelConversationAvatar(typeDetail.conversationId)
+            ChannelConversationAvatar(typeDetail.conversationId, isPrivateChannel = typeDetail.isPrivate)
 
         is ConversationTypeDetail.Group.Regular ->
-            GroupConversationAvatar(typeDetail.conversationId)
+            RegularGroupConversationAvatar(typeDetail.conversationId)
 
         is ConversationTypeDetail.Connection -> {
             /** NO-OP for Connections **/

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -60,7 +60,7 @@ import com.wire.android.ui.home.conversations.info.ConversationAvatar
 import com.wire.android.ui.home.conversations.info.ConversationDetailsData
 import com.wire.android.ui.home.conversations.info.ConversationInfoViewState
 import com.wire.android.ui.home.conversationslist.common.ChannelConversationAvatar
-import com.wire.android.ui.home.conversationslist.common.GroupConversationAvatar
+import com.wire.android.ui.home.conversationslist.common.RegularGroupConversationAvatar
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
@@ -206,7 +206,7 @@ private fun Avatar(
 ) {
     when (conversationAvatar) {
         is ConversationAvatar.Group.Regular ->
-            GroupConversationAvatar(
+            RegularGroupConversationAvatar(
                 conversationId = conversationAvatar.conversationId,
                 size = dimensions().avatarConversationTopBarSize,
                 cornerRadius = dimensions().groupAvatarConversationTopBarCornerRadius,
@@ -219,6 +219,7 @@ private fun Avatar(
                 size = dimensions().avatarConversationTopBarSize,
                 cornerRadius = dimensions().groupAvatarConversationTopBarCornerRadius,
                 padding = dimensions().avatarConversationTopBarClickablePadding,
+                isPrivateChannel = conversationAvatar.isPrivate,
             )
 
         is ConversationAvatar.OneOne -> UserProfileAvatar(
@@ -380,7 +381,7 @@ fun PreviewConversationScreenTopAppBarShortTitleChannel() = WireTheme {
             conversationId = ConversationId("value", "domain"),
             conversationName = UIText.DynamicString("Short title"),
             conversationDetailsData = ConversationDetailsData.Group(null, conversationId),
-            conversationAvatar = ConversationAvatar.Group.Channel(conversationId)
+            conversationAvatar = ConversationAvatar.Group.Channel(conversationId, true)
         ),
         onBackButtonClick = {},
         onDropDownClick = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -121,6 +121,7 @@ import com.wire.android.ui.home.conversations.folder.ConversationFoldersNavBackA
 import com.wire.android.ui.home.conversations.folder.RemoveConversationFromFolderArgs
 import com.wire.android.ui.home.conversations.folder.RemoveConversationFromFolderVM
 import com.wire.android.ui.home.conversations.folder.RemoveConversationFromFolderVMImpl
+import com.wire.android.ui.home.conversations.info.ConversationAvatar
 import com.wire.android.ui.home.conversationslist.model.DialogState
 import com.wire.android.ui.home.conversationslist.model.GroupDialogState
 import com.wire.android.ui.home.conversationslist.model.LeaveGroupDialogState
@@ -424,12 +425,17 @@ private fun GroupConversationDetailsContent(
         },
         topBarCollapsing = {
             conversationSheetState.conversationSheetContent?.let {
+                val conversationTypeDetail = it.conversationTypeDetail
+                val avatarData = if (conversationTypeDetail is ConversationTypeDetail.Group.Channel) {
+                    ConversationAvatar.Group.Channel(it.conversationId, conversationTypeDetail.isPrivate)
+                } else {
+                    ConversationAvatar.Group.Regular(it.conversationId)
+                }
                 GroupConversationDetailsTopBarCollapsing(
                     title = it.title,
-                    conversationId = it.conversationId,
                     totalParticipants = groupParticipantsState.data.allCount,
                     isLoading = isLoading,
-                    isChannel = it.conversationTypeDetail is ConversationTypeDetail.Group.Channel,
+                    conversationAvatar = avatarData,
                     onSearchConversationMessagesClick = onSearchConversationMessagesClick,
                     onConversationMediaClick = onConversationMediaClick,
                     isUnderLegalHold = it.isUnderLegalHold,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsTopBarCollapsing.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsTopBarCollapsing.kt
@@ -36,7 +36,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import com.wire.android.R
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.VerticalSpace
-import com.wire.android.ui.home.conversationslist.common.ChannelConversationAvatar
+import com.wire.android.ui.home.conversations.info.ConversationAvatar
 import com.wire.android.ui.home.conversationslist.common.GroupConversationAvatar
 import com.wire.android.ui.legalhold.banner.LegalHoldSubjectBanner
 import com.wire.android.ui.theme.WireTheme
@@ -49,11 +49,10 @@ import com.wire.kalium.logic.data.id.ConversationId
 @Composable
 fun GroupConversationDetailsTopBarCollapsing(
     title: String,
-    conversationId: ConversationId,
     totalParticipants: Int,
     isLoading: Boolean,
     isUnderLegalHold: Boolean,
-    isChannel: Boolean,
+    conversationAvatar: ConversationAvatar.Group,
     isWireCellEnabled: Boolean,
     onSearchConversationMessagesClick: () -> Unit,
     onConversationMediaClick: () -> Unit,
@@ -68,21 +67,12 @@ fun GroupConversationDetailsTopBarCollapsing(
             .wrapContentHeight()
     ) {
         Box(contentAlignment = Alignment.Center) {
-            if (isChannel) {
-                ChannelConversationAvatar(
-                    conversationId = conversationId,
-                    size = dimensions().groupAvatarConversationDetailsTopBarSize,
-                    cornerRadius = dimensions().groupAvatarConversationDetailsCornerRadius,
-                    padding = dimensions().avatarConversationTopBarClickablePadding,
-                )
-            } else {
-                GroupConversationAvatar(
-                    conversationId = conversationId,
-                    size = dimensions().groupAvatarConversationDetailsTopBarSize,
-                    cornerRadius = dimensions().groupAvatarConversationDetailsCornerRadius,
-                    padding = dimensions().avatarConversationTopBarClickablePadding,
-                )
-            }
+            GroupConversationAvatar(
+                avatarData = conversationAvatar,
+                size = dimensions().groupAvatarConversationDetailsTopBarSize,
+                cornerRadius = dimensions().groupAvatarConversationDetailsCornerRadius,
+                padding = dimensions().avatarConversationTopBarClickablePadding,
+            )
         }
         ConstraintLayout(
             Modifier
@@ -154,11 +144,10 @@ fun PreviewGroupConversationDetailsTopBarCollapsing() {
     WireTheme {
         GroupConversationDetailsTopBarCollapsing(
             title = "Conversation Title",
-            conversationId = ConversationId("conversationId", "domain"),
             totalParticipants = 10,
             isUnderLegalHold = true,
             isLoading = false,
-            isChannel = false,
+            conversationAvatar = ConversationAvatar.Group.Regular(ConversationId("ConversationId", "domain")),
             isWireCellEnabled = false,
             onSearchConversationMessagesClick = {},
             onConversationMediaClick = {},
@@ -173,11 +162,28 @@ fun PreviewChannelConversationDetailsTopBarCollapsing() {
     WireTheme {
         GroupConversationDetailsTopBarCollapsing(
             title = "Conversation Title",
-            conversationId = ConversationId("ConversationId", "domain"),
             totalParticipants = 10,
             isUnderLegalHold = true,
             isLoading = false,
-            isChannel = true,
+            conversationAvatar = ConversationAvatar.Group.Channel(ConversationId("ConversationId", "domain"), false),
+            isWireCellEnabled = false,
+            onSearchConversationMessagesClick = {},
+            onConversationMediaClick = {},
+            onLegalHoldLearnMoreClick = {},
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewPrivateChannelConversationDetailsTopBarCollapsing() {
+    WireTheme {
+        GroupConversationDetailsTopBarCollapsing(
+            title = "Conversation Title",
+            totalParticipants = 10,
+            isUnderLegalHold = true,
+            isLoading = false,
+            conversationAvatar = ConversationAvatar.Group.Channel(ConversationId("ConversationId", "domain"), true),
             isWireCellEnabled = false,
             onSearchConversationMessagesClick = {},
             onConversationMediaClick = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -166,10 +166,11 @@ class GroupConversationDetailsViewModel @Inject constructor(
                     title = groupDetails.conversation.name.orEmpty(),
                     conversationId = conversationId,
                     mutingConversationState = groupDetails.conversation.mutedStatus,
-                    conversationTypeDetail = if (isChannel) {
+                    conversationTypeDetail = if (groupDetails is ConversationDetails.Group.Channel) {
                         ConversationTypeDetail.Group.Channel(
                             conversationId = conversationId,
-                            isFromTheSameTeam = groupDetails.conversation.teamId == getSelfUser()?.teamId
+                            isFromTheSameTeam = groupDetails.conversation.teamId == getSelfUser()?.teamId,
+                            isPrivate = groupDetails.access == ConversationDetails.Group.Channel.ChannelAccess.PRIVATE
                         )
                     } else {
                         ConversationTypeDetail.Group.Regular(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewModel.kt
@@ -164,7 +164,10 @@ class ConversationInfoViewModel @Inject constructor(
                 )
 
             is ConversationDetails.Group.Regular -> ConversationAvatar.Group.Regular(conversationDetails.conversation.id)
-            is ConversationDetails.Group.Channel -> ConversationAvatar.Group.Channel(conversationDetails.conversation.id)
+            is ConversationDetails.Group.Channel -> {
+                val isPrivate = conversationDetails.access == ConversationDetails.Group.Channel.ChannelAccess.PRIVATE
+                ConversationAvatar.Group.Channel(conversationDetails.conversation.id, isPrivate)
+            }
             else -> ConversationAvatar.None
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/info/ConversationInfoViewState.kt
@@ -65,6 +65,6 @@ sealed interface ConversationAvatar {
         val conversationId: QualifiedID
 
         data class Regular(override val conversationId: QualifiedID) : Group
-        data class Channel(override val conversationId: QualifiedID) : Group
+        data class Channel(override val conversationId: QualifiedID, val isPrivate: Boolean) : Group
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -540,7 +540,8 @@ private fun ConversationItem.hideIndicatorForSelfUserUnderLegalHold(isSelfUserUn
     when (isSelfUserUnderLegalHold) {
         true -> when (this) {
             is ConversationItem.ConnectionConversation -> this.copy(showLegalHoldIndicator = false)
-            is ConversationItem.GroupConversation -> this.copy(showLegalHoldIndicator = false)
+            is ConversationItem.Group.Regular -> this.copy(showLegalHoldIndicator = false)
+            is ConversationItem.Group.Channel -> this.copy(showLegalHoldIndicator = false)
             is ConversationItem.PrivateConversation -> this.copy(showLegalHoldIndicator = false)
         }
 
@@ -616,7 +617,7 @@ private fun List<ConversationItem>.unreadToReadConversationsItems(): Pair<List<C
                 }
 
             MutedConversationStatus.AllMuted -> false
-        } || (it is ConversationItem.GroupConversation && it.hasOnGoingCall)
+        } || (it is ConversationItem.Group && it.hasOnGoingCall)
     }
 
     val remainingConversations = this - unreadConversations.toSet()
@@ -627,7 +628,7 @@ private fun searchConversation(conversationDetails: List<ConversationItem>, sear
     conversationDetails.filter { details ->
         when (details) {
             is ConversationItem.ConnectionConversation -> details.conversationInfo.name.contains(searchQuery, true)
-            is ConversationItem.GroupConversation -> details.groupName.contains(searchQuery, true)
+            is ConversationItem.Group -> details.groupName.contains(searchQuery, true)
             is ConversationItem.PrivateConversation -> details.conversationInfo.name.contains(searchQuery, true)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ChannelConversationAvatar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ChannelConversationAvatar.kt
@@ -46,8 +46,8 @@ import com.wire.kalium.logic.data.id.ConversationId
 @Composable
 fun ChannelConversationAvatar(
     conversationId: ConversationId,
+    isPrivateChannel: Boolean,
     modifier: Modifier = Modifier,
-    isPrivateChannel: Boolean = false,
     size: Dp = MaterialTheme.wireDimensions.avatarDefaultSize,
     cornerRadius: Dp = MaterialTheme.wireDimensions.groupAvatarCornerRadius,
     padding: Dp = MaterialTheme.wireDimensions.avatarClickablePadding,
@@ -98,10 +98,21 @@ private fun ChannelLock(modifier: Modifier = Modifier) {
 
 @MultipleThemePreviews
 @Composable
-fun PreviewChannelConversationAvatar() {
+fun PreviewChannelPrivateConversationAvatar() {
     WireTheme {
         ChannelConversationAvatar(
             isPrivateChannel = true,
+            conversationId = ConversationId("value", "domain")
+        )
+    }
+}
+
+@MultipleThemePreviews
+@Composable
+fun PreviewChannelConversationAvatar() {
+    WireTheme {
+        ChannelConversationAvatar(
+            isPrivateChannel = false,
             conversationId = ConversationId("value", "domain")
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -50,6 +50,7 @@ import com.wire.android.ui.common.WireRadioButton
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.shimmerPlaceholder
+import com.wire.android.ui.home.conversations.info.ConversationAvatar
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.UILastMessageContent
 import com.wire.android.ui.home.conversationslist.model.BadgeEventType
@@ -166,7 +167,7 @@ private fun GeneralConversationItem(
     onStopCurrentAudio: () -> Unit = {}
 ) {
     when (conversation) {
-        is ConversationItem.GroupConversation -> {
+        is ConversationItem.Group -> {
             with(conversation) {
                 RowItemTemplate(
                     modifier = modifier,
@@ -177,11 +178,12 @@ private fun GeneralConversationItem(
                                     selectOnRadioGroup()
                                 })
                             }
-                            if (isChannel) {
-                                ChannelConversationAvatar(conversationId)
+                            val avatar = if (conversation is ConversationItem.Group.Channel) {
+                                ConversationAvatar.Group.Channel(conversationId, conversation.isPrivate)
                             } else {
-                                GroupConversationAvatar(conversationId)
+                                ConversationAvatar.Group.Regular(conversationId)
                             }
+                            GroupConversationAvatar(avatar)
                         }
                     },
                     title = {
@@ -387,7 +389,7 @@ fun PreviewLoadingConversationItem() = WireTheme {
 @Composable
 fun PreviewGroupConversationItemWithUnreadCount() = WireTheme {
     ConversationItemFactory(
-        conversation = ConversationItem.GroupConversation(
+        conversation = ConversationItem.Group.Regular(
             "groupName looooooooooooooooooooooooooooooooooooong",
             conversationId = QualifiedID("value", "domain"),
             mutedStatus = MutedConversationStatus.AllAllowed,
@@ -399,7 +401,6 @@ fun PreviewGroupConversationItemWithUnreadCount() = WireTheme {
             teamId = null,
             isArchived = false,
             isFromTheSameTeam = false,
-            isChannel = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
@@ -417,8 +418,8 @@ fun PreviewGroupConversationItemWithUnreadCount() = WireTheme {
 @Composable
 fun PreviewChannelGroupConversationItemWithUnreadCount() = WireTheme {
     ConversationItemFactory(
-        conversation = ConversationItem.GroupConversation(
-            "groupName looooooooooooooooooooooooooooooooooooong",
+        conversation = ConversationItem.Group.Channel(
+            "Some Channel",
             conversationId = QualifiedID("value", "domain"),
             mutedStatus = MutedConversationStatus.AllAllowed,
             lastMessageContent = UILastMessageContent.TextMessage(
@@ -429,12 +430,42 @@ fun PreviewChannelGroupConversationItemWithUnreadCount() = WireTheme {
             teamId = null,
             isArchived = false,
             isFromTheSameTeam = false,
-            isChannel = true,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
             folder = null,
-            playingAudio = null
+            playingAudio = null,
+            isPrivate = false
+        ),
+        modifier = Modifier,
+        isSelectableItem = false,
+        isChecked = false,
+        {}, {}, {}, {}, {}, {},
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewPrivateChannelGroupConversationItemWithUnreadCount() = WireTheme {
+    ConversationItemFactory(
+        conversation = ConversationItem.Group.Channel(
+            "Channel looooooooooooooooooooooooooooooooooooong",
+            conversationId = QualifiedID("anotherValue", "domain"),
+            mutedStatus = MutedConversationStatus.AllAllowed,
+            lastMessageContent = UILastMessageContent.TextMessage(
+                MessageBody(UIText.DynamicString("Very looooooooooong messageeeeeeeeeeeeeee"))
+            ),
+            badgeEventType = BadgeEventType.UnreadMessage(100),
+            selfMemberRole = null,
+            teamId = null,
+            isArchived = false,
+            isFromTheSameTeam = false,
+            mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+            isFavorite = false,
+            folder = null,
+            playingAudio = null,
+            isPrivate = true
         ),
         modifier = Modifier,
         isSelectableItem = false,
@@ -447,7 +478,7 @@ fun PreviewChannelGroupConversationItemWithUnreadCount() = WireTheme {
 @Composable
 fun PreviewGroupConversationItemWithNoBadges() = WireTheme {
     ConversationItemFactory(
-        conversation = ConversationItem.GroupConversation(
+        conversation = ConversationItem.Group.Regular(
             "groupName looooooooooooooooooooooooooooooooooooong",
             conversationId = QualifiedID("value", "domain"),
             mutedStatus = MutedConversationStatus.AllAllowed,
@@ -459,7 +490,6 @@ fun PreviewGroupConversationItemWithNoBadges() = WireTheme {
             teamId = null,
             isArchived = false,
             isFromTheSameTeam = false,
-            isChannel = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
@@ -477,7 +507,7 @@ fun PreviewGroupConversationItemWithNoBadges() = WireTheme {
 @Composable
 fun PreviewGroupConversationItemWithLastDeletedMessage() = WireTheme {
     ConversationItemFactory(
-        conversation = ConversationItem.GroupConversation(
+        conversation = ConversationItem.Group.Regular(
             "groupName looooooooooooooooooooooooooooooooooooong",
             conversationId = QualifiedID("value", "domain"),
             mutedStatus = MutedConversationStatus.AllAllowed,
@@ -491,7 +521,6 @@ fun PreviewGroupConversationItemWithLastDeletedMessage() = WireTheme {
             teamId = null,
             isArchived = false,
             isFromTheSameTeam = false,
-            isChannel = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
@@ -509,7 +538,7 @@ fun PreviewGroupConversationItemWithLastDeletedMessage() = WireTheme {
 @Composable
 fun PreviewGroupConversationItemWithMutedBadgeAndUnreadMentionBadge() = WireTheme {
     ConversationItemFactory(
-        conversation = ConversationItem.GroupConversation(
+        conversation = ConversationItem.Group.Regular(
             "groupName looooooooooooooooooooooooooooooooooooong",
             conversationId = QualifiedID("value", "domain"),
             mutedStatus = MutedConversationStatus.OnlyMentionsAndRepliesAllowed,
@@ -521,7 +550,6 @@ fun PreviewGroupConversationItemWithMutedBadgeAndUnreadMentionBadge() = WireThem
             teamId = null,
             isArchived = false,
             isFromTheSameTeam = false,
-            isChannel = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
@@ -539,7 +567,7 @@ fun PreviewGroupConversationItemWithMutedBadgeAndUnreadMentionBadge() = WireThem
 @Composable
 fun PreviewGroupConversationItemWithOngoingCall() = WireTheme {
     ConversationItemFactory(
-        conversation = ConversationItem.GroupConversation(
+        conversation = ConversationItem.Group.Regular(
             "groupName looooooooooooooooooooooooooooooooooooong",
             conversationId = QualifiedID("value", "domain"),
             mutedStatus = MutedConversationStatus.OnlyMentionsAndRepliesAllowed,
@@ -552,7 +580,6 @@ fun PreviewGroupConversationItemWithOngoingCall() = WireTheme {
             hasOnGoingCall = true,
             isArchived = false,
             isFromTheSameTeam = false,
-            isChannel = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
@@ -656,7 +683,7 @@ fun PreviewPrivateConversationItemWithBlockedBadge() = WireTheme {
 @Composable
 fun PreviewPrivateConversationItemWithPlayingAudio() = WireTheme {
     ConversationItemFactory(
-        conversation = ConversationItem.GroupConversation(
+        conversation = ConversationItem.Group.Regular(
             "groupName looooooooooooooooooooooooooooooooooooong",
             conversationId = QualifiedID("value", "domain"),
             mutedStatus = MutedConversationStatus.OnlyMentionsAndRepliesAllowed,
@@ -668,7 +695,6 @@ fun PreviewPrivateConversationItemWithPlayingAudio() = WireTheme {
             teamId = null,
             isArchived = false,
             isFromTheSameTeam = false,
-            isChannel = false,
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -256,56 +256,88 @@ fun ConversationList(
     }
 }
 
+@Suppress("MagicNumber")
 fun previewConversationList(count: Int, startIndex: Int = 0, unread: Boolean = false, searchQuery: String = "") = buildList {
     repeat(count) { index ->
         val currentIndex = startIndex + index
-        when (index % 2) {
-            0 -> add(
-                ConversationItem.GroupConversation(
-                    groupName = "Conversation $currentIndex",
-                    conversationId = QualifiedID(currentIndex.toString(), "domain"),
-                    mutedStatus = MutedConversationStatus.AllAllowed,
-                    lastMessageContent = UILastMessageContent.TextMessage(MessageBody(UIText.DynamicString("Message"))),
-                    badgeEventType = if (unread) BadgeEventType.UnreadMessage(1) else BadgeEventType.None,
-                    selfMemberRole = null,
-                    teamId = null,
-                    hasOnGoingCall = false,
-                    isArchived = false,
-                    isFromTheSameTeam = false,
-                    isChannel = false,
-                    mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
-                    proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
-                    searchQuery = searchQuery,
-                    isFavorite = false,
-                    folder = null,
-                    playingAudio = null
-                )
-            )
-
-            1 -> add(
-                ConversationItem.PrivateConversation(
-                    userAvatarData = UserAvatarData(),
-                    conversationId = QualifiedID(currentIndex.toString(), "domain"),
-                    mutedStatus = MutedConversationStatus.AllAllowed,
-                    lastMessageContent = UILastMessageContent.TextMessage(MessageBody(UIText.DynamicString("Message"))),
-                    badgeEventType = if (unread) BadgeEventType.UnreadMessage(1) else BadgeEventType.None,
-                    conversationInfo = ConversationInfo("User $currentIndex"),
-                    blockingState = BlockingState.BLOCKED,
-                    teamId = null,
-                    userId = UserId("userId_$currentIndex", "domain"),
-                    isArchived = false,
-                    mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
-                    proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
-                    searchQuery = searchQuery,
-                    isFavorite = false,
-                    isUserDeleted = false,
-                    folder = null,
-                    playingAudio = null
-                )
-            )
+        when (index % 3) {
+            0 -> add(fakeRegularGroup(currentIndex, unread, searchQuery))
+            1 -> add(fakePrivateConversation(currentIndex, unread, searchQuery))
+            2 -> add(fakeChannel(currentIndex, unread, searchQuery))
         }
     }
 }.toImmutableList()
+
+private fun fakeRegularGroup(
+    currentIndex: Int,
+    unread: Boolean,
+    searchQuery: String
+) = ConversationItem.Group.Regular(
+    groupName = "Conversation $currentIndex",
+    conversationId = QualifiedID(currentIndex.toString(), "domain"),
+    mutedStatus = MutedConversationStatus.AllAllowed,
+    lastMessageContent = UILastMessageContent.TextMessage(MessageBody(UIText.DynamicString("Message"))),
+    badgeEventType = if (unread) BadgeEventType.UnreadMessage(1) else BadgeEventType.None,
+    selfMemberRole = null,
+    teamId = null,
+    hasOnGoingCall = false,
+    isArchived = false,
+    isFromTheSameTeam = false,
+    mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+    proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+    searchQuery = searchQuery,
+    isFavorite = false,
+    folder = null,
+    playingAudio = null
+)
+
+private fun fakePrivateConversation(
+    currentIndex: Int,
+    unread: Boolean,
+    searchQuery: String
+) = ConversationItem.PrivateConversation(
+    userAvatarData = UserAvatarData(),
+    conversationId = QualifiedID(currentIndex.toString(), "domain"),
+    mutedStatus = MutedConversationStatus.AllAllowed,
+    lastMessageContent = UILastMessageContent.TextMessage(MessageBody(UIText.DynamicString("Message"))),
+    badgeEventType = if (unread) BadgeEventType.UnreadMessage(1) else BadgeEventType.None,
+    conversationInfo = ConversationInfo("User $currentIndex"),
+    blockingState = BlockingState.BLOCKED,
+    teamId = null,
+    userId = UserId("userId_$currentIndex", "domain"),
+    isArchived = false,
+    mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+    proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+    searchQuery = searchQuery,
+    isFavorite = false,
+    isUserDeleted = false,
+    folder = null,
+    playingAudio = null
+)
+
+private fun fakeChannel(
+    currentIndex: Int,
+    unread: Boolean,
+    searchQuery: String
+) = ConversationItem.Group.Channel(
+    groupName = "Conversation $currentIndex",
+    conversationId = QualifiedID(currentIndex.toString(), "domain"),
+    mutedStatus = MutedConversationStatus.AllAllowed,
+    lastMessageContent = UILastMessageContent.TextMessage(MessageBody(UIText.DynamicString("Message"))),
+    badgeEventType = if (unread) BadgeEventType.UnreadMessage(1) else BadgeEventType.None,
+    selfMemberRole = null,
+    teamId = null,
+    hasOnGoingCall = false,
+    isArchived = false,
+    isFromTheSameTeam = false,
+    mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+    proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+    searchQuery = searchQuery,
+    isFavorite = false,
+    folder = null,
+    playingAudio = null,
+    isPrivate = currentIndex % 2 == 0
+)
 
 fun previewConversationFoldersFlow(
     searchQuery: String = "",

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/RegularGroupConversationAvatar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/RegularGroupConversationAvatar.kt
@@ -33,14 +33,46 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import com.wire.android.ui.common.colorsScheme
-import com.wire.android.ui.common.groupConversationColor
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.groupConversationColor
+import com.wire.android.ui.home.conversations.info.ConversationAvatar
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.kalium.logic.data.id.ConversationId
 
 @Composable
 fun GroupConversationAvatar(
+    avatarData: ConversationAvatar.Group,
+    modifier: Modifier = Modifier,
+    size: Dp = MaterialTheme.wireDimensions.avatarDefaultSize,
+    cornerRadius: Dp = MaterialTheme.wireDimensions.groupAvatarCornerRadius,
+    padding: Dp = MaterialTheme.wireDimensions.avatarClickablePadding,
+    borderWidth: Dp = dimensions().avatarBorderWidth,
+    borderColor: Color = colorsScheme().outline
+) = when (avatarData) {
+    is ConversationAvatar.Group.Channel -> ChannelConversationAvatar(
+        avatarData.conversationId,
+        avatarData.isPrivate,
+        modifier,
+        size,
+        cornerRadius,
+        padding,
+        borderWidth
+    )
+
+    is ConversationAvatar.Group.Regular -> RegularGroupConversationAvatar(
+        avatarData.conversationId,
+        modifier,
+        size,
+        cornerRadius,
+        padding,
+        borderWidth,
+        borderColor
+    )
+}
+
+@Composable
+fun RegularGroupConversationAvatar(
     conversationId: ConversationId,
     modifier: Modifier = Modifier,
     size: Dp = MaterialTheme.wireDimensions.avatarDefaultSize,
@@ -73,7 +105,7 @@ fun GroupConversationAvatar(
 @Composable
 fun PreviewGroupConversationAvatar() {
     WireTheme {
-        GroupConversationAvatar(
+        RegularGroupConversationAvatar(
             conversationId = ConversationId("conversationId", "domain")
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -33,47 +33,79 @@ import kotlinx.serialization.Serializable
 import com.wire.kalium.logic.data.conversation.ConversationFolder as CurrentFolder
 
 @Serializable
-sealed class ConversationItem : ConversationFolderItem {
-    abstract val conversationId: ConversationId
-    abstract val mutedStatus: MutedConversationStatus
-    abstract val showLegalHoldIndicator: Boolean
-    abstract val lastMessageContent: UILastMessageContent?
-    abstract val badgeEventType: BadgeEventType
-    abstract val teamId: TeamId?
-    abstract val isArchived: Boolean
-    abstract val isFavorite: Boolean
-    abstract val folder: CurrentFolder?
-    abstract val mlsVerificationStatus: Conversation.VerificationStatus
-    abstract val proteusVerificationStatus: Conversation.VerificationStatus
-    abstract val hasNewActivitiesToShow: Boolean
-    abstract val searchQuery: String
-    abstract val playingAudio: PlayingAudioInConversation?
+sealed interface ConversationItem : ConversationFolderItem {
+    val conversationId: ConversationId
+    val mutedStatus: MutedConversationStatus
+    val showLegalHoldIndicator: Boolean
+    val lastMessageContent: UILastMessageContent?
+    val badgeEventType: BadgeEventType
+    val teamId: TeamId?
+    val isArchived: Boolean
+    val isFavorite: Boolean
+    val folder: CurrentFolder?
+    val mlsVerificationStatus: Conversation.VerificationStatus
+    val proteusVerificationStatus: Conversation.VerificationStatus
+    val hasNewActivitiesToShow: Boolean
+    val searchQuery: String
+    val playingAudio: PlayingAudioInConversation?
 
     val isTeamConversation get() = teamId != null
 
     @Serializable
-    data class GroupConversation(
-        val groupName: String,
-        val hasOnGoingCall: Boolean = false,
-        val selfMemberRole: Conversation.Member.Role?,
-        val isFromTheSameTeam: Boolean,
-        val isChannel: Boolean,
-        val isSelfUserMember: Boolean = true,
-        override val conversationId: ConversationId,
-        override val mutedStatus: MutedConversationStatus,
-        override val showLegalHoldIndicator: Boolean = false,
-        override val lastMessageContent: UILastMessageContent?,
-        override val badgeEventType: BadgeEventType,
-        override val teamId: TeamId?,
-        override val isArchived: Boolean,
-        override val isFavorite: Boolean,
-        override val folder: CurrentFolder?,
-        override val mlsVerificationStatus: Conversation.VerificationStatus,
-        override val proteusVerificationStatus: Conversation.VerificationStatus,
-        override val hasNewActivitiesToShow: Boolean = false,
-        override val searchQuery: String = "",
-        override val playingAudio: PlayingAudioInConversation?
-    ) : ConversationItem()
+    sealed interface Group : ConversationItem {
+        val groupName: String
+        val hasOnGoingCall: Boolean
+        val selfMemberRole: Conversation.Member.Role?
+        val isFromTheSameTeam: Boolean
+        val isSelfUserMember: Boolean
+
+        @Serializable
+        data class Regular(
+            override val groupName: String,
+            override val hasOnGoingCall: Boolean = false,
+            override val selfMemberRole: Conversation.Member.Role?,
+            override val isFromTheSameTeam: Boolean,
+            override val isSelfUserMember: Boolean = true,
+            override val conversationId: ConversationId,
+            override val mutedStatus: MutedConversationStatus,
+            override val showLegalHoldIndicator: Boolean = false,
+            override val lastMessageContent: UILastMessageContent?,
+            override val badgeEventType: BadgeEventType,
+            override val teamId: TeamId?,
+            override val isArchived: Boolean,
+            override val isFavorite: Boolean,
+            override val folder: CurrentFolder?,
+            override val mlsVerificationStatus: Conversation.VerificationStatus,
+            override val proteusVerificationStatus: Conversation.VerificationStatus,
+            override val hasNewActivitiesToShow: Boolean = false,
+            override val searchQuery: String = "",
+            override val playingAudio: PlayingAudioInConversation?
+        ) : Group
+
+        @Serializable
+        data class Channel(
+            override val groupName: String,
+            override val hasOnGoingCall: Boolean = false,
+            override val selfMemberRole: Conversation.Member.Role?,
+            override val isFromTheSameTeam: Boolean,
+            override val isSelfUserMember: Boolean = true,
+            override val conversationId: ConversationId,
+            override val mutedStatus: MutedConversationStatus,
+            override val showLegalHoldIndicator: Boolean = false,
+            override val lastMessageContent: UILastMessageContent?,
+            override val badgeEventType: BadgeEventType,
+            override val teamId: TeamId?,
+            override val isArchived: Boolean,
+            override val isFavorite: Boolean,
+            override val folder: CurrentFolder?,
+            override val mlsVerificationStatus: Conversation.VerificationStatus,
+            override val proteusVerificationStatus: Conversation.VerificationStatus,
+            override val hasNewActivitiesToShow: Boolean = false,
+            override val searchQuery: String = "",
+            override val playingAudio: PlayingAudioInConversation?,
+            val isPrivate: Boolean,
+        ) : Group
+    }
 
     @Serializable
     data class PrivateConversation(
@@ -96,7 +128,7 @@ sealed class ConversationItem : ConversationFolderItem {
         override val hasNewActivitiesToShow: Boolean = false,
         override val searchQuery: String = "",
         override val playingAudio: PlayingAudioInConversation?
-    ) : ConversationItem()
+    ) : ConversationItem
 
     @Serializable
     data class ConnectionConversation(
@@ -112,7 +144,7 @@ sealed class ConversationItem : ConversationFolderItem {
         override val folder: CurrentFolder? = null,
         override val hasNewActivitiesToShow: Boolean = false,
         override val searchQuery: String = "",
-    ) : ConversationItem() {
+    ) : ConversationItem {
         override val teamId: TeamId? = null
         override val mlsVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         override val proteusVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversationItem.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversationItem.kt
@@ -51,7 +51,7 @@ object TestConversationItem {
         playingAudio = null
     )
 
-    val GROUP = ConversationItem.GroupConversation(
+    val GROUP = ConversationItem.Group.Regular(
         "groupName looooooooooooooooooooooooooooooooooooong",
         conversationId = QualifiedID("value", "domain"),
         mutedStatus = MutedConversationStatus.AllAllowed,
@@ -61,7 +61,6 @@ object TestConversationItem {
         badgeEventType = BadgeEventType.UnreadMessage(100),
         selfMemberRole = null,
         isFromTheSameTeam = false,
-        isChannel = false,
         teamId = null,
         isArchived = false,
         mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,

--- a/app/src/test/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContentTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationSheetContentTest.kt
@@ -18,7 +18,7 @@
 package com.wire.android.ui.common.bottomsheet.conversation
 
 import com.wire.android.framework.TestUser
-import com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModelTest.Companion.testGroup
+import com.wire.android.ui.home.conversations.details.GroupDetailsViewModelTest.Companion.testGroup
 import com.wire.android.ui.home.conversationslist.model.BlockingState
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.TeamId

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupDetailsViewModelTest.kt
@@ -88,7 +88,7 @@ import org.junit.jupiter.params.provider.EnumSource
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
 @ExtendWith(NavigationTestExtension::class)
-class GroupConversationDetailsViewModelTest {
+class GroupDetailsViewModelTest {
     @Test
     fun `given a group conversation, when solving the conversation name, then the name of the conversation is used`() = runTest {
         // Given
@@ -392,7 +392,9 @@ class GroupConversationDetailsViewModelTest {
         coVerify(exactly = 1) {
             arrangement.updateConversationAccessRoleUseCase(
                 conversationId = details.conversation.id,
-                accessRoles = Conversation.defaultGroupAccessRoles.toMutableSet().apply { remove(Conversation.AccessRole.NON_TEAM_MEMBER) },
+                accessRoles = Conversation.defaultGroupAccessRoles.toMutableSet().apply {
+                    remove(Conversation.AccessRole.NON_TEAM_MEMBER)
+                },
                 access = Conversation.defaultGroupAccess
             )
         }
@@ -962,11 +964,12 @@ internal class GroupConversationDetailsViewModelArrangement {
     val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
 
     init {
-
         // Tests setup
         MockKAnnotations.init(this, relaxUnitFun = true)
 
-        every { savedStateHandle.navArgs<GroupConversationAllParticipantsNavArgs>() } returns GroupConversationAllParticipantsNavArgs(
+        every {
+            savedStateHandle.navArgs<GroupConversationAllParticipantsNavArgs>()
+        } returns GroupConversationAllParticipantsNavArgs(
             conversationId = conversationId
         )
         every { savedStateHandle.navArgs<GroupConversationDetailsNavArgs>() } returns GroupConversationDetailsNavArgs(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupParticipantsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupParticipantsViewModelTest.kt
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
 @ExtendWith(NavigationTestExtension::class)
-class GroupConversationParticipantsViewModelTest {
+class GroupParticipantsViewModelTest {
 
     private fun testSize(givenParticipantsSize: Int, expectedParticipantsSize: Int) = runTest {
         // Given

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
@@ -144,7 +144,7 @@ class GetConversationsFromSearchUseCaseTest {
             }
             // Then
             val conversation = result.first()
-            assertInstanceOf<ConversationItem.GroupConversation>(conversation)
+            assertInstanceOf<ConversationItem.Group>(conversation)
             assertEquals(true, conversation.isFromTheSameTeam)
         }
 
@@ -163,7 +163,7 @@ class GetConversationsFromSearchUseCaseTest {
             }
             // Then
             val conversation = result.first()
-            assertInstanceOf<ConversationItem.GroupConversation>(conversation)
+            assertInstanceOf<ConversationItem.Group>(conversation)
             assertEquals(false, conversation.isFromTheSameTeam)
         }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16931" title="WPB-16931" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16931</a>  [Android] Lock icon missing from private channel avatar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We're not displaying the Lock icon on channels that are private.

### Causes

Some pieces of our don't even get the information about the channel access.

### Solutions

Refactored the `ConversationItem` model, replacing `GroupConversation` with a more structured hierarchy of `Group.Regular` and `Group.Channel`. Introduced properties like `isPrivate` for `Channel` and updated related logic, factory methods, tests, and previews accordingly.

Also, change the `ConversationAvatar.Group.Channel` to accept an `isPrivate` boolean.

### Attachments

![image](https://github.com/user-attachments/assets/77696f71-b365-490a-a7ec-3a5aba31b07a)

![image](https://github.com/user-attachments/assets/83ee2279-1d7b-45f2-ac7e-9f1bd2a98b9e)

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
