### PR TITLE
fix: make sure coroutine is init before using it on analytics manager [WPB-17078]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -244,8 +244,7 @@ class WireApplication : BaseApp() {
             },
             migrationHandler = { manager ->
                 manager.onMigrationComplete()
-            },
-            dispatcher = Dispatchers.IO
+            }
         )
 
         AnonymousAnalyticsManagerImpl.applicationOnCreate()

--- a/core/analytics-enabled/src/test/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerTest.kt
+++ b/core/analytics-enabled/src/test/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerTest.kt
@@ -31,19 +31,19 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.verify
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class AnonymousAnalyticsManagerTest {
-    private val dispatcher = StandardTestDispatcher()
 
     @Test
-    fun givenAnonymousAnalyticsManager_whenInitializing_thenAnalyticsImplementationIsConfiguredCorrectly() = runTest(dispatcher) {
+    fun givenAnonymousAnalyticsManager_whenInitializing_thenAnalyticsImplementationIsConfiguredCorrectly() = runTest {
         // given
         val (arrangement, manager) = Arrangement()
             .withAnonymousAnalyticsRecorderConfigure()
@@ -58,8 +58,7 @@ class AnonymousAnalyticsManagerTest {
             analyticsResultFlow = arrangement.analyticsResultChannel.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             migrationHandler = arrangement.migrationHandler,
-            propagationHandler = arrangement.propagationHandler,
-            dispatcher = dispatcher
+            propagationHandler = arrangement.propagationHandler
         )
         advanceUntilIdle()
 
@@ -73,7 +72,7 @@ class AnonymousAnalyticsManagerTest {
     }
 
     @Test
-    fun givenIsEnabledFlowIsTrue_whenSendingAnEvent_thenEventIsSent() = runTest(dispatcher) {
+    fun givenIsEnabledFlowIsTrue_whenSendingAnEvent_thenEventIsSent() = runTest {
         // given
         val (arrangement, manager) = Arrangement()
             .withAnonymousAnalyticsRecorderConfigure()
@@ -93,8 +92,7 @@ class AnonymousAnalyticsManagerTest {
             analyticsResultFlow = arrangement.analyticsResultChannel.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             migrationHandler = arrangement.migrationHandler,
-            propagationHandler = arrangement.propagationHandler,
-            dispatcher = dispatcher
+            propagationHandler = arrangement.propagationHandler
         )
         advanceUntilIdle()
 
@@ -108,7 +106,7 @@ class AnonymousAnalyticsManagerTest {
     }
 
     @Test
-    fun givenIsEnabledFlowIsTrue_whenSettingToFalseAndSendingEvent_thenNoEventsAreSent() = runTest(dispatcher) {
+    fun givenIsEnabledFlowIsTrue_whenSettingToFalseAndSendingEvent_thenNoEventsAreSent() = runTest {
         // given
         val (arrangement, manager) = Arrangement()
             .withAnonymousAnalyticsRecorderConfigure()
@@ -128,8 +126,7 @@ class AnonymousAnalyticsManagerTest {
             analyticsResultFlow = arrangement.analyticsResultChannel.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             migrationHandler = arrangement.migrationHandler,
-            propagationHandler = arrangement.propagationHandler,
-            dispatcher = dispatcher
+            propagationHandler = arrangement.propagationHandler
         )
 
         manager.sendEvent(event)
@@ -146,7 +143,7 @@ class AnonymousAnalyticsManagerTest {
     }
 
     @Test
-    fun givenIsEnabledFlowIsFalse_whenCallingOnStart_thenRecorderOnStartIsNotCalled() = runTest(dispatcher) {
+    fun givenIsEnabledFlowIsFalse_whenCallingOnStart_thenRecorderOnStartIsNotCalled() = runTest {
         // given
         val (arrangement, manager) = Arrangement()
             .withAnonymousAnalyticsRecorderConfigure()
@@ -161,8 +158,7 @@ class AnonymousAnalyticsManagerTest {
             analyticsResultFlow = arrangement.analyticsResultChannel.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             migrationHandler = arrangement.migrationHandler,
-            propagationHandler = arrangement.propagationHandler,
-            dispatcher = dispatcher
+            propagationHandler = arrangement.propagationHandler
         )
 
         manager.onStart(activity = mockk<Activity>())
@@ -174,7 +170,7 @@ class AnonymousAnalyticsManagerTest {
     }
 
     @Test
-    fun givenIsEnabledFlowIsFalse_whenCallingOnStop_thenRecorderOnStopIsNotCalled() = runTest(dispatcher) {
+    fun givenIsEnabledFlowIsFalse_whenCallingOnStop_thenRecorderOnStopIsNotCalled() = runTest {
         // given
         val (arrangement, manager) = Arrangement()
             .withAnonymousAnalyticsRecorderConfigure()
@@ -189,8 +185,7 @@ class AnonymousAnalyticsManagerTest {
             analyticsResultFlow = arrangement.analyticsResultChannel.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             migrationHandler = arrangement.migrationHandler,
-            propagationHandler = arrangement.propagationHandler,
-            dispatcher = dispatcher
+            propagationHandler = arrangement.propagationHandler
         )
 
         manager.onStop(activity = mockk<Activity>())
@@ -203,7 +198,7 @@ class AnonymousAnalyticsManagerTest {
     }
 
     @Test
-    fun givenIsEnabledFlowIsFalseAndOneActivityStarted_whenTogglingEnabledToTrue_thenCallStartAfterToggled() = runTest(dispatcher) {
+    fun givenIsEnabledFlowIsFalseAndOneActivityStarted_whenTogglingEnabledToTrue_thenCallStartAfterToggled() = runTest {
         // given
         val (arrangement, manager) = Arrangement()
             .withAnonymousAnalyticsRecorderConfigure()
@@ -217,8 +212,7 @@ class AnonymousAnalyticsManagerTest {
             analyticsResultFlow = arrangement.analyticsResultChannel.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             migrationHandler = arrangement.migrationHandler,
-            propagationHandler = arrangement.propagationHandler,
-            dispatcher = dispatcher
+            propagationHandler = arrangement.propagationHandler
         )
 
         manager.onStart(activity)
@@ -238,7 +232,7 @@ class AnonymousAnalyticsManagerTest {
     }
 
     @Test
-    fun givenManagerInitialized_whenTogglingEnabledToFalse_thenHaltIsCalled() = runTest(dispatcher) {
+    fun givenManagerInitialized_whenTogglingEnabledToFalse_thenHaltIsCalled() = runTest {
         // given
         val (arrangement, manager) = Arrangement()
             .withAnonymousAnalyticsRecorderConfigure()
@@ -250,8 +244,7 @@ class AnonymousAnalyticsManagerTest {
             analyticsResultFlow = arrangement.analyticsResultChannel.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             migrationHandler = arrangement.migrationHandler,
-            propagationHandler = arrangement.propagationHandler,
-            dispatcher = dispatcher
+            propagationHandler = arrangement.propagationHandler
         )
 
         // when
@@ -265,7 +258,7 @@ class AnonymousAnalyticsManagerTest {
     }
 
     @Test
-    fun givenManagerInitialized_whenRecordingView_thenScreenIsRecorded() = runTest(dispatcher) {
+    fun givenManagerInitialized_whenRecordingView_thenScreenIsRecorded() = runTest {
         // given
         val (arrangement, manager) = Arrangement()
             .withAnonymousAnalyticsRecorderConfigure()
@@ -281,8 +274,7 @@ class AnonymousAnalyticsManagerTest {
             analyticsResultFlow = arrangement.analyticsResultChannel.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             migrationHandler = arrangement.migrationHandler,
-            propagationHandler = arrangement.propagationHandler,
-            dispatcher = dispatcher
+            propagationHandler = arrangement.propagationHandler
         )
         advanceUntilIdle()
 
@@ -296,7 +288,7 @@ class AnonymousAnalyticsManagerTest {
     }
 
     @Test
-    fun givenManagerInitialized_whenRecordingViewAndFlagDisabled_thenScreenIsNOTRecorded() = runTest(dispatcher) {
+    fun givenManagerInitialized_whenRecordingViewAndFlagDisabled_thenScreenIsNOTRecorded() = runTest {
         // given
         val (arrangement, manager) = Arrangement()
             .withAnonymousAnalyticsRecorderConfigure()
@@ -312,8 +304,7 @@ class AnonymousAnalyticsManagerTest {
             analyticsResultFlow = arrangement.analyticsResultChannel.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             migrationHandler = arrangement.migrationHandler,
-            propagationHandler = arrangement.propagationHandler,
-            dispatcher = dispatcher
+            propagationHandler = arrangement.propagationHandler
         )
         advanceUntilIdle()
 
@@ -327,7 +318,7 @@ class AnonymousAnalyticsManagerTest {
     }
 
     @Test
-    fun givenManagerInitialized_whenStoppingView_thenScreenIsStoppedToRecord() = runTest(dispatcher) {
+    fun givenManagerInitialized_whenStoppingView_thenScreenIsStoppedToRecord() = runTest {
         // given
         val (arrangement, manager) = Arrangement()
             .withAnonymousAnalyticsRecorderConfigure()
@@ -343,8 +334,7 @@ class AnonymousAnalyticsManagerTest {
             analyticsResultFlow = arrangement.analyticsResultChannel.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             migrationHandler = arrangement.migrationHandler,
-            propagationHandler = arrangement.propagationHandler,
-            dispatcher = dispatcher
+            propagationHandler = arrangement.propagationHandler
         )
         advanceUntilIdle()
 
@@ -358,7 +348,7 @@ class AnonymousAnalyticsManagerTest {
     }
 
     @Test
-    fun givenManagerInitialized_whenApplicationCreated_thenApplicationOnCreateIsRecorded() = runTest(dispatcher) {
+    fun givenManagerInitialized_whenApplicationCreated_thenApplicationOnCreateIsRecorded() = runTest {
         // given
         val (arrangement, manager) = Arrangement()
             .withAnonymousAnalyticsRecorderConfigure()
@@ -373,8 +363,7 @@ class AnonymousAnalyticsManagerTest {
             analyticsResultFlow = arrangement.analyticsResultChannel.consumeAsFlow(),
             anonymousAnalyticsRecorder = arrangement.anonymousAnalyticsRecorder,
             migrationHandler = arrangement.migrationHandler,
-            propagationHandler = arrangement.propagationHandler,
-            dispatcher = dispatcher
+            propagationHandler = arrangement.propagationHandler
         )
         advanceUntilIdle()
 
@@ -413,6 +402,7 @@ class AnonymousAnalyticsManagerTest {
             every { anonymousAnalyticsRecorder.applicationOnCreate() } returns Unit
             coEvery { anonymousAnalyticsRecorder.setTrackingIdentifierWithMerge(any(), any(), any()) } returns Unit
             coEvery { anonymousAnalyticsRecorder.setTrackingIdentifierWithoutMerge(any(), any(), any(), any()) } returns Unit
+            withAnonymousAnalyticsDispatcher()
         }
 
         private val manager by lazy {
@@ -423,6 +413,11 @@ class AnonymousAnalyticsManagerTest {
 
         fun withAnonymousAnalyticsRecorderConfigure() = apply {
             every { anonymousAnalyticsRecorder.configure(any(), any()) } returns Unit
+        }
+
+        fun withAnonymousAnalyticsDispatcher() = apply {
+            mockkObject(AnonymousAnalyticsManagerImpl)
+            every { AnonymousAnalyticsManagerImpl.getDispatcher() } returns UnconfinedTestDispatcher()
         }
 
         suspend fun withAnalyticsResult(result: AnalyticsResult<DummyManager>) = apply {

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManager.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManager.kt
@@ -24,7 +24,6 @@ import com.wire.android.feature.analytics.handler.AnalyticsPropagationHandler
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.feature.analytics.model.AnalyticsResult
 import com.wire.android.feature.analytics.model.AnalyticsSettings
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 
 var globalAnalyticsManager: AnonymousAnalyticsManager = AnonymousAnalyticsManagerStub()
@@ -39,7 +38,6 @@ interface AnonymousAnalyticsManager {
         anonymousAnalyticsRecorder: AnonymousAnalyticsRecorder,
         migrationHandler: AnalyticsMigrationHandler<T>,
         propagationHandler: AnalyticsPropagationHandler<T>,
-        dispatcher: CoroutineDispatcher
     )
 
     fun sendEvent(event: AnalyticsEvent)

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerStub.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerStub.kt
@@ -24,7 +24,6 @@ import com.wire.android.feature.analytics.handler.AnalyticsPropagationHandler
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.feature.analytics.model.AnalyticsResult
 import com.wire.android.feature.analytics.model.AnalyticsSettings
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 
 open class AnonymousAnalyticsManagerStub : AnonymousAnalyticsManager {

--- a/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerStub.kt
+++ b/core/analytics/src/main/kotlin/com/wire/android/feature/analytics/AnonymousAnalyticsManagerStub.kt
@@ -36,7 +36,6 @@ open class AnonymousAnalyticsManagerStub : AnonymousAnalyticsManager {
         anonymousAnalyticsRecorder: AnonymousAnalyticsRecorder,
         migrationHandler: AnalyticsMigrationHandler<T>,
         propagationHandler: AnalyticsPropagationHandler<T>,
-        dispatcher: CoroutineDispatcher
     ) = Unit
 
     override fun sendEvent(event: AnalyticsEvent) = Unit


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17078" title="WPB-17078" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17078</a>  [Android] play store crash related to countly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

It seems there is a case where we are trying to access the coroutine scope and this is not init.

### Causes (Optional)

Edge case of init not being called ?

### Solutions

Just check for the coroutine to be init before accessing it.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
