### PR TITLE
fix: download dialog not showing for assets in conversation (WPB-17023)

### DIFF
--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.paging.PagingData
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
+import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.media.audiomessage.AudioSpeed
 import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
@@ -114,6 +115,9 @@ class ConversationMessagesViewModelArrangement {
     @MockK
     lateinit var deleteMessage: DeleteMessageUseCase
 
+    @MockK
+    lateinit var globalDataStore: GlobalDataStore
+
     private val viewModel: ConversationMessagesViewModel by lazy {
         ConversationMessagesViewModel(
             savedStateHandle,
@@ -132,6 +136,7 @@ class ConversationMessagesViewModelArrangement {
             clearUsersTypingEvents,
             getSearchedConversationMessagePosition,
             deleteMessage,
+            globalDataStore,
         )
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -53,6 +53,11 @@ import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionResult
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.MutedConversationStatus
+import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -62,6 +67,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.datetime.Instant
 import okio.Path
 
 class ConversationMessagesViewModelArrangement {
@@ -237,5 +243,43 @@ class ConversationMessagesViewModelArrangement {
         return this
     }
 
+    fun withWireCellEnabled() = apply {
+        coEvery { globalDataStore.wireCellsEnabled() } returns flowOf(true)
+        coEvery { observeConversationDetails(any()) } returns flowOf(
+            ObserveConversationDetailsUseCase.Result.Success(
+                ConversationDetails.Group.Regular(
+                    conversation = conversationStub,
+                    isSelfUserMember = true,
+                    selfRole = Conversation.Member.Role.Member,
+                    wireCell = "test_cell"
+                )
+            )
+        )
+    }
+
     fun arrange() = this to viewModel
 }
+
+private val conversationStub = Conversation(
+    id = ConversationId("some-dummy-value", "some.dummy.domain"),
+    type = Conversation.Type.Group.Regular,
+    name = "Test",
+    access = listOf(Conversation.Access.PRIVATE),
+    accessRole = listOf(Conversation.AccessRole.TEAM_MEMBER),
+    protocol = Conversation.ProtocolInfo.Proteus,
+    teamId = TeamId("someTeam"),
+    lastReadDate = Instant.UNIX_FIRST_DATE,
+    creatorId = "someCreatorId",
+    receiptMode = Conversation.ReceiptMode.DISABLED,
+    messageTimer = null,
+    userMessageTimer = null,
+    archived = false,
+    archivedDateTime = null,
+    mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+    proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+    legalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
+    mutedStatus = MutedConversationStatus.AllAllowed,
+    removedBy = null,
+    lastNotificationDate = null,
+    lastModifiedDate = null,
+)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17023" title="WPB-17023" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17023</a>  [Android]Download modal missing when long pressing audio file/image
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-17023

# What's new in this PR?

### Issues

Dialog with the download / open actions not showing for asset.

### Causes (Optional)
Caused by new UX introduced for Wire Cells feature.

### Solutions
Enable new behavior only if Wire Cell is enabled for the conversation.

