### PR TITLE
fix: old login flow does not continue after entering verification code [WPB-17234]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -92,7 +92,7 @@ class LoginEmailViewModel @Inject constructor(
 
     val secondFactorVerificationCodeTextState: TextFieldState = TextFieldState()
     var secondFactorVerificationCodeState by mutableStateOf(VerificationCodeState())
-    var autoLoginWhenFullCodeEntered: Boolean = false
+    var autoLoginWhenFullCodeEntered: Boolean = true
 
     @VisibleForTesting
     internal val loginJobData = MutableStateFlow<LoginJobData?>(null)

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCode.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCode.kt
@@ -28,11 +28,13 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
@@ -42,6 +44,7 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.util.ui.PreviewMultipleThemes
+import kotlinx.coroutines.job
 
 @Composable
 fun VerificationCode(
@@ -54,6 +57,7 @@ fun VerificationCode(
     showLoadingProgress: Boolean = true,
 ) {
     val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier.fillMaxWidth(),
@@ -90,6 +94,13 @@ fun VerificationCode(
                     progressColor = MaterialTheme.wireColorScheme.primary,
                     size = MaterialTheme.wireDimensions.spacing24x,
                 )
+            }
+        }
+
+        LaunchedEffect(Unit) {
+            coroutineContext.job.invokeOnCompletion {
+                focusRequester.requestFocus()
+                keyboardController?.show()
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17234" title="WPB-17234" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17234</a>  [Android] Old login flow does not continue after entering verification code
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

User is not able to log in using the old login flow when 2FA is enabled.
After entering the code nothing happens.

### Causes (Optional)

Wrong default value of `autoLoginWhenFullCodeEntered`.

### Solutions

Changed default value of `autoLoginWhenFullCodeEntered`.
Also, added opening the keyboard for the code input.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
