### PR TITLE
fix: wrong sorting of tags when generating release change log [WPB-17307]

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -36,7 +36,11 @@ jobs:
       - name: 'Set previous Git tag from local repo (semantic version sort)'
         run: |
           TAGS=$(git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\+|$)' | sort -V)
-          PREVIOUS_TAG=$(echo "$TAGS" | tail -n 2 | head -n 1)
+          if [ $(echo "$TAGS" | wc -l) -lt 2 ]; then
+            PREVIOUS_TAG=""
+          else
+            PREVIOUS_TAG=$(echo "$TAGS" | tail -n 2 | head -n 1)
+          fi
           echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> "$GITHUB_ENV"
 
       - name: 'Print environment variables'

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -33,8 +33,11 @@ jobs:
         if: "${{ github.event.inputs.current-release-tag == '' }}"
         run: echo "CURRENT_TAG=$(git tag --points-at ${{github.sha}} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\+|$)' | tail -n 1)" >> "$GITHUB_ENV"
 
-      - name: 'Set previous Git tag from commit'
-        run: echo "PREVIOUS_TAG=$(git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\+|$)' | tail -n 2 | head -n 1)" >> "$GITHUB_ENV"
+      - name: 'Set previous Git tag from local repo (semantic version sort)'
+        run: |
+          TAGS=$(git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\+|$)' | sort -V)
+          PREVIOUS_TAG=$(echo "$TAGS" | tail -n 2 | head -n 1)
+          echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> "$GITHUB_ENV"
 
       - name: 'Print environment variables'
         run: |


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17307" title="WPB-17307" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17307</a>  [CI] relaease change log action is not working as expected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

wrong sorting of tags when generating release change log
the sorting is based on char level causing it to stuck on v4.9.1 as latest 

### Solutions

add sort -V to make it version aware

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
