### PR TITLE
fix: move mls jobs to start from te UI [WPB-17367]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -207,17 +207,26 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun provideMLSMigrationManager(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): MLSMigrationManager =
+    fun provideMLSMigrationManager(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): MLSMigrationManager =
         coreLogic.getSessionScope(currentAccount).mlsMigrationManager
 
     @ViewModelScoped
     @Provides
-    fun provideMLSClientManager(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): MLSClientManager =
+    fun provideMLSClientManager(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): MLSClientManager =
         coreLogic.getSessionScope(currentAccount).mlsClientManager
 
     @ViewModelScoped
     @Provides
-    fun provideKeyingMaterialsManager(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): KeyingMaterialsManager =
+    fun provideKeyingMaterialsManager(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): KeyingMaterialsManager =
         coreLogic.getSessionScope(currentAccount).keyingMaterialsManager
 
     @ViewModelScoped

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -33,12 +33,15 @@ import com.wire.kalium.logic.feature.analytics.GetCurrentAnalyticsTrackingIdenti
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
 import com.wire.kalium.logic.feature.auth.sso.ValidateSSOCodeUseCase
+import com.wire.kalium.logic.feature.client.MLSClientManager
 import com.wire.kalium.logic.feature.connection.BlockUserUseCase
 import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveOtherUserSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
+import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManager
 import com.wire.kalium.logic.feature.e2ei.usecase.FetchConversationMLSVerificationStatusUseCase
 import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCase
+import com.wire.kalium.logic.feature.mlsmigration.MLSMigrationManager
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveTeamSettingsSelfDeletingStatusUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
@@ -201,6 +204,21 @@ class UseCaseModule {
     @Provides
     fun provideValidateSSOCodeUseCase(@KaliumCoreLogic coreLogic: CoreLogic): ValidateSSOCodeUseCase =
         coreLogic.getGlobalScope().validateSSOCodeUseCase
+
+    @ViewModelScoped
+    @Provides
+    fun provideMLSMigrationManager(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): MLSMigrationManager =
+        coreLogic.getSessionScope(currentAccount).mlsMigrationManager
+
+    @ViewModelScoped
+    @Provides
+    fun provideMLSClientManager(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): MLSClientManager =
+        coreLogic.getSessionScope(currentAccount).mlsClientManager
+
+    @ViewModelScoped
+    @Provides
+    fun provideKeyingMaterialsManager(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): KeyingMaterialsManager =
+        coreLogic.getSessionScope(currentAccount).keyingMaterialsManager
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -49,7 +49,6 @@ class KaliumConfigsModule {
             // we use upsert, available from SQL3.24, which is supported from Android API30, so for older APIs we have to use SQLCipher
             shouldEncryptData = !BuildConfig.DEBUG || Build.VERSION.SDK_INT < Build.VERSION_CODES.R,
             lowerKeyPackageLimits = BuildConfig.LOWER_KEYPACKAGE_LIMIT,
-            lowerKeyingMaterialsUpdateThreshold = BuildConfig.PRIVATE_BUILD,
             developmentApiEnabled = BuildConfig.DEVELOPMENT_API_ENABLED,
             ignoreSSLCertificatesForUnboundCalls = BuildConfig.IGNORE_SSL_CERTIFICATES,
             encryptProteusStorage = true,

--- a/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
@@ -19,10 +19,14 @@ package com.wire.android.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.wire.android.appLogger
+import com.wire.kalium.logic.feature.client.MLSClientManager
+import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManager
 import com.wire.kalium.logic.feature.e2ei.SyncCertificateRevocationListUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
 import com.wire.kalium.logic.feature.featureConfig.FeatureFlagsSyncWorker
+import com.wire.kalium.logic.feature.mlsmigration.MLSMigrationManager
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -39,8 +43,11 @@ class AppSyncViewModel @Inject constructor(
     private val syncCertificateRevocationListUseCase: SyncCertificateRevocationListUseCase,
     private val observeCertificateRevocationForSelfClient: ObserveCertificateRevocationForSelfClientUseCase,
     private val featureFlagsSyncWorker: FeatureFlagsSyncWorker,
-    private val updateApiVersions: UpdateApiVersionsUseCase
-) : ViewModel() {
+    private val updateApiVersions: UpdateApiVersionsUseCase,
+    private val mLSMigrationManager: MLSMigrationManager,
+    private val keyingMaterialsManager: KeyingMaterialsManager,
+    private val mLSClientManager: MLSClientManager,
+    ) : ViewModel() {
 
     private val minIntervalBetweenPulls: Duration = MIN_INTERVAL_BETWEEN_PULLS
 
@@ -77,6 +84,9 @@ class AppSyncViewModel @Inject constructor(
                 viewModelScope.launch { featureFlagsSyncWorker.execute() },
                 viewModelScope.launch { observeCertificateRevocationForSelfClient.invoke() },
                 viewModelScope.launch { updateApiVersions() },
+                viewModelScope.launch { mLSClientManager() },
+                viewModelScope.launch { mLSMigrationManager() },
+                viewModelScope.launch { keyingMaterialsManager() },
             ).joinAll()
         } catch (e: Exception) {
             appLogger.e("Error while syncing app config", e)

--- a/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
@@ -19,7 +19,6 @@ package com.wire.android.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.wire.android.appLogger
 import com.wire.kalium.logic.feature.client.MLSClientManager
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManager

--- a/app/src/test/kotlin/com/wire/android/ui/home/AppSyncViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/AppSyncViewModelTest.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.android.ui.home
 
-import androidx.compose.ui.Modifier
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.kalium.logic.feature.client.MLSClientManager
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManager
@@ -30,7 +29,6 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
-import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest

--- a/app/src/test/kotlin/com/wire/android/ui/home/AppSyncViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/AppSyncViewModelTest.kt
@@ -17,10 +17,14 @@
  */
 package com.wire.android.ui.home
 
+import androidx.compose.ui.Modifier
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.kalium.logic.feature.client.MLSClientManager
+import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManager
 import com.wire.kalium.logic.feature.e2ei.SyncCertificateRevocationListUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
 import com.wire.kalium.logic.feature.featureConfig.FeatureFlagsSyncWorker
+import com.wire.kalium.logic.feature.mlsmigration.MLSMigrationManager
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -42,6 +46,9 @@ class AppSyncViewModelTest {
             withFeatureFlagsSyncWorker()
             withSyncCertificateRevocationListUseCase()
             withUpdateApiVersions()
+            withMlsClientManager()
+            withMlsMigrationManager()
+            withKeyingMaterialsManager()
         }
 
         viewModel.startSyncingAppConfig()
@@ -51,6 +58,9 @@ class AppSyncViewModelTest {
         coVerify { arrangement.syncCertificateRevocationListUseCase.invoke() }
         coVerify { arrangement.featureFlagsSyncWorker.execute() }
         coVerify { arrangement.updateApiVersions() }
+        coVerify { arrangement.mlsClientManager() }
+        coVerify { arrangement.mlsMigrationManager() }
+        coVerify { arrangement.keyingMaterialsManager() }
     }
 
     @Test
@@ -60,6 +70,9 @@ class AppSyncViewModelTest {
             withFeatureFlagsSyncWorker(1000)
             withSyncCertificateRevocationListUseCase(1000)
             withUpdateApiVersions(1000)
+            withMlsClientManager(1000)
+            withMlsMigrationManager(1000)
+            withKeyingMaterialsManager(1000)
         }
 
         viewModel.startSyncingAppConfig()
@@ -71,6 +84,9 @@ class AppSyncViewModelTest {
         coVerify(exactly = 1) { arrangement.syncCertificateRevocationListUseCase.invoke() }
         coVerify(exactly = 1) { arrangement.featureFlagsSyncWorker.execute() }
         coVerify(exactly = 1) { arrangement.updateApiVersions() }
+        coVerify(exactly = 1) { arrangement.mlsClientManager() }
+        coVerify(exactly = 1) { arrangement.mlsMigrationManager() }
+        coVerify(exactly = 1) { arrangement.keyingMaterialsManager() }
     }
 
     private class Arrangement {
@@ -87,6 +103,15 @@ class AppSyncViewModelTest {
         @MockK
         lateinit var updateApiVersions: UpdateApiVersionsUseCase
 
+        @MockK
+        lateinit var mlsClientManager: MLSClientManager
+
+        @MockK
+        lateinit var mlsMigrationManager: MLSMigrationManager
+
+        @MockK
+        lateinit var keyingMaterialsManager: KeyingMaterialsManager
+
         init {
             MockKAnnotations.init(this)
         }
@@ -95,10 +120,12 @@ class AppSyncViewModelTest {
             syncCertificateRevocationListUseCase,
             observeCertificateRevocationForSelfClient,
             featureFlagsSyncWorker,
-            updateApiVersions
+            updateApiVersions,
+            mLSClientManager = mlsClientManager,
+            mLSMigrationManager = mlsMigrationManager,
+            keyingMaterialsManager = keyingMaterialsManager
         )
 
-        @OptIn(InternalCoroutinesApi::class)
         fun withObserveCertificateRevocationForSelfClient(delayMs: Long = 0) {
             coEvery { observeCertificateRevocationForSelfClient.invoke() } coAnswers {
                 delay(delayMs)
@@ -119,6 +146,24 @@ class AppSyncViewModelTest {
 
         fun withUpdateApiVersions(delayMs: Long = 0) {
             coEvery { updateApiVersions() } coAnswers {
+                delay(delayMs)
+            }
+        }
+
+        fun withMlsClientManager(delayMs: Long = 0) {
+            coEvery { mlsClientManager() } coAnswers {
+                delay(delayMs)
+            }
+        }
+
+        fun withMlsMigrationManager(delayMs: Long = 0) {
+            coEvery { mlsMigrationManager() } coAnswers {
+                delay(delayMs)
+            }
+        }
+
+        fun withKeyingMaterialsManager(delayMs: Long = 0) {
+            coEvery { keyingMaterialsManager() } coAnswers {
                 delay(delayMs)
             }
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17367" title="WPB-17367" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17367</a>  [Android] unlimited MLS jobs when sync goes live
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

move MLS jobs to kick start only from the foreground

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
