### PR TITLE
fix(channels): allow team admins to edit guests and self-deleting settings [WPB-17100]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModel.kt
@@ -30,9 +30,13 @@ import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.to
 import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
 import com.wire.android.ui.navArgs
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTimerUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -48,6 +52,8 @@ class EditSelfDeletingMessagesViewModel @Inject constructor(
     private val observeConversationMembers: ObserveParticipantsForConversationUseCase,
     private val observeSelfDeletionTimerSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase,
     private val updateMessageTimer: UpdateMessageTimerUseCase,
+    private val selfUser: ObserveSelfUserUseCase,
+    private val conversationDetails: ObserveConversationDetailsUseCase,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -64,9 +70,24 @@ class EditSelfDeletingMessagesViewModel @Inject constructor(
 
     private fun observeSelfDeletionTimerSettingsForConversation() {
         viewModelScope.launch {
+            // TODO(refactor): Move all this logic to a UseCase
+            val canPerformAdminActionsFlow = combine(
+                observeConversationMembers(conversationId).map { it.isSelfAnAdmin },
+                selfUser(),
+                conversationDetails(conversationId),
+                :: Triple
+            ).map { (isSelfAnAdmin, selfUser, conversationDetailsResult) ->
+                if (conversationDetailsResult !is ObserveConversationDetailsUseCase.Result.Success)
+                     return@map false
+                val conversationDetails = conversationDetailsResult.conversationDetails
+                val isChannel = conversationDetails is ConversationDetails.Group.Channel
+                val isTeamAdmin = selfUser.userType in setOf(UserType.ADMIN, UserType.OWNER)
+                val isSelfUserInConversationTeam = selfUser.teamId == conversationDetails.conversation.teamId
+                isSelfAnAdmin || (isChannel && isTeamAdmin && isSelfUserInConversationTeam)
+            }
             combine(
                 observeSelfDeletionTimerSettingsForConversation(conversationId, considerSelfUserSettings = false),
-                observeConversationMembers(conversationId).map { it.isSelfAnAdmin },
+                canPerformAdminActionsFlow,
                 ::Pair
             )
                 .distinctUntilChanged()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModel.kt
@@ -75,10 +75,11 @@ class EditSelfDeletingMessagesViewModel @Inject constructor(
                 observeConversationMembers(conversationId).map { it.isSelfAnAdmin },
                 selfUser(),
                 conversationDetails(conversationId),
-                :: Triple
+                ::Triple
             ).map { (isSelfAnAdmin, selfUser, conversationDetailsResult) ->
-                if (conversationDetailsResult !is ObserveConversationDetailsUseCase.Result.Success)
-                     return@map false
+                if (conversationDetailsResult !is ObserveConversationDetailsUseCase.Result.Success) {
+                    return@map false
+                }
                 val conversationDetails = conversationDetailsResult.conversationDetails
                 val isChannel = conversationDetails is ConversationDetails.Group.Channel
                 val isTeamAdmin = selfUser.userType in setOf(UserType.ADMIN, UserType.OWNER)
@@ -122,14 +123,18 @@ class EditSelfDeletingMessagesViewModel @Inject constructor(
             val currentSelectedDuration = state.locallySelected
             state = when (updateMessageTimer(conversationId, currentSelectedDuration?.value?.inWholeMilliseconds)) {
                 is UpdateMessageTimerUseCase.Result.Failure -> {
-                    appLogger.e("Failed to update self deleting enforced duration for conversation=${conversationId.toLogString()} " +
-                            "with new duration=${currentSelectedDuration?.name}")
+                    appLogger.e(
+                        "Failed to update self deleting enforced duration for conversation=${conversationId.toLogString()} " +
+                                "with new duration=${currentSelectedDuration?.name}"
+                    )
                     state.copy(isLoading = true)
                 }
 
                 UpdateMessageTimerUseCase.Result.Success -> {
-                    appLogger.d("Success updating self deleting enforced duration for conversation=${conversationId.toLogString()} " +
-                            "with new duration=${currentSelectedDuration?.name}")
+                    appLogger.d(
+                        "Success updating self deleting enforced duration for conversation=${conversationId.toLogString()} " +
+                                "with new duration=${currentSelectedDuration?.name}"
+                    )
                     state.copy(
                         isLoading = false,
                         remotelySelected = currentSelectedDuration

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModelTest.kt
@@ -26,6 +26,7 @@ import com.wire.android.config.NavigationTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.TestConversation
 import com.wire.android.framework.TestConversationDetails
+import com.wire.android.framework.TestUser
 import com.wire.android.ui.home.conversations.details.participants.model.ConversationParticipantsData
 import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
 import com.wire.android.ui.navArgs
@@ -44,6 +45,7 @@ import com.wire.kalium.logic.feature.conversation.guestroomlink.ObserveGuestRoom
 import com.wire.kalium.logic.feature.conversation.guestroomlink.RevokeGuestRoomLinkResult
 import com.wire.kalium.logic.feature.conversation.guestroomlink.RevokeGuestRoomLinkUseCase
 import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.guestroomlink.ObserveGuestRoomLinkFeatureFlagUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -287,6 +289,9 @@ class EditGuestAccessViewModelTest {
         @MockK
         lateinit var getDefaultProtocolUseCase: GetDefaultProtocolUseCase
 
+        @MockK
+        lateinit var observeSelfUserUseCase: ObserveSelfUserUseCase
+
         val editGuestAccessViewModel: EditGuestAccessViewModel by lazy {
             EditGuestAccessViewModel(
                 savedStateHandle = savedStateHandle,
@@ -300,7 +305,8 @@ class EditGuestAccessViewModelTest {
                 canCreatePasswordProtectedLinks = canCreatePasswordProtectedLinks,
                 dispatcher = dispatcherProvider,
                 syncConversationCode = syncConversationCodeUseCase,
-                getDefaultProtocol = getDefaultProtocolUseCase
+                getDefaultProtocol = getDefaultProtocolUseCase,
+                selfUser = observeSelfUserUseCase
             )
         }
 
@@ -319,6 +325,7 @@ class EditGuestAccessViewModelTest {
             coEvery { observeGuestRoomLink(any()) } returns flowOf()
             coEvery { observeGuestRoomLinkFeatureFlag() } returns flowOf()
             coEvery { canCreatePasswordProtectedLinks() } returns true
+            coEvery { observeSelfUserUseCase() } returns flowOf(TestUser.SELF_USER)
             every { getDefaultProtocolUseCase() } returns SupportedProtocol.PROTEUS
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModelTest.kt
@@ -19,16 +19,20 @@ package com.wire.android.ui.home.conversations.details.editselfdeletingmessages
 
 import androidx.lifecycle.SavedStateHandle
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.NavigationTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.TestConversation
-import com.wire.android.config.NavigationTestExtension
+import com.wire.android.framework.TestConversationDetails
+import com.wire.android.framework.TestUser
 import com.wire.android.ui.home.conversations.details.participants.model.ConversationParticipantsData
 import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
 import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
 import com.wire.android.ui.navArgs
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTimerUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
-import com.wire.kalium.logic.data.message.SelfDeletionTimer
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -49,44 +53,38 @@ import kotlin.time.Duration.Companion.minutes
 class EditSelfDeletingMessagesViewModelTest {
 
     @Test
-    fun `given self deleting messages option enabled, when disabling it, then it updates proper state`() =
-        runTest {
-            // Given
-            val (arrangement, viewModel) = Arrangement()
-                .withSelfDeletingMessagesGroupSettings(SelfDeletionTimer.Enabled(5.minutes))
-                .withUpdateMessageTimerSuccess()
-                .arrange()
+    fun `given self deleting messages option enabled, when disabling it, then it updates proper state`() = runTest {
+        // Given
+        val (arrangement, viewModel) = Arrangement().withSelfDeletingMessagesGroupSettings(SelfDeletionTimer.Enabled(5.minutes))
+            .withUpdateMessageTimerSuccess().arrange()
 
-            // When
-            viewModel.updateSelfDeletingMessageOption(false)
-            viewModel.applyNewDuration(arrangement.onCompleted)
+        // When
+        viewModel.updateSelfDeletingMessageOption(false)
+        viewModel.applyNewDuration(arrangement.onCompleted)
 
-            // Then
-            assertEquals(false, viewModel.state.isEnabled)
-            assertEquals(null, viewModel.state.locallySelected)
-            verify { arrangement.onCompleted() }
-        }
+        // Then
+        assertEquals(false, viewModel.state.isEnabled)
+        assertEquals(null, viewModel.state.locallySelected)
+        verify { arrangement.onCompleted() }
+    }
 
     @Test
-    fun `given self deleting messages option disabled, when enabling it, then it updates proper state`() =
-        runTest {
-            // Given
-            val newTimer = SelfDeletionDuration.FiveMinutes
-            val (arrangement, viewModel) = Arrangement()
-                .withSelfDeletingMessagesGroupSettings(SelfDeletionTimer.Enabled(Duration.ZERO))
-                .withUpdateMessageTimerSuccess()
-                .arrange()
+    fun `given self deleting messages option disabled, when enabling it, then it updates proper state`() = runTest {
+        // Given
+        val newTimer = SelfDeletionDuration.FiveMinutes
+        val (arrangement, viewModel) = Arrangement().withSelfDeletingMessagesGroupSettings(SelfDeletionTimer.Enabled(Duration.ZERO))
+            .withUpdateMessageTimerSuccess().arrange()
 
-            // When
-            viewModel.updateSelfDeletingMessageOption(true)
-            viewModel.onSelectDuration(newTimer)
-            viewModel.applyNewDuration(arrangement.onCompleted)
+        // When
+        viewModel.updateSelfDeletingMessageOption(true)
+        viewModel.onSelectDuration(newTimer)
+        viewModel.applyNewDuration(arrangement.onCompleted)
 
-            // Then
-            assertEquals(newTimer, viewModel.state.remotelySelected)
-            assertEquals(newTimer, viewModel.state.locallySelected)
-            verify { arrangement.onCompleted() }
-        }
+        // Then
+        assertEquals(newTimer, viewModel.state.remotelySelected)
+        assertEquals(newTimer, viewModel.state.locallySelected)
+        verify { arrangement.onCompleted() }
+    }
 
     private class Arrangement {
 
@@ -102,6 +100,12 @@ class EditSelfDeletingMessagesViewModelTest {
         @MockK
         private lateinit var updateMessageTimer: UpdateMessageTimerUseCase
 
+        @MockK
+        private lateinit var selfUser: ObserveSelfUserUseCase
+
+        @MockK
+        private lateinit var conversationDetails: ObserveConversationDetailsUseCase
+
         @MockK(relaxed = true)
         lateinit var onCompleted: () -> Unit
 
@@ -111,7 +115,9 @@ class EditSelfDeletingMessagesViewModelTest {
                 dispatcher = TestDispatcherProvider(),
                 observeConversationMembers = observerConversationMembers,
                 observeSelfDeletionTimerSettingsForConversation = observeSelfDeletionTimerSettingsForConversation,
-                updateMessageTimer = updateMessageTimer
+                updateMessageTimer = updateMessageTimer,
+                selfUser = selfUser,
+                conversationDetails = conversationDetails,
             )
         }
 
@@ -119,6 +125,11 @@ class EditSelfDeletingMessagesViewModelTest {
             MockKAnnotations.init(this, relaxUnitFun = true)
             every { savedStateHandle.navArgs<EditSelfDeletingMessagesNavArgs>() } returns EditSelfDeletingMessagesNavArgs(
                 conversationId = TestConversation.ID
+            )
+
+            coEvery { selfUser() } returns flowOf(TestUser.SELF_USER)
+            coEvery { conversationDetails(any()) } returns flowOf(
+                ObserveConversationDetailsUseCase.Result.Success(TestConversationDetails.GROUP)
             )
 
             coEvery { observerConversationMembers(any()) } returns flowOf(ConversationParticipantsData(isSelfAnAdmin = true))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17100" title="WPB-17100" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17100</a>  [Android]Team owner does not receive admin privileges when joining a channel created by a team member
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Team admin is unable to change Self-Deleting and Guest settings in channel conversations.

### Causes

- I missed these places when working on previous PRs
- Logic is spread out in many ViewModels instead of in a few UseCases

### Solutions

For now... snowball the hack. Change the missing ViewModels to account for channels and team admin.

For the future: centralise all logic in UseCases.

### Testing

#### Test Coverage (Optional)

I did _not_ write tests for code that I want to erase.

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
