### PR TITLE
feat: handle federated case for user ids in QR code (WPB-10530)

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/util/UserLinkQRMapperTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/util/UserLinkQRMapperTest.kt
@@ -65,5 +65,4 @@ class UserLinkQRMapperTest {
 
         assertEquals(UserLinkQRMapper.UserLinkQRResult.Success(QualifiedID("user-id", "domain")), result)
     }
-
 }

--- a/app/src/androidTest/kotlin/com/wire/android/util/UserLinkQRMapperTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/util/UserLinkQRMapperTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import android.net.Uri
+import androidx.core.net.toUri
+import com.wire.android.util.deeplink.UserLinkQRMapper
+import com.wire.kalium.logic.data.id.QualifiedID
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UserLinkQRMapperTest {
+
+    @Test
+    fun givenAUriFullQualifiedUrl_thenMapCorrectly() {
+        val uri: Uri = "wire://user/domain/user-id".toUri()
+        val result = UserLinkQRMapper.fromDeepLinkToQualifiedId(uri, "defaultDomain")
+
+        assertEquals(UserLinkQRMapper.UserLinkQRResult.Success(QualifiedID("user-id", "domain")), result)
+    }
+
+    @Test
+    fun givenAUriWrongFormat_thenMapToError() {
+        val uri: Uri = "wire://user".toUri()
+        val result = UserLinkQRMapper.fromDeepLinkToQualifiedId(uri, "defaultDomain")
+
+        assertEquals(UserLinkQRMapper.UserLinkQRResult.Failure, result)
+    }
+
+    @Test
+    fun givenAUriFullUnqualified_thenMapCorrectlyWithDefaultDomain() {
+        val uri: Uri = "wire://user/user-id".toUri()
+        val result = UserLinkQRMapper.fromDeepLinkToQualifiedId(uri, "defaultDomain")
+
+        assertEquals(UserLinkQRMapper.UserLinkQRResult.Success(QualifiedID("user-id", "defaultDomain")), result)
+    }
+
+    @Test
+    fun givenAUriQualifiedButNotSupportedFormat_thenMapCorrectlyWithDefaultDomain() {
+        val uri: Uri = "wire://user/USER-ID@domain".toUri()
+        val result = UserLinkQRMapper.fromDeepLinkToQualifiedId(uri, "defaultDomain")
+
+        assertEquals(UserLinkQRMapper.UserLinkQRResult.Success(QualifiedID("user-id", "domain")), result)
+    }
+
+    @Test
+    fun givenAUriWithUpperCaseId_thenMapCorrectlyWithLowercaseId() {
+        val uri: Uri = "wire://user/uSer-Id@domain".toUri()
+        val result = UserLinkQRMapper.fromDeepLinkToQualifiedId(uri, "defaultDomain")
+
+        assertEquals(UserLinkQRMapper.UserLinkQRResult.Success(QualifiedID("user-id", "domain")), result)
+    }
+
+}

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeScreen.kt
@@ -280,7 +280,8 @@ fun PreviewSelfQRCodeContent() {
             SelfQRCodeState(
                 userId = UserId("userId", "wire.com"),
                 handle = "userid",
-                userProfileLink = "https://account.wire.com/user-profile/?id=aaaaaaa-222-3333-4444-55555555"
+                userProfileLink = "wire://user/wire.com/aaaaaaa-222-3333-4444-55555555",
+                userAccountProfileLink = "https://account.wire.com/user-profile/?id=aaaaaaa-222-3333-4444-55555555@wire.com"
             ),
             { "".toUri() },
             { }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeViewModel.kt
@@ -111,7 +111,7 @@ class SelfQRCodeViewModel @Inject constructor(
 
     private fun generateSelfUserUrls(accountsUrl: String): SelfQRCodeState =
         selfQRCodeState.copy(
-            userAccountProfileLink = String.format(BASE_USER_PROFILE_URL, accountsUrl, selfUserId.value),
+            userAccountProfileLink = String.format(BASE_USER_PROFILE_URL, accountsUrl, selfUserId),
             userProfileLink = String.format(DIRECT_BASE_USER_PROFILE_URL, selfUserId.domain, selfUserId.value)
         )
 

--- a/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
@@ -152,9 +152,9 @@ class DeepLinkProcessor @Inject constructor(
         val segments = uri.pathSegments
         return when (segments.size) {
             1 -> {
-                uri.lastPathSegment?.toDefaultQualifiedId(accountInfo.userId.domain)?.let {
+                segments.first().toDefaultQualifiedId(accountInfo.userId.domain).let {
                     DeepLinkResult.OpenOtherUserProfile(it, switchedAccount)
-                } ?: DeepLinkResult.Unknown
+                }
             }
 
             2 -> {

--- a/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
@@ -152,7 +152,7 @@ class DeepLinkProcessor @Inject constructor(
         val segments = uri.pathSegments
         return when (segments.size) {
             1 -> {
-                segments.first().toDefaultQualifiedId(accountInfo.userId.domain).let {
+                segments.last().toDefaultQualifiedId(accountInfo.userId.domain).let {
                     DeepLinkResult.OpenOtherUserProfile(it, switchedAccount)
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/util/deeplink/UserLinkQRMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/util/deeplink/UserLinkQRMapper.kt
@@ -1,0 +1,61 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util.deeplink
+
+import android.net.Uri
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
+
+object UserLinkQRMapper {
+
+    val qualifiedIdMapper = QualifiedIdMapperImpl(null)
+
+    fun fromDeepLinkToQualifiedId(uri: Uri, defaultDomain: String): UserLinkQRResult {
+        val segments = uri.pathSegments
+        return when (segments.size) {
+            1 -> {
+                val userId = qualifiedIdMapper.fromStringToQualifiedID(segments.last())
+                val sanitizedId = userId.value.toDefaultQualifiedId(userDomain = userId.domain.takeIf { it.isNotBlank() } ?: defaultDomain)
+                UserLinkQRResult.Success(sanitizedId)
+            }
+
+            2 -> {
+                val domain = segments.first()
+                val userId = segments.last()
+                UserLinkQRResult.Success(userId.toDefaultQualifiedId(domain))
+            }
+
+            else -> {
+                UserLinkQRResult.Failure
+            }
+        }
+    }
+
+    /**
+     * Converts the string to a [QualifiedID] with the current user domain or default.
+     * IMPORTANT! This also handles the special case where iOS is sending the ID in uppercase.
+     */
+    private fun String.toDefaultQualifiedId(userDomain: String): QualifiedID {
+        return QualifiedID(this.lowercase(), userDomain)
+    }
+
+    sealed class UserLinkQRResult {
+        data class Success(val qualifiedUserId: QualifiedID) : UserLinkQRResult()
+        data object Failure : UserLinkQRResult()
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/util/deeplink/UserLinkQRMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/util/deeplink/UserLinkQRMapper.kt
@@ -30,7 +30,11 @@ object UserLinkQRMapper {
         return when (segments.size) {
             1 -> {
                 val userId = qualifiedIdMapper.fromStringToQualifiedID(segments.last())
-                val sanitizedId = userId.value.toDefaultQualifiedId(userDomain = userId.domain.takeIf { it.isNotBlank() } ?: defaultDomain)
+                val sanitizedId = userId.value.toDefaultQualifiedId(
+                    userDomain = userId.domain.takeIf {
+                        it.isNotBlank()
+                    } ?: defaultDomain
+                )
                 UserLinkQRResult.Success(sanitizedId)
             }
 

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeViewModelTest.kt
@@ -39,7 +39,7 @@ class SelfQRCodeViewModelTest {
         )
 
         assertEquals(
-            expected = "${ServerConfig.STAGING.accounts}/user-profile/?id=${TestUser.SELF_USER.id.value}",
+            expected = "${ServerConfig.STAGING.accounts}/user-profile/?id=${TestUser.SELF_USER.id}",
             actual = viewModel.selfQRCodeState.userAccountProfileLink,
         )
     }

--- a/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
@@ -305,7 +305,7 @@ class DeepLinkProcessorTest {
         val conversationResult = deepLinkProcessor(arrangement.uri)
         assertInstanceOf(DeepLinkResult.OpenOtherUserProfile::class.java, conversationResult)
         assertEquals(
-            DeepLinkResult.OpenOtherUserProfile(UserId("other_user", "domain"), false),
+            DeepLinkResult.OpenOtherUserProfile(UserId("other_user", "other_domain"), false),
             conversationResult
         )
     }

--- a/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
@@ -387,7 +387,7 @@ class DeepLinkProcessorTest {
 
         fun withOtherUserProfileQRDeepLink(userIdToOpen: UserId = OTHER_USER_ID, userId: UserId = CURRENT_USER_ID) = apply {
             coEvery { uri.host } returns DeepLinkProcessor.OPEN_USER_PROFILE_DEEPLINK_HOST
-            coEvery { uri.lastPathSegment } returns userIdToOpen.value
+            coEvery { uri.pathSegments } returns listOf(userIdToOpen.domain, userIdToOpen.value)
             coEvery { uri.getQueryParameter(DeepLinkProcessor.USER_TO_USE_QUERY_PARAM) } returns userId.toString()
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10530" title="WPB-10530" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10530</a>  [Android] QR code Profile link Federation - update domain
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Federated case handling for QR code user profile. parsing, sharing, displaying.

### Causes (Optional)

Not prioritized before

### Solutions

Implement it.


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
