### PR TITLE
fix: schema validation for attachments (WPB-17546)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -154,6 +154,7 @@ class WireApplication : BaseApp() {
             )
             StrictMode.setVmPolicy(
                 StrictMode.VmPolicy.Builder()
+                    .detectFileUriExposure()
                     .detectLeakedSqlLiteObjects()
                     .detectLeakedClosableObjects()
                     .penaltyLog()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCase.kt
@@ -79,6 +79,7 @@ class HandleUriAssetUseCase @Inject constructor(
     /**
      * Handles the correctness of the supported schema of the URI.
      */
+    @Suppress("TooGenericExceptionCaught")
     private fun isValidUriSchema(uri: Uri): Boolean {
         return try {
             fileManager.checkValidSchema(uri)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCase.kt
@@ -83,7 +83,7 @@ class HandleUriAssetUseCase @Inject constructor(
         return try {
             fileManager.checkValidSchema(uri)
             true
-        } catch (exception: IllegalArgumentException) {
+        } catch (e: Exception) {
             false
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCase.kt
@@ -40,6 +40,10 @@ class HandleUriAssetUseCase @Inject constructor(
         saveToDeviceIfInvalid: Boolean = false,
         specifiedMimeType: String? = null, // specify a particular mimetype, otherwise it will be taken from the uri / file extension
     ): Result = withContext(dispatchers.io()) {
+        if (!isValidUriSchema(uri)) {
+            return@withContext Result.Failure.Unknown
+        }
+
         val tempAssetPath = kaliumFileSystem.tempFilePath(UUID.randomUUID().toString())
         val assetBundle = fileManager.getAssetBundleFromUri(
             attachmentUri = uri,
@@ -69,6 +73,18 @@ class HandleUriAssetUseCase @Inject constructor(
             }
         } else {
             return@withContext Result.Failure.Unknown
+        }
+    }
+
+    /**
+     * Handles the correctness of the supported schema of the URI.
+     */
+    private fun isValidUriSchema(uri: Uri): Boolean {
+        return try {
+            fileManager.checkValidSchema(uri)
+            true
+        } catch (exception: IllegalArgumentException) {
+            false
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/util/FileManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileManager.kt
@@ -117,6 +117,8 @@ class FileManager @Inject constructor(@ApplicationContext private val context: C
         dispatcher: DispatcherProvider = DefaultDispatcherProvider(),
     ): AssetBundle? = withContext(dispatcher.io()) {
         try {
+            // validate if the uri has a valid schema
+            checkValidSchema(attachmentUri)
             val assetKey = UUID.randomUUID().toString()
             val assetFileName = context.getFileName(attachmentUri)
                 ?: throw IOException("The selected asset has an invalid name")
@@ -143,6 +145,17 @@ class FileManager @Inject constructor(@ApplicationContext private val context: C
 
     fun openUrlWithExternalApp(url: String, mimeType: String, onError: () -> Unit) {
         openAssetUrlWithExternalApp(url, mimeType, context, onError)
+    }
+
+    /**
+     * Validates the schema of the given Uri.
+     * We are excluding file, as we don't process file URIs.
+     *
+     * If invalid schema is found, an [IllegalArgumentException] is thrown.
+     */
+    fun checkValidSchema(uri: Uri) {
+        appLogger.d("Validating Uri schema for path: ${uri.path} with scheme: ${uri.scheme}")
+        if (uri.scheme == "file") throw IllegalArgumentException("File URI is not supported")
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/util/FileManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileManager.kt
@@ -155,11 +155,12 @@ class FileManager @Inject constructor(@ApplicationContext private val context: C
      */
     fun checkValidSchema(uri: Uri) {
         appLogger.d("Validating Uri schema for path: ${uri.path} with scheme: ${uri.scheme}")
-        if (uri.scheme == "file") throw IllegalArgumentException("File URI is not supported")
+        if (INVALID_SCHEMA.equals(uri.scheme, ignoreCase = true)) throw IllegalArgumentException("File URI is not supported")
     }
 
     companion object {
         private const val TEMP_IMG_ATTACHMENT_FILENAME = "image_attachment.jpg"
         private const val TEMP_VIDEO_ATTACHMENT_FILENAME = "video_attachment.mp4"
+        private const val INVALID_SCHEMA = "file"
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCaseTest.kt
@@ -17,8 +17,9 @@
  */
 package com.wire.android.ui.home.conversations.usecase
 
+import android.net.Uri
+import android.os.Build
 import androidx.core.net.toUri
-import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.FakeKaliumFileSystem
 import com.wire.android.ui.home.conversations.model.AssetBundle
@@ -30,44 +31,40 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
-@OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(CoroutineTestExtension::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
 class HandleUriAssetUseCaseTest {
+
+    private val dispatcher = StandardTestDispatcher()
 
     @Test
     fun `given an invalid url schema, when invoked, then result should not succeed`() =
-        runTest {
+        runTest(dispatcher) {
             // Given
             val limit = GetAssetSizeLimitUseCaseImpl.ASSET_SIZE_DEFAULT_LIMIT_BYTES
-            val mockedAttachment = AssetBundle(
-                "key",
-                "image/jpeg",
-                "some-data-path".toPath(),
-                limit - 1L,
-                "mocked_image.jpeg",
-                AttachmentType.IMAGE
-            )
             val (_, useCase) = Arrangement()
                 .withGetAssetSizeLimitUseCase(true, limit)
-                .withGetAssetBundleFromUri(mockedAttachment)
+                .withGetAssetBundleFromUri(null)
                 .arrange()
 
             // When
-            val result = useCase.invoke("file://mocked_image.jpeg".toUri(), false)
+            val result = useCase.invoke(Uri.Builder().scheme("file").path("/data/asdasdasd.txt").build(), false)
 
             // Then
-            assert(result is HandleUriAssetUseCase.Result.Failure)
+            assert(result is HandleUriAssetUseCase.Result.Failure.Unknown)
         }
 
     @Test
     fun `given a user picks an image asset less than limit, when invoked, then result should succeed`() =
-        runTest {
+        runTest(dispatcher) {
             // Given
             val limit = GetAssetSizeLimitUseCaseImpl.ASSET_SIZE_DEFAULT_LIMIT_BYTES
             val mockedAttachment = AssetBundle(
@@ -92,7 +89,7 @@ class HandleUriAssetUseCaseTest {
 
     @Test
     fun `given a user picks an image asset larger than limit, when invoked, then result is asset too large failure`() =
-        runTest {
+        runTest(dispatcher) {
             // Given
             val limit = GetAssetSizeLimitUseCaseImpl.ASSET_SIZE_DEFAULT_LIMIT_BYTES
             val mockedAttachment = AssetBundle(
@@ -117,7 +114,7 @@ class HandleUriAssetUseCaseTest {
 
     @Test
     fun `given that a user picks too large asset that needs saving if invalid, when invoked, then saveToExternalMediaStorage is called`() =
-        runTest {
+        runTest(dispatcher) {
             // Given
             val limit = GetAssetSizeLimitUseCaseImpl.ASSET_SIZE_DEFAULT_LIMIT_BYTES
             val mockedAttachment = AssetBundle(
@@ -152,7 +149,7 @@ class HandleUriAssetUseCaseTest {
 
     @Test
     fun `given that a user picks asset, when getting uri returns null, then it should return error`() =
-        runTest {
+        runTest(dispatcher) {
             // Given
             val limit = GetAssetSizeLimitUseCaseImpl.ASSET_SIZE_DEFAULT_LIMIT_BYTES
             val (_, useCase) = Arrangement()

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCaseTest.kt
@@ -41,6 +41,31 @@ import org.junit.jupiter.api.extension.ExtendWith
 class HandleUriAssetUseCaseTest {
 
     @Test
+    fun `given an invalid url schema, when invoked, then result should not succeed`() =
+        runTest {
+            // Given
+            val limit = GetAssetSizeLimitUseCaseImpl.ASSET_SIZE_DEFAULT_LIMIT_BYTES
+            val mockedAttachment = AssetBundle(
+                "key",
+                "image/jpeg",
+                "some-data-path".toPath(),
+                limit - 1L,
+                "mocked_image.jpeg",
+                AttachmentType.IMAGE
+            )
+            val (_, useCase) = Arrangement()
+                .withGetAssetSizeLimitUseCase(true, limit)
+                .withGetAssetBundleFromUri(mockedAttachment)
+                .arrange()
+
+            // When
+            val result = useCase.invoke("file://mocked_image.jpeg".toUri(), false)
+
+            // Then
+            assert(result is HandleUriAssetUseCase.Result.Failure)
+        }
+
+    @Test
     fun `given a user picks an image asset less than limit, when invoked, then result should succeed`() =
         runTest {
             // Given

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/HandleUriAssetUseCaseTest.kt
@@ -17,8 +17,8 @@
  */
 package com.wire.android.ui.home.conversations.usecase
 
+import android.app.Application
 import android.net.Uri
-import android.os.Build
 import androidx.core.net.toUri
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.FakeKaliumFileSystem
@@ -40,7 +40,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+@Config(application = Application::class)
 class HandleUriAssetUseCaseTest {
 
     private val dispatcher = StandardTestDispatcher()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17546" title="WPB-17546" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17546</a>  [Android] Sanitize schema for sharing assets
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Extra handling needed for the app about sharing attachments, to be more restrict about what can be shared or not

### Solutions

Deny the usage of `file://` schema. We don't need it in the app, we use as supposed to content resolvers for it.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
