### PR TITLE
fix: use content resolver for sending audio messages (WPB-17546)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -21,7 +21,6 @@ import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
@@ -37,6 +36,7 @@ import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.SUPPORTED_AUDIO_MIME_TYPE
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.fileDateTime
+import com.wire.android.util.fromNioPathToContentUri
 import com.wire.android.util.getAudioLengthInMs
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
@@ -321,12 +321,12 @@ class RecordAudioViewModel @Inject constructor(
             onAudioRecorded(
                 UriAsset(
                     uri = if (didSucceed) {
-                        audioMediaRecorder.mp4OutputPath!!.toFile().toUri()
+                        context.fromNioPathToContentUri(nioPath = audioMediaRecorder.mp4OutputPath!!.toNioPath())
                     } else {
                         if (state.shouldApplyEffects) {
-                            state.effectsOutputFile!!.toUri()
+                            context.fromNioPathToContentUri(nioPath = state.effectsOutputFile!!.toPath())
                         } else {
-                            state.originalOutputFile!!.toUri()
+                            context.fromNioPathToContentUri(nioPath = state.originalOutputFile!!.toPath())
                         }
                     },
                     mimeType = if (didSucceed) {

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -57,6 +57,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import okio.Path
+import okio.Path.Companion.toOkioPath
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -179,6 +180,8 @@ private fun Context.saveFileDataToMediaFolder(assetName: String, downloadedDataP
     resolver.copyFile(insertedUri, downloadedDataPath)
     return insertedUri
 }
+
+fun Context.fromNioPathToContentUri(nioPath: java.nio.file.Path): Uri = this.pathToUri(nioPath.toOkioPath(), null)
 
 fun Context.pathToUri(assetDataPath: Path, assetName: String?): Uri =
     FileProvider.getUriForFile(this, getProviderAuthority(), assetDataPath.toFile(), assetName ?: assetDataPath.name)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17546" title="WPB-17546" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17546</a>  [Android] Sanitize schema for sharing assets
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When implementing the restrictions on file usage, audio messages were using direct access.

### Causes (Optional)

Not able to send audio messages

### Solutions

Use content schema instead of file for sending audio messages, the same as it is currently for other attachments.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Sending audio messages should work


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
