### PR TITLE
fix: init Amplituda lib causing NullPointerException on some devices [WPB-17405] 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/AppModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/AppModule.kt
@@ -39,7 +39,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import linc.com.amplituda.Amplituda
+import com.linc.amplituda.Amplituda
 import javax.inject.Named
 import javax.inject.Qualifier
 import javax.inject.Singleton

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioState.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioState.kt
@@ -32,10 +32,10 @@ data class AudioState(
     val audioMediaPlayingState: AudioMediaPlayingState,
     val currentPositionInMs: Int,
     val totalTimeInMs: TotalTimeInMs,
-    val wavesMask: List<Int>
+    val wavesMask: List<Int>?
 ) {
     companion object {
-        val DEFAULT = AudioState(AudioMediaPlayingState.Stopped, 0, TotalTimeInMs.NotKnown, listOf())
+        val DEFAULT = AudioState(AudioMediaPlayingState.Stopped, 0, TotalTimeInMs.NotKnown, null)
     }
 
     // if the back-end returned the total time, we use that, in case it didn't we use what we get from
@@ -146,7 +146,7 @@ sealed class AudioMediaPlayerStateUpdate(
     data class WaveMaskUpdate(
         override val conversationId: ConversationId,
         override val messageId: String,
-        val waveMask: List<Int>
+        val waveMask: List<Int>?
     ) : AudioMediaPlayerStateUpdate(conversationId, messageId)
 }
 

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioWavesMaskHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioWavesMaskHelper.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.android.media.audiomessage
 
+import android.content.Context
 import dagger.Lazy
 import com.linc.amplituda.Amplituda
 import com.linc.amplituda.Cache
@@ -31,11 +32,13 @@ class AudioWavesMaskHelper @Inject constructor(
     private val amplituda: Lazy<Amplituda>
 ) {
 
+    lateinit var context: Context
     companion object {
         private const val WAVES_AMOUNT = 75
         private const val WAVE_MAX = 32
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun getAmplituda(): Amplituda? = try {
         amplituda.get()
     } catch (e: NullPointerException) {

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayer.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayer.kt
@@ -184,11 +184,13 @@ class RecordAudioMessagePlayer @Inject constructor(
         audioMediaPlayer.seekTo(position)
         audioMediaPlayer.start()
 
-        audioMessageStateUpdate.emit(
-            RecordAudioMediaPlayerStateUpdate.WaveMaskUpdate(
-                wavesMaskHelper.getWaveMask(audioFile)
+        wavesMaskHelper.getWaveMask(audioFile)?.let { waveMask ->
+            audioMessageStateUpdate.emit(
+                RecordAudioMediaPlayerStateUpdate.WaveMaskUpdate(
+                    waveMask = waveMask
+                )
             )
-        )
+        }
 
         audioMessageStateUpdate.emit(
             RecordAudioMediaPlayerStateUpdate.RecordAudioMediaPlayingStateUpdate(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -335,12 +335,12 @@ fun SuccessfulAudioMessageContent(
 private fun AudioMessageSlider(
     audioDuration: AudioDuration,
     totalTimeInMs: AudioState.TotalTimeInMs,
-    waveMask: List<Int>,
+    waveMask: List<Int>?,
     onSliderPositionChange: (Float) -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxWidth()) {
         val totalMs = if (totalTimeInMs is AudioState.TotalTimeInMs.Known) totalTimeInMs.value.toFloat() else 0f
-        val waves = waveMask.ifEmpty { getDefaultWaveMask() }
+        val waves = waveMask?.ifEmpty { getDefaultWaveMask() }?: getDefaultWaveMask()
         val wavesAmount = waves.size
 
         Row(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -340,7 +340,7 @@ private fun AudioMessageSlider(
 ) {
     Box(modifier = Modifier.fillMaxWidth()) {
         val totalMs = if (totalTimeInMs is AudioState.TotalTimeInMs.Known) totalTimeInMs.value.toFloat() else 0f
-        val waves = waveMask?.ifEmpty { getDefaultWaveMask() }?: getDefaultWaveMask()
+        val waves = waveMask?.ifEmpty { getDefaultWaveMask() } ?: getDefaultWaveMask()
         val wavesAmount = waves.size
 
         Row(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ androidx-biometric = "1.1.0"
 androidx-startup = "1.2.0"
 androidx-compose-runtime = "1.7.2"
 compose-qr = "1.0.1"
-amplituda = "2.2.2"
+amplituda = "2.3.0"
 
 # Compose
 composeBom = "2024.12.01"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17405" title="WPB-17405" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17405</a>  [Android] crash when init Amplituda lib
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

some devices in the play store are crashing with NullPointerException on Amplituda lib init
was unable to repro but try catching the init and handling this case by not generating an audio wave should take care of it

### Solutions

try catch

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
