### PR TITLE
bugfix: channel screen UI used for group name edit screen (#WPB-17540)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationMetadataViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationMetadataViewModel.kt
@@ -32,6 +32,7 @@ import com.wire.android.ui.common.groupname.GroupNameValidator
 import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.ui.navArgs
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.RenameConversationUseCase
@@ -80,7 +81,8 @@ class EditConversationMetadataViewModel @Inject constructor(
                 .collectLatest {
                     editConversationNameTextState.setTextAndPlaceCursorAtEnd(it.conversation.name.orEmpty())
                     editConversationState = editConversationState.copy(
-                        originalGroupName = it.conversation.name.orEmpty()
+                        originalGroupName = it.conversation.name.orEmpty(),
+                        isChannel = it.conversation.type == Conversation.Type.Group.Channel,
                     )
                 }
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17540" title="WPB-17540" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17540</a>  [Android] Channels copies being used in 'Update Group Name' screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-17540
----

# What's new in this PR?

### Issues
Edit conversation name screen is showing edit channel name UI when changing a group name.

### Causes (Optional)
IsChannel flag is not initialized in conversation metadata, default true value is used.

### Solutions
Set isChannel name based on the conversation type.

