### PR TITLE
fix: align channel and group icon colors with other platforms (#WPB-17690)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/AppThemeExt.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/AppThemeExt.kt
@@ -19,6 +19,7 @@
 package com.wire.android.ui.common
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import com.wire.android.ui.theme.WireColorScheme
 import com.wire.kalium.logic.data.id.ConversationId
 import kotlin.math.absoluteValue
@@ -29,6 +30,7 @@ internal fun WireColorScheme.channelConversationColor(id: ConversationId) = chan
 @Composable
 internal fun WireColorScheme.groupConversationColor(id: ConversationId) = groupAvatarColors.withConversationId(id)
 
+@Stable
 private fun <T> List<T>.withConversationId(id: ConversationId): T {
     val hash = id.value.lowercase().hashCode()
     return this[hash.absoluteValue % this.size]

--- a/app/src/main/kotlin/com/wire/android/ui/common/AppThemeExt.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/AppThemeExt.kt
@@ -19,20 +19,17 @@
 package com.wire.android.ui.common
 
 import androidx.compose.runtime.Composable
-import com.wire.android.ui.theme.ChannelAvatarColors
-import com.wire.android.ui.theme.GroupAvatarColors
 import com.wire.android.ui.theme.WireColorScheme
 import com.wire.kalium.logic.data.id.ConversationId
 import kotlin.math.absoluteValue
 
 @Composable
-internal fun WireColorScheme.channelConversationColor(id: ConversationId): ChannelAvatarColors {
-    val colors = this.channelAvatarColors
-    return colors[(id.hashCode() % colors.size).absoluteValue]
-}
+internal fun WireColorScheme.channelConversationColor(id: ConversationId) = channelAvatarColors.withConversationId(id)
 
 @Composable
-internal fun WireColorScheme.groupConversationColor(id: ConversationId): GroupAvatarColors {
-    val colors = this.groupAvatarColors
-    return colors[(id.hashCode() % colors.size).absoluteValue]
+internal fun WireColorScheme.groupConversationColor(id: ConversationId) = groupAvatarColors.withConversationId(id)
+
+private fun <T> List<T>.withConversationId(id: ConversationId): T {
+    val hash = id.value.lowercase().hashCode()
+    return this[hash.absoluteValue % this.size]
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17690" title="WPB-17690" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17690</a>  [Android] Inconsistent channel icon color across clients (Android, iOS, Web)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-17690

# What's new in this PR?

### Issues
Channel icon color on Android does not match color on iOS and Web clients.

### Causes (Optional)
iOS/Web use only conversation id value for calculating the color index.

### Solutions
Adjust color index calculation.
