### PR TITLE
fix: call activity closing (#WPB-15667)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/StartingCallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/StartingCallActivity.kt
@@ -70,7 +70,11 @@ class StartingCallActivity : CallActivity() {
     private fun handleNewIntent(intent: Intent) {
         conversationId = intent.extras?.getString(EXTRA_CONVERSATION_ID)
         userId = intent.extras?.getString(EXTRA_USER_ID)
-        screenType = intent.extras?.getString(EXTRA_SCREEN_TYPE)?.let { StartingCallScreenType.byName(it) }
+        intent.extras?.getString(EXTRA_SCREEN_TYPE)?.let { StartingCallScreenType.byName(it) }?.let {
+            screenType = it
+        } ?: run {
+            appLogger.e("$TAG No screen type provided in intent extras")
+        }
         switchAccountIfNeeded(userId)
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15667" title="WPB-15667" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15667</a>  [Xiaomi Poco M4 Pro 4G/ Android 13] 1:1 Call: Call window doesn't show after initiating a call.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-15667

# What's new in this PR?

### Issues
Call screen is instantly closed after starting a call. Call is not dropped. Call screen keeps closing after returning.
https://platform.applause.com/services/links/v1/external/35dac118cb89cf8374917779d6ab82c431ee68e4ca2a136d7b695e514b214636

### Causes (Optional)
I cannot reproduce the issue. The only way to reproduce it was by manually calling `finish()` after creating the screen UI. This looks exactly like on the video from the ticket.
The only scenario I found that could possibly cause the issue is a new intent received by the activity with no `screenType` extra set.

### Solutions
Ensure screenType variable is not set to null if received intent does not contain screenType extra.