### PR TITLE
fix: error message not visible when trying to record audio during cal…

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageComposerViewState.kt
@@ -32,6 +32,7 @@ data class MessageComposerViewState(
     val mentionSearchResult: List<Contact> = listOf(),
     val mentionSearchQuery: String = String.EMPTY,
     val enterToSend: Boolean = false,
+    val isCallOngoing: Boolean = false,
 )
 
 sealed class AssetTooLargeDialogState {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -17,7 +17,9 @@
  */
 package com.wire.android.ui.home.messagecomposer
 
+import android.content.Context
 import android.net.Uri
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
@@ -81,10 +83,11 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
-import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
-import com.wire.android.ui.common.bottombar.bottomNavigationBarHeight
+import com.wire.android.R
 import com.wire.android.ui.common.attachmentdraft.model.AttachmentDraftUi
 import com.wire.android.ui.common.attachmentdraft.model.allUploaded
+import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
+import com.wire.android.ui.common.bottombar.bottomNavigationBarHeight
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.textfield.MessageComposerDefault
@@ -455,7 +458,13 @@ fun EnabledMessageComposer(
                             optionsVisible = inputStateHolder.optionsVisible,
                             isFileSharingEnabled = messageComposerViewState.value.isFileSharingEnabled,
                             additionalOptionsState = additionalOptionStateHolder.additionalOptionsSubMenuState,
-                            onRecordAudioMessageClicked = ::toAudioRecording,
+                            onRecordAudioMessageClicked = {
+                                if (!messageComposerViewState.value.isCallOngoing) {
+                                    toAudioRecording()
+                                } else {
+                                    showRecordNotAllowedMessage(context)
+                                }
+                            },
                             onCloseAdditionalAttachment = ::toInitialAttachmentOptions,
                             onLocationPickerClicked = onLocationClicked,
                             onImagesPicked = { onImagesPicked(it, false) },
@@ -481,6 +490,10 @@ fun EnabledMessageComposer(
             }
         }
     }
+}
+
+private fun showRecordNotAllowedMessage(context: Context) {
+    Toast.makeText(context, R.string.record_audio_unable_due_to_ongoing_call, Toast.LENGTH_SHORT).show()
 }
 
 private fun Size.getDistanceToCorner(corner: Offset): Float {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelArrangement.kt
@@ -99,6 +99,7 @@ internal class MessageComposerViewModelArrangement {
             currentSessionFlowUseCase()
         } returns flowOf(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.USER_ID)))
         coEvery { globalDataStore.enterToSendFlow() } returns flowOf(false)
+        coEvery { observeEstablishedCalls() } returns emptyFlow()
     }
 
     @MockK
@@ -149,6 +150,9 @@ internal class MessageComposerViewModelArrangement {
     @MockK
     lateinit var globalDataStore: GlobalDataStore
 
+    @MockK
+    lateinit var observeEstablishedCalls: ObserveEstablishedCallsUseCase
+
     private val fakeKaliumFileSystem = FakeKaliumFileSystem()
 
     private val viewModel by lazy {
@@ -167,6 +171,7 @@ internal class MessageComposerViewModelArrangement {
             kaliumFileSystem = fakeKaliumFileSystem,
             fileManager = fileManager,
             currentSessionFlowUseCase = currentSessionFlowUseCase,
+            observeEstablishedCalls = observeEstablishedCalls,
             globalDataStore = globalDataStore,
         )
     }


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-12178

# What's new in this PR?

### Issues
Recording an audio message is not allowed when there is an ongoing call. There are issues with showing the error message to the user.
- Snackbar message is not visible / partially visible
- Error is shown when trying to record the audio message. According to the design the app should show the error when user selects "Audio" from attachment options.

### Solutions
- Observe ongoing calls and add `isCallOngoing` property to the MessageComposerViewState
- Show toast message (guaranteed to be displayed on top of all views) when "Audio" is selected in attachment options and `isCallOngoing == true`

