### PR TITLE
fix: call video not paused in background [WPB-16609]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -299,7 +299,6 @@ private fun HandleSendingVideoFeed(
     }
 }
 
-
 @Suppress("CyclomaticComplexMethod")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -268,17 +269,15 @@ private fun HandleSendingVideoFeed(
 ) {
     // Pause the video feed when the lifecycle is paused and resume it when the lifecycle is resumed.
     val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
+    val currentCallState by rememberUpdatedState(callState)
     DisposableEffect(lifecycleOwner) {
-
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_PAUSE && callState.callStatus == CallStatus.ESTABLISHED && callState.isCameraOn) {
-                pauseSendingVideoFeed()
-            }
-            if (event == Lifecycle.Event.ON_RESUME && callState.callStatus == CallStatus.ESTABLISHED && callState.isCameraOn) {
-                startSendingVideoFeed()
-            }
-            if (event == Lifecycle.Event.ON_DESTROY) {
-                clearVideoPreview()
+            with(currentCallState) {
+                when {
+                    event == Lifecycle.Event.ON_PAUSE && callStatus == CallStatus.ESTABLISHED && isCameraOn -> pauseSendingVideoFeed()
+                    event == Lifecycle.Event.ON_RESUME && callStatus == CallStatus.ESTABLISHED && isCameraOn -> startSendingVideoFeed()
+                    event == Lifecycle.Event.ON_DESTROY -> clearVideoPreview()
+                }
             }
         }
 
@@ -299,6 +298,7 @@ private fun HandleSendingVideoFeed(
         }
     }
 }
+
 
 @Suppress("CyclomaticComplexMethod")
 @OptIn(ExperimentalMaterial3Api::class)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16609" title="WPB-16609" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16609</a>  [Android] No video shown from Android but still sorted in the tiles on Web that have video
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Video is not paused when user puts the call into background.

### Causes (Optional)

`callState` not being updated and always represents the state from the moment when `DisposableEffect` was created.

### Solutions

Use `rememberUpdatedState` to make sure the `LifecycleEventObserver` always uses the current state.

### Testing

#### How to Test

Start a call with video, put the call into background, others should see "video paused" info on your tile.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
