### PR TITLE
fix: anr on initial setup screen (#WPB-17964)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncViewModel.kt
@@ -54,12 +54,13 @@ class InitialSyncViewModel @Inject constructor(
     }
 
     private fun waitUntilSyncIsCompleted() =
-        viewModelScope.launch {
+        viewModelScope.launch(dispatchers.io()) {
             delay(DefaultDurationMillis.toLong()) // it can be triggered instantly so it's added to keep smooth transitions
             withContext(dispatchers.io()) {
-                observeSyncState().firstOrNull { it is SyncState.Live }
+                observeSyncState().firstOrNull { it is SyncState.Live }?.let {
+                    userDataStoreProvider.getOrCreate(userId).setInitialSyncCompleted()
+                }
             }?.let {
-                userDataStoreProvider.getOrCreate(userId).setInitialSyncCompleted()
                 isSyncCompleted = true
             } ?: run {
                 appLogger.e("InitialSyncViewModel: SyncState is null")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17964" title="WPB-17964" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17964</a>  [Android] Stuck on setup page when logging In — app resumes after ~1 Min Delay 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-17964
----

# What's new in this PR?

### Issues
ANR on initial setup screen.

### Causes (Optional)
Persisting flag in UserDataStore on MainThread (probably also creating the first UserDataStore instance)

### Solutions
Move operation to IO thread
