### PR TITLE
feat(new-registration): team account creation from app to team settings embedded (WPB-17526)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeViewModel.kt
@@ -48,7 +48,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-// TODO: Cover this viewModel  with unit test
 @HiltViewModel
 class CreateAccountVerificationCodeViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
@@ -125,6 +125,7 @@ fun CreateAccountDataDetailScreen(
             nameTextState = nameTextState,
             passwordTextState = passwordTextState,
             confirmPasswordTextState = confirmPasswordTextState,
+            teamCreationUrl = teamCreationUrl() + stringResource(R.string.create_account_email_backlink_to_team_suffix_url),
             tosUrl = tosUrl(),
             onPrivacyPolicyAccepted = ::onPrivacyPolicyAccepted,
             onTermsDialogDismiss = ::onTermsDialogDismiss,
@@ -144,6 +145,7 @@ private fun AccountDetailsContent(
     nameTextState: TextFieldState,
     passwordTextState: TextFieldState,
     confirmPasswordTextState: TextFieldState,
+    teamCreationUrl: String,
     tosUrl: String,
     onPrivacyPolicyAccepted: (Boolean) -> Unit,
     onTermsDialogDismiss: () -> Unit,
@@ -301,7 +303,7 @@ private fun AccountDetailsContent(
             )
 
             Row(modifier = Modifier.fillMaxWidth()) {
-                BackLinkToTeamCreation()
+                BackLinkToTeamCreation(teamCreationUrl)
             }
 
             if (state.termsDialogVisible) {
@@ -320,19 +322,16 @@ private fun AccountDetailsContent(
 }
 
 @Composable
-private fun RowScope.BackLinkToTeamCreation() {
+private fun RowScope.BackLinkToTeamCreation(teamCreationUrl: String) {
     val context = LocalContext.current
     val annotatedString = buildAnnotatedString {
         append(stringResource(R.string.create_account_email_backlink_to_team_label))
         append("\n")
-        val createATeam = stringResource(R.string.welcome_button_create_team)
         withLink(
             link = LinkAnnotation.Clickable(
                 tag = "teamCreation",
                 styles = TextLinkStyles(SpanStyle(textDecoration = TextDecoration.Underline)),
-                linkInteractionListener = {
-                    CustomTabsHelper.launchUrl(context, createATeam)
-                },
+                linkInteractionListener = { CustomTabsHelper.launchUrl(context, teamCreationUrl) }
             ),
         ) {
             append(stringResource(R.string.welcome_button_create_team))
@@ -482,6 +481,7 @@ fun PreviewCreateAccountDetailsScreen() = WireTheme {
                 nameTextState = TextFieldState(),
                 passwordTextState = TextFieldState(),
                 confirmPasswordTextState = TextFieldState(),
+                teamCreationUrl = "",
                 tosUrl = "",
                 onPrivacyPolicyAccepted = {},
                 onTermsDialogDismiss = {},

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
@@ -43,7 +43,7 @@ import javax.inject.Inject
 @HiltViewModel
 class CreateAccountDataDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val validatePasswordUseCase: ValidatePasswordUseCase,
+    private val validatePassword: ValidatePasswordUseCase,
     private val validateEmail: ValidateEmailUseCase,
     @KaliumCoreLogic private val coreLogic: CoreLogic,
 ) : ViewModel() {
@@ -133,7 +133,7 @@ class CreateAccountDataDetailViewModel @Inject constructor(
         detailsState = detailsState.copy(loading = true, continueEnabled = false)
         viewModelScope.launch {
             val detailsError = when {
-                !validatePasswordUseCase(passwordTextState.text.toString()).isValid ->
+                !validatePassword(passwordTextState.text.toString()).isValid ->
                     CreateAccountDataDetailViewState.DetailsError.PasswordError.InvalidPasswordError
 
                 passwordTextState.text.toString() != confirmPasswordTextState.text.toString() ->

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
@@ -59,6 +59,7 @@ class CreateAccountDataDetailViewModel @Inject constructor(
 
     val serverConfig: ServerConfig.Links = createAccountNavArgs.customServerConfig.orDefault()
     fun tosUrl(): String = serverConfig.tos
+    fun teamCreationUrl(): String = serverConfig.teams
 
     init {
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
@@ -19,6 +19,8 @@
 package com.wire.android.ui.registration.selector
 
 import android.annotation.SuppressLint
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -39,11 +41,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.R
 import com.wire.android.config.orDefault
+import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.annotation.app.WireDestination
@@ -52,6 +57,7 @@ import com.wire.android.ui.authentication.create.common.CreateAccountDataNavArgs
 import com.wire.android.ui.authentication.create.common.CreateAccountNavGraph
 import com.wire.android.ui.authentication.create.common.ServerTitle
 import com.wire.android.ui.authentication.create.common.UserRegistrationInfo
+import com.wire.android.ui.authentication.login.PreFilledUserIdentifierType
 import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
@@ -59,11 +65,13 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.preview.EdgeToEdgePreview
 import com.wire.android.ui.destinations.CreateAccountDataDetailScreenDestination
+import com.wire.android.ui.destinations.NewLoginPasswordScreenDestination
 import com.wire.android.ui.newauthentication.login.NewAuthContainer
 import com.wire.android.ui.newauthentication.login.NewAuthHeader
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.CustomTabsHelper
 import com.wire.kalium.logic.configuration.server.ServerConfig
 
 @CreateAccountNavGraph(start = true)
@@ -76,7 +84,7 @@ fun CreateAccountSelectorScreen(
     navigator: Navigator,
     viewModel: CreateAccountSelectorViewModel = hiltViewModel()
 ) {
-
+    val context = LocalContext.current
     fun navigateToEmailScreen() {
         val createAccountNavArgs = CreateAccountDataNavArgs(
             customServerConfig = viewModel.serverConfig.orDefault(),
@@ -85,20 +93,30 @@ fun CreateAccountSelectorScreen(
         navigator.navigate(NavigationCommand(CreateAccountDataDetailScreenDestination(createAccountNavArgs)))
     }
 
-    fun navigateToEmailTeamScreen() {
-        // TODO: this will be addressed in next PR for task WPB-17526
-//        val createAccountNavArgs = CreateAccountNavArgs(
-//            flowType = CreateAccountFlowType.CreateTeam,
-//            customServerConfig = viewModel.serverConfig.orDefault(),
-//            userRegistrationInfo = UserRegistrationInfo(viewModel.email)
-//        )
-//        navigator.navigate(NavigationCommand(CreateAccountEmailScreenDestination(createAccountNavArgs)))
+    val startForResult = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { _ ->
+        navigator.navigate(
+            NavigationCommand(
+                NewLoginPasswordScreenDestination(
+                    PreFilledUserIdentifierType.PreFilled(
+                        viewModel.email,
+                        editable = true
+                    )
+                ),
+                BackStackMode.REMOVE_CURRENT_NESTED_GRAPH
+            )
+        )
+    }
+
+    fun navigateToTeamScreen() {
+        val customTabsIntent = CustomTabsHelper.buildCustomTabIntent(context)
+        customTabsIntent.intent.setData(viewModel.teamAccountCreationUrl.toUri())
+        startForResult.launch(customTabsIntent.intent)
     }
 
     CreateAccountSelectorContent(
         customServerLinks = viewModel.serverConfig,
         onPersonalAccountCreationClicked = ::navigateToEmailScreen,
-        onTeamAccountCreationClicked = ::navigateToEmailTeamScreen,
+        onTeamAccountCreationClicked = ::navigateToTeamScreen,
         onNavigateBack = navigator::navigateBack,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
@@ -96,12 +96,7 @@ fun CreateAccountSelectorScreen(
     val startForResult = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { _ ->
         navigator.navigate(
             NavigationCommand(
-                NewLoginPasswordScreenDestination(
-                    PreFilledUserIdentifierType.PreFilled(
-                        viewModel.email,
-                        editable = true
-                    )
-                ),
+                NewLoginPasswordScreenDestination(PreFilledUserIdentifierType.PreFilled(viewModel.email)),
                 BackStackMode.REMOVE_CURRENT_NESTED_GRAPH
             )
         )

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
@@ -102,9 +102,12 @@ fun CreateAccountSelectorScreen(
         )
     }
 
+    val teamAccountCreationUrl =
+        viewModel.teamAccountCreationUrl + stringResource(R.string.create_account_email_backlink_to_team_suffix_url)
+
     fun navigateToTeamScreen() {
         val customTabsIntent = CustomTabsHelper.buildCustomTabIntent(context)
-        customTabsIntent.intent.setData(viewModel.teamAccountCreationUrl.toUri())
+        customTabsIntent.intent.setData(teamAccountCreationUrl.toUri())
         startForResult.launch(customTabsIntent.intent)
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModel.kt
@@ -32,5 +32,5 @@ class CreateAccountSelectorViewModel @Inject constructor(
     val navArgs: CreateAccountSelectorNavArgs = savedStateHandle.navArgs()
     val serverConfig: ServerConfig.Links = navArgs.customServerConfig.orDefault()
     val email: String = navArgs.email.orEmpty()
-    val teamAccountCreationUrl = serverConfig.teams + "/signup/account?origin=android"
+    val teamAccountCreationUrl = serverConfig.teams
 }

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModel.kt
@@ -32,4 +32,5 @@ class CreateAccountSelectorViewModel @Inject constructor(
     val navArgs: CreateAccountSelectorNavArgs = savedStateHandle.navArgs()
     val serverConfig: ServerConfig.Links = navArgs.customServerConfig.orDefault()
     val email: String = navArgs.email.orEmpty()
+    val teamAccountCreationUrl = serverConfig.teams + "/signup/account?origin=android"
 }

--- a/app/src/main/kotlin/com/wire/android/util/CustomTabsHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CustomTabsHelper.kt
@@ -34,13 +34,8 @@ object CustomTabsHelper {
 
     @JvmStatic
     fun launchUri(context: Context, uri: Uri) {
-        val builder = CustomTabsIntent.Builder()
-            .setCloseButtonIcon(BitmapFactory.decodeResource(context.resources, R.drawable.ic_close))
-            .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
-            .setShowTitle(true)
         try {
-            val customTabsIntent = builder.build()
-            customTabsIntent.intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse("android-app://" + context.packageName))
+            val customTabsIntent = buildCustomTabIntent(context)
             customTabsIntent.launchUrl(context, uri)
         } catch (exception: ActivityNotFoundException) {
             AppJsonStyledLogger.log(
@@ -49,6 +44,17 @@ object CustomTabsHelper {
                 jsonStringKeyValues = mapOf("targetURI" to uri),
                 error = exception
             )
+        }
+    }
+
+    fun buildCustomTabIntent(context: Context): CustomTabsIntent {
+        val customTabsIntent = CustomTabsIntent.Builder()
+            .setCloseButtonIcon(BitmapFactory.decodeResource(context.resources, R.drawable.ic_close))
+            .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
+            .setShowTitle(true)
+
+        return customTabsIntent.build().apply {
+            intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse("android-app://" + context.packageName))
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -501,6 +501,7 @@
     <string name="create_account_email_share_anonymous_data_link_label">Privacy Policy</string>
     <string name="create_account_email_share_anonymous_data_optional_label">(Optional)</string>
     <string name="create_account_email_backlink_to_team_label">Looking for team collaboration?</string>
+    <string name="create_account_email_backlink_to_team_suffix_url" translatable="false">/signup/account?origin=android</string>
     <string name="create_account_email_terms_dialog_view_policy">View ToU and Privacy Policy</string>
     <string name="create_account_email_already_in_use_error">The email address is already in use.</string>
     <string name="create_account_email_blacklisted_error">Your email has been identified as not trusted, for example, due to a rejection by a spam filter.</string>

--- a/app/src/test/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModelTest.kt
@@ -1,0 +1,126 @@
+package com.wire.android.ui.registration.details
+
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.NavigationTestExtension
+import com.wire.android.config.SnapshotExtension
+import com.wire.android.ui.authentication.create.common.CreateAccountDataNavArgs
+import com.wire.android.ui.authentication.create.common.UserRegistrationInfo
+import com.wire.android.ui.navArgs
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.feature.auth.AuthenticationScope
+import com.wire.kalium.logic.feature.auth.ValidateEmailUseCase
+import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
+import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
+import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
+import com.wire.kalium.logic.feature.register.RequestActivationCodeUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class, NavigationTestExtension::class)
+class CreateAccountDataDetailViewModelTest {
+
+    @Test
+    fun `given invalid password, when executing, then show error`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .withValidatePasswordResult(ValidatePasswordResult.Invalid())
+            .arrange()
+        viewModel.passwordTextState.setTextAndPlaceCursorAtEnd("password")
+
+        viewModel.onDetailsContinue()
+        advanceUntilIdle()
+
+        assertEquals(false, viewModel.detailsState.success)
+    }
+
+    @Test
+    fun `given passwords do not match, when executing, then show error`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .withValidatePasswordResult(ValidatePasswordResult.Valid)
+            .arrange()
+        viewModel.passwordTextState.setTextAndPlaceCursorAtEnd("password")
+        viewModel.confirmPasswordTextState.setTextAndPlaceCursorAtEnd("different-password")
+
+        viewModel.onDetailsContinue()
+        advanceUntilIdle()
+
+        assertInstanceOf<CreateAccountDataDetailViewState.DetailsError.PasswordError.PasswordsNotMatchingError>(
+            viewModel.detailsState.error
+        )
+        assertEquals(false, viewModel.detailsState.success)
+    }
+
+    @Test
+    fun `given valid passwords, when executing, then validate email`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .withValidatePasswordResult(ValidatePasswordResult.Valid)
+            .withValidateEmailResult(true)
+            .arrange()
+        viewModel.passwordTextState.setTextAndPlaceCursorAtEnd("password")
+        viewModel.confirmPasswordTextState.setTextAndPlaceCursorAtEnd("password")
+
+        viewModel.onDetailsContinue()
+        advanceUntilIdle()
+
+        assertInstanceOf<CreateAccountDataDetailViewState.DetailsError.None>(viewModel.detailsState.error)
+        assertEquals(false, viewModel.detailsState.success)
+        coVerify(exactly = 1) { arrangement.validateEmailUseCase(any()) }
+        assertInstanceOf<CreateAccountDataDetailViewState.DetailsError.None>(viewModel.detailsState.error)
+    }
+
+    private class Arrangement {
+        @MockK
+        lateinit var savedStateHandle: SavedStateHandle
+
+        @MockK
+        lateinit var validateEmailUseCase: ValidateEmailUseCase
+
+        @MockK
+        lateinit var coreLogic: CoreLogic
+
+        @MockK
+        lateinit var autoVersionAuthScopeUseCase: AutoVersionAuthScopeUseCase
+
+        @MockK
+        lateinit var versionedAuthenticationScope: AuthenticationScope
+
+        @MockK
+        lateinit var requestActivationCodeUseCase: RequestActivationCodeUseCase
+
+        @MockK
+        lateinit var validatePasswordUseCase: ValidatePasswordUseCase
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+            every { savedStateHandle.navArgs<CreateAccountDataNavArgs>() } returns
+                    CreateAccountDataNavArgs(userRegistrationInfo = UserRegistrationInfo())
+        }
+
+        fun withValidateEmailResult(result: Boolean) = apply {
+            coEvery { validateEmailUseCase(any()) } returns result
+        }
+
+        fun withValidatePasswordResult(result: ValidatePasswordResult) = apply {
+            coEvery { validatePasswordUseCase(any()) } returns result
+        }
+
+        fun arrange() = this to CreateAccountDataDetailViewModel(
+            savedStateHandle = savedStateHandle,
+            validateEmail = validateEmailUseCase,
+            validatePassword = validatePasswordUseCase,
+            coreLogic = coreLogic
+        )
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModelTest.kt
@@ -1,0 +1,61 @@
+package com.wire.android.ui.registration.selector
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.NavigationTestExtension
+import com.wire.android.config.SnapshotExtension
+import com.wire.android.ui.navArgs
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class, NavigationTestExtension::class)
+class CreateAccountSelectorViewModelTest {
+
+    @Test
+    fun `given view model is initialized, then server config`() = runTest {
+        val (_, createAccountSelectorViewModel) = Arrangement().arrange()
+
+        assertEquals(ServerConfig.STAGING, createAccountSelectorViewModel.serverConfig)
+    }
+
+    @Test
+    fun `given view model is initialized, then get email if there is one from nav args`() = runTest {
+        val expectedEmail = "alice@mail.com"
+        val (_, createAccountSelectorViewModel) = Arrangement().withEmailNavArgs(expectedEmail).arrange()
+
+        assertEquals(expectedEmail, createAccountSelectorViewModel.email)
+    }
+
+    @Test
+    fun `given view model is initialized, then load teams url from server config`() = runTest {
+        val (_, createAccountSelectorViewModel) = Arrangement().arrange()
+
+        assertEquals(ServerConfig.STAGING.teams, createAccountSelectorViewModel.teamAccountCreationUrl)
+    }
+
+    private class Arrangement {
+        @MockK
+        lateinit var savedStateHandle: SavedStateHandle
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+            every { savedStateHandle.navArgs<CreateAccountSelectorNavArgs>() } returns
+                    CreateAccountSelectorNavArgs(ServerConfig.STAGING)
+        }
+
+        fun withEmailNavArgs(email: String) = apply {
+            every { savedStateHandle.navArgs<CreateAccountSelectorNavArgs>() } returns
+                    CreateAccountSelectorNavArgs(ServerConfig.STAGING, email)
+        }
+
+        fun arrange() = this to CreateAccountSelectorViewModel(savedStateHandle)
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModelTest.kt
@@ -3,7 +3,6 @@ package com.wire.android.ui.registration.selector
 import androidx.lifecycle.SavedStateHandle
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
-import com.wire.android.config.SnapshotExtension
 import com.wire.android.ui.navArgs
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import io.mockk.MockKAnnotations
@@ -16,7 +15,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class, NavigationTestExtension::class)
+@ExtendWith(CoroutineTestExtension::class, NavigationTestExtension::class)
 class CreateAccountSelectorViewModelTest {
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17526" title="WPB-17526" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-17526</a>  [Android] New Registration Flows - Team account creation flow via webview
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Team account creation using custom tabs as per spec on the new flow.

### Solutions

- Use the new Team settings account creation from the app using a custom tab
- Navigation needed to be handled specially back to login, so we extend `CustomTabHelper` to give us a`CustomTabIntent` and handle `ActivityForResult` to achieve that.

### Dependencies (Optional)

- https://github.com/wireapp/wire-android/pull/4060

Needs releases with:

- [x] GitHub link to other pull request

#### How to Test

Use the flow on Anta, the team account creation should be displayed in a customtab.

### Attachments (Optional)

https://github.com/user-attachments/assets/b3dfa8e0-9dd1-4ba9-835f-67b074417d5a


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
