### PR TITLE
fix: avatar picker on landscape tablet [WPB-17288]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/imagepreview/BulletHoleImagePreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/imagepreview/BulletHoleImagePreview.kt
@@ -23,30 +23,36 @@ import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.geometry.toRect
-import androidx.compose.ui.graphics.Outline
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.geometry.center
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.ScaleFactor
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.painterResource
+import androidx.core.net.toUri
 import coil.compose.rememberAsyncImagePainter
-import com.wire.android.ui.common.dimensions
+import com.wire.android.R
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.toBitmap
+import com.wire.android.util.ui.PreviewMultipleThemesForLandscape
+import com.wire.android.util.ui.PreviewMultipleThemesForPortrait
+import com.wire.android.util.ui.PreviewMultipleThemesForSquare
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlin.math.min
 
 @Composable
 private fun loadBitMap(imageUri: Uri): State<Bitmap?> {
@@ -62,91 +68,61 @@ private fun loadBitMap(imageUri: Uri): State<Bitmap?> {
 fun BulletHoleImagePreview(
     imageUri: Uri,
     contentDescription: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    scrimColor: Color = MaterialTheme.colorScheme.surface.copy(alpha = 0.65f)
 ) {
-    ConstraintLayout(
-        modifier
-            .aspectRatio(1f)
-            .height(dimensions().imagePreviewHeight)
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier.fillMaxSize()
     ) {
-        val (avatarImage, semiTransparentBackground) = createRefs()
+        Image(
+            painter = when {
+                LocalInspectionMode.current -> painterResource(id = R.drawable.ic_create_team_success)
+                else -> rememberAsyncImagePainter(loadBitMap(imageUri).value)
+            },
+            contentScale = FillCenterSquare,
+            contentDescription = contentDescription,
+            modifier = Modifier.fillMaxSize(),
+        )
         Box(
-            Modifier
+            modifier = Modifier
                 .fillMaxSize()
-                .constrainAs(avatarImage) {
-                    top.linkTo(parent.top)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                    bottom.linkTo(parent.bottom)
+                .drawWithContent { // this cuts out the center circle
+                    with(drawContext.canvas.nativeCanvas) {
+                        val checkPoint = saveLayer(null, null)
+                        drawContent()
+                        drawCircle(
+                            color = Color.Black,
+                            radius = min(drawContext.size.width, drawContext.size.height) / 2f,
+                            center = drawContext.size.center,
+                            blendMode = BlendMode.Clear
+                        )
+                        restoreToCount(checkPoint)
+                    }
                 }
         ) {
-            Image(
-                painter = rememberAsyncImagePainter(loadBitMap(imageUri).value),
-                contentScale = ContentScale.Crop,
-                contentDescription = contentDescription,
-                modifier = Modifier.fillMaxSize(),
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color = scrimColor)
             )
         }
-        Box(
-            Modifier
-                .fillMaxSize()
-                .constrainAs(semiTransparentBackground) {
-                    top.linkTo(parent.top)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                    bottom.linkTo(parent.bottom)
-                }
-                .graphicsLayer(
-                    shape = BulletHoleShape(),
-                    alpha = 0.65f,
-                    clip = true
-                )
-                .background(color = MaterialTheme.colorScheme.surface)
-        )
     }
 }
 
-// Custom Shape creating a "hole" around the shape of the provided Composable
-// in case of ImagePreview that would be a rectangular shape, creating an effect of the "hole" around the rectangle
-@Suppress("MagicNumber")
-class BulletHoleShape : Shape {
-
-    override fun createOutline(
-        size: Size,
-        layoutDirection: LayoutDirection,
-        density: Density
-    ): Outline {
-        return Outline.Generic(
-            drawBulletHolePath(size)
-        )
+@Stable
+private val FillCenterSquare = object : ContentScale { // this scales the image to fill the center square
+    override fun computeScaleFactor(srcSize: Size, dstSize: Size): ScaleFactor {
+        val squareSize = min(dstSize.width, dstSize.height)
+        val scaleFactor = squareSize / min(srcSize.width, srcSize.height)
+        return ScaleFactor(scaleFactor, scaleFactor)
     }
+}
 
-    private fun drawBulletHolePath(size: Size): Path {
-        val backgroundWrappingRect = size.toRect()
-
-        val path = Path().apply {
-            reset()
-            // move the origin point to the middle of the backgroundWrappingRect on the left side
-            moveTo(x = 0f, y = backgroundWrappingRect.height / 2)
-            // draw a line to from the middle of backgroundWrappingRect to the top on the left side
-            lineTo(x = 0f, y = 0f)
-            // draw a line from the left edge to the right edge on the top side
-            lineTo(x = backgroundWrappingRect.width, y = 0f)
-            // draw a backgroundWrappingRect from the right edge to the middle of backgroundWrappingRect on the right side
-            lineTo(x = size.width, y = backgroundWrappingRect.height / 2)
-            // arc -180 degrees from the start point of backgroundWrappingRect -
-            arcTo(backgroundWrappingRect, 0f, -180f, true)
-            // draw a line from middle of backgroundWrappingRect to the bottom of backgroundWrappingRect on the left side
-            lineTo(x = 0f, y = backgroundWrappingRect.height)
-            // draw a line from the bottom edge of backgroundWrappingRect to the right edge on the bottom side
-            lineTo(x = backgroundWrappingRect.width, y = backgroundWrappingRect.height)
-            // draw a line from the bottom edge of the backgroundWrappingRect to the middle of backgroundWrappingRect on the right side
-            lineTo(x = backgroundWrappingRect.width, y = backgroundWrappingRect.height / 2)
-            // arc 180 degrees - we are back on middle of the backgroundWrappingRect on the left side now
-            arcTo(backgroundWrappingRect, 0f, 180f, true)
-            // we drew the outline, we can close the path now
-            close()
-        }
-        return path
-    }
+@PreviewMultipleThemesForPortrait
+@PreviewMultipleThemesForLandscape
+@PreviewMultipleThemesForSquare
+@Composable
+fun BulletHoleImagePreviewPreview() = WireTheme {
+    BulletHoleImagePreview(imageUri = "".toUri(), contentDescription = "")
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
@@ -19,22 +19,21 @@
 package com.wire.android.ui.userprofile.avatarpicker
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.RootNavGraph
@@ -60,8 +59,13 @@ import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.home.conversations.PermissionPermanentlyDeniedDialogState
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.userprofile.avatarpicker.AvatarPickerViewModel.PictureState
+import com.wire.android.util.ui.PreviewMultipleThemesForLandscape
+import com.wire.android.util.ui.PreviewMultipleThemesForPortrait
+import com.wire.android.util.ui.PreviewMultipleThemesForSquare
 
 @RootNavGraph
 @WireDestination(
@@ -141,30 +145,25 @@ private fun AvatarPickerContent(
     WireScaffold(
         topBar = { AvatarPickerTopBar(onCloseClick = onCloseClick) }
     ) { internalPadding ->
-        Box(
-            Modifier
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
                 .fillMaxSize()
                 .padding(internalPadding)
+                .background(MaterialTheme.wireColorScheme.background)
         ) {
-            Column(
-                Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.wireColorScheme.background)
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.weight(1f)
             ) {
-                Box(Modifier.weight(1f)) {
-                    Box(Modifier.align(Alignment.Center)) {
-                        AvatarPreview(pictureState)
-                    }
-                }
-                HorizontalDivider()
-                Spacer(Modifier.height(4.dp))
-                AvatarPickerActionButtons(
-                    pictureState = pictureState,
-                    onSaveClick = onSaveClick,
-                    onCancelClick = onCancelClick,
-                    onChangeImage = state::showModalBottomSheet,
-                )
+                AvatarPreview(pictureState)
             }
+            AvatarPickerActionButtons(
+                pictureState = pictureState,
+                onSaveClick = onSaveClick,
+                onCancelClick = onCancelClick,
+                onChangeImage = state::showModalBottomSheet,
+            )
         }
     }
 
@@ -221,36 +220,41 @@ private fun AvatarPickerActionButtons(
     onCancelClick: () -> Unit,
     onChangeImage: () -> Unit
 ) {
-    when (pictureState) {
-        is PictureState.Uploading, is PictureState.Picked -> {
-            val isUploading = pictureState is PictureState.Uploading
+    Surface(
+        shadowElevation = dimensions().bottomNavigationShadowElevation,
+        color = MaterialTheme.wireColorScheme.background
+    ) {
+        Box(modifier = Modifier.padding(MaterialTheme.wireDimensions.spacing16x)) {
+            when (pictureState) {
+                is PictureState.Uploading, is PictureState.Picked -> {
+                    val isUploading = pictureState is PictureState.Uploading
 
-            Row(Modifier.fillMaxWidth()) {
-                WireSecondaryButton(
-                    modifier = Modifier
-                        .padding(dimensions().spacing16x)
-                        .weight(1f),
-                    text = stringResource(R.string.label_cancel),
-                    onClick = onCancelClick
-                )
-                WirePrimaryButton(
-                    modifier = Modifier
-                        .padding(dimensions().spacing16x)
-                        .weight(1f),
-                    text = stringResource(R.string.label_confirm),
-                    onClick = onSaveClick,
-                    loading = isUploading,
-                    state = if (isUploading) WireButtonState.Disabled else WireButtonState.Default
-                )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.wireDimensions.spacing16x),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        WireSecondaryButton(
+                            modifier = Modifier.weight(1f),
+                            text = stringResource(R.string.label_cancel),
+                            onClick = onCancelClick
+                        )
+                        WirePrimaryButton(
+                            modifier = Modifier.weight(1f),
+                            text = stringResource(R.string.label_confirm),
+                            onClick = onSaveClick,
+                            loading = isUploading,
+                            state = if (isUploading) WireButtonState.Disabled else WireButtonState.Default
+                        )
+                    }
+                }
+
+                else -> {
+                    WirePrimaryButton(
+                        text = stringResource(R.string.profile_image_change_image_button_label),
+                        onClick = onChangeImage
+                    )
+                }
             }
-        }
-
-        else -> {
-            WirePrimaryButton(
-                modifier = Modifier.padding(dimensions().spacing16x),
-                text = stringResource(R.string.profile_image_change_image_button_label),
-                onClick = onChangeImage
-            )
         }
     }
 }
@@ -261,5 +265,25 @@ private fun AvatarPickerTopBar(onCloseClick: () -> Unit) {
         onNavigationPressed = onCloseClick,
         navigationIconType = NavigationIconType.Back(R.string.content_description_change_picture_back_btn),
         title = stringResource(R.string.profile_image_top_bar_label),
+    )
+}
+
+@PreviewMultipleThemesForPortrait
+@PreviewMultipleThemesForLandscape
+@PreviewMultipleThemesForSquare
+@Composable
+fun AvatarPickerPreview() = WireTheme {
+    AvatarPickerContent(
+        pictureState = PictureState.Picked("https://example.com/avatar.jpg".toUri()),
+        state = rememberAvatarPickerState(
+            onImageSelected = {},
+            onCameraPermissionPermanentlyDenied = {},
+            onGalleryPermissionPermanentlyDenied = {},
+            onPictureTaken = {},
+            targetPictureFileUri = "https://example.com/avatar.jpg".toUri(),
+        ),
+        onCloseClick = {},
+        onCancelClick = {},
+        onSaveClick = {}
     )
 }

--- a/app/src/main/kotlin/com/wire/android/util/ui/PreviewMultipleThemes.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/PreviewMultipleThemes.kt
@@ -76,6 +76,7 @@ internal annotation class PreviewMultipleThemes
 )
 internal annotation class PreviewMultipleThemesForPortrait
 
+@SuppressLint("ComposePreviewNaming")
 @Preview(
     name = "Landscape Dark theme",
     group = "Landscape",
@@ -96,6 +97,7 @@ internal annotation class PreviewMultipleThemesForPortrait
 )
 internal annotation class PreviewMultipleThemesForLandscape
 
+@SuppressLint("ComposePreviewNaming")
 @Preview(
     name = "Square Dark theme",
     group = "Square",

--- a/app/src/screenshotTest/kotlin/com/wire/android/kotlin/ui/home/conversations/messages/item/PreviewMessageTypes.kt
+++ b/app/src/screenshotTest/kotlin/com/wire/android/kotlin/ui/home/conversations/messages/item/PreviewMessageTypes.kt
@@ -212,7 +212,8 @@ fun PreviewImportedMediaAssetMessageContent() {
             assetExtension = "rar.tgz",
             assetSizeInBytes = 99201224L,
             onAssetClick = Clickable(enabled = false),
-            assetTransferStatus = AssetTransferStatus.NOT_DOWNLOADED
+            assetTransferStatus = AssetTransferStatus.NOT_DOWNLOADED,
+            assetDataPath = null,
         )
     }
 }
@@ -226,7 +227,8 @@ fun PreviewLoadingAssetMessage() {
             assetExtension = "rar.tgz",
             assetSizeInBytes = 99201224L,
             onAssetClick = Clickable(enabled = false),
-            assetTransferStatus = AssetTransferStatus.DOWNLOAD_IN_PROGRESS
+            assetTransferStatus = AssetTransferStatus.DOWNLOAD_IN_PROGRESS,
+            assetDataPath = null,
         )
     }
 }
@@ -240,7 +242,8 @@ fun PreviewFailedDownloadAssetMessage() {
             assetExtension = "rar.tgz",
             assetSizeInBytes = 99201224L,
             onAssetClick = Clickable(enabled = false),
-            assetTransferStatus = AssetTransferStatus.FAILED_DOWNLOAD
+            assetTransferStatus = AssetTransferStatus.FAILED_DOWNLOAD,
+            assetDataPath = null,
         )
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17288" title="WPB-17288" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-17288</a>  [Android] - Landscape mode (Android 16 support) - Profile picture
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Image on avatar picker screen is not centered and the avatar picker itself looks different from the designs.

### Solutions

Centered the image, cleaned-up and simplified code and made it look more like on designs (adaptive to different image proportions), added and fixed some previews.

### Testing

#### How to Test

Open avatar picker on landscape tablet or fold device.

### Attachments (Optional)

#### Image with landscape proportions
| Before | After |
| ----------- | ------------ |
| <img width="400" src="https://github.com/user-attachments/assets/e1e47921-8f51-48b5-97d0-cae090bcca45"/> | <img width="400" src="https://github.com/user-attachments/assets/985cbd85-4e50-4c70-89c7-7dd8c5d6851a"/> |

#### Image with portrait proportions
| Before | After |
| ----------- | ------------ |
| <img width="400" src="https://github.com/user-attachments/assets/e1a491c9-aad7-47ee-a45a-da9522cd7a12"/> | <img width="400" src="https://github.com/user-attachments/assets/4c9ad48e-b0e5-4b85-b9bf-453b6c9c388c"/> |


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
