### PR TITLE
fix: change scope of hang up actions - extract to use case [WPB-18174]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -28,12 +28,12 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.mapper.UICallParticipantMapper
 import com.wire.android.mapper.UserTypeMapper
-import com.wire.android.media.CallRinger
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.calling.model.InCallReaction
 import com.wire.android.ui.calling.model.ReactionSender
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.ongoing.incallreactions.InCallReactions
+import com.wire.android.ui.calling.usecase.HangUpCallUseCase
 import com.wire.android.util.ExpiringMap
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.extension.withDelayAfterFirst
@@ -45,13 +45,11 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.FlipToBackCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.FlipToFrontCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallWithSortedParticipantsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCase
-import com.wire.kalium.logic.feature.call.usecase.ObserveSpeakerUseCase
 import com.wire.kalium.logic.feature.call.usecase.SetVideoPreviewUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
@@ -61,6 +59,7 @@ import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
 import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.logic.feature.call.usecase.ObserveSpeakerUseCase
 import com.wire.kalium.logic.util.PlatformView
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -91,7 +90,7 @@ class SharedCallingViewModel @AssistedInject constructor(
     @Assisted val conversationId: ConversationId,
     private val conversationDetails: ObserveConversationDetailsUseCase,
     private val observeEstablishedCallWithSortedParticipants: ObserveEstablishedCallWithSortedParticipantsUseCase,
-    private val endCall: EndCallUseCase,
+    private val hangUpCall: HangUpCallUseCase,
     private val muteCall: MuteCallUseCase,
     private val unMuteCall: UnMuteCallUseCase,
     private val updateVideoState: UpdateVideoStateUseCase,
@@ -104,7 +103,6 @@ class SharedCallingViewModel @AssistedInject constructor(
     private val observeInCallReactionsUseCase: ObserveInCallReactionsUseCase,
     private val sendInCallReactionUseCase: SendInCallReactionUseCase,
     private val getCurrentClientId: ObserveCurrentClientIdUseCase,
-    private val callRinger: CallRinger,
     private val uiCallParticipantMapper: UICallParticipantMapper,
     private val userTypeMapper: UserTypeMapper,
     private val dispatchers: DispatcherProvider
@@ -223,23 +221,8 @@ class SharedCallingViewModel @AssistedInject constructor(
     }
 
     fun hangUpCall(onCompleted: () -> Unit) {
-        viewModelScope.launch {
-            onCompleted()
-            endCall(conversationId)
-            resetCallConfig()
-            callRinger.stop()
-        }
-    }
-
-    private suspend fun resetCallConfig() {
-        // we need to update mute state to false, so if the user re-join the call te mic will will be muted
-        muteCall(conversationId, false)
-        if (callState.isCameraOn) {
-            flipToFrontCamera(conversationId)
-        }
-        if (callState.isSpeakerOn) {
-            turnLoudSpeakerOff()
-        }
+        hangUpCall(conversationId)
+        onCompleted()
     }
 
     fun toggleSpeaker() {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/usecase/HangUpCallUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/usecase/HangUpCallUseCase.kt
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.calling.usecase
+
+import com.wire.android.di.ApplicationScope
+import com.wire.android.media.CallRinger
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.FlipToFrontCameraUseCase
+import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveSpeakerUseCase
+import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
+import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@ViewModelScoped
+class HangUpCallUseCase @Inject constructor(
+    @ApplicationScope private val coroutineScope: CoroutineScope,
+    private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
+    private val observeSpeaker: ObserveSpeakerUseCase,
+    private val endCall: EndCallUseCase,
+    private val muteCall: MuteCallUseCase,
+    private val turnLoudSpeakerOff: TurnLoudSpeakerOffUseCase,
+    private val flipToFrontCamera: FlipToFrontCameraUseCase,
+    private val callRinger: CallRinger,
+) {
+
+    operator fun invoke(conversationId: ConversationId) {
+        coroutineScope.launch {
+            resetCallConfig(conversationId)
+            endCall(conversationId)
+            callRinger.stop()
+        }
+    }
+
+    private suspend fun resetCallConfig(conversationId: ConversationId) {
+        // we need to update mute state to false, so if the user re-join the call te mic will will be muted
+        muteCall(conversationId, false)
+        // we need to update speaker state to false, so if the user re-join the call the speaker will be off
+        observeSpeaker().firstOrNull()?.let { isSpeakerOn ->
+            if (isSpeakerOn) {
+                turnLoudSpeakerOff()
+            }
+        }
+        // we need to flip the camera to front, so if the user re-join the call the camera will be on front
+        observeEstablishedCalls().firstOrNull()?.firstOrNull { it.conversationId == conversationId }?.let { call ->
+            if (call.isCameraOn) {
+                flipToFrontCamera(conversationId)
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -27,15 +27,15 @@ import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.TestUser
 import com.wire.android.mapper.UICallParticipantMapper
 import com.wire.android.mapper.UserTypeMapper
-import com.wire.android.media.CallRinger
 import com.wire.android.ui.calling.model.ReactionSender
+import com.wire.android.ui.calling.usecase.HangUpCallUseCase
 import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.InCallReactionMessage
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.FlipToBackCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.FlipToFrontCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
@@ -50,11 +50,9 @@ import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
 import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
-import com.wire.kalium.common.functional.Either
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -76,7 +74,7 @@ class SharedCallingViewModelTest {
     private lateinit var observeEstablishedCall: ObserveEstablishedCallWithSortedParticipantsUseCase
 
     @MockK
-    private lateinit var endCall: EndCallUseCase
+    private lateinit var hangUpCall: HangUpCallUseCase
 
     @MockK
     private lateinit var muteCall: MuteCallUseCase
@@ -118,9 +116,6 @@ class SharedCallingViewModelTest {
     lateinit var getCurrentClientId: ObserveCurrentClientIdUseCase
 
     @MockK
-    private lateinit var callRinger: CallRinger
-
-    @MockK
     private lateinit var view: View
 
     @MockK
@@ -153,7 +148,7 @@ class SharedCallingViewModelTest {
             conversationId = conversationId,
             conversationDetails = observeConversationDetails,
             observeEstablishedCallWithSortedParticipants = observeEstablishedCall,
-            endCall = endCall,
+            hangUpCall = hangUpCall,
             muteCall = muteCall,
             flipToFrontCamera = flipToFrontCamera,
             flipToBackCamera = flipToBackCamera,
@@ -163,7 +158,6 @@ class SharedCallingViewModelTest {
             turnLoudSpeakerOff = turnLoudSpeakerOff,
             turnLoudSpeakerOn = turnLoudSpeakerOn,
             observeSpeaker = observeSpeaker,
-            callRinger = callRinger,
             uiCallParticipantMapper = uiCallParticipantMapper,
             userTypeMapper = userTypeMapper,
             observeInCallReactionsUseCase = observeInCallReactionsUseCase,
@@ -286,42 +280,13 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun `given an active call, when the user ends call, then invoke endCall useCase`() = runTest(dispatcherProvider.main()) {
-        coEvery { endCall(any()) } returns Unit
-        coEvery { muteCall(any(), false) } returns Unit
-        every { callRinger.stop() } returns Unit
+    fun `given an active call, when the user ends call, then invoke hangUpCall useCase`() = runTest(dispatcherProvider.main()) {
+        coEvery { hangUpCall(any()) } returns Unit
 
         sharedCallingViewModel.hangUpCall(onCompleted)
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { endCall(any()) }
-        coVerify(exactly = 1) { muteCall(any(), false) }
-        coVerify(exactly = 1) { callRinger.stop() }
-        verify(exactly = 1) { onCompleted() }
-    }
-
-    @Test
-    fun `given an active call, when the user ends call, then reset call config`() = runTest(dispatcherProvider.main()) {
-        sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(
-            isCameraOn = true,
-            isSpeakerOn = true
-        )
-
-        coEvery { endCall(any()) } returns Unit
-        coEvery { muteCall(any(), false) } returns Unit
-        every { callRinger.stop() } returns Unit
-        coEvery { flipToFrontCamera(any()) } returns Unit
-        coEvery { turnLoudSpeakerOff() } returns Unit
-
-        sharedCallingViewModel.hangUpCall(onCompleted)
-        advanceUntilIdle()
-
-        coVerify(exactly = 1) { endCall(any()) }
-        coVerify(exactly = 1) { muteCall(any(), false) }
-        coVerify(exactly = 1) { flipToFrontCamera(any()) }
-        coVerify(exactly = 1) { turnLoudSpeakerOff() }
-        coVerify(exactly = 1) { muteCall(any(), false) }
-        coVerify(exactly = 1) { callRinger.stop() }
+        coVerify(exactly = 1) { hangUpCall(any()) }
         verify(exactly = 1) { onCompleted() }
     }
 
@@ -400,7 +365,7 @@ class SharedCallingViewModelTest {
 
         // then
         coVerify(exactly = 1) {
-            sendInCallReactionUseCase(OngoingCallViewModelTest.Companion.conversationId, "👍")
+            sendInCallReactionUseCase(OngoingCallViewModelTest.conversationId, "👍")
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/calling/usecase/HangUpCallUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/usecase/HangUpCallUseCaseTest.kt
@@ -133,7 +133,7 @@ class HangUpCallUseCaseTest {
         coVerify(exactly = 0) { arrangement.flipToFrontCameraUseCase(call.conversationId) }
     }
 
-    inner class Arrangement() {
+    inner class Arrangement {
 
         private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
 

--- a/app/src/test/kotlin/com/wire/android/ui/calling/usecase/HangUpCallUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/usecase/HangUpCallUseCaseTest.kt
@@ -1,0 +1,201 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.calling.usecase
+
+import com.wire.android.media.CallRinger
+import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.FlipToFrontCameraUseCase
+import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveSpeakerUseCase
+import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class HangUpCallUseCaseTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Test
+    fun `given an active call, when hanging up, then end call and stop ringer`() = runTest(dispatcher) {
+        // given
+        val call = CALL
+        val (arrangement, hangUpCallUseCase) = Arrangement()
+            .withEstablishedCall(call)
+            .arrange()
+        // when
+        hangUpCallUseCase(call.conversationId)
+        advanceUntilIdle()
+        // then
+        coVerify(exactly = 1) { arrangement.endCallUseCase(call.conversationId) }
+        coVerify(exactly = 1) { arrangement.callRinger.stop() }
+    }
+
+    @Test
+    fun `given an active call, when hanging up, then reset call mute status`() = runTest(dispatcher) {
+        // given
+        val call = CALL
+        val (arrangement, hangUpCallUseCase) = Arrangement()
+            .withEstablishedCall(call)
+            .arrange()
+        // when
+        hangUpCallUseCase(call.conversationId)
+        advanceUntilIdle()
+        // then
+        coVerify(exactly = 1) { arrangement.muteCallUseCase(call.conversationId, false) }
+    }
+
+    @Test
+    fun `given an active call with speaker on, when hanging up, then reset speaker status to false`() = runTest(dispatcher) {
+        // given
+        val call = CALL
+        val (arrangement, hangUpCallUseCase) = Arrangement()
+            .withEstablishedCall(call)
+            .withSpeaker(true)
+            .arrange()
+        // when
+        hangUpCallUseCase(call.conversationId)
+        advanceUntilIdle()
+        // then
+        coVerify(exactly = 1) { arrangement.turnLoudSpeakerOffUseCase() }
+    }
+
+    @Test
+    fun `given an active call with speaker off, when hanging up, then do not reset speaker status to false`() = runTest(dispatcher) {
+        // given
+        val call = CALL
+        val (arrangement, hangUpCallUseCase) = Arrangement()
+            .withEstablishedCall(call)
+            .withSpeaker(false)
+            .arrange()
+        // when
+        hangUpCallUseCase(call.conversationId)
+        advanceUntilIdle()
+        // then
+        coVerify(exactly = 0) { arrangement.turnLoudSpeakerOffUseCase() }
+    }
+
+    @Test
+    fun `given an active call with camera on, when hanging up, then reset call camera status to front`() = runTest(dispatcher) {
+        // given
+        val call = CALL.copy(isCameraOn = true)
+        val (arrangement, hangUpCallUseCase) = Arrangement()
+            .withEstablishedCall(call)
+            .arrange()
+        // when
+        hangUpCallUseCase(call.conversationId)
+        advanceUntilIdle()
+        // then
+        coVerify(exactly = 1) { arrangement.flipToFrontCameraUseCase(call.conversationId) }
+    }
+
+    @Test
+    fun `given an active call with camera off, when hanging up, then do not reset call camera status to front`() = runTest(dispatcher) {
+        // given
+        val call = CALL.copy(isCameraOn = false)
+        val (arrangement, hangUpCallUseCase) = Arrangement()
+            .withEstablishedCall(call)
+            .arrange()
+        // when
+        hangUpCallUseCase(call.conversationId)
+        advanceUntilIdle()
+        // then
+        coVerify(exactly = 0) { arrangement.flipToFrontCameraUseCase(call.conversationId) }
+    }
+
+    inner class Arrangement() {
+
+        private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
+
+        @MockK
+        lateinit var observeEstablishedCallsUseCase: ObserveEstablishedCallsUseCase
+
+        @MockK
+        lateinit var observeSpeakerUseCase: ObserveSpeakerUseCase
+
+        @MockK
+        lateinit var endCallUseCase: EndCallUseCase
+
+        @MockK
+        lateinit var muteCallUseCase: MuteCallUseCase
+
+        @MockK
+        lateinit var turnLoudSpeakerOffUseCase: TurnLoudSpeakerOffUseCase
+
+        @MockK
+        lateinit var flipToFrontCameraUseCase: FlipToFrontCameraUseCase
+
+        @MockK
+        lateinit var callRinger: CallRinger
+
+        init {
+            MockKAnnotations.init(this, relaxed = true)
+            withEstablishedCall(CALL)
+            withSpeaker(false)
+        }
+
+        fun withEstablishedCall(call: Call) = apply {
+            coEvery { observeEstablishedCallsUseCase() } returns flowOf(listOf(call))
+        }
+
+        fun withSpeaker(isOn: Boolean) = apply {
+            every { observeSpeakerUseCase() } returns flowOf(isOn)
+        }
+
+        fun arrange() = this to HangUpCallUseCase(
+            coroutineScope = scope,
+            observeEstablishedCalls = observeEstablishedCallsUseCase,
+            observeSpeaker = observeSpeakerUseCase,
+            endCall = endCallUseCase,
+            muteCall = muteCallUseCase,
+            turnLoudSpeakerOff = turnLoudSpeakerOffUseCase,
+            flipToFrontCamera = flipToFrontCameraUseCase,
+            callRinger = callRinger
+        )
+    }
+
+    companion object {
+        private val CALL = Call(
+            conversationId = ConversationId("ongoing_call_id", "some_domain"),
+            status = CallStatus.ESTABLISHED,
+            isMuted = false,
+            isCameraOn = true,
+            isCbrEnabled = false,
+            callerId = QualifiedID("some_id", "some_domain"),
+            conversationName = "some_name",
+            conversationType = Conversation.Type.Group.Regular,
+            callerName = "some_name",
+            callerTeamName = "some_team_name"
+        )
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18174" title="WPB-18174" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18174</a>  [Android] Change scope of call hang up actions to not be cancelled when closing VM
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Call hang up actions and clean-up are being executed in view model's scope, so when the view model gets destroyed (e.g. when the app navigates out of the call) then this actions may get cancelled, but should be executed properly.

### Solutions

Extract these hang up actions into a dedicated use case and execute on app's scope.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Join a group call, enable camera and speaker, switch to back camera, hang up the call and join again - call should be hung up properly and call state (speaker and camera) should be restored.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
