### PR TITLE
chore: use correct string for channel name label (#WPB-17876)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -108,6 +108,7 @@ fun GroupConversationSettings(
             GroupNameItem(
                 groupName = state.groupName,
                 canBeChanged = state.isUpdatingNameAllowed,
+                isChannel = state.isChannel,
                 onClick = onEditGroupName,
             )
         }
@@ -243,10 +244,13 @@ fun ConversationProtocolDetails(
 private fun GroupNameItem(
     groupName: String,
     canBeChanged: Boolean,
+    isChannel: Boolean,
     onClick: () -> Unit = {},
 ) {
     GroupConversationOptionsItem(
-        label = stringResource(id = R.string.conversation_details_options_group_name),
+        label = stringResource(
+            id = if (isChannel) R.string.channel_name_title else R.string.conversation_details_options_group_name
+        ),
         title = groupName,
         clickable = Clickable(
             enabled = canBeChanged,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17876" title="WPB-17876" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17876</a>  [Android]Group lablel is used on channel detail page
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-17876
----
# What's new in this PR?
Use correct string label for channel name in group conversation options.