### PR TITLE
fix: adjust more screens for tablet landscape [WPB-18123] 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/MainNavHost.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/MainNavHost.kt
@@ -62,7 +62,7 @@ fun MainNavHost(
         )
     )
 
-    adjustDestinationStylesForTablets()
+    AdjustDestinationStylesForTablets()
     DestinationsNavHost(
         modifier = modifier,
         navGraph = WireMainNavGraph,

--- a/app/src/main/kotlin/com/wire/android/navigation/TabletStyleHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/TabletStyleHelper.kt
@@ -30,17 +30,29 @@ import com.wire.android.ui.destinations.GroupConversationDetailsScreenDestinatio
 import com.wire.android.ui.destinations.OtherUserProfileScreenDestination
 import com.wire.android.ui.destinations.SelfUserProfileScreenDestination
 import com.wire.android.ui.destinations.ServiceDetailsScreenDestination
+import com.wire.android.ui.destinations.DeviceDetailsScreenDestination
+import com.wire.android.ui.destinations.EditGuestAccessScreenDestination
+import com.wire.android.ui.destinations.EditSelfDeletingMessagesScreenDestination
+import com.wire.android.ui.destinations.ChannelAccessOnUpdateScreenDestination
+import com.wire.android.ui.destinations.ConversationFoldersScreenDestination
+import com.wire.android.ui.destinations.NewConversationFolderScreenDestination
 import com.wire.android.ui.theme.isTablet
 
 @Composable
-fun adjustDestinationStylesForTablets() {
+fun AdjustDestinationStylesForTablets() {
     ServiceDetailsScreenDestination.style = if (isTablet) DialogNavigation else PopUpNavigationAnimation
     OtherUserProfileScreenDestination.style = if (isTablet) DialogNavigation else PopUpNavigationAnimation
     SelfUserProfileScreenDestination.style = if (isTablet) DialogNavigation else PopUpNavigationAnimation
+    DeviceDetailsScreenDestination.style = if (isTablet) DialogNavigation else SlideNavigationAnimation
     ChangeDisplayNameScreenDestination.style = if (isTablet) DialogNavigation else SlideNavigationAnimation
     ChangeHandleScreenDestination.style = if (isTablet) DialogNavigation else SlideNavigationAnimation
     ChangeEmailScreenDestination.style = if (isTablet) DialogNavigation else SlideNavigationAnimation
     AvatarPickerScreenDestination.style = if (isTablet) DialogNavigation else SlideNavigationAnimation
     GroupConversationDetailsScreenDestination.style = if (isTablet) DialogNavigation else PopUpNavigationAnimation
     EditConversationNameScreenDestination.style = if (isTablet) DialogNavigation else SlideNavigationAnimation
+    EditGuestAccessScreenDestination.style = if (isTablet) DialogNavigation else SlideNavigationAnimation
+    ChannelAccessOnUpdateScreenDestination.style = if (isTablet) DialogNavigation else SlideNavigationAnimation
+    EditSelfDeletingMessagesScreenDestination.style = if (isTablet) DialogNavigation else SlideNavigationAnimation
+    ConversationFoldersScreenDestination.style = if (isTablet) DialogNavigation else SlideNavigationAnimation
+    NewConversationFolderScreenDestination.style = if (isTablet) DialogNavigation else SlideNavigationAnimation
 }

--- a/app/src/main/kotlin/com/wire/android/navigation/TabletStyleHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/TabletStyleHelper.kt
@@ -38,6 +38,7 @@ import com.wire.android.ui.destinations.ConversationFoldersScreenDestination
 import com.wire.android.ui.destinations.NewConversationFolderScreenDestination
 import com.wire.android.ui.theme.isTablet
 
+@Suppress("CyclomaticComplexMethod")
 @Composable
 fun AdjustDestinationStylesForTablets() {
     ServiceDetailsScreenDestination.style = if (isTablet) DialogNavigation else PopUpNavigationAnimation

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -68,7 +68,7 @@ import com.wire.android.appLogger
 import com.wire.android.navigation.HomeDestination
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
-import com.wire.android.navigation.adjustDestinationStylesForTablets
+import com.wire.android.navigation.AdjustDestinationStylesForTablets
 import com.wire.android.navigation.annotation.app.WireDestination
 import com.wire.android.navigation.handleNavigation
 import com.wire.android.ui.NavGraphs
@@ -384,7 +384,7 @@ fun HomeContent(
                                 rootDefaultAnimations = RootNavGraphDefaultAnimations.ACCOMPANIST_FADING
                             )
 
-                            adjustDestinationStylesForTablets()
+                            AdjustDestinationStylesForTablets()
                             DestinationsNavHost(
                                 navGraph = NavGraphs.home,
                                 engine = navHostEngine,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.RootNavGraph
+import com.ramcosta.composedestinations.spec.DestinationStyle
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
@@ -64,7 +65,8 @@ import com.wire.android.util.shareViaIntent
 @Suppress("ComplexMethod")
 @RootNavGraph
 @WireDestination(
-    navArgsDelegate = EditGuestAccessNavArgs::class
+    navArgsDelegate = EditGuestAccessNavArgs::class,
+    style = DestinationStyle.Runtime::class, // default should be SlideNavigationAnimation
 )
 @Composable
 fun EditGuestAccessScreen(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.RootNavGraph
+import com.ramcosta.composedestinations.spec.DestinationStyle
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.annotation.app.WireDestination
@@ -62,7 +63,8 @@ import com.wire.android.util.extension.folderWithElements
 
 @RootNavGraph
 @WireDestination(
-    navArgsDelegate = EditSelfDeletingMessagesNavArgs::class
+    navArgsDelegate = EditSelfDeletingMessagesNavArgs::class,
+    style = DestinationStyle.Runtime::class, // default should be SlideNavigationAnimation
 )
 @Composable
 fun EditSelfDeletingMessagesScreen(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updatechannelaccess/ChannelAccessOnUpdateScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updatechannelaccess/ChannelAccessOnUpdateScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.ramcosta.composedestinations.result.ResultBackNavigator
+import com.ramcosta.composedestinations.spec.DestinationStyle
 import com.wire.android.R
 import com.wire.android.navigation.annotation.app.WireDestination
 import com.wire.android.ui.common.dimensions
@@ -32,7 +33,10 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.home.newconversation.channelaccess.ChannelAccessScreenContent
 
 @RootNavGraph
-@WireDestination(navArgsDelegate = UpdateChannelAccessArgs::class)
+@WireDestination(
+    navArgsDelegate = UpdateChannelAccessArgs::class,
+    style = DestinationStyle.Runtime::class, // default should be SlideNavigationAnimation
+)
 @Composable
 fun ChannelAccessOnUpdateScreen(
     resultNavigator: ResultBackNavigator<UpdateChannelAccessArgs>,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/ConversationFoldersScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/ConversationFoldersScreen.kt
@@ -39,6 +39,7 @@ import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.ramcosta.composedestinations.result.ResultRecipient
+import com.ramcosta.composedestinations.spec.DestinationStyle
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.navigation.NavigationCommand
@@ -64,7 +65,7 @@ import com.wire.kalium.logic.data.conversation.FolderType
 @RootNavGraph
 @WireDestination(
     navArgsDelegate = ConversationFoldersNavArgs::class,
-    style = PopUpNavigationAnimation::class
+    style = DestinationStyle.Runtime::class, // default should be PopUpNavigationAnimation
 )
 @Composable
 fun ConversationFoldersScreen(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/ConversationFoldersScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/ConversationFoldersScreen.kt
@@ -45,7 +45,6 @@ import com.wire.android.model.Clickable
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.annotation.app.WireDestination
-import com.wire.android.navigation.style.PopUpNavigationAnimation
 import com.wire.android.ui.common.bottomsheet.RichMenuItemState
 import com.wire.android.ui.common.bottomsheet.SelectableMenuBottomSheetItem
 import com.wire.android.ui.common.button.WireButton

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/NewConversationFolderScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/NewConversationFolderScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.ramcosta.composedestinations.result.ResultBackNavigator
+import com.ramcosta.composedestinations.spec.DestinationStyle
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.annotation.app.WireDestination
@@ -62,7 +63,9 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.SnackBarMessageHandler
 
 @RootNavGraph
-@WireDestination
+@WireDestination(
+    style = DestinationStyle.Runtime::class, // default should be SlideNavigationAnimation
+)
 @Composable
 fun NewConversationFolderScreen(
     navigator: Navigator,

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.RootNavGraph
+import com.ramcosta.composedestinations.spec.DestinationStyle
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
@@ -104,7 +105,8 @@ import kotlinx.datetime.Instant
 
 @RootNavGraph
 @WireDestination(
-    navArgsDelegate = DeviceDetailsNavArgs::class
+    navArgsDelegate = DeviceDetailsNavArgs::class,
+    style = DestinationStyle.Runtime::class, // default should be SlideNavigationAnimation
 )
 @Composable
 fun DeviceDetailsScreen(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18123" title="WPB-18123" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18123</a>  [Android] Landscape mode - various pages should be shown as cards
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After playtesting the landscape mode, we noted the need to adapt some more screens for tablet landscape:
- specific group options screens: self-deleting, guests, channel access
- move conversation to folder, add folder
- user device details

### Solutions

Set "runtime" style for these screens:
- DeviceDetailsScreenDestination
- EditGuestAccessScreenDestination
- EditSelfDeletingMessagesScreenDestination
- ChannelAccessOnUpdateScreenDestination
- ConversationFoldersScreenDestination
- NewConversationFolderScreenDestination
Also, changed the name of the `AdjustDestinationStylesForTablets` function to be uppercase (lint rule).

### Testing

#### How to Test

Install the app on tablet, open conversation details and choose one of the specific options, open other user device details or move the conversation to folder.

### Attachments (Optional)

https://github.com/user-attachments/assets/55c952f7-2fcd-48da-ade9-6ce08a407d91

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
