### PR TITLE
fix: new registration general fixes about navigation and copies (WPB-17410)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/username/CreateAccountUsernameScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/username/CreateAccountUsernameScreen.kt
@@ -93,7 +93,7 @@ private fun UsernameContent(
             NewAuthHeader(
                 title = {
                     Text(
-                        text = stringResource(id = R.string.create_personal_account_title),
+                        text = stringResource(id = R.string.create_account_set_username_title),
                         style = MaterialTheme.wireTypography.title01,
                     )
                 },

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -70,10 +70,12 @@ import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.wire.android.BuildConfig.ENABLE_NEW_REGISTRATION
 import com.wire.android.R
 import com.wire.android.config.LocalCustomUiConfigurationProvider
+import com.wire.android.config.orDefault
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.annotation.app.WireDestination
 import com.wire.android.navigation.style.PopUpNavigationAnimation
+import com.wire.android.ui.authentication.create.common.CreateAccountDataNavArgs
 import com.wire.android.ui.authentication.create.common.ServerTitle
 import com.wire.android.ui.authentication.login.LoginPasswordPath
 import com.wire.android.ui.common.button.WirePrimaryButton
@@ -87,9 +89,8 @@ import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.visbility.rememberVisibilityState
-import com.wire.android.ui.destinations.CreateAccountSelectorScreenDestination
+import com.wire.android.ui.destinations.CreateAccountDataDetailScreenDestination
 import com.wire.android.ui.destinations.CreatePersonalAccountOverviewScreenDestination
-import com.wire.android.ui.destinations.CreateTeamAccountOverviewScreenDestination
 import com.wire.android.ui.destinations.LoginScreenDestination
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
@@ -132,6 +133,7 @@ private fun WelcomeContent(
     navigateBack: () -> Unit,
     navigate: (NavigationCommand) -> Unit
 ) {
+    val teamCreationUrl = state.teams + stringResource(R.string.create_account_email_backlink_to_team_suffix_url)
     val enterpriseDisabledWithProxyDialogState = rememberVisibilityState<FeatureDisabledWithProxyDialogState>()
     val createPersonalAccountDisabledWithProxyDialogState = rememberVisibilityState<FeatureDisabledWithProxyDialogState>()
     val context = LocalContext.current
@@ -206,7 +208,7 @@ private fun WelcomeContent(
                                 )
                             )
                         } else {
-                            navigate(NavigationCommand(CreateTeamAccountOverviewScreenDestination(state)))
+                            CustomTabsHelper.launchUrl(context, teamCreationUrl)
                         }
                     }
                 }
@@ -224,7 +226,8 @@ private fun WelcomeContent(
                             )
                         } else {
                             if (ENABLE_NEW_REGISTRATION) {
-                                navigate(NavigationCommand(CreateAccountSelectorScreenDestination(state)))
+                                val createAccountNavArgs = CreateAccountDataNavArgs(customServerConfig = state.orDefault())
+                                navigate(NavigationCommand(CreateAccountDataDetailScreenDestination(createAccountNavArgs)))
                             } else {
                                 navigate(NavigationCommand(CreatePersonalAccountOverviewScreenDestination(state)))
                             }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -91,6 +91,7 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.destinations.CreateAccountDataDetailScreenDestination
 import com.wire.android.ui.destinations.CreatePersonalAccountOverviewScreenDestination
+import com.wire.android.ui.destinations.CreateTeamAccountOverviewScreenDestination
 import com.wire.android.ui.destinations.LoginScreenDestination
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
@@ -208,7 +209,11 @@ private fun WelcomeContent(
                                 )
                             )
                         } else {
-                            CustomTabsHelper.launchUrl(context, teamCreationUrl)
+                            if (ENABLE_NEW_REGISTRATION) {
+                                CustomTabsHelper.launchUrl(context, teamCreationUrl)
+                            } else {
+                                navigate(NavigationCommand(CreateTeamAccountOverviewScreenDestination(state)))
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -231,8 +231,15 @@ private fun WelcomeContent(
                             )
                         } else {
                             if (ENABLE_NEW_REGISTRATION) {
-                                val createAccountNavArgs = CreateAccountDataNavArgs(customServerConfig = state.orDefault())
-                                navigate(NavigationCommand(CreateAccountDataDetailScreenDestination(createAccountNavArgs)))
+                                navigate(
+                                    NavigationCommand(
+                                        CreateAccountDataDetailScreenDestination(
+                                            CreateAccountDataNavArgs(
+                                                customServerConfig = state.orDefault()
+                                            )
+                                        )
+                                    )
+                                )
                             } else {
                                 navigate(NavigationCommand(CreatePersonalAccountOverviewScreenDestination(state)))
                             }

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
@@ -18,7 +18,7 @@
 
 package com.wire.android.ui.registration.details
 
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -201,10 +201,12 @@ private fun AccountDetailsContent(
                         .testTag("emailField")
                         .focusRequester(emailFocusRequester)
                 )
-                if (state.error.isEmailError()) {
-                    AnimatedVisibility(visible = state.error.isEmailError()) { EmailErrorDetailText(state.error) }
-                } else {
-                    VerticalSpace.x16()
+
+                AnimatedContent(state.error.isEmailError()) { isEmailError ->
+                    when (isEmailError) {
+                        true -> EmailErrorDetailText(state.error)
+                        false -> VerticalSpace.x16()
+                    }
                 }
 
                 WireTextField(

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
@@ -72,6 +72,7 @@ import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.error.CoreFailureErrorDialog
 import com.wire.android.ui.common.preview.EdgeToEdgePreview
+import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.textfield.DefaultEmailDone
 import com.wire.android.ui.common.textfield.DefaultPassword
 import com.wire.android.ui.common.textfield.WirePasswordTextField
@@ -196,16 +197,14 @@ private fun AccountDetailsContent(
                     keyboardOptions = KeyboardOptions.DefaultEmailDone,
                     onKeyboardAction = { keyboardController?.hide() },
                     modifier = Modifier
-                        .padding(
-                            start = MaterialTheme.wireDimensions.spacing16x,
-                            end = MaterialTheme.wireDimensions.spacing16x,
-                            bottom = MaterialTheme.wireDimensions.spacing16x
-                        )
+                        .padding(horizontal = MaterialTheme.wireDimensions.spacing16x)
                         .testTag("emailField")
                         .focusRequester(emailFocusRequester)
                 )
-                AnimatedVisibility(visible = state.error.isEmailError()) {
-                    EmailErrorDetailText(state.error)
+                if (state.error.isEmailError()) {
+                    AnimatedVisibility(visible = state.error.isEmailError()) { EmailErrorDetailText(state.error) }
+                } else {
+                    VerticalSpace.x16()
                 }
 
                 WireTextField(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -531,6 +531,7 @@
     <string name="create_account_username_title">Your Username</string>
     <string name="create_account_username_placeholder">jane.doe</string>
     <string name="create_account_username_label">USERNAME</string>
+    <string name="create_account_set_username_title">Set username</string>
     <string name="create_account_username_text">Enter your username. It helps others to find you in Wire and connect with you.</string>
     <string name="create_account_username_taken_error">This username is already taken. Please choose another one.</string>
     <string name="create_account_username_description">At least 2 characters, a-z, 0-9, “_”, “-” and “.”</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -377,7 +377,7 @@
     <string name="enterprise_login_user_identifier_label_placeholder">Enter Email or SSO Code</string>
     <string name="enterprise_login_error_invalid_user_identifier">Please enter a valid email or SSO code</string>
     <string name="enterprise_login_create_account_label">Don\'t have a Wire account?</string>
-    <string name="enterprise_login_create_account_text_button">Create account</string>
+    <string name="enterprise_login_create_account_text_button">Create account or team</string>
     <string name="enterprise_login_on_prem_welcome_title">Welcome to Wire Enterprise for %s!</string>
     <string name="enterprise_login_verification_code_title">You have mail</string>
     <!-- Login -->


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17410" title="WPB-17410" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-17410</a>  [Android] New Registrations Flows - Account creation type selector
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After design review and early QA, some issues were raised, see https://wearezeta.atlassian.net/browse/WPB-17410?focusedCommentId=138906

- Copies for enterprise login outdated
- Extra Padding for email error
- Navigation from the old Welcome screen, updated to redirect to the new flows.

### Solutions

Fix the issues

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
