### PR TITLE
fix: correctly show both mls thumbprint and e2ei shield (#WPB-18230)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.feature.conversation.GetAllContactsNotInConversatio
 import com.wire.kalium.logic.feature.e2ei.SyncCertificateRevocationListUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMLSClientIdentityUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMembersE2EICertificateStatusesUseCase
-import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.GetUserMlsClientIdentitiesUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.IsOtherUserE2EIVerifiedUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
 import com.wire.kalium.logic.feature.featureConfig.FeatureFlagsSyncWorker
@@ -234,8 +234,8 @@ class UserModule {
 
     @ViewModelScoped
     @Provides
-    fun provideGetUserE2eiCertificates(userScope: UserScope): GetUserE2eiCertificatesUseCase =
-        userScope.getUserE2eiCertificates
+    fun provideGetUserMlsClientIdentities(userScope: UserScope): GetUserMlsClientIdentitiesUseCase =
+        userScope.getUserMlsClientIdentities
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
@@ -64,6 +64,7 @@ fun OtherUserDevicesScreen(
             else -> OtherUserDevicesContent(
                 fullName = state.fullName,
                 devices = devices,
+                shouldShowE2EIInfo = state.isE2EIEnabled,
                 lazyListState = lazyListState,
                 onDeviceClick = onDeviceClick
             )
@@ -105,6 +106,7 @@ private fun OtherUserEmptyDevicesContent() {
 private fun OtherUserDevicesContent(
     fullName: String,
     devices: List<Device>,
+    shouldShowE2EIInfo: Boolean,
     lazyListState: LazyListState = rememberLazyListState(),
     onDeviceClick: (Device) -> Unit
 ) {
@@ -144,7 +146,7 @@ private fun OtherUserDevicesContent(
                 onClickAction = onDeviceClick,
                 icon = { ArrowRightIcon(contentDescription = R.string.content_description_empty) },
                 shouldShowVerifyLabel = true,
-                shouldShowE2EIInfo = item.mlsClientIdentity != null
+                shouldShowE2EIInfo = shouldShowE2EIInfo,
             )
             if (index < devices.lastIndex) WireDivider()
         }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -73,6 +73,7 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusU
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMLSClientIdentityUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.IsOtherUserE2EIVerifiedUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
+import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
@@ -109,6 +110,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     private val getUserE2eiCertificateStatus: IsOtherUserE2EIVerifiedUseCase,
     private val isOneToOneConversationCreated: IsOneToOneConversationCreatedUseCase,
     private val mlsClientIdentity: GetMLSClientIdentityUseCase,
+    private val isE2EIEnabled: IsE2EIEnabledUseCase,
     savedStateHandle: SavedStateHandle
 ) : ViewModel(), OtherUserProfileEventsHandler, OtherUserProfileBottomSheetEventsHandler {
 
@@ -137,11 +139,13 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         persistClients()
         getMLSVerificationStatus()
         getIfConversationExist()
+        getE2EIStatus()
     }
 
     private fun getIfConversationExist() {
         viewModelScope.launch {
-            state = state.copy(isConversationStarted = isOneToOneConversationCreated(userId))
+            val isOneToOneConversationCreated = isOneToOneConversationCreated(userId)
+            state = state.copy(isConversationStarted = isOneToOneConversationCreated)
         }
     }
 
@@ -150,6 +154,11 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             val isMLSVerified = getUserE2eiCertificateStatus(userId)
             state = state.copy(isMLSVerified = isMLSVerified)
         }
+    }
+
+    private fun getE2EIStatus() = viewModelScope.launch {
+        val isE2EIEnabled = isE2EIEnabled()
+        state = state.copy(isE2EIEnabled = isE2EIEnabled)
     }
 
     override fun observeClientList() {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -56,7 +56,8 @@ data class OtherUserProfileState(
     val expiresAt: Instant? = null,
     val accentId: Int = -1,
     val errorLoadingUser: ErrorLoadingUser? = null,
-    val isDeletedUser: Boolean = false
+    val isDeletedUser: Boolean = false,
+    val isE2EIEnabled: Boolean = true,
 ) {
     fun updateMuteStatus(status: MutedConversationStatus): OtherUserProfileState {
         return conversationSheetContent?.let {

--- a/app/src/test/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModelTest.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.feature.client.FetchSelfClientsFromRemoteUseCase
 import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
 import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.client.SelfClientsResult
-import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.GetUserMlsClientIdentitiesUseCase
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -80,7 +80,7 @@ class SelfDevicesViewModelTest {
             viewModel.loadCertificates()
 
             // then
-            coVerify(exactly = 2) { arragne.getUserE2eiCertificates(any()) }
+            coVerify(exactly = 2) { arragne.getUserMlsClientIdentities(any()) }
         }
 
     private class Arrangement {
@@ -95,7 +95,7 @@ class SelfDevicesViewModelTest {
         lateinit var fetchSelfClientsFromRemote: FetchSelfClientsFromRemoteUseCase
 
         @MockK
-        lateinit var getUserE2eiCertificates: GetUserE2eiCertificatesUseCase
+        lateinit var getUserMlsClientIdentities: GetUserMlsClientIdentitiesUseCase
 
         @MockK
         lateinit var isE2EIEnabledUseCase: IsE2EIEnabledUseCase
@@ -108,7 +108,7 @@ class SelfDevicesViewModelTest {
                 currentAccountId = selfId,
                 currentClientIdUseCase = currentClientId,
                 fetchSelfClientsFromRemote = fetchSelfClientsFromRemote,
-                getUserE2eiCertificates = getUserE2eiCertificates,
+                getUserMlsClientIdentities = getUserMlsClientIdentities,
                 isE2EIEnabledUseCase = isE2EIEnabledUseCase
             )
         }
@@ -119,7 +119,7 @@ class SelfDevicesViewModelTest {
             coEvery { currentClientId.invoke() } returns flowOf(TestClient.CLIENT_ID)
             coEvery { fetchSelfClientsFromRemote.invoke() } returns SelfClientsResult.Success(listOf(), null)
             coEvery { observeClientsByUserId(any()) } returns flowOf(ObserveClientsByUserIdUseCase.Result.Success(listOf()))
-            coEvery { getUserE2eiCertificates.invoke(any()) } returns mapOf()
+            coEvery { getUserMlsClientIdentities.invoke(any()) } returns mapOf()
             coEvery { isE2EIEnabledUseCase() } returns true
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -48,6 +48,7 @@ import com.wire.kalium.logic.feature.e2ei.MLSClientIdentity
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMLSClientIdentityUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.IsOtherUserE2EIVerifiedUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
+import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import io.mockk.MockKAnnotations
@@ -115,6 +116,9 @@ internal class OtherUserProfileViewModelArrangement {
     @MockK
     lateinit var mlsIdentity: MLSClientIdentity
 
+    @MockK
+    lateinit var isE2EIEnabled: IsE2EIEnabledUseCase
+
     private val viewModel by lazy {
         OtherUserProfileScreenViewModel(
             TestDispatcherProvider(),
@@ -134,6 +138,7 @@ internal class OtherUserProfileViewModelArrangement {
             getUserE2eiCertificateStatus,
             isOneToOneConversationCreated,
             mlsClientIdentity,
+            isE2EIEnabled,
             savedStateHandle,
         )
     }
@@ -165,6 +170,7 @@ internal class OtherUserProfileViewModelArrangement {
         coEvery { getUserE2eiCertificateStatus.invoke(any()) } returns true
         coEvery { mlsClientIdentity.invoke(any()) } returns mlsIdentity.right()
         coEvery { isOneToOneConversationCreated.invoke(any()) } returns true
+        coEvery { isE2EIEnabled.invoke() } returns true
     }
 
     suspend fun withBlockUserResult(result: BlockUserResult) = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18230" title="WPB-18230" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18230</a>  [Android] E2EI Verififaction shield shown when E2EI is not enabled for the team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-18230

# What's new in this PR?

### Issues
Need to show MLS thumbprints for devices even if E2EI is disabled for the team.

### Solutions
- Request MLS client info with the new use case which returns data even if E2EI is disabled
- Request E2EI status separately from device info and pass it to the view to hide E2EI shield if it is disabled
- Fixed issue in OtherUserProfileScreenViewModel: suspend function called in copy constructor causing inconsistent state updates
