### PR TITLE
fix: general improvements new registration flows (WPB-18329)(WPB-18333)(WPB-18334)(WPB-18335)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
@@ -64,8 +64,6 @@ import com.wire.android.ui.authentication.create.common.ServerTitle
 import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
 import com.wire.android.ui.common.WireCheckbox
 import com.wire.android.ui.common.WireDialog
-import com.wire.android.ui.common.WireDialogButtonProperties
-import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
@@ -385,12 +383,7 @@ private fun TermsConditionsDialog(onDialogDismiss: () -> Unit, onContinuePressed
     WireDialog(
         title = stringResource(R.string.create_account_email_terms_dialog_title),
         text = stringResource(R.string.create_account_email_terms_dialog_text),
-        onDismiss = onDialogDismiss,
-        optionButton1Properties = WireDialogButtonProperties(
-            onClick = onContinuePressed,
-            text = stringResource(id = R.string.label_continue),
-            type = WireDialogButtonType.Primary,
-        )
+        onDismiss = onDialogDismiss
     ) {
         Column {
             WireSecondaryButton(
@@ -408,7 +401,15 @@ private fun TermsConditionsDialog(onDialogDismiss: () -> Unit, onContinuePressed
                 fillMaxWidth = true,
                 modifier = Modifier
                     .fillMaxWidth()
+                    .padding(bottom = MaterialTheme.wireDimensions.spacing8x)
                     .testTag("viewTC")
+            )
+            WirePrimaryButton(
+                text = stringResource(id = R.string.label_continue),
+                onClick = onContinuePressed,
+                fillMaxWidth = true,
+                modifier = Modifier
+                    .fillMaxWidth()
             )
         }
     }
@@ -492,6 +493,16 @@ fun PreviewCreateAccountDetailsScreen() = WireTheme {
                 onErrorDismiss = {},
                 serverConfig = ServerConfig.DEFAULT
             )
+        }
+    }
+}
+
+@Composable
+@PreviewMultipleThemes
+fun PreviewTosDialogsScreen() = WireTheme {
+    EdgeToEdgePreview(useDarkIcons = false) {
+        WireAuthBackgroundLayout {
+            TermsConditionsDialog({}, {}, {})
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
@@ -116,7 +116,7 @@ fun CreateAccountDataDetailScreen(
 
         LaunchedEffect(createAccountDataDetailViewModel.detailsState.success) {
             if (createAccountDataDetailViewModel.detailsState.success) {
-                createAccountDataDetailViewModel.onCodeSent()
+                createAccountDataDetailViewModel.onCodeSentHandled()
                 navigateToCodeScreen()
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
@@ -176,7 +176,7 @@ private fun AccountDetailsContent(
         contentPadding = dimensions().spacing16x,
         content = {
             val keyboardController = LocalSoftwareKeyboardController.current
-            val emailFocusRequester = remember { FocusRequester() }
+            val nameFocusRequester = remember { FocusRequester() }
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Top,
@@ -197,7 +197,6 @@ private fun AccountDetailsContent(
                     modifier = Modifier
                         .padding(horizontal = MaterialTheme.wireDimensions.spacing16x)
                         .testTag("emailField")
-                        .focusRequester(emailFocusRequester)
                 )
 
                 AnimatedContent(state.error.isEmailError()) { isEmailError ->
@@ -225,7 +224,8 @@ private fun AccountDetailsContent(
                             end = MaterialTheme.wireDimensions.spacing16x,
                             bottom = MaterialTheme.wireDimensions.spacing16x
                         )
-                        .testTag("firstName"),
+                        .focusRequester(nameFocusRequester)
+                        .testTag("name"),
                 )
 
                 WirePasswordTextField(
@@ -282,7 +282,7 @@ private fun AccountDetailsContent(
             }
 
             LaunchedEffect(Unit) {
-                emailFocusRequester.requestFocus()
+                nameFocusRequester.requestFocus()
                 keyboardController?.show()
             }
 

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
@@ -115,7 +115,10 @@ fun CreateAccountDataDetailScreen(
         )
 
         LaunchedEffect(createAccountDataDetailViewModel.detailsState.success) {
-            if (createAccountDataDetailViewModel.detailsState.success) navigateToCodeScreen()
+            if (createAccountDataDetailViewModel.detailsState.success) {
+                createAccountDataDetailViewModel.onCodeSent()
+                navigateToCodeScreen()
+            }
         }
 
         AccountDetailsContent(

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
@@ -129,6 +129,10 @@ class CreateAccountDataDetailViewModel @Inject constructor(
         }
     }
 
+    fun onCodeSent() {
+        detailsState = detailsState.copy(success = false)
+    }
+
     fun onDetailsContinue() {
         detailsState = detailsState.copy(loading = true, continueEnabled = false)
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
@@ -123,7 +123,7 @@ class CreateAccountDataDetailViewModel @Inject constructor(
             }
 
             val email = emailTextState.text.toString().trim().lowercase()
-            val emailError = when (!detailsState.isCodeSent) {
+            val emailError = when (detailsState.isCodeSent) {
                 false -> authScope.registerScope.requestActivationCode(email).toEmailError()
                 true -> detailsState.error
             }

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
@@ -123,13 +123,18 @@ class CreateAccountDataDetailViewModel @Inject constructor(
             }
 
             val email = emailTextState.text.toString().trim().lowercase()
-            val emailError = authScope.registerScope.requestActivationCode(email).toEmailError()
+            val emailError = when (!detailsState.isCodeSent) {
+                false -> authScope.registerScope.requestActivationCode(email).toEmailError()
+                true -> detailsState.error
+            }
             detailsState = detailsState.copy(loading = false, continueEnabled = true, error = emailError)
-            if (emailError is CreateAccountDataDetailViewState.DetailsError.None) detailsState = detailsState.copy(success = true)
+            if (emailError is CreateAccountDataDetailViewState.DetailsError.None) {
+                detailsState = detailsState.copy(success = true, isCodeSent = true)
+            }
         }
     }
 
-    fun onCodeSent() {
+    fun onCodeSentHandled() {
         detailsState = detailsState.copy(success = false)
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewState.kt
@@ -27,6 +27,7 @@ data class CreateAccountDataDetailViewState(
     val continueEnabled: Boolean = false,
     val loading: Boolean = false,
     val error: DetailsError = DetailsError.None,
+    val isCodeSent: Boolean = false,
     val success: Boolean = false,
 ) {
     sealed class DetailsError {

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.style.TextAlign
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.R
@@ -72,6 +72,7 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.configuration.server.ServerConfig
 
 @CreateAccountNavGraph(start = true)
@@ -217,10 +218,18 @@ private fun AccountType(
                 text = title.uppercase(),
                 style = MaterialTheme.wireTypography.title03,
                 color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(horizontal = dimensions().spacing8x)
+                    .fillMaxWidth()
             )
             Text(
                 text = subtitle,
                 style = MaterialTheme.wireTypography.body01,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(horizontal = dimensions().spacing8x)
+                    .fillMaxWidth()
             )
             HorizontalDivider(modifier = Modifier.padding(horizontal = dimensions().spacing16x))
             highlights.forEach { highlight ->
@@ -272,7 +281,7 @@ private fun AccountType(
 }
 
 @Composable
-@Preview
+@PreviewMultipleThemes
 fun PreviewCreateAccountSelectorScreen() = WireTheme {
     EdgeToEdgePreview(useDarkIcons = false) {
         WireAuthBackgroundLayout {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18329" title="WPB-18329" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18329</a>  [Android]Back arrow does not work on "Create Personal Account" verification screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After playtest from last Friday, some visual and user experience issues were raised.  Some of them from the current production behavior in the old flows.

Tickets:
- https://wearezeta.atlassian.net/browse/WPB-18329
- https://wearezeta.atlassian.net/browse/WPB-18333
- https://wearezeta.atlassian.net/browse/WPB-18334
- https://wearezeta.atlassian.net/browse/WPB-18335

### Causes (Optional)

The screens were ported as-is.

### Solutions

Fix the issues only for the new flows.

### Attachments

[fixes.webm](https://github.com/user-attachments/assets/81967af8-97b5-4037-8521-7fa26436835c)

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
