### PR TITLE
fix: save backup screen state on orientation change (#WPB-18247)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackUpAndRestoreStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackUpAndRestoreStateHolder.kt
@@ -18,13 +18,25 @@
 
 package com.wire.android.ui.home.settings.backup
 
+import android.os.Parcelable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import kotlinx.parcelize.Parcelize
 
 class BackUpAndRestoreStateHolder {
+
+    companion object {
+        fun saver(): Saver<BackUpAndRestoreStateHolder, *> {
+            return Saver(
+                save = { it.dialogState },
+                restore = { BackUpAndRestoreStateHolder().apply { dialogState = it } }
+            )
+        }
+    }
 
     var dialogState: BackupAndRestoreDialog by mutableStateOf(
         BackupAndRestoreDialog.None
@@ -45,12 +57,13 @@ class BackUpAndRestoreStateHolder {
 
 @Composable
 fun rememberBackUpAndRestoreStateHolder(): BackUpAndRestoreStateHolder {
-    return remember {
+    return rememberSaveable(saver = BackUpAndRestoreStateHolder.saver()) {
         BackUpAndRestoreStateHolder()
     }
 }
 
-sealed class BackupAndRestoreDialog {
+@Parcelize
+sealed class BackupAndRestoreDialog : Parcelable {
     object None : BackupAndRestoreDialog()
     object CreateBackup : BackupAndRestoreDialog()
     object RestoreBackup : BackupAndRestoreDialog()

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogStateHolder.kt
@@ -18,17 +18,27 @@
 
 package com.wire.android.ui.home.settings.backup.dialog.create
 
+import android.os.Parcelable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import kotlinx.parcelize.Parcelize
 
 @Stable
 class CreateBackupDialogStateHolder {
     companion object {
         val INITIAL_STEP = BackUpDialogStep.SetPassword
+
+        fun saver(): Saver<CreateBackupDialogStateHolder, *> {
+            return Saver(
+                save = { it.currentBackupDialogStep },
+                restore = { CreateBackupDialogStateHolder().apply { currentBackupDialogStep = it } }
+            )
+        }
     }
 
     var currentBackupDialogStep: BackUpDialogStep by mutableStateOf(INITIAL_STEP)
@@ -62,12 +72,13 @@ class CreateBackupDialogStateHolder {
 
 @Composable
 fun rememberBackUpDialogState(): CreateBackupDialogStateHolder {
-    return remember("someData") { CreateBackupDialogStateHolder() }
+    return rememberSaveable(saver = CreateBackupDialogStateHolder.saver()) { CreateBackupDialogStateHolder() }
 }
 
-sealed interface BackUpDialogStep {
-    object SetPassword : BackUpDialogStep
+@Parcelize
+sealed interface BackUpDialogStep : Parcelable {
+    data object SetPassword : BackUpDialogStep
     data class CreatingBackup(val progress: Float) : BackUpDialogStep
     data class Finished(val fileName: String) : BackUpDialogStep
-    object Failure : BackUpDialogStep
+    data object Failure : BackUpDialogStep
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogStateHolder.kt
@@ -75,10 +75,12 @@ fun rememberBackUpDialogState(): CreateBackupDialogStateHolder {
     return rememberSaveable(saver = CreateBackupDialogStateHolder.saver()) { CreateBackupDialogStateHolder() }
 }
 
-@Parcelize
 sealed interface BackUpDialogStep : Parcelable {
-    data object SetPassword : BackUpDialogStep
-    data class CreatingBackup(val progress: Float) : BackUpDialogStep
-    data class Finished(val fileName: String) : BackUpDialogStep
-    data object Failure : BackUpDialogStep
+    @Parcelize data object SetPassword : BackUpDialogStep
+
+    @Parcelize data class CreatingBackup(val progress: Float) : BackUpDialogStep
+
+    @Parcelize data class Finished(val fileName: String) : BackUpDialogStep
+
+    @Parcelize data object Failure : BackUpDialogStep
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogStateHolder.kt
@@ -72,12 +72,14 @@ fun rememberRestoreDialogState(): RestoreDialogStateHolder {
     return rememberSaveable(saver = RestoreDialogStateHolder.saver()) { RestoreDialogStateHolder() }
 }
 
-@Parcelize
 sealed interface RestoreDialogStep : Parcelable {
-    data object ChooseBackupFile : RestoreDialogStep
-    data object EnterPassword : RestoreDialogStep
-    data object RestoreBackup : RestoreDialogStep
-    data class Failure(val restoreFailure: RestoreFailure) : RestoreDialogStep
+    @Parcelize data object ChooseBackupFile : RestoreDialogStep
+
+    @Parcelize data object EnterPassword : RestoreDialogStep
+
+    @Parcelize data object RestoreBackup : RestoreDialogStep
+
+    @Parcelize data class Failure(val restoreFailure: RestoreFailure) : RestoreDialogStep
 }
 
 enum class RestoreFailure(@StringRes val title: Int, @StringRes val message: Int) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogStateHolder.kt
@@ -18,19 +18,29 @@
 
 package com.wire.android.ui.home.settings.backup.dialog.restore
 
+import android.os.Parcelable
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.wire.android.R
+import kotlinx.parcelize.Parcelize
 
 @Stable
 class RestoreDialogStateHolder {
     companion object {
         val INITIAL_STEP = RestoreDialogStep.ChooseBackupFile
+
+        fun saver(): Saver<RestoreDialogStateHolder, *> {
+            return Saver(
+                save = { it.currentRestoreDialogStep },
+                restore = { RestoreDialogStateHolder().apply { currentRestoreDialogStep = it } }
+            )
+        }
     }
 
     var currentRestoreDialogStep: RestoreDialogStep by mutableStateOf(INITIAL_STEP)
@@ -59,13 +69,14 @@ class RestoreDialogStateHolder {
 
 @Composable
 fun rememberRestoreDialogState(): RestoreDialogStateHolder {
-    return remember { RestoreDialogStateHolder() }
+    return rememberSaveable(saver = RestoreDialogStateHolder.saver()) { RestoreDialogStateHolder() }
 }
 
-sealed interface RestoreDialogStep {
-    object ChooseBackupFile : RestoreDialogStep
-    object EnterPassword : RestoreDialogStep
-    object RestoreBackup : RestoreDialogStep
+@Parcelize
+sealed interface RestoreDialogStep : Parcelable {
+    data object ChooseBackupFile : RestoreDialogStep
+    data object EnterPassword : RestoreDialogStep
+    data object RestoreBackup : RestoreDialogStep
     data class Failure(val restoreFailure: RestoreFailure) : RestoreDialogStep
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18247" title="WPB-18247" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18247</a>  [Android] Backup dialogue disappearing when rotating the screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-18247

# What's new in this PR?

### Issues
Backup screen and related dialogs state is lost on screen rotation.

### Solutions
Use rememberSaveable function to keep state holders on screen rotation.
