### PR TITLE
fix: crash when accepting call with no permissions (#WPB-16441)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/permission/PermissionsRequestFlow.kt
+++ b/app/src/main/kotlin/com/wire/android/util/permission/PermissionsRequestFlow.kt
@@ -46,18 +46,20 @@ fun rememberCheckPermissionsRequestFlow(
 
     val permissionLauncher: ManagedActivityResultLauncher<Array<String>, Map<String, @JvmSuppressWildcards Boolean>> =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { areGranted ->
-            if (areGranted.all { it.value }) {
-                onAllPermissionsGranted()
-            } else {
-                context.getActivity()?.let { activity ->
-                    val shouldShowRequestPermissionRationaleForAnyPermission = permissions
-                        .map { permission -> shouldShowRequestPermissionRationale(activity, permission) }
-                        .any { it }
+            if (areGranted.isNotEmpty()) {
+                if (areGranted.all { it.value }) {
+                    onAllPermissionsGranted()
+                } else {
+                    context.getActivity()?.let { activity ->
+                        val shouldShowRequestPermissionRationaleForAnyPermission = permissions
+                            .map { permission -> shouldShowRequestPermissionRationale(activity, permission) }
+                            .any { it }
 
-                    if (shouldShowRequestPermissionRationaleForAnyPermission) {
-                        onAnyPermissionDenied()
-                    } else {
-                        onAnyPermissionPermanentlyDenied()
+                        if (shouldShowRequestPermissionRationaleForAnyPermission) {
+                            onAnyPermissionDenied()
+                        } else {
+                            onAnyPermissionPermanentlyDenied()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16441" title="WPB-16441" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16441</a>  [SGA52s/A.14] Chat - App crashes when accepting an audio call without accepting the access
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-16441

# What's new in this PR?

### Issues

Application crashes when accepting call from notification and permissions request dialog is open.
- Get incoming call
- Accept the call from the Starting Call screen
- Permissions request dialog is opened
- Try to accept the call again from notification without closing the permissions dialog

### Causes

When re-opening the activity from notification the permissions callback returns empty list for granted permissions which is interpreted as all permissions granted.

### Solutions

Do not accept call if granted permissions list is empty.
