### PR TITLE
fix: new registration flows fixes to code verification screen (WPB-18400) (WPB-18401)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeScreen.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.ui.registration.code
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -127,6 +128,10 @@ fun CreateAccountVerificationCodeScreen(
                 )
             }
         }
+        BackHandler {
+            if (codeState.loading) return@BackHandler
+            navigator.navigateBack()
+        }
     }
 }
 
@@ -157,7 +162,10 @@ private fun CodeContent(
                     }
                 },
                 canNavigateBack = true,
-                onNavigateBack = onBackPressed
+                onNavigateBack = {
+                    if (state.loading) return@NewAuthHeader
+                    onBackPressed()
+                }
             )
         },
         contentPadding = dimensions().spacing16x,

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
@@ -123,13 +123,10 @@ class CreateAccountDataDetailViewModel @Inject constructor(
             }
 
             val email = emailTextState.text.toString().trim().lowercase()
-            val emailError = when (detailsState.isCodeSent) {
-                false -> authScope.registerScope.requestActivationCode(email).toEmailError()
-                true -> detailsState.error
-            }
+            val emailError = authScope.registerScope.requestActivationCode(email).toEmailError()
             detailsState = detailsState.copy(loading = false, continueEnabled = true, error = emailError)
             if (emailError is CreateAccountDataDetailViewState.DetailsError.None) {
-                detailsState = detailsState.copy(success = true, isCodeSent = true)
+                detailsState = detailsState.copy(success = true)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewState.kt
@@ -27,7 +27,6 @@ data class CreateAccountDataDetailViewState(
     val continueEnabled: Boolean = false,
     val loading: Boolean = false,
     val error: DetailsError = DetailsError.None,
-    val isCodeSent: Boolean = false,
     val success: Boolean = false,
 ) {
     sealed class DetailsError {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18400" title="WPB-18400" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18400</a>  [Android]App becomes unstable If back button Is pressed during OTP processing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After fixing the navigation bug to being stuck on the code verification screen, a couple of bugs were introduced as a side effect, specifically: 

- Navigation should be disabled while processing an OTP.
- If a change of email happens in between we need to resend the code, this was an optimization introduced.

### Solutions

Fix them.

- Avoid back navigation while the code is being loaded or processed.
- Rollback optimization, leave it as is to request the code each time we navigate from prev. screen.

#### How to Test

- While on the registration process, and loading the OTP, by resend for example or verifying, try to navigate back, this should not be allowed. 
- If you go to verification code, then navigate back and change your email, you should receive a verification code in the edited email address.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
