### PR TITLE
fix: request 2fa code when removing client (#WPB-11401)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceState.kt
@@ -25,7 +25,8 @@ data class RemoveDeviceState(
     val deviceList: List<Device>,
     val removeDeviceDialogState: RemoveDeviceDialogState = RemoveDeviceDialogState.Hidden,
     val isLoadingClientsList: Boolean,
-    val error: RemoveDeviceError = RemoveDeviceError.None
+    val error: RemoveDeviceError = RemoveDeviceError.None,
+    val is2FAInProgress: Boolean = false,
 )
 
 sealed class RemoveDeviceDialogState {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceVerificationCodeScreen.kt
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.authentication.devices.remove
+
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.wire.android.ui.authentication.verificationcode.VerificationCodeScreenContent
+
+@Composable
+fun RemoveDeviceVerificationCodeScreen(
+    viewModel: RemoveDeviceViewModel = hiltViewModel()
+) = VerificationCodeScreenContent(
+    viewModel.secondFactorVerificationCodeTextState,
+    viewModel.secondFactorVerificationCodeState,
+    viewModel.state.is2FAInProgress,
+    viewModel::onCodeResend,
+    viewModel::onCodeVerificationBackPress
+)

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModel.kt
@@ -27,10 +27,13 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.BuildConfig
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.ui.authentication.devices.model.Device
+import com.wire.android.ui.authentication.verificationcode.VerificationCodeState
 import com.wire.android.ui.common.ActionsViewModel
 import com.wire.android.ui.common.textfield.textAsFlow
+import com.wire.kalium.logic.data.auth.verification.VerifiableAction
 import com.wire.kalium.logic.data.client.ClientType
 import com.wire.kalium.logic.data.client.DeleteClientParam
+import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerificationCodeUseCase
 import com.wire.kalium.logic.feature.client.DeleteClientResult
 import com.wire.kalium.logic.feature.client.DeleteClientUseCase
 import com.wire.kalium.logic.feature.client.FetchSelfClientsFromRemoteUseCase
@@ -38,6 +41,7 @@ import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.client.RegisterClientUseCase
 import com.wire.kalium.logic.feature.client.SelfClientsResult
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
@@ -47,13 +51,16 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions")
 @HiltViewModel
 class RemoveDeviceViewModel @Inject constructor(
     private val fetchSelfClientsFromRemote: FetchSelfClientsFromRemoteUseCase,
     private val deleteClientUseCase: DeleteClientUseCase,
     private val registerClientUseCase: GetOrRegisterClientUseCase,
     private val isPasswordRequired: IsPasswordRequiredUseCase,
-    private val userDataStore: UserDataStore
+    private val userDataStore: UserDataStore,
+    private val getSelfUser: GetSelfUserUseCase,
+    private val requestSecondFactorVerificationCodeUseCase: RequestSecondFactorVerificationCodeUseCase,
 ) : ActionsViewModel<RemoveDeviceViewAction>() {
 
     val passwordTextState: TextFieldState = TextFieldState()
@@ -62,9 +69,26 @@ class RemoveDeviceViewModel @Inject constructor(
     )
         private set
 
+    val secondFactorVerificationCodeTextState: TextFieldState = TextFieldState()
+    var secondFactorVerificationCodeState: VerificationCodeState by mutableStateOf(VerificationCodeState())
+        private set
+
     init {
         loadClientsList()
         observePasswordTextChanges()
+
+        viewModelScope.launch {
+            secondFactorVerificationCodeTextState.textAsFlow().collectLatest {
+                secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(isCurrentCodeInvalid = false)
+                if (it.length == VerificationCodeState.DEFAULT_VERIFICATION_CODE_LENGTH) {
+                    state = state.copy(
+                        is2FAInProgress = true,
+                        removeDeviceDialogState = RemoveDeviceDialogState.Hidden
+                    )
+                    registerClient(passwordTextState.text.toString(), it.toString())
+                }
+            }
+        }
     }
 
     private fun observePasswordTextChanges() {
@@ -131,10 +155,12 @@ class RemoveDeviceViewModel @Inject constructor(
         }
     }
 
-    private suspend fun registerClient(password: String?) {
+    private suspend fun registerClient(password: String?, secondFactorVerificationCode: String? = null) {
         registerClientUseCase(
             RegisterClientUseCase.RegisterClientParam(
-                password, null,
+                password = password,
+                secondFactorVerificationCode = secondFactorVerificationCode,
+                capabilities = null,
                 modelPostfix = if (BuildConfig.PRIVATE_BUILD) " [${BuildConfig.FLAVOR}_${BuildConfig.BUILD_TYPE}]" else null
             )
         ).also { result ->
@@ -144,6 +170,14 @@ class RemoveDeviceViewModel @Inject constructor(
                 }
 
                 is RegisterClientResult.Failure.Generic -> state = state.copy(error = RemoveDeviceError.GenericError(result.genericFailure))
+                is RegisterClientResult.Failure.InvalidCredentials.Missing2FA -> request2FACode()
+                is RegisterClientResult.Failure.InvalidCredentials.Invalid2FA -> {
+                    state = state.copy(is2FAInProgress = false)
+                    secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(
+                        isCodeInputNecessary = true,
+                        isCurrentCodeInvalid = true,
+                    )
+                }
                 is RegisterClientResult.Failure.InvalidCredentials -> state = state.copy(error = RemoveDeviceError.InvalidCredentialsError)
                 is RegisterClientResult.Failure.TooManyClients -> loadClientsList()
                 is RegisterClientResult.Success -> sendAction(OnComplete(userDataStore.initialSyncCompleted.first(), false))
@@ -200,6 +234,43 @@ class RemoveDeviceViewModel @Inject constructor(
 
     private companion object {
         const val REGISTER_CLIENT_AFTER_DELETE_DELAY = 2000L
+    }
+
+    fun onCodeResend() {
+        viewModelScope.launch {
+            request2FACode()
+        }
+    }
+
+    fun onCodeVerificationBackPress() {
+        secondFactorVerificationCodeTextState.clearText()
+        secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(
+            isCodeInputNecessary = false,
+            emailUsed = "",
+        )
+    }
+
+    private suspend fun request2FACode() {
+        getSelfUser()?.email?.let { email ->
+            requestSecondFactorVerificationCodeUseCase(
+                email = email,
+                verifiableAction = VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION
+            ).let { result ->
+                when (result) {
+                    is RequestSecondFactorVerificationCodeUseCase.Result.Success,
+                    is RequestSecondFactorVerificationCodeUseCase.Result.Failure.TooManyRequests -> {
+                        secondFactorVerificationCodeState = secondFactorVerificationCodeState.copy(
+                            isCodeInputNecessary = true,
+                            emailUsed = email,
+                        )
+                    }
+
+                    is RequestSecondFactorVerificationCodeUseCase.Result.Failure.Generic -> {
+                        state = state.copy(error = RemoveDeviceError.GenericError(result.cause))
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModelTest.kt
@@ -22,10 +22,12 @@ import com.wire.android.config.SnapshotExtension
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.framework.TestClient.CLIENT
 import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerificationCodeUseCase
 import com.wire.kalium.logic.feature.client.DeleteClientUseCase
 import com.wire.kalium.logic.feature.client.FetchSelfClientsFromRemoteUseCase
 import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
 import com.wire.kalium.logic.feature.client.SelfClientsResult
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -98,6 +100,12 @@ class RemoveDeviceViewModelTest {
         @MockK
         lateinit var userDataStore: UserDataStore
 
+        @MockK
+        lateinit var getSelfUser: GetSelfUserUseCase
+
+        @MockK
+        lateinit var requestSecondFactorVerificationCodeUseCase: RequestSecondFactorVerificationCodeUseCase
+
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
         }
@@ -111,7 +119,9 @@ class RemoveDeviceViewModelTest {
             deleteClientUseCase = deleteClientUseCase,
             registerClientUseCase = registerClientUseCase,
             isPasswordRequired = isPasswordRequired,
-            userDataStore = userDataStore
+            userDataStore = userDataStore,
+            getSelfUser = getSelfUser,
+            requestSecondFactorVerificationCodeUseCase = requestSecondFactorVerificationCodeUseCase,
         )
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11401" title="WPB-11401" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11401</a>  [Android] Handle the case where client register got failed/interacted when 2FA is active
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-11401

# What's new in this PR?

### Issues
User logs in and need to remove client because he already has too many. No 2FA core is requested if new client registration fails with "Verification Code Missing" error. See ticket for exact scenario to reproduce.

### Causes (Optional)
2FA errors not handled when registering new client after removing client.

### Solutions
Request 2FA verification code if registering new client fails with "Verification Code Missing" error.
