### PR TITLE
feat: add team management access from main navigation (WPB-17721)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/HomeDestination.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/HomeDestination.kt
@@ -20,6 +20,7 @@ package com.wire.android.navigation
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.core.net.toUri
 import com.ramcosta.composedestinations.spec.Direction
 import com.wire.android.R
 import com.wire.android.ui.destinations.AllConversationsScreenDestination
@@ -38,6 +39,7 @@ sealed class HomeDestination(
     val withUserAvatar: Boolean = true,
     val direction: Direction,
     val searchBar: SearchBarOptions? = null,
+    val isExternalDestination: Boolean = false
 ) {
     data object Conversations : HomeDestination(
         title = UIText.StringResource(R.string.conversations_screen_title),
@@ -70,13 +72,21 @@ sealed class HomeDestination(
     data object Support : HomeDestination(
         title = UIText.StringResource(R.string.support_screen_title),
         icon = R.drawable.ic_support,
-        direction = SupportScreenDestination
+        direction = SupportScreenDestination,
+        isExternalDestination = true
     )
 
     data object WhatsNew : HomeDestination(
         title = UIText.StringResource(R.string.whats_new_screen_title),
         icon = R.drawable.ic_star,
         direction = WhatsNewScreenDestination
+    )
+
+    data class TeamManagement(val teamUrl: String) : HomeDestination(
+        title = UIText.StringResource(R.string.team_management_screen_title),
+        icon = R.drawable.ic_team_management,
+        direction = TeamManagementScreenDestination(uri = teamUrl.toUri()),
+        isExternalDestination = true
     )
 
     data object Cells : HomeDestination(

--- a/app/src/main/kotlin/com/wire/android/navigation/HomeDestination.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/HomeDestination.kt
@@ -20,7 +20,6 @@ package com.wire.android.navigation
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.core.net.toUri
 import com.ramcosta.composedestinations.spec.Direction
 import com.wire.android.R
 import com.wire.android.ui.destinations.AllConversationsScreenDestination

--- a/app/src/main/kotlin/com/wire/android/navigation/HomeDestination.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/HomeDestination.kt
@@ -80,10 +80,10 @@ sealed class HomeDestination(
         direction = WhatsNewScreenDestination
     )
 
-    data class TeamManagement(val teamUrl: String) : HomeDestination(
+    data object TeamManagement : HomeDestination(
         title = UIText.StringResource(R.string.team_management_screen_title),
         icon = R.drawable.ic_team_management,
-        direction = TeamManagementScreenDestination(uri = teamUrl.toUri())
+        direction = TeamManagementScreenDestination
     )
 
     data object Cells : HomeDestination(
@@ -107,6 +107,6 @@ sealed class HomeDestination(
             values().find { it.direction.route.getBaseRoute() == fullRoute.getBaseRoute() }
 
         fun values(): Array<HomeDestination> =
-            arrayOf(Conversations, Settings, Vault, Archive, Support, WhatsNew, Cells)
+            arrayOf(Conversations, Settings, Vault, Archive, Support, TeamManagement, WhatsNew, Cells)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/navigation/HomeDestination.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/HomeDestination.kt
@@ -39,7 +39,6 @@ sealed class HomeDestination(
     val withUserAvatar: Boolean = true,
     val direction: Direction,
     val searchBar: SearchBarOptions? = null,
-    val isExternalDestination: Boolean = false
 ) {
     data object Conversations : HomeDestination(
         title = UIText.StringResource(R.string.conversations_screen_title),
@@ -72,8 +71,7 @@ sealed class HomeDestination(
     data object Support : HomeDestination(
         title = UIText.StringResource(R.string.support_screen_title),
         icon = R.drawable.ic_support,
-        direction = SupportScreenDestination,
-        isExternalDestination = true
+        direction = SupportScreenDestination
     )
 
     data object WhatsNew : HomeDestination(
@@ -85,8 +83,7 @@ sealed class HomeDestination(
     data class TeamManagement(val teamUrl: String) : HomeDestination(
         title = UIText.StringResource(R.string.team_management_screen_title),
         icon = R.drawable.ic_team_management,
-        direction = TeamManagementScreenDestination(uri = teamUrl.toUri()),
-        isExternalDestination = true
+        direction = TeamManagementScreenDestination(uri = teamUrl.toUri())
     )
 
     data object Cells : HomeDestination(

--- a/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
@@ -57,6 +57,8 @@ object SupportScreenDestination : ExternalUriStringResDirection {
         get() = R.string.url_support
 }
 
+data class TeamManagementScreenDestination(override val uri: Uri) : ExternalUriDirection
+
 object PrivacyPolicyScreenDestination : ExternalUriStringResDirection {
     override val uriStringRes: Int
         get() = R.string.url_privacy_policy

--- a/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
@@ -34,7 +34,7 @@ import com.wire.android.util.multipleFileSharingIntent
 import com.wire.android.util.sha256
 
 /**
- * The route is not that relevant the route will not be used for navigation, it will be overridden by a direct custom tab launch.
+ * The route is not that relevant as won't be used for navigation, it will be overridden by a direct custom tab launch.
  */
 interface ExternalDirectionLess : Direction {
     override val route: String

--- a/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
@@ -34,7 +34,7 @@ import com.wire.android.util.multipleFileSharingIntent
 import com.wire.android.util.sha256
 
 /**
- * The route is not relevant as an action is triggered by the navigation
+ * The route is not that relevant the route will not be used for navigation, it will be overridden by a direct custom tab launch.
  */
 interface ExternalDirectionLess : Direction {
     override val route: String

--- a/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
@@ -33,6 +33,14 @@ import com.wire.android.util.getUrisOfFilesInDirectory
 import com.wire.android.util.multipleFileSharingIntent
 import com.wire.android.util.sha256
 
+/**
+ * The route is not relevant as an action is triggered by the navigation
+ */
+interface ExternalDirectionLess : Direction {
+    override val route: String
+        get() = this::class.qualifiedName.orEmpty()
+}
+
 interface ExternalUriDirection : Direction {
     val uri: Uri
     override val route: String
@@ -57,7 +65,7 @@ object SupportScreenDestination : ExternalUriStringResDirection {
         get() = R.string.url_support
 }
 
-data class TeamManagementScreenDestination(override val uri: Uri) : ExternalUriDirection
+data object TeamManagementScreenDestination : ExternalDirectionLess
 
 object PrivacyPolicyScreenDestination : ExternalUriStringResDirection {
     override val uriStringRes: Int

--- a/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawer.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
+import com.wire.android.navigation.ExternalUriDirection
+import com.wire.android.navigation.ExternalUriStringResDirection
 import com.wire.android.navigation.HomeDestination
 import com.wire.android.ui.common.Logo
 import com.wire.android.ui.common.colorsScheme
@@ -125,8 +127,7 @@ fun HomeDrawer(
             DrawerItem(
                 destination = item,
                 selected = currentRoute == item.direction.route,
-                onItemClick = remember { { navigateAndCloseDrawer(item) } },
-                isExternalDestination = item.isExternalDestination
+                onItemClick = remember { { navigateAndCloseDrawer(item) } }
             )
         }
     }
@@ -139,7 +140,6 @@ fun DrawerItem(
     onItemClick: () -> Unit,
     modifier: Modifier = Modifier,
     unreadCount: Int = 0,
-    isExternalDestination: Boolean = false
 ) {
     val backgroundColor = if (selected) MaterialTheme.colorScheme.primary else Color.Transparent
     val contentColor = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onBackground
@@ -170,14 +170,16 @@ fun DrawerItem(
                 .weight(1F)
         )
         UnreadMessageEventBadge(unreadMessageCount = unreadCount)
-        if (isExternalDestination) {
-            HorizontalSpace.x8()
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.OpenInNew,
-                contentDescription = null,
-                tint = colorsScheme().secondaryText,
-                modifier = Modifier.size(dimensions().spacing16x)
-            )
+        with(destination) {
+            if (direction is ExternalUriDirection || direction is ExternalUriStringResDirection) {
+                HorizontalSpace.x8()
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                    contentDescription = null,
+                    tint = colorsScheme().secondaryText,
+                    modifier = Modifier.size(dimensions().spacing16x)
+                )
+            }
         }
         HorizontalSpace.x12()
     }
@@ -214,10 +216,9 @@ fun PreviewUnSelectedArchivedItemWithUnreadCount() {
 fun PreviewItemWithExternalDestination() {
     Box(modifier = Modifier.background(color = MaterialTheme.colorScheme.surface)) {
         DrawerItem(
-            destination = HomeDestination.Archive,
+            destination = HomeDestination.Support,
             selected = false,
             onItemClick = {},
-            isExternalDestination = true
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawer.kt
@@ -27,8 +27,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -46,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.navigation.HomeDestination
 import com.wire.android.ui.common.Logo
+import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.selectableBackground
 import com.wire.android.ui.common.spacers.HorizontalSpace
@@ -109,12 +114,19 @@ fun HomeDrawer(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        val bottomItems = listOf(HomeDestination.WhatsNew, HomeDestination.Settings, HomeDestination.Support)
+        val bottomItems = buildList {
+            add(HomeDestination.WhatsNew)
+            add(HomeDestination.Settings)
+            if (homeDrawerState.teamManagementUrl.isNotBlank()) add(HomeDestination.TeamManagement(homeDrawerState.teamManagementUrl))
+            add(HomeDestination.Support)
+        }
+
         bottomItems.forEach { item ->
             DrawerItem(
                 destination = item,
                 selected = currentRoute == item.direction.route,
-                onItemClick = remember { { navigateAndCloseDrawer(item) } }
+                onItemClick = remember { { navigateAndCloseDrawer(item) } },
+                isExternalDestination = item.isExternalDestination
             )
         }
     }
@@ -127,6 +139,7 @@ fun DrawerItem(
     onItemClick: () -> Unit,
     modifier: Modifier = Modifier,
     unreadCount: Int = 0,
+    isExternalDestination: Boolean = false
 ) {
     val backgroundColor = if (selected) MaterialTheme.colorScheme.primary else Color.Transparent
     val contentColor = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onBackground
@@ -157,6 +170,15 @@ fun DrawerItem(
                 .weight(1F)
         )
         UnreadMessageEventBadge(unreadMessageCount = unreadCount)
+        if (isExternalDestination) {
+            HorizontalSpace.x8()
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                contentDescription = null,
+                tint = colorsScheme().secondaryText,
+                modifier = Modifier.size(dimensions().spacing16x)
+            )
+        }
         HorizontalSpace.x12()
     }
 }
@@ -183,6 +205,19 @@ fun PreviewUnSelectedArchivedItemWithUnreadCount() {
             selected = false,
             onItemClick = {},
             unreadCount = 100
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewItemWithExternalDestination() {
+    Box(modifier = Modifier.background(color = MaterialTheme.colorScheme.surface)) {
+        DrawerItem(
+            destination = HomeDestination.Archive,
+            selected = false,
+            onItemClick = {},
+            isExternalDestination = true
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawer.kt
@@ -43,11 +43,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
+import com.wire.android.navigation.ExternalDirectionLess
 import com.wire.android.navigation.ExternalUriDirection
 import com.wire.android.navigation.ExternalUriStringResDirection
 import com.wire.android.navigation.HomeDestination
@@ -59,6 +61,7 @@ import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.home.conversationslist.common.UnreadMessageEventBadge
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
@@ -69,6 +72,7 @@ fun HomeDrawer(
     onCloseDrawer: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
     Column(
         modifier = modifier
             .padding(
@@ -119,7 +123,7 @@ fun HomeDrawer(
         val bottomItems = buildList {
             add(HomeDestination.WhatsNew)
             add(HomeDestination.Settings)
-            if (homeDrawerState.teamManagementUrl.isNotBlank()) add(HomeDestination.TeamManagement(homeDrawerState.teamManagementUrl))
+            if (homeDrawerState.teamManagementUrl.isNotBlank()) add(HomeDestination.TeamManagement)
             add(HomeDestination.Support)
         }
 
@@ -127,7 +131,18 @@ fun HomeDrawer(
             DrawerItem(
                 destination = item,
                 selected = currentRoute == item.direction.route,
-                onItemClick = remember { { navigateAndCloseDrawer(item) } }
+                onItemClick = when (item) {
+                    is HomeDestination.TeamManagement -> remember {
+                        {
+                            CustomTabsHelper.launchUrl(context, homeDrawerState.teamManagementUrl)
+                            onCloseDrawer()
+                        }
+                    }
+
+                    else -> {
+                        remember { { navigateAndCloseDrawer(item) } }
+                    }
+                }
             )
         }
     }
@@ -171,7 +186,7 @@ fun DrawerItem(
         )
         UnreadMessageEventBadge(unreadMessageCount = unreadCount)
         with(destination) {
-            if (direction is ExternalUriDirection || direction is ExternalUriStringResDirection) {
+            if (direction is ExternalUriDirection || direction is ExternalUriStringResDirection || direction is ExternalDirectionLess) {
                 HorizontalSpace.x8()
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.OpenInNew,

--- a/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerState.kt
@@ -18,7 +18,10 @@
 
 package com.wire.android.ui.home.drawer
 
+import com.wire.android.util.EMPTY
+
 data class HomeDrawerState(
     val unreadArchiveConversationsCount: Int,
     val showFilesOption: Boolean,
+    val teamManagementUrl: String = String.EMPTY
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerState.kt
@@ -18,10 +18,8 @@
 
 package com.wire.android.ui.home.drawer
 
-import com.wire.android.util.EMPTY
-
 data class HomeDrawerState(
     val unreadArchiveConversationsCount: Int,
     val showFilesOption: Boolean,
-    val teamManagementUrl: String = String.EMPTY
+    val teamManagementUrl: String
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerState.kt
@@ -19,7 +19,8 @@
 package com.wire.android.ui.home.drawer
 
 data class HomeDrawerState(
-    val unreadArchiveConversationsCount: Int,
-    val showFilesOption: Boolean,
-    val teamManagementUrl: String
+    /**
+     * The items to be displayed in the drawer [Pair] of "top" and "bottom" items.
+     */
+    val items: Pair<List<DrawerUiItem>, List<DrawerUiItem>> = emptyList<DrawerUiItem>() to emptyList<DrawerUiItem>()
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModel.kt
@@ -48,6 +48,7 @@ class HomeDrawerViewModel @Inject constructor(
         HomeDrawerState(
             unreadArchiveConversationsCount = 0,
             showFilesOption = false,
+            teamManagementUrl = ""
         )
     )
         private set

--- a/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModel.kt
@@ -25,12 +25,16 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.navigation.HomeDestination
 import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.conversation.ObserveArchivedUnreadConversationsCountUseCase
 import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -38,34 +42,25 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeDrawerViewModel @Inject constructor(
     val savedStateHandle: SavedStateHandle,
-    private val observeArchivedUnreadConversationsCountUseCase: ObserveArchivedUnreadConversationsCountUseCase,
+    private val observeArchivedUnreadConversationsCount: ObserveArchivedUnreadConversationsCountUseCase,
     private val observeSelfUser: ObserveSelfUserUseCase,
     private val getTeamUrl: GetTeamUrlUseCase,
     private val globalDataStore: GlobalDataStore,
 ) : ViewModel() {
 
-    var drawerState by mutableStateOf(
-        HomeDrawerState(
-            unreadArchiveConversationsCount = 0,
-            showFilesOption = false,
-            teamManagementUrl = ""
-        )
-    )
+    var drawerState by mutableStateOf(HomeDrawerState())
         private set
 
     init {
-        observeUnreadArchiveConversationsCount()
-        observeWireCellsFeatureState()
-        observeTeamManagementUrlForUser()
+        buildDrawerItems()
     }
 
-    private fun observeTeamManagementUrlForUser() = viewModelScope.launch {
-        observeSelfUser().collect {
+    private suspend fun observeTeamManagementUrlForUser(): Flow<String> {
+        return observeSelfUser().map {
             when (it.userType) {
                 UserType.ADMIN,
                 UserType.OWNER -> {
-                    val teamManagementUrl = getTeamUrl()
-                    drawerState = drawerState.copy(teamManagementUrl = teamManagementUrl)
+                    getTeamUrl()
                 }
 
                 UserType.INTERNAL,
@@ -74,22 +69,54 @@ class HomeDrawerViewModel @Inject constructor(
                 UserType.GUEST,
                 UserType.SERVICE,
                 UserType.NONE -> {
-                    drawerState = drawerState.copy(teamManagementUrl = String.EMPTY)
+                    String.EMPTY
                 }
             }
         }
     }
 
-    private fun observeWireCellsFeatureState() = viewModelScope.launch {
-        globalDataStore.wireCellsEnabled().collect {
-            drawerState = drawerState.copy(showFilesOption = it)
-        }
-    }
-
-    private fun observeUnreadArchiveConversationsCount() {
+    private fun buildDrawerItems() {
         viewModelScope.launch {
-            observeArchivedUnreadConversationsCountUseCase()
-                .collect { drawerState = drawerState.copy(unreadArchiveConversationsCount = it.toInt()) }
+            combine(
+                globalDataStore.wireCellsEnabled(),
+                observeArchivedUnreadConversationsCount(),
+                observeTeamManagementUrlForUser()
+            ) { wireCellsEnabled, unreadArchiveConversationsCount, teamManagementUrl ->
+                buildList {
+                    add(DrawerUiItem.RegularItem(destination = HomeDestination.Conversations))
+                    if (wireCellsEnabled) {
+                        add(DrawerUiItem.RegularItem(destination = HomeDestination.Cells))
+                    }
+                    add(
+                        DrawerUiItem.UnreadCounterItem(
+                            destination = HomeDestination.Archive,
+                            unreadCount = unreadArchiveConversationsCount
+                        )
+                    )
+                } to buildList {
+                    add(DrawerUiItem.RegularItem(destination = HomeDestination.WhatsNew))
+                    add(DrawerUiItem.RegularItem(destination = HomeDestination.Settings))
+                    if (teamManagementUrl.isNotBlank()) add(
+                        DrawerUiItem.DynamicExternalNavigationItem(
+                            destination = HomeDestination.TeamManagement,
+                            url = teamManagementUrl
+                        )
+                    )
+                    add(DrawerUiItem.RegularItem(destination = HomeDestination.Support))
+                }
+            }.collect {
+                drawerState = drawerState.copy(items = it)
+            }
         }
     }
+}
+
+/**
+ * The type of the main navigation item.
+ * Regular, with counter or with external navigation.
+ */
+sealed class DrawerUiItem(open val destination: HomeDestination) {
+    data class RegularItem(override val destination: HomeDestination) : DrawerUiItem(destination)
+    data class UnreadCounterItem(override val destination: HomeDestination, val unreadCount: Long) : DrawerUiItem(destination)
+    data class DynamicExternalNavigationItem(override val destination: HomeDestination, val url: String) : DrawerUiItem(destination)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModel.kt
@@ -96,12 +96,14 @@ class HomeDrawerViewModel @Inject constructor(
                 } to buildList {
                     add(DrawerUiItem.RegularItem(destination = HomeDestination.WhatsNew))
                     add(DrawerUiItem.RegularItem(destination = HomeDestination.Settings))
-                    if (teamManagementUrl.isNotBlank()) add(
-                        DrawerUiItem.DynamicExternalNavigationItem(
-                            destination = HomeDestination.TeamManagement,
-                            url = teamManagementUrl
+                    if (teamManagementUrl.isNotBlank()) {
+                        add(
+                            DrawerUiItem.DynamicExternalNavigationItem(
+                                destination = HomeDestination.TeamManagement,
+                                url = teamManagementUrl
+                            )
                         )
-                    )
+                    }
                     add(DrawerUiItem.RegularItem(destination = HomeDestination.Support))
                 }
             }.collect {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -578,6 +578,7 @@ fun PersonalSelfUserProfileScreenPreview() {
                 fullName = "Some User",
                 userName = "some-user",
                 teamName = null,
+                teamUrl = "some-url",
                 otherAccounts = listOf(
                     OtherAccount(
                         id = UserId("id1", "domain"),

--- a/app/src/main/res/drawable/ic_team_management.xml
+++ b/app/src/main/res/drawable/ic_team_management.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M2.909,5.002V10.998L8,14.013L13.091,10.998V5.002L8,1.987L2.909,5.002ZM7.17,0.203C7.628,-0.069 8.376,-0.066 8.83,0.203L14.17,3.364C14.628,3.635 15,4.301 15,4.839V11.161C15,11.704 14.624,12.367 14.17,12.636L8.83,15.797C8.372,16.069 7.624,16.066 7.17,15.797L1.83,12.636C1.372,12.365 1,11.699 1,11.161V4.839C1,4.296 1.376,3.633 1.83,3.364L7.17,0.203Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -318,6 +318,7 @@
     <string name="backup_and_restore_screen_title">Back up &amp; Restore Conversations</string>
     <string name="search_bar_conversations_hint">Search conversations</string>
     <string name="search_no_results">No matches found</string>
+    <string name="team_management_screen_title">Team Management</string>
     <!--Whats New -->
     <string name="whats_new_screen_title">What\'s new</string>
     <string name="whats_new_welcome_to_new_android_app_label">👋 Welcome to Wire\'s New Android App!</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModelTest.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -59,7 +59,7 @@ class HomeDrawerViewModelTest {
 
         // Then
         assertEquals(
-            unreadCount.toInt(),
+            unreadCount,
             listOf(
                 viewModel.drawerState.items.first,
                 viewModel.drawerState.items.second
@@ -72,11 +72,12 @@ class HomeDrawerViewModelTest {
     @Test
     fun `given userIsAdmin, when starts observing, then set team url`() = runTest {
         // Given
-        val (_, viewModel) = Arrangement()
+        val (arrangement, viewModel) = Arrangement()
             .withSelfUserType(UserType.ADMIN)
             .arrange()
 
         // When
+        arrangement.unreadArchivedConversationsCountChannel.send(0L)
         advanceUntilIdle()
 
         // Then

--- a/app/src/test/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModelTest.kt
@@ -22,7 +22,6 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.framework.TestUser
-import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.conversation.ObserveArchivedUnreadConversationsCountUseCase
 import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
@@ -59,8 +58,14 @@ class HomeDrawerViewModelTest {
         advanceUntilIdle()
 
         // Then
-        assertEquals(unreadCount.toInt(), viewModel.drawerState.unreadArchiveConversationsCount)
-        assertEquals(String.EMPTY, viewModel.drawerState.teamManagementUrl)
+        assertEquals(
+            unreadCount.toInt(),
+            listOf(
+                viewModel.drawerState.items.first,
+                viewModel.drawerState.items.second
+            ).filterIsInstance<DrawerUiItem.UnreadCounterItem>()
+                .first().unreadCount
+        )
     }
 
     @Test
@@ -74,7 +79,14 @@ class HomeDrawerViewModelTest {
         advanceUntilIdle()
 
         // Then
-        assertEquals(Arrangement.TEAM_URL, viewModel.drawerState.teamManagementUrl)
+        assertEquals(
+            Arrangement.TEAM_URL,
+            listOf(
+                viewModel.drawerState.items.first,
+                viewModel.drawerState.items.second
+            ).filterIsInstance<DrawerUiItem.DynamicExternalNavigationItem>()
+                .first().url
+        )
     }
 
     private class Arrangement {
@@ -111,7 +123,7 @@ class HomeDrawerViewModelTest {
 
         fun arrange() = this to HomeDrawerViewModel(
             savedStateHandle = savedStateHandle,
-            observeArchivedUnreadConversationsCountUseCase = observeArchivedUnreadConversationsCount,
+            observeArchivedUnreadConversationsCount = observeArchivedUnreadConversationsCount,
             globalDataStore = globalDataStore,
             observeSelfUser = observeSelfUserUseCase,
             getTeamUrl = getTeamUrlUseCase

--- a/app/src/test/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModelTest.kt
@@ -63,7 +63,8 @@ class HomeDrawerViewModelTest {
             listOf(
                 viewModel.drawerState.items.first,
                 viewModel.drawerState.items.second
-            ).filterIsInstance<DrawerUiItem.UnreadCounterItem>()
+            ).flatten()
+                .filterIsInstance<DrawerUiItem.UnreadCounterItem>()
                 .first().unreadCount
         )
     }
@@ -84,7 +85,8 @@ class HomeDrawerViewModelTest {
             listOf(
                 viewModel.drawerState.items.first,
                 viewModel.drawerState.items.second
-            ).filterIsInstance<DrawerUiItem.DynamicExternalNavigationItem>()
+            ).flatten()
+                .filterIsInstance<DrawerUiItem.DynamicExternalNavigationItem>()
                 .first().url
         )
     }
@@ -111,7 +113,6 @@ class HomeDrawerViewModelTest {
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
             coEvery { observeArchivedUnreadConversationsCount() } returns unreadArchivedConversationsCountChannel.consumeAsFlow()
-            every { globalDataStore.wireCellsEnabled() } returns flowOf(false)
             every { globalDataStore.wireCellsEnabled() } returns flowOf(false)
             withSelfUserType()
             coEvery { getTeamUrlUseCase() } returns TEAM_URL


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17721" title="WPB-17721" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-17721</a>  [Android] Add link to Team Management (TM) in main menu for admins and team owners
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Add from the main app drawer the navigation to team management
- Add external link indicator to items that they are
- This navigation is available for admins and team owners only

#### How to Test

- Login the app, as an admin or owner, see the link to team management (TM)
- Login as a regular user, you should not see a link to TM

### Attachments (Optional)

[Screen_recording_20250630_154354.webm](https://github.com/user-attachments/assets/8c315be9-42fb-42d7-88be-04a16049fee5)

![Screenshot 2025-06-30 at 15 45 14](https://github.com/user-attachments/assets/1767e69e-87b0-4e4f-8d73-0518c698f571)


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
