### PR TITLE
fix: channel history indicator alignment and flickering [WPB-15859]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/PageLoadingIndicator.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/PageLoadingIndicator.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import com.wire.android.R
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
@@ -68,6 +69,7 @@ fun PageLoadingIndicator(
                 text = text,
                 style = typography().subline01,
                 color = colorsScheme().secondaryText,
+                textAlign = TextAlign.Center,
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -1333,7 +1334,18 @@ fun MessageList(
                                     .fillMaxWidth()
                                     .padding(dimensions().spacing16x),
                             ) {
-                                val (text, prefixIconResId) = when (lazyPagingMessages.loadState.prepend.endOfPaginationReached) {
+                                var allMessagesPrepended by remember { mutableStateOf(false) }
+                                LaunchedEffect(lazyPagingMessages.loadState) {
+                                    // When the list is being refreshed, the load state for prepend is cleared so the app doesn't know if
+                                    // the end of pagination is reached or not for prepend until the refresh is done, so we don't want to
+                                    // update the allMessagesPrepended state while refreshing and in that case keep the last updated state,
+                                    // otherwise the indicator will flicker while refreshing.
+                                    if (lazyPagingMessages.loadState.refresh is LoadState.NotLoading) {
+                                        allMessagesPrepended = lazyPagingMessages.loadState.prepend.endOfPaginationReached
+                                    }
+                                }
+
+                                val (text, prefixIconResId) = when (allMessagesPrepended) {
                                     true -> stringResource(R.string.conversation_history_loaded) to null
                                     false -> stringResource(R.string.conversation_history_loading) to R.drawable.ic_undo
                                 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15859" title="WPB-15859" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-15859</a>  [Android] Join a channel - Initial message (system message) - no history available
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Text on the "all pages loaded" indicator is not centered.
- Indicator flickers when the list is being refreshed after some new event is received, even if no new message is being added, but still the load state is reset and "loading next page" indicator is being shown for a split second.

### Solutions

- Add center alignment.
- Calculate the "end of pagination" state for prepending by checking the refresh state and don't update it while refreshing.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <img width="626" alt="image" src="https://github.com/user-attachments/assets/8b1b65d1-677b-446c-9710-f46d77fcd1c8" /> | <img width="619" alt="image" src="https://github.com/user-attachments/assets/b1db2ef7-3247-4d44-9f00-5f2a8fecab8d" /> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
