### PR TITLE
fix: notifications not showing (#WPB-18531)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -538,6 +538,6 @@ class WireNotificationManager @Inject constructor(
 
     companion object {
         private const val TAG = "WireNotificationManager"
-        private val STAY_ALIVE_TIME_ON_PUSH_DURATION = 1.seconds
+        private val STAY_ALIVE_TIME_ON_PUSH_DURATION = 5.seconds
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18531" title="WPB-18531" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18531</a>  [Android] Notification not showing if app process was not running
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-18531
----
# What's new in this PR?

### Issues
Notification for new message is not showing.

### Causes (Optional)
NotificationFetchWorker stops 1 second after receiving Live sync status, but the WebSocket is still not connected and actual message is not received.

### Solutions
Increase the waiting interval for the NotificationFetchWorker so that it can receive the message from socket and show notification.
This is a temporary workaround until we can solve the inconsistent sync status issue.
