### PR TITLE
fix: crash when opening MLS conversation details [WPB-18647]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -271,7 +271,7 @@ private fun conversationProtocolDetailsItems(
             )
         }
 
-        addIf(BuildConfig.PRIVATE_BUILD) {
+        if (BuildConfig.PRIVATE_BUILD) {
             add {
                 ProtocolDetails(
                     label = UIText.StringResource(R.string.last_key_material_update_label),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18647" title="WPB-18647" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18647</a>  [Android]App crashes when navigating to conversation details of a group chat
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app crashes when trying to open conversation details screen of any MLS conversation or channel.

### Causes (Optional)

`if` clause was wrongly replaced by a new function `addIf` in one place.

### Solutions

Revert to use `if` in this particular place.

### Testing

#### How to Test

Open any MLS conversation or channel on private build (so dev, staging, internal or beta) and try to open details.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
