### PR TITLE
fix: reset registration analytics unfinished process (WPB-17459)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -153,6 +153,7 @@ class WireActivityViewModel @Inject constructor(
         observeScreenshotCensoringConfigState()
         observeAppThemeState()
         observeLogoutState()
+        resetNewRegistrationAnalyticsState()
     }
 
     private suspend fun shouldEnrollToE2ei(): Boolean = observeCurrentValidUserId.first()?.let {
@@ -248,7 +249,7 @@ class WireActivityViewModel @Inject constructor(
     @VisibleForTesting
     internal suspend fun initValidSessionsFlowIfNeeded() {
         if (::validSessions.isInitialized.not()) { // initialise valid sessions flow if not already initialised
-                validSessions = validSessionsFlow().stateIn(viewModelScope, SharingStarted.Eagerly, validSessionsFlow().first())
+            validSessions = validSessionsFlow().stateIn(viewModelScope, SharingStarted.Eagerly, validSessionsFlow().first())
         }
     }
 
@@ -511,6 +512,13 @@ class WireActivityViewModel @Inject constructor(
                     }
                 }
         }
+    }
+
+    /**
+     * Reset any unfinished registration process analytics where the user aborted and enabled the registration analytics.
+     */
+    private fun resetNewRegistrationAnalyticsState() = viewModelScope.launch {
+        globalDataStore.get().setAnonymousRegistrationEnabled(false)
     }
 
     private fun CurrentScreen.isGlobalDialogAllowed(): Boolean = when (this) {

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
@@ -121,6 +121,7 @@ fun CreateAccountSelectorScreen(
     )
 
     LaunchedEffect(Unit) {
+        // reset registration enabled analytics state when coming from navigation from child
         viewModel.onPageLoaded()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -118,6 +119,10 @@ fun CreateAccountSelectorScreen(
         onTeamAccountCreationClicked = ::navigateToTeamScreen,
         onNavigateBack = navigator::navigateBack,
     )
+
+    LaunchedEffect(Unit) {
+        viewModel.onPageLoaded()
+    }
 }
 
 @SuppressLint("ComposeModifierMissing")

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModel.kt
@@ -39,7 +39,6 @@ class CreateAccountSelectorViewModel @Inject constructor(
     val teamAccountCreationUrl = serverConfig.teams
 
     fun onPageLoaded() = viewModelScope.launch {
-        println("ym. resetting analytics state")
         globalDataStore.setAnonymousRegistrationEnabled(false)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModel.kt
@@ -19,18 +19,27 @@ package com.wire.android.ui.registration.selector
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.wire.android.config.orDefault
+import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.ui.navArgs
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class CreateAccountSelectorViewModel @Inject constructor(
+    private val globalDataStore: GlobalDataStore,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     val navArgs: CreateAccountSelectorNavArgs = savedStateHandle.navArgs()
     val serverConfig: ServerConfig.Links = navArgs.customServerConfig.orDefault()
     val email: String = navArgs.email.orEmpty()
     val teamAccountCreationUrl = serverConfig.teams
+
+    fun onPageLoaded() = viewModelScope.launch {
+        println("ym. resetting analytics state")
+        globalDataStore.setAnonymousRegistrationEnabled(false)
+    }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -372,6 +372,16 @@ class WireActivityViewModelTest {
     }
 
     @Test
+    fun `given app started, then should  clean any unfinished analytics state`() = runTest {
+        val (arrangement, _) = Arrangement()
+            .withSomeCurrentSession()
+            .withAppUpdateRequired(false)
+            .arrange()
+
+        coEvery { arrangement.globalDataStore.setAnonymousRegistrationEnabled(eq(false)) }
+    }
+
+    @Test
     fun `given appUpdate is required, then should show the appUpdate dialog`() = runTest {
         val (_, viewModel) = Arrangement()
             .withNoCurrentSession()

--- a/app/src/test/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModelTest.kt
@@ -3,6 +3,7 @@ package com.wire.android.ui.registration.selector
 import androidx.lifecycle.SavedStateHandle
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
+import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.ui.navArgs
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import io.mockk.MockKAnnotations
@@ -41,6 +42,10 @@ class CreateAccountSelectorViewModelTest {
     }
 
     private class Arrangement {
+
+        @MockK
+        lateinit var globalDataStore: GlobalDataStore
+
         @MockK
         lateinit var savedStateHandle: SavedStateHandle
 
@@ -55,6 +60,6 @@ class CreateAccountSelectorViewModelTest {
                     CreateAccountSelectorNavArgs(ServerConfig.STAGING, email)
         }
 
-        fun arrange() = this to CreateAccountSelectorViewModel(savedStateHandle)
+        fun arrange() = this to CreateAccountSelectorViewModel(globalDataStore, savedStateHandle)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17459" title="WPB-17459" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-17459</a>  [Android] New Registrations Flows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Reset status of registration analytics in case there it was unfinished and the user enabled it.

### Causes (Optional)

Edge case not handled

### Solutions

Reset on app start.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
