### PR TITLE
fix: keep conversation filter, asset options, self-deleting and member change sheets when rotating [WPB-18248]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
@@ -78,6 +78,7 @@ import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.openDownloadFolder
 import com.wire.kalium.logic.data.id.ConversationId
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
 
 @WireDestination(
     navArgsDelegate = ConversationMediaNavArgs::class,
@@ -263,6 +264,7 @@ enum class ConversationMediaScreenTabItem(@StringRes val titleResId: Int) : TabI
     override val title: UIText = UIText.StringResource(titleResId)
 }
 
+@Serializable
 data class AssetOptionsData(val messageId: String, val isMyMessage: Boolean, val isMultipart: Boolean)
 
 @PreviewMultipleThemes

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/filter/ConversationFilterSheetState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/filter/ConversationFilterSheetState.kt
@@ -29,7 +29,7 @@ import kotlinx.serialization.Serializable
 class ConversationFilterSheetState(
     conversationFilterSheetData: ConversationFilterSheetData = ConversationFilterSheetData(
         currentFilter = ConversationFilter.All,
-        folders = persistentListOf()
+        folders = listOf()
     )
 ) {
     var currentData: ConversationFilterSheetData by mutableStateOf(conversationFilterSheetData)
@@ -47,9 +47,10 @@ class ConversationFilterSheetState(
 data class ConversationFilterSheetData(
     val tab: FilterTab = FilterTab.FILTERS,
     val currentFilter: ConversationFilter,
-    val folders: PersistentList<ConversationFolder>
+    val folders: List<ConversationFolder>
 )
 
+@Serializable
 enum class FilterTab {
     FILTERS,
     FOLDERS

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/filter/ConversationFilterSheetState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/filter/ConversationFilterSheetState.kt
@@ -22,8 +22,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.wire.kalium.logic.data.conversation.ConversationFilter
 import com.wire.kalium.logic.data.conversation.ConversationFolder
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.serialization.Serializable
 
 class ConversationFilterSheetState(

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.data.user.BotService
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
 
 data class OtherUserProfileState(
     val userId: UserId,
@@ -93,6 +94,7 @@ data class OtherUserProfileState(
     ))
 }
 
+@Serializable
 data class OtherUserProfileGroupState(
     val groupName: String,
     val role: Member.Role,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18248" title="WPB-18248" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18248</a>  [Android] Bottom sheets disappearing on screen rotation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When rotating screen, bottom sheets disappear.

### Causes (Optional)

State classes cannot be saved and restored.

### Solutions

Make state classes serializable and replace PersistentList with regular List so that states can be saved and restored. 

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
