### PR TITLE
chore: upgrade AGP to 8.10.1 [WPB-8645]

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,15 +1,334 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.6.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.6.0)" variant="all" version="8.6.0">
+<issues format="6" by="lint 8.10.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.1)" variant="all" version="8.10.1">
 
     <issue
-        id="ProduceStateDoesNotAssignValue"
-        message="produceState calls should assign `value` inside the producer lambda"
-        errorLine1="    return produceState&lt;Bitmap?>(initialValue = null, imageUri) {"
-        errorLine2="           ~~~~~~~~~~~~">
+        id="ComposeViewModelForwarding"
+        message="Forwarding a ViewModel through multiple @Composable functions should be avoided. Consider using state hoisting.See https://slackhq.github.io/compose-lints/rules/#hoist-all-the-things for more information."
+        errorLine1="    CreateAccountOverviewScreen(navigator, CreateAccountFlowType.CreatePersonalAccount, viewModel)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/kotlin/com/wire/android/ui/common/imagepreview/BulletHoleImagePreview.kt"
+            file="src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreatePersonalAccountOverviewScreen.kt"
+            line="71"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeViewModelForwarding"
+        message="Forwarding a ViewModel through multiple @Composable functions should be avoided. Consider using state hoisting.See https://slackhq.github.io/compose-lints/rules/#hoist-all-the-things for more information."
+        errorLine1="    CreateAccountOverviewScreen(navigator, CreateAccountFlowType.CreateTeam, viewModel)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreatePersonalAccountOverviewScreen.kt"
+            line="81"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeViewModelForwarding"
+        message="Forwarding a ViewModel through multiple @Composable functions should be avoided. Consider using state hoisting.See https://slackhq.github.io/compose-lints/rules/#hoist-all-the-things for more information."
+        errorLine1="    LoginContent("
+        errorLine2="    ^">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt"
+            line="95"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeViewModelForwarding"
+        message="Forwarding a ViewModel through multiple @Composable functions should be avoided. Consider using state hoisting.See https://slackhq.github.io/compose-lints/rules/#hoist-all-the-things for more information."
+        errorLine1="    LoginStateNavigationAndDialogs(loginEmailViewModel, navigator)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/newauthentication/login/password/NewLoginPasswordScreen.kt"
+            line="113"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeViewModelForwarding"
+        message="Forwarding a ViewModel through multiple @Composable functions should be avoided. Consider using state hoisting.See https://slackhq.github.io/compose-lints/rules/#hoist-all-the-things for more information."
+        errorLine1="    LoginStateNavigationAndDialogs(loginEmailViewModel, navigator)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/newauthentication/code/NewLoginVerificationCodeScreen.kt"
+            line="65"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="SlotReused"
+        message="Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot&apos;s internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information."
+        errorLine1="    emptyListContent: @Composable (domain: String) -> Unit = {},"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt"
+            line="95"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="SlotReused"
+        message="Slots should be invoked in at most once place to meet lifecycle expectations. Slots should not be invoked in multiple places in source code, where the invoking location changes based on some condition. This will preserve the slot&apos;s internal state when the invoking location changes. See https://slackhq.github.io/compose-lints/rules/#do-not-invoke-slots-in-more-than-once-place for more information."
+        errorLine1="    loadingListContent: @Composable (LazyListState) -> Unit = { ConversationListLoadingContent(it) },"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt"
+            line="97"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun AppSettingsScreen() {"
+        errorLine2="    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/home/settings/appsettings/AppSettingsScreen.kt"
+            line="39"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun PreviewWireDialogWithWaves() = WireTheme {"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/home/newconversation/search/ChannelNotAvailableDialog.kt"
+            line="49"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun EditSelfDeletingMessagesScreen("
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt"
+            line="68"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun EmptySearchQueryScreen() {"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/home/conversations/search/EmptySearchQueryScreen.kt"
+            line="48"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun MembersMentionListPreview() {"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/home/messagecomposer/MembersMentionList.kt"
+            line="75"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun NewAuthContainer("
+        errorLine2="    ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginContainer.kt"
+            line="59"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun NewAuthHeader("
+        errorLine2="    ~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginContainer.kt"
+            line="93"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun NewWelcomeEmptyStartScreen() {"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/newauthentication/welcome/NewWelcomeScreen.kt"
+            line="55"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun RegisterDeviceScreen("
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt"
+            line="80"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun RemoveDeviceScreen("
+        errorLine2="    ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceScreen.kt"
+            line="78"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun TeamMigrationContainer("
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/userprofile/teammigration/common/TeamMigrationContainer.kt"
+            line="53"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun VerificationCodeScreenContent("
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeScreenContent.kt"
+            line="45"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun RowScope.ConversationVerificationIcons("
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/common/VerifiedIcons.kt"
+            line="35"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierMissing"
+        message="This @Composable function emits content but doesn&apos;t have a modifier parameter.See https://slackhq.github.io/compose-lints/rules/#when-should-i-expose-modifier-parameters for more information."
+        errorLine1="fun RowScope.MLSVerificationIcon(mlsVerificationStatus: MLSClientE2EIStatus?) {"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/common/VerifiedIcons.kt"
+            line="71"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierReused"
+        message="Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital &apos;M&apos;) to construct a new Modifier that you can pass to other composables.See https://slackhq.github.io/compose-lints/rules/#dont-re-use-modifiers for more information."
+        errorLine1="    Box(modifier = modifier.padding(top = 60.dp, bottom = 80.dp)) { // paddings to simulate top and bottom bars"
+        errorLine2="    ^">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt"
+            line="130"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierReused"
+        message="Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital &apos;M&apos;) to construct a new Modifier that you can pass to other composables.See https://slackhq.github.io/compose-lints/rules/#dont-re-use-modifiers for more information."
+        errorLine1="        BoxWithConstraints(modifier = modifier.fillMaxSize()) {"
+        errorLine2="        ^">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt"
+            line="131"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierReused"
+        message="Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital &apos;M&apos;) to construct a new Modifier that you can pass to other composables.See https://slackhq.github.io/compose-lints/rules/#dont-re-use-modifiers for more information."
+        errorLine1="    Column("
+        errorLine2="    ^">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt"
+            line="87"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ComposeModifierReused"
+        message="Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital &apos;M&apos;) to construct a new Modifier that you can pass to other composables.See https://slackhq.github.io/compose-lints/rules/#dont-re-use-modifiers for more information."
+        errorLine1="        ConnectivityStatusBar("
+        errorLine2="        ^">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt"
+            line="92"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ComposeParameterOrder"
+        message="Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.&#xA;Current params are: [forgotPasswordUrl: String, textColor: Color = colorsScheme().primary, modifier: Modifier = Modifier] but should be [forgotPasswordUrl: String, modifier: Modifier = Modifier, textColor: Color = colorsScheme().primary].&#xA;See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information."
+        errorLine1="fun ForgotPasswordLabel("
+        errorLine2="                       ^">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt"
+            line="269"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="ComposeParameterOrder"
+        message="Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.&#xA;Current params are: [loading: Boolean, enabled: Boolean, text: String = stringResource(R.string.label_login), loadingText: String = stringResource(R.string.label_logging_in), modifier: Modifier = Modifier, onClick: () -> Unit] but should be [loading: Boolean, enabled: Boolean, modifier: Modifier = Modifier, text: String = stringResource(R.string.label_login), loadingText: String = stringResource(R.string.label_logging_in), onClick: () -> Unit].&#xA;See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information."
+        errorLine1="fun LoginButton("
+        errorLine2="               ^">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt"
+            line="302"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="ComposeParameterOrder"
+        message="Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.&#xA;Current params are: [title: String, verticalPadding: Dp = dimensions().spacing2x, modifier: Modifier = Modifier] but should be [title: String, modifier: Modifier = Modifier, verticalPadding: Dp = dimensions().spacing2x].&#xA;See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information."
+        errorLine1="fun NewAuthTitle("
+        errorLine2="                ^">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginContainer.kt"
+            line="130"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="ComposeParameterOrder"
+        message="Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.&#xA;Current params are: [title: String, verticalPadding: Dp = dimensions().spacing2x, modifier: Modifier = Modifier] but should be [title: String, modifier: Modifier = Modifier, verticalPadding: Dp = dimensions().spacing2x].&#xA;See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information."
+        errorLine1="fun NewAuthSubtitle("
+        errorLine2="                   ^">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginContainer.kt"
+            line="146"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="ComposeParameterOrder"
+        message="Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.&#xA;Current params are: [participants: List&lt;UICallParticipant>, isSelfUserMuted: Boolean, isSelfUserCameraOn: Boolean, isInPictureInPictureMode: Boolean, isOnFrontCamera: Boolean, contentHeight: Dp, contentWidth: Dp, recentReactions: Map&lt;UserId, String>, onSelfVideoPreviewCreated: (view: View) -> Unit, onSelfClearVideoPreview: () -> Unit, requestVideoStreams: (participants: List&lt;UICallParticipant>) -> Unit, onDoubleTap: (selectedParticipant: SelectedParticipant) -> Unit, flipCamera: () -> Unit, gridParams: CallingGridParams = CallingGridParams.fromScreenDimensions(width = contentWidth, height = contentHeight), modifier: Modifier = Modifier] but should be [participants: List&lt;UICallParticipant>, isSelfUserMuted: Boolean, isSelfUserCameraOn: Boolean, isInPictureInPictureMode: Boolean, isOnFrontCamera: Boolean, contentHeight: Dp, contentWidth: Dp, recentReactions: Map&lt;UserId, String>, onSelfVideoPreviewCreated: (view: View) -> Unit, onSelfClearVideoPreview: () -> Unit, requestVideoStreams: (participants: List&lt;UICallParticipant>) -> Unit, onDoubleTap: (selectedParticipant: SelectedParticipant) -> Unit, flipCamera: () -> Unit, modifier: Modifier = Modifier, gridParams: CallingGridParams = CallingGridParams.fromScreenDimensions(width = contentWidth, height = contentHeight)].&#xA;See https://slackhq.github.io/compose-lints/rules/#ordering-composable-parameters-properly for more information."
+        errorLine1="fun VerticalCallingPager("
+        errorLine2="                        ^">
+        <location
+            file="src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt"
             line="54"
-            column="12"/>
+            column="25"/>
     </issue>
 
 </issues>

--- a/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/MessageNotificationManager.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.notification
 
+import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationManager
 import android.content.Context
@@ -137,6 +138,8 @@ class MessageNotificationManager
         }
     }
 
+    @SuppressLint("MissingPermission")
+    // TODO(permissions): Check for permission before calling notificationManagerCompat.notify
     private fun showConversationNotification(
         localConversation: LocalNotification.Conversation,
         userId: QualifiedID,
@@ -150,6 +153,8 @@ class MessageNotificationManager
         }
     }
 
+    // TODO(permissions): Check for permission before calling notificationManagerCompat.notify
+    @SuppressLint("MissingPermission")
     private fun updateConversationNotification(
         conversationId: ConversationId,
         updateMessages: List<LocalNotification.UpdateMessage>,
@@ -462,6 +467,7 @@ class MessageNotificationManager
          * @param replyText String text the user replied to the conversation.
          * If it's null then just update the notification to remove send reply loading.
          */
+        @SuppressLint("MissingPermission")
         fun updateNotificationAfterQuickReply(
             context: Context,
             conversationId: String,
@@ -498,6 +504,7 @@ class MessageNotificationManager
                 setStyle(messagesStyle)
             }.build()
 
+            // TODO(permissions): Check for permission before calling notificationManagerCompat.notify
             NotificationManagerCompat.from(context).notify(conversationNotificationId, notification)
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBar.kt
@@ -54,7 +54,7 @@ import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
 import com.wire.android.ui.common.preview.EdgeToEdgePreview
 import com.wire.android.ui.theme.WireColorScheme
 import com.wire.android.ui.theme.WireTheme
-import com.wire.android.ui.theme.updateSystemBarIconsAppearance
+import com.wire.android.ui.theme.UpdateSystemBarIconsAppearance
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
@@ -82,7 +82,7 @@ fun CommonTopAppBar(
         if (colorScheme.getStatusBarUseDarkIcons(colorType)) 1f else 0f
     }
 
-    updateSystemBarIconsAppearance(systemBarUseDarkIcons.value > 0.5f)
+    UpdateSystemBarIconsAppearance(systemBarUseDarkIcons.value > 0.5f)
 
     Column(
         modifier = modifier

--- a/core/navigation/src/main/kotlin/com/wire/android/navigation/PreviewResultRecipient.kt
+++ b/core/navigation/src/main/kotlin/com/wire/android/navigation/PreviewResultRecipient.kt
@@ -17,12 +17,14 @@
  */
 package com.wire.android.navigation
 
+import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisallowComposableCalls
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultRecipient
 import com.ramcosta.composedestinations.spec.DestinationSpec
 
+@SuppressLint("ComposeNamingUppercase")
 object PreviewResultRecipient : ResultRecipient<DestinationSpec<Unit>, String> {
 
     @Composable

--- a/core/navigation/src/main/kotlin/com/wire/android/navigation/wrapper/TabletDialogWrapper.kt
+++ b/core/navigation/src/main/kotlin/com/wire/android/navigation/wrapper/TabletDialogWrapper.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import com.ramcosta.composedestinations.scope.DestinationScope
@@ -32,16 +34,17 @@ object TabletDialogWrapper : DestinationWrapper {
 
     @Composable
     override fun <T> DestinationScope<T>.Wrap(screenContent: @Composable () -> Unit) {
+        val movableContent = remember(screenContent) { movableContentOf(screenContent) }
         if (this.destination.style is DestinationStyle.Dialog) {
             Row(
                 modifier = Modifier
                     .clip(RoundedCornerShape(dimensions().spacing20x))
                     .imePadding()
             ) {
-                screenContent()
+                movableContent()
             }
         } else {
-            screenContent()
+            movableContent()
         }
     }
 }

--- a/core/navigation/src/main/kotlin/com/wire/android/navigation/wrapper/WaitUntilTransitionEndsWrapper.kt
+++ b/core/navigation/src/main/kotlin/com/wire/android/navigation/wrapper/WaitUntilTransitionEndsWrapper.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -38,6 +39,7 @@ object WaitUntilTransitionEndsWrapper : DestinationWrapper {
 
     @Composable
     override fun <T> DestinationScope<T>.Wrap(screenContent: @Composable () -> Unit) {
+        val movableContent = remember(screenContent) { movableContentOf(screenContent) }
         if (this is AnimatedDestinationScope<T>) {
             var transitionComplete by remember { mutableStateOf(false) }
             LaunchedEffect(transition.isRunning, transition.currentState, transition.targetState) {
@@ -45,7 +47,7 @@ object WaitUntilTransitionEndsWrapper : DestinationWrapper {
                     transitionComplete = !isRunning && currentState == targetState && currentState == EnterExitState.Visible
                 }
             }
-            screenContent()
+            movableContent()
             if (!transitionComplete) {
                 Box(
                     modifier = Modifier
@@ -56,7 +58,7 @@ object WaitUntilTransitionEndsWrapper : DestinationWrapper {
                 )
             }
         } else {
-            screenContent()
+            movableContent()
         }
     }
 }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireBottomSheetDefaults.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireBottomSheetDefaults.kt
@@ -41,9 +41,9 @@ object WireBottomSheetDefaults {
     val WireSheetTonalElevation: Dp @Composable get() = 0.dp
 
     @Composable
-    fun WireDragHandle() {
+    fun WireDragHandle(modifier: Modifier = Modifier) {
         Box(
-            Modifier
+            modifier
                 .padding(vertical = dimensions().spacing12x)
                 .size(width = dimensions().modalBottomSheetDividerWidth, height = dimensions().spacing4x)
                 .background(color = colorsScheme().secondaryText, shape = RoundedCornerShape(size = dimensions().spacing2x))

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/button/WireSwitch.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/button/WireSwitch.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
@@ -97,7 +98,7 @@ fun wireSwitchColors(
     disabledUncheckedIconColor = disabledUncheckedIconColor
 )
 
-@PreviewMultipleThemes
+@PreviewLightDark
 @Composable
 fun PreviewWireSwitchOn() = WireTheme {
     WireSwitch(checked = true, onCheckedChange = {})

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/progress/CenteredCircularProgressBarIndicator.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/progress/CenteredCircularProgressBarIndicator.kt
@@ -26,8 +26,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
-fun CenteredCircularProgressBarIndicator() {
-    Box(Modifier.fillMaxSize()) {
+fun CenteredCircularProgressBarIndicator(modifier: Modifier = Modifier) {
+    Box(modifier.fillMaxSize()) {
         CircularProgressIndicator(Modifier.align(Alignment.Center))
     }
 }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/progress/WireCircularProgressIndicator.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/progress/WireCircularProgressIndicator.kt
@@ -28,8 +28,8 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun WireCircularProgressIndicator(
-    modifier: Modifier = Modifier,
     progressColor: Color,
+    modifier: Modifier = Modifier,
     strokeWidth: Dp = 2.dp,
     size: Dp = 16.dp
 ) {

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/snackbar/SwipeableSnackbar.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/snackbar/SwipeableSnackbar.kt
@@ -62,6 +62,7 @@ import kotlin.math.roundToInt
 fun SwipeableSnackbar(
     hostState: SnackbarHostState,
     data: SnackbarData,
+    modifier: Modifier = Modifier,
     onDismiss: () -> Unit = { hostState.currentSnackbarData?.dismiss() },
 ) {
     val density = LocalDensity.current
@@ -105,7 +106,7 @@ fun SwipeableSnackbar(
     Snackbar(
         snackbarData = data,
         shape = RoundedCornerShape(MaterialTheme.wireDimensions.buttonSmallCornerSize),
-        modifier = Modifier
+        modifier = modifier
             .anchoredDraggable(
                 state = state,
                 orientation = Orientation.Horizontal

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/StatusBarsHelper.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/StatusBarsHelper.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
 @Composable
-fun updateSystemBarIconsAppearance(useDarkSystemBarIcons: Boolean) {
+fun UpdateSystemBarIconsAppearance(useDarkSystemBarIcons: Boolean) {
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/Theme.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/Theme.kt
@@ -55,7 +55,7 @@ fun WireTheme(
             typography = wireTypography.toTypography()
         ) {
             if (!isPreview) {
-                updateSystemBarIconsAppearance(wireColorScheme.useDarkSystemBarIcons)
+                UpdateSystemBarIconsAppearance(wireColorScheme.useDarkSystemBarIcons)
             }
             content()
         }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/tags/AddRemoveTagsScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/tags/AddRemoveTagsScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.feature.cells.R
@@ -292,6 +293,7 @@ fun AddRemoveTagsScreenContent(
 }
 
 @MultipleThemePreviews
+@Preview
 @Composable
 fun PreviewAddRemoveTagsScreen() {
     WireTheme {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ datafaker = "2.4.2"
 detekt = "1.23.8"
 google-gms = "4.4.2"
 gms-location = "21.3.0"
-android-gradlePlugin = "8.6.0"
+android-gradlePlugin = "8.10.1"
 desugaring = "2.1.3"
 firebaseBOM = "33.6.0"
 fragment = "1.5.6"
@@ -54,7 +54,7 @@ compose-compiler = "1.5.13"
 compose-constraint = "1.1.0"
 compose-navigation = "2.7.7" # adjusted to work with compose-destinations "1.9.54"
 compose-destinations = "1.11.9"
-screenshot = "0.0.1-alpha08"
+screenshot = "0.0.1-alpha10"
 
 # Compose Preview
 compose-edgetoedge-preview = "0.3.0" # update after changing target sdk to 35 and androidx-core to 1.15.0


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8645" title="WPB-8645" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-8645</a>  [Android] Infrastructure code and developer experience
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Upgrade AGP to latest possible version without breaking changes.
AGP 8.11 requires newer Gradle version.
Newer Gradle version breaks `dagCommand`.
`dagCommand` has an update, which requires JDK 21.
Newer JDK breaks SQLDelight migration checks.

So we're stuck on AGP 8.10.1 + Gradle Wrapper 8.11.1 + JDK 17

## New Lint Checks

There are many new lint checks and our app was flagged for it.

I fixed some, but 30+ were added to the baseline. Mostly composable related, I didn't want to spend time on this specific PR to fix the new warnings