### PR TITLE
fix(4.11): not federating error missing when creating new conversation [WPB-16880] 🍒

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
@@ -18,21 +18,25 @@
 package com.wire.android.ui.home.newconversation.common
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.ui.common.DialogTextSuffixLink
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.typography
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.DialogErrorStrings
 import com.wire.android.util.ui.PreviewMultipleThemes
+import com.wire.android.util.ui.stringWithStyledArgs
 
 @Composable
 fun CreateGroupErrorDialog(
     error: CreateGroupState.Error,
     onDismiss: () -> Unit,
-    onAccept: () -> Unit,
+    onEditParticipantsList: () -> Unit,
     onCancel: () -> Unit
 ) {
     val (dialogStrings, dialogSuffixLink) = when (error) {
@@ -48,11 +52,15 @@ fun CreateGroupErrorDialog(
 
         is CreateGroupState.Error.ConflictedBackends -> DialogErrorStrings(
             title = stringResource(id = R.string.group_can_not_be_created_title),
-            message = stringResource(
-                    id = R.string.group_can_not_be_created_federation_conflict_description,
-                    error.domains.dropLast(1).joinToString(", "),
-                    error.domains.last()
-                ),
+            annotatedMessage = LocalContext.current.resources.stringWithStyledArgs(
+                stringResId = R.string.group_can_not_be_created_federation_conflict_description,
+                normalStyle = typography().body01,
+                argsStyle = typography().body02,
+                normalColor = colorsScheme().secondaryText,
+                argsColor = colorsScheme().onBackground,
+                error.domains.dropLast(1).joinToString(", "),
+                error.domains.last()
+            ),
         ) to DialogTextSuffixLink(
             linkText = stringResource(id = R.string.label_learn_more),
             linkUrl = stringResource(id = R.string.url_message_details_offline_backends_learn_more)
@@ -66,7 +74,7 @@ fun CreateGroupErrorDialog(
         onDismiss = onDismiss,
         buttonsHorizontalAlignment = false,
         optionButton1Properties = WireDialogButtonProperties(
-            onClick = if (error.isConflictedBackends) onAccept else onDismiss,
+            onClick = if (error.isConflictedBackends) onEditParticipantsList else onDismiss,
             text = stringResource(
                 id = if (error.isConflictedBackends) {
                     R.string.group_can_not_be_created_edit_participiant_list

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
@@ -54,7 +54,7 @@ import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.destinations.ConversationScreenDestination
 import com.wire.android.ui.destinations.HomeScreenDestination
-import com.wire.android.ui.destinations.NewConversationSearchPeopleScreenDestination
+import com.wire.android.ui.destinations.NewGroupConversationSearchPeopleScreenDestination
 import com.wire.android.ui.home.conversations.details.options.ArrowType
 import com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsItem
 import com.wire.android.ui.home.newconversation.common.CreateGroupErrorDialog
@@ -89,7 +89,7 @@ fun GroupOptionScreen(
         onAllowGuestsClicked = { newConversationViewModel.onAllowGuestsClicked(::navigateToGroup) },
         onEditParticipantsClick = {
             newConversationViewModel.onCreateGroupErrorDismiss()
-            navigator.navigate(NavigationCommand(NewConversationSearchPeopleScreenDestination, BackStackMode.UPDATE_EXISTED))
+            navigator.navigate(NavigationCommand(NewGroupConversationSearchPeopleScreenDestination, BackStackMode.UPDATE_EXISTED))
         },
         onDiscardGroupCreationClick = {
             newConversationViewModel.onCreateGroupErrorDismiss()

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupname/NewGroupNameScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupname/NewGroupNameScreen.kt
@@ -30,7 +30,7 @@ import com.wire.android.ui.common.groupname.GroupNameScreen
 import com.wire.android.ui.destinations.ConversationScreenDestination
 import com.wire.android.ui.destinations.GroupOptionScreenDestination
 import com.wire.android.ui.destinations.HomeScreenDestination
-import com.wire.android.ui.destinations.NewConversationSearchPeopleScreenDestination
+import com.wire.android.ui.destinations.NewGroupConversationSearchPeopleScreenDestination
 import com.wire.android.ui.home.newconversation.NewConversationViewModel
 import com.wire.android.ui.home.newconversation.common.CreateGroupErrorDialog
 import com.wire.android.ui.home.newconversation.common.NewConversationNavGraph
@@ -65,9 +65,9 @@ fun NewGroupNameScreen(
         CreateGroupErrorDialog(
             error = it,
             onDismiss = newConversationViewModel::onCreateGroupErrorDismiss,
-            onAccept = {
+            onEditParticipantsList = {
                 newConversationViewModel.onCreateGroupErrorDismiss()
-                navigator.navigate(NavigationCommand(NewConversationSearchPeopleScreenDestination, BackStackMode.UPDATE_EXISTED))
+                navigator.navigate(NavigationCommand(NewGroupConversationSearchPeopleScreenDestination, BackStackMode.UPDATE_EXISTED))
             },
             onCancel = {
                 newConversationViewModel.onCreateGroupErrorDismiss()


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16880" title="WPB-16880" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16880</a>  [Android] No alert displayed when user is trying to create a group with 2 users, who don't federat with each other
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


This PR was manually cherry-picked based on the following PR:
 - #4042

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Dialog informing about federation error about conflicting backends is not displayed when creating new conversation.

### Causes (Optional)

Due to some changes in kalium, the use case doesn’t return proper failure but completes successfully with adding system message informing that some users couldn’t be added.

### Solutions

Update kalium version to use the [fix](https://github.com/wireapp/kalium/pull/3459). Additionally, change the way domains are presented on the dialog so that it matches other system messages/dialogs and fix the navigation when user clicks “Edit Participants List” - open proper screen where the user chooses participants instead of opening the initial new conversation flow screen.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/3459

### Testing

#### Test Coverage (Optional)

#### How to Test

Try to create a conversation selecting people whose backends do not federate with each other.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/user-attachments/assets/ec6c20d6-ca55-4397-bc15-e48f01bd4f73"/> | <video width="400" src="https://github.com/user-attachments/assets/4873c37e-fd45-4aff-96c0-4f74f9c18090"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
