### PR TITLE
feat: add compile time flag to enable/disable in call reactions [WPB-18894]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -354,7 +354,10 @@ class SharedCallingViewModel @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(conversationId: ConversationId, inCallReactionsEnabled: Boolean = BuildConfig.IN_CALL_REACTIONS_ENABLED): SharedCallingViewModel
+        fun create(
+            conversationId: ConversationId,
+            inCallReactionsEnabled: Boolean = BuildConfig.IN_CALL_REACTIONS_ENABLED
+        ): SharedCallingViewModel
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -90,6 +90,7 @@ import kotlinx.coroutines.launch
 @HiltViewModel(assistedFactory = SharedCallingViewModel.Factory::class)
 class SharedCallingViewModel @AssistedInject constructor(
     @Assisted val conversationId: ConversationId,
+    @Assisted val inCallReactionsEnabled: Boolean,
     private val conversationDetails: ObserveConversationDetailsUseCase,
     private val observeEstablishedCallWithSortedParticipants: ObserveEstablishedCallWithSortedParticipantsUseCase,
     private val endCall: EndCallUseCase,
@@ -317,7 +318,7 @@ class SharedCallingViewModel @AssistedInject constructor(
     }
 
     private suspend fun observeInCallReactions() {
-        if (!BuildConfig.IN_CALL_REACTIONS_ENABLED) return
+        if (!inCallReactionsEnabled) return
 
         observeInCallReactionsUseCase(conversationId).collect { message ->
             val sender = participantsState.senderName(message.senderUserId)?.let { name ->
@@ -335,7 +336,7 @@ class SharedCallingViewModel @AssistedInject constructor(
     }
 
     fun onReactionClick(emoji: String) {
-        if (!BuildConfig.IN_CALL_REACTIONS_ENABLED) return
+        if (!inCallReactionsEnabled) return
 
         viewModelScope.launch {
             sendInCallReactionUseCase(conversationId, emoji).onSuccess {
@@ -353,7 +354,7 @@ class SharedCallingViewModel @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(conversationId: ConversationId): SharedCallingViewModel
+        fun create(conversationId: ConversationId, inCallReactionsEnabled: Boolean = BuildConfig.IN_CALL_REACTIONS_ENABLED): SharedCallingViewModel
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.BuildConfig
 import com.wire.android.appLogger
 import com.wire.android.mapper.UICallParticipantMapper
 import com.wire.android.mapper.UserTypeMapper
@@ -318,21 +319,25 @@ class SharedCallingViewModel @AssistedInject constructor(
     private suspend fun observeInCallReactions() {
         observeInCallReactionsUseCase(conversationId).collect { message ->
 
-            val sender = participantsState.senderName(message.senderUserId)?.let { name ->
-                ReactionSender.Other(name)
-            } ?: ReactionSender.Unknown
+            if (BuildConfig.IN_CALL_REACTIONS_ENABLED) {
+                val sender = participantsState.senderName(message.senderUserId)?.let { name ->
+                    ReactionSender.Other(name)
+                } ?: ReactionSender.Unknown
 
-            message.emojis.forEach { emoji ->
-                _inCallReactions.send(InCallReaction(emoji, sender))
-            }
+                message.emojis.forEach { emoji ->
+                    _inCallReactions.send(InCallReaction(emoji, sender))
+                }
 
-            if (message.emojis.isNotEmpty()) {
-                recentReactions.put(message.senderUserId, message.emojis.last())
+                if (message.emojis.isNotEmpty()) {
+                    recentReactions.put(message.senderUserId, message.emojis.last())
+                }
             }
         }
     }
 
     fun onReactionClick(emoji: String) {
+        if (!BuildConfig.IN_CALL_REACTIONS_ENABLED) return
+        
         viewModelScope.launch {
             sendInCallReactionUseCase(conversationId, emoji).onSuccess {
                 _inCallReactions.send(InCallReaction(emoji, ReactionSender.You))

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -417,7 +417,7 @@ private fun OngoingCallContent(
                             .fillMaxSize()
                             .drawInCallReactions(
                                 state = inCallReactionsState,
-                                enabled = !inPictureInPictureMode,
+                                enabled = BuildConfig.IN_CALL_REACTIONS_ENABLED && !inPictureInPictureMode,
                             )
                     ) {
 
@@ -494,7 +494,7 @@ private fun OngoingCallContent(
                 }
             }
 
-            if (showInCallReactionsPanel && !inPictureInPictureMode) {
+            if (BuildConfig.IN_CALL_REACTIONS_ENABLED && showInCallReactionsPanel && !inPictureInPictureMode) {
                 InCallReactionsPanel(
                     onReactionClick = onReactionClick,
                     onMoreClick = { showEmojiPicker = true }
@@ -502,7 +502,7 @@ private fun OngoingCallContent(
             }
 
             EmojiPickerBottomSheet(
-                isVisible = showEmojiPicker,
+                isVisible = BuildConfig.IN_CALL_REACTIONS_ENABLED && showEmojiPicker,
                 onEmojiSelected = {
                     showEmojiPicker = false
                     onReactionClick(it)
@@ -608,11 +608,13 @@ private fun CallingControls(
                 onSpeakerButtonClicked = toggleSpeaker
             )
 
-            InCallReactionsButton(
-                isSelected = isShowingCallReactions,
-                isEnabled = !isConnecting,
-                onInCallReactionsClick = onCallReactionsClick
-            )
+            if (BuildConfig.IN_CALL_REACTIONS_ENABLED) {
+                InCallReactionsButton(
+                    isSelected = isShowingCallReactions,
+                    isEnabled = !isConnecting,
+                    onInCallReactionsClick = onCallReactionsClick
+                )
+            }
 
             HangUpOngoingButton(
                 onHangUpButtonClicked = onHangUpCall

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
@@ -76,6 +76,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import com.waz.avs.CameraPreviewBuilder
 import com.waz.avs.VideoRenderer
+import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
@@ -184,27 +185,29 @@ fun ParticipantTile(
                 )
             }
 
-            AnimatedVisibility(
-                modifier = Modifier
-                    .padding(dimensions().spacing12x),
-                visible = recentReaction != null,
-                enter = fadeIn(),
-                exit = fadeOut(),
-            ) {
-                Box(
+            if (BuildConfig.IN_CALL_REACTIONS_ENABLED) {
+                AnimatedVisibility(
                     modifier = Modifier
-                        .size(dimensions().inCallReactionRecentReactionSize)
-                        .background(
-                            color = colorsScheme().emojiBackgroundColor,
-                            shape = RoundedCornerShape(dimensions().corner6x)
-                        ),
-                    contentAlignment = Alignment.Center,
+                        .padding(dimensions().spacing12x),
+                    visible = recentReaction != null,
+                    enter = fadeIn(),
+                    exit = fadeOut(),
                 ) {
-                    Text(
-                        text = recentReaction ?: "",
-                        textAlign = TextAlign.Center,
-                        style = typography().inCallReactionRecentEmoji,
-                    )
+                    Box(
+                        modifier = Modifier
+                            .size(dimensions().inCallReactionRecentReactionSize)
+                            .background(
+                                color = colorsScheme().emojiBackgroundColor,
+                                shape = RoundedCornerShape(dimensions().corner6x)
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = recentReaction ?: "",
+                            textAlign = TextAlign.Center,
+                            style = typography().inCallReactionRecentEmoji,
+                        )
+                    }
                 }
             }
 

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -151,6 +151,7 @@ class SharedCallingViewModelTest {
 
         sharedCallingViewModel = SharedCallingViewModel(
             conversationId = conversationId,
+            inCallReactionsEnabled = true,
             conversationDetails = observeConversationDetails,
             observeEstablishedCallWithSortedParticipants = observeEstablishedCall,
             endCall = endCall,
@@ -435,6 +436,76 @@ class SharedCallingViewModelTest {
             // then
             expectNoEvents()
         }
+    }
+
+    @Test
+    fun givenInCallReactionsDisabled_WhenInCallReactionIsReceived_ThenNoEmojiIsEmitted() = runTest(dispatcherProvider.main()) {
+        // given
+        val viewModel = SharedCallingViewModel(
+            conversationId = conversationId,
+            inCallReactionsEnabled = false,
+            conversationDetails = observeConversationDetails,
+            observeEstablishedCallWithSortedParticipants = observeEstablishedCall,
+            endCall = endCall,
+            muteCall = muteCall,
+            flipToFrontCamera = flipToFrontCamera,
+            flipToBackCamera = flipToBackCamera,
+            unMuteCall = unMuteCall,
+            setVideoPreview = setVideoPreview,
+            updateVideoState = updateVideoState,
+            turnLoudSpeakerOff = turnLoudSpeakerOff,
+            turnLoudSpeakerOn = turnLoudSpeakerOn,
+            observeSpeaker = observeSpeaker,
+            callRinger = callRinger,
+            uiCallParticipantMapper = uiCallParticipantMapper,
+            userTypeMapper = userTypeMapper,
+            observeInCallReactionsUseCase = observeInCallReactionsUseCase,
+            sendInCallReactionUseCase = sendInCallReactionUseCase,
+            getCurrentClientId = getCurrentClientId,
+            dispatchers = dispatcherProvider
+        )
+
+        viewModel.inCallReactions.test {
+            // when
+            reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍")))
+
+            // then
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun givenInCallReactionsDisabled_WhenReactionIsClicked_ThenNoReactionIsSent() = runTest(dispatcherProvider.main()) {
+        // given
+        val viewModel = SharedCallingViewModel(
+            conversationId = conversationId,
+            inCallReactionsEnabled = false,
+            conversationDetails = observeConversationDetails,
+            observeEstablishedCallWithSortedParticipants = observeEstablishedCall,
+            endCall = endCall,
+            muteCall = muteCall,
+            flipToFrontCamera = flipToFrontCamera,
+            flipToBackCamera = flipToBackCamera,
+            unMuteCall = unMuteCall,
+            setVideoPreview = setVideoPreview,
+            updateVideoState = updateVideoState,
+            turnLoudSpeakerOff = turnLoudSpeakerOff,
+            turnLoudSpeakerOn = turnLoudSpeakerOn,
+            observeSpeaker = observeSpeaker,
+            callRinger = callRinger,
+            uiCallParticipantMapper = uiCallParticipantMapper,
+            userTypeMapper = userTypeMapper,
+            observeInCallReactionsUseCase = observeInCallReactionsUseCase,
+            sendInCallReactionUseCase = sendInCallReactionUseCase,
+            getCurrentClientId = getCurrentClientId,
+            dispatchers = dispatcherProvider
+        )
+
+        // when
+        viewModel.onReactionClick("👍")
+
+        // then
+        coVerify(exactly = 0) { sendInCallReactionUseCase(any(), any()) }
     }
 
     companion object {

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -105,6 +105,7 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
 
     PICTURE_IN_PICTURE_ENABLED("picture_in_picture_enabled", ConfigType.BOOLEAN),
     PAGINATED_CONVERSATION_LIST_ENABLED("paginated_conversation_list_enabled", ConfigType.BOOLEAN),
+    IN_CALL_REACTIONS_ENABLED("in_call_reactions_enabled", ConfigType.BOOLEAN),
 
     /**
      * Anonymous Analytics

--- a/default.json
+++ b/default.json
@@ -133,5 +133,6 @@
     "limit_team_members_fetch_during_slow_sync": 2000,
     "picture_in_picture_enabled": false,
     "paginated_conversation_list_enabled": false,
-    "should_display_release_notes": true
+    "should_display_release_notes": true,g
+    "in_call_reactions_enabled": false
 }

--- a/default.json
+++ b/default.json
@@ -133,6 +133,6 @@
     "limit_team_members_fetch_during_slow_sync": 2000,
     "picture_in_picture_enabled": false,
     "paginated_conversation_list_enabled": false,
-    "should_display_release_notes": true,g
+    "should_display_release_notes": true,
     "in_call_reactions_enabled": false
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18894" title="WPB-18894" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18894</a>  [Android] Turn off in-call reactions at build time for RC
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

add compile time flag to enable/disable in call reactions 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
