### PR TITLE
chore: remove oauth state [WPB-18140]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/e2ei/OAuthUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/e2ei/OAuthUseCase.kt
@@ -47,12 +47,9 @@ import java.security.SecureRandom
 class OAuthUseCase(
     context: Context,
     private val authUrl: String,
-    private val claims: JsonObject,
-    oAuthState: String?
+    private val claims: JsonObject
 ) {
-    private var authState: AuthState = oAuthState?.let {
-        AuthState.jsonDeserialize(it)
-    } ?: AuthState()
+    private var authState: AuthState = AuthState()
 
     private var authorizationService: AuthorizationService
     private lateinit var authServiceConfig: AuthorizationServiceConfiguration

--- a/app/src/main/kotlin/com/wire/android/feature/e2ei/OAuthUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/e2ei/OAuthUseCase.kt
@@ -82,7 +82,8 @@ class OAuthUseCase(
                 } else {
                     resultHandler(
                         OAuthResult.Success(
-                            idToken.toString(), _authState.jsonSerializeString()
+                            idToken.toString(),
+                            _authState.jsonSerializeString()
                         )
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/GetE2EICertificateUI.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/GetE2EICertificateUI.kt
@@ -41,7 +41,7 @@ fun GetE2EICertificateUI(
 
     LaunchedEffect(Unit) {
         viewModel.requestOAuthFlow.onEach {
-            OAuthUseCase(context, it.target, it.oAuthClaims, it.oAuthState).launch(
+            OAuthUseCase(context, it.target, it.oAuthClaims).launch(
                 context.getActivity()!!.activityResultRegistry, forceLoginFlow = true
             ) { result -> viewModel.handleOAuthResult(result, it) }
         }.launchIn(coroutineScope)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18140" title="WPB-18140" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18140</a>  [Android] Do not use refresh token for E2EI certificate renewal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In latest core crypto refreshToken was removed -> https://github.com/wireapp/kalium/pull/3539, so `oauthState` is no longer needed