### PR TITLE
fix: resend code timer [WPB-18364]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeScreen.kt
@@ -185,7 +185,11 @@ private fun CodeContent(
                         modifier = Modifier.padding(vertical = MaterialTheme.wireDimensions.spacing16x)
                     )
                 }
-                ResendCodeText(onResendCodePressed = onResendCodePressed, clickEnabled = !state.loading)
+                ResendCodeText(
+                    onResendCodePressed = onResendCodePressed,
+                    clickEnabled = !state.loading,
+                    timerText = state.remainingTimerText,
+                )
             }
             Spacer(modifier = Modifier.weight(1f))
         }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeViewState.kt
@@ -27,6 +27,7 @@ data class CreateAccountCodeViewState(
     val email: String = "",
     val loading: Boolean = false,
     val result: Result = Result.None,
+    val remainingTimerText: String? = null,
 ) {
     sealed interface Result {
         data object None : Result

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
@@ -53,6 +53,7 @@ class RegisterDeviceViewModel @Inject constructor(
     private val userDataStore: UserDataStore,
     private val getSelfUser: GetSelfUserUseCase,
     private val requestSecondFactorVerificationCodeUseCase: RequestSecondFactorVerificationCodeUseCase,
+    private val resendCodeTimer: CountdownTimer,
 ) : ViewModel() {
 
     val passwordTextState: TextFieldState = TextFieldState()
@@ -62,8 +63,6 @@ class RegisterDeviceViewModel @Inject constructor(
     val secondFactorVerificationCodeTextState: TextFieldState = TextFieldState()
     var secondFactorVerificationCodeState: VerificationCodeState by mutableStateOf(VerificationCodeState())
         private set
-
-    private var resendCodeTimer = CountdownTimer()
 
     init {
         runBlocking {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -70,6 +70,7 @@ class LoginEmailViewModel @Inject constructor(
     authServerConfigProvider: AuthServerConfigProvider,
     userDataStoreProvider: UserDataStoreProvider,
     @KaliumCoreLogic coreLogic: CoreLogic,
+    private val resendCodeTimer: CountdownTimer,
     private val dispatchers: DispatcherProvider
 ) : LoginViewModel(
     clientScopeProviderFactory,
@@ -90,8 +91,6 @@ class LoginEmailViewModel @Inject constructor(
 
     val secondFactorVerificationCodeTextState: TextFieldState = TextFieldState()
     var secondFactorVerificationCodeState by mutableStateOf(VerificationCodeState())
-
-    private var resendCodeTimer = CountdownTimer()
 
     init {
         userIdentifierTextState.setTextAndPlaceCursorAtEnd(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/ResendCodeText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/ResendCodeText.kt
@@ -39,12 +39,12 @@ fun ResendCodeText(
     onResendCodePressed: () -> Unit,
     clickEnabled: Boolean,
     modifier: Modifier = Modifier,
-    elapsedTimerText: String? = null,
+    timerText: String? = null,
 ) {
-    val enabled = elapsedTimerText == null && clickEnabled
+    val enabled = timerText == null && clickEnabled
     val label = stringResource(R.string.create_account_code_resend)
     Text(
-        text = elapsedTimerText?.let { "$label ($it)" } ?: label,
+        text = timerText?.let { "$label ($it)" } ?: label,
         style = MaterialTheme.wireTypography.body02.copy(
             textDecoration = if (enabled) {
                 TextDecoration.Underline

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/ResendCodeText.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/ResendCodeText.kt
@@ -30,23 +30,39 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import com.wire.android.R
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 
 @Composable
-fun ResendCodeText(onResendCodePressed: () -> Unit, clickEnabled: Boolean, modifier: Modifier = Modifier) {
+fun ResendCodeText(
+    onResendCodePressed: () -> Unit,
+    clickEnabled: Boolean,
+    modifier: Modifier = Modifier,
+    elapsedTimerText: String? = null,
+) {
+    val enabled = elapsedTimerText == null && clickEnabled
+    val label = stringResource(R.string.create_account_code_resend)
     Text(
-        text = stringResource(R.string.create_account_code_resend),
+        text = elapsedTimerText?.let { "$label ($it)" } ?: label,
         style = MaterialTheme.wireTypography.body02.copy(
-            textDecoration = TextDecoration.Underline,
-            color = MaterialTheme.colorScheme.primary
+            textDecoration = if (enabled) {
+                TextDecoration.Underline
+            } else {
+                TextDecoration.None
+            },
+            color = if (enabled) {
+                MaterialTheme.wireColorScheme.primary
+            } else {
+                MaterialTheme.wireColorScheme.onSurface
+            }
         ),
         textAlign = TextAlign.Center,
         modifier = modifier
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
-                enabled = clickEnabled,
+                enabled = enabled,
                 onClick = onResendCodePressed
             )
             .padding(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCode.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCode.kt
@@ -48,7 +48,7 @@ fun VerificationCode(
     isCurrentCodeInvalid: Boolean,
     onResendCode: () -> Unit,
     modifier: Modifier = Modifier,
-    elapsedTimerText: String? = null,
+    timerText: String? = null,
 ) {
     val focusRequester = remember { FocusRequester() }
     Column(
@@ -79,7 +79,7 @@ fun VerificationCode(
         ResendCodeText(
             onResendCodePressed = onResendCode,
             clickEnabled = !isLoading,
-            elapsedTimerText = elapsedTimerText,
+            timerText = timerText,
         )
     }
 }
@@ -105,6 +105,6 @@ fun PreviewVerificationCodeTimer() = WireTheme {
         isLoading = false,
         isCurrentCodeInvalid = false,
         onResendCode = {},
-        elapsedTimerText = "00:30",
+        timerText = "00:30",
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCode.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCode.kt
@@ -47,7 +47,8 @@ fun VerificationCode(
     isLoading: Boolean,
     isCurrentCodeInvalid: Boolean,
     onResendCode: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    elapsedTimerText: String? = null,
 ) {
     val focusRequester = remember { FocusRequester() }
     Column(
@@ -77,7 +78,8 @@ fun VerificationCode(
 
         ResendCodeText(
             onResendCodePressed = onResendCode,
-            clickEnabled = !isLoading
+            clickEnabled = !isLoading,
+            elapsedTimerText = elapsedTimerText,
         )
     }
 }
@@ -91,5 +93,18 @@ fun PreviewVerificationCode() = WireTheme {
         isLoading = false,
         isCurrentCodeInvalid = false,
         onResendCode = {}
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewVerificationCodeTimer() = WireTheme {
+    VerificationCode(
+        codeLength = 6,
+        codeState = TextFieldState(),
+        isLoading = false,
+        isCurrentCodeInvalid = false,
+        onResendCode = {},
+        elapsedTimerText = "00:30",
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeScreenContent.kt
@@ -106,7 +106,7 @@ private fun MainContent(
         isLoading = isLoading,
         isCurrentCodeInvalid = codeState.isCurrentCodeInvalid,
         onResendCode = onResendCode,
-        elapsedTimerText = codeState.elapsedTimerText,
+        timerText = codeState.remainingTimerText,
     )
     Spacer(
         modifier = Modifier
@@ -140,7 +140,7 @@ internal fun VerificationCodeScreenPreviewTimer() = WireTheme {
             codeLength = 6,
             isCurrentCodeInvalid = false,
             emailUsed = "",
-            elapsedTimerText = "04:30"
+            remainingTimerText = "04:30"
         ),
         isLoading = false,
         onCodeResend = {},

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeScreenContent.kt
@@ -48,9 +48,11 @@ fun VerificationCodeScreenContent(
     isLoading: Boolean,
     onCodeResend: () -> Unit,
     onBackPressed: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     BackHandler { onBackPressed() }
     WireScaffold(
+        modifier = modifier,
         topBar = {
             WireCenterAlignedTopAppBar(
                 elevation = dimensions().spacing0x,
@@ -78,7 +80,7 @@ private fun MainContent(
     codeState: VerificationCodeState,
     isLoading: Boolean,
     onResendCode: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) = Column(
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Center,
@@ -104,6 +106,7 @@ private fun MainContent(
         isLoading = isLoading,
         isCurrentCodeInvalid = codeState.isCurrentCodeInvalid,
         onResendCode = onResendCode,
+        elapsedTimerText = codeState.elapsedTimerText,
     )
     Spacer(
         modifier = Modifier
@@ -121,6 +124,23 @@ internal fun VerificationCodeScreenPreview() = WireTheme {
             codeLength = 6,
             isCurrentCodeInvalid = false,
             emailUsed = ""
+        ),
+        isLoading = false,
+        onCodeResend = {},
+        onBackPressed = {},
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+internal fun VerificationCodeScreenPreviewTimer() = WireTheme {
+    VerificationCodeScreenContent(
+        verificationCodeTextState = TextFieldState(),
+        verificationCodeState = VerificationCodeState(
+            codeLength = 6,
+            isCurrentCodeInvalid = false,
+            emailUsed = "",
+            elapsedTimerText = "04:30"
         ),
         isLoading = false,
         onCodeResend = {},

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeState.kt
@@ -23,7 +23,7 @@ data class VerificationCodeState(
     val emailUsed: String = "",
     val isCodeInputNecessary: Boolean = false,
     val isCurrentCodeInvalid: Boolean = false,
-    val elapsedTimerText: String? = null,
+    val remainingTimerText: String? = null,
 ) {
     companion object {
         const val DEFAULT_VERIFICATION_CODE_LENGTH = 6

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/verificationcode/VerificationCodeState.kt
@@ -23,6 +23,7 @@ data class VerificationCodeState(
     val emailUsed: String = "",
     val isCodeInputNecessary: Boolean = false,
     val isCurrentCodeInvalid: Boolean = false,
+    val elapsedTimerText: String? = null,
 ) {
     companion object {
         const val DEFAULT_VERIFICATION_CODE_LENGTH = 6

--- a/app/src/main/kotlin/com/wire/android/util/ui/CountdownTimer.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/CountdownTimer.kt
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util.ui
+
+import android.text.format.DateUtils.formatElapsedTime
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
+
+class CountdownTimer {
+    private var timerJob: Job? = null
+
+    suspend fun start(seconds: Long, onUpdate: (String) -> Unit, onFinish: () -> Unit) {
+        timerJob?.cancel()
+        timerJob = coroutineScope {
+            launch {
+                var countdown = seconds
+                while (countdown > 0 && isActive) {
+                    onUpdate(formatElapsedTime(countdown--))
+                    delay(1.seconds)
+                }
+                onFinish()
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/util/ui/CountdownTimer.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/CountdownTimer.kt
@@ -23,9 +23,10 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
-class CountdownTimer {
+class CountdownTimer @Inject constructor() {
     private var timerJob: Job? = null
 
     suspend fun start(seconds: Long, onUpdate: (String) -> Unit, onFinish: () -> Unit) {

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
@@ -27,6 +27,7 @@ import com.wire.android.datastore.UserDataStore
 import com.wire.android.framework.TestClient
 import com.wire.android.framework.TestUser
 import com.wire.android.util.EMPTY
+import com.wire.android.util.ui.CountdownTimer
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.data.auth.verification.VerifiableAction
 import com.wire.kalium.logic.data.user.SelfUser
@@ -296,12 +297,16 @@ class RegisterDeviceViewModelTest {
         @MockK
         internal lateinit var userDataStore: UserDataStore
 
+        @MockK
+        internal lateinit var countdownTimer: CountdownTimer
+
         init {
             MockKAnnotations.init(this)
             mockUri()
             coEvery { isPasswordRequiredUseCase() } returns IsPasswordRequiredUseCase.Result.Success(true)
             every { userDataStore.initialSyncCompleted } returns flowOf(true)
             coEvery { getSelfUserUseCase() } returns SELF_USER
+            coEvery { countdownTimer.start(any(), any(), any()) } returns Unit
         }
 
         fun arrange() = this to RegisterDeviceViewModel(
@@ -310,6 +315,7 @@ class RegisterDeviceViewModelTest {
             userDataStore,
             getSelfUserUseCase,
             requestSecondFactorVerificationCodeUseCase,
+            countdownTimer,
         )
 
         fun withRegisterClientReturning(result: RegisterClientResult) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -33,6 +33,7 @@ import com.wire.android.framework.TestClient
 import com.wire.android.ui.authentication.login.LoginState
 import com.wire.android.util.EMPTY
 import com.wire.android.util.newServerConfig
+import com.wire.android.util.ui.CountdownTimer
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.CoreLogic
@@ -541,6 +542,9 @@ class LoginEmailViewModelTest {
         @MockK
         internal lateinit var authenticationScope: AuthenticationScope
 
+        @MockK
+        internal lateinit var countdownTimer: CountdownTimer
+
         init {
             MockKAnnotations.init(this)
             mockUri()
@@ -557,6 +561,7 @@ class LoginEmailViewModelTest {
             every { authenticationScope.login } returns loginUseCase
             every { authenticationScope.requestSecondFactorVerificationCode } returns requestSecondFactorCodeUseCase
             every { coreLogic.versionedAuthenticationScope(any()) } returns autoVersionAuthScopeUseCase
+            coEvery { countdownTimer.start(any(), any(), any()) } returns Unit
         }
 
         fun arrange() = this to LoginEmailViewModel(
@@ -566,6 +571,7 @@ class LoginEmailViewModelTest {
             authServerConfigProvider,
             userDataStoreProvider,
             coreLogic,
+            countdownTimer,
             dispatcherProvider
         )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18364" title="WPB-18364" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18364</a>  [Android]Resend code button on verification screen of Next-Column-3 is not clickable
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-18364
----
# What's new in this PR?

### Issues
"Resend Code" button allows user to request 2FA codes more frequent than allowed by server rate limitation.

### Solutions
Disable "Resend Code" button for 5 minutes after requesting 2FA code.

<img width="300" alt="resend_code_timer" src="https://github.com/user-attachments/assets/c5987c5b-bd8d-40b1-945b-080712ffa939" />
