### PR TITLE
fix: crash on logout [WPB-18706]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -31,12 +31,16 @@ import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
 import com.wire.android.navigation.SavedStateViewModel
+import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.feature.client.NeedsToRegisterClientUseCase
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
+import dagger.Lazy
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -55,7 +59,8 @@ class HomeViewModel @Inject constructor(
     private val needsToRegisterClient: NeedsToRegisterClientUseCase,
     private val canMigrateFromPersonalToTeam: CanMigrateFromPersonalToTeamUseCase,
     private val observeLegalHoldStatusForSelfUser: ObserveLegalHoldStateForSelfUserUseCase,
-    private val shouldTriggerMigrationForUser: ShouldTriggerMigrationForUserUserCase
+    private val shouldTriggerMigrationForUser: ShouldTriggerMigrationForUserUserCase,
+    private val currentSessionFlow: Lazy<CurrentSessionFlowUseCase>,
 ) : SavedStateViewModel(savedStateHandle) {
 
     @VisibleForTesting
@@ -124,7 +129,7 @@ class HomeViewModel @Inject constructor(
                 needsToRegisterClient() -> // check if the client needs to be registered
                     onRequirement(HomeRequirement.RegisterDevice)
 
-                !dataStore.initialSyncCompleted.first() -> // check if the initial sync needs to be completed
+                !dataStore.initialSyncCompleted.first() && isLoggedIn() -> // check if the initial sync needs to be completed
                     onRequirement(HomeRequirement.InitialSync)
 
                 selfUser.handle.isNullOrEmpty() -> // check if the user handle needs to be set
@@ -145,5 +150,10 @@ class HomeViewModel @Inject constructor(
             globalDataStore.setWelcomeScreenPresented()
             homeState = homeState.copy(shouldDisplayWelcomeMessage = false)
         }
+    }
+
+    private suspend fun isLoggedIn(): Boolean {
+        val accountInfo = (currentSessionFlow.get().invoke().firstOrNull() as? CurrentSessionResult.Success)?.accountInfo
+        return accountInfo is AccountInfo.Valid
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/HomeViewModelTest.kt
@@ -23,12 +23,15 @@ import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.framework.TestUser
 import com.wire.android.migration.userDatabase.ShouldTriggerMigrationForUserUserCase
+import com.wire.android.ui.WireActivityViewModelTest.Companion.TEST_ACCOUNT_INFO
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.feature.client.NeedsToRegisterClientUseCase
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -211,6 +214,9 @@ class HomeViewModelTest {
         @MockK
         lateinit var canMigrateFromPersonalToTeam: CanMigrateFromPersonalToTeamUseCase
 
+        @MockK
+        lateinit var currentSessionFlow: CurrentSessionFlowUseCase
+
         @RelaxedMockK
         lateinit var onRequirement: (HomeRequirement) -> Unit
 
@@ -224,6 +230,7 @@ class HomeViewModelTest {
                 observeLegalHoldStatusForSelfUser = observeLegalHoldStatusForSelfUser,
                 shouldTriggerMigrationForUser = shouldTriggerMigrationForUser,
                 canMigrateFromPersonalToTeam = canMigrateFromPersonalToTeam,
+                currentSessionFlow = { currentSessionFlow },
             )
         }
 
@@ -232,6 +239,7 @@ class HomeViewModelTest {
             withSelfUser(flowOf(TestUser.SELF_USER))
             withCanMigrateFromPersonalToTeamReturning(true)
             withLegalHoldStatus(flowOf(LegalHoldStateForSelfUser.Disabled))
+            coEvery { currentSessionFlow() } returns flowOf(CurrentSessionResult.Success(TEST_ACCOUNT_INFO))
         }
 
         fun withSelfUser(result: Flow<SelfUser>) = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18706" title="WPB-18706" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18706</a>  [Android] Crash when account was deleted or device was removed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-18706

# What's new in this PR?

### Issues
Application crash when current client is deleted from other device.

### Causes (Optional)
1. Current client removal triggers logout and clears data. 
2. Data clear resets the "initialSyncCompleted" flag and HomeViewModel navigates to InitialSyncScreen. 
3. This screen is not supposed to be called with no session and crashes on dependencies setup.

### Solutions
Check current session availability in HomeViewModel before navigating to InitialSyncScreen.
