### PR TITLE
fix: show cell video file name (WPB-19188)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/multipart/standalone/VideoAssetPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/multipart/standalone/VideoAssetPreview.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.decode.VideoFrameDecoder
@@ -104,6 +105,16 @@ internal fun VideoAssetPreview(
             extension = item.mimeType.substringAfter("/"),
             size = item.assetSize,
         )
+
+        item.fileName?.let {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = it.substringBeforeLast("."),
+                style = typography().body02,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
 
         Box(
             modifier = Modifier


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19188" title="WPB-19188" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19188</a>  [Android] Cells- include file names for video and mp3 reviews
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-19188

# What's new in this PR?

Show file name in video / mp4 cell files preview.