### PR TITLE
fix: updating dialog when removing a member [WPB-19134]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileInfoMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileInfoMessageType.kt
@@ -41,6 +41,8 @@ sealed class OtherUserProfileInfoMessageType(override val uiText: UIText) : Snac
     // remove conversation member
     object RemoveConversationMemberError :
         OtherUserProfileInfoMessageType(UIText.StringResource(R.string.dialog_remove_conversation_member_error))
+    data class RemoveConversationMemberSuccess(val userName: String) :
+        OtherUserProfileInfoMessageType(UIText.PluralResource(R.plurals.label_system_message_federation_member_removed, 1, userName))
 
     // Conversation BottomSheet
     object BlockingUserOperationError : OtherUserProfileInfoMessageType(UIText.StringResource(R.string.error_blocking_user))

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -208,6 +208,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
 
     override fun onRemoveConversationMember(state: RemoveConversationMemberState) {
         viewModelScope.launch {
+            removeConversationMemberDialogState.update { it.copy(loading = true) }
             val response = withContext(dispatchers.io()) {
                 removeMemberFromConversation(
                     state.conversationId,
@@ -218,6 +219,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             if (response is RemoveMemberFromConversationUseCase.Result.Failure) {
                 onMessage(RemoveConversationMemberError)
             }
+            removeConversationMemberDialogState.dismiss()
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -37,6 +37,7 @@ import com.wire.android.ui.userprofile.common.UsernameMapper.fromOtherUser
 import com.wire.android.ui.userprofile.group.RemoveConversationMemberState
 import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.ChangeGroupRoleError
 import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.RemoveConversationMemberError
+import com.wire.android.ui.userprofile.other.OtherUserProfileInfoMessageType.RemoveConversationMemberSuccess
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -215,9 +216,9 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                     userId
                 )
             }
-
-            if (response is RemoveMemberFromConversationUseCase.Result.Failure) {
-                onMessage(RemoveConversationMemberError)
+            when (response) {
+                is RemoveMemberFromConversationUseCase.Result.Failure -> onMessage(RemoveConversationMemberError)
+                is RemoveMemberFromConversationUseCase.Result.Success -> onMessage(RemoveConversationMemberSuccess(state.userName))
             }
             removeConversationMemberDialogState.dismiss()
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -728,7 +728,7 @@
     <!-- Remove Conversation Member Dialog -->
     <string name="dialog_remove_conversation_member_title">Remove from conversation?</string>
     <string name="dialog_remove_conversation_member_description">%1$s (@%2$s) will not be able to send or receive messages in this conversation.</string>
-    <string name="dialog_remove_conversation_member_error">There was an error while removing the participant from the conversatrion</string>
+    <string name="dialog_remove_conversation_member_error">There was an error while removing the participant from the conversation</string>
     <string name="conversation_role_admin">Admin</string>
     <string name="conversation_role_member">Member</string>
     <!-- Logout Wipe Data Dialog -->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19134" title="WPB-19134" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19134</a>  [Android] Remove from group alert not disappearing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

"remove member" dialog doesn't disappear after executing a removal.

### Causes (Optional)

Actions to "update loading" and "dismiss" hasn't been added after refactoring bottom sheet and moving dialog state.

### Solutions

Added "update loading" and "dismiss" actions for this dialog.
Added a snackbar message after removing a member and fixed a typo for error message.

### Testing

#### How to Test

STR:
- have a group conversation where you are admin
- go to group details > participants list
- select the user to remove
- tap on remove from conversation button
- tap on remove on the alert

Expected:
- Alert should close
- I should see a toast message that user was removed
- User should be removed

Actual:
- Alert stays open
- No toast is shown
- But user is removed from group

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/user-attachments/assets/7217e837-16cf-4470-821c-f48cb1a9d6ff"/> | <video width="400" src="https://github.com/user-attachments/assets/84199194-f52e-4b21-a58f-019a700371e5"/> |


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
