### PR TITLE
fix: calling bottom bar not filling full width on tablets [WPB-6414]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -36,10 +36,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberBottomSheetScaffoldState
-import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -88,12 +85,12 @@ import com.wire.android.ui.calling.ongoing.participantsview.VerticalCallingPager
 import com.wire.android.ui.common.ConversationVerificationIcons
 import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.banner.SecurityClassificationBannerForConversation
-import com.wire.android.ui.common.bottomsheet.WireBottomSheetScaffold
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dialogs.PermissionPermanentlyDeniedDialog
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
+import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.visbility.rememberVisibilityState
@@ -327,27 +324,15 @@ private fun OngoingCallContent(
     inPictureInPictureMode: Boolean,
     initialShowInCallReactionsPanel: Boolean = false, // for preview purposes
 ) {
-    val sheetInitialValue = SheetValue.PartiallyExpanded
-    val sheetState = rememberStandardBottomSheetState(
-        initialValue = sheetInitialValue
-    )
-
-    val scaffoldState = rememberBottomSheetScaffoldState(
-        bottomSheetState = sheetState
-    )
-
     var shouldOpenFullScreen by remember { mutableStateOf(false) }
 
     var showInCallReactionsPanel by remember { mutableStateOf(initialShowInCallReactionsPanel) }
     val emojiPickerState = rememberWireModalSheetState<Unit>(skipPartiallyExpanded = false)
     val isConnecting = participants.isEmpty()
 
-    WireBottomSheetScaffold(
-        sheetDragHandle = null,
-        topBar = if (inPictureInPictureMode) {
-            null
-        } else {
-            {
+    WireScaffold(
+        topBar = {
+            if (!inPictureInPictureMode) {
                 OngoingCallTopBar(
                     conversationName = when (callState.conversationName) {
                         is ConversationName.Known -> callState.conversationName.name
@@ -361,38 +346,10 @@ private fun OngoingCallContent(
                     proteusVerificationStatus = callState.proteusVerificationStatus
                 )
             }
-        },
-        sheetPeekHeight = if (inPictureInPictureMode) 0.dp else dimensions().defaultSheetPeekHeight,
-        scaffoldState = scaffoldState,
-        sheetShadowElevation = dimensions().spacing0x,
-        sheetContent = {
-            if (!inPictureInPictureMode) {
-                CallingControls(
-                    conversationId = callState.conversationId,
-                    isMuted = callState.isMuted ?: true,
-                    isCameraOn = callState.isCameraOn,
-                    isSpeakerOn = callState.isSpeakerOn,
-                    isShowingCallReactions = showInCallReactionsPanel,
-                    isConnecting = isConnecting,
-                    toggleSpeaker = toggleSpeaker,
-                    toggleMute = toggleMute,
-                    onHangUpCall = hangUpCall,
-                    onToggleVideo = toggleVideo,
-                    onCallReactionsClick = {
-                        showInCallReactionsPanel = !showInCallReactionsPanel
-                    },
-                    onCameraPermissionPermanentlyDenied = onCameraPermissionPermanentlyDenied
-                )
-            }
-        },
-        sheetContainerColor = colorsScheme().background,
+        }
     ) {
         Column(
-            modifier = Modifier
-                .padding(
-                    top = it.calculateTopPadding(),
-                    bottom = if (inPictureInPictureMode) 0.dp else dimensions().defaultSheetPeekHeight
-                )
+            modifier = Modifier.padding(it)
         ) {
 
             BoxWithConstraints(
@@ -504,11 +461,29 @@ private fun OngoingCallContent(
                 }
             }
 
-            if (showInCallReactionsPanel && !inPictureInPictureMode) {
-                InCallReactionsPanel(
-                    onReactionClick = onReactionClick,
-                    onMoreClick = { emojiPickerState.show(Unit) },
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
+            if (!inPictureInPictureMode) {
+                if (showInCallReactionsPanel) {
+                    InCallReactionsPanel(
+                        onReactionClick = onReactionClick,
+                        onMoreClick = { emojiPickerState.show(Unit) },
+                        modifier = Modifier.align(Alignment.CenterHorizontally),
+                    )
+                }
+                CallingControls(
+                    conversationId = callState.conversationId,
+                    isMuted = callState.isMuted ?: true,
+                    isCameraOn = callState.isCameraOn,
+                    isSpeakerOn = callState.isSpeakerOn,
+                    isShowingCallReactions = showInCallReactionsPanel,
+                    isConnecting = isConnecting,
+                    toggleSpeaker = toggleSpeaker,
+                    toggleMute = toggleMute,
+                    onHangUpCall = hangUpCall,
+                    onToggleVideo = toggleVideo,
+                    onCallReactionsClick = {
+                        showInCallReactionsPanel = !showInCallReactionsPanel
+                    },
+                    onCameraPermissionPermanentlyDenied = onCameraPermissionPermanentlyDenied
                 )
             }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6414" title="WPB-6414" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6414</a>  [Android Tablet] Calling UI buttons card not filling full screen with
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On tablet in portrait mode, the card in the calling UI where we see the buttons for ending call, enabling video, etc. is not scaling as expected. Also the banners connected to that card are not scaling as expected.

### Causes (Optional)

This bottom bar is created inside a bottom sheet and bottom sheets have a max width limits (640.dp).

### Solutions

Remove the scaffold with bottom sheet in favor of the default one - recent design changes regarding in-call reactions changed the designs for this bar as well and now it's not a bottom-sheet-like anymore so there's no need to keep using scaffold with bottom sheet on that screen and trying to find a way to make it fill the full width.

### Testing

#### How to Test

Start a call on tablet in landscape.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <img width="400" src="https://github.com/user-attachments/assets/7a08c909-5ed1-4e3e-9c47-d0f290b05af9" /> | <img width="400" src="https://github.com/user-attachments/assets/444b1c3e-1292-47bf-8a58-95d1602d2dba" /> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
