### PR TITLE
fix: update tags when opening tags filter (WPB-19374)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
@@ -19,11 +19,11 @@ package com.wire.android.feature.cells.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.wire.android.feature.cells.ui.destinations.AddRemoveTagsScreenDestination
 import com.wire.android.feature.cells.ui.destinations.ConversationFilesScreenDestination
-import com.wire.android.feature.cells.ui.destinations.ConversationFilesScreenDestination.invoke
 import com.wire.android.feature.cells.ui.destinations.PublicLinkScreenDestination
 import com.wire.android.feature.cells.ui.filter.FilterBottomSheet
 import com.wire.android.navigation.NavigationCommand
@@ -98,20 +98,21 @@ fun AllFilesScreen(
     )
 
     if (searchBarState.isFilterActive) {
+        viewModel.loadTags()
         sheetState.show()
     } else {
         sheetState.hide()
     }
 
     FilterBottomSheet(
-        selectableTags = viewModel.tags,
-        selectedTags = viewModel.selectedTags,
+        selectableTags = viewModel.tags.collectAsState().value,
+        selectedTags = viewModel.selectedTags.collectAsState().value,
         onApply = {
             searchBarState.onFilterActiveChanged(false)
             viewModel.updateSelectedTags(it)
         },
         onClearAll = {
-            viewModel.updateSelectedTags(emptyList())
+            viewModel.updateSelectedTags(emptySet())
         },
         onDismiss = { searchBarState.onFilterActiveChanged(false) },
         sheetState = sheetState

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/filter/FilterBottomSheet.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/filter/FilterBottomSheet.kt
@@ -58,14 +58,12 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.preview.MultipleThemePreviews
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 fun FilterBottomSheet(
-    selectableTags: StateFlow<List<String>>,
-    selectedTags: StateFlow<List<String>>,
-    onApply: (List<String>) -> Unit,
+    selectableTags: Set<String>,
+    selectedTags: Set<String>,
+    onApply: (Set<String>) -> Unit,
     onClearAll: () -> Unit,
     onDismiss: () -> Unit,
     sheetState: WireModalSheetState<Unit> = rememberWireModalSheetState<Unit>(WireSheetValue.Expanded(Unit))
@@ -80,9 +78,9 @@ fun FilterBottomSheet(
 
 @Composable
 private fun SheetContent(
-    selectableTags: StateFlow<List<String>>,
-    selectedTags: StateFlow<List<String>>,
-    onApply: (List<String>) -> Unit = {},
+    selectableTags: Set<String>,
+    selectedTags: Set<String>,
+    onApply: (Set<String>) -> Unit = {},
     onClearAll: () -> Unit = {},
 ) {
     var isExpanded by remember { mutableStateOf(true) }
@@ -93,7 +91,7 @@ private fun SheetContent(
         targetValue = if (isExpanded) 0f else 180f,
     )
 
-    val selectedChips = remember { mutableStateOf(selectedTags.value) }
+    var selectedChips by remember { mutableStateOf(selectedTags) }
 
     Column(modifier = Modifier.padding(horizontal = dimensions().spacing16x)) {
         Box(
@@ -146,8 +144,8 @@ private fun SheetContent(
                         bottom = dimensions().spacing16x
                     )
                 ) {
-                    selectableTags.value.forEach { tag ->
-                        val isSelected = selectedChips.value.contains(tag)
+                    selectableTags.forEach { tag ->
+                        val isSelected = selectedChips.contains(tag)
 
                         item {
                             WireFilterChip(
@@ -155,10 +153,10 @@ private fun SheetContent(
                                 isSelected = isSelected,
                                 modifier = Modifier.padding(end = dimensions().spacing16x),
                                 onSelectChip = { label ->
-                                    selectedChips.value = if (isSelected) {
-                                        selectedChips.value - label
+                                    selectedChips = if (isSelected) {
+                                        selectedChips - label
                                     } else {
-                                        selectedChips.value + label
+                                        selectedChips + label
                                     }
                                 }
                             )
@@ -181,7 +179,7 @@ private fun SheetContent(
                 modifier = Modifier.weight(1f),
                 text = stringResource(R.string.clear_all_label),
                 onClick = {
-                    selectedChips.value = emptyList()
+                    selectedChips = emptySet()
                     onClearAll()
                 },
             )
@@ -191,7 +189,7 @@ private fun SheetContent(
             WirePrimaryButton(
                 modifier = Modifier.weight(1f),
                 text = stringResource(R.string.apply_label),
-                onClick = { onApply(selectedChips.value) },
+                onClick = { onApply(selectedChips) },
                 state = WireButtonState.Default,
             )
         }
@@ -203,8 +201,8 @@ private fun SheetContent(
 fun PreviewFilterBottomSheet() {
     WireTheme {
         FilterBottomSheet(
-            MutableStateFlow(listOf("Android", "iOS", "Web", "QA")),
-            MutableStateFlow(emptyList()),
+            setOf("Android", "iOS", "Web", "QA"),
+            emptySet(),
             onApply = {},
             onClearAll = {},
             onDismiss = {}

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/tags/AddRemoveTagsScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/tags/AddRemoveTagsScreen.kt
@@ -71,8 +71,6 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 
 @WireDestination(
     navArgsDelegate = AddRemoveTagsNavArgs::class,
@@ -126,8 +124,8 @@ fun AddRemoveTagsScreen(
         AddRemoveTagsScreenContent(
             internalPadding = internalPadding,
             textFieldState = addRemoveTagsViewModel.tagsTextState,
-            addedTags = addRemoveTagsViewModel.addedTags,
-            suggestedTags = addRemoveTagsViewModel.suggestedTags,
+            addedTags = addRemoveTagsViewModel.addedTags.collectAsState().value,
+            suggestedTags = addRemoveTagsViewModel.suggestedTags.collectAsState().value,
             onAddTag = { tag ->
                 addRemoveTagsViewModel.addTag(tag)
             },
@@ -160,8 +158,8 @@ fun AddRemoveTagsScreen(
 fun AddRemoveTagsScreenContent(
     internalPadding: PaddingValues,
     textFieldState: TextFieldState,
-    addedTags: StateFlow<List<String>>,
-    suggestedTags: StateFlow<List<String>>,
+    addedTags: Set<String>,
+    suggestedTags: Set<String>,
     onAddTag: (String) -> Unit,
     onRemoveTag: (String) -> Unit,
     modifier: Modifier = Modifier
@@ -214,7 +212,7 @@ fun AddRemoveTagsScreenContent(
                 color = colorsScheme().secondaryText,
             )
         )
-        AnimatedContent(addedTags.collectAsState().value.isEmpty()) { isEmpty ->
+        AnimatedContent(addedTags.isEmpty()) { isEmpty ->
             if (isEmpty) {
                 Text(
                     modifier = Modifier.padding(
@@ -239,7 +237,7 @@ fun AddRemoveTagsScreenContent(
                         )
                         .animateContentSize()
                 ) {
-                    addedTags.collectAsState().value.forEach { tag ->
+                    addedTags.forEach { tag ->
                         WireFilterChip(
                             modifier = Modifier.padding(
                                 end = dimensions().spacing8x,
@@ -269,13 +267,12 @@ fun AddRemoveTagsScreenContent(
 
         HorizontalDivider(color = MaterialTheme.wireColorScheme.outline)
 
-        val items = suggestedTags.collectAsState().value
         LazyRow(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(dimensions().spacing16x)
         ) {
-            items.forEach { tag ->
+            suggestedTags.forEach { tag ->
                 item {
                     WireFilterChip(
                         modifier = Modifier.padding(
@@ -300,8 +297,8 @@ fun PreviewAddRemoveTagsScreen() {
         AddRemoveTagsScreenContent(
             internalPadding = PaddingValues(0.dp),
             textFieldState = TextFieldState(),
-            addedTags = MutableStateFlow(listOf("Android", "Web", "iOS")),
-            suggestedTags = MutableStateFlow(listOf("Marketing", "Finance", "HR")),
+            addedTags = setOf("Android", "Web", "iOS"),
+            suggestedTags = setOf("Marketing", "Finance", "HR"),
             onAddTag = {},
             onRemoveTag = {},
             modifier = Modifier.fillMaxSize()

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
@@ -227,7 +227,7 @@ class CellViewModelTest {
 
             with(expectMostRecentItem()) {
                 assertEquals(testFile, node)
-                assertEquals(NodeBottomSheetAction.SAVE, actions.first())
+                assertEquals(NodeBottomSheetAction.SAVE, actions[1])
             }
         }
     }
@@ -398,6 +398,8 @@ class CellViewModelTest {
             every { kaliumFileSystem.providePersistentAssetPath(any()) } returns localFilePath
 
             every { kaliumFileSystem.exists(any()) } returns false
+
+            coEvery { getAllTagsUseCase.invoke() } returns emptySet<String>().right()
         }
 
         fun withLoadSuccess() = apply {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -109,7 +109,7 @@ junit5 = "5.11.0"
 mockk = "1.13.16"
 okio = "3.9.0"
 turbine = "1.2.0"
-robolectric = "4.14"
+robolectric = "4.14.1"
 hamcrest = "3.0"
 
 [plugins]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19374" title="WPB-19374" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19374</a>  [Android] Newly created tags do not appear immediately in the filter menu
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-19374

# What's new in this PR?

### Issues
New tag becomes available for selection in filters menu only after app restart.

### Causes (Optional)
Tags list for filter menu is updated only once.

### Solutions
Fetch list of tags when opening the filter menu.
Fix issue with incorrect usage of StateFlow from compose.
