### PR TITLE
feat: fetch default SSO code when user identifier is empty [WPB-19294]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -138,7 +138,7 @@ class NewLoginViewModel(
                     },
                     onSuccess = { defaultSSOCode ->
                         if (defaultSSOCode != null && userIdentifierTextState.text.isEmpty()) {
-                            appLogger.d("NewLoginViewModel: Successfully fetched default SSO code $defaultSSOCode")
+                            appLogger.d("NewLoginViewModel: Successfully fetched default SSO code")
                             withContext(dispatchers.main()) {
                                 userIdentifierTextState.setTextAndPlaceCursorAtEnd(defaultSSOCode)
                                 savedStateHandle[USER_IDENTIFIER_SAVED_STATE_KEY] = defaultSSOCode
@@ -249,7 +249,7 @@ class NewLoginViewModel(
                 onAuthScopeFailure = { updateLoginFlowState(it.toLoginError()) },
                 onFetchSSOSettingsFailure = { updateLoginFlowState(it.toLoginError()) },
                 onSuccess = { defaultSSOCode ->
-                    appLogger.d("NewLoginViewModel: Successfully fetched default SSO code $defaultSSOCode")
+                    appLogger.d("NewLoginViewModel: Successfully fetched default SSO code")
 
                     when {
                         defaultSSOCode != null -> {

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -14,6 +14,7 @@ import com.wire.android.ui.authentication.login.DomainClaimedByOrg
 import com.wire.android.ui.authentication.login.LoginNavArgs
 import com.wire.android.ui.authentication.login.LoginPasswordPath
 import com.wire.android.ui.authentication.login.LoginViewModelExtension
+import com.wire.android.ui.authentication.login.PreFilledUserIdentifierType
 import com.wire.android.ui.authentication.login.sso.LoginSSOViewModelExtension
 import com.wire.android.ui.authentication.login.sso.SSOUrlConfig
 import com.wire.android.ui.navArgs
@@ -742,7 +743,7 @@ class NewLoginViewModelTest {
         fun withPreFilledUserIdentifier(userIdentifier: String) = apply {
             every {
                 savedStateHandle.navArgs<LoginNavArgs>()
-            } returns LoginNavArgs(userHandle = com.wire.android.ui.authentication.login.PreFilledUserIdentifierType.PreFilled(userIdentifier))
+            } returns LoginNavArgs(userHandle = PreFilledUserIdentifierType.PreFilled(userIdentifier))
         }
 
         fun withFetchDefaultSSOCodeSuccessAfterDelay(defaultSSOCode: String?) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -593,6 +593,9 @@ class NewLoginViewModelTest {
             every {
                 savedStateHandle[any()] = any<String>()
             } returns Unit
+            every {
+                savedStateHandle.navArgs<LoginNavArgs>()
+            } returns LoginNavArgs()
         }
 
         fun withNavArgsServerConfig(serverConfig: ServerConfig.Links) = apply {
@@ -721,6 +724,37 @@ class NewLoginViewModelTest {
             }
         }
 
+        fun withEmptyUserIdentifierAndNoPreFilledIdentifier() = apply {
+            every {
+                savedStateHandle.get<String>(any())
+            } returns null
+            every {
+                savedStateHandle.navArgs<LoginNavArgs>()
+            } returns LoginNavArgs()
+        }
+
+        fun withUserIdentifierAlreadySet(userIdentifier: String) = apply {
+            every {
+                savedStateHandle.get<String>(any())
+            } returns userIdentifier
+        }
+
+        fun withPreFilledUserIdentifier(userIdentifier: String) = apply {
+            every {
+                savedStateHandle.navArgs<LoginNavArgs>()
+            } returns LoginNavArgs(userHandle = com.wire.android.ui.authentication.login.PreFilledUserIdentifierType.PreFilled(userIdentifier))
+        }
+
+        fun withFetchDefaultSSOCodeSuccessAfterDelay(defaultSSOCode: String?) = apply {
+            coEvery {
+                loginSSOViewModelExtension.fetchDefaultSSOCode(any(), any(), any(), any())
+            } coAnswers {
+                // Simulate delay before calling success callback
+                kotlinx.coroutines.delay(100)
+                arg<suspend (String?) -> Unit>(3)(defaultSSOCode)
+            }
+        }
+
         fun arrange() = this to NewLoginViewModel(
             validateEmailOrSSOCodeUseCase,
             coreLogic,
@@ -732,6 +766,209 @@ class NewLoginViewModelTest {
             dispatchers
         )
     }
+
+    @Test
+    fun `given empty user identifier and no pre-filled identifier, when initializing view model, then fetch default SSO code`() =
+        runTest(dispatchers.main()) {
+            val defaultSSOCode = SSO_CODE_WITH_PREFIX
+            val (arrangement, _) = Arrangement()
+                .withEmptyUserIdentifierAndNoPreFilledIdentifier()
+                .withFetchDefaultSSOCodeSuccess(defaultSSOCode)
+                .arrange()
+
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                arrangement.loginSSOViewModelExtension.fetchDefaultSSOCode(any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `given user identifier already set, when initializing view model, then do not fetch default SSO code`() =
+        runTest(dispatchers.main()) {
+            val (arrangement, _) = Arrangement()
+                .withUserIdentifierAlreadySet("existing@user.com")
+                .arrange()
+
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                arrangement.loginSSOViewModelExtension.fetchDefaultSSOCode(any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `given pre-filled identifier exists, when initializing view model, then do not fetch default SSO code`() =
+        runTest(dispatchers.main()) {
+            val (arrangement, _) = Arrangement()
+                .withPreFilledUserIdentifier("prefilled@user.com")
+                .arrange()
+
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                arrangement.loginSSOViewModelExtension.fetchDefaultSSOCode(any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `given auth scope failure during init, when fetching default SSO code, then handle error gracefully`() =
+        runTest(dispatchers.main()) {
+            val (arrangement, viewModel) = Arrangement()
+                .withEmptyUserIdentifierAndNoPreFilledIdentifier()
+                .withFetchDefaultSSOCodeAuthScopeFailure(AutoVersionAuthScopeUseCase.Result.Failure.UnknownServerVersion)
+                .arrange()
+
+            advanceUntilIdle()
+
+            assertEquals("", viewModel.userIdentifierTextState.text.toString())
+        }
+
+    @Test
+    fun `given fetch SSO settings failure during init, when fetching default SSO code, then handle error gracefully`() =
+        runTest(dispatchers.main()) {
+            val failure = CoreFailure.Unknown(RuntimeException("Network error"))
+            val (arrangement, viewModel) = Arrangement()
+                .withEmptyUserIdentifierAndNoPreFilledIdentifier()
+                .withFetchDefaultSSOCodeFailure(FetchSSOSettingsUseCase.Result.Failure(failure))
+                .arrange()
+
+            advanceUntilIdle()
+
+            assertEquals("", viewModel.userIdentifierTextState.text.toString())
+        }
+
+    @Test
+    fun `given default SSO code available during init, when fetching succeeds and text field is empty, then set SSO code`() =
+        runTest(dispatchers.main()) {
+            val defaultSSOCode = SSO_CODE_WITH_PREFIX
+            val (arrangement, viewModel) = Arrangement()
+                .withEmptyUserIdentifierAndNoPreFilledIdentifier()
+                .withFetchDefaultSSOCodeSuccess(defaultSSOCode)
+                .arrange()
+
+            advanceUntilIdle()
+
+            assertEquals(defaultSSOCode, viewModel.userIdentifierTextState.text.toString())
+        }
+
+    @Test
+    fun `given null default SSO code during init, when fetching succeeds, then do not set text field`() =
+        runTest(dispatchers.main()) {
+            val (arrangement, viewModel) = Arrangement()
+                .withEmptyUserIdentifierAndNoPreFilledIdentifier()
+                .withFetchDefaultSSOCodeSuccess(null)
+                .arrange()
+
+            advanceUntilIdle()
+
+            assertEquals("", viewModel.userIdentifierTextState.text.toString())
+        }
+
+    @Test
+    fun `given user identifier changed during fetch, when default SSO code returns, then do not override user input`() =
+        runTest(dispatchers.main()) {
+            val defaultSSOCode = SSO_CODE_WITH_PREFIX
+            val userInput = "user@typed.com"
+            val (arrangement, viewModel) = Arrangement()
+                .withEmptyUserIdentifierAndNoPreFilledIdentifier()
+                .withFetchDefaultSSOCodeSuccessAfterDelay(defaultSSOCode)
+                .arrange()
+
+            // Simulate user typing during the fetch
+            viewModel.userIdentifierTextState.setTextAndPlaceCursorAtEnd(userInput)
+            advanceUntilIdle()
+
+            assertEquals(userInput, viewModel.userIdentifierTextState.text.toString())
+        }
+
+    @Test
+    fun `when onDismissDialog is called, then reset state to default`() =
+        runTest(dispatchers.main()) {
+            val (arrangement, viewModel) = Arrangement()
+                .arrange()
+
+            // Call onDismissDialog which should reset state to default
+            viewModel.onDismissDialog()
+
+            // Verify the state is reset to default
+            assertEquals(NewLoginFlowState.Default, viewModel.state.flowState)
+        }
+
+    @Test
+    fun `given onCustomServerDialogConfirm called, when fetchDefaultSSOCode onSuccess lambda is triggered, then lambda executes correctly`() =
+        runTest(dispatchers.main()) {
+            val serverConfig = newServerConfig(1).links
+            val defaultSSOCode = SSO_CODE_WITH_PREFIX
+            val (arrangement, viewModel) = Arrangement()
+                .withFetchDefaultSSOCodeSuccess(defaultSSOCode)
+                .arrange()
+
+            viewModel.onCustomServerDialogConfirm(serverConfig)
+            advanceUntilIdle()
+
+            // Verify the fetchDefaultSSOCode method was called
+            coVerify(exactly = 1) {
+                arrangement.loginSSOViewModelExtension.fetchDefaultSSOCode(
+                    serverConfig = serverConfig,
+                    onAuthScopeFailure = any(),
+                    onFetchSSOSettingsFailure = any(),
+                    onSuccess = any()
+                )
+            }
+
+            // Verify that initiateSSO was called (meaning the onSuccess lambda was executed)
+            coVerify(exactly = 1) {
+                arrangement.loginSSOViewModelExtension.initiateSSO(serverConfig, defaultSSOCode, any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `given CustomServerDetailsDialog onConfirm called, when onCustomServerDialogConfirm is executed, then action proceeds and dialog dismisses`() =
+        runTest(dispatchers.main()) {
+            val serverConfig = newServerConfig(1).links
+            val (arrangement, viewModel) = Arrangement()
+                .withFetchDefaultSSOCodeSuccess(null)
+                .arrange()
+
+            viewModel.actions.test {
+                // Call onCustomServerDialogConfirm (simulating the dialog's onConfirm callback)
+                viewModel.onCustomServerDialogConfirm(serverConfig)
+                advanceUntilIdle()
+
+                // Verify the action was sent
+                assertInstanceOf<NewLoginAction.CustomConfig>(expectMostRecentItem()).let {
+                    assertEquals(serverConfig, it.customServerConfig)
+                }
+
+                // Verify the dialog state was reset to default (dialog dismissed)
+                assertEquals(NewLoginFlowState.Default, viewModel.state.flowState)
+            }
+        }
+
+    @Test
+    fun `given enterprise login with CustomBackend path, when executed, then CustomConfigDialog state is set`() =
+        runTest(dispatchers.main()) {
+            val email = "user@custom-domain.com"
+            val customServerConfig = newServerConfig(2).links
+            val (arrangement, viewModel) = Arrangement()
+                .withEmailOrSSOCodeValidatorReturning(ValidEmail)
+                .withAuthenticationScopeSuccess()
+                .withGetLoginFlowForDomainReturning(
+                    EnterpriseLoginResult.Success(LoginRedirectPath.CustomBackend(customServerConfig))
+                )
+                .arrange()
+
+            // Set user input to trigger enterprise login
+            viewModel.userIdentifierTextState.setTextAndPlaceCursorAtEnd(email)
+
+            // Start the login flow
+            viewModel.onLoginStarted()
+            advanceUntilIdle()
+
+            // Verify the CustomConfigDialog state is set (this triggers the dialog to show)
+            assertEquals(NewLoginFlowState.CustomConfigDialog(customServerConfig), viewModel.state.flowState)
+        }
 
     companion object {
         private const val SSO_CODE_WITHOUT_PREFIX: String = "fd994b20-b9af-11ec-ae36-00163e9b33ca"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19294" title="WPB-19294" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19294</a>  [Android] Default-SSO Code is not pre-filled in Login screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

if the user uses deep link or have on prem server baked in the default sso code is not prefilled 

### Causes (Optional)

it was not in the specs before

### Solutions

prefill user default sso code iff preFilledUserIdentifier is NONE, this mean the user is not coming from domain redirect to avoid double API calls

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
