### PR TITLE
chore: hide cells debug switch on prod (WPB-19406)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
@@ -119,11 +119,11 @@ internal fun UserDebugContent(
                     buildVariant = "${BuildConfig.FLAVOR}${BuildConfig.BUILD_TYPE.replaceFirstChar { it.uppercase() }}",
                     onCopyText = debugContentState::copyToClipboard,
                 )
-                DebugWireCellOptions(
-                    isCellFeatureEnabled = isWireCellFeatureEnabled,
-                    onCheckedChange = onEnableWireCellsFeature,
-                )
                 if (BuildConfig.PRIVATE_BUILD) {
+                    DebugWireCellOptions(
+                        isCellFeatureEnabled = isWireCellFeatureEnabled,
+                        onCheckedChange = onEnableWireCellsFeature,
+                    )
                     DangerOptions()
                 }
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19406" title="WPB-19406" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19406</a>  [Android] - Hide Wire Cells toggle on prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-19406

# What's new in this PR?

Hide wire cells switch in debug menu on production build.