### PR TITLE
fix: load active one on one conversation options based on other user active conversation id (WPB-19073)

### DIFF
--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -10,6 +10,9 @@ env:
 
 jobs:
   coverage:
+    env:
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=2g -Xmx4G"'
+      DISABLE_ABOUT_LIBRARIES: TRUE
     runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - name: Checkout

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -354,10 +354,10 @@ private fun TopBarHeader(
         },
         elevation = elevation,
         actions = {
-            if (state.conversationId != null) {
+            if (state.activeOneOnOneConversationId != null) {
                 MoreOptionIcon(
                     contentDescription = R.string.content_description_user_profile_more_btn,
-                    onButtonClicked = { openConversationBottomSheet(state.conversationId) },
+                    onButtonClicked = { openConversationBottomSheet(state.activeOneOnOneConversationId) },
                     state = if (state.isMetadataEmpty()) WireButtonState.Disabled else WireButtonState.Default
                 )
             }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -259,11 +259,13 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             expiresAt = otherUser.expiresAt,
             accentId = otherUser.accentId,
             isDeletedUser = otherUser.deleted,
+            activeOneOnOneConversationId = otherUser.activeOneOnOneConversationId
         )
     }
 
     private fun onMessage(message: SnackBarMessage) = sendAction(OtherUserProfileViewAction.Message(message))
 }
+
 sealed interface OtherUserProfileViewAction {
     data class Message(val message: SnackBarMessage) : OtherUserProfileViewAction
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -34,6 +34,7 @@ import kotlinx.serialization.Serializable
 data class OtherUserProfileState(
     val userId: UserId,
     val conversationId: ConversationId? = null,
+    val activeOneOnOneConversationId: ConversationId? = null,
     val userAvatarAsset: UserAvatarAsset? = null,
     val isDataLoading: Boolean = false,
     val isAvatarLoading: Boolean = false,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19073" title="WPB-19073" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19073</a>  [Android] 1:1 conversation details access missing on other users profile
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Conversation Options are not visible for 1 on 1 conversations, due to a refactor did recently.

### Causes (Optional)

Conversation Id is not always passed as an argument.

### Solutions

To display the options of otheruser profile, use the activeOneOnOneConversationId instead of the conversationId.
This allow to show (if present) the relevant options. Not the group conversation Id for example, that has no relationship to the other user profile.


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
