### PR TITLE
fix: crash when starting a call [WPB-17676]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -299,25 +299,27 @@ class WireActivity : AppCompatActivity() {
             backgroundType = backgroundType,
             onReturnToCallClick = { establishedCall ->
                 getOngoingCallIntent(
-                    this@WireActivity,
-                    establishedCall.conversationId.toString()
+                    context = this@WireActivity,
+                    conversationId = establishedCall.conversationId.toString(),
+                    userId = establishedCall.userId.toString(),
                 ).run {
                     startActivity(this)
                 }
             },
             onReturnToIncomingCallClick = {
                 getIncomingCallIntent(
-                    this@WireActivity,
-                    it.conversationId.toString(),
-                    it.userId.toString(),
+                    context = this@WireActivity,
+                    conversationId = it.conversationId.toString(),
+                    userId = it.userId.toString(),
                 ).run {
                     startActivity(this)
                 }
             },
             onReturnToOutgoingCallClick = {
                 getOutgoingCallIntent(
-                    this@WireActivity,
-                    it.conversationId.toString()
+                    context = this@WireActivity,
+                    conversationId = it.conversationId.toString(),
+                    userId = it.userId.toString(),
                 ).run {
                     startActivity(this)
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/StartingCallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/StartingCallActivity.kt
@@ -119,28 +119,30 @@ class StartingCallActivity : CallActivity() {
                             modifier = Modifier.semantics { testTagsAsResourceId = true },
                             label = currentScreenType.name
                         ) { screenType ->
-                            conversationId?.let {
-                                when (screenType) {
-                                    StartingCallScreenType.Outgoing -> {
-                                        OutgoingCallScreen(
-                                            conversationId = qualifiedIdMapper.fromStringToQualifiedID(it)
-                                        ) {
-                                            getOngoingCallIntent(this@StartingCallActivity, it).run {
-                                                this@StartingCallActivity.startActivity(this)
+                            conversationId?.let { conversationId ->
+                                userId?.let { userId ->
+                                    when (screenType) {
+                                        StartingCallScreenType.Outgoing -> {
+                                            OutgoingCallScreen(
+                                                conversationId = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
+                                            ) {
+                                                getOngoingCallIntent(this@StartingCallActivity, conversationId, userId).run {
+                                                    this@StartingCallActivity.startActivity(this)
+                                                }
+                                                this@StartingCallActivity.finishAndRemoveTask()
                                             }
-                                            this@StartingCallActivity.finishAndRemoveTask()
                                         }
-                                    }
 
-                                    StartingCallScreenType.Incoming -> {
-                                        IncomingCallScreen(
-                                            conversationId = qualifiedIdMapper.fromStringToQualifiedID(it),
-                                            shouldTryToAnswerCallAutomatically = shouldAnswerCall,
-                                        ) {
-                                            this@StartingCallActivity.startActivity(
-                                                getOngoingCallIntent(this@StartingCallActivity, it)
-                                            )
-                                            this@StartingCallActivity.finishAndRemoveTask()
+                                        StartingCallScreenType.Incoming -> {
+                                            IncomingCallScreen(
+                                                conversationId = qualifiedIdMapper.fromStringToQualifiedID(conversationId),
+                                                shouldTryToAnswerCallAutomatically = shouldAnswerCall,
+                                            ) {
+                                                this@StartingCallActivity.startActivity(
+                                                    getOngoingCallIntent(this@StartingCallActivity, conversationId, userId)
+                                                )
+                                                this@StartingCallActivity.finishAndRemoveTask()
+                                            }
                                         }
                                     }
                                 }
@@ -174,9 +176,11 @@ class StartingCallActivity : CallActivity() {
 
 fun getOutgoingCallIntent(
     context: Context,
-    conversationId: String
+    conversationId: String,
+    userId: String,
 ) = Intent(context, StartingCallActivity::class.java).apply {
     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    putExtra(EXTRA_USER_ID, userId)
     putExtra(EXTRA_CONVERSATION_ID, conversationId)
     putExtra(EXTRA_SCREEN_TYPE, StartingCallScreenType.Outgoing.name)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
@@ -48,6 +48,7 @@ import com.wire.android.services.ServicesManager
 import com.wire.android.ui.LocalActivity
 import com.wire.android.ui.calling.CallActivity
 import com.wire.android.ui.calling.CallActivity.Companion.EXTRA_CONVERSATION_ID
+import com.wire.android.ui.calling.CallActivity.Companion.EXTRA_USER_ID
 import com.wire.android.ui.calling.common.ProximitySensorManager
 import com.wire.android.ui.calling.ongoing.OngoingCallActivity.Companion.TAG
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
@@ -85,6 +86,8 @@ class OngoingCallActivity : CallActivity() {
         conversationId = intent.extras?.getString(EXTRA_CONVERSATION_ID)
         userId = intent.extras?.getString(EXTRA_USER_ID)
         shouldAnswerCall = intent.extras?.getBoolean(EXTRA_SHOULD_ANSWER_CALL) ?: false
+        require(conversationId != null) { "$TAG No conversation ID provided in intent extras" }
+        require(userId != null) { "$TAG No user ID provided in intent extras" }
         switchAccountIfNeeded(userId)
     }
 
@@ -167,10 +170,12 @@ class OngoingCallActivity : CallActivity() {
 
 fun getOngoingCallIntent(
     context: Context,
-    conversationId: String
+    conversationId: String,
+    userId: String,
 ) = Intent(context, OngoingCallActivity::class.java).apply {
     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     putExtra(EXTRA_CONVERSATION_ID, conversationId)
+    putExtra(EXTRA_USER_ID, userId)
 }
 
 private const val ASPECT_RATIO_NUMERATOR = 2

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -333,12 +333,12 @@ fun ConversationScreen(
     HandleActions(conversationCallViewModel.actions) { action ->
         when (action) {
             is ConversationCallViewActions.InitiatedCall -> {
-                context.startActivity(getOutgoingCallIntent(context, action.conversationId.toString()))
+                context.startActivity(getOutgoingCallIntent(context, action.conversationId.toString(), action.userId.toString()))
                 AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallInitiated)
             }
 
             is ConversationCallViewActions.JoinedCall -> {
-                context.startActivity(getOngoingCallIntent(context, action.conversationId.toString()))
+                context.startActivity(getOngoingCallIntent(context, action.conversationId.toString(), action.userId.toString()))
                 AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallJoined)
             }
         }
@@ -391,8 +391,8 @@ fun ConversationScreen(
                         showDialog,
                         coroutineScope,
                         conversationInfoViewModel.conversationInfoViewState.conversationType,
-                        onOpenOngoingCallScreen = {
-                            getOngoingCallIntent(context, it.toString()).run {
+                        onOpenOngoingCallScreen = { conversationId, userId ->
+                            getOngoingCallIntent(context, conversationId.toString(), userId.toString()).run {
                                 context.startActivity(this)
                             }
                         }
@@ -453,8 +453,8 @@ fun ConversationScreen(
                         showDialog,
                         coroutineScope,
                         conversationInfoViewModel.conversationInfoViewState.conversationType,
-                        onOpenOngoingCallScreen = {
-                            getOngoingCallIntent(context, it.toString()).run {
+                        onOpenOngoingCallScreen = { conversationId, userId ->
+                            getOngoingCallIntent(context, conversationId.toString(), userId.toString()).run {
                                 context.startActivity(this)
                             }
                         }
@@ -558,8 +558,8 @@ fun ConversationScreen(
                 showDialog,
                 coroutineScope,
                 conversationInfoViewModel.conversationInfoViewState.conversationType,
-                onOpenOngoingCallScreen = {
-                    getOngoingCallIntent(context, it.toString()).run {
+                onOpenOngoingCallScreen = { conversationId, userId ->
+                    getOngoingCallIntent(context, conversationId.toString(), userId.toString()).run {
                         context.startActivity(this)
                     }
                 }
@@ -810,7 +810,7 @@ private fun startCallIfPossible(
     showDialog: MutableState<ConversationScreenDialogType>,
     coroutineScope: CoroutineScope,
     conversationType: Conversation.Type,
-    onOpenOngoingCallScreen: (ConversationId) -> Unit
+    onOpenOngoingCallScreen: (ConversationId, UserId) -> Unit
 ) {
     coroutineScope.launch {
         if (!conversationCallViewModel.hasStableConnectivity()) {
@@ -832,7 +832,7 @@ private fun startCallIfPossible(
                 }
 
                 ConferenceCallingResult.Disabled.Established -> {
-                    onOpenOngoingCallScreen(conversationCallViewModel.conversationId)
+                    onOpenOngoingCallScreen(conversationCallViewModel.conversationId, conversationCallViewModel.currentAccount)
                     AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallJoined)
                     ConversationScreenDialogType.NONE
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/ConversationCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/ConversationCallViewModel.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.wire.android.di.CurrentAccount
 import com.wire.android.ui.common.ActionsViewModel
 import com.wire.android.ui.home.conversations.ConversationNavArgs
 import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
@@ -32,6 +33,7 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.sync.SyncState
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ConferenceCallingResult
@@ -59,6 +61,7 @@ import javax.inject.Inject
 @Suppress("LongParameterList", "TooManyFunctions")
 class ConversationCallViewModel @Inject constructor(
     val savedStateHandle: SavedStateHandle,
+    @CurrentAccount val currentAccount: UserId,
     private val observeOngoingCalls: ObserveOngoingCallsUseCase,
     private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
     private val observeParticipantsForConversation: ObserveParticipantsForConversationUseCase,
@@ -175,7 +178,7 @@ class ConversationCallViewModel @Inject constructor(
             } else {
                 dismissJoinCallAnywayDialog()
                 answerCall(conversationId = conversationId)
-                sendAction(ConversationCallViewActions.JoinedCall(conversationId))
+                sendAction(ConversationCallViewActions.JoinedCall(conversationId, currentAccount))
             }
         }
     }
@@ -193,7 +196,7 @@ class ConversationCallViewModel @Inject constructor(
             establishedCallConversationId?.let {
                 endCall(it)
             }
-            sendAction(ConversationCallViewActions.InitiatedCall(conversationId))
+            sendAction(ConversationCallViewActions.InitiatedCall(conversationId, currentAccount))
         }
     }
 
@@ -223,6 +226,6 @@ class ConversationCallViewModel @Inject constructor(
 }
 
 sealed interface ConversationCallViewActions {
-    data class JoinedCall(val conversationId: ConversationId) : ConversationCallViewActions
-    data class InitiatedCall(val conversationId: ConversationId) : ConversationCallViewActions
+    data class JoinedCall(val conversationId: ConversationId, val userId: UserId) : ConversationCallViewActions
+    data class InitiatedCall(val conversationId: ConversationId, val userId: UserId) : ConversationCallViewActions
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListCallViewModel.kt
@@ -19,11 +19,13 @@
 package com.wire.android.ui.home.conversationslist
 
 import androidx.lifecycle.viewModelScope
+import com.wire.android.di.CurrentAccount
 import com.wire.android.ui.common.ActionsManager
 import com.wire.android.ui.common.ActionsViewModel
 import com.wire.android.ui.common.visbility.VisibilityState
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
@@ -45,6 +47,7 @@ object ConversationListCallViewModelPreview : ConversationListCallViewModel
 @Suppress("MagicNumber", "TooManyFunctions", "LongParameterList")
 @HiltViewModel
 class ConversationListCallViewModelImpl @Inject constructor(
+    @CurrentAccount val currentAccount: UserId,
     private val answerCall: AnswerCallUseCase,
     private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
     private val endCall: EndCallUseCase
@@ -88,7 +91,7 @@ class ConversationListCallViewModelImpl @Inject constructor(
             viewModelScope.launch {
                 answerCall(conversationId = conversationId)
             }
-            sendAction(ConversationListCallViewActions.JoinedCall(conversationId))
+            sendAction(ConversationListCallViewActions.JoinedCall(conversationId, currentAccount))
         }
     }
 
@@ -98,5 +101,5 @@ class ConversationListCallViewModelImpl @Inject constructor(
 }
 
 sealed interface ConversationListCallViewActions {
-    data class JoinedCall(val conversationId: ConversationId) : ConversationListCallViewActions
+    data class JoinedCall(val conversationId: ConversationId, val userId: UserId) : ConversationListCallViewActions
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -110,7 +110,7 @@ fun ConversationsScreenContent(
         when (action) {
             is ConversationListCallViewActions.JoinedCall -> {
                 AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallJoined)
-                getOngoingCallIntent(context, action.conversationId.toString()).run {
+                getOngoingCallIntent(context, action.conversationId.toString(), action.userId.toString()).run {
                     context.startActivity(this)
                 }
             }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/call/ConversationCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/call/ConversationCallViewModelTest.kt
@@ -26,6 +26,7 @@ import com.wire.android.ui.home.conversations.ConversationNavArgs
 import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
 import com.wire.android.ui.navArgs
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
@@ -79,7 +80,7 @@ class ConversationCallViewModelTest {
             viewModel.joinOngoingCall()
 
             coVerify(exactly = 1) { arrangement.joinCall(conversationId = arrangement.conversationId) }
-            assertEquals(ConversationCallViewActions.JoinedCall(arrangement.conversationId), awaitItem())
+            assertEquals(ConversationCallViewActions.JoinedCall(arrangement.conversationId, arrangement.currentAccount), awaitItem())
             assertEquals(false, viewModel.conversationCallViewState.shouldShowJoinAnywayDialog)
         }
     }
@@ -192,6 +193,7 @@ class ConversationCallViewModelTest {
         lateinit var observeConferenceCallingEnabled: ObserveConferenceCallingEnabledUseCase
 
         val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
+        val currentAccount = UserId("current-account-id", "domain.com")
 
         init {
             MockKAnnotations.init(this)
@@ -238,7 +240,8 @@ class ConversationCallViewModelTest {
             setUserInformedAboutVerification = setUserInformedAboutVerificationUseCase,
             observeDegradedConversationNotified = observeDegradedConversationNotifiedUseCase,
             observeConferenceCallingEnabled = observeConferenceCallingEnabled,
-            observeSelf = observeSelfUserUseCase
+            observeSelf = observeSelfUserUseCase,
+            currentAccount = currentAccount,
         )
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListCallViewModelTest.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
@@ -61,7 +62,7 @@ class ConversationListCallViewModelTest {
 
                 // Then
                 coVerify(exactly = 1) { arrangement.answerCall(conversationId = conversationId) }
-                assertEquals(ConversationListCallViewActions.JoinedCall(conversationId), awaitItem())
+                assertEquals(ConversationListCallViewActions.JoinedCall(conversationId, currentAccount), awaitItem())
             }
     }
 
@@ -94,7 +95,7 @@ class ConversationListCallViewModelTest {
 
                 // Then
                 coVerify(exactly = 1) { arrangement.answerCall(conversationId = any()) }
-                assertEquals(ConversationListCallViewActions.JoinedCall(conversationId), awaitItem())
+                assertEquals(ConversationListCallViewActions.JoinedCall(conversationId, currentAccount), awaitItem())
                 assertEquals(false, conversationListCallViewModel.joinCallDialogState.isVisible)
             }
     }
@@ -154,12 +155,14 @@ class ConversationListCallViewModelTest {
         fun arrange() = this to ConversationListCallViewModelImpl(
             answerCall = answerCall,
             endCall = endCall,
-            observeEstablishedCalls = observeEstablishedCalls
+            observeEstablishedCalls = observeEstablishedCalls,
+            currentAccount = currentAccount,
         )
     }
 
     companion object {
         private val conversationId = ConversationId("some_id", "some_domain")
+        private val currentAccount = UserId("current-account-id", "domain.com")
         private val call = Call(
             conversationId = ConversationId("ongoing_call_id", "some_domain"),
             status = CallStatus.ESTABLISHED,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17676" title="WPB-17676" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17676</a>  [SG S23 Ultra/Android 14] Call - Accept call in the notification does not start the call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This is a follow-up PR to this one: https://github.com/wireapp/wire-android/pull/4188

### Issues

There's a crash when starting a new call.

### Causes (Optional)

After applying changes to the way incoming call is accepted and how opening `StartingCallActivity` is handled, it's missing analogous changes for handling outgoing call.

### Solutions

Add required `userId` parameter when creating `StartingCallActivity` for outgoing call as well the same as it's already done for incoming call. The call should always be identified by a pair of `conversationId` and `userId`, not only the first one as the `conversationId` can be the same for two or more accounts at the same time if all of them are participants of that call so it matters which user answers or initiates the call.

### Testing

#### How to Test

Start a call.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
