### PR TITLE
fix: call automatically initiates answering on fullscreen without permissions [WPB-17676]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/CallNotificationManager.kt
@@ -233,7 +233,7 @@ class CallNotificationBuilder @Inject constructor(
             )
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-            .setContentIntent(outgoingCallPendingIntent(context, conversationIdString))
+            .setContentIntent(outgoingCallPendingIntent(context, conversationIdString, userIdString))
             .build()
     }
 

--- a/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/PendingIntents.kt
@@ -34,14 +34,9 @@ import com.wire.android.notification.broadcastreceivers.NotificationReplyReceive
 import com.wire.android.notification.broadcastreceivers.PlayPauseAudioMessageReceiver
 import com.wire.android.notification.broadcastreceivers.StopAudioMessageReceiver
 import com.wire.android.ui.WireActivity
-import com.wire.android.ui.calling.CallActivity.Companion.EXTRA_CONVERSATION_ID
-import com.wire.android.ui.calling.CallActivity.Companion.EXTRA_SCREEN_TYPE
-import com.wire.android.ui.calling.CallActivity.Companion.EXTRA_SHOULD_ANSWER_CALL
-import com.wire.android.ui.calling.CallActivity.Companion.EXTRA_USER_ID
-import com.wire.android.ui.calling.StartingCallActivity
-import com.wire.android.ui.calling.StartingCallScreenType
 import com.wire.android.ui.calling.getIncomingCallIntent
-import com.wire.android.ui.calling.ongoing.OngoingCallActivity
+import com.wire.android.ui.calling.getOutgoingCallIntent
+import com.wire.android.ui.calling.ongoing.getOngoingCallIntent
 import com.wire.android.util.deeplink.DeepLinkProcessor
 
 fun messagePendingIntent(context: Context, conversationId: String, userId: String?): PendingIntent {
@@ -97,10 +92,15 @@ fun openOngoingCallPendingIntent(
     userId: String,
     shouldAnswerCall: Boolean = false
 ): PendingIntent {
-    val intent = ongoingCallIntent(context, conversationId, userId, shouldAnswerCall)
+    val intent = getOngoingCallIntent(
+        context = context,
+        conversationId = conversationId,
+        userId = userId,
+        shouldAnswerCall = shouldAnswerCall
+    )
     return PendingIntent.getActivity(
         context.applicationContext,
-        OPEN_ONGOING_CALL_REQUEST_CODE,
+        getRequestCode(OPEN_ONGOING_CALL_REQUEST_CODE, userId, conversationId, shouldAnswerCall.toString()),
         intent,
         PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
     )
@@ -160,12 +160,15 @@ fun answerCallPendingIntent(context: Context, conversationId: String, userId: St
     }
 }
 
-fun outgoingCallPendingIntent(context: Context, conversationId: String): PendingIntent {
-    val intent = openOutgoingCallIntent(context, conversationId)
-
+fun outgoingCallPendingIntent(context: Context, conversationId: String, userId: String): PendingIntent {
+    val intent = getOutgoingCallIntent(
+        context = context,
+        conversationId = conversationId,
+        userId = userId
+    )
     return PendingIntent.getActivity(
         context,
-        OUTGOING_CALL_REQUEST_CODE,
+        getRequestCode(OUTGOING_CALL_REQUEST_CODE, conversationId, userId),
         intent,
         PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
     )
@@ -177,31 +180,18 @@ fun fullScreenIncomingCallPendingIntent(
     userId: String,
     shouldAnswerCall: Boolean = false
 ): PendingIntent {
-    val intent = getIncomingCallIntent(context, conversationId, userId, shouldAnswerCall)
-
+    val intent = getIncomingCallIntent(
+        context = context,
+        conversationId = conversationId,
+        userId = userId,
+        shouldAnswerCall = shouldAnswerCall
+    )
     return PendingIntent.getActivity(
         context,
-        getRequestCode(FULL_SCREEN_REQUEST_CODE, userId, conversationId),
+        getRequestCode(FULL_SCREEN_REQUEST_CODE, userId, conversationId, shouldAnswerCall.toString()),
         intent,
         PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
     )
-}
-
-private fun openOutgoingCallIntent(context: Context, conversationId: String) =
-    Intent(context.applicationContext, StartingCallActivity::class.java).apply {
-        putExtra(EXTRA_CONVERSATION_ID, conversationId)
-        putExtra(EXTRA_SCREEN_TYPE, StartingCallScreenType.Outgoing.name)
-    }
-
-private fun ongoingCallIntent(
-    context: Context,
-    conversationId: String,
-    userId: String,
-    shouldAnswerCall: Boolean
-) = Intent(context.applicationContext, OngoingCallActivity::class.java).apply {
-    putExtra(EXTRA_CONVERSATION_ID, conversationId)
-    putExtra(EXTRA_USER_ID, userId)
-    putExtra(EXTRA_SHOULD_ANSWER_CALL, shouldAnswerCall)
 }
 
 private fun openMigrationLoginIntent(context: Context, userHandle: String) =
@@ -216,7 +206,7 @@ private fun openMigrationLoginIntent(context: Context, userHandle: String) =
 fun openMigrationLoginPendingIntent(context: Context, userHandle: String): PendingIntent =
     PendingIntent.getActivity(
         context.applicationContext,
-        OPEN_MIGRATION_LOGIN_REQUEST_CODE,
+        getRequestCode(OPEN_MIGRATION_LOGIN_REQUEST_CODE, userHandle),
         openMigrationLoginIntent(context, userHandle),
         PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
     )
@@ -260,9 +250,9 @@ fun stopAudioPendingIntent(context: Context): PendingIntent {
 private const val MESSAGE_NOTIFICATIONS_SUMMARY_REQUEST_CODE = 0
 private const val DECLINE_CALL_REQUEST_CODE = "decline_call_"
 private const val FULL_SCREEN_REQUEST_CODE = "incoming_call_"
-private const val OPEN_ONGOING_CALL_REQUEST_CODE = 4
-private const val OPEN_MIGRATION_LOGIN_REQUEST_CODE = 5
-private const val OUTGOING_CALL_REQUEST_CODE = 6
+private const val OPEN_ONGOING_CALL_REQUEST_CODE = "ongoing_call_"
+private const val OPEN_MIGRATION_LOGIN_REQUEST_CODE = "migration_login_"
+private const val OUTGOING_CALL_REQUEST_CODE = "outgoing_call_"
 private const val END_ONGOING_CALL_REQUEST_CODE = "hang_up_call_"
 private const val PLAY_PAUSE_AUDIO_REQUEST_CODE = "play_or_pause_audio_"
 private const val STOP_AUDIO_REQUEST_CODE = "stop_audio_"
@@ -270,5 +260,5 @@ private const val OPEN_MESSAGE_REQUEST_CODE_PREFIX = "open_message_"
 private const val OPEN_OTHER_USER_PROFILE_CODE_PREFIX = "open_other_user_profile_"
 private const val REPLY_MESSAGE_REQUEST_CODE_PREFIX = "reply_"
 
-private fun getRequestCode(prefix: String, userId: String = "", conversationId: String = ""): Int =
-    (prefix + userId + conversationId).hashCode()
+private fun getRequestCode(prefix: String, vararg parameters: String): Int =
+    (prefix + parameters.joinToString("_")).hashCode()

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
@@ -48,6 +48,7 @@ import com.wire.android.services.ServicesManager
 import com.wire.android.ui.LocalActivity
 import com.wire.android.ui.calling.CallActivity
 import com.wire.android.ui.calling.CallActivity.Companion.EXTRA_CONVERSATION_ID
+import com.wire.android.ui.calling.CallActivity.Companion.EXTRA_SHOULD_ANSWER_CALL
 import com.wire.android.ui.calling.CallActivity.Companion.EXTRA_USER_ID
 import com.wire.android.ui.calling.common.ProximitySensorManager
 import com.wire.android.ui.calling.ongoing.OngoingCallActivity.Companion.TAG
@@ -172,10 +173,12 @@ fun getOngoingCallIntent(
     context: Context,
     conversationId: String,
     userId: String,
+    shouldAnswerCall: Boolean = false,
 ) = Intent(context, OngoingCallActivity::class.java).apply {
     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     putExtra(EXTRA_CONVERSATION_ID, conversationId)
     putExtra(EXTRA_USER_ID, userId)
+    putExtra(EXTRA_SHOULD_ANSWER_CALL, shouldAnswerCall)
 }
 
 private const val ASPECT_RATIO_NUMERATOR = 2


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17676" title="WPB-17676" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17676</a>  [SG S23 Ultra/Android 14] Call - Accept call in the notification does not start the call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the app doesn't have microphone permissions and receives incoming call when the screen is turned off so that it shows the notification as a fullscreen intent, then it automatically initiates process of answering the call without user clicking anything.

### Causes (Optional)

Incoming call notification with fullscreen intent creates two pending intents with different value for `shouldAnswerCall` parameter - for the "answer" button it's `true` but for fullscreen intent it's `false`, but both pending intents use the same exact request code with `FLAG_UPDATE_CURRENT` so it's being overridden and fullscreen gets the intent with `shouldAnswerCall` set to `true`.

### Solutions

Separate pending intents by giving them distinct request codes (for all pending events that we use, so it should fix also other pending intents where request code was improperly reused). Add `userId` to the outgoing call where it was still missing it. Reuse methods to create intents instead of having such methods in two places.

### Testing

#### How to Test

Remove microphone permission, turn off screen, receive incoming call - it should open fullscreen incoming call window but it shouldn't open the "ask for permission" dialog without user clicking green button "answer call".

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
