### PR TITLE
fix: search and media access missing on other users profile [WPB-19073]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -313,14 +313,16 @@ class WireNotificationManager @Inject constructor(
             .collect { screens ->
                 when (screens) {
                     is CurrentScreen.Conversation -> messagesNotificationManager.hideNotification(
-                        screens.id,
-                        userId
+                        conversationsId = screens.id,
+                        userId = userId
                     )
 
-                    is CurrentScreen.OtherUserProfile -> messagesNotificationManager.hideNotification(
-                        screens.id,
-                        userId
-                    )
+                    is CurrentScreen.OtherUserProfile -> screens.groupConversationId?.let {
+                        messagesNotificationManager.hideNotification(
+                            conversationsId = screens.groupConversationId,
+                            userId = userId
+                        )
+                    }
 
                     else -> {}
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileNavArgs.kt
@@ -20,7 +20,12 @@ package com.wire.android.ui.userprofile.other
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 
+/**
+ * @param userId the id of the user whose profile is accessed
+ * @param groupConversationId the id of the group conversation from which the user profile is accessed, to show and edit the member role
+ * for that user, if the profile is not accessed from a conversation members list or mention then this parameter should be null
+ */
 data class OtherUserProfileNavArgs(
     val userId: UserId,
-    val conversationId: ConversationId? = null
+    val groupConversationId: ConversationId? = null
 )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -84,6 +84,7 @@ import com.wire.android.ui.connection.ConnectionActionButton
 import com.wire.android.ui.destinations.ConversationFoldersScreenDestination
 import com.wire.android.ui.destinations.ConversationMediaScreenDestination
 import com.wire.android.ui.destinations.ConversationScreenDestination
+import com.wire.android.ui.destinations.DebugConversationScreenDestination
 import com.wire.android.ui.destinations.DeviceDetailsScreenDestination
 import com.wire.android.ui.destinations.SearchConversationMessagesScreenDestination
 import com.wire.android.ui.home.conversations.details.SearchAndMediaRow
@@ -125,28 +126,15 @@ fun OtherUserProfileScreen(
     val snackbarHostState = LocalSnackbarHostState.current
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val conversationId = viewModel.state.conversationId
     val onSearchConversationMessagesClick: () -> Unit = {
-        conversationId?.let {
-            navigator.navigate(
-                NavigationCommand(
-                    SearchConversationMessagesScreenDestination(
-                        conversationId = it
-                    )
-                )
-            )
+        viewModel.state.activeOneOnOneConversationId?.let {
+            navigator.navigate(NavigationCommand(SearchConversationMessagesScreenDestination(conversationId = it)))
         }
     }
 
     val onConversationMediaClick: () -> Unit = {
-        conversationId?.let {
-            navigator.navigate(
-                NavigationCommand(
-                    ConversationMediaScreenDestination(
-                        conversationId = it
-                    )
-                )
-            )
+        viewModel.state.activeOneOnOneConversationId?.let {
+            navigator.navigate(NavigationCommand(ConversationMediaScreenDestination(conversationId = it)))
         }
     }
 
@@ -190,7 +178,10 @@ fun OtherUserProfileScreen(
         onLegalHoldLearnMoreClick = remember { { legalHoldSubjectDialogState.show(Unit) } },
         onMoveToFolder = {
             navigator.navigate(NavigationCommand(ConversationFoldersScreenDestination(it)))
-        }
+        },
+        openConversationDebugMenu = { conversationId ->
+            navigator.navigate(NavigationCommand(DebugConversationScreenDestination(conversationId)))
+        },
     )
 
     HandleActions(viewModel.actions) { action ->
@@ -245,6 +236,7 @@ fun OtherProfileScreenContent(
     navigateBack: () -> Unit = {},
     onLegalHoldLearnMoreClick: () -> Unit = {},
     onMoveToFolder: (ConversationFoldersNavArgs) -> Unit = {},
+    openConversationDebugMenu: (ConversationId) -> Unit = {},
 ) {
     val otherUserProfileScreenState = rememberOtherUserProfileScreenState()
     val tabItems by remember(state) {
@@ -316,6 +308,7 @@ fun OtherProfileScreenContent(
     ConversationOptionsModalSheetLayout(
         sheetState = conversationOptionsSheetState,
         openConversationFolders = onMoveToFolder,
+        openConversationDebugMenu = openConversationDebugMenu,
     )
     EditGroupRoleBottomSheet(
         sheetState = changeRoleSheetState,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -85,12 +85,12 @@ class OtherUserProfileScreenViewModel @Inject constructor(
 
     private val otherUserProfileNavArgs: OtherUserProfileNavArgs = savedStateHandle.navArgs()
     private val userId: QualifiedID = otherUserProfileNavArgs.userId
-    private val conversationId: QualifiedID? = otherUserProfileNavArgs.conversationId
+    private val groupConversationId: QualifiedID? = otherUserProfileNavArgs.groupConversationId
 
     var state: OtherUserProfileState by mutableStateOf(
         OtherUserProfileState(
             userId = userId,
-            conversationId = conversationId,
+            groupConversationId = groupConversationId,
             isDataLoading = true,
             isAvatarLoading = true
         )
@@ -180,7 +180,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     }
 
     private suspend fun observeGroupInfo(): Flow<OtherUserProfileGroupState?> {
-        return conversationId?.let {
+        return groupConversationId?.let {
             observeConversationRoleForUser(it, userId)
                 .map { conversationRoleData ->
                     conversationRoleData.userRole?.let { userRole ->
@@ -197,8 +197,8 @@ class OtherUserProfileScreenViewModel @Inject constructor(
 
     fun onChangeMemberRole(role: Conversation.Member.Role) {
         viewModelScope.launch {
-            if (conversationId != null) {
-                updateMemberRole(conversationId, userId, role).also {
+            if (groupConversationId != null) {
+                updateMemberRole(groupConversationId, userId, role).also {
                     if (it is UpdateConversationMemberRoleResult.Failure) {
                         onMessage(ChangeGroupRoleError)
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.Serializable
 
 data class OtherUserProfileState(
     val userId: UserId,
-    val conversationId: ConversationId? = null,
+    val groupConversationId: ConversationId? = null,
     val activeOneOnOneConversationId: ConversationId? = null,
     val userAvatarAsset: UserAvatarAsset? = null,
     val isDataLoading: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -59,6 +59,7 @@ import com.wire.android.ui.destinations.WelcomeChooserScreenDestination
 import com.wire.android.ui.destinations.WelcomeScreenDestination
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -198,8 +199,8 @@ sealed class CurrentScreen {
     }
 
     // Another User Profile Screen is opened
-    data class OtherUserProfile(val id: ConversationId) : CurrentScreen() {
-        override fun toString(): String = "OtherUserProfile(${id.toString().obfuscateId()})"
+    data class OtherUserProfile(val userId: UserId, val groupConversationId: ConversationId?) : CurrentScreen() {
+        override fun toString(): String = "OtherUserProfile(${userId.toLogString()}, ${groupConversationId?.toLogString()})"
         override fun toScreenName() = "OtherUserProfileScreen"
     }
 
@@ -237,7 +238,7 @@ sealed class CurrentScreen {
                     Conversation(destination.argsFrom(arguments).conversationId)
 
                 is OtherUserProfileScreenDestination ->
-                    destination.argsFrom(arguments).conversationId?.let { OtherUserProfile(it) } ?: SomeOther(destination.baseRoute)
+                    OtherUserProfile(destination.argsFrom(arguments).userId, destination.argsFrom(arguments).groupConversationId)
 
                 is ImportMediaScreenDestination -> ImportMedia
 

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -70,7 +70,7 @@ class OtherUserProfileScreenViewModelTest {
                 arrangement.observeConversationRoleForUserUseCase(CONVERSATION_ID, USER_ID)
             }
             assertEquals(groupState, expected)
-            assertEquals(viewModel.state.conversationId, CONVERSATION_ID)
+            assertEquals(viewModel.state.groupConversationId, CONVERSATION_ID)
         }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -120,7 +120,7 @@ internal class OtherUserProfileViewModelArrangement {
         mockUri()
 
         every { savedStateHandle.navArgs<OtherUserProfileNavArgs>() } returns OtherUserProfileNavArgs(
-            conversationId = CONVERSATION_ID,
+            groupConversationId = CONVERSATION_ID,
             userId = USER_ID
         )
 
@@ -151,7 +151,7 @@ internal class OtherUserProfileViewModelArrangement {
     fun withConversationIdInSavedState(conversationId: ConversationId?) = apply {
         every { savedStateHandle.navArgs<OtherUserProfileNavArgs>() } returns OtherUserProfileNavArgs(
             userId = USER_ID,
-            conversationId = conversationId
+            groupConversationId = conversationId
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19073" title="WPB-19073" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19073</a>  [Android] 1:1 conversation details access missing on other users profile
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Follow-up to this one: https://github.com/wireapp/wire-android/pull/4195

### Issues

On other user profile screen, "search" and "media" buttons doesn't do anything.

### Causes (Optional)

These buttons were improperly using `conversationId` from `navArgs`, so sometimes it was not available at all and sometimes it was wrongly opening search or media of the group conversation from which the app navigated to other user profile instead of 1:1 conversation with that user.

### Solutions

- for these buttons use `activeOneOnOneConversationId` instead
- rename id from `navArgs` to `groupConversationId` and add description to make it more clear
- fix `OtherUserProfile` in `CurrentScreenManager` by adding `userId` field as well; this screen was being wrongly mapped to `SomeOther` when there was no `groupConvresationId` passed
- fix "Inspect conversation" debug option from bottom sheet on other user profile (the button was doing nothing when clicked)

### Testing

#### How to Test

Open other user profile and click "search" or "media" button.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
