### PR TITLE
fix: close attachments menu after selecting file (WPB-19407)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -518,6 +518,7 @@ fun ConversationScreen(
         onAttachmentPicked = {
             if (conversationInfoViewModel.conversationInfoViewState.isWireCellEnabled) {
                 messageAttachmentsViewModel.onFilesSelected(listOf(it.uri))
+                messageComposerStateHolder.messageCompositionInputStateHolder.showAttachments(false)
             } else {
                 val bundle = ComposableMessageBundle.UriPickedBundle(conversationInfoViewModel.conversationId, it)
                 sendMessageViewModel.trySendMessage(bundle)
@@ -526,6 +527,7 @@ fun ConversationScreen(
         onAudioRecorded = {
             if (conversationInfoViewModel.conversationInfoViewState.isWireCellEnabled) {
                 messageAttachmentsViewModel.onFilesSelected(listOf(it.uri))
+                messageComposerStateHolder.messageCompositionInputStateHolder.showAttachments(false)
             } else {
                 val bundle = ComposableMessageBundle.AudioMessageBundle(conversationInfoViewModel.conversationId, it)
                 sendMessageViewModel.trySendMessage(bundle)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19407" title="WPB-19407" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19407</a>  [Android] Bottom sheet menu stays open after file upload
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-19407

# What's new in this PR?

### Issues
Attachments dialog not closed after selecting file in conversation with wire cells enabled

