### PR TITLE
fix: do not hide filters dialog on clear action (WPB-19477)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
@@ -104,7 +104,6 @@ fun AllFilesScreen(
                 viewModel.updateSelectedTags(it)
             },
             onClearAll = {
-                searchBarState.onFilterActiveChanged(false)
                 viewModel.updateSelectedTags(emptySet())
             },
             onDismiss = { searchBarState.onFilterActiveChanged(false) },

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/filter/FilterBottomSheet.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/filter/FilterBottomSheet.kt
@@ -82,7 +82,7 @@ fun FilterBottomSheet(
             },
             onClearAll = {
                 if (sheetState.currentValue is WireSheetValue.Expanded) {
-                    sheetState.hide { onClearAll() }
+                    onClearAll()
                 }
             }
         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19477" title="WPB-19477" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19477</a>  [Android] Filters dialog not closed on clear action
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-19477

# What's new in this PR?

Do not hide the filters dialog on "clear" action, as requested by design. 