### PR TITLE
fix: strings update for cells feature (WPB-19566)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -53,6 +54,7 @@ import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.preview.MultipleThemePreviews
+import com.wire.android.ui.common.typography
 import com.wire.android.ui.theme.WireTheme
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -241,6 +243,14 @@ private fun EmptyScreen(
                 .fillMaxHeight()
                 .weight(1f)
         )
+        if (!isSearchResult && !isRecycleBin) {
+            Text(
+                text = stringResource(R.string.file_list_empty_title),
+                style = typography().title01,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(dimensions().spacing16x))
+        }
         Text(
             text = when {
                 isSearchResult -> stringResource(R.string.file_list_search_empty_message)

--- a/features/cells/src/main/res/values/strings.xml
+++ b/features/cells/src/main/res/values/strings.xml
@@ -18,8 +18,8 @@
 <resources>
     <string name="retry">Retry</string>
     <string name="file_list_load_error">There was an error loading the files list. Please try again</string>
-    <string name="file_list_empty_message">There are no files yet You\'ll find all files shared across your conversations here.</string>
-    <string name="conversation_file_list_empty_message">There are no files in this conversation.</string>
+    <string name="file_list_empty_message">You\'ll find all files shared across your conversations here.</string>
+    <string name="conversation_file_list_empty_message">You\'ll find all files and folders shared in this conversation here.</string>
     <string name="file_list_search_empty_message">No files found.</string>
     <string name="save_label">Save</string>
     <string name="share_label">Share</string>
@@ -28,14 +28,14 @@
     <string name="delete_permanently">Delete permanently</string>
     <string name="restore_label">Restore</string>
     <string name="add_remove_tags_label">Add or remove tags</string>
-    <string name="move_label">Move</string>
+    <string name="move_label">Move to Folder</string>
     <string name="download_label">Download</string>
     <string name="copy_link">Copy Link</string>
     <string name="share_link">Share Link</string>
     <string name="copied_to_clipboard_message">Link copied to clipboard</string>
     <string name="file_subtitle">%1$s in %2$s</string>
     <string name="file_subtitle_modified">%1$s by %2$s</string>
-    <string name="public_link_message_file">Upload and share your file via a public link. All recipients can view and download it.</string>
+    <string name="public_link_message_file">Upload and share your file via a public link. All recipients can view and download the folder and it\'s contents.</string>
     <string name="public_link_message_folder">Upload and share your folder via a public link. All recipients can view and download it.</string>
     <string name="create_public_link">Create public link</string>
     <string name="share_file_via_link">Share file via link</string>
@@ -76,8 +76,8 @@
     <string name="recycle_bin">Recycle Bin</string>
     <string name="open_recycle_bin">Open Recycle Bin</string>
     <string name="empty_recycle_bin">You \'ll find all deleted files and folders here.</string>
-    <string name="dialog_restore_file_title">Restore File?</string>
-    <string name="dialog_restore_folder_title">Restore Folder?</string>
+    <string name="dialog_restore_file_title">Restore File</string>
+    <string name="dialog_restore_folder_title">Restore Folder</string>
     <string name="dialog_restore_file_description">This file %1$s will be restored and available again to everyone in this conversation.</string>
     <string name="dialog_restore_folder_description">This folder %1$s will be restored and available again to everyone in this conversation.</string>
     <string name="dialog_restore_button_label">Restore</string>
@@ -105,8 +105,9 @@
     <string name="added_tags_label">Added tags</string>
     <string name="add_tag_label">Add tag</string>
     <string name="enter_name_label">Enter tag name</string>
-    <string name="no_tags_message">No tags has been added this file.</string>
+    <string name="no_tags_message">No tags were added yet.</string>
     <string name="tags_edited">Tags were edited</string>
     <string name="failed_edit_tags">Failed to edit tags</string>
-    <string name="create_folder_invalid_name">Name cannot contain "/" or "." characters</string>
+    <string name="create_folder_invalid_name">Use a name without "/" or "."</string>
+    <string name="file_list_empty_title">There are no files or folders yet</string>
 </resources>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19566" title="WPB-19566" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19566</a>  [Android] Update strings for wire cells
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-19566

# What's new in this PR?

- Added title for empty files screen
- Some strings updated