### PR TITLE
feat: group multipart message assets (WPB-17177)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/multipart/MultipartAttachmentsView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/multipart/MultipartAttachmentsView.kt
@@ -20,8 +20,6 @@ package com.wire.android.ui.home.conversations.model.messagetypes.multipart
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -57,27 +55,45 @@ fun MultipartAttachmentsView(
     viewModel: MultipartAttachmentsViewModel = hiltViewModel<MultipartAttachmentsViewModel>(key = conversationId.value),
 ) {
 
-    // File attachments are shown separately after media files grid
-    val (media, files) = viewModel.mapAttachments(attachments)
-
-    if (media.size > 1) {
-        AttachmentsGrid(
-            attachments = media,
-            onClick = { viewModel.onClick(it) },
-            modifier = modifier,
-        )
-        Spacer(modifier = Modifier.height(dimensions().spacing8x))
-        AttachmentsList(
-            attachments = files,
-            onClick = { viewModel.onClick(it) }
-        )
+    if (attachments.size == 1) {
+        attachments.first().toUiModel().let {
+            AssetPreview(
+                item = it,
+                onClick = { viewModel.onClick(it) },
+            )
+        }
     } else {
-        AttachmentsList(
-            attachments = (media + files),
-            onClick = { viewModel.onClick(it) }
-        )
-    }
 
+        val groups = viewModel.mapAttachments(attachments)
+
+        Column(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(dimensions().spacing8x)
+        ) {
+            groups.forEach { group ->
+                when (group) {
+                    is MultipartAttachmentsViewModel.MultipartAttachmentGroup.Media ->
+                        if (group.attachments.size == 1) {
+                            AssetPreview(
+                                item = group.attachments.first(),
+                                onClick = { viewModel.onClick(group.attachments.first()) },
+                            )
+                        } else {
+                            AttachmentsGrid(
+                                attachments = group.attachments,
+                                onClick = { viewModel.onClick(it) },
+                            )
+                        }
+
+                    is MultipartAttachmentsViewModel.MultipartAttachmentGroup.Files ->
+                        AttachmentsList(
+                            attachments = group.attachments,
+                            onClick = { viewModel.onClick(it) }
+                        )
+                }
+            }
+        }
+    }
     LaunchedEffect(attachments) {
         attachments.onEach { viewModel.refreshAssetState(it.toUiModel()) }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17177" title="WPB-17177" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17177</a>  [Android] [Design Review] Attachments should appear in the original order
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-17177

# What's new in this PR?

Applying files grouping rules when showing multipart message with multiple files:
1. Files in message must be shown in the same order they were added
2. Adjacent media files must be grouped shown as a grid when possible
3. Other files are displayed as a list.

<img width="400" alt="assets_grouping" src="https://github.com/user-attachments/assets/992edcc6-9c3b-45d9-818c-a1736fae13d9" />
