### PR TITLE
feat: message bubble footer [WPB-19597] [WPB-19598] [WPB-19599]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageExpiration.kt
@@ -26,10 +26,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.wire.android.R
+import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable.Companion.HIGH_END_TIME_ELAPSED_RATIO_BOUNDARY_FOR_PROPORTIONAL_ALPHA_CHANGE
+import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable.Companion.LOW_END_TIME_ELAPSED_RATIO_BOUNDARY_FOR_PROPORTIONAL_ALPHA_CHANGE
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.kalium.logic.data.message.Message
@@ -130,6 +131,10 @@ class SelfDeletionTimerHelper(private val stringResourceProvider: StringResource
 
             var timeLeft by mutableStateOf(calculateTimeLeft())
                 private set
+
+            val fractionLeft: Float by derivedStateOf {
+                ((timeLeft / expireAfter).toFloat()).coerceIn(0f, 1f)
+            }
 
             @Suppress("MagicNumber", "ComplexMethod")
             val timeLeftFormatted: String by derivedStateOf {
@@ -257,7 +262,7 @@ class SelfDeletionTimerHelper(private val stringResourceProvider: StringResource
                         recalculateTimeLeft()
                     }
                 }
-                val lifecycleOwner = LocalLifecycleOwner.current
+                val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
                 LaunchedEffect(lifecycleOwner) {
                     lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                         recalculateTimeLeft()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageBubbleItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageBubbleItem.kt
@@ -62,7 +62,7 @@ fun MessageBubbleItem(
     showAuthor: Boolean = true,
     useSmallBottomPadding: Boolean = false,
     leading: (@Composable () -> Unit)? = null,
-    footer: (@Composable () -> Unit)? = null,
+    footer: (@Composable (inner: PaddingValues) -> Unit)? = null,
     header: (@Composable (inner: PaddingValues) -> Unit)? = null,
     content: @Composable (inner: PaddingValues) -> Unit
 ) {
@@ -130,6 +130,7 @@ fun MessageBubbleItem(
             } else {
                 null
             }
+            val paddingValue = dimensions().spacing10x
 
             Surface(
                 color = bubbleColor,
@@ -148,25 +149,24 @@ fun MessageBubbleItem(
                 Column {
                     val contentModifier = if (message.hasMediaWidth) {
                         Modifier.padding(
-                            bottom = if (useSmallBottomPadding) dimensions().spacing0x else dimensions().spacing10x
+                            bottom = if (useSmallBottomPadding) dimensions().spacing0x else paddingValue
                         )
                     } else {
-                        Modifier.padding(all = dimensions().spacing10x)
+                        Modifier.padding(all = paddingValue)
                     }
                     val contentPadding = if (message.hasMediaWidth) {
-                        PaddingValues(horizontal = dimensions().spacing10x)
-                    } else {
-                        PaddingValues()
-                    }
-
-                    val headerPadding = if (message.hasMediaWidth) {
-                        PaddingValues(start = dimensions().spacing10x, end = dimensions().spacing10x, top = dimensions().spacing10x)
+                        PaddingValues(horizontal = paddingValue)
                     } else {
                         PaddingValues()
                     }
 
                     Column(contentModifier) {
                         if (header != null) {
+                            val headerPadding = if (message.hasMediaWidth) {
+                                PaddingValues(start = paddingValue, end = paddingValue, top = paddingValue)
+                            } else {
+                                PaddingValues()
+                            }
                             header(headerPadding)
                         }
                         content(contentPadding)
@@ -175,7 +175,8 @@ fun MessageBubbleItem(
             }
 
             if (footer != null) {
-                footer()
+                val footerPadding = PaddingValues(horizontal = paddingValue)
+                footer(footerPadding)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentItem.kt
@@ -18,21 +18,16 @@
 package com.wire.android.ui.home.conversations.messages.item
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.wire.android.R
-import com.wire.android.ui.common.StatusBox
-import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.spacers.VerticalSpace
@@ -40,11 +35,8 @@ import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper
 import com.wire.android.ui.home.conversations.info.ConversationDetailsData
 import com.wire.android.ui.home.conversations.model.MessageFlowStatus
 import com.wire.android.ui.home.conversations.model.MessageSource
-import com.wire.android.ui.home.conversations.model.MessageStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.theme.wireColorScheme
-import com.wire.android.util.compactLabel
-import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
 
 @Suppress("CyclomaticComplexMethod")
@@ -108,6 +100,7 @@ fun MessageContentItem(
                     VerticalSpace.x4()
                     MessageReactionsItem(
                         messageFooter = messageFooter,
+                        messageStyle = messageStyle,
                         onReactionClicked = clickActions.onReactionClicked
                     )
                 }
@@ -150,9 +143,12 @@ fun MessageContentItem(
                         messageStyle = messageStyle
                     )
                     MessageBubbleExpireFooter(
-                        message = message,
                         messageStyle = messageStyle,
                         selfDeletionTimerState = selfDeletionTimerState,
+                        accentColor = MaterialTheme.wireColorScheme.wireAccentColors.getOrDefault(
+                            header.accent,
+                            MaterialTheme.wireColorScheme.primary
+                        )
                     )
 
                     if (isMyMessage && shouldDisplayMessageStatus) {
@@ -170,105 +166,5 @@ fun MessageContentItem(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun MessageBubbleEphemeralItem(
-    message: UIMessage.Regular,
-    conversationDetailsData: ConversationDetailsData,
-    selfDeletionTimerState: SelfDeletionTimerHelper.SelfDeletionTimerState = SelfDeletionTimerHelper.SelfDeletionTimerState.NotExpirable,
-) {
-    with(message) {
-        when (selfDeletionTimerState) {
-            is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable -> {
-                EphemeralMessageExpiredLabel(
-                    message.isMyMessage,
-                    conversationDetailsData,
-                    color = if (source == MessageSource.Self) {
-                        MaterialTheme.wireColorScheme.wireAccentColors.getOrDefault(
-                            header.accent,
-                            MaterialTheme.wireColorScheme.primary
-                        )
-                    } else {
-                        MaterialTheme.wireColorScheme.primary
-                    }
-                )
-            }
-
-            SelfDeletionTimerHelper.SelfDeletionTimerState.NotExpirable -> {
-                Text(
-                    UIText.StringResource(R.string.deleted_message_text).asString(),
-                    color = if (source == MessageSource.Self) {
-                        MaterialTheme.wireColorScheme.wireAccentColors.getOrDefault(
-                            header.accent,
-                            MaterialTheme.wireColorScheme.primary
-                        )
-                    } else {
-                        colorsScheme().secondaryText
-                    }
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun MessageBubbleExpireFooter(
-    message: UIMessage.Regular,
-    messageStyle: MessageStyle,
-    selfDeletionTimerState: SelfDeletionTimerHelper.SelfDeletionTimerState,
-    modifier: Modifier = Modifier,
-) {
-    with(message) {
-        when (selfDeletionTimerState) {
-            is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable -> {
-                Row(modifier) {
-                    HorizontalSpace.x8()
-//                    SelfDeletingMessageIcon(selfDeletionTimerState) // TODO will be handled in other PR
-                    HorizontalSpace.x4()
-                    MessageTimeLabel(
-                        messageTime = selfDeletionTimerState.timeLeft.compactLabel(),
-                        messageStyle = messageStyle
-                    )
-                }
-            }
-
-            SelfDeletionTimerHelper.SelfDeletionTimerState.NotExpirable -> {}
-        }
-    }
-}
-
-@Composable
-private fun MessageStatusAndExpireTimer(
-    message: UIMessage.Regular,
-    conversationDetailsData: ConversationDetailsData,
-    selfDeletionTimerState: SelfDeletionTimerHelper.SelfDeletionTimerState,
-    modifier: Modifier = Modifier,
-) {
-    with(message) {
-        Box(modifier) {
-            if (selfDeletionTimerState is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
-                MessageExpireLabel(messageContent, selfDeletionTimerState.timeLeftFormatted)
-                // if the message is marked as deleted and is [SelfDeletionTimer.SelfDeletionTimerState.Expirable]
-                // the deletion responsibility belongs to the receiver, therefore we need to wait for the receiver
-                // timer to expire to permanently delete the message, in the meantime we show the EphemeralMessageExpiredLabel
-                if (isDeleted) {
-                    EphemeralMessageExpiredLabel(
-                        message.isMyMessage,
-                        conversationDetailsData
-                    )
-                }
-            } else {
-                MessageStatusLabel(messageStatus = message.header.messageStatus)
-            }
-        }
-    }
-}
-
-@Composable
-private fun MessageStatusLabel(messageStatus: MessageStatus) {
-    messageStatus.badgeText?.let {
-        StatusBox(it.asString())
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageExpirationItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageExpirationItems.kt
@@ -1,0 +1,276 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.messages.item
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.wire.android.R
+import com.wire.android.ui.common.StatusBox
+import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.spacers.HorizontalSpace
+import com.wire.android.ui.common.typography
+import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper
+import com.wire.android.ui.home.conversations.info.ConversationDetailsData
+import com.wire.android.ui.home.conversations.model.MessageSource
+import com.wire.android.ui.home.conversations.model.MessageStatus
+import com.wire.android.ui.home.conversations.model.UIMessage
+import com.wire.android.ui.home.conversations.model.UIMessageContent
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.util.compactLabel
+import com.wire.android.util.ui.UIText
+
+@SuppressLint("ComposeModifierMissing")
+@Composable
+fun MessageBubbleEphemeralItem(
+    message: UIMessage.Regular,
+    conversationDetailsData: ConversationDetailsData,
+    selfDeletionTimerState: SelfDeletionTimerHelper.SelfDeletionTimerState = SelfDeletionTimerHelper.SelfDeletionTimerState.NotExpirable,
+) {
+    with(message) {
+        when (selfDeletionTimerState) {
+            is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable -> {
+                EphemeralMessageExpiredLabel(
+                    isSelfMessage = message.isMyMessage,
+                    conversationDetailsData = conversationDetailsData,
+                    color = if (source == MessageSource.Self) {
+                        MaterialTheme.wireColorScheme.wireAccentColors.getOrDefault(
+                            header.accent,
+                            MaterialTheme.wireColorScheme.primary
+                        )
+                    } else {
+                        MaterialTheme.wireColorScheme.primary
+                    }
+                )
+            }
+
+            SelfDeletionTimerHelper.SelfDeletionTimerState.NotExpirable -> {
+                Text(
+                    text = UIText.StringResource(R.string.deleted_message_text).asString(),
+                    style = typography().body05,
+                    color = if (source == MessageSource.Self) {
+                        MaterialTheme.wireColorScheme.wireAccentColors.getOrDefault(
+                            header.accent,
+                            MaterialTheme.wireColorScheme.primary
+                        )
+                    } else {
+                        colorsScheme().secondaryText
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun MessageBubbleExpireFooter(
+    messageStyle: MessageStyle,
+    accentColor: Color,
+    selfDeletionTimerState: SelfDeletionTimerHelper.SelfDeletionTimerState,
+    modifier: Modifier = Modifier,
+) {
+    when (selfDeletionTimerState) {
+        is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable -> {
+            Row(modifier) {
+                HorizontalSpace.x8()
+                SelfDeletionTimerIcon(selfDeletionTimerState, messageStyle, accentColor)
+                HorizontalSpace.x4()
+                MessageTimeLabel(
+                    messageTime = selfDeletionTimerState.timeLeft.compactLabel(),
+                    messageStyle = messageStyle
+                )
+            }
+        }
+
+        SelfDeletionTimerHelper.SelfDeletionTimerState.NotExpirable -> {}
+    }
+}
+
+@Composable
+private fun SelfDeletionTimerIcon(
+    state: SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable,
+    messageStyle: MessageStyle,
+    accentColor: Color,
+    modifier: Modifier = Modifier,
+    size: Dp = 11.dp,
+    discreteSteps: Int? = 8,
+) {
+
+    val emptyColor = when (messageStyle) {
+        MessageStyle.BUBBLE_SELF -> accentColor
+        MessageStyle.BUBBLE_OTHER -> colorsScheme().background
+        MessageStyle.NORMAL -> colorsScheme().background
+    }
+
+    val filledColor = when (messageStyle) {
+        MessageStyle.BUBBLE_SELF -> colorsScheme().onPrimary
+        MessageStyle.BUBBLE_OTHER -> colorsScheme().secondaryText
+        MessageStyle.NORMAL -> colorsScheme().secondaryText
+    }
+
+    val rawFractionLeft = state.fractionLeft
+    val displayFractionLeft =
+        if (discreteSteps != null && discreteSteps > 0) {
+            (kotlin.math.ceil(rawFractionLeft * discreteSteps) / discreteSteps)
+                .coerceIn(0f, 1f)
+        } else {
+            rawFractionLeft
+        }
+
+    val elapsedFraction = 1f - displayFractionLeft
+    val emptySweepDegrees = 360f * elapsedFraction
+    val startAngle = -90f
+    val backgroundAlpha = state.alphaBackgroundColor()
+
+    Canvas(
+        modifier
+            .size(size)
+            .semantics(mergeDescendants = true) {
+                contentDescription = "Time left ${"%.0f".format(displayFractionLeft * 100)}%"
+            }
+    ) {
+        if (backgroundAlpha > 0f) {
+            drawCircle(color = filledColor.copy(alpha = backgroundAlpha))
+        }
+
+        drawCircle(color = filledColor)
+
+        if (emptySweepDegrees > 0f) {
+            drawArc(
+                color = emptyColor,
+                startAngle = startAngle,
+                sweepAngle = emptySweepDegrees,
+                useCenter = true
+            )
+        }
+
+        drawCircle(
+            color = filledColor,
+            style = Stroke(width = size.value * 0.08f)
+        )
+    }
+}
+
+@Suppress("ModifierParameter")
+@Composable
+fun MessageStatusAndExpireTimer(
+    message: UIMessage.Regular,
+    conversationDetailsData: ConversationDetailsData,
+    selfDeletionTimerState: SelfDeletionTimerHelper.SelfDeletionTimerState,
+) {
+    with(message) {
+        if (selfDeletionTimerState is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable) {
+            MessageExpireLabel(messageContent, selfDeletionTimerState.timeLeftFormatted)
+            // if the message is marked as deleted and is [SelfDeletionTimer.SelfDeletionTimerState.Expirable]
+            // the deletion responsibility belongs to the receiver, therefore we need to wait for the receiver
+            // timer to expire to permanently delete the message, in the meantime we show the EphemeralMessageExpiredLabel
+            if (isDeleted) {
+                EphemeralMessageExpiredLabel(
+                    isSelfMessage = isMyMessage,
+                    conversationDetailsData = conversationDetailsData
+                )
+            }
+        } else {
+            MessageStatusLabel(messageStatus = message.header.messageStatus)
+        }
+    }
+}
+
+@Composable
+private fun MessageStatusLabel(messageStatus: MessageStatus) {
+    messageStatus.badgeText?.let {
+        StatusBox(it.asString())
+    }
+}
+
+@Composable
+private fun EphemeralMessageExpiredLabel(
+    isSelfMessage: Boolean,
+    conversationDetailsData: ConversationDetailsData,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified
+) {
+
+    val stringResource = if (!isSelfMessage) {
+        stringResource(id = R.string.label_information_waiting_for_deleation_when_self_not_sender)
+    } else if (conversationDetailsData is ConversationDetailsData.OneOne) {
+        conversationDetailsData.otherUserName?.let {
+            stringResource(
+                R.string.label_information_waiting_for_recipient_timer_to_expire_one_to_one,
+                conversationDetailsData.otherUserName
+            )
+        } ?: stringResource(id = R.string.unknown_user_name)
+    } else {
+        stringResource(R.string.label_information_waiting_for_recipient_timer_to_expire_group)
+    }
+
+    Text(
+        modifier = modifier,
+        color = color,
+        text = stringResource,
+        style = typography().body05
+    )
+}
+
+@Composable
+fun MessageExpireLabel(messageContent: UIMessageContent?, timeLeft: String) {
+    when (messageContent) {
+        is UIMessageContent.Location,
+        is UIMessageContent.AssetMessage,
+        is UIMessageContent.AudioAssetMessage,
+        is UIMessageContent.ImageMessage,
+        is UIMessageContent.TextMessage -> {
+            StatusBox(
+                statusText = stringResource(
+                    R.string.self_deleting_message_time_left,
+                    timeLeft
+                )
+            )
+        }
+
+        is UIMessageContent.Deleted -> {
+            val context = LocalContext.current
+
+            StatusBox(
+                statusText = stringResource(
+                    R.string.self_deleting_message_time_left,
+                    context.resources.getQuantityString(
+                        R.plurals.seconds_left,
+                        0,
+                        0
+                    )
+                )
+            )
+        }
+
+        else -> {}
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageExpirationItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageExpirationItems.kt
@@ -136,45 +136,33 @@ private fun SelfDeletionTimerIcon(
         MessageStyle.NORMAL -> colorsScheme().secondaryText
     }
 
-    val rawFractionLeft = state.fractionLeft
-    val displayFractionLeft =
-        if (discreteSteps != null && discreteSteps > 0) {
-            (kotlin.math.ceil(rawFractionLeft * discreteSteps) / discreteSteps)
-                .coerceIn(0f, 1f)
-        } else {
-            rawFractionLeft
-        }
-
-    val elapsedFraction = 1f - displayFractionLeft
-    val emptySweepDegrees = 360f * elapsedFraction
-    val startAngle = -90f
-    val backgroundAlpha = state.alphaBackgroundColor()
+    val metrics = state.iconMetrics(discreteSteps = discreteSteps)
 
     Canvas(
         modifier
             .size(size)
             .semantics(mergeDescendants = true) {
-                contentDescription = "Time left ${"%.0f".format(displayFractionLeft * 100)}%"
+                contentDescription = "Time left ${"%.0f".format(metrics.displayFractionLeft * 100)}%"
             }
     ) {
-        if (backgroundAlpha > 0f) {
-            drawCircle(color = filledColor.copy(alpha = backgroundAlpha))
+        if (metrics.backgroundAlpha > 0f) {
+            drawCircle(color = filledColor.copy(alpha = metrics.backgroundAlpha))
         }
 
         drawCircle(color = filledColor)
 
-        if (emptySweepDegrees > 0f) {
+        if (metrics.emptySweepDegrees > 0f) {
             drawArc(
                 color = emptyColor,
-                startAngle = startAngle,
-                sweepAngle = emptySweepDegrees,
+                startAngle = START_ANGLE_TOP_DEG,
+                sweepAngle = metrics.emptySweepDegrees,
                 useCenter = true
             )
         }
 
         drawCircle(
             color = filledColor,
-            style = Stroke(width = size.value * 0.08f)
+            style = Stroke(width = this.size.minDimension * STROKE_WIDTH_FRACTION)
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageReactionsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageReactionsItem.kt
@@ -32,10 +32,13 @@ import com.wire.android.ui.home.conversations.model.MessageFooter
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 
+private const val BUBBLE_MAX_REACTIONS_IN_ROW = 4
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun MessageReactionsItem(
     messageFooter: MessageFooter,
+    messageStyle: MessageStyle,
     onReactionClicked: (String, String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -45,6 +48,7 @@ fun MessageReactionsItem(
             modifier = modifier,
             horizontalArrangement = Arrangement.spacedBy(dimensions().spacing4x, Alignment.Start),
             verticalArrangement = Arrangement.spacedBy(dimensions().spacing6x, Alignment.Top),
+            maxItemsInEachRow = if (messageStyle.isBubble()) BUBBLE_MAX_REACTIONS_IN_ROW else Int.MAX_VALUE
         ) {
             messageFooter.reactions.entries
                 .sortedBy { it.key }
@@ -67,8 +71,33 @@ fun MessageReactionsItem(
 @PreviewMultipleThemes
 @Composable
 fun LongMessageReactionsItemPreview() = WireTheme {
-    Box(modifier = Modifier.width(200.dp)) {
+    Box(modifier = Modifier.width(300.dp)) {
         MessageReactionsItem(
+            messageStyle = MessageStyle.NORMAL,
+            messageFooter = MessageFooter(
+                messageId = "messageId",
+                reactions = mapOf(
+                    "👍" to 1,
+                    "👎" to 2,
+                    "👏" to 3,
+                    "🤔" to 4,
+                    "🤷" to 5,
+                    "🤦" to 6,
+                    "🤢" to 7
+                ),
+                ownReactions = setOf("👍"),
+            ),
+            onReactionClicked = { _, _ -> }
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun LongMessageReactionsBubbleItemPreview() = WireTheme {
+    Box(modifier = Modifier.width(300.dp)) {
+        MessageReactionsItem(
+            messageStyle = MessageStyle.BUBBLE_OTHER,
             messageFooter = MessageFooter(
                 messageId = "messageId",
                 reactions = mapOf(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
@@ -22,23 +22,15 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import com.wire.android.R
-import com.wire.android.ui.common.StatusBox
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.common.typography
 import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper
 import com.wire.android.ui.home.conversations.info.ConversationDetailsData
 import com.wire.android.ui.home.conversations.model.DeliveryStatusContent
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.UIMessage
-import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
 
 // TODO: a definite candidate for a refactor and cleanup WPB-14390
@@ -69,13 +61,14 @@ fun RegularMessageItem(
         }
 
         if (isBubbleUiEnabled) {
-            val footerSlot: (@Composable () -> Unit)? =
+            val footerSlot: (@Composable (inner: PaddingValues) -> Unit)? =
                 if (shouldDisplayFooter) {
-                    {
+                    { innerPadding ->
                         MessageReactionsItem(
                             messageFooter = message.messageFooter,
+                            messageStyle = messageStyle,
                             onReactionClicked = clickActions.onReactionClicked,
-                            modifier = Modifier.padding(horizontal = dimensions().spacing10x)
+                            modifier = Modifier.padding(innerPadding)
                         )
                     }
                 } else {
@@ -227,70 +220,6 @@ fun RegularMessageItem(
         }
 
         SwipeableMessageConfiguration.NotSwipeable -> messageContent()
-    }
-}
-
-@Composable
-fun EphemeralMessageExpiredLabel(
-    isSelfMessage: Boolean,
-    conversationDetailsData: ConversationDetailsData,
-    modifier: Modifier = Modifier,
-    color: Color = Color.Unspecified
-) {
-
-    val stringResource = if (!isSelfMessage) {
-        stringResource(id = R.string.label_information_waiting_for_deleation_when_self_not_sender)
-    } else if (conversationDetailsData is ConversationDetailsData.OneOne) {
-        conversationDetailsData.otherUserName?.let {
-            stringResource(
-                R.string.label_information_waiting_for_recipient_timer_to_expire_one_to_one,
-                conversationDetailsData.otherUserName
-            )
-        } ?: stringResource(id = R.string.unknown_user_name)
-    } else {
-        stringResource(R.string.label_information_waiting_for_recipient_timer_to_expire_group)
-    }
-
-    Text(
-        modifier = modifier,
-        color = color,
-        text = stringResource,
-        style = typography().body05
-    )
-}
-
-@Composable
-fun MessageExpireLabel(messageContent: UIMessageContent?, timeLeft: String) {
-    when (messageContent) {
-        is UIMessageContent.Location,
-        is UIMessageContent.AssetMessage,
-        is UIMessageContent.AudioAssetMessage,
-        is UIMessageContent.ImageMessage,
-        is UIMessageContent.TextMessage -> {
-            StatusBox(
-                statusText = stringResource(
-                    R.string.self_deleting_message_time_left,
-                    timeLeft
-                )
-            )
-        }
-
-        is UIMessageContent.Deleted -> {
-            val context = LocalContext.current
-
-            StatusBox(
-                statusText = stringResource(
-                    R.string.self_deleting_message_time_left,
-                    context.resources.getQuantityString(
-                        R.plurals.seconds_left,
-                        0,
-                        0
-                    )
-                )
-            )
-        }
-
-        else -> {}
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SelfDeletionTimerHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SelfDeletionTimerHelper.kt
@@ -1,0 +1,67 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.messages.item
+
+import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper
+
+data class DeletionIconMetrics(
+    val displayFractionLeft: Float,
+    val elapsedFraction: Float,
+    val emptySweepDegrees: Float,
+    val backgroundAlpha: Float
+)
+
+enum class QuantizeStrategy { FLOOR, CEIL, NEAREST }
+
+fun computeDeletionIconMetrics(
+    fractionLeft: Float,
+    backgroundAlpha: Float,
+    discreteSteps: Int? = 8,
+    strategy: QuantizeStrategy = QuantizeStrategy.FLOOR
+): DeletionIconMetrics {
+    val clamped = fractionLeft.coerceIn(0f, 1f)
+    val display = if (discreteSteps == null || discreteSteps <= 0) {
+        clamped
+    } else {
+        val s = discreteSteps.toFloat()
+        val stepped = when (strategy) {
+            QuantizeStrategy.FLOOR -> kotlin.math.floor(clamped * s)
+            QuantizeStrategy.CEIL -> kotlin.math.ceil(clamped * s)
+            QuantizeStrategy.NEAREST -> kotlin.math.round(clamped * s)
+        } / s
+        stepped.coerceIn(0f, 1f)
+    }
+    val elapsed = 1f - display
+    val sweep = FULL_CIRCLE_DEGREES * elapsed
+    return DeletionIconMetrics(
+        displayFractionLeft = display,
+        elapsedFraction = elapsed,
+        emptySweepDegrees = sweep,
+        backgroundAlpha = backgroundAlpha.coerceIn(0f, 1f)
+    )
+}
+
+fun SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable.iconMetrics(
+    discreteSteps: Int? = 8,
+    strategy: QuantizeStrategy = QuantizeStrategy.FLOOR
+): DeletionIconMetrics =
+    computeDeletionIconMetrics(fractionLeft, alphaBackgroundColor(), discreteSteps, strategy)
+
+private const val FULL_CIRCLE_DEGREES = 360f
+internal const val START_ANGLE_TOP_DEG = -90f
+internal const val STROKE_WIDTH_FRACTION = 0.08f

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewMesssageBubbleTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewMesssageBubbleTypes.kt
@@ -26,12 +26,19 @@ import androidx.compose.ui.graphics.Color
 import com.wire.android.ui.home.conversations.info.ConversationDetailsData
 import com.wire.android.ui.home.conversations.messages.item.MessageClickActions
 import com.wire.android.ui.home.conversations.messages.item.RegularMessageItem
+import com.wire.android.ui.home.conversations.mock.mockFooterWithMultipleReactions
+import com.wire.android.ui.home.conversations.mock.mockHeaderWithExpiration
 import com.wire.android.ui.home.conversations.mock.mockMessageWithText
 import com.wire.android.ui.home.conversations.mock.mockMessageWithTextContent
+import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.message.Message
+import kotlinx.datetime.Instant
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 @PreviewMultipleThemes
 @Composable
@@ -178,6 +185,88 @@ fun PreviewBubbleOtherMultipleTextMessage() {
                 conversationDetailsData = ConversationDetailsData.None(null),
                 clickActions = MessageClickActions.Content(),
                 isBubbleUiEnabled = true
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewBubbleMultipleTextMessagesWithReactions() {
+    WireTheme {
+        Column(modifier = Modifier.background(Color.Gray)) {
+            RegularMessageItem(
+                message = mockMessageWithTextContent("Hello").copy(
+                    header = mockMessageWithText.header.copy(
+                        username = UIText.DynamicString(
+                            "Paul Nagel"
+                        )
+                    ),
+                    messageFooter = mockFooterWithMultipleReactions,
+                ),
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true,
+            )
+            RegularMessageItem(
+                message = mockMessageWithTextContent("Hello").copy(
+                    source = MessageSource.OtherUser,
+                    header = mockMessageWithText.header.copy(
+                        username = UIText.DynamicString(
+                            "Paul Nagel"
+                        )
+                    ),
+                    messageFooter = mockFooterWithMultipleReactions,
+                ),
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true,
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewBubbleMultipleDeletedMessages() {
+    WireTheme {
+        Column(modifier = Modifier.background(Color.Gray)) {
+            RegularMessageItem(
+                message = mockMessageWithTextContent("Hello").copy(
+                    header = mockHeaderWithExpiration(
+                        ExpirationStatus.Expirable(
+                            expireAfter = 1.toDuration(DurationUnit.MINUTES),
+                            selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.Started(Instant.DISTANT_FUTURE),
+                        ),
+                        isDeleted = true
+                    ).copy(
+                        username = UIText.DynamicString(
+                            "Paul Nagel"
+                        )
+                    ),
+                ),
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true,
+            )
+            RegularMessageItem(
+                message = mockMessageWithTextContent("Hello").copy(
+                    source = MessageSource.OtherUser,
+                    header = mockHeaderWithExpiration(
+                        ExpirationStatus.Expirable(
+                            expireAfter = 1.toDuration(DurationUnit.MINUTES),
+                            selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.Started(Instant.DISTANT_FUTURE),
+                        ),
+                        isDeleted = true
+                    ).copy(
+                        username = UIText.DynamicString(
+                            "Paul Nagel"
+                        )
+                    ),
+                ),
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true,
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/mock/Mock.kt
@@ -1,3 +1,4 @@
+@file:Suppress("TooManyFunctions", "MagicNumber")
 /*
  * Wire
  * Copyright (C) 2024 Wire Swiss GmbH
@@ -46,6 +47,20 @@ import okio.Path.Companion.toPath
 
 private const val MOCK_TIME_IN_SECONDS: Long = 1729837498
 val mockFooter = MessageFooter("", mapOf("👍" to 1), setOf("👍"))
+
+val mockFooterWithMultipleReactions = MessageFooter(
+    messageId = "messageId",
+    reactions = mapOf(
+        "👍" to 1,
+        "👎" to 2,
+        "👏" to 3,
+        "🤔" to 4,
+        "🤷" to 5,
+        "🤦" to 6,
+        "🤢" to 7
+    ),
+    ownReactions = setOf("👍"),
+)
 val mockEmptyFooter = MessageFooter("", emptyMap(), emptySet())
 val mockMessageTime = MessageTime(Instant.fromEpochSeconds(MOCK_TIME_IN_SECONDS))
 
@@ -62,6 +77,14 @@ val mockHeader = MessageHeader(
     connectionState = ConnectionState.ACCEPTED,
     isSenderDeleted = false,
     isSenderUnavailable = false
+)
+
+fun mockHeaderWithExpiration(expirable: ExpirationStatus.Expirable, isDeleted: Boolean = false) = mockHeader.copy(
+    messageStatus = MessageStatus(
+        flowStatus = MessageFlowStatus.Delivered,
+        expirationStatus = expirable,
+        isDeleted = isDeleted
+    )
 )
 
 val mockMessageWithText = UIMessage.Regular(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/DeletionIconMetricsTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/DeletionIconMetricsTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.messages
+
+import com.wire.android.ui.home.conversations.messages.item.QuantizeStrategy
+import com.wire.android.ui.home.conversations.messages.item.computeDeletionIconMetrics
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DeletionIconMetricsTest {
+
+    @Test
+    fun `quantizes fraction to steps`() {
+        val m = computeDeletionIconMetrics(
+            fractionLeft = 0.83f,
+            backgroundAlpha = 0.4f,
+            discreteSteps = 4,
+            strategy = QuantizeStrategy.FLOOR
+        )
+        assertEquals(0.75f, m.displayFractionLeft, 1e-6f)
+        assertEquals(0.25f, m.elapsedFraction, 1e-6f)
+        assertEquals(90f, m.emptySweepDegrees, 1e-6f) // 360 * 0.25
+        assertEquals(0.4f, m.backgroundAlpha, 1e-6f)
+    }
+
+    @Test
+    fun `no quantization keeps raw fraction`() {
+        val m = computeDeletionIconMetrics(
+            fractionLeft = 0.42f,
+            backgroundAlpha = 0.0f,
+            discreteSteps = null
+        )
+        assertEquals(0.42f, m.displayFractionLeft, 1e-6f)
+        assertEquals(0.58f, m.elapsedFraction, 1e-6f)
+        assertEquals(208.8f, m.emptySweepDegrees, 1e-3f)
+    }
+
+    @Test
+    fun `clamps inputs to valid ranges`() {
+        val m1 = computeDeletionIconMetrics(-0.3f, -1f, discreteSteps = 4)
+        assertEquals(0f, m1.displayFractionLeft, 1e-6f)
+        assertEquals(1f, m1.elapsedFraction, 1e-6f)
+        assertEquals(360f, m1.emptySweepDegrees, 1e-6f)
+        assertEquals(0f, m1.backgroundAlpha, 1e-6f)
+
+        val m2 = computeDeletionIconMetrics(1.7f, 2f, discreteSteps = 4)
+        assertEquals(1f, m2.displayFractionLeft, 1e-6f)
+        assertEquals(0f, m2.elapsedFraction, 1e-6f)
+        assertEquals(0f, m2.emptySweepDegrees, 1e-6f)
+        assertEquals(1f, m2.backgroundAlpha, 1e-6f)
+    }
+
+    @Test
+    fun `invariants hold`() {
+        val m = computeDeletionIconMetrics(0.42f, 0.3f, discreteSteps = 8)
+        assertEquals(1f, m.displayFractionLeft + m.elapsedFraction, 1e-6f)
+        assertEquals(360f * m.elapsedFraction, m.emptySweepDegrees, 1e-6f)
+    }
+
+    @Test
+    fun `quantization strategies behave correctly`() {
+        val f = 0.62f
+        val steps = 4
+
+        val floor = computeDeletionIconMetrics(f, 0f, steps, QuantizeStrategy.FLOOR)
+        assertEquals(0.50f, floor.displayFractionLeft, 1e-6f)
+
+        val ceil = computeDeletionIconMetrics(f, 0f, steps, QuantizeStrategy.CEIL)
+        assertEquals(0.75f, ceil.displayFractionLeft, 1e-6f)
+
+        val nearestLow = computeDeletionIconMetrics(0.63f, 0f, steps, QuantizeStrategy.NEAREST)
+        assertEquals(0.75f, nearestLow.displayFractionLeft, 1e-6f)
+
+        val nearestHigh = computeDeletionIconMetrics(0.62f, 0f, steps, QuantizeStrategy.NEAREST)
+        assertEquals(0.50f, nearestHigh.displayFractionLeft, 1e-6f)
+    }
+
+    @Test
+    fun `exact step boundaries stay exact regardless of strategy`() {
+        val f = 0.75f
+        val steps = 4
+        for (s in QuantizeStrategy.entries) {
+            val m = computeDeletionIconMetrics(f, 0f, steps, s)
+            assertEquals(0.75f, m.displayFractionLeft, 1e-6f)
+            assertEquals(0.25f, m.elapsedFraction, 1e-6f)
+            assertEquals(90f, m.emptySweepDegrees, 1e-6f)
+        }
+    }
+
+    @Test
+    fun `edge discreteSteps behave as expected`() {
+        val none = computeDeletionIconMetrics(0.33f, 0f, 0)
+        assertEquals(0.33f, none.displayFractionLeft, 1e-6f)
+
+        val s1a = computeDeletionIconMetrics(0.01f, 0f, 1, QuantizeStrategy.FLOOR)
+        assertEquals(0f, s1a.displayFractionLeft, 1e-6f)
+        val s1b = computeDeletionIconMetrics(0.99f, 0f, 1, QuantizeStrategy.CEIL)
+        assertEquals(1f, s1b.displayFractionLeft, 1e-6f)
+
+        val many = computeDeletionIconMetrics(0.3333f, 0f, 1000, QuantizeStrategy.NEAREST)
+        assertEquals(0.3333f, many.displayFractionLeft, 1e-3f)
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19597" title="WPB-19597" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19597</a>  [Android] Chat bubbles: Message reactions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Implemented message bubble footer with:
- self deleting information with clock icon
- max emojis per row (4)
- changed deleted text style to italic

Also moved expiration items to separate file and added  inner `footerPadding`


https://github.com/user-attachments/assets/2476f4a6-710f-4881-8b53-44d547f77a04

<img width="816" height="481" alt="previews" src="https://github.com/user-attachments/assets/64716847-87a1-4fa9-be29-e5f6407fedc1" />

