### PR TITLE
feat: message bubble swipe gestures and edited state [WPB-19600] [WPB-19601]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageAuthorRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageAuthorRow.kt
@@ -68,8 +68,8 @@ fun MessageAuthorRow(
                 }
             }
             if (!messageStyle.isBubble()) {
-                MessageTimeLabel(
-                    messageTime = messageHeader.messageTime.formattedDate,
+                MessageSmallLabel(
+                    text = messageHeader.messageTime.formattedDate,
                     messageStyle = messageStyle,
                     modifier = Modifier.padding(start = dimensions().spacing6x)
                 )
@@ -94,8 +94,8 @@ private fun Username(username: String, accent: Accent, modifier: Modifier = Modi
 }
 
 @Composable
-fun MessageTimeLabel(
-    messageTime: String,
+fun MessageSmallLabel(
+    text: String,
     messageStyle: MessageStyle,
     modifier: Modifier = Modifier
 ) {
@@ -106,7 +106,7 @@ fun MessageTimeLabel(
     }
 
     Text(
-        text = messageTime,
+        text = text,
         style = MaterialTheme.typography.labelSmall.copy(color = color),
         maxLines = 1,
         modifier = modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentItem.kt
@@ -28,11 +28,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper
 import com.wire.android.ui.home.conversations.info.ConversationDetailsData
+import com.wire.android.ui.home.conversations.model.MessageEditStatus
 import com.wire.android.ui.home.conversations.model.MessageFlowStatus
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.UIMessage
@@ -131,17 +134,27 @@ fun MessageContentItem(
                     }
                 )
             }
-            if (messageStyle.isBubble() && !useSmallBottomPadding) {
+            if (messageStyle.isBubble() && (!useSmallBottomPadding || header.messageStatus.editStatus is MessageEditStatus.Edited)) {
                 VerticalSpace.x4()
                 Row(
                     Modifier.padding(innerPadding),
                     horizontalArrangement = if (source == MessageSource.Self) Arrangement.End else Arrangement.Start,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    MessageTimeLabel(
-                        messageTime = header.messageTime.formattedDate,
+                    MessageSmallLabel(
+                        text = header.messageTime.formattedDate,
                         messageStyle = messageStyle
                     )
+
+                    if (header.messageStatus.editStatus is MessageEditStatus.Edited) {
+                        HorizontalSpace.x8()
+                        MessageSmallLabel(
+                            text = "• " + stringResource(R.string.label_message_status_edited),
+                            messageStyle = messageStyle
+                        )
+                        HorizontalSpace.x8()
+                    }
+
                     MessageBubbleExpireFooter(
                         messageStyle = messageStyle,
                         selfDeletionTimerState = selfDeletionTimerState,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageExpirationItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageExpirationItems.kt
@@ -103,8 +103,8 @@ fun MessageBubbleExpireFooter(
                 HorizontalSpace.x8()
                 SelfDeletionTimerIcon(selfDeletionTimerState, messageStyle, accentColor)
                 HorizontalSpace.x4()
-                MessageTimeLabel(
-                    messageTime = selfDeletionTimerState.timeLeft.compactLabel(),
+                MessageSmallLabel(
+                    text = selfDeletionTimerState.timeLeft.compactLabel(),
                     messageStyle = messageStyle
                 )
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageStatusIndicator.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageStatusIndicator.kt
@@ -121,3 +121,14 @@ fun PreviewMessageStatusSending() {
         )
     }
 }
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewMessageStatusDelivered() {
+    WireTheme {
+        MessageStatusIndicator(
+            MessageFlowStatus.Delivered,
+            messageStyle = MessageStyle.NORMAL
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -31,6 +32,7 @@ import com.wire.android.ui.home.conversations.info.ConversationDetailsData
 import com.wire.android.ui.home.conversations.model.DeliveryStatusContent
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.UIMessage
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
 
 // TODO: a definite candidate for a refactor and cleanup WPB-14390
@@ -52,14 +54,14 @@ fun RegularMessageItem(
     selfDeletionTimerState: SelfDeletionTimerHelper.SelfDeletionTimerState = SelfDeletionTimerHelper.SelfDeletionTimerState.NotExpirable,
     isBubbleUiEnabled: Boolean = false
 ): Unit = with(message) {
+    val messageStyle = when {
+        !isBubbleUiEnabled -> MessageStyle.NORMAL
+        message.isMyMessage -> MessageStyle.BUBBLE_SELF
+        else -> MessageStyle.BUBBLE_OTHER
+    }
+
     @Composable
     fun messageContent() {
-        val messageStyle = when {
-            !isBubbleUiEnabled -> MessageStyle.NORMAL
-            message.isMyMessage -> MessageStyle.BUBBLE_SELF
-            else -> MessageStyle.BUBBLE_OTHER
-        }
-
         if (isBubbleUiEnabled) {
             val footerSlot: (@Composable (inner: PaddingValues) -> Unit)? =
                 if (shouldDisplayFooter) {
@@ -214,7 +216,14 @@ fun RegularMessageItem(
 
     when (swipeableMessageConfiguration) {
         is SwipeableMessageConfiguration.Swipeable -> {
-            SwipeableMessageBox(swipeableMessageConfiguration) {
+            SwipeableMessageBox(
+                configuration = swipeableMessageConfiguration,
+                messageStyle = messageStyle,
+                accentColor = MaterialTheme.wireColorScheme.wireAccentColors.getOrDefault(
+                    header.accent,
+                    MaterialTheme.wireColorScheme.primary
+                )
+            ) {
                 messageContent()
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewMesssageBubbleTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewMesssageBubbleTypes.kt
@@ -27,10 +27,12 @@ import com.wire.android.ui.home.conversations.info.ConversationDetailsData
 import com.wire.android.ui.home.conversations.messages.item.MessageClickActions
 import com.wire.android.ui.home.conversations.messages.item.RegularMessageItem
 import com.wire.android.ui.home.conversations.mock.mockFooterWithMultipleReactions
+import com.wire.android.ui.home.conversations.mock.mockHeader
 import com.wire.android.ui.home.conversations.mock.mockHeaderWithExpiration
 import com.wire.android.ui.home.conversations.mock.mockMessageWithText
 import com.wire.android.ui.home.conversations.mock.mockMessageWithTextContent
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
+import com.wire.android.ui.home.conversations.model.MessageEditStatus
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
@@ -259,6 +261,43 @@ fun PreviewBubbleMultipleDeletedMessages() {
                         ),
                         isDeleted = true
                     ).copy(
+                        username = UIText.DynamicString(
+                            "Paul Nagel"
+                        )
+                    ),
+                ),
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true,
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewBubbleMultipleEditedMessages() {
+    WireTheme {
+        Column(modifier = Modifier.background(Color.Gray)) {
+            RegularMessageItem(
+                message = mockMessageWithTextContent("Hello").copy(
+                    header = mockMessageWithText.header.copy(
+                        messageStatus = mockHeader.messageStatus.copy(
+                            editStatus = MessageEditStatus.Edited("timestamp")
+                        ),
+                    ),
+                ),
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true,
+            )
+            RegularMessageItem(
+                message = mockMessageWithTextContent("Hello").copy(
+                    source = MessageSource.OtherUser,
+                    header = mockMessageWithText.header.copy(
+                        messageStatus = mockHeader.messageStatus.copy(
+                            editStatus = MessageEditStatus.Edited("timestamp")
+                        ),
                         username = UIText.DynamicString(
                             "Paul Nagel"
                         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19600" title="WPB-19600" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19600</a>  [Android] Chat bubbles: Edited messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
- added edited state to message bubble footer
- adapted colors to message bubble swipe gestures

<img width="819" height="218" alt="edited_status" src="https://github.com/user-attachments/assets/b4b19462-dc76-4636-bd68-441fe4e38154" />

https://github.com/user-attachments/assets/e0fd8d13-af6b-4c44-8591-6fe60145f934


