### PR TITLE
fix: fullscreen label should not hide automatically [WPB-10823]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.ui.calling.model.CallState
 import com.wire.android.ui.calling.model.UICallParticipant
-import com.wire.android.ui.calling.ongoing.OngoingCallViewModel.Companion.DOUBLE_TAP_TOAST_DISPLAY_TIME
 import com.wire.android.ui.calling.ongoing.buildPreviewParticipantsList
 import com.wire.android.ui.calling.ongoing.participantsview.ParticipantTile
 import com.wire.android.ui.common.dimensions
@@ -109,9 +108,6 @@ fun FullScreenTile(
             LaunchedEffect(Unit) {
                 delay(200)
                 shouldShowDoubleTapToast = true
-
-                delay(DOUBLE_TAP_TOAST_DISPLAY_TIME)
-                shouldShowDoubleTapToast = false
             }
             DoubleTapToast(
                 modifier = Modifier


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10823" title="WPB-10823" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10823</a>  [Android] After being in a place with bad connecting in an ongoing call, only one participant was left 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Right now, the "Double tap to go back" banner indicating that the user is in the fullscreen mode is hidden after 7 seconds, so after that user may forget that opened full screen and think that there is only one person on the call.
According to the designs: 

> To indicate that this is the maximised view of a group call, the banner which explains how to leave this view is shown. It does NOT automatically disappear, but it can be dismissed by tapping on it.

This PR removes the logic of hiding this banner after 7 seconds, it stays on the screen until the user clicks on it or closes the fullscreen mode.

### Testing

#### How to Test

Join/start a call, double click on a tile to open a fullscreen and check the banner.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
