### PR TITLE
fix: invalid rename folder text field description (WPB-19876)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/rename/RenameNodeScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/rename/RenameNodeScreen.kt
@@ -117,11 +117,6 @@ fun RenameNodeScreen(
                     lineLimits = TextFieldLineLimits.SingleLine,
                     state = computeNameErrorState(renameNodeViewModel.displayNameState.error, renameNodeViewModel.isFolder()),
                     keyboardOptions = KeyboardOptions.DefaultText,
-                    descriptionText = if (renameNodeViewModel.isFolder() == true) {
-                        stringResource(id = R.string.rename_long_folder_name_error)
-                    } else {
-                        stringResource(id = R.string.rename_long_file_name_error)
-                    },
                     onKeyboardAction = { keyboardController?.hide() },
                     modifier = Modifier.padding(
                         horizontal = MaterialTheme.wireDimensions.spacing16x

--- a/features/cells/src/main/res/values/strings.xml
+++ b/features/cells/src/main/res/values/strings.xml
@@ -86,8 +86,8 @@
     <string name="rename_label">Rename</string>
     <string name="rename_file_name_label">File name</string>
     <string name="rename_folder_name_label">Folder name</string>
-    <string name="rename_long_file_name_error">Use a shorter file name (most 64 characters)</string>
-    <string name="rename_long_folder_name_error">Use a shorter folder name (most 64 characters)</string>
+    <string name="rename_long_file_name_error">Use a shorter file name (at most 64 characters)</string>
+    <string name="rename_long_folder_name_error">Use a shorter folder name (at most 64 characters)</string>
     <string name="rename_enter_file_name">Enter a file name</string>
     <string name="rename_enter_folder_name">Enter a folder name</string>
     <string name="rename_file_renamed">File was renamed</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19876" title="WPB-19876" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19876</a>  [Android] Wrong default description under the input field when renaming a file
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-19876

# What's new in this PR?

### Issues
- Error text was used as a default description to the text input field
- Typo in error message