### PR TITLE
feat: update strings for different empty screens (WPB-19191)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
@@ -71,6 +71,7 @@ fun AllFilesScreen(
         isRestoreInProgress = viewModel.isRestoreInProgress.collectAsState().value,
         isRecycleBin = viewModel.isRecycleBin(),
         isSearchResult = viewModel.hasSearchQuery(),
+        isFiltering = viewModel.selectedTags.collectAsState().value.isNotEmpty(),
         showPublicLinkScreen = { publicLinkScreenData ->
             navigator.navigate(
                 NavigationCommand(

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -76,6 +75,7 @@ internal fun CellScreenContent(
     isAllFiles: Boolean,
     isRecycleBin: Boolean,
     isSearchResult: Boolean = false,
+    isFiltering: Boolean = false
 ) {
 
     val context = LocalContext.current
@@ -94,6 +94,7 @@ internal fun CellScreenContent(
             isSearchResult = isSearchResult,
             isAllFiles = isAllFiles,
             isRecycleBin = isRecycleBin,
+            isFiltering = isFiltering,
             onRetry = { pagingListItems.retry() }
         )
 
@@ -231,6 +232,7 @@ private fun EmptyScreen(
     isSearchResult: Boolean = false,
     isAllFiles: Boolean = true,
     isRecycleBin: Boolean = false,
+    isFiltering: Boolean = false,
     onRetry: () -> Unit = {},
 ) {
     Column(
@@ -245,16 +247,19 @@ private fun EmptyScreen(
                 .fillMaxHeight()
                 .weight(1f)
         )
-        if (!isSearchResult && !isRecycleBin) {
-            Text(
-                text = stringResource(R.string.file_list_empty_title),
-                style = typography().title01,
-                textAlign = TextAlign.Center,
-            )
-            Spacer(modifier = Modifier.height(dimensions().spacing16x))
+        val emptyMessage = when {
+            isFiltering || isSearchResult -> stringResource(R.string.no_results_found_label)
+            isAllFiles -> stringResource(R.string.file_list_empty_title)
+            else -> stringResource(R.string.file_list_empty_title)
         }
         Text(
+            text = emptyMessage,
+            style = typography().title01,
+            textAlign = TextAlign.Center,
+        )
+        Text(
             text = when {
+                isFiltering -> stringResource(R.string.filters_try_adjusting_your_filters_label)
                 isSearchResult -> stringResource(R.string.file_list_search_empty_message)
                 isAllFiles -> stringResource(R.string.file_list_empty_message)
                 isRecycleBin -> stringResource(R.string.empty_recycle_bin)
@@ -266,10 +271,10 @@ private fun EmptyScreen(
         Spacer(
             modifier = Modifier
                 .fillMaxHeight()
-                .weight(1f)
+                .weight(1.5f)
         )
 
-        if (!isSearchResult && isAllFiles) {
+        if (!isSearchResult && isAllFiles && !isFiltering) {
             WirePrimaryButton(
                 text = stringResource(R.string.reload),
                 onClick = onRetry

--- a/features/cells/src/main/res/values/strings.xml
+++ b/features/cells/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="file_list_load_error">There was an error loading the files list. Please try again</string>
     <string name="file_list_empty_message">You\'ll find all files shared across your conversations here.</string>
     <string name="conversation_file_list_empty_message">You\'ll find all files and folders shared in this conversation here.</string>
-    <string name="file_list_search_empty_message">No files found.</string>
+    <string name="file_list_search_empty_message">Try adjusting your search</string>
     <string name="save_label">Save</string>
     <string name="share_label">Share</string>
     <string name="delete_label">Delete</string>
@@ -75,7 +75,7 @@
     <string name="content_description_conversation_files_more_button">Open files options</string>
     <string name="recycle_bin">Recycle Bin</string>
     <string name="open_recycle_bin">Open Recycle Bin</string>
-    <string name="empty_recycle_bin">You \'ll find all deleted files and folders here.</string>
+    <string name="empty_recycle_bin">You\'ll find all deleted files and folders here.</string>
     <string name="dialog_restore_file_title">Restore File</string>
     <string name="dialog_restore_folder_title">Restore Folder</string>
     <string name="dialog_restore_file_description">This file %1$s will be restored and available again to everyone in this conversation.</string>
@@ -110,4 +110,6 @@
     <string name="failed_edit_tags">Failed to edit tags</string>
     <string name="create_folder_invalid_name">Use a name without "/" or "."</string>
     <string name="file_list_empty_title">There are no files or folders yet</string>
+    <string name="no_results_found_label">No results found</string>
+    <string name="filters_try_adjusting_your_filters_label">Try adjusting your filters.</string>
 </resources>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19191" title="WPB-19191" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19191</a>  [Android] Cells - add breadcrumbs to recycle bin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Updated copies of different empty screens of cells

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
