### PR TITLE
feat: add strict MLS filter configuration for conversation retrieval [WPB-20097]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
@@ -47,7 +47,7 @@ class GetConversationsFromSearchUseCase @Inject constructor(
     private val observeConversationsFromFromFolder: ObserveConversationsFromFolderUseCase,
     private val userTypeMapper: UserTypeMapper,
     private val dispatchers: DispatcherProvider,
-    private val getSelfUser: GetSelfUserUseCase
+    private val getSelfUser: GetSelfUserUseCase,
 ) {
     @Suppress("LongParameterList")
     suspend operator fun invoke(
@@ -56,7 +56,8 @@ class GetConversationsFromSearchUseCase @Inject constructor(
         newActivitiesOnTop: Boolean = false,
         onlyInteractionEnabled: Boolean = false,
         conversationFilter: ConversationFilter = ConversationFilter.All,
-        playingAudioMessage: PlayingAudioMessage = PlayingAudioMessage.None
+        playingAudioMessage: PlayingAudioMessage = PlayingAudioMessage.None,
+        useStrictMlsFilter: Boolean,
     ): Flow<PagingData<ConversationItem>> {
         val pagingConfig = PagingConfig(
             pageSize = PAGE_SIZE,
@@ -78,6 +79,7 @@ class GetConversationsFromSearchUseCase @Inject constructor(
                 ),
                 pagingConfig = pagingConfig,
                 startingOffset = 0L,
+                strictMlsFilter = useStrictMlsFilter
             )
 
             ConversationFilter.Favorites -> {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -153,7 +153,8 @@ class ConversationListViewModelImpl @AssistedInject constructor(
                 conversationFilter = conversationsSource.toFilter(),
                 onlyInteractionEnabled = false,
                 newActivitiesOnTop = containsNewActivitiesSection,
-                playingAudioMessage = playingAudioMessage
+                playingAudioMessage = playingAudioMessage,
+                useStrictMlsFilter = BuildConfig.USE_STRICT_MLS_FILTER,
             ).map { pagingData ->
                 pagingData
                     .map { it.hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold) }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.map
+import com.wire.android.BuildConfig
 import com.wire.android.appLogger
 import com.wire.android.model.ImageAsset
 import com.wire.android.model.SnackBarMessage
@@ -90,6 +91,7 @@ class ImportMediaAuthenticatedViewModel @Inject constructor(
                 fromArchive = false,
                 onlyInteractionEnabled = true,
                 newActivitiesOnTop = false,
+                useStrictMlsFilter = BuildConfig.USE_STRICT_MLS_FILTER
             ).map {
                 it.map {
                     it as ConversationFolderItem

--- a/app/src/test/kotlin/com/wire/android/mapper/MessagePreviewContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessagePreviewContentMapperTest.kt
@@ -273,9 +273,9 @@ class MessagePreviewContentMapperTest {
             val otherRemovedUsers = listOf(UserId("otherValue", "a-domain"), UserId("otherValue2", "a-domain2"))
             val messagePreview = TestMessage.PREVIEW.copy(
                 content = MessagePreviewContent.WithUser.ConversationMembersRemoved(
-                    "admin",
+                    username = "admin",
                     isSelfUserRemoved = true,
-                    otherRemovedUsers
+                    otherUserIdList = otherRemovedUsers
                 )
             )
 
@@ -291,9 +291,9 @@ class MessagePreviewContentMapperTest {
             val otherUsersAdded = listOf(UserId("otherValue", "a-domain"), UserId("otherValue2", "a-domain2"))
             val messagePreview = TestMessage.PREVIEW.copy(
                 content = MessagePreviewContent.WithUser.MembersAdded(
-                    "admin",
+                    username = "admin",
                     isSelfUserAdded = true,
-                    otherUsersAdded
+                    otherUserIdList = otherUsersAdded
                 )
             )
 
@@ -308,9 +308,9 @@ class MessagePreviewContentMapperTest {
         val otherUsersAdded = listOf(UserId("otherValue", "a-domain"), UserId("otherValue2", "a-domain2"))
         val messagePreview = TestMessage.PREVIEW.copy(
             content = MessagePreviewContent.WithUser.MembersAdded(
-                "admin",
+                username = "admin",
                 isSelfUserAdded = false,
-                otherUsersAdded
+                otherUserIdList = otherUsersAdded
             ),
             isSelfMessage = true
         )
@@ -322,22 +322,21 @@ class MessagePreviewContentMapperTest {
     }
 
     @Test
-    fun givenOtherUsersWereAddedToConversationMessage_whenMappingToUILastMessageContent_thenCorrectContentShouldBeReturned() =
-        runTest {
-            val otherUsersAdded = listOf(UserId("otherValue", "a-domain"), UserId("otherValue2", "a-domain2"))
-            val messagePreview = TestMessage.PREVIEW.copy(
-                content = MessagePreviewContent.WithUser.MembersAdded(
-                    "admin",
-                    isSelfUserAdded = false,
-                    otherUsersAdded
-                )
+    fun givenOtherUsersWereAddedToConversationMessage_whenMappingToUILastMessageContent_thenCorrectContentShouldBeReturned() = runTest {
+        val otherUsersAdded = listOf(UserId("otherValue", "a-domain"), UserId("otherValue2", "a-domain2"))
+        val messagePreview = TestMessage.PREVIEW.copy(
+            content = MessagePreviewContent.WithUser.MembersAdded(
+                username = "admin",
+                isSelfUserAdded = false,
+                otherUserIdList = otherUsersAdded
             )
+        )
 
-            val uiPreviewMessage = messagePreview.uiLastMessageContent().shouldBeInstanceOf<UILastMessageContent.TextMessage>()
-            val previewString = uiPreviewMessage.messageBody.message.shouldBeInstanceOf<UIText.PluralResource>()
-            previewString.count shouldBeEqualTo otherUsersAdded.size
-            previewString.resId shouldBeEqualTo R.plurals.last_message_other_added_other_users
-        }
+        val uiPreviewMessage = messagePreview.uiLastMessageContent().shouldBeInstanceOf<UILastMessageContent.TextMessage>()
+        val previewString = uiPreviewMessage.messageBody.message.shouldBeInstanceOf<UIText.PluralResource>()
+        previewString.count shouldBeEqualTo otherUsersAdded.size
+        previewString.resId shouldBeEqualTo R.plurals.last_message_other_added_other_users
+    }
 
     @Test
     fun givenFederatedUsersWereRemovedFromConversationMessage_whenMappingToUILastMessageContent_thenCorrectContentShouldBeReturned() =
@@ -346,7 +345,7 @@ class MessagePreviewContentMapperTest {
             val messagePreview = TestMessage.PREVIEW.copy(
                 content = MessagePreviewContent.FederatedMembersRemoved(
                     isSelfUserRemoved = true,
-                    otherRemovedUsers
+                    otherUserIdList = otherRemovedUsers
                 )
             )
 
@@ -363,7 +362,7 @@ class MessagePreviewContentMapperTest {
             val messagePreview = TestMessage.PREVIEW.copy(
                 content = MessagePreviewContent.FederatedMembersRemoved(
                     isSelfUserRemoved = false,
-                    otherRemovedUsers
+                    otherUserIdList = otherRemovedUsers
                 )
             )
 
@@ -374,16 +373,15 @@ class MessagePreviewContentMapperTest {
         }
 
     @Test
-    fun givenLastMessageIsDeleted_whenMappingToUILastMessageContent_thenCorrectContentShouldBeReturned() =
-        runTest {
-            val messagePreview = TestMessage.PREVIEW.copy(
-                content = MessagePreviewContent.WithUser.Deleted("admin"),
-                isSelfMessage = false
-            )
+    fun givenLastMessageIsDeleted_whenMappingToUILastMessageContent_thenCorrectContentShouldBeReturned() = runTest {
+        val messagePreview = TestMessage.PREVIEW.copy(
+            content = MessagePreviewContent.WithUser.Deleted("admin"),
+            isSelfMessage = false
+        )
 
-            val senderWithMessage = messagePreview.uiLastMessageContent().shouldBeInstanceOf<UILastMessageContent.SenderWithMessage>()
-            val result = senderWithMessage.message.shouldBeInstanceOf<UIText.StringResource>()
+        val senderWithMessage = messagePreview.uiLastMessageContent().shouldBeInstanceOf<UILastMessageContent.SenderWithMessage>()
+        val result = senderWithMessage.message.shouldBeInstanceOf<UIText.StringResource>()
 
-            result.resId shouldBeEqualTo R.string.deleted_message_text
-        }
+        result.resId shouldBeEqualTo R.string.deleted_message_text
+    }
 }

--- a/app/src/test/kotlin/com/wire/android/mapper/SystemMessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/SystemMessageContentMapperTest.kt
@@ -152,7 +152,8 @@ class SystemMessageContentMapperTest {
         val contentFederationRemoved = MessageContent.MemberChange.FederationRemoved(listOf(userId2, userId3))
         val contentCreationAdded = MessageContent.MemberChange.CreationAdded(listOf(userId2, userId3))
         val contentFailedToAdd = MessageContent.MemberChange.FailedToAdd(
-            listOf(userId2, userId3), MessageContent.MemberChange.FailedToAdd.Type.Unknown
+            listOf(userId2, userId3),
+            MessageContent.MemberChange.FailedToAdd.Type.Unknown
         )
 
         val member1 = TestUser.MEMBER_OTHER.copy(TestUser.OTHER_USER.copy(id = userId1, name = "member1"))

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
@@ -58,11 +58,22 @@ class GetConversationsFromSearchUseCaseTest {
         val (arrangement, useCase) = Arrangement().arrange()
         // When
         with(arrangement.queryConfig) {
-            useCase(searchQuery, fromArchive, newActivitiesOnTop, onlyInteractionEnabled)
+            useCase(
+                searchQuery = searchQuery,
+                fromArchive = fromArchive,
+                newActivitiesOnTop = newActivitiesOnTop,
+                onlyInteractionEnabled = onlyInteractionEnabled,
+                useStrictMlsFilter = true
+            )
         }
         // Then
         coVerify {
-            arrangement.useCase(queryConfig = eq(arrangement.queryConfig), pagingConfig = any(), startingOffset = any())
+            arrangement.useCase(
+                queryConfig = eq(arrangement.queryConfig),
+                pagingConfig = any(),
+                startingOffset = any(),
+                strictMlsFilter = any()
+            )
         }
     }
 
@@ -74,13 +85,16 @@ class GetConversationsFromSearchUseCaseTest {
             ConversationDetailsWithEvents(TestConversationDetails.CONVERSATION_ONE_ONE),
             ConversationDetailsWithEvents(TestConversationDetails.GROUP),
         )
-        val (arrangement, useCase) = Arrangement()
-            .withPaginatedResult(conversationsList)
-            .withSelfUser()
-            .arrange()
+        val (arrangement, useCase) = Arrangement().withPaginatedResult(conversationsList).withSelfUser().arrange()
         // When
         val result = with(arrangement.queryConfig) {
-            useCase(searchQuery, fromArchive, newActivitiesOnTop, onlyInteractionEnabled).asSnapshot()
+            useCase(
+                searchQuery = searchQuery,
+                fromArchive = fromArchive,
+                newActivitiesOnTop = newActivitiesOnTop,
+                onlyInteractionEnabled = onlyInteractionEnabled,
+                useStrictMlsFilter = true,
+            ).asSnapshot()
         }
         // Then
         result.forEachIndexed { index, conversationItem ->
@@ -100,11 +114,8 @@ class GetConversationsFromSearchUseCaseTest {
             ConversationDetailsWithEvents(TestConversationDetails.CONVERSATION_ONE_ONE)
         )
 
-        val (arrangement, useCase) = Arrangement()
-            .withFavoriteFolderResult(folderResult)
-            .withFolderConversationsResult(conversationsList)
-            .withSelfUser()
-            .arrange()
+        val (arrangement, useCase) = Arrangement().withFavoriteFolderResult(folderResult).withFolderConversationsResult(conversationsList)
+            .withSelfUser().arrange()
 
         // When
         useCase(
@@ -112,13 +123,14 @@ class GetConversationsFromSearchUseCaseTest {
             fromArchive = false,
             newActivitiesOnTop = false,
             onlyInteractionEnabled = false,
-            conversationFilter = ConversationFilter.Favorites
+            conversationFilter = ConversationFilter.Favorites,
+            useStrictMlsFilter = true,
         ).asSnapshot()
 
         // Then
         coVerify(exactly = 1) { arrangement.getFavoriteFolderUseCase.invoke() }
         coVerify(exactly = 1) { arrangement.observeConversationsFromFolderUseCase.invoke(favoriteFolderId) }
-        coVerify(exactly = 0) { arrangement.useCase(any(), any(), any()) }
+        coVerify(exactly = 0) { arrangement.useCase(any(), any(), any(), any()) }
     }
 
     @Test
@@ -134,13 +146,16 @@ class GetConversationsFromSearchUseCaseTest {
                     )
                 )
             )
-            val (arrangement, useCase) = Arrangement()
-                .withPaginatedResult(conversationsList)
-                .withSelfUser()
-                .arrange()
+            val (arrangement, useCase) = Arrangement().withPaginatedResult(conversationsList).withSelfUser().arrange()
             // When
             val result = with(arrangement.queryConfig) {
-                useCase(searchQuery, fromArchive, newActivitiesOnTop, onlyInteractionEnabled).asSnapshot()
+                useCase(
+                    searchQuery = searchQuery,
+                    fromArchive = fromArchive,
+                    newActivitiesOnTop = newActivitiesOnTop,
+                    onlyInteractionEnabled = onlyInteractionEnabled,
+                    useStrictMlsFilter = true
+                ).asSnapshot()
             }
             // Then
             val conversation = result.first()
@@ -153,13 +168,16 @@ class GetConversationsFromSearchUseCaseTest {
         runTest(dispatcherProvider.main()) {
             // Given
             val conversationsList = listOf(ConversationDetailsWithEvents(TestConversationDetails.GROUP))
-            val (arrangement, useCase) = Arrangement()
-                .withPaginatedResult(conversationsList)
-                .withSelfUser()
-                .arrange()
+            val (arrangement, useCase) = Arrangement().withPaginatedResult(conversationsList).withSelfUser().arrange()
             // When
             val result = with(arrangement.queryConfig) {
-                useCase(searchQuery, fromArchive, newActivitiesOnTop, onlyInteractionEnabled).asSnapshot()
+                useCase(
+                    searchQuery = searchQuery,
+                    fromArchive = fromArchive,
+                    newActivitiesOnTop = newActivitiesOnTop,
+                    onlyInteractionEnabled = onlyInteractionEnabled,
+                    useStrictMlsFilter = true
+                ).asSnapshot()
             }
             // Then
             val conversation = result.first()
@@ -199,7 +217,7 @@ class GetConversationsFromSearchUseCaseTest {
 
         fun withPaginatedResult(conversations: List<ConversationDetailsWithEvents> = emptyList()) = apply {
             coEvery {
-                useCase.invoke(any(), any(), any())
+                useCase.invoke(any(), any(), any(), any())
             } returns flowOf(PagingData.from(conversations))
         }
 
@@ -218,12 +236,7 @@ class GetConversationsFromSearchUseCaseTest {
         }
 
         fun arrange() = this to GetConversationsFromSearchUseCase(
-            useCase,
-            getFavoriteFolderUseCase,
-            observeConversationsFromFolderUseCase,
-            userTypeMapper,
-            dispatcherProvider,
-            getSelfUser
+            useCase, getFavoriteFolderUseCase, observeConversationsFromFolderUseCase, userTypeMapper, dispatcherProvider, getSelfUser
         )
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -78,7 +78,13 @@ class ConversationListViewModelTest {
             (conversationListViewModel.conversationListState as ConversationListState.Paginated).conversations.test {
                 // Then
                 coVerify(exactly = 1) {
-                    arrangement.getConversationsPaginated("", false, true, false)
+                    arrangement.getConversationsPaginated(
+                        searchQuery = "",
+                        fromArchive = false,
+                        newActivitiesOnTop = true,
+                        onlyInteractionEnabled = false,
+                        useStrictMlsFilter = true,
+                    )
                 }
                 cancelAndIgnoreRemainingEvents()
             }
@@ -98,7 +104,13 @@ class ConversationListViewModelTest {
 
                 // Then
                 coVerify(exactly = 1) {
-                    arrangement.getConversationsPaginated(searchQueryText, false, true, false)
+                    arrangement.getConversationsPaginated(
+                        searchQuery = searchQueryText,
+                        fromArchive = false,
+                        newActivitiesOnTop = true,
+                        onlyInteractionEnabled = false,
+                        useStrictMlsFilter = true,
+                    )
                 }
                 cancelAndIgnoreRemainingEvents()
             }
@@ -118,7 +130,13 @@ class ConversationListViewModelTest {
 
                 // Then
                 coVerify(exactly = 1) {
-                    arrangement.getConversationsPaginated(searchQueryText, true, false, false)
+                    arrangement.getConversationsPaginated(
+                        searchQuery = searchQueryText,
+                        fromArchive = true,
+                        newActivitiesOnTop = false,
+                        onlyInteractionEnabled = false,
+                        useStrictMlsFilter = true
+                    )
                 }
                 cancelAndIgnoreRemainingEvents()
             }
@@ -202,7 +220,7 @@ class ConversationListViewModelTest {
 
                 // use case is called initially
                 coVerify(exactly = 1) {
-                    arrangement.getConversationsPaginated(any(), any(), any(), any(), any())
+                    arrangement.getConversationsPaginated(any(), any(), any(), any(), useStrictMlsFilter = any())
                 }
 
                 // when legal hold state is changed
@@ -211,7 +229,7 @@ class ConversationListViewModelTest {
 
                 // then use case should be called again (in total 2 executions) to create new PagingData
                 coVerify(exactly = 2) {
-                    arrangement.getConversationsPaginated(any(), any(), any(), any(), any())
+                    arrangement.getConversationsPaginated(any(), any(), any(), any(), useStrictMlsFilter = any())
                 }
 
                 cancelAndIgnoreRemainingEvents()
@@ -238,7 +256,7 @@ class ConversationListViewModelTest {
 
             // use case is called initially
             coVerify(exactly = 1) {
-                arrangement.getConversationsPaginated(any(), any(), any(), any(), any())
+                arrangement.getConversationsPaginated(any(), any(), any(), any(), useStrictMlsFilter = any())
             }
 
             // flow is collected second time
@@ -246,7 +264,7 @@ class ConversationListViewModelTest {
 
             // use case should NOT be called again, there should be still only one call
             coVerify(exactly = 1) {
-                arrangement.getConversationsPaginated(any(), any(), any(), any(), any())
+                arrangement.getConversationsPaginated(any(), any(), any(), any(), useStrictMlsFilter = any())
             }
         }
 
@@ -294,7 +312,7 @@ class ConversationListViewModelTest {
 
         fun withConversationsPaginated(items: List<ConversationItem>) = apply {
             coEvery {
-                getConversationsPaginated.invoke(any(), any(), any(), any())
+                getConversationsPaginated.invoke(any(), any(), any(), useStrictMlsFilter = any())
             } returns flowOf(
                 PagingData.from(
                     data = items,

--- a/app/src/test/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModelTest.kt
@@ -63,6 +63,7 @@ class ImportMediaAuthenticatedViewModelTest {
                     fromArchive = false,
                     newActivitiesOnTop = false,
                     onlyInteractionEnabled = true,
+                    useStrictMlsFilter = true
                 )
             }
             cancelAndIgnoreRemainingEvents()
@@ -89,7 +90,7 @@ class ImportMediaAuthenticatedViewModelTest {
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
             coEvery {
-                getConversationsPaginated.invoke(any(), any(), any(), any())
+                getConversationsPaginated.invoke(any(), any(), any(), any(), useStrictMlsFilter = any())
             } returns flowOf(
                 PagingData.from(listOf(TestConversationItem.CONNECTION, TestConversationItem.PRIVATE, TestConversationItem.GROUP))
             )

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -120,4 +120,5 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
     ANALYTICS_APP_KEY("analytics_app_key", ConfigType.STRING),
     ANALYTICS_SERVER_URL("analytics_server_url", ConfigType.STRING),
     IS_MLS_RESET_ENABLED("is_mls_reset_enabled", ConfigType.BOOLEAN),
+    USE_STRICT_MLS_FILTER("use_strict_mls_filter", ConfigType.BOOLEAN),
 }

--- a/default.json
+++ b/default.json
@@ -77,7 +77,8 @@
             "analytics_enabled": true,
             "analytics_app_key": "8ffae535f1836ed5f58fd5c8a11c00eca07c5438",
             "analytics_server_url": "https://wire.count.ly/",
-            "enable_new_registration": true
+            "enable_new_registration": true,
+             "use_strict_mls_filter": false
         },
         "fdroid": {
             "application_id": "com.wire",
@@ -144,5 +145,6 @@
     "use_new_login_for_default_backend": true,
     "enable_crossplatform_backup": true,
     "mls_read_receipts_enabled": false,
-    "is_mls_reset_enabled": true
+    "is_mls_reset_enabled": true,
+    "use_strict_mls_filter": true
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20097" title="WPB-20097" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20097</a>  [Android] do not hide conversaitons that are awaiting ongoing MLS welcome message after reset
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. MLS conversations that are awaiting MLS welcome message after a reset are hidden
2. adding an option to not hide even pending MLS conv for internal use

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
