### PR TITLE
chore: remove danger zone from public build settings (WPB-20037)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
@@ -133,7 +133,9 @@ internal fun UserDebugContent(
                     onCopyText = debugContentState::copyToClipboard,
                     onManualMigrationPressed = onManualMigrationPressed
                 )
-                DangerOptions()
+                if (BuildConfig.PRIVATE_BUILD) {
+                    DangerOptions()
+                }
             }
         }
     }
@@ -151,36 +153,34 @@ fun DangerOptions(
     Column(modifier = modifier) {
         FolderHeader("Danger Zone DO NOT TOUCH")
         @SuppressLint("ComposeViewModelInjection")
-        if (BuildConfig.PRIVATE_BUILD) {
-            val backupAndRestoreStateHolder = rememberBackUpAndRestoreStateHolder()
+        val backupAndRestoreStateHolder = rememberBackUpAndRestoreStateHolder()
 
-            SettingsItem(
-                text = "Create Obfuscated Database Copy",
-                onRowPressed = Clickable(enabled = true, onClick = backupAndRestoreStateHolder::showBackupDialog),
-                modifier = Modifier.background(Color.Red)
-            )
-            when (backupAndRestoreStateHolder.dialogState) {
-                BackupAndRestoreDialog.CreateBackup -> {
-                    CreateObfuscatedCopyFlow(
-                        backUpAndRestoreState = exportObfuscatedCopyViewModel.state,
-                        backupPasswordTextState = exportObfuscatedCopyViewModel.createBackupPasswordState,
-                        onCreateBackup = exportObfuscatedCopyViewModel::createObfuscatedCopy,
-                        onSaveBackup = exportObfuscatedCopyViewModel::saveCopy,
-                        onShareBackup = exportObfuscatedCopyViewModel::shareCopy,
-                        onCancelCreateBackup = {
-                            backupAndRestoreStateHolder.dismissDialog()
-                            exportObfuscatedCopyViewModel.cancelBackupCreation()
-                        },
-                        onPermissionPermanentlyDenied = {}
-                    )
-                }
-
-                BackupAndRestoreDialog.None -> {
-                    /*no-op*/
-                }
-
-                BackupAndRestoreDialog.RestoreBackup -> TODO("Restore backup not implemented")
+        SettingsItem(
+            text = "Create Obfuscated Database Copy",
+            onRowPressed = Clickable(enabled = true, onClick = backupAndRestoreStateHolder::showBackupDialog),
+            modifier = Modifier.background(Color.Red)
+        )
+        when (backupAndRestoreStateHolder.dialogState) {
+            BackupAndRestoreDialog.CreateBackup -> {
+                CreateObfuscatedCopyFlow(
+                    backUpAndRestoreState = exportObfuscatedCopyViewModel.state,
+                    backupPasswordTextState = exportObfuscatedCopyViewModel.createBackupPasswordState,
+                    onCreateBackup = exportObfuscatedCopyViewModel::createObfuscatedCopy,
+                    onSaveBackup = exportObfuscatedCopyViewModel::saveCopy,
+                    onShareBackup = exportObfuscatedCopyViewModel::shareCopy,
+                    onCancelCreateBackup = {
+                        backupAndRestoreStateHolder.dismissDialog()
+                        exportObfuscatedCopyViewModel.cancelBackupCreation()
+                    },
+                    onPermissionPermanentlyDenied = {}
+                )
             }
+
+            BackupAndRestoreDialog.None -> {
+                /*no-op*/
+            }
+
+            BackupAndRestoreDialog.RestoreBackup -> TODO("Restore backup not implemented")
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20037" title="WPB-20037" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20037</a>  [Android] Remove "Danger zone" from settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20037

# What's new in this PR?
Hiding `DANGER ZONE` settings label from public builds.