### PR TITLE
fix: location bottom sheet keeps showing (WPB-20139)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/location/LocationPickerComponent.kt
@@ -77,7 +77,7 @@ fun LocationPickerComponent(
 
     val locationFlow = rememberCurrentLocationPermissionFlow(
         onAllPermissionsGranted = viewModel::getCurrentLocation,
-        onAnyPermissionDenied = { /* do nothing */ },
+        onAnyPermissionDenied = { sheetState.hide() },
         onAnyPermissionPermanentlyDenied = viewModel::onPermissionPermanentlyDenied
     )
 

--- a/app/src/main/kotlin/com/wire/android/util/permission/PermissionsDeniedRequestDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/util/permission/PermissionsDeniedRequestDialog.kt
@@ -53,7 +53,10 @@ fun PermissionsDeniedRequestDialog(
             state = WireButtonState.Default
         ),
         optionButton1Properties = WireDialogButtonProperties(
-            onClick = context::openAppInfoScreen,
+            onClick = {
+                context.openAppInfoScreen()
+                onDismiss()
+            },
             text = stringResource(id = positiveButton),
             type = WireDialogButtonType.Primary,
             state = WireButtonState.Default


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20139" title="WPB-20139" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20139</a>  [Android] First share location does not forward to setting location options user disables sharing his own position
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20139
----

# What's new in this PR?

### Issues
Location bottom sheet keeps showing with endless spinner if user denies location permission.

### Solutions

[Screen_recording_20250910_084058.webm](https://github.com/user-attachments/assets/530b048e-b52f-4603-8548-85247560cfc4)
