### PR TITLE
fix: device fingerprint (WPB-20127)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -266,11 +266,11 @@ fun DeviceDetailsContent(
                 HorizontalDivider(color = MaterialTheme.wireColorScheme.background)
             }
 
-            if (!state.isCurrentDevice) {
+            if (!state.isCurrentDevice && state.fingerPrint != null) {
                 item {
                     DeviceVerificationItem(
                         state.device.isVerifiedProteus,
-                        state.fingerPrint != null,
+                        true,
                         state.isSelfClient,
                         state.userName,
                         onUpdateClientVerification


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20127" title="WPB-20127" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20127</a>  [Android] Can not verify proteus client - likely due to missing proteus fingerprint
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20127

# What's new in this PR?

### Issues
Device fingerprint verification is shown in disabled state when not available.

### Solutions
Hide fingerprint verification if fingerprint is not available.