### PR TITLE
fix: socket setting description (WPB-20137)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -52,7 +52,6 @@ fun NetworkSettingsScreen(
         onBackPressed = navigator::navigateBack,
         isWebSocketEnabled = networkSettingsViewModel.networkSettingsState.isPersistentWebSocketConnectionEnabled,
         setWebSocketState = { networkSettingsViewModel.setWebSocketState(it) },
-        backendName = networkSettingsViewModel.backendName
     )
 }
 
@@ -61,7 +60,6 @@ fun NetworkSettingsScreenContent(
     onBackPressed: () -> Unit,
     isWebSocketEnabled: Boolean,
     setWebSocketState: (Boolean) -> Unit,
-    backendName: String,
     modifier: Modifier = Modifier
 ) {
     WireScaffold(
@@ -96,10 +94,7 @@ fun NetworkSettingsScreenContent(
 
             GroupConversationOptionsItem(
                 title = stringResource(R.string.settings_keep_connection_to_websocket),
-                subtitle = stringResource(
-                    R.string.settings_keep_connection_to_websocket_description,
-                    backendName
-                ),
+                subtitle = stringResource(R.string.settings_keep_connection_to_websocket_description),
                 switchState = switchState,
                 arrowType = ArrowType.NONE
             )
@@ -114,6 +109,5 @@ fun PreviewNetworkSettingsScreen() = WireTheme {
         onBackPressed = {},
         isWebSocketEnabled = true,
         setWebSocketState = {},
-        backendName = ""
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModel.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
-import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
@@ -41,8 +40,6 @@ class NetworkSettingsViewModel
     private val currentSession: CurrentSessionUseCase
 ) : ViewModel() {
     var networkSettingsState by mutableStateOf(NetworkSettingsState())
-
-    val backendName = ServerConfig.DEFAULT.title
 
     init {
         observePersistentWebSocketConnection()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1011,7 +1011,7 @@
     <string name="settings_network_settings_label">Netzwerkeinstellungen</string>
     <string name="settings_manage_devices_label">Geräte verwalten</string>
     <string name="settings_keep_connection_to_websocket">Verbindung zu Websocket behalten</string>
-    <string name="settings_keep_connection_to_websocket_description">Verbessern Sie den Empfang von Benachrichtigungen, indem Sie eine ständige Verbindung zu %1$s aufrechterhalten. Es ersetzt die Benachrichtigungsdienste, wenn die Google-Dienste auf Ihrem Gerät nicht verfügbar sind.</string>
+    <string name="settings_keep_connection_to_websocket_description">Verbessern Sie den Empfang von Benachrichtigungen, indem Sie eine ständige Verbindung zum Server Ihrer Organisation aufrechterhalten. Es ersetzt die Benachrichtigungsdienste, wenn die Google-Dienste auf Ihrem Gerät nicht verfügbar sind.</string>
     <string name="settings_service_is_running">Dienst wird ausgeführt</string>
     <!--Settings, Appearance -->
     <string name="settings_customization_label">Anpassung</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -768,7 +768,6 @@ Hasta 500 personas pueden unirse a una conversaci&#243;n en grupo.</string>
     <string name="settings_network_settings_label">Configuraci&#243;n de red</string>
     <string name="settings_manage_devices_label">Administrar tus dispositivos</string>
     <string name="settings_keep_connection_to_websocket">Mantener conexi&#243;n al websocket</string>
-    <string name="settings_keep_connection_to_websocket_description">Mejore la recepci&#243;n de notificaciones manteniendo una conexi&#243;n constante con %1$s. Reemplazar&#225; los servicios de notificaci&#243;n si Google Services no est&#225;n disponibles en su dispositivo.</string>
     <string name="settings_service_is_running">el servicio est&#225; en ejecuci&#243;n</string>
     <!--Settings, Appearance -->
     <!--Settings, My Account -->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1068,7 +1068,6 @@
     <string name="settings_network_settings_label">Hálózati beállítások</string>
     <string name="settings_manage_devices_label">Eszközök kezelése</string>
     <string name="settings_keep_connection_to_websocket">Tartsa fenn a kapcsolatot a Websockettel</string>
-    <string name="settings_keep_connection_to_websocket_description">Javítson az értesítések fogadásán a(z) %1$s szolgáltatáshoz való állandó kapcsolattal. Ez helyettesíti az értesítési szolgáltatásokat, ha a Google-szolgáltatások nem elérhetők az eszközén.</string>
     <string name="settings_service_is_running">szolgáltatás fut</string>
     <!--Settings, Appearance -->
     <string name="settings_customization_label">Testreszabás</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -878,7 +878,6 @@ Rispondendo qui, verr&#224; riagganciata l\'altra chiamata.</string>
     <string name="settings_network_settings_label">Impostazioni Rete</string>
     <string name="settings_manage_devices_label">Gestisci i tuoi Dispositivi</string>
     <string name="settings_keep_connection_to_websocket">Mantieni la Connessione al Websocket</string>
-    <string name="settings_keep_connection_to_websocket_description">Migliora la ricezione di notifiche mantenendo una costante connessione a %1$s. Questo servizio sostituir&#224; i servizi di notifica se Google Services non sono disponibili sul tuo dispositivo.</string>
     <string name="settings_service_is_running">il servizio &#232; in esecuzione</string>
     <!--Settings, Appearance -->
     <string name="settings_appearance_theme_label">Tema</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -735,7 +735,6 @@ Do&#322;&#261;czenie do tego po&#322;&#261;czenia spowoduje zako&#324;czenie tam
     <string name="settings_network_settings_label">Ustawienia sieci</string>
     <string name="settings_manage_devices_label">Zarz&#261;dzaj swoimi urz&#261;dzeniami</string>
     <string name="settings_keep_connection_to_websocket">Utrzymaj po&#322;&#261;czenie z Websocketem</string>
-    <string name="settings_keep_connection_to_websocket_description">Popraw otrzymywanie powiadomie&#324; poprzez utrzymywanie sta&#322;ego po&#322;&#261;czenia z %1$s. Zast&#261;pi to us&#322;ugi powiadomie&#324;, je&#347;li us&#322;ugi Google nie s&#261; dost&#281;pne na Twoim urz&#261;dzeniu.</string>
     <string name="settings_service_is_running">us&#322;uga dzia&#322;a</string>
     <!--Settings, Appearance -->
     <!--Settings, My Account -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -810,7 +810,6 @@ Até 500 pessoas podem participar de uma conversa em grupo.</string>
     <string name="settings_network_settings_label">Configurações de Conexão</string>
     <string name="settings_manage_devices_label">Gerenciar seus Dispositivos</string>
     <string name="settings_keep_connection_to_websocket">Manter conexão ativa</string>
-    <string name="settings_keep_connection_to_websocket_description">Melhore o recebimento de notificações mantendo uma conexão ativa com %1$s. Recomendado se seu aparalho não possui serviços da Google para recebimentos de notificações.</string>
     <string name="settings_service_is_running">Serviço está rodando</string>
     <!--Settings, Appearance -->
     <!--Settings, My Account -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1103,7 +1103,6 @@
     <string name="settings_network_settings_label">Настройки сети</string>
     <string name="settings_manage_devices_label">Управление устройствами</string>
     <string name="settings_keep_connection_to_websocket">Поддерживать соединение с веб-сокетом</string>
-    <string name="settings_keep_connection_to_websocket_description">Позволяет оптимизировать получение уведомлений, поддерживая постоянное соединение с %1$s. Эта опция заменит службу уведомлений, если Google Services недоступны на устройстве.</string>
     <string name="settings_service_is_running">активен</string>
     <!--Settings, Appearance -->
     <string name="settings_customization_label">Внешний вид</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -891,7 +891,6 @@
     <string name="settings_network_settings_label">ජාල සැකසුම්</string>
     <string name="settings_manage_devices_label">උපාංගය කළමනාකරණය</string>
     <string name="settings_keep_connection_to_websocket">වියමන කෙවෙනියට සම්බන්ධතාවය තබා ගන්න</string>
-    <string name="settings_keep_connection_to_websocket_description">%1$s වෙත ස්ථායී සම්බන්ධතාවයක් පවත්වා ගැනීමෙන් දැනුම්දීම් ලැබීම වැඩි දියුණු කරගන්න. ඔබගේ උපාංගයේ ගූගල් සේවා නැති නම් දැනුම්දීමේ සේවා සඳහා විසඳුමක් වේ.</string>
     <string name="settings_service_is_running">සේවාව ධාවනය වෙමින්</string>
     <!--Settings, Appearance -->
     <string name="settings_appearance_theme_label">තේමාව</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1108,7 +1108,7 @@
     <string name="settings_network_settings_label">Network Settings</string>
     <string name="settings_manage_devices_label">Manage your Devices</string>
     <string name="settings_keep_connection_to_websocket">Keep Connection to Websocket</string>
-    <string name="settings_keep_connection_to_websocket_description">Improve receiving notifications by keeping a constant connection to %1$s. It will replace notification services if Google Services are not available on your device.</string>
+    <string name="settings_keep_connection_to_websocket_description">Improve receiving notifications by keeping a constant connection to your organization\'s server. It will replace notification services if Google Services are not available on your device.</string>
     <string name="settings_service_is_running">service is running</string>
     <!--Settings, Appearance -->
     <string name="settings_customization_label">Customization</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20137" title="WPB-20137" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20137</a>  [Android] In network configuration, weird mention of "product"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20137

# What's new in this PR?

### Issues
"Keep socket connection" setting description always had a "production" word regardless of app language.

### Causes (Optional)
Hardcoded environment title passed as parameter.

### Solutions
- Removed hardcoded parameter
- Updated string and translation for DE
- Removed all other translations (to be updated once merged into develop)
