### PR TITLE
fix: show info when trying to open or save already deleted asset [WPB-11385]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/DownloadedAssetDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/DownloadedAssetDialog.kt
@@ -65,5 +65,17 @@ fun DownloadedAssetDialog(
                 onClick = { hideOnAssetDownloadedDialog() }
             ),
         )
+    } else if (downloadedAssetDialogState is DownloadedAssetDialogVisibilityState.AlreadyDeleted) {
+        WireDialog(
+            title = stringResource(R.string.asset_download_not_available_text),
+            text = stringResource(R.string.asset_download_deleted_text),
+            buttonsHorizontalAlignment = false,
+            onDismiss = { hideOnAssetDownloadedDialog() },
+            optionButton1Properties = WireDialogButtonProperties(
+                text = stringResource(R.string.label_ok),
+                type = WireDialogButtonType.Primary,
+                onClick = hideOnAssetDownloadedDialog
+            ),
+        )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -50,6 +50,7 @@ import com.wire.kalium.logic.data.asset.AssetTransferStatus
 import com.wire.kalium.logic.data.asset.AttachmentType
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
@@ -273,12 +274,20 @@ class ConversationMessagesViewModel @Inject constructor(
         return when {
             messageDataResult !is GetMessageByIdUseCase.Result.Success -> {
                 appLogger.w("Failed when fetching details of message to download asset: $messageDataResult")
+                onSnackbarMessage(ConversationSnackbarMessages.ErrorDownloadingAsset)
+                null
+            }
+
+            (messageDataResult.message as? Message.Regular)?.visibility == Message.Visibility.DELETED -> {
+                appLogger.w("Attempting to download asset of a deleted message.")
+                showOnAssetDownloadAlreadyDeletedDialog()
                 null
             }
 
             messageDataResult.message.content !is MessageContent.Asset -> {
                 // This _should_ not even happen, tho. Unless UI is buggy. So... do we crash?! Better not.
                 appLogger.w("Attempting to download assets of a non-asset message. Ignoring user input.")
+                hideOnAssetDownloadedDialog()
                 null
             }
 
@@ -328,6 +337,12 @@ class ConversationMessagesViewModel @Inject constructor(
     fun showOnAssetDownloadedDialog(assetBundle: AssetBundle, messageId: String) {
         conversationViewState = conversationViewState.copy(
             downloadedAssetDialogState = DownloadedAssetDialogVisibilityState.Displayed(assetBundle, messageId)
+        )
+    }
+
+    fun showOnAssetDownloadAlreadyDeletedDialog() {
+        conversationViewState = conversationViewState.copy(
+            downloadedAssetDialogState = DownloadedAssetDialogVisibilityState.AlreadyDeleted
         )
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewState.kt
@@ -42,4 +42,5 @@ data class ConversationMessagesViewState(
 sealed class DownloadedAssetDialogVisibilityState {
     data object Hidden : DownloadedAssetDialogVisibilityState()
     data class Displayed(val assetData: AssetBundle, val messageId: String) : DownloadedAssetDialogVisibilityState()
+    data object AlreadyDeleted : DownloadedAssetDialogVisibilityState()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -529,6 +529,8 @@
     <string name="asset_message_saved_externally_text">Saved</string>
     <string name="asset_message_failed_download_text">File not available</string>
     <string name="asset_message_failed_upload_text">File upload failed</string>
+    <string name="asset_download_not_available_text">File is not available anymore</string>
+    <string name="asset_download_deleted_text">You can\'t download this file as it was deleted.</string>
     <string name="asset_download_dialog_text">Do you want to open the file, or save it to your
         device\'s download folder?
  </string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -35,6 +35,7 @@ import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveSt
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
@@ -124,6 +125,51 @@ class ConversationMessagesViewModelTest {
             // Then
             coVerify(exactly = 1) { arrangement.fileManager.saveToExternalStorage(any(), any(), any(), any(), any()) }
             assert(viewModel.conversationViewState.downloadedAssetDialogState == DownloadedAssetDialogVisibilityState.Hidden)
+        }
+
+    @Test
+    fun `given a deleted asset message, when downloading to open or save, then show already deleted dialog`() =
+        runTest {
+            // Given
+            val message = TestMessage.ASSET_MESSAGE.copy(visibility = Message.Visibility.DELETED)
+            val (_, viewModel) = ConversationMessagesViewModelArrangement()
+                .withSuccessfulViewModelInit()
+                .withGetMessageByIdReturning(message)
+                .arrange()
+            // When
+            viewModel.downloadOrFetchAssetAndShowDialog(message.id)
+            // Then
+            assert(viewModel.conversationViewState.downloadedAssetDialogState == DownloadedAssetDialogVisibilityState.AlreadyDeleted)
+        }
+
+    @Test
+    fun `given a deleted asset message, when opening it, then show already deleted dialog`() =
+        runTest {
+            // Given
+            val message = TestMessage.ASSET_MESSAGE.copy(visibility = Message.Visibility.DELETED)
+            val (_, viewModel) = ConversationMessagesViewModelArrangement()
+                .withSuccessfulViewModelInit()
+                .withGetMessageByIdReturning(message)
+                .arrange()
+            // When
+            viewModel.downloadAndOpenAsset(message.id)
+            // Then
+            assert(viewModel.conversationViewState.downloadedAssetDialogState == DownloadedAssetDialogVisibilityState.AlreadyDeleted)
+        }
+
+    @Test
+    fun `given a deleted asset message, when downloading to external storage, then show already deleted dialog`() =
+        runTest {
+            // Given
+            val message = TestMessage.ASSET_MESSAGE.copy(visibility = Message.Visibility.DELETED)
+            val (_, viewModel) = ConversationMessagesViewModelArrangement()
+                .withSuccessfulViewModelInit()
+                .withGetMessageByIdReturning(message)
+                .arrange()
+            // When
+            viewModel.downloadAssetExternally(message.id)
+            // Then
+            assert(viewModel.conversationViewState.downloadedAssetDialogState == DownloadedAssetDialogVisibilityState.AlreadyDeleted)
         }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11385" title="WPB-11385" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11385</a>  [Android] Download dialogue still showing up, when self deleting asset was already deleted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When we receive a self deleting asset and want to download it, but stay for a long time on the download/save dialogue, the dialogue is still shown after the timer for the self deleting asset ran out.
When the user clicks on “Save” or “Open” in this state, nothing happens.

### Solutions

Show a dialog with proper information when user tries to download already deleted asset.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- receive a file as self deleting file 
- longtap on the file
- stay on open/save/cancel dialogue until timer runs out for self deleting file
- after file is deleted, tap on open or save

### Attachments (Optional)

https://github.com/user-attachments/assets/d323ddbf-7e5c-4c29-912c-83538d240a52

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
