### PR TITLE
fix: profile screen loading (WPB-20140)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -138,7 +138,8 @@ class OtherUserProfileScreenViewModel @Inject constructor(
 
     private fun getIfConversationExist() {
         viewModelScope.launch {
-            state = state.copy(isConversationStarted = isOneToOneConversationCreated(userId))
+            val isOneToOneConversationCreated = isOneToOneConversationCreated(userId)
+            state = state.copy(isConversationStarted = isOneToOneConversationCreated)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20140" title="WPB-20140" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20140</a>  [Android] Can only open Conversation details every second time
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20140

# What's new in this PR?

### Issues
Sometimes profile screen stays in loading screen after opening.

### Causes (Optional)
Incorrect usage of suspend function in data class copy function.

### Solutions
Remove suspend function from copy function.
