### PR TITLE
fix: send wire cell flag when creating a channel (WPB-20045)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -268,7 +268,8 @@ class NewConversationViewModel @Inject constructor(
                         nonTeamMembersAllowed = groupOptionsState.isAllowGuestEnabled
                     ),
                     access = Conversation.accessFor(groupOptionsState.isAllowGuestEnabled),
-                    channelAddPermission = newGroupState.channelAddPermissionType.toDomainEnum()
+                    channelAddPermission = newGroupState.channelAddPermissionType.toDomainEnum(),
+                    wireCellEnabled = groupOptionsState.isWireCellsEnabled ?: false,
                     // TODO: include channel history type
                 )
             )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20045" title="WPB-20045" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20045</a>  [Android] Channel creation with Wire Cells not working
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20045
----

# What's new in this PR?
Send wire cell flag when creating a new channel.