### PR TITLE
feat: new cell feature system messages on conversation ceation (WPB-20116)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
@@ -74,6 +74,9 @@ class SystemMessageContentMapper @Inject constructor(
         is MessageContent.ConversationProtocolChangedDuringACall -> mapConversationProtocolChangedDuringACall()
         is MessageContent.ConversationStartedUnverifiedWarning -> mapConversationCreatedUnverifiedWarning()
         is MessageContent.LegalHold -> mapLegalHoldMessage(content, message.senderUserId, members)
+        is MessageContent.NewConversationWithCellMessage -> UIMessageContent.SystemMessage.NewConversationWithCellStarted
+        is MessageContent.NewConversationWithCellSelfDeleteDisabledMessage ->
+            UIMessageContent.SystemMessage.NewConversationWithCellSelfDeleteDisabled
     }
 
     private fun mapConversationCreated(senderUserId: UserId, date: Instant, userList: List<User>): UIMessageContent.SystemMessage {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -188,6 +188,16 @@ fun GroupConversationSettings(
                         )
                     )
                 }
+                addIf(state.isWireCellEnabled) {
+                    GroupConversationOptionsItem(
+                        title = stringResource(id = R.string.conversation_options_self_deleting_messages_label),
+                        subtitle = stringResource(id = R.string.conversation_options_self_deleting_messages_cells_description),
+                        trailingOnText = null,
+                        switchState = SwitchState.TextOnly(),
+                        arrowType = ArrowType.NONE,
+                        clickable = Clickable(enabled = false)
+                    )
+                }
                 addIf(state.protocolInfo !is Conversation.ProtocolInfo.MLS || mlsReadReceiptsEnabled) {
                     ReadReceiptOption(
                         isSwitchEnabled = state.isUpdatingReadReceiptAllowed,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SystemMessageItem.kt
@@ -19,6 +19,7 @@
 
 package com.wire.android.ui.home.conversations.messages.item
 
+import android.R.attr.author
 import androidx.annotation.DrawableRes
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
@@ -525,6 +526,24 @@ private fun SystemMessage.buildContent() = when (this) {
             appendVerticalSpace()
             append("") // so that "learn more" can be on a new line below another vertical space
         }
+    }
+
+    is SystemMessage.NewConversationWithCellStarted -> buildContent(
+        iconResId = R.drawable.ic_files,
+        iconTintColor = MaterialTheme.wireColorScheme.onBackground,
+    ) {
+        stringResource(R.string.label_system_message_cell_enabled_for_conversation).toMarkdownAnnotatedString()
+    }
+
+    is SystemMessage.NewConversationWithCellSelfDeleteDisabled -> buildContent(
+        iconResId = R.drawable.ic_timer,
+        iconTintColor = MaterialTheme.wireColorScheme.onBackground,
+    ) {
+        val arg = stringResource(R.string.label_system_message_cell_self_delete_disabled)
+        stringResource(
+            id = R.string.label_system_message_cell_self_delete_disabled_for_conversation,
+            formatArgs = arrayOf(arg.markdownBold())
+        ).toMarkdownAnnotatedString()
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -594,6 +594,12 @@ sealed interface UIMessageContent {
                 data object Conversation : Disabled
             }
         }
+
+        @Serializable
+        data object NewConversationWithCellStarted : SystemMessage
+
+        @Serializable
+        data object NewConversationWithCellSelfDeleteDisabled : SystemMessage
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -639,6 +639,7 @@
     <string name="conversation_details_is_not_classified">SECURITY LEVEL: UNCLASSIFIED</string>
     <string name="conversation_options_self_deleting_messages_label">Self-deleting messages</string>
     <string name="conversation_options_self_deleting_messages_description">When this is on, all messages in this conversation will disappear after a certain time.</string>
+    <string name="conversation_options_self_deleting_messages_cells_description">Self-deleting messages are currently not available for conversations with Cells.</string>
     <string name="conversation_options_guests_label">Guests</string>
     <string name="conversation_details_guest_description">When this is ON, people from outside your team can join this conversation</string>
     <string name="conversation_options_guest_description">Turn this option ON to open this conversation to people outside your team, even if they don\'t have Wire.</string>
@@ -884,6 +885,9 @@
     <string name="label_system_message_conversation_started_sensitive_information_footer">Please still be careful with who you share sensitive information.</string>
     <string name="label_conversations_details_verified_proteus">Verified (Proteus)</string>
     <string name="label_conversations_details_verified_mls">Verified (End-to-end Identity)</string>
+    <string name="label_system_message_cell_enabled_for_conversation">Cell is on for everyone</string>
+    <string name="label_system_message_cell_self_delete_disabled_for_conversation">Self-deleting messages are %1$s in conversations with Cells</string>
+    <string name="label_system_message_cell_self_delete_disabled">off</string>
     <!-- Last messages -->
     <plurals name="last_message_self_added_users">
         <item quantity="one">You added 1 person to the conversation</item>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ val ignorableModules = setOf("buildSrc", "kalium")
 rootDir
     .walk()
     .maxDepth(1)
+    .filter { it != rootDir }
     .filter { project ->
         basePathModules.contains(project.name) || ignorableModules.none { project.name == it }
                 && project.isDirectory && file("${project.absolutePath}/build.gradle.kts").exists()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20116" title="WPB-20116" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20116</a>  [Android] Self-deleting messages: Restore feature, add disable option instead of removal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20116
----

# What's new in this PR?

- New system messages when creating group / channel with cells feature enabled.
<img width="280" alt="Screenshot_20250912_102048" src="https://github.com/user-attachments/assets/bffce951-ab77-4ebd-b7d7-ef81740c3260" />

- Show self-deleting option as disabled in group settings with the custom description text
<img width="280" alt="Screenshot_20250912_102431" src="https://github.com/user-attachments/assets/4c9b88c6-5a06-4ace-8ef4-fa263b54a7ca" />
