### PR TITLE
chore: adding padding to the files list (WPB-20211)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellFilesScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -58,9 +59,8 @@ internal fun CellFilesScreen(
 ) {
 
     LazyColumn(
-        modifier = Modifier
-            .background(color = colorsScheme().surface)
-            .fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(bottom = dimensions().spacing80x),
     ) {
         items(
             count = cellNodes.itemCount,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20211" title="WPB-20211" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20211</a>  [Android] Last item menu is hidden behind floating +NEW button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20211
----

# What's new in this PR?

Added padding to the files list to avoid overlapping the the action button.

<img width="280" alt="Screenshot_20250912_113934" src="https://github.com/user-attachments/assets/9cd9d2e0-7a61-4c4f-9668-cca2622e4e3a" />
