### PR TITLE
fix: open bottom sheet properly with disabled animations [WPB-19522]

### DIFF
--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
@@ -30,9 +30,15 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -60,7 +66,18 @@ fun <T : Any> WireModalSheetLayout(
                 BackHandler(!shouldDismissOnBackPress) {
                     onBackPress()
                 }
-                sheetContent(expandedValue.value)
+                var contentHeight: Int by remember { mutableStateOf(0) }
+                Column(
+                    modifier = Modifier
+                        .onSizeChanged {
+                            contentHeight = it.height
+                        }
+                ) {
+                    sheetContent(expandedValue.value)
+                }
+                LaunchedEffect(contentHeight) {
+                    sheetState.sheetState.show() // ensure the sheet height is readjusted after content height change
+                }
             },
             containerColor = containerColor,
             contentColor = contentColor,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19522" title="WPB-19522" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19522</a>  [Android]Bottom sheet freezes when Animator duration scale is set to Off
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Bottom sheet sometimes freezes on the loading state and doesn't fully open when the data is fully fetched.

### Causes (Optional)

`AnchoredDraggable`, which is used by the Material3 `ModalBottomSheet`, kind of relies on animations - it has a `dragMutex` and it's using `tryMutate` so it doesn't suspend but skips some measure updates when they are close together, but when there's an animation ongoing then it will eventually happen in the next frame.

### Solutions

Re-trigger calculating and setting the offset by calling `SheetState.show()` when the height of the content changes - it  calls `animateTo`/`dragTo` again, so it eventually executes what has just been skipped because `dragMutex` was blocked at that moment.

### Testing

#### How to Test

Disable animations and try to open conversation options or message options (these two have a "loading" state and their own ViewModels to fetch data).

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/user-attachments/assets/65cd8c6a-cc1f-4c25-a9d6-76bfb6d0e08f"/> | <video width="400" src="https://github.com/user-attachments/assets/898ad4bb-1154-4775-b75e-63a30aebeb34"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
