### PR TITLE
chore: show delete confirmation toast (WPB-20177)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
@@ -218,6 +218,14 @@ internal fun CellScreenContent(
             is HideRestoreConfirmation -> restoreConfirmation = null
             is HideRestoreParentFolderDialog -> restoreParentFolderConfirmation = null
             is HideDeleteConfirmation -> deleteConfirmation = null
+            is ShowFileDeletedMessage -> {
+                val message = if (action.permanently) {
+                    context.getString(R.string.cells_file_permanently_deleted_message)
+                } else {
+                    context.getString(R.string.cells_file_deleted_message)
+                }
+                Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+            }
         }
     }
 

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
@@ -452,6 +452,9 @@ class CellViewModel @Inject constructor(
         } else {
             null
         }
+
+        sendAction(ShowFileDeletedMessage(isRecycleBin()))
+
         deleteCellAsset(node.uuid, localPath)
             .onSuccess {
                 removedItemsFlow.update { currentList ->
@@ -570,6 +573,7 @@ internal data class ShowMoveToFolderScreen(val currentPath: String, val nodeToMo
 internal data object ShowUnableToRestoreDialog : CellViewAction
 internal data class ShowRestoreParentFolderDialog(val cellNode: CellNodeUi) : CellViewAction
 internal data object HideRestoreParentFolderDialog : CellViewAction
+internal data class ShowFileDeletedMessage(val permanently: Boolean) : CellViewAction
 internal data object RefreshData : CellViewAction
 
 internal enum class CellError(val message: Int) {

--- a/features/cells/src/main/res/values/strings.xml
+++ b/features/cells/src/main/res/values/strings.xml
@@ -119,4 +119,6 @@
     <string name="file_list_empty_title">There are no files or folders yet</string>
     <string name="no_results_found_label">No results found</string>
     <string name="filters_try_adjusting_your_filters_label">Try adjusting your filters.</string>
+    <string name="cells_file_deleted_message">File was deleted</string>
+    <string name="cells_file_permanently_deleted_message">File was permanently deleted</string>
 </resources>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20177" title="WPB-20177" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20177</a>  [Android]Show toast notifications for file/folder deletion actions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20177

# What's new in this PR?

Show toast message when file is moved to recycle bin or permanently deleted.