### PR TITLE
fix: use file uuid for restore operation (WPB-20001)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
@@ -107,6 +108,10 @@ fun ConversationFilesScreen(
         sendIntent = { viewModel.sendIntent(it) },
         onRefresh = { viewModel.onPullToRefresh() },
     )
+
+    LaunchedEffect(Unit) {
+        viewModel.clearRemovedItems()
+    }
 }
 
 @Composable


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20001" title="WPB-20001" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20001</a>  [Android] Restored files still appear as "Not Available" in conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20001

# What's new in this PR?
Use file uuid for updated restore file use case instead of path.