### PR TITLE
feat: selected reactions on bottom sheet [WPB-19602]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/PreviewWireModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/PreviewWireModalSheetLayout.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 fun PreviewMenuModalSheetContentWithoutHeader() {
     WireMenuModalSheetContent(
         header = MenuModalSheetHeader.Gone,
-        menuItems = listOf { ReactionOption({}) }
+        menuItems = listOf { ReactionOption(setOf(), {}) }
     )
 }
 
@@ -46,6 +46,6 @@ fun PreviewMenuModalSheetContentWithHeader() {
             },
             dimensions().spacing8x
         ),
-        menuItems = listOf { ReactionOption({}) }
+        menuItems = listOf { ReactionOption(setOf(), {}) }
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/edit/ReactionOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/ReactionOption.kt
@@ -17,7 +17,9 @@
  */
 package com.wire.android.ui.edit
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -25,6 +27,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -43,11 +47,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.wire.android.R
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.emoji.EmojiPickerBottomSheet
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
@@ -57,6 +61,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReactionOption(
+    ownReactions: Set<String>,
     onReactionClick: (emoji: String) -> Unit,
     modifier: Modifier = Modifier,
     emojiFontSize: TextUnit = 28.sp
@@ -64,6 +69,7 @@ fun ReactionOption(
     val emojiPickerState = rememberWireModalSheetState<Unit>(skipPartiallyExpanded = false)
     CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onSurface) {
         Column(modifier = modifier) {
+            VerticalSpace.x8()
             Row {
                 Spacer(modifier = Modifier.width(dimensions().spacing8x))
                 Text(
@@ -76,18 +82,25 @@ fun ReactionOption(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
-                listOf("👍", "🙂", "❤️", "☹️", "👎").forEach { emoji ->
+                ownReactions.plus(listOf("👍", "🙂", "❤️", "☹️", "👎")).take(5).forEach { emoji ->
                     CompositionLocalProvider(
                         LocalMinimumInteractiveComponentSize provides Dp.Unspecified,
                     ) {
+                        val containerColor = if (ownReactions.contains(emoji)) {
+                            MaterialTheme.wireColorScheme.primaryVariant
+                        } else {
+                            MaterialTheme.wireColorScheme.surface
+                        }
+
                         Button(
                             onClick = {
                                 onReactionClick(emoji)
                             },
-                            modifier = Modifier.defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),
-                            contentPadding = PaddingValues(dimensions().spacing8x),
+                            shape = RoundedCornerShape(corner = CornerSize(dimensions().spacing12x)),
+                            modifier = Modifier.defaultMinSize(minWidth = dimensions().spacing1x, minHeight = dimensions().spacing1x),
+                            contentPadding = PaddingValues(dimensions().spacing6x),
                             colors = ButtonDefaults.buttonColors(
-                                containerColor = MaterialTheme.wireColorScheme.surface,
+                                containerColor = containerColor,
                                 contentColor = MaterialTheme.wireColorScheme.secondaryButtonSelectedOutline
                             )
                         ) {
@@ -106,6 +119,7 @@ fun ReactionOption(
                     )
                 }
             }
+            VerticalSpace.x8()
         }
     }
     EmojiPickerBottomSheet(
@@ -119,6 +133,11 @@ fun ReactionOption(
 
 @PreviewMultipleThemes
 @Composable
-private fun BasePreview() = WireTheme {
-    ReactionOption(onReactionClick = {})
+private fun PreviewReactionOption() = WireTheme {
+    Box(modifier = Modifier.background(MaterialTheme.wireColorScheme.surface)) {
+        ReactionOption(
+            setOf("😆"),
+            onReactionClick = {}
+        )
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/AssetOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/AssetOptionsMenuItems.kt
@@ -30,6 +30,7 @@ import com.wire.android.ui.edit.ShareAssetMenuOption
 @Composable
 fun assetMessageOptionsMenuItems(
     isEphemeral: Boolean,
+    ownReactions: Set<String>,
     onDeleteClick: () -> Unit,
     onDetailsClick: () -> Unit,
     onShareAsset: () -> Unit,
@@ -54,7 +55,7 @@ fun assetMessageOptionsMenuItems(
             }
 
             else -> {
-                add { ReactionOption(onReactionClick) }
+                add { ReactionOption(ownReactions, onReactionClick) }
                 add { MessageDetailsMenuOption(onDetailsClick) }
                 add { ReplyMessageOption(onReplyClick) }
                 add { DownloadAssetExternallyOption(onDownloadAsset) }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsMenuItems.kt
@@ -29,6 +29,7 @@ fun messageOptionsMenuItems(
     isComposite: Boolean,
     isEditable: Boolean,
     isCopyable: Boolean,
+    ownReactions: Set<String>,
     onCopyClick: () -> Unit,
     onDeleteClick: () -> Unit,
     onReactionClick: (reactionEmoji: String) -> Unit,
@@ -41,6 +42,7 @@ fun messageOptionsMenuItems(
 ): List<@Composable () -> Unit> {
     return if (isAssetMessage) {
         assetMessageOptionsMenuItems(
+            ownReactions = ownReactions,
             isEphemeral = isEphemeral,
             isUploading = isUploading,
             isOpenable = isOpenable,
@@ -54,6 +56,7 @@ fun messageOptionsMenuItems(
         )
     } else {
         textMessageEditMenuItems(
+            ownReactions = ownReactions,
             isEphemeral = isEphemeral,
             isUploading = isUploading,
             isComposite = isComposite,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
@@ -121,6 +121,7 @@ private fun MessageOptionsModalContent(
     WireMenuModalSheetContent(
         header = MenuModalSheetHeader.Gone,
         menuItems = messageOptionsMenuItems(
+            ownReactions = message.messageFooter.ownReactions,
             isAssetMessage = message.isAssetMessage,
             isUploading = message.isPending,
             isComposite = message.messageContent is UIMessageContent.Composite,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/TextMessageOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/TextMessageOptionsMenuItems.kt
@@ -27,6 +27,7 @@ import com.wire.android.ui.edit.ReplyMessageOption
 
 @Composable
 fun textMessageEditMenuItems(
+    ownReactions: Set<String>,
     isEphemeral: Boolean,
     isUploading: Boolean,
     isComposite: Boolean,
@@ -41,7 +42,7 @@ fun textMessageEditMenuItems(
 ): List<@Composable () -> Unit> {
     return buildList {
         if (!isUploading) {
-            if (!isEphemeral && !isComposite) add { ReactionOption(onReactionClick) }
+            if (!isEphemeral && !isComposite) add { ReactionOption(ownReactions, onReactionClick) }
             add { MessageDetailsMenuOption(onDetailsClick) }
             if (isCopyable) { add { CopyItemMenuOption(onCopyClick) } }
             if (!isEphemeral && !isComposite) add { ReplyMessageOption(onReplyClick) }

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -233,6 +233,7 @@ private fun MediaGalleryOptionsBottomSheetLayout(
                         onDeleteClick = onDeleteClick,
                         onShareAsset = onShareAssetClick,
                         onDownloadAsset = downloadAsset,
+                        ownReactions = setOf()
                     )
                 } else {
                     assetOptionsMenuItems(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19602" title="WPB-19602" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19602</a>  [Android] Chat bubbles: Message context menu
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Implemented selected reactions on message context menu

<img width="417" height="265" alt="selected_reactions" src="https://github.com/user-attachments/assets/502e6d7a-e3b9-476a-930a-ba6fd446952b" />
