### PR TITLE
fix: message bubble assets [WPB-20219]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/attachmentdraft/ui/FileHeaderView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/attachmentdraft/ui/FileHeaderView.kt
@@ -41,6 +41,7 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.typography
 import com.wire.android.ui.home.conversations.messages.item.MessageStyle
+import com.wire.android.ui.home.conversations.messages.item.textColor
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.DeviceUtil
 import com.wire.android.util.ui.PreviewMultipleThemes
@@ -58,12 +59,6 @@ fun FileHeaderView(
 ) {
     val attachmentFileType = type ?: remember(extension) { AttachmentFileType.fromExtension(extension) }
     val sizeString = remember(size) { size?.let { DeviceUtil.formatSize(size) } ?: "" }
-
-    val color = when (messageStyle) {
-        MessageStyle.BUBBLE_SELF -> colorsScheme().onPrimary
-        MessageStyle.BUBBLE_OTHER -> colorsScheme().secondaryText
-        MessageStyle.NORMAL -> colorsScheme().secondaryText
-    }
 
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -87,14 +82,14 @@ fun FileHeaderView(
         Text(
             text = "${extension.uppercase()} ($sizeString)",
             style = typography().subline01,
-            color = color,
+            color = messageStyle.textColor(),
         )
         Spacer(modifier = Modifier.weight(1f))
         label?.let {
             Text(
                 text = label,
                 style = typography().subline01,
-                color = labelColor ?: color,
+                color = labelColor ?: messageStyle.textColor(),
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ImageAssetsContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ImageAssetsContent.kt
@@ -43,6 +43,7 @@ import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.home.conversations.messages.item.MessageStyle
 import com.wire.android.ui.home.conversations.mock.mockUIAssetMessage
 import com.wire.android.ui.home.conversations.model.MediaAssetImage
 import com.wire.android.ui.home.conversations.usecase.UIImageAssetPagingItem
@@ -150,7 +151,8 @@ private fun ImageAssetGrid(
                                 size = DpSize(itemSize, itemSize),
                                 transferStatus = assetStatuses[uiAsset.messageId]?.transferStatus,
                                 onImageClick = currentOnImageClick,
-                                assetPath = uiAsset.assetPath
+                                assetPath = uiAsset.assetPath,
+                                messageStyle = MessageStyle.NORMAL
                             )
                         }
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
@@ -248,24 +248,34 @@ private fun MessageContent(
                 when {
                     messageContent.mimeType.contains("image/") -> {
                         RestrictedAssetMessage(
-                            R.drawable.ic_gallery,
-                            stringResource(id = R.string.prohibited_images_message)
+                            assetTypeIcon = R.drawable.ic_gallery,
+                            restrictedAssetMessage = stringResource(id = R.string.prohibited_images_message),
+                            messageStyle = messageStyle
                         )
                     }
 
                     messageContent.mimeType.contains("video/") -> {
-                        RestrictedAssetMessage(R.drawable.ic_video, stringResource(id = R.string.prohibited_videos_message))
+                        RestrictedAssetMessage(
+                            assetTypeIcon = R.drawable.ic_video,
+                            restrictedAssetMessage = stringResource(id = R.string.prohibited_videos_message),
+                            messageStyle = messageStyle
+                        )
                     }
 
                     messageContent.mimeType.contains("audio/") -> {
                         RestrictedAssetMessage(
-                            R.drawable.ic_speaker_on,
-                            stringResource(id = R.string.prohibited_audio_message)
+                            assetTypeIcon = R.drawable.ic_speaker_on,
+                            restrictedAssetMessage = stringResource(id = R.string.prohibited_audio_message),
+                            messageStyle = messageStyle
                         )
                     }
 
                     else -> {
-                        RestrictedGenericFileMessage(messageContent.assetName, messageContent.assetSizeInBytes)
+                        RestrictedGenericFileMessage(
+                            fileName = messageContent.assetName,
+                            fileSize = messageContent.assetSizeInBytes,
+                            messageStyle = messageStyle
+                        )
                     }
                 }
                 PartialDeliveryInformation(messageContent.deliveryStatus)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageStyle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageStyle.kt
@@ -17,6 +17,11 @@
  */
 package com.wire.android.ui.home.conversations.messages.item
 
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.wire.android.ui.theme.wireColorScheme
+
 enum class MessageStyle {
     BUBBLE_SELF,
     BUBBLE_OTHER,
@@ -29,6 +34,15 @@ fun MessageStyle.alpha() = when (this) {
     MessageStyle.BUBBLE_SELF -> SELF_BUBBLE_OPACITY
     MessageStyle.BUBBLE_OTHER -> 1F
     MessageStyle.NORMAL -> 1F
+}
+
+@Composable
+fun MessageStyle.textColor(): Color {
+    return when (this) {
+        MessageStyle.BUBBLE_SELF -> MaterialTheme.wireColorScheme.onPrimary
+        MessageStyle.BUBBLE_OTHER -> MaterialTheme.wireColorScheme.secondaryText
+        MessageStyle.NORMAL -> MaterialTheme.wireColorScheme.secondaryText
+    }
 }
 
 private const val SELF_BUBBLE_OPACITY = 0.5F

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -228,6 +228,7 @@ fun MessageImage(
                 ImageMessageInProgress(
                     size = imgParams.normalizedSize(),
                     isDownloading = transferStatus == DOWNLOAD_IN_PROGRESS,
+                    messageStyle = messageStyle,
                     modifier = alignCenterModifier
                 )
             }
@@ -263,6 +264,7 @@ fun MediaAssetImage(
     asset: ImageAsset.Remote?,
     size: DpSize,
     transferStatus: AssetTransferStatus?,
+    messageStyle: MessageStyle,
     onImageClick: Clickable,
     modifier: Modifier = Modifier,
     assetPath: Path? = null
@@ -289,6 +291,7 @@ fun MediaAssetImage(
                     size = size,
                     isDownloading = true,
                     showText = false,
+                    messageStyle = messageStyle,
                     modifier = Modifier.align(Alignment.Center)
                 )
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/asset/AssetMessageTypes.kt
@@ -58,6 +58,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.home.conversations.messages.item.MessageStyle
 import com.wire.android.ui.home.conversations.messages.item.isBubble
+import com.wire.android.ui.home.conversations.messages.item.textColor
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -94,7 +95,7 @@ internal fun MessageAsset(
             .clickable(if (isNotClickable(assetTransferStatus)) null else onAssetClick)
     ) {
         if (assetTransferStatus == AssetTransferStatus.UPLOAD_IN_PROGRESS) {
-            UploadInProgressAssetMessage()
+            UploadInProgressAssetMessage(messageStyle)
         } else {
             val assetModifier = Modifier
                 .align(Alignment.Center)
@@ -115,7 +116,8 @@ internal fun MessageAsset(
                     style = MaterialTheme.wireTypography.body02,
                     fontSize = 15.sp,
                     maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
+                    color = messageStyle.textColor()
                 )
 
                 assetDataPath?.let { localPath ->
@@ -130,7 +132,7 @@ internal fun MessageAsset(
 }
 
 @Composable
-fun UploadInProgressAssetMessage(modifier: Modifier = Modifier) {
+fun UploadInProgressAssetMessage(messageStyle: MessageStyle, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -139,21 +141,21 @@ fun UploadInProgressAssetMessage(modifier: Modifier = Modifier) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         WireCircularProgressIndicator(
-            progressColor = MaterialTheme.wireColorScheme.secondaryText,
+            progressColor = messageStyle.textColor(),
             size = dimensions().spacing16x
         )
         Spacer(modifier = Modifier.size(MaterialTheme.wireDimensions.spacing8x))
         Text(
             modifier = Modifier.padding(end = dimensions().spacing4x),
             text = stringResource(R.string.asset_message_upload_in_progress_text),
-            color = MaterialTheme.wireColorScheme.secondaryText,
+            color = messageStyle.textColor(),
             style = MaterialTheme.wireTypography.subline01
         )
     }
 }
 
 @Composable
-fun RestrictedAssetMessage(assetTypeIcon: Int, restrictedAssetMessage: String, modifier: Modifier = Modifier) {
+fun RestrictedAssetMessage(assetTypeIcon: Int, restrictedAssetMessage: String, messageStyle: MessageStyle, modifier: Modifier = Modifier) {
     Card(
         modifier = modifier,
         shape = RoundedCornerShape(dimensions().messageAssetBorderRadius),
@@ -175,12 +177,12 @@ fun RestrictedAssetMessage(assetTypeIcon: Int, restrictedAssetMessage: String, m
                 ),
                 alignment = Alignment.Center,
                 contentDescription = stringResource(R.string.content_description_image_message),
-                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.secondaryText)
+                colorFilter = ColorFilter.tint(messageStyle.textColor())
             )
 
             Text(
                 text = restrictedAssetMessage,
-                style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
+                style = MaterialTheme.wireTypography.body01.copy(color = messageStyle.textColor()),
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1
             )
@@ -189,7 +191,7 @@ fun RestrictedAssetMessage(assetTypeIcon: Int, restrictedAssetMessage: String, m
 }
 
 @Composable
-fun RestrictedGenericFileMessage(fileName: String, fileSize: Long, modifier: Modifier = Modifier) {
+fun RestrictedGenericFileMessage(fileName: String, fileSize: Long, messageStyle: MessageStyle, modifier: Modifier = Modifier) {
     Card(
         modifier = modifier,
         shape = RoundedCornerShape(dimensions().messageAssetBorderRadius),
@@ -236,12 +238,12 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long, modifier: Mod
                 ),
                 alignment = Alignment.Center,
                 contentDescription = stringResource(R.string.content_description_image_message),
-                colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.secondaryText)
+                colorFilter = ColorFilter.tint(messageStyle.textColor())
             )
 
             Text(
                 text = assetDescription,
-                style = MaterialTheme.wireTypography.body01,
+                style = MaterialTheme.wireTypography.body01.copy(color = messageStyle.textColor()),
                 modifier = Modifier
                     .padding(start = dimensions().spacing4x)
                     .constrainAs(size) {
@@ -253,7 +255,7 @@ fun RestrictedGenericFileMessage(fileName: String, fileSize: Long, modifier: Mod
 
             Text(
                 text = stringResource(id = R.string.prohibited_file_message),
-                style = MaterialTheme.wireTypography.body01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
+                style = MaterialTheme.wireTypography.body01.copy(color = messageStyle.textColor()),
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1,
                 modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -70,6 +70,7 @@ import com.wire.android.ui.common.applyIf
 import com.wire.android.ui.common.attachmentdraft.ui.FileHeaderView
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
+import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.clickable
 import com.wire.android.ui.common.colorsScheme
@@ -78,6 +79,7 @@ import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.home.conversations.messages.item.MessageStyle
 import com.wire.android.ui.home.conversations.messages.item.isBubble
+import com.wire.android.ui.home.conversations.messages.item.textColor
 import com.wire.android.ui.home.conversations.model.messagetypes.asset.UploadInProgressAssetMessage
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
@@ -150,7 +152,7 @@ private fun UploadingAudioMessage(
     messageStyle: MessageStyle,
     modifier: Modifier = Modifier
 ) = AudioMessageLayout(extension, size, messageStyle, modifier) {
-    UploadInProgressAssetMessage()
+    UploadInProgressAssetMessage(messageStyle)
 }
 
 @Composable
@@ -287,12 +289,6 @@ fun SuccessfulAudioMessageContent(
                 MessageStyle.NORMAL -> MaterialTheme.wireColorScheme.primary
             }
 
-            val totalTimeColor = when (messageStyle) {
-                MessageStyle.BUBBLE_SELF -> MaterialTheme.wireColorScheme.onPrimary
-                MessageStyle.BUBBLE_OTHER -> MaterialTheme.wireColorScheme.secondaryText
-                MessageStyle.NORMAL -> MaterialTheme.wireColorScheme.secondaryText
-            }
-
             Row {
                 Text(
                     modifier = Modifier
@@ -305,25 +301,47 @@ fun SuccessfulAudioMessageContent(
                 )
 
                 if (audioState.audioMediaPlayingState is AudioMediaPlayingState.Playing && onAudioSpeedChange != null) {
-                    WirePrimaryButton(
-                        onClick = onAudioSpeedChange,
-                        text = stringResource(audioSpeed.titleRes),
-                        textStyle = MaterialTheme.wireTypography.label03,
-                        contentPadding = PaddingValues(
-                            horizontal = MaterialTheme.wireDimensions.spacing4x,
-                            vertical = MaterialTheme.wireDimensions.spacing2x
-                        ),
-                        shape = RoundedCornerShape(MaterialTheme.wireDimensions.corner4x),
-                        minSize = DpSize(
-                            dimensions().spacing32x,
-                            dimensions().spacing16x
-                        ),
-                        minClickableSize = DpSize(
-                            dimensions().spacing40x,
-                            dimensions().spacing16x
-                        ),
-                        fillMaxWidth = false
-                    )
+                    if (messageStyle == MessageStyle.BUBBLE_SELF) {
+                        WireSecondaryButton(
+                            onClick = onAudioSpeedChange,
+                            text = stringResource(audioSpeed.titleRes),
+                            textStyle = MaterialTheme.wireTypography.label03,
+                            contentPadding = PaddingValues(
+                                horizontal = MaterialTheme.wireDimensions.spacing4x,
+                                vertical = MaterialTheme.wireDimensions.spacing2x
+                            ),
+                            shape = RoundedCornerShape(MaterialTheme.wireDimensions.corner4x),
+                            minSize = DpSize(
+                                dimensions().spacing32x,
+                                dimensions().spacing16x
+                            ),
+                            minClickableSize = DpSize(
+                                dimensions().spacing40x,
+                                dimensions().spacing16x
+                            ),
+                            fillMaxWidth = false
+                        )
+                    } else {
+                        WirePrimaryButton(
+                            onClick = onAudioSpeedChange,
+                            text = stringResource(audioSpeed.titleRes),
+                            textStyle = MaterialTheme.wireTypography.label03,
+                            contentPadding = PaddingValues(
+                                horizontal = MaterialTheme.wireDimensions.spacing4x,
+                                vertical = MaterialTheme.wireDimensions.spacing2x
+                            ),
+                            shape = RoundedCornerShape(MaterialTheme.wireDimensions.corner4x),
+                            minSize = DpSize(
+                                dimensions().spacing32x,
+                                dimensions().spacing16x
+                            ),
+                            minClickableSize = DpSize(
+                                dimensions().spacing40x,
+                                dimensions().spacing16x
+                            ),
+                            fillMaxWidth = false
+                        )
+                    }
                 }
 
                 Spacer(Modifier.weight(1F))
@@ -340,7 +358,7 @@ fun SuccessfulAudioMessageContent(
                             .padding(vertical = MaterialTheme.wireDimensions.spacing2x),
                         text = audioDuration.formattedTotalTime(),
                         style = MaterialTheme.typography.labelSmall,
-                        color = totalTimeColor,
+                        color = messageStyle.textColor(),
                         maxLines = 1
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/image/ImageMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/image/ImageMessageTypes.kt
@@ -44,6 +44,8 @@ import com.wire.android.R
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
+import com.wire.android.ui.home.conversations.messages.item.MessageStyle
+import com.wire.android.ui.home.conversations.messages.item.textColor
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
@@ -100,6 +102,7 @@ fun AsyncImageMessage(
 fun ImageMessageInProgress(
     size: DpSize,
     isDownloading: Boolean,
+    messageStyle: MessageStyle,
     modifier: Modifier = Modifier,
     showText: Boolean = true
 ) {
@@ -111,7 +114,7 @@ fun ImageMessageInProgress(
             .padding(MaterialTheme.wireDimensions.spacing8x)
     ) {
         WireCircularProgressIndicator(
-            progressColor = MaterialTheme.wireColorScheme.primary,
+            progressColor = messageStyle.textColor(),
             size = MaterialTheme.wireDimensions.spacing24x
         )
         if (showText) {
@@ -121,7 +124,7 @@ fun ImageMessageInProgress(
                     id = if (isDownloading) R.string.asset_message_download_in_progress_text
                     else R.string.asset_message_upload_in_progress_text
                 ),
-                style = MaterialTheme.wireTypography.subline01.copy(color = MaterialTheme.wireColorScheme.secondaryText),
+                style = MaterialTheme.wireTypography.subline01.copy(color = messageStyle.textColor()),
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1
             )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20219" title="WPB-20219" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20219</a>  [Android] Wrong color used for upload indicator when sharing assets
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- fixed colors of uploading assets, asset text colors and backgrounds