### PR TITLE
feat: update tags when opening filter screen (WPB-20375)

### DIFF
--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
@@ -21,18 +21,22 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.unit.Density
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalMaterial3Api::class)
 open class WireModalSheetState<T : Any>(
@@ -130,3 +134,17 @@ inline fun <reified T : Any> rememberWireModalSheetState(
 
 // to simplify execution of the sheet with Unit value
 fun WireModalSheetState<Unit>.show(hideKeyboard: Boolean = false) = this.show(Unit, hideKeyboard = hideKeyboard)
+
+@Composable
+fun WireModalSheetState<*>.onShow(throttle: Long? = 30, block: () -> Unit) {
+    LaunchedEffect(this) {
+        snapshotFlow { isVisible }
+            .filter { it }
+            .collect {
+                block()
+                throttle?.let {
+                    delay(it.seconds)
+                }
+            }
+    }
+}

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
-import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalMaterial3Api::class)
 open class WireModalSheetState<T : Any>(
@@ -136,15 +135,12 @@ inline fun <reified T : Any> rememberWireModalSheetState(
 fun WireModalSheetState<Unit>.show(hideKeyboard: Boolean = false) = this.show(Unit, hideKeyboard = hideKeyboard)
 
 @Composable
-fun WireModalSheetState<*>.onShow(throttle: Long? = 30, block: () -> Unit) {
+fun WireModalSheetState<*>.onShow(block: suspend () -> Unit) {
     LaunchedEffect(this) {
         snapshotFlow { isVisible }
             .filter { it }
             .collect {
                 block()
-                throttle?.let {
-                    delay(it.seconds)
-                }
             }
     }
 }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.wire.android.feature.cells.domain.model.CellsFilter
 import com.wire.android.feature.cells.ui.destinations.AddRemoveTagsScreenDestination
 import com.wire.android.feature.cells.ui.destinations.ConversationFilesScreenDestination
 import com.wire.android.feature.cells.ui.destinations.PublicLinkScreenDestination
@@ -30,7 +31,6 @@ import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.WireNavigator
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.common.search.SearchBarState
-import com.wire.android.feature.cells.domain.model.CellsFilter
 import kotlinx.coroutines.delay
 
 /**
@@ -122,5 +122,8 @@ fun AllFilesScreen(
         onDismiss = {
             filterBottomSheetState.hide()
         },
+        onShow = {
+            viewModel.loadTags()
+        }
     )
 }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
@@ -70,6 +70,7 @@ import okio.Path
 import okio.Path.Companion.toOkioPath
 import okio.Path.Companion.toPath
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @Suppress("TooManyFunctions", "LongParameterList")
 @HiltViewModel
@@ -127,7 +128,9 @@ class CellViewModel @Inject constructor(
     private val refreshTrigger = MutableSharedFlow<Unit>(replay = 0)
 
     init {
-        loadTags()
+        viewModelScope.launch {
+            loadTags()
+        }
     }
 
     internal val nodesFlow = flow {
@@ -523,8 +526,10 @@ class CellViewModel @Inject constructor(
         }
     }
 
-    fun loadTags() = viewModelScope.launch {
+    suspend fun loadTags() {
         getAllTagsUseCase().onSuccess { updated -> _tags.update { updated } }
+        // apply delay to avoid too frequent requests
+        delay(30.seconds)
     }
 
     companion object {

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/filter/FilterBottomSheet.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/filter/FilterBottomSheet.kt
@@ -48,6 +48,7 @@ import com.wire.android.feature.cells.R
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.common.bottomsheet.WireSheetValue
+import com.wire.android.ui.common.bottomsheet.onShow
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
@@ -66,6 +67,7 @@ fun FilterBottomSheet(
     onApply: (Set<String>) -> Unit,
     onClearAll: () -> Unit,
     onDismiss: () -> Unit,
+    onShow: () -> Unit = {},
     sheetState: WireModalSheetState<Unit> = rememberWireModalSheetState<Unit>(WireSheetValue.Expanded(Unit))
 ) {
     WireModalSheetLayout(
@@ -87,6 +89,8 @@ fun FilterBottomSheet(
             }
         )
     }
+
+    sheetState.onShow { onShow() }
 }
 
 @Composable
@@ -218,7 +222,7 @@ fun PreviewFilterBottomSheet() {
             emptySet(),
             onApply = {},
             onClearAll = {},
-            onDismiss = {}
+            onDismiss = {},
         )
     }
 }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/filter/FilterBottomSheet.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/filter/FilterBottomSheet.kt
@@ -67,7 +67,7 @@ fun FilterBottomSheet(
     onApply: (Set<String>) -> Unit,
     onClearAll: () -> Unit,
     onDismiss: () -> Unit,
-    onShow: () -> Unit = {},
+    onShow: suspend () -> Unit = {},
     sheetState: WireModalSheetState<Unit> = rememberWireModalSheetState<Unit>(WireSheetValue.Expanded(Unit))
 ) {
     WireModalSheetLayout(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20375" title="WPB-20375" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20375</a>  [Android] List of tags not automatically updated
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20375

# What's new in this PR?

### Issues
New tags created by other users are not visible without application restart.

### Causes (Optional)
Tags are fetched when the files list screen is opened for the first time. No additional updates done.

### Solutions
Refresh list of available tags when user opens the tags filter. Add 30 seconds throttling to avoid too frequent requests.
