### PR TITLE
fix: rename file validation (WPB-20373)

### DIFF
--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/rename/RenameNodeViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/rename/RenameNodeViewModelTest.kt
@@ -143,6 +143,20 @@ class RenameNodeViewModelTest {
         )
     }
 
+    @Test
+    fun `given name not changed, when text is emitted, then save is disabled`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .arrange()
+
+        advanceUntilIdle()
+
+        assertFalse(viewModel.displayNameState.saveEnabled)
+        assertEquals(
+            DisplayNameState.NameError.None,
+            viewModel.displayNameState.error
+        )
+    }
+
     private class Arrangement {
 
         @MockK


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20373" title="WPB-20373" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20373</a>  [Android] It’s possible to rename file to it’s current name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20373

# What's new in this PR?

### Issues
User can save file name even if it was not changed.

### Causes (Optional)
Text input without file extension was compared to file name with extension.

### Solutions
Fix validation logic. Minor refactoring.
