### PR TITLE
fix: message bubble markdown [WPB-20418]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -61,8 +61,10 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.typography
 import com.wire.android.ui.home.conversations.messages.item.MessageStyle
+import com.wire.android.ui.home.conversations.messages.item.highlighted
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.markdown.MarkdownInline
+import com.wire.android.ui.markdown.MessageColors
 import com.wire.android.ui.markdown.NodeData
 import com.wire.android.ui.markdown.getFirstInlines
 import com.wire.android.ui.markdown.toMarkdownDocument
@@ -407,7 +409,7 @@ private fun QuotedText(
                     StatusBox(it.asString())
                 }
             }
-            MainMarkdownText(text)
+            MainMarkdownText(text, messageStyle = style.messageStyle)
         },
         footerContent = {
             QuotedMessageOriginalDate(originalDateTimeDescription)
@@ -604,7 +606,7 @@ fun QuotedAudioMessage(
 }
 
 @Composable
-private fun MainMarkdownText(text: String, fontStyle: FontStyle = FontStyle.Normal) {
+private fun MainMarkdownText(text: String, messageStyle: MessageStyle, fontStyle: FontStyle = FontStyle.Normal) {
     val nodeData = NodeData(
         color = colorsScheme().onSurfaceVariant,
         style = MaterialTheme.wireTypography.subline01.copy(fontStyle = fontStyle),
@@ -613,6 +615,8 @@ private fun MainMarkdownText(text: String, fontStyle: FontStyle = FontStyle.Norm
         searchQuery = "",
         mentions = listOf(),
         disableLinks = true,
+        messageStyle = messageStyle,
+        messageColors = MessageColors(highlighted = messageStyle.highlighted())
     )
 
     val markdownPreview = remember(text) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageStyle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageStyle.kt
@@ -17,6 +17,11 @@
  */
 package com.wire.android.ui.home.conversations.messages.item
 
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.wire.android.ui.theme.wireColorScheme
+
 enum class MessageStyle {
     BUBBLE_SELF,
     BUBBLE_OTHER,
@@ -29,6 +34,36 @@ fun MessageStyle.alpha() = when (this) {
     MessageStyle.BUBBLE_SELF -> SELF_BUBBLE_OPACITY
     MessageStyle.BUBBLE_OTHER -> 1F
     MessageStyle.NORMAL -> 1F
+}
+
+@Composable
+fun MessageStyle.textColor(): Color {
+    return when (this) {
+        MessageStyle.BUBBLE_SELF -> MaterialTheme.wireColorScheme.onPrimary
+        MessageStyle.BUBBLE_OTHER -> MaterialTheme.wireColorScheme.secondaryText
+        MessageStyle.NORMAL -> MaterialTheme.wireColorScheme.secondaryText
+    }
+}
+
+@Composable
+fun MessageStyle.surface(): Color = when (this) {
+    MessageStyle.BUBBLE_SELF -> MaterialTheme.wireColorScheme.scrim
+    MessageStyle.BUBBLE_OTHER -> MaterialTheme.wireColorScheme.surfaceVariant
+    MessageStyle.NORMAL -> MaterialTheme.wireColorScheme.outline
+}
+
+@Composable
+fun MessageStyle.highlighted(): Color = when (this) {
+    MessageStyle.BUBBLE_SELF -> MaterialTheme.wireColorScheme.onPrimary
+    MessageStyle.BUBBLE_OTHER -> MaterialTheme.wireColorScheme.primary
+    MessageStyle.NORMAL -> MaterialTheme.wireColorScheme.primary
+}
+
+@Composable
+fun MessageStyle.onNodeBackground(): Color = when (this) {
+    MessageStyle.BUBBLE_SELF -> MaterialTheme.wireColorScheme.markdownNodeTextColor
+    MessageStyle.BUBBLE_OTHER -> MaterialTheme.wireColorScheme.onBackground
+    MessageStyle.NORMAL -> MaterialTheme.wireColorScheme.onBackground
 }
 
 private const val SELF_BUBBLE_OPACITY = 0.5F

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewMesssageBubbleTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewMesssageBubbleTypes.kt
@@ -23,17 +23,22 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.home.conversations.info.ConversationDetailsData
 import com.wire.android.ui.home.conversations.messages.item.MessageClickActions
 import com.wire.android.ui.home.conversations.messages.item.RegularMessageItem
 import com.wire.android.ui.home.conversations.mock.mockFooterWithMultipleReactions
 import com.wire.android.ui.home.conversations.mock.mockHeader
 import com.wire.android.ui.home.conversations.mock.mockHeaderWithExpiration
+import com.wire.android.ui.home.conversations.mock.mockMessageWithMarkdownListAndImages
+import com.wire.android.ui.home.conversations.mock.mockMessageWithMarkdownTablesAndBlocks
+import com.wire.android.ui.home.conversations.mock.mockMessageWithMarkdownTextAndLinks
 import com.wire.android.ui.home.conversations.mock.mockMessageWithText
 import com.wire.android.ui.home.conversations.mock.mockMessageWithTextContent
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.MessageEditStatus
 import com.wire.android.ui.home.conversations.model.MessageSource
+import com.wire.android.ui.theme.Accent
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
@@ -306,6 +311,98 @@ fun PreviewBubbleMultipleEditedMessages() {
                 conversationDetailsData = ConversationDetailsData.None(null),
                 clickActions = MessageClickActions.Content(),
                 isBubbleUiEnabled = true,
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewMessageBubbleSelfWithMarkdownTextAndLinks() {
+    WireTheme {
+        Box(modifier = Modifier.background(color = colorsScheme().surface)) {
+            RegularMessageItem(
+                message = mockMessageWithMarkdownTextAndLinks,
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewMessageBubbleOtherWithMarkdownTextAndLinks() {
+    WireTheme {
+        Box(modifier = Modifier.background(color = colorsScheme().surface)) {
+            RegularMessageItem(
+                message = mockMessageWithMarkdownTextAndLinks.copy(source = MessageSource.OtherUser),
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewMessageBubbleSelfWithMarkdownListAndImages() {
+    WireTheme {
+        Box(modifier = Modifier.background(color = colorsScheme().surface)) {
+            RegularMessageItem(
+                message = mockMessageWithMarkdownListAndImages,
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewMessageBubbleOtherWithMarkdownListAndImages() {
+    WireTheme {
+        Box(modifier = Modifier.background(color = colorsScheme().surface)) {
+            RegularMessageItem(
+                message = mockMessageWithMarkdownListAndImages.copy(source = MessageSource.OtherUser),
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewMessageBubbleSelfWithMarkdownTablesAndBlocks() {
+    WireTheme {
+        Box(modifier = Modifier.background(color = colorsScheme().surface)) {
+            RegularMessageItem(
+                message = mockMessageWithMarkdownTablesAndBlocks.copy(
+                    header = mockMessageWithMarkdownTablesAndBlocks.header.copy(accent = Accent.Amber)
+                ),
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewMessageBubbleOtherWithMarkdownTablesAndBlocks() {
+    WireTheme {
+        Box(modifier = Modifier.background(color = colorsScheme().surface)) {
+            RegularMessageItem(
+                message = mockMessageWithMarkdownTablesAndBlocks.copy(source = MessageSource.OtherUser),
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -51,6 +51,7 @@ import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.home.conversations.CompositeMessageViewModel
 import com.wire.android.ui.home.conversations.CompositeMessageViewModelImpl
 import com.wire.android.ui.home.conversations.messages.item.MessageStyle
+import com.wire.android.ui.home.conversations.messages.item.highlighted
 import com.wire.android.ui.home.conversations.messages.item.isBubble
 import com.wire.android.ui.home.conversations.mock.mockedPrivateAsset
 import com.wire.android.ui.home.conversations.model.messagetypes.image.AsyncImageMessage
@@ -61,6 +62,7 @@ import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMess
 import com.wire.android.ui.markdown.DisplayMention
 import com.wire.android.ui.markdown.MarkdownConstants.MENTION_MARK
 import com.wire.android.ui.markdown.MarkdownDocument
+import com.wire.android.ui.markdown.MessageColors
 import com.wire.android.ui.markdown.NodeActions
 import com.wire.android.ui.markdown.NodeData
 import com.wire.android.ui.markdown.toMarkdownDocument
@@ -122,7 +124,8 @@ internal fun MessageBody(
             onOpenProfile = onOpenProfile,
             onLinkClick = onLinkClick
         ),
-        messageStyle = messageStyle
+        messageStyle = messageStyle,
+        messageColors = MessageColors(highlighted = messageStyle.highlighted())
     )
 
     val markdownDocument = remember(text) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.text.style.TextOverflow
 import com.wire.android.ui.markdown.MarkdownConstants
 import com.wire.android.ui.markdown.MarkdownInline
+import com.wire.android.ui.markdown.MessageColors
 import com.wire.android.ui.markdown.NodeData
 import com.wire.android.ui.markdown.getFirstInlines
 import com.wire.android.ui.markdown.toMarkdownDocument
@@ -57,7 +58,8 @@ private fun LastMessageMarkdown(text: String, leadingText: String = "") {
         typography = MaterialTheme.wireTypography,
         searchQuery = "",
         mentions = listOf(),
-        disableLinks = true
+        disableLinks = true,
+        messageColors = MessageColors(highlighted = MaterialTheme.wireColorScheme.primary,)
     )
 
     val markdownPreview = remember(text) {

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownBlockQuote.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownBlockQuote.kt
@@ -28,12 +28,12 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.home.conversations.messages.item.textColor
 import com.wire.android.ui.theme.wireTypography
 
 @Composable
 fun MarkdownBlockQuote(blockQuote: MarkdownNode.Block.BlockQuote, nodeData: NodeData, modifier: Modifier = Modifier) {
-    val color = MaterialTheme.wireColorScheme.onBackground
+    val color = nodeData.messageStyle.textColor()
     val xOffset = dimensions().spacing12x.value
     Column(
         modifier = modifier

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownCodeBlock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownCodeBlock.kt
@@ -27,19 +27,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.home.conversations.messages.item.onNodeBackground
+import com.wire.android.ui.home.conversations.messages.item.surface
 import com.wire.android.ui.theme.wireTypography
 
 @Composable
 fun MarkdownIndentedCodeBlock(indentedCodeBlock: MarkdownNode.Block.IntendedCode, nodeData: NodeData, modifier: Modifier = Modifier) {
     Text(
         text = highlightText(nodeData, indentedCodeBlock.literal),
-        style = MaterialTheme.wireTypography.body01,
+        style = MaterialTheme.wireTypography.body01.copy(color = nodeData.messageStyle.onNodeBackground()),
         fontFamily = FontFamily.Monospace,
         modifier = modifier
             .fillMaxWidth()
             .padding(vertical = dimensions().spacing4x)
-            .background(MaterialTheme.wireColorScheme.surfaceVariant, shape = RoundedCornerShape(dimensions().spacing16x))
+            .background(nodeData.messageStyle.surface(), shape = RoundedCornerShape(dimensions().spacing16x))
             .padding(dimensions().spacing8x)
     )
 }
@@ -48,12 +49,12 @@ fun MarkdownIndentedCodeBlock(indentedCodeBlock: MarkdownNode.Block.IntendedCode
 fun MarkdownFencedCodeBlock(fencedCodeBlock: MarkdownNode.Block.FencedCode, nodeData: NodeData, modifier: Modifier = Modifier) {
     Text(
         text = highlightText(nodeData, fencedCodeBlock.literal),
-        style = MaterialTheme.wireTypography.body01,
+        style = MaterialTheme.wireTypography.body01.copy(color = nodeData.messageStyle.onNodeBackground()),
         fontFamily = FontFamily.Monospace,
         modifier = modifier
             .fillMaxWidth()
             .padding(vertical = dimensions().spacing4x)
-            .background(MaterialTheme.wireColorScheme.surfaceVariant, shape = RoundedCornerShape(dimensions().spacing16x))
+            .background(nodeData.messageStyle.surface(), shape = RoundedCornerShape(dimensions().spacing16x))
             .padding(dimensions().spacing8x)
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownComposer.kt
@@ -184,7 +184,7 @@ fun inlineNodeChildren(
                 } else {
                     annotatedString.pushStyle(
                         SpanStyle(
-                            color = nodeData.colorScheme.primary,
+                            color = nodeData.messageColors.highlighted,
                             textDecoration = TextDecoration.Underline
                         )
                     )
@@ -358,7 +358,7 @@ fun highlightText(nodeData: NodeData, text: String): AnnotatedString {
                     addStyle(
                         style = SpanStyle(
                             background = nodeData.colorScheme.highlight,
-                            color = nodeData.colorScheme.onHighlight,
+                            color = nodeData.colorScheme.onPrimaryVariant,
                             fontFamily = nodeData.typography.body02.fontFamily,
                             fontWeight = FontWeight.Bold
                         ),

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownTable.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownTable.kt
@@ -22,7 +22,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,7 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.buildAnnotatedString
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.home.conversations.messages.item.onNodeBackground
+import com.wire.android.ui.home.conversations.messages.item.surface
 
 @Composable
 fun MarkdownTable(
@@ -64,22 +66,23 @@ fun MarkdownTable(
     }
 
     // Create a table
-    Column(modifier = modifier.padding(bottom = dimensions().spacing8x)) {
+    Column(
+        modifier = modifier
+            .padding(bottom = dimensions().spacing8x)
+            .background(
+                nodeData.messageStyle.surface(),
+                shape = RoundedCornerShape(dimensions().spacing16x)
+            )
+    ) {
         tableData.map { row ->
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(
-                        if (row.firstOrNull()?.isHeader == true) {
-                            MaterialTheme.wireColorScheme.outline
-                        } else {
-                            MaterialTheme.wireColorScheme.background
-                        }
-                    )
             ) {
                 for (columnIndex in 0 until columnCount) {
                     MarkdownText(
                         annotatedString = row[columnIndex].annotatedString,
+                        color = nodeData.messageStyle.onNodeBackground(),
                         modifier = Modifier
                             .weight(1f)
                             .padding(dimensions().spacing8x),
@@ -87,6 +90,9 @@ fun MarkdownTable(
                         onOpenProfile = nodeData.actions?.onOpenProfile
                     )
                 }
+            }
+            if (row.firstOrNull()?.isHeader == true) {
+                HorizontalDivider(color = nodeData.messageStyle.onNodeBackground())
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/NodeData.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/NodeData.kt
@@ -35,8 +35,11 @@ data class NodeData(
     val searchQuery: String,
     val disableLinks: Boolean = false,
     val actions: NodeActions? = null,
-    val messageStyle: MessageStyle = MessageStyle.NORMAL
+    val messageStyle: MessageStyle = MessageStyle.NORMAL,
+    val messageColors: MessageColors
 )
+
+data class MessageColors(val highlighted: Color)
 
 data class NodeActions(
     val onLongClick: (() -> Unit)? = null,

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -91,8 +91,10 @@ class WireColorScheme(
     val channelAvatarColors: List<ChannelAvatarColors>,
     val wireAccentColors: WireAccentColors,
 
+    // custom
     val emojiBackgroundColor: Color,
-    val defaultSelectedItemInLoadingState: Color
+    val defaultSelectedItemInLoadingState: Color,
+    val markdownNodeTextColor: Color
 
     ) {
     fun toColorScheme(): ColorScheme = ColorScheme(
@@ -212,8 +214,10 @@ private val LightWireColorScheme = WireColorScheme(
             Accent.Unknown -> WireColorPalette.LightBlue500
         }
     },
+    // custom
     emojiBackgroundColor = Color.White,
-    defaultSelectedItemInLoadingState = WireColorPalette.LightBlue100
+    defaultSelectedItemInLoadingState = WireColorPalette.LightBlue100,
+    markdownNodeTextColor = Color.White
 )
 
 // Dark WireColorScheme
@@ -307,7 +311,8 @@ private val DarkWireColorScheme = WireColorScheme(
         }
     },
     emojiBackgroundColor = Color.Black,
-    defaultSelectedItemInLoadingState = WireColorPalette.DarkBlue800
+    defaultSelectedItemInLoadingState = WireColorPalette.DarkBlue800,
+    markdownNodeTextColor = Color.White
 )
 
 @PackagePrivate


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20418" title="WPB-20418" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20418</a>  [Android] Message bubble markdown
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Improvements for markdown in message bubbles
<img width="653" height="903" alt="tables_and_blocks" src="https://github.com/user-attachments/assets/812554e6-94aa-493c-8d37-aa261fe94bc6" />
<img width="562" height="910" alt="list_and_images" src="https://github.com/user-attachments/assets/0f453c8d-2e73-4a96-b0eb-063b9994ba5e" />
<img width="662" height="809" alt="text_and_links" src="https://github.com/user-attachments/assets/4becc070-3b04-4775-8f7f-34df7e5ce046" />

