### PR TITLE
chore: show error message when max file name length exceeded (WPB-20379)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/rename/RenameNodeScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/rename/RenameNodeScreen.kt
@@ -113,7 +113,13 @@ fun RenameNodeScreen(
                     } else {
                         stringResource(R.string.rename_file_label).uppercase()
                     },
-                    inputTransformation = InputTransformation.maxLengthWithCallback(NAME_MAX_COUNT, animate),
+                    inputTransformation = InputTransformation.maxLengthWithCallback(
+                        maxLength = NAME_MAX_COUNT,
+                        onIncorrectChangesFound = {
+                            renameNodeViewModel.onMaxLengthExceeded()
+                            animate()
+                        }
+                    ),
                     lineLimits = TextFieldLineLimits.SingleLine,
                     state = computeNameErrorState(renameNodeViewModel.displayNameState.error, renameNodeViewModel.isFolder()),
                     keyboardOptions = KeyboardOptions.DefaultText,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20379" title="WPB-20379" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20379</a>  [Android]Character limit warning not displayed when renaming file or folder
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20379

# What's new in this PR?

Show error message when user reaches maximum allowed length for file name
