### PR TITLE
chore: show different delete message for files and folders (WPB-20489)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.android.feature.cells.ui
 
+import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -224,14 +225,7 @@ internal fun CellScreenContent(
             is HideRestoreConfirmation -> restoreConfirmation = null
             is HideRestoreParentFolderDialog -> restoreParentFolderConfirmation = null
             is HideDeleteConfirmation -> deleteConfirmation = null
-            is ShowFileDeletedMessage -> {
-                val message = if (action.permanently) {
-                    context.getString(R.string.cells_file_permanently_deleted_message)
-                } else {
-                    context.getString(R.string.cells_file_deleted_message)
-                }
-                Toast.makeText(context, message, Toast.LENGTH_LONG).show()
-            }
+            is ShowFileDeletedMessage -> showDeleteConfirmation(context, action.isFile, action.permanently)
         }
     }
 
@@ -348,6 +342,20 @@ private fun EmptyScreen(
             )
         }
     }
+}
+
+private fun showDeleteConfirmation(
+    context: Context,
+    isFile: Boolean,
+    isPermanentlyDeleted: Boolean
+) {
+    val message = when {
+        !isFile && isPermanentlyDeleted -> R.string.cells_folder_permanently_deleted_message
+        !isFile && !isPermanentlyDeleted -> R.string.cells_folder_deleted_message
+        isFile && isPermanentlyDeleted -> R.string.cells_file_permanently_deleted_message
+        else -> R.string.cells_file_deleted_message
+    }
+    Toast.makeText(context, message, Toast.LENGTH_LONG).show()
 }
 
 @MultipleThemePreviews

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
@@ -450,7 +450,12 @@ class CellViewModel @Inject constructor(
             .onSuccess {
                 _isDeleteInProgress.value = false
                 sendAction(HideDeleteConfirmation)
-                sendAction(ShowFileDeletedMessage(isRecycleBin()))
+                sendAction(
+                    ShowFileDeletedMessage(
+                        isFile = node is CellNodeUi.File,
+                        permanently = isRecycleBin()
+                    )
+                )
                 refreshNodes()
                 // Wait until refresh completes
                 pagingRefreshDone.first()
@@ -559,7 +564,7 @@ internal data class ShowMoveToFolderScreen(val currentPath: String, val nodeToMo
 internal data object ShowUnableToRestoreDialog : CellViewAction
 internal data class ShowRestoreParentFolderDialog(val cellNode: CellNodeUi) : CellViewAction
 internal data object HideRestoreParentFolderDialog : CellViewAction
-internal data class ShowFileDeletedMessage(val permanently: Boolean) : CellViewAction
+internal data class ShowFileDeletedMessage(val isFile: Boolean, val permanently: Boolean) : CellViewAction
 internal data object RefreshData : CellViewAction
 
 internal enum class CellError(val message: Int) {

--- a/features/cells/src/main/res/values/strings.xml
+++ b/features/cells/src/main/res/values/strings.xml
@@ -123,5 +123,7 @@
     <string name="no_results_found_label">No results found</string>
     <string name="filters_try_adjusting_your_filters_label">Try adjusting your filters.</string>
     <string name="cells_file_deleted_message">File was deleted</string>
+    <string name="cells_folder_deleted_message">Folder was deleted</string>
     <string name="cells_file_permanently_deleted_message">File was permanently deleted</string>
+    <string name="cells_folder_permanently_deleted_message">Folder was permanently deleted</string>
 </resources>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20489" title="WPB-20489" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20489</a>  [Android]Incorrect toast message after deleting a folder
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20489

# What's new in this PR?

Show different messages for:
- Deleted file
- Deleted folder
- Permanently deleted file
- Permanently deleted folder