### PR TITLE
fix: call "show" only when bottom sheet content state changes, not each time content height changes [WPB-20487]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationOptionsModalSheetLayout.kt
@@ -142,7 +142,9 @@ fun ConversationOptionsModalSheetLayout(
                     openDebugMenu = { conversationId ->
                         sheetState.hide { openConversationDebugMenu(conversationId) }
                     }
-                )
+                ).also {
+                    sheetState.updateContent()
+                }
 
                 ConversationOptionsMenuState.Loading -> WireCircularProgressIndicator( // loading state - show a progress indicator
                     progressColor = colorsScheme().onSurface,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
@@ -83,7 +83,9 @@ fun MessageOptionsModalSheetLayout(
                     onShareAssetClick = onShareAssetClick,
                     onDownloadAssetClick = onDownloadAssetClick,
                     onOpenAssetClick = onOpenAssetClick
-                )
+                ).also {
+                    sheetState.updateContent()
+                }
 
                 MessageOptionsMenuState.Loading -> WireCircularProgressIndicator( // loading state - show a progress indicator
                     progressColor = colorsScheme().onSurface,

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
@@ -30,15 +30,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -66,18 +60,7 @@ fun <T : Any> WireModalSheetLayout(
                 BackHandler(!shouldDismissOnBackPress) {
                     onBackPress()
                 }
-                var contentHeight: Int by remember { mutableStateOf(0) }
-                Column(
-                    modifier = Modifier
-                        .onSizeChanged {
-                            contentHeight = it.height
-                        }
-                ) {
-                    sheetContent(expandedValue.value)
-                }
-                LaunchedEffect(contentHeight) {
-                    sheetState.sheetState.show() // ensure the sheet height is readjusted after content height change
-                }
+                sheetContent(expandedValue.value)
             },
             containerColor = containerColor,
             contentColor = contentColor,

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetState.kt
@@ -73,6 +73,17 @@ open class WireModalSheetState<T : Any>(
 
     fun hide() = hide {}
 
+    /**
+     *  To be used when the content needs to be updated while the sheet is already shown, e.g. when switching from "loading" state
+     *  to the actual content. It's a workaround for the cases when the animations and/or drag gestures are disabled or limited
+     *  and then bottom sheet doesn't update its peek height correctly after the content height changes.
+     */
+    fun updateContent() {
+        scope.launch {
+            sheetState.show()
+        }
+    }
+
     fun onDismissRequest() {
         onDismissAction()
         currentValue = WireSheetValue.Hidden


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20487" title="WPB-20487" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20487</a>  [Android] Wired animation in bottom sheet modal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After applying this [fix for the case with disabled/limited animations and drag gestures](https://github.com/wireapp/wire-android/pull/4263), animations that are inside the content make the bottom sheet to jump up and down when animating.

### Causes (Optional)

Each content animation that changes the height invokes the "show" function that is supposed to ensure that the bottom sheet is properly open after content height changes even when animations and drag gestures are disabled or limited, so it's been executed each time height changes and makes it so that the bottom sheet changes their offset multiple times.

### Solutions

Call "show" function to readjust offset only when it's really needed, so when the content size changes from "loading" to proper data, instead of each time when content height changes.

### Testing

#### How to Test

Disable animations and try to open message options or conversation options bottom sheet (long click on message or conversation).
Enable animations, open Wire Cells filters options bottom sheet and expand/collapse tags section.

### Attachments (Optional)

https://github.com/user-attachments/assets/b7d4299e-205b-43d5-85d9-6090ab7ab1c5

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
