### PR TITLE
fix: restore from recycle bin not working (WPB-20559)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
@@ -66,8 +66,8 @@ fun AllFilesScreen(
         actionsFlow = viewModel.actions,
         pagingListItems = pagingListItems,
         sendIntent = { viewModel.sendIntent(it) },
-        onFolderClick = {
-            navigator.navigate(NavigationCommand(ConversationFilesScreenDestination(it.remotePath)))
+        openFolder = { path, _, _ ->
+            navigator.navigate(NavigationCommand(ConversationFilesScreenDestination(path)))
         },
         downloadFileState = viewModel.downloadFileSheet,
         menuState = viewModel.menu,

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellFilesNavArgs.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellFilesNavArgs.kt
@@ -21,7 +21,8 @@ data class CellFilesNavArgs(
     val conversationId: String? = null,
     val screenTitle: String? = null,
     val isRecycleBin: Boolean? = false,
-    val breadcrumbs: Array<String>? = null
+    val breadcrumbs: Array<String>? = null,
+    val parentFolderUuid: String? = null,
 ) {
 
     override fun hashCode(): Int {

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
@@ -72,7 +72,7 @@ internal fun CellScreenContent(
     actionsFlow: Flow<CellViewAction>,
     pagingListItems: LazyPagingItems<CellNodeUi>,
     sendIntent: (CellViewIntent) -> Unit,
-    onFolderClick: (CellNodeUi.Folder) -> Unit,
+    openFolder: (String, String, String?) -> Unit,
     downloadFileState: StateFlow<CellNodeUi.File?>,
     menuState: Flow<MenuOptions?>,
     showPublicLinkScreen: (PublicLinkScreenData) -> Unit,
@@ -117,12 +117,7 @@ internal fun CellScreenContent(
         else ->
             CellFilesScreen(
                 cellNodes = pagingListItems,
-                onItemClick = {
-                    when (it) {
-                        is CellNodeUi.File -> sendIntent(CellViewIntent.OnFileClick(it))
-                        is CellNodeUi.Folder -> onFolderClick(it)
-                    }
-                },
+                onItemClick = { sendIntent(CellViewIntent.OnItemClick(it)) },
                 onItemMenuClick = { sendIntent(CellViewIntent.OnItemMenuClick(it)) },
                 isRefreshing = isRefreshing,
                 onRefresh = onRefresh
@@ -191,7 +186,7 @@ internal fun CellScreenContent(
             itemName = it.name ?: "",
             isRestoreInProgress = isRestoreInProgress,
             onConfirm = {
-                sendIntent(CellViewIntent.OnParentFolderRestoreConfirmed(it as CellNodeUi.Folder))
+                sendIntent(CellViewIntent.OnParentFolderRestoreConfirmed(it))
             },
             onDismiss = {
                 restoreParentFolderConfirmation = null
@@ -223,6 +218,7 @@ internal fun CellScreenContent(
             is HideRestoreParentFolderDialog -> restoreParentFolderConfirmation = null
             is HideDeleteConfirmation -> deleteConfirmation = null
             is ShowFileDeletedMessage -> showDeleteConfirmation(context, action.isFile, action.permanently)
+            is OpenFolder -> openFolder(action.path, action.title, action.parentFolderUuid)
         }
     }
 

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
@@ -212,31 +212,19 @@ class CellViewModel @Inject constructor(
 
     internal fun sendIntent(intent: CellViewIntent) {
         when (intent) {
-            is CellViewIntent.OnFileClick -> onFileClick(intent.file)
+            is CellViewIntent.OnItemClick -> when (intent.file) {
+                is CellNodeUi.File -> onFileClick(intent.file)
+                is CellNodeUi.Folder -> onFolderClick(intent.file)
+            }
             is CellViewIntent.OnItemMenuClick -> onItemMenuClick(intent.cellNode)
             is CellViewIntent.OnMenuItemActionSelected -> onMenuItemAction(intent.node, intent.action)
             is CellViewIntent.OnFileDownloadConfirmed -> downloadNode(intent.file)
             is CellViewIntent.OnNodeDeleteConfirmed -> deleteFile(intent.node)
             is CellViewIntent.OnNodeRestoreConfirmed -> restoreNodeFromRecycleBin(intent.node)
             is CellViewIntent.OnDownloadMenuClosed -> onDownloadMenuClosed()
-            is CellViewIntent.OnParentFolderRestoreConfirmed -> restoreNodeFromRecycleBin(
-                node = intent.folder.copy(remotePath = recycleBinTopFolderPath(intent.folder.remotePath ?: "")),
-                isParentNode = true
-            )
+            is CellViewIntent.OnParentFolderRestoreConfirmed -> restoreNodeFromRecycleBin(intent.node)
         }
     }
-
-    private fun recycleBinTopFolderPath(path: String): String? {
-        val parts = path.trimStart('/').split("/")
-        val index = parts.indexOf("recycle_bin")
-
-        return if (index != -1 && index + 1 < parts.size) {
-            parts.subList(0, index + 2).joinToString("/")
-        } else {
-            null
-        }
-    }
-
     internal fun currentNodeUuid(): String? = navArgs.conversationId
     internal fun isRecycleBin(): Boolean = navArgs.isRecycleBin ?: false
     private fun isSearching(): Boolean = searchQueryFlow.value.isNotEmpty()
@@ -252,6 +240,36 @@ class CellViewModel @Inject constructor(
             cellNode.canOpenWithUrl() -> openFileContentUrl(cellNode)
             else -> viewModelScope.launch { _downloadFileSheet.emit(cellNode) }
         }
+    }
+
+    private fun onFolderClick(cellNode: CellNodeUi.Folder) {
+        val path = when {
+            isRecycleBin() -> if (currentNodeUuid()?.contains("recycle_bin") == true) {
+                "${currentNodeUuid()}/${cellNode.name}"
+            } else {
+                "${currentNodeUuid()}/recycle_bin/${cellNode.name}"
+            }
+            isConversationFiles() -> "${currentNodeUuid()}/${cellNode.name}"
+            else -> cellNode.remotePath
+        } ?: run {
+            sendAction(ShowError(CellError.OTHER_ERROR))
+            return
+        }
+
+        // UUID of the top parent folder for Recycle Bin items, used when restoring a folder
+        val parentFolderUuid = if (isRecycleBin()) {
+            navArgs.parentFolderUuid ?: cellNode.uuid
+        } else {
+            null
+        }
+
+        sendAction(
+            OpenFolder(
+                path = path,
+                title = cellNode.name ?: "",
+                parentFolderUuid = parentFolderUuid,
+            )
+        )
     }
 
     private fun downloadNode(node: CellNodeUi) = viewModelScope.launch {
@@ -412,12 +430,10 @@ class CellViewModel @Inject constructor(
             NodeBottomSheetAction.RENAME -> sendAction(ShowRenameScreen(node))
             NodeBottomSheetAction.DOWNLOAD -> downloadNode(node)
             NodeBottomSheetAction.RESTORE -> {
-                node.remotePath?.let {
-                    if (!isExactlyOneLevelUnderRecycleBin(it) && node is CellNodeUi.Folder) {
-                        sendAction(ShowRestoreParentFolderDialog(node))
-                    } else {
-                        sendAction(ShowRestoreConfirmation(node = node))
-                    }
+                if (navArgs.parentFolderUuid != null) {
+                    sendAction(ShowRestoreParentFolderDialog(node))
+                } else {
+                    sendAction(ShowRestoreConfirmation(node = node))
                 }
             }
 
@@ -470,14 +486,14 @@ class CellViewModel @Inject constructor(
             }
     }
 
-    private fun restoreNodeFromRecycleBin(node: CellNodeUi, isParentNode: Boolean = false) {
+    private fun restoreNodeFromRecycleBin(node: CellNodeUi) {
         viewModelScope.launch {
             _isRestoreInProgress.value = true
             removeFromListUi(node)
-            restoreNodeFromRecycleBinUseCase(node.uuid)
+            restoreNodeFromRecycleBinUseCase(navArgs.parentFolderUuid ?: node.uuid)
                 .onSuccess {
                     _isRestoreInProgress.value = false
-                    if (isParentNode) {
+                    if (navArgs.parentFolderUuid != null) {
                         sendAction(HideRestoreParentFolderDialog)
                         _navigateToRecycleBinRoot.value = true
                         // delay to allow navigation to complete before refreshing data
@@ -490,7 +506,7 @@ class CellViewModel @Inject constructor(
                 .onFailure {
                     _isRestoreInProgress.value = false
                     addToListUi(node)
-                    if (isParentNode) {
+                    if (navArgs.parentFolderUuid != null) {
                         sendAction(HideRestoreParentFolderDialog)
                     } else {
                         sendAction(HideRestoreConfirmation)
@@ -503,17 +519,6 @@ class CellViewModel @Inject constructor(
     private fun removeFromListUi(node: CellNodeUi) = removedItemsFlow.update { it + node.uuid }
     private fun addToListUi(node: CellNodeUi) = removedItemsFlow.update { it - node.uuid }
     fun clearRemovedItems() = removedItemsFlow.update { emptyList() }
-
-    private fun isExactlyOneLevelUnderRecycleBin(path: String): Boolean {
-        val normalized = path.trimEnd('/')
-        val parts = normalized.split("/")
-
-        val recycleBinIndex = parts.indexOf("recycle_bin")
-
-        // Must have exactly one segment after "recycle_bin"
-        return recycleBinIndex != -1 && parts.size - recycleBinIndex == 2
-    }
-
     private fun onDownloadMenuClosed() {
         _downloadFileSheet.update { null }
     }
@@ -546,13 +551,13 @@ class CellViewModel @Inject constructor(
 }
 
 sealed interface CellViewIntent {
-    data class OnFileClick(val file: CellNodeUi.File) : CellViewIntent
+    data class OnItemClick(val file: CellNodeUi) : CellViewIntent
     data class OnItemMenuClick(val cellNode: CellNodeUi) : CellViewIntent
     data class OnMenuItemActionSelected(val node: CellNodeUi, val action: NodeBottomSheetAction) : CellViewIntent
     data class OnFileDownloadConfirmed(val file: CellNodeUi.File) : CellViewIntent
     data class OnNodeDeleteConfirmed(val node: CellNodeUi) : CellViewIntent
     data class OnNodeRestoreConfirmed(val node: CellNodeUi) : CellViewIntent
-    data class OnParentFolderRestoreConfirmed(val folder: CellNodeUi.Folder) : CellViewIntent
+    data class OnParentFolderRestoreConfirmed(val node: CellNodeUi) : CellViewIntent
     data object OnDownloadMenuClosed : CellViewIntent
 }
 
@@ -571,6 +576,11 @@ internal data class ShowRestoreParentFolderDialog(val cellNode: CellNodeUi) : Ce
 internal data object HideRestoreParentFolderDialog : CellViewAction
 internal data class ShowFileDeletedMessage(val isFile: Boolean, val permanently: Boolean) : CellViewAction
 internal data object RefreshData : CellViewAction
+internal data class OpenFolder(
+    val path: String,
+    val title: String,
+    val parentFolderUuid: String?
+) : CellViewAction
 
 internal enum class CellError(val message: Int) {
     DOWNLOAD_FAILED(R.string.cell_files_download_failure_message),

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesScreen.kt
@@ -243,19 +243,15 @@ fun ConversationFilesScreenContent(
                 isRestoreInProgress = isRestoreInProgress,
                 isDeleteInProgress = isDeleteInProgress,
                 isRecycleBin = isRecycleBin,
-                onFolderClick = {
-                    val folderPath = "$currentNodeUuid/${it.name}"
-
+                openFolder = { path, title, parentFolderUuid ->
                     navigator.navigate(
                         NavigationCommand(
                             ConversationFilesWithSlideInTransitionScreenDestination(
-                                conversationId = folderPath,
-                                screenTitle = it.name,
+                                conversationId = path,
+                                screenTitle = title,
                                 isRecycleBin = isRecycleBin,
                                 breadcrumbs = if (!isRecycleBin) {
-                                    it.name?.let { name ->
-                                        (breadcrumbs ?: emptyArray()) + name
-                                    }
+                                    (breadcrumbs ?: emptyArray()) + title
                                 } else { null }
                             ),
                             BackStackMode.NONE,

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/recyclebin/RecycleBinScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/recyclebin/RecycleBinScreen.kt
@@ -84,15 +84,14 @@ fun RecycleBinScreen(
                     isRecycleBin = true,
                     isRestoreInProgress = cellViewModel.isRestoreInProgress.collectAsState().value,
                     isDeleteInProgress = cellViewModel.isDeleteInProgress.collectAsState().value,
-                    onFolderClick = {
-                        val folderPath = "${cellViewModel.currentNodeUuid()}/recycle_bin/${it.name}"
-
+                    openFolder = { path, title, parentFolderUuid ->
                         navigator.navigate(
                             NavigationCommand(
                                 ConversationFilesWithSlideInTransitionScreenDestination(
-                                    conversationId = folderPath,
-                                    screenTitle = it.name,
-                                    isRecycleBin = true
+                                    conversationId = path,
+                                    screenTitle = title,
+                                    isRecycleBin = true,
+                                    parentFolderUuid = parentFolderUuid,
                                 ),
                                 BackStackMode.NONE,
                                 launchSingleTop = false

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.android.feature.cells.ui
 
+import android.os.Environment
 import androidx.lifecycle.SavedStateHandle
 import androidx.paging.LoadState
 import androidx.paging.LoadStates
@@ -46,6 +47,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -61,6 +63,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.io.File
 
 @ExtendWith(NavigationTestExtension::class)
 class CellViewModelTest {
@@ -140,7 +143,7 @@ class CellViewModelTest {
             .withLoadSuccess()
             .arrange()
 
-        viewModel.sendIntent(CellViewIntent.OnFileClick(testFiles[0].toUiModel()))
+        viewModel.sendIntent(CellViewIntent.OnItemClick(testFiles[0].toUiModel()))
 
         coVerify(exactly = 1) { arrangement.fileHelper.openAssetFileWithExternalApp(any(), any(), any(), any()) }
     }
@@ -156,7 +159,7 @@ class CellViewModelTest {
             contentUrl = "https://example.com/file"
         )
 
-        viewModel.sendIntent(CellViewIntent.OnFileClick(testFile.toUiModel()))
+        viewModel.sendIntent(CellViewIntent.OnItemClick(testFile.toUiModel()))
 
         coVerify(exactly = 1) { arrangement.fileHelper.openAssetUrlWithExternalApp(any(), any(), any()) }
     }
@@ -173,7 +176,7 @@ class CellViewModelTest {
         ).toUiModel()
 
         viewModel.downloadFileSheet.test {
-            viewModel.sendIntent(CellViewIntent.OnFileClick(testFile))
+            viewModel.sendIntent(CellViewIntent.OnItemClick(testFile))
 
             with(expectMostRecentItem()) {
                 assertEquals(testFile, this)
@@ -565,6 +568,12 @@ class CellViewModelTest {
         }
 
         fun arrange(): Pair<Arrangement, CellViewModel> {
+
+            mockkStatic(Environment::class)
+
+            every { fileNameResolver.getUniqueFile(any(), any()) } returns File("")
+            coEvery { Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) } returns File("")
+
             return this to CellViewModel(
                 savedStateHandle = savedStateHandle,
                 getCellFilesPaged = getCellFilesPagedUseCase,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20559" title="WPB-20559" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20559</a>  [Android] Cannot restore items from recycle bin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20559

# What's new in this PR?

### Issues
If deleted folder has children it is not possible to restore any of it's children.

### Causes (Optional)
After merging this PR https://github.com/wireapp/wire-android/pull/4272 we started to use UUID when restoring the files/folders from recycle bin. But the flow of restoring parent folder was not fixed and was still passing a path instead of UUID.

### Solutions
- Store UUID of the root parent folder when navigating through the recycle bin. 
- Use this UUID for restoring parent folder.

