### PR TITLE
fix: show restore error dialog (WPB-20484)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
@@ -94,7 +94,7 @@ internal fun CellScreenContent(
 
     var deleteConfirmation by remember { mutableStateOf<Pair<CellNodeUi, Boolean>?>((null)) }
     var restoreConfirmation by remember { mutableStateOf<CellNodeUi?>(null) }
-    var unableToRestore by remember { mutableStateOf(false) }
+    var showRestoreError by remember { mutableStateOf<ShowUnableToRestoreDialog?>(null) }
     var restoreParentFolderConfirmation by remember { mutableStateOf<CellNodeUi?>(null) }
     var menu by remember { mutableStateOf<MenuOptions?>(null) }
 
@@ -177,14 +177,11 @@ internal fun CellScreenContent(
         )
     }
 
-    if (unableToRestore) {
+    showRestoreError?.let {
         UnableToRestoreDialog(
-            isFolder = restoreConfirmation is CellNodeUi.Folder,
-            onConfirm = {
-                unableToRestore = false
-            },
+            isFolder = it.isFolder,
             onDismiss = {
-                unableToRestore = false
+                showRestoreError = null
             }
         )
     }
@@ -220,7 +217,7 @@ internal fun CellScreenContent(
             is ShowMoveToFolderScreen -> showMoveToFolderScreen(action.currentPath, action.nodeToMovePath, action.uuid)
             is ShowAddRemoveTagsScreen -> showAddRemoveTagsScreen(action.cellNode)
             is RefreshData -> pagingListItems.refresh()
-            is ShowUnableToRestoreDialog -> unableToRestore = true
+            is ShowUnableToRestoreDialog -> showRestoreError = action
             is ShowRestoreParentFolderDialog -> restoreParentFolderConfirmation = action.cellNode
             is HideRestoreConfirmation -> restoreConfirmation = null
             is HideRestoreParentFolderDialog -> restoreParentFolderConfirmation = null

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
@@ -490,12 +490,12 @@ class CellViewModel @Inject constructor(
                 .onFailure {
                     _isRestoreInProgress.value = false
                     addToListUi(node)
-                    sendAction(ShowError(CellError.OTHER_ERROR))
                     if (isParentNode) {
                         sendAction(HideRestoreParentFolderDialog)
                     } else {
                         sendAction(HideRestoreConfirmation)
                     }
+                    sendAction(ShowUnableToRestoreDialog(node is CellNodeUi.Folder))
                 }
         }
     }
@@ -566,7 +566,7 @@ internal data class ShowPublicLinkScreen(val cellNode: CellNodeUi) : CellViewAct
 internal data class ShowRenameScreen(val cellNode: CellNodeUi) : CellViewAction
 internal data class ShowAddRemoveTagsScreen(val cellNode: CellNodeUi) : CellViewAction
 internal data class ShowMoveToFolderScreen(val currentPath: String, val nodeToMovePath: String, val uuid: String) : CellViewAction
-internal data object ShowUnableToRestoreDialog : CellViewAction
+internal data class ShowUnableToRestoreDialog(val isFolder: Boolean) : CellViewAction
 internal data class ShowRestoreParentFolderDialog(val cellNode: CellNodeUi) : CellViewAction
 internal data object HideRestoreParentFolderDialog : CellViewAction
 internal data class ShowFileDeletedMessage(val isFile: Boolean, val permanently: Boolean) : CellViewAction

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/recyclebin/UnableToRestoreDialog.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/recyclebin/UnableToRestoreDialog.kt
@@ -30,7 +30,6 @@ import com.wire.android.ui.theme.WireTheme
 @Composable
 fun UnableToRestoreDialog(
     isFolder: Boolean,
-    onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     WireDialog(
@@ -48,7 +47,7 @@ fun UnableToRestoreDialog(
         },
         onDismiss = onDismiss,
         optionButton1Properties = WireDialogButtonProperties(
-            onClick = onConfirm,
+            onClick = onDismiss,
             text = stringResource(id = R.string.ok_label),
             type = WireDialogButtonType.Primary,
         ),
@@ -63,7 +62,6 @@ fun PreviewUnableToRestoreDialog() {
     WireTheme {
         UnableToRestoreDialog(
             isFolder = true,
-            onConfirm = {},
             onDismiss = {}
         )
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20484" title="WPB-20484" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20484</a>  [Android]Incorrect error handling when restore fails
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20484

# What's new in this PR?

Show error dialog when file / folder cannot be restored from recycle bin