### PR TITLE
fix: message bubble self message reaction alignment

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageBubbleItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageBubbleItem.kt
@@ -79,6 +79,7 @@ fun MessageBubbleItem(
                 bottom = if (useSmallBottomPadding) dimensions().spacing1x else dimensions().messageItemBottomPadding
             ),
         verticalArrangement = Arrangement.spacedBy(-dimensions().spacing8x, alignment = Alignment.Bottom),
+        horizontalAlignment = if (isSelfMessage) Alignment.End else Alignment.Start
     ) {
         val paddingValue = dimensions().spacing10x
         val leadingPadding = if (leading != null) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixed wrong alignment of reactions for self messages