### PR TITLE
fix: markdown on accent colors [WPB-20626]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownBlockQuote.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownBlockQuote.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.home.conversations.messages.item.onBackground
 import com.wire.android.ui.home.conversations.messages.item.textColor
 import com.wire.android.ui.theme.wireTypography
 
@@ -58,7 +59,7 @@ fun MarkdownBlockQuote(blockQuote: MarkdownNode.Block.BlockQuote, nodeData: Node
                 is MarkdownNode.Block.Paragraph -> {
                     val text = buildAnnotatedString {
                         pushStyle(
-                            MaterialTheme.wireTypography.body01.toSpanStyle()
+                            MaterialTheme.wireTypography.body01.copy(color = nodeData.messageStyle.onBackground()).toSpanStyle()
                                 .plus(SpanStyle(fontStyle = FontStyle.Italic))
                         )
                         inlineNodeChildren(child.children, this, nodeData)

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHeading.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHeading.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.home.conversations.messages.item.onBackground
 
 @Composable
 @Suppress("MagicNumber")
@@ -46,7 +47,7 @@ fun MarkdownHeading(heading: MarkdownNode.Block.Heading, nodeData: NodeData, mod
         }
         MarkdownText(
             annotatedString = text,
-            style = style,
+            style = style.copy(color = nodeData.messageStyle.onBackground()),
             onLongClick = nodeData.actions?.onLongClick,
             onOpenProfile = nodeData.actions?.onOpenProfile
         )

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownList.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.buildAnnotatedString
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.home.conversations.messages.item.onBackground
 import com.wire.android.ui.markdown.MarkdownConstants.BULLET_MARK
 import com.wire.android.ui.theme.wireTypography
 
@@ -33,7 +34,7 @@ fun MarkdownBulletList(bulletList: MarkdownNode.Block.ListBlock.Bullet, nodeData
     val bottom = if (bulletList.isParentDocument) dimensions().spacing8x else dimensions().spacing0x
 
     val text = buildAnnotatedString {
-        pushStyle(MaterialTheme.wireTypography.body01.toSpanStyle())
+        pushStyle(MaterialTheme.wireTypography.body01.copy(color = nodeData.messageStyle.onBackground()).toSpanStyle())
         append("$BULLET_MARK ")
         pop()
     }
@@ -43,7 +44,7 @@ fun MarkdownBulletList(bulletList: MarkdownNode.Block.ListBlock.Bullet, nodeData
             Row {
                 MarkdownText(
                     annotatedString = text,
-                    style = MaterialTheme.wireTypography.body01,
+                    style = MaterialTheme.wireTypography.body01.copy(color = nodeData.messageStyle.onBackground()),
                     onLongClick = nodeData.actions?.onLongClick,
                     onOpenProfile = nodeData.actions?.onOpenProfile
                 )
@@ -54,13 +55,17 @@ fun MarkdownBulletList(bulletList: MarkdownNode.Block.ListBlock.Bullet, nodeData
 }
 
 @Composable
-fun MarkdownOrderedList(orderedList: MarkdownNode.Block.ListBlock.Ordered, nodeData: NodeData, modifier: Modifier = Modifier) {
+fun MarkdownOrderedList(
+    orderedList: MarkdownNode.Block.ListBlock.Ordered,
+    nodeData: NodeData,
+    modifier: Modifier = Modifier
+) {
     val bottom = if (orderedList.isParentDocument) dimensions().spacing8x else dimensions().spacing0x
 
     Column(modifier = modifier.padding(bottom = bottom)) {
         orderedList.children.forEach { listItem ->
             val text = buildAnnotatedString {
-                pushStyle(MaterialTheme.wireTypography.body01.toSpanStyle())
+                pushStyle(MaterialTheme.wireTypography.body01.copy(color = nodeData.messageStyle.onBackground()).toSpanStyle())
                 append("${listItem.orderNumber}${orderedList.delimiter} ")
                 pop()
             }
@@ -68,7 +73,7 @@ fun MarkdownOrderedList(orderedList: MarkdownNode.Block.ListBlock.Ordered, nodeD
             Row {
                 MarkdownText(
                     annotatedString = text,
-                    style = MaterialTheme.wireTypography.body01,
+                    style = MaterialTheme.wireTypography.body01.copy(color = nodeData.messageStyle.onBackground()),
                     onLongClick = nodeData.actions?.onLongClick,
                     onOpenProfile = nodeData.actions?.onOpenProfile
                 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20626" title="WPB-20626" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20626</a>  [Android] Markdown has white text on Turquiose accent color in dark mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

On turquoise accent in dark mode some of markdown texts had wrong colors

Before:
<img width="236" height="635" alt="wrong colors" src="https://github.com/user-attachments/assets/da5039e7-d844-4ff4-9423-ebaa2c0ac74e" />

After:

<img width="243" height="645" alt="proper colors" src="https://github.com/user-attachments/assets/54e9806b-1844-45d4-8071-8b1eff71280d" />

