### PR TITLE
fix: "offset" crash when showing SwipeableSnackbar [WPB-20591]

### DIFF
--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/snackbar/SwipeableSnackbar.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/snackbar/SwipeableSnackbar.kt
@@ -19,6 +19,7 @@ package com.wire.android.ui.common.snackbar
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.layout.offset
@@ -31,7 +32,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
 import com.wire.android.ui.theme.wireDimensions
 import kotlin.math.roundToInt
 
@@ -59,10 +63,21 @@ fun SwipeableSnackbar(
     modifier: Modifier = Modifier,
     onDismiss: () -> Unit = { hostState.currentSnackbarData?.dismiss() },
 ) {
+    val density = LocalDensity.current
+    val configuration = LocalConfiguration.current
+
+    val currentScreenWidth = with(density) { configuration.screenWidthDp.dp.toPx() }
+
+    val anchors = DraggableAnchors {
+        SnackBarState.Visible at 0f
+        SnackBarState.DismissedLeft at currentScreenWidth
+        SnackBarState.DismissedRight at -currentScreenWidth
+    }
 
     val state = remember {
         AnchoredDraggableState(
             initialValue = SnackBarState.Visible,
+            anchors = anchors,
         )
     }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20591" title="WPB-20591" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20591</a>  [Android] Crash when removing conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After updating compose BOM to "2025.09.00" in this PR: #4288 , now there’s another crash:
```
java.lang.IllegalStateException: The offset was read before being initialized. Did you access the offset in a phase before layout, like effects or composition?
    at androidx.compose.foundation.internal.InlineClassHelperKt.throwIllegalStateException(InlineClassHelper.kt:26)
    at androidx.compose.foundation.gestures.AnchoredDraggableState.requireOffset(AnchoredDraggable.kt:1763)
    at com.wire.android.ui.common.snackbar.SwipeableSnackbarKt.SwipeableSnackbar$lambda$5$lambda$4(SwipeableSnackbar.kt:82)
...
```

### Causes (Optional)

When updating Compose BOM, we removed anchors from `SwipeableSnackbar` but `AnchoredDraggable` needs anchors. 😅 

### Solutions

Bring back anchors.

### Dependencies (Optional)

### Testing

#### How to Test

Make an action that shows the snackbar like copy message text, remove conversation or someone from a conversation.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.


[WPB-9777]: https://wearezeta.atlassian.net/browse/WPB-9777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ