### PR TITLE
fix: message bubble reply accent background

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -77,7 +77,8 @@ private const val TEXT_QUOTE_MAX_LINES = 7
 
 data class QuotedMessageStyle(
     val quotedStyle: QuotedStyle,
-    val messageStyle: MessageStyle
+    val messageStyle: MessageStyle,
+    val selfAccent: Accent
 )
 
 /**
@@ -188,7 +189,7 @@ fun QuotedMessagePreview(
         modifier = modifier,
         messageData = quotedMessageData,
         clickable = null,
-        style = QuotedMessageStyle(QuotedStyle.PREVIEW, MessageStyle.NORMAL)
+        style = QuotedMessageStyle(QuotedStyle.PREVIEW, MessageStyle.NORMAL, Accent.Unknown)
     ) {
         Box(
             modifier = Modifier
@@ -228,7 +229,11 @@ private fun QuotedMessageContent(
 ) {
     val quoteOutlineShape = RoundedCornerShape(dimensions().messageAssetBorderRadius)
     val background = when (style.messageStyle) {
-        MessageStyle.BUBBLE_SELF -> MaterialTheme.wireColorScheme.primaryVariant
+        MessageStyle.BUBBLE_SELF -> MaterialTheme.wireColorScheme.accentVariantColors.getOrDefault(
+            style.selfAccent,
+            colorsScheme().primaryVariant
+        )
+
         MessageStyle.BUBBLE_OTHER -> MaterialTheme.wireColorScheme.surface
         MessageStyle.NORMAL -> MaterialTheme.wireColorScheme.surfaceVariant
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
@@ -169,14 +169,19 @@ private fun MessageContent(
                     when (it) {
                         is UIQuotedMessage.UIQuotedData -> QuotedMessage(
                             messageData = it,
-                            style = QuotedMessageStyle(quotedStyle = QuotedStyle.COMPLETE, messageStyle = messageStyle),
+                            style = QuotedMessageStyle(
+                                quotedStyle = QuotedStyle.COMPLETE,
+                                messageStyle = messageStyle,
+                                selfAccent = accent
+                            ),
                             clickable = onReplyClick
                         )
 
                         UIQuotedMessage.UnavailableData -> QuotedUnavailable(
                             style = QuotedMessageStyle(
                                 quotedStyle = QuotedStyle.COMPLETE,
-                                messageStyle = messageStyle
+                                messageStyle = messageStyle,
+                                selfAccent = accent
                             )
                         )
                     }
@@ -204,7 +209,8 @@ private fun MessageContent(
                             messageData = it,
                             style = QuotedMessageStyle(
                                 quotedStyle = QuotedStyle.COMPLETE,
-                                messageStyle = messageStyle
+                                messageStyle = messageStyle,
+                                selfAccent = accent
                             ),
                             clickable = onReplyClick
                         )
@@ -212,7 +218,8 @@ private fun MessageContent(
                         UIQuotedMessage.UnavailableData -> QuotedUnavailable(
                             style = QuotedMessageStyle(
                                 quotedStyle = QuotedStyle.COMPLETE,
-                                messageStyle = messageStyle
+                                messageStyle = messageStyle,
+                                selfAccent = accent
                             )
                         )
                     }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -64,6 +64,7 @@ class WireColorScheme(
     val surfaceContainerHighest: Color,
     val defaultBubbleContainerBackgroundColor: Color,
     val bubbleContainerAccentBackgroundColor: WireAccentColors,
+    val accentVariantColors: WireAccentColors,
 
     // buttons
     val primaryButtonEnabled: Color, val onPrimaryButtonEnabled: Color,
@@ -164,6 +165,17 @@ private val LightWireColorScheme = WireColorScheme(
             Accent.Red -> WireColorPalette.LightRed400
             Accent.Petrol -> WireColorPalette.LightPetrol400
             Accent.Unknown -> WireColorPalette.LightBlue400
+        }
+    },
+    accentVariantColors = WireAccentColors {
+        when (it) {
+            Accent.Amber -> WireColorPalette.LightAmber50
+            Accent.Blue -> WireColorPalette.LightBlue50
+            Accent.Green -> WireColorPalette.LightGreen50
+            Accent.Purple -> WireColorPalette.LightPurple50
+            Accent.Red -> WireColorPalette.LightRed50
+            Accent.Petrol -> WireColorPalette.LightPetrol50
+            Accent.Unknown -> WireColorPalette.LightBlue50
         }
     },
 
@@ -272,6 +284,17 @@ private val DarkWireColorScheme = WireColorScheme(
             Accent.Red -> WireColorPalette.DarkRed400
             Accent.Petrol -> WireColorPalette.DarkPetrol400
             Accent.Unknown -> WireColorPalette.DarkBlue400
+        }
+    },
+    accentVariantColors = WireAccentColors {
+        when (it) {
+            Accent.Amber -> WireColorPalette.DarkAmber800
+            Accent.Blue -> WireColorPalette.DarkBlue800
+            Accent.Green -> WireColorPalette.DarkGreen800
+            Accent.Purple -> WireColorPalette.DarkPurple800
+            Accent.Red -> WireColorPalette.DarkRed800
+            Accent.Petrol -> WireColorPalette.DarkPetrol800
+            Accent.Unknown -> WireColorPalette.DarkBlue800
         }
     },
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixed self message reply background color to be accent variant