### PR TITLE
feat: use m4a extension when recording an audio (WPB-20662)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -72,7 +72,7 @@ class AudioMediaRecorder @Inject constructor(
     private var assetLimitInMB: Long = ASSET_SIZE_DEFAULT_LIMIT_BYTES
 
     var originalOutputPath: Path? = null
-    var mp4OutputPath: Path? = null
+    var m4aOutputPath: Path? = null
 
     private val _maxFileSizeReached = MutableSharedFlow<RecordAudioDialogState>()
     fun getMaxFileSizeReached(): Flow<RecordAudioDialogState> =
@@ -99,8 +99,8 @@ class AudioMediaRecorder @Inject constructor(
             originalOutputPath = kaliumFileSystem
                 .tempFilePath(getRecordingAudioFileName())
 
-            mp4OutputPath = kaliumFileSystem
-                .tempFilePath(getRecordingMP4AudioFileName())
+            m4aOutputPath = kaliumFileSystem
+                .tempFilePath(getRecordingM4aAudioFileName())
         }
     }
 
@@ -217,14 +217,14 @@ class AudioMediaRecorder @Inject constructor(
     }
 
     @Suppress("LongMethod", "CyclomaticComplexMethod", "TooGenericExceptionCaught")
-    suspend fun convertWavToMp4(inputFilePath: String): Boolean = withContext(Dispatchers.IO) {
+    suspend fun convertWavToM4a(inputFilePath: String): Boolean = withContext(Dispatchers.IO) {
         var codec: MediaCodec? = null
         var muxer: MediaMuxer? = null
         var success = true
 
         try {
             FileInputStream(File(inputFilePath)).use { fileInputStream ->
-                mp4OutputPath?.toFile()?.let { outputFile ->
+                m4aOutputPath?.toFile()?.let { outputFile ->
                     ParcelFileDescriptor.open(
                         outputFile,
                         ParcelFileDescriptor.MODE_READ_WRITE or ParcelFileDescriptor.MODE_CREATE
@@ -327,12 +327,12 @@ class AudioMediaRecorder @Inject constructor(
                         }
                     }
                 } ?: run {
-                    appLogger.e("[RecordAudio] convertWavToMp4: mp4OutputPath is null")
+                    appLogger.e("[RecordAudio] convertWavToM4a: m4aOutputPath is null")
                     success = false
                 }
             }
         } catch (e: Exception) {
-            appLogger.e("Could not convert wav to mp4: ${e.message}", throwable = e)
+            appLogger.e("Could not convert wav to m4a: ${e.message}", throwable = e)
         } finally {
             try {
                 muxer?.let { safeMuxer ->
@@ -359,7 +359,7 @@ class AudioMediaRecorder @Inject constructor(
 
     companion object {
         fun getRecordingAudioFileName(): String = "wire-audio-${DateTimeUtil.currentInstant().fileDateTime()}.wav"
-        fun getRecordingMP4AudioFileName(): String = "wire-audio-${DateTimeUtil.currentInstant().fileDateTime()}.mp4"
+        fun getRecordingM4aAudioFileName(): String = "wire-audio-${DateTimeUtil.currentInstant().fileDateTime()}.m4a"
 
         const val SIZE_OF_1MB = 1024 * 1024
         const val AUDIO_CHANNELS = 1 // Mono

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -291,9 +291,9 @@ class RecordAudioViewModel @Inject constructor(
             )
 
             val didSucceed = if (state.shouldApplyEffects) {
-                audioMediaRecorder.convertWavToMp4(effectsFile!!.toString())
+                audioMediaRecorder.convertWavToM4a(effectsFile!!.toString())
             } else {
-                audioMediaRecorder.convertWavToMp4(outputFile!!.toString())
+                audioMediaRecorder.convertWavToM4a(outputFile!!.toString())
             }
 
             try {
@@ -318,7 +318,7 @@ class RecordAudioViewModel @Inject constructor(
                 RecordAudioViewActions.Recorded(
                     UriAsset(
                         uri = if (didSucceed) {
-                            context.fromNioPathToContentUri(nioPath = audioMediaRecorder.mp4OutputPath!!.toNioPath())
+                            context.fromNioPathToContentUri(nioPath = audioMediaRecorder.m4aOutputPath!!.toNioPath())
                         } else {
                             if (state.shouldApplyEffects) {
                                 context.fromNioPathToContentUri(nioPath = state.effectsOutputFile!!.toPath())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20662" title="WPB-20662" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20662</a>  [Android] Video preview appears after recording audio
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Updated the output file naming to use the .m4a extension as it is more appropriate for audio-only files

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
