### PR TITLE
feat(emm): add compile time flag to enable EMM support based on flavors (WPB-20290)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/ManagedConfigurationsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/ManagedConfigurationsModule.kt
@@ -18,9 +18,11 @@
 package com.wire.android.di
 
 import android.content.Context
+import com.wire.android.BuildConfig
 import com.wire.android.config.ServerConfigProvider
 import com.wire.android.emm.ManagedConfigurationsManager
 import com.wire.android.emm.ManagedConfigurationsManagerImpl
+import com.wire.android.util.EMPTY
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import dagger.Module
@@ -53,8 +55,13 @@ class ManagedConfigurationsModule {
     fun provideCurrentServerConfig(
         managedConfigurationsManager: ManagedConfigurationsManager
     ): ServerConfig.Links {
-        // Returns the current resolved server configuration links, which could be either managed or default
-        return managedConfigurationsManager.currentServerConfig
+        return if (BuildConfig.EMM_SUPPORT_ENABLED) {
+            // Returns the current resolved server configuration links, which could be either managed or default
+            managedConfigurationsManager.currentServerConfig
+        } else {
+            // If EMM support is disabled, always return the static default server configuration links
+            provideServerConfigProvider().getDefaultServerConfig(null)
+        }
     }
 
     @Provides
@@ -62,7 +69,12 @@ class ManagedConfigurationsModule {
     fun provideCurrentSSOCodeConfig(
         managedConfigurationsManager: ManagedConfigurationsManager
     ): String {
-        // Returns the current SSO code configuration, which could be either managed or empty
-        return managedConfigurationsManager.currentSSOCodeConfig
+        return if (BuildConfig.EMM_SUPPORT_ENABLED) {
+            // Returns the current resolved SSO code from managed configurations, or empty if none
+            managedConfigurationsManager.currentSSOCodeConfig
+        } else {
+            // If EMM support is disabled, always return empty SSO code
+            String.EMPTY
+        }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/DynamicReceiversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/DynamicReceiversManager.kt
@@ -20,6 +20,7 @@ package com.wire.android.notification.broadcastreceivers
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import com.wire.android.BuildConfig.EMM_SUPPORT_ENABLED
 import com.wire.android.appLogger
 import com.wire.android.emm.ManagedConfigurationsReceiver
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -36,13 +37,17 @@ class DynamicReceiversManager @Inject constructor(
     private val managedConfigurationsReceiver: ManagedConfigurationsReceiver
 ) {
     fun registerAll() {
-        appLogger.i("$TAG Registering Runtime broadcast receivers")
-        context.registerReceiver(managedConfigurationsReceiver, IntentFilter(Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED))
+        if (EMM_SUPPORT_ENABLED) {
+            appLogger.i("$TAG Registering Runtime ManagedConfigurations Broadcast receiver")
+            context.registerReceiver(managedConfigurationsReceiver, IntentFilter(Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED))
+        }
     }
 
     fun unregisterAll() {
-        appLogger.i("$TAG Unregistering Runtime broadcast receivers")
-        context.unregisterReceiver(managedConfigurationsReceiver)
+        if (EMM_SUPPORT_ENABLED) {
+            appLogger.i("$TAG Unregistering Runtime ManagedConfigurations Broadcast receiver")
+            context.unregisterReceiver(managedConfigurationsReceiver)
+        }
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -214,9 +214,11 @@ class WireActivity : AppCompatActivity() {
     override fun onStart() {
         super.onStart()
         dynamicReceiversManager.registerAll()
-        lifecycleScope.launch(Dispatchers.IO) {
-            managedConfigurationsManager.refreshServerConfig()
-            managedConfigurationsManager.refreshSSOCodeConfig()
+        if (BuildConfig.EMM_SUPPORT_ENABLED) {
+            lifecycleScope.launch(Dispatchers.IO) {
+                managedConfigurationsManager.refreshServerConfig()
+                managedConfigurationsManager.refreshSSOCodeConfig()
+            }
         }
     }
 

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -52,6 +52,7 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
     ENABLE_CROSSPLATFORM_BACKUP("enable_crossplatform_backup", ConfigType.BOOLEAN),
     ENABLE_NEW_REGISTRATION("enable_new_registration", ConfigType.BOOLEAN),
     MLS_READ_RECEIPTS_ENABLED("mls_read_receipts_enabled", ConfigType.BOOLEAN),
+    EMM_SUPPORT_ENABLED("emm_support_enabled", ConfigType.BOOLEAN),
 
     /**
      * Security/Cryptography stuff

--- a/default.json
+++ b/default.json
@@ -67,7 +67,8 @@
             "analytics_enabled": true,
             "analytics_app_key": "8ffae535f1836ed5f58fd5c8a11c00eca07c5438",
             "analytics_server_url": "https://wire.count.ly/",
-            "enable_new_registration": true
+            "enable_new_registration": true,
+            "emm_support_enabled": true
         },
         "internal": {
             "application_id": "com.wire.internal",
@@ -79,7 +80,8 @@
             "analytics_app_key": "8ffae535f1836ed5f58fd5c8a11c00eca07c5438",
             "analytics_server_url": "https://wire.count.ly/",
             "enable_new_registration": true,
-             "use_strict_mls_filter": false
+            "use_strict_mls_filter": false,
+            "emm_support_enabled": true
         },
         "fdroid": {
             "application_id": "com.wire",
@@ -148,5 +150,6 @@
     "mls_read_receipts_enabled": false,
     "is_mls_reset_enabled": true,
     "use_strict_mls_filter": true,
-    "meetings_enabled": false
+    "meetings_enabled": false,
+    "emm_support_enabled": false
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20290" title="WPB-20290" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-20290</a>  [Android] Base setup for RestrictionManager & Managed Configurations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Disable by default, and enable based on feature compile flag.

### Causes (Optional)

Control over release

### Solutions

Implement as usual `default.json` flag, and assume old default behavior if disabled.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
