### PR TITLE
chore: restore subfolders (WPB-20559)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesScreen.kt
@@ -249,6 +249,7 @@ fun ConversationFilesScreenContent(
                                 conversationId = path,
                                 screenTitle = title,
                                 isRecycleBin = isRecycleBin,
+                                parentFolderUuid = parentFolderUuid,
                                 breadcrumbs = if (!isRecycleBin) {
                                     (breadcrumbs ?: emptyArray()) + title
                                 } else { null }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20559" title="WPB-20559" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20559</a>  [Android] Cannot restore items from recycle bin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20559
----

# What's new in this PR?

### Issues
Subfolder cannot be restored from recycle bin if it is more than 1 level deeper in folders hierarchy.

### Causes (Optional)
Parent folder UUID not passed when navigating to subfolder in recycle bin.
