### PR TITLE
fix: crash on use case inject (WPB-20230)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/IsProfileQRCodeEnabledUseCaseProvider.kt
+++ b/app/src/main/kotlin/com/wire/android/di/IsProfileQRCodeEnabledUseCaseProvider.kt
@@ -1,0 +1,39 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.di
+
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.client.IsProfileQRCodeEnabledUseCase
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+
+class IsProfileQRCodeEnabledUseCaseProvider @AssistedInject constructor(
+    @KaliumCoreLogic private val coreLogic: CoreLogic,
+    @Assisted private val userId: UserId
+) {
+
+    val isProfileQRCodeEnabled: IsProfileQRCodeEnabledUseCase
+        get() = coreLogic.getSessionScope(userId).users.isProfileQRCodeEnabled
+
+    @AssistedFactory
+    interface Factory {
+        fun create(userId: UserId): IsProfileQRCodeEnabledUseCaseProvider
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -30,6 +30,7 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.di.IsProfileQRCodeEnabledUseCaseProvider
 import com.wire.android.di.ObserveIfE2EIRequiredDuringLoginUseCaseProvider
 import com.wire.android.di.ObserveScreenshotCensoringConfigUseCaseProvider
 import com.wire.android.di.ObserveSyncStateUseCaseProvider
@@ -846,7 +847,7 @@ class WireActivityViewModelTest {
         lateinit var observeEstablishedCalls: ObserveEstablishedCallsUseCase
 
         @MockK
-        lateinit var isProfileQRCodeEnabled: IsProfileQRCodeEnabledUseCase
+        lateinit var isProfileQRCodeEnabledFactory: IsProfileQRCodeEnabledUseCaseProvider.Factory
 
         private val viewModel by lazy {
             WireActivityViewModel(
@@ -868,7 +869,7 @@ class WireActivityViewModelTest {
                 globalDataStore = { globalDataStore },
                 observeIfE2EIRequiredDuringLoginUseCaseProviderFactory = observeIfE2EIRequiredDuringLoginUseCaseProviderFactory,
                 workManager = { workManager },
-                isProfileQRCodeEnabled = isProfileQRCodeEnabled,
+                isProfileQRCodeEnabledFactory = isProfileQRCodeEnabledFactory,
             )
         }
 
@@ -989,7 +990,9 @@ class WireActivityViewModelTest {
         }
 
         suspend fun withProfileQRCodeEnabled(isEnabled: Boolean = true) = apply {
-            coEvery { isProfileQRCodeEnabled() } returns isEnabled
+            val useCase = mockk<IsProfileQRCodeEnabledUseCase>()
+            coEvery { isProfileQRCodeEnabledFactory.create(any()).isProfileQRCodeEnabled } returns useCase
+            coEvery { useCase() } returns isEnabled
         }
 
         fun arrange() = this to viewModel


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20230" title="WPB-20230" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20230</a>  [Android] Respond to QR code backend feature flag and turn QR code feature on / off according to flag setting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20230
----

# What's new in this PR?

### Issues
App crash when user is not logged in.

### Causes (Optional)
Injecting IsProfileQRCodeEnabledUseCase requires logged in user.

### Solutions
Use Provider \ Factory pattern to handle users switch and handle no user case.
