### PR TITLE
feat: update group options UI for cells conversations (WPB-20993)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -159,6 +159,16 @@ fun GroupConversationSettings(
                             onCheckedChange = onServiceSwitchClicked
                         )
                     }
+                    addIf(state.isWireCellEnabled) {
+                        GroupConversationOptionsItem(
+                            title = stringResource(id = R.string.conversation_options_file_collaboration_label),
+                            subtitle = stringResource(id = R.string.conversation_options_file_collaboration_description),
+                            trailingOnText = null,
+                            switchState = SwitchState.TextOnly(true),
+                            arrowType = ArrowType.NONE,
+                            clickable = Clickable(enabled = false)
+                        )
+                    }
                 }
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -636,7 +636,7 @@
     <string name="conversation_details_is_not_classified">SECURITY LEVEL: UNCLASSIFIED</string>
     <string name="conversation_options_self_deleting_messages_label">Self-deleting messages</string>
     <string name="conversation_options_self_deleting_messages_description">When this is on, all messages in this conversation will disappear after a certain time.</string>
-    <string name="conversation_options_self_deleting_messages_cells_description">Self-deleting messages are currently not available for conversations with Cells.</string>
+    <string name="conversation_options_self_deleting_messages_cells_description">The feature is not available for conversations with Cells.</string>
     <string name="conversation_options_guests_label">Guests</string>
     <string name="conversation_details_guest_description">When this is ON, people from outside your team can join this conversation</string>
     <string name="conversation_options_guest_description">Turn this option ON to open this conversation to people outside your team, even if they don\'t have Wire.</string>
@@ -1881,4 +1881,6 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="content_description_filter_files">Filter files</string>
 
     <string name="profile_deeplink_feature_unavailable_title_alert">This feature is not available. Please contact your administrator.</string>
+    <string name="conversation_options_file_collaboration_label">File collaboration (Cells)</string>
+    <string name="conversation_options_file_collaboration_description">Permanently on for this conversation.</string>
 </resources>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20993" title="WPB-20993" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20993</a>  [Android] Conversation details with Cells on update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20993

# What's new in this PR?

### Issues
- Added new read-only "Files collaboration" section
- Updated description text for disabled self-deleting messages feature

<img width="369" height="3104" alt="Screenshot_20251013_125551" src="https://github.com/user-attachments/assets/421979e2-4144-4d70-96d1-2acc96485147" />
