### PR TITLE
fix: message bubble paddings, colors, reactions [WPB-20857] [WPB-20867] [WPB-20868] [WPB-20873] [WPB-20875] [WPB-20852]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/debug/featureflags/DebugFeatureFlagsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/featureflags/DebugFeatureFlagsViewModel.kt
@@ -69,7 +69,7 @@ class DebugFeatureFlagsViewModel @Inject constructor(
                             addFeature("Allowed Global Operations", allowedGlobalOperationsModel?.status, allowedGlobalOperationsModel)
                             addFeature("Wire Cells", cellsModel?.status)
                             addFeature("User Profile QR code", enableUserProfileQRCodeConfigModel?.status)
-
+                            addFeature("Message bubbles", chatBubblesModel?.status)
                             add(
                                 Feature(
                                     name = "Channels",

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageBubbleItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageBubbleItem.kt
@@ -27,7 +27,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -86,8 +86,7 @@ fun MessageBubbleItem(
             dimensions().spacing0x
         }
         Row(
-            modifier = Modifier
-                .fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = if (isSelfMessage) {
                 Arrangement.End
             } else {
@@ -96,7 +95,7 @@ fun MessageBubbleItem(
             verticalAlignment = Alignment.Bottom
         ) {
             if (leading != null) {
-                Box(Modifier.size(leadingPadding), contentAlignment = Alignment.BottomStart) {
+                Box(Modifier.width(leadingPadding), contentAlignment = Alignment.BottomStart) {
                     leading()
                 }
             } else {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageExpirationItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageExpirationItems.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
@@ -32,11 +33,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.ui.common.StatusBox
 import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.typography
 import com.wire.android.ui.home.conversations.SelfDeletionTimerHelper
@@ -99,7 +99,10 @@ fun MessageBubbleExpireFooter(
 ) {
     when (selfDeletionTimerState) {
         is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable -> {
-            Row(modifier) {
+            Row(
+                modifier,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 HorizontalSpace.x8()
                 SelfDeletionTimerIcon(
                     selfDeletionTimerState,
@@ -125,8 +128,7 @@ private fun SelfDeletionTimerIcon(
     messageStyle: MessageStyle,
     accentColor: Color,
     modifier: Modifier = Modifier,
-    size: Dp = 11.dp,
-    discreteSteps: Int? = 8,
+    discreteSteps: Int? = 8
 ) {
 
     val emptyColor = when (messageStyle) {
@@ -141,7 +143,7 @@ private fun SelfDeletionTimerIcon(
 
     Canvas(
         modifier
-            .size(size)
+            .size(dimensions().spacing12x)
             .semantics(mergeDescendants = true) {
                 contentDescription = "Time left ${"%.0f".format(metrics.displayFractionLeft * 100)}%"
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageStyle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageStyle.kt
@@ -64,6 +64,15 @@ fun MessageStyle.surface(): Color = when (this) {
 }
 
 @Composable
+fun MessageStyle.onSurface(): Color {
+    return when (this) {
+        MessageStyle.BUBBLE_SELF -> MaterialTheme.wireColorScheme.onPrimary
+        MessageStyle.BUBBLE_OTHER -> MaterialTheme.wireColorScheme.onSurface
+        MessageStyle.NORMAL -> MaterialTheme.wireColorScheme.onSurface
+    }
+}
+
+@Composable
 fun MessageStyle.highlighted(): Color = when (this) {
     MessageStyle.BUBBLE_SELF -> MaterialTheme.wireColorScheme.onPrimary
     MessageStyle.BUBBLE_OTHER -> MaterialTheme.wireColorScheme.primary

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItem.kt
@@ -67,7 +67,7 @@ fun RegularMessageItem(
     fun messageContent() {
         if (isBubbleUiEnabled) {
             val footerSlot: (@Composable (inner: PaddingValues) -> Unit)? =
-                if (shouldDisplayFooter) {
+                if (shouldDisplayFooter && !message.header.messageStatus.isDeleted) {
                     { innerPadding ->
                         MessageReactionsItem(
                             messageFooter = message.messageFooter,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/video/VideoMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/video/VideoMessage.kt
@@ -57,6 +57,7 @@ import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.typography
 import com.wire.android.ui.home.conversations.messages.item.MessageStyle
 import com.wire.android.ui.home.conversations.messages.item.isBubble
+import com.wire.android.ui.home.conversations.messages.item.onSurface
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.DateAndTimeParsers
 import com.wire.android.util.ui.PreviewMultipleThemes
@@ -180,20 +181,20 @@ fun VideoMessage(
                 AssetTransferStatus.NOT_DOWNLOADED ->
                     Text(
                         text = stringResource(R.string.asset_message_tap_to_download_text),
-                        color = colorsScheme().onSurface,
+                        color = messageStyle.onSurface(),
                         style = typography().subline01,
                     )
 
                 AssetTransferStatus.DOWNLOAD_IN_PROGRESS ->
                     WireCircularProgressIndicator(
                         modifier = Modifier.size(dimensions().spacing32x),
-                        progressColor = colorsScheme().inverseOnSurface,
+                        progressColor = messageStyle.onSurface()
                     )
 
                 AssetTransferStatus.FAILED_DOWNLOAD ->
                     Text(
                         text = stringResource(R.string.asset_message_failed_download_text),
-                        color = colorsScheme().onSurface,
+                        color = messageStyle.onSurface(),
                         style = typography().subline01,
                     )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20857" title="WPB-20857" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20857</a>  [Android]Add chat bubbles feature flag to debug feature flags screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- added chat bubbles feature flag to debug feature flags screen
- fixed colors in asset message status for bubbles
- reactions are hidden when message is deleted
- fixed inconsistent vertical spacing between consecutive message bubbles
- fixed self-deleting message timer icon vertical alignment

