### PR TITLE
feat: precheck when renaming file (WPB-20937)

### DIFF
--- a/features/cells/src/main/res/values/strings.xml
+++ b/features/cells/src/main/res/values/strings.xml
@@ -104,6 +104,7 @@
     <string name="rename_folder_renamed">Folder was renamed</string>
     <string name="rename_failure">Failed to rename</string>
     <string name="rename_invalid_name">Use a name without "/" or "."</string>
+    <string name="rename_already_exist">File with this name already exists</string>
     <string name="filter_label">Filter</string>
     <string name="tags_label">Tags</string>
     <string name="select_tags_label">select tags</string>

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/rename/RenameNodeViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/rename/RenameNodeViewModelTest.kt
@@ -20,10 +20,11 @@ package com.wire.android.feature.cells.ui.rename
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.wire.android.feature.cells.ui.navArgs
-import com.wire.android.model.DisplayNameState
+import com.wire.kalium.cells.domain.usecase.RenameNodeFailure
 import com.wire.kalium.cells.domain.usecase.RenameNodeUseCase
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.left
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -67,8 +68,8 @@ class RenameNodeViewModelTest {
         advanceUntilIdle()
         viewModel.actions.test {
             with(expectMostRecentItem()) {
-                assertEquals(false, viewModel.displayNameState.loading)
-                assertEquals(DisplayNameState.Completed.Success, viewModel.displayNameState.completed)
+                assertEquals(false, viewModel.viewState.loading)
+                assertEquals(RenameNodeViewState.Completed.Success, viewModel.viewState.completed)
                 assertTrue(this is RenameNodeViewModelAction.Success)
                 coVerify(exactly = 1) { arrangement.renameNodeUseCase(eq(UUID), eq(CURRENT_PATH), eq("newFileName.txt")) }
             }
@@ -78,16 +79,15 @@ class RenameNodeViewModelTest {
     @Test
     fun `given renameNodeUseCase failure, when rename is called, then send failure action`() = runTest {
         val (arrangement, viewModel) = Arrangement()
-            .withRenameNodeUseCaseReturning(Either.Left(CoreFailure.InvalidEventSenderID))
+            .withRenameNodeUseCaseReturning(RenameNodeFailure.Other(CoreFailure.InvalidEventSenderID).left())
             .arrange()
 
         viewModel.renameNode("")
 
         advanceUntilIdle()
+
         viewModel.actions.test {
             with(expectMostRecentItem()) {
-                assertEquals(false, viewModel.displayNameState.loading)
-                assertEquals(DisplayNameState.Completed.Failure, viewModel.displayNameState.completed)
                 assertTrue(this is RenameNodeViewModelAction.Failure)
                 coVerify(exactly = 1) { arrangement.renameNodeUseCase(any(), any(), any()) }
             }
@@ -103,10 +103,10 @@ class RenameNodeViewModelTest {
 
         advanceUntilIdle()
 
-        assertFalse(viewModel.displayNameState.saveEnabled)
+        assertFalse(viewModel.viewState.saveEnabled)
         assertEquals(
-            DisplayNameState.NameError.TextFieldError.InvalidNameError,
-            viewModel.displayNameState.error
+            RenameNodeViewState.RenameError.TextFieldError.InvalidName,
+            viewModel.viewState.error
         )
     }
 
@@ -118,11 +118,10 @@ class RenameNodeViewModelTest {
             .arrange()
 
         advanceUntilIdle()
-
-        assertFalse(viewModel.displayNameState.saveEnabled)
+        assertFalse(viewModel.viewState.saveEnabled)
         assertEquals(
-            DisplayNameState.NameError.TextFieldError.NameEmptyError,
-            viewModel.displayNameState.error
+            RenameNodeViewState.RenameError.TextFieldError.NameEmpty,
+            viewModel.viewState.error
         )
     }
 
@@ -136,10 +135,10 @@ class RenameNodeViewModelTest {
 
         advanceUntilIdle()
 
-        assertFalse(viewModel.displayNameState.saveEnabled)
+        assertFalse(viewModel.viewState.saveEnabled)
         assertEquals(
-            DisplayNameState.NameError.TextFieldError.NameExceedLimitError,
-            viewModel.displayNameState.error
+            RenameNodeViewState.RenameError.TextFieldError.NameExceedLimit,
+            viewModel.viewState.error
         )
     }
 
@@ -150,10 +149,10 @@ class RenameNodeViewModelTest {
 
         advanceUntilIdle()
 
-        assertFalse(viewModel.displayNameState.saveEnabled)
+        assertFalse(viewModel.viewState.saveEnabled)
         assertEquals(
-            DisplayNameState.NameError.None,
-            viewModel.displayNameState.error
+            RenameNodeViewState.RenameError.None,
+            viewModel.viewState.error
         )
     }
 
@@ -188,7 +187,7 @@ class RenameNodeViewModelTest {
             )
         }
 
-        fun withRenameNodeUseCaseReturning(result: Either<CoreFailure, Unit>) = apply {
+        fun withRenameNodeUseCaseReturning(result: Either<RenameNodeFailure, Unit>) = apply {
             coEvery { renameNodeUseCase(any(), any(), any()) } returns result
         }
         fun withNodeNameReturning(name: String) = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20937" title="WPB-20937" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20937</a>  [Android] Check if filename exists when renaming
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20937

# What's new in this PR?

### Issues
When renaming a file user can enter name of already existing file. No error displayed and the name is changed. New file name will have a "-1" suffix added.

### Solutions

Handle new error type and show "File already exists" error message.
Define a state for the rename screen instead of using the state from other screen.
Trim file name when renaming.

<img width="300" height="3104" alt="Screenshot_20251013_174309" src="https://github.com/user-attachments/assets/69a8fc0c-04e2-4023-8c90-6b21722779bf" />

