### PR TITLE
fix: scroll to bottom button when last message is long

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -1494,9 +1495,14 @@ fun JumpToLastMessageButton(
 ) {
     val bottomPadding = dimensions().typingIndicatorHeight + dimensions().spacing8x
     val bottomPaddingPx = with(LocalDensity.current) { bottomPadding.toPx() }
+    val showButton by remember(lazyListState, bottomPaddingPx) {
+        derivedStateOf {
+            lazyListState.firstVisibleItemIndex > 0 || lazyListState.firstVisibleItemScrollOffset > bottomPaddingPx
+        }
+    }
     AnimatedVisibility(
         modifier = modifier.padding(bottom = bottomPadding, end = dimensions().spacing16x),
-        visible = lazyListState.firstVisibleItemIndex > 0 || lazyListState.firstVisibleItemScrollOffset > bottomPaddingPx,
+        visible = showButton,
         enter = scaleIn(),
         exit = scaleOut(),
     ) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -24,8 +24,8 @@ import android.net.Uri
 import android.text.format.DateUtils
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandIn
-import androidx.compose.animation.shrinkOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -68,6 +68,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -1491,11 +1492,13 @@ fun JumpToLastMessageButton(
     modifier: Modifier = Modifier,
     coroutineScope: CoroutineScope = rememberCoroutineScope()
 ) {
+    val bottomPadding = dimensions().typingIndicatorHeight + dimensions().spacing8x
+    val bottomPaddingPx = with(LocalDensity.current) { bottomPadding.toPx() }
     AnimatedVisibility(
-        modifier = modifier,
-        visible = lazyListState.firstVisibleItemIndex > 0,
-        enter = expandIn { it },
-        exit = shrinkOut { it }
+        modifier = modifier.padding(bottom = bottomPadding, end = dimensions().spacing16x),
+        visible = lazyListState.firstVisibleItemIndex > 0 || lazyListState.firstVisibleItemScrollOffset > bottomPaddingPx,
+        enter = scaleIn(),
+        exit = scaleOut(),
     ) {
         SmallFloatingActionButton(
             onClick = { coroutineScope.launch { lazyListState.animateScrollToItem(0) } },
@@ -1503,13 +1506,6 @@ fun JumpToLastMessageButton(
             contentColor = MaterialTheme.wireColorScheme.onPrimaryButtonEnabled,
             shape = CircleShape,
             elevation = FloatingActionButtonDefaults.elevation(dimensions().spacing0x),
-            modifier = Modifier
-                .padding(
-                    PaddingValues(
-                        bottom = dimensions().typingIndicatorHeight + dimensions().spacing8x,
-                        end = dimensions().spacing16x
-                    )
-                )
         ) {
             Icon(
                 imageVector = Icons.Default.KeyboardArrowDown,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The "scroll to bottom" button appears only when the last message is fully scrolled out, so users are not able to use the “scroll to bottom” button when the last message is long even if they have already scrolled down a lot.

### Solutions

Adjust the logic so that the button shows when the last message starts to disappear while scrolling. 
Apply a nice-looking scale animation to the button.

| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/user-attachments/assets/bededba3-c09f-43bd-a793-805e7765ec46"/> | <video width="400" src="https://github.com/user-attachments/assets/e0b4044d-278a-45d9-adb2-bdaa0b593e10"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
