### PR TITLE
feat: allow "." symbol in file and folder names (WPB-21090)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/createfolder/CreateFolderViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/createfolder/CreateFolderViewModel.kt
@@ -59,11 +59,10 @@ class CreateFolderViewModel @Inject constructor(
         viewModelScope.launch {
             fileNameTextFieldState.textAsFlow().collectLatest {
                 displayNameState = displayNameState.copy(
-                    saveEnabled = it.trim().isNotEmpty() && it.length <= NAME_MAX_COUNT &&
-                            !it.contains("/") && !it.contains("."),
+                    saveEnabled = it.trim().isNotEmpty() && it.length <= NAME_MAX_COUNT && !it.contains("/"),
                     error = when {
                         it.length > NAME_MAX_COUNT -> DisplayNameState.NameError.TextFieldError.NameExceedLimitError
-                        it.contains("/") || it.contains(".") -> DisplayNameState.NameError.TextFieldError.InvalidNameError
+                        it.contains("/") -> DisplayNameState.NameError.TextFieldError.InvalidNameError
                         else -> DisplayNameState.NameError.None
                     }
                 )

--- a/features/cells/src/main/res/values/strings.xml
+++ b/features/cells/src/main/res/values/strings.xml
@@ -103,7 +103,7 @@
     <string name="rename_file_renamed">File was renamed</string>
     <string name="rename_folder_renamed">Folder was renamed</string>
     <string name="rename_failure">Failed to rename</string>
-    <string name="rename_invalid_name">Use a name without "/" or "."</string>
+    <string name="rename_invalid_name">Use a name without "/"</string>
     <string name="rename_already_exist">File with this name already exists</string>
     <string name="filter_label">Filter</string>
     <string name="tags_label">Tags</string>

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/rename/RenameNodeViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/rename/RenameNodeViewModelTest.kt
@@ -176,7 +176,7 @@ class RenameNodeViewModelTest {
             )
             every { savedStateHandle.get<String>("uuid") } returns UUID
             every { savedStateHandle.get<String>("currentPath") } returns CURRENT_PATH
-            every { savedStateHandle.get<Boolean>("isFolder") } returns true
+            every { savedStateHandle.get<Boolean>("isFolder") } returns false
             every { savedStateHandle.get<String>("nodeName") } returns NODE_NAME
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21090" title="WPB-21090" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21090</a>  [Android] Allow . in file and folder names
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-21090

# What's new in this PR?

Allow users to use "." symbol when renaming files and folders.