### PR TITLE
fix: inject LoginTypeSelector into AppLockActivity [WPB-21183]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import com.wire.android.appLogger
+import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.MainNavHost
 import com.wire.android.navigation.rememberNavigator
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
@@ -34,9 +35,13 @@ import com.wire.android.ui.destinations.EnterLockCodeScreenDestination
 import com.wire.android.ui.destinations.SetLockCodeScreenDestination
 import com.wire.android.ui.theme.WireTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class AppLockActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var loginTypeSelector: LoginTypeSelector
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -69,7 +74,7 @@ class AppLockActivity : AppCompatActivity() {
 
                     MainNavHost(
                         navigator = navigator,
-                        loginTypeSelector = null, // LoginTypeSelector is not needed for destinations in AppLockActivity
+                        loginTypeSelector = loginTypeSelector,
                         startDestination = startDestination
                     )
                 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21183" title="WPB-21183" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21183</a>  [Android] crash when clocking forgot my password
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

  1. Enable App Lock in Settings → Privacy & Security → App Lock
  2. Set a passcode for the app lock
  3. Close the app completely (swipe away from recent apps)
  4. Reopen the app - the Enter Lock Code screen should appear
  5. Tap the "Forgot your passcode?" button below the password field

```
  com.wire.android.ui.destinations.ForgotLockCodeScreenDestination$Content$1.invoke
  Exception java.lang.RuntimeException:
    at com.ramcosta.composedestinations.navigation.DestinationDependenciesContainerImpl.require (DestinationDependenciesContainer.kt:124)
    at com.wire.android.ui.destinations.ForgotLockCodeScreenDestination$Content$1.invoke (ForgotLockCodeScreenDestination.java:58)
    at com.wire.android.ui.destinations.ForgotLockCodeScreenDestination$Content$1.invoke (ForgotLockCodeScreenDestination.java:40)
    at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke (ComposableLambda.jvm.kt:109)
    ...
```
### Causes (Optional)

`ForgotLockCodeScreen` requires `LoginTypeSelector` as a dependency (used at line 80 to determine which login screen to navigate to after device reset). However, `AppLockActivity` was passing `loginTypeSelector = null` to `MainNavHost`
  (line 72 in AppLockActivity.kt), causing the dependency container to throw a `RuntimeException` when trying to require this missing dependency.

  The outdated comment in AppLockActivity.kt stated:
  ```kotlin
  loginTypeSelector = null, // LoginTypeSelector is not needed for destinations in AppLockActivity

  This assumption became incorrect when ForgotLockCodeScreen was added to the app lock flow and required this dependency.

```

### Solutions

  Inject LoginTypeSelector into AppLockActivity and pass it to MainNavHost, consistent with how WireActivity handles this dependency.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
