### PR TITLE
fix: clipped deletion timer icon [WPB-21088]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageExpirationItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageExpirationItems.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.inset
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -148,25 +149,30 @@ private fun SelfDeletionTimerIcon(
                 contentDescription = "Time left ${"%.0f".format(metrics.displayFractionLeft * 100)}%"
             }
     ) {
-        if (metrics.backgroundAlpha > 0f) {
-            drawCircle(color = filledColor.copy(alpha = metrics.backgroundAlpha))
-        }
+        val strokePx = this.size.minDimension * STROKE_WIDTH_FRACTION
+        val insetPx = strokePx / 2f
 
-        drawCircle(color = filledColor)
+        inset(insetPx, insetPx) {
+            if (metrics.backgroundAlpha > 0f) {
+                drawCircle(color = filledColor.copy(alpha = metrics.backgroundAlpha))
+            }
 
-        if (metrics.emptySweepDegrees > 0f) {
-            drawArc(
-                color = emptyColor,
-                startAngle = START_ANGLE_TOP_DEG,
-                sweepAngle = metrics.emptySweepDegrees,
-                useCenter = true
+            drawCircle(color = filledColor)
+
+            if (metrics.emptySweepDegrees > 0f) {
+                drawArc(
+                    color = emptyColor,
+                    startAngle = START_ANGLE_TOP_DEG,
+                    sweepAngle = metrics.emptySweepDegrees,
+                    useCenter = true
+                )
+            }
+
+            drawCircle(
+                color = filledColor,
+                style = Stroke(width = this.size.minDimension * STROKE_WIDTH_FRACTION)
             )
         }
-
-        drawCircle(
-            color = filledColor,
-            style = Stroke(width = this.size.minDimension * STROKE_WIDTH_FRACTION)
-        )
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SelfDeletionTimerHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SelfDeletionTimerHelper.kt
@@ -64,4 +64,4 @@ fun SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable.iconMetrics(
 
 private const val FULL_CIRCLE_DEGREES = 360f
 internal const val START_ANGLE_TOP_DEG = -90f
-internal const val STROKE_WIDTH_FRACTION = 0.08f
+internal const val STROKE_WIDTH_FRACTION = 0.11f


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21088" title="WPB-21088" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21088</a>  [Android]Clock icon appears clipped and not round on sender’s own message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
- Deletion timer icon looked “clipped”/not fully rounded on small sizes
- Visual aliasing on the outline due to the stroke being drawn on the canvas edge.

### Causes (Optional)
The outline (Stroke) was rendered exactly on the canvas boundary, so half of the stroke fell outside the drawable area, causing clipping and harsh edges.

### Solutions
- Inset all drawing operations by half the stroke to keep the outline fully inside the canvas
- Draw background glow, filled disk, arc “cutout”, and outline inside the inset block to avoid edge clipping.
