### PR TITLE
fix: asset bubble border flicker [WPB-20865]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageBubbleItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageBubbleItem.kt
@@ -36,8 +36,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
 import com.wire.android.ui.common.applyIf
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
@@ -168,7 +169,11 @@ fun MessageBubbleItem(
                     shape = shape,
                     border = borderColor?.let { BorderStroke(dimensions().spacing1x, it) },
                     modifier = bubbleWidthMod
-                        .clip(shape)
+                        .graphicsLayer {
+                            clip = true
+                            this.shape = shape
+                            compositingStrategy = CompositingStrategy.Offscreen
+                        }
                         .interceptCombinedClickable(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = LocalIndication.current,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentItem.kt
@@ -190,6 +190,9 @@ fun MessageContentItem(
                         HorizontalSpace.x12()
                     }
                 }
+                if (useSmallBottomPadding) {
+                    VerticalSpace.x4()
+                }
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20865" title="WPB-20865" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20865</a>  [Android]Image and Video Bubble Borders Not Fully Displayed — Edges Flicker or Disappear During Scroll
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Message bubbles with images/videos showed a brief flicker on rounded corners while scrolling (especially screenshots matching app background).

### Solutions

- Use a single clip with `graphicsLayer { clip = true; shape = …; compositingStrategy = Offscreen }.`
- Added also small improvement in paddings for message with footer