### PR TITLE
fix: resolve crash when video tile moves to second page mid-animation [WPB-21283]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
@@ -97,7 +97,6 @@ fun VerticalCallingPager(
                     GroupCallGrid(
                         gridParams = gridParams,
                         participants = participantsPages[pageIndex],
-                        pageIndex = pageIndex,
                         isSelfUserMuted = isSelfUserMuted,
                         isSelfUserCameraOn = isSelfUserCameraOn,
                         contentHeight = contentHeight,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt
@@ -88,37 +88,33 @@ fun GroupCallGrid(
             key = { it.id.value + it.clientId },
             contentType = { getContentType(it.isCameraOn, it.isSharingScreen) }
         ) { participant ->
-            Box(
+            ParticipantTile(
                 modifier = Modifier
                     .height(tileHeight)
                     .animateItem()
-            ) {
-                ParticipantTile(
-                    modifier = Modifier
-                        .pointerInput(Unit) {
-                            detectTapGestures(
-                                onDoubleTap = {
-                                    onDoubleTap(
-                                        SelectedParticipant(
-                                            userId = participant.id,
-                                            clientId = participant.clientId,
-                                            isSelfUser = participant.isSelfUser,
-                                        )
+                    .pointerInput(Unit) {
+                        detectTapGestures(
+                            onDoubleTap = {
+                                onDoubleTap(
+                                    SelectedParticipant(
+                                        userId = participant.id,
+                                        clientId = participant.clientId,
+                                        isSelfUser = participant.isSelfUser,
                                     )
-                                }
-                            )
-                        },
-                    participantTitleState = participant,
-                    isOnPiPMode = isInPictureInPictureMode,
-                    isSelfUserMuted = isSelfUserMuted,
-                    isSelfUserCameraOn = isSelfUserCameraOn,
-                    onSelfUserVideoPreviewCreated = onSelfVideoPreviewCreated,
-                    onClearSelfUserVideoPreview = onSelfClearVideoPreview,
-                    recentReaction = recentReactions[participant.id],
-                    isOnFrontCamera = isOnFrontCamera,
-                    flipCamera = flipCamera,
-                )
-            }
+                                )
+                            }
+                        )
+                    },
+                participantTitleState = participant,
+                isOnPiPMode = isInPictureInPictureMode,
+                isSelfUserMuted = isSelfUserMuted,
+                isSelfUserCameraOn = isSelfUserCameraOn,
+                onSelfUserVideoPreviewCreated = onSelfVideoPreviewCreated,
+                onClearSelfUserVideoPreview = onSelfClearVideoPreview,
+                recentReaction = recentReactions[participant.id],
+                isOnFrontCamera = isOnFrontCamera,
+                flipCamera = flipCamera,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt
@@ -53,7 +53,6 @@ import com.wire.kalium.logic.data.user.UserId
 fun GroupCallGrid(
     gridParams: CallingGridParams,
     participants: List<UICallParticipant>,
-    pageIndex: Int,
     isSelfUserMuted: Boolean,
     isSelfUserCameraOn: Boolean,
     contentHeight: Dp,
@@ -136,7 +135,6 @@ private fun PreviewGroupCallGrid(participants: List<UICallParticipant>, modifier
             GroupCallGrid(
                 gridParams = CallingGridParams.fromScreenDimensions(maxWidth, maxHeight),
                 participants = participants,
-                pageIndex = 0,
                 isSelfUserMuted = false,
                 isSelfUserCameraOn = false,
                 contentHeight = maxHeight,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt
@@ -86,36 +86,40 @@ fun GroupCallGrid(
 
         items(
             items = participants,
-            key = { it.id.toString() + it.clientId + pageIndex },
+            key = { it.id.value + it.clientId },
             contentType = { getContentType(it.isCameraOn, it.isSharingScreen) }
         ) { participant ->
-            ParticipantTile(
+            Box(
                 modifier = Modifier
-                    .pointerInput(Unit) {
-                        detectTapGestures(
-                            onDoubleTap = {
-                                onDoubleTap(
-                                    SelectedParticipant(
-                                        userId = participant.id,
-                                        clientId = participant.clientId,
-                                        isSelfUser = participant.isSelfUser,
-                                    )
-                                )
-                            }
-                        )
-                    }
                     .height(tileHeight)
-                    .animateItem(),
-                participantTitleState = participant,
-                isOnPiPMode = isInPictureInPictureMode,
-                isSelfUserMuted = isSelfUserMuted,
-                isSelfUserCameraOn = isSelfUserCameraOn,
-                onSelfUserVideoPreviewCreated = onSelfVideoPreviewCreated,
-                onClearSelfUserVideoPreview = onSelfClearVideoPreview,
-                recentReaction = recentReactions[participant.id],
-                isOnFrontCamera = isOnFrontCamera,
-                flipCamera = flipCamera,
-            )
+                    .animateItem()
+            ) {
+                ParticipantTile(
+                    modifier = Modifier
+                        .pointerInput(Unit) {
+                            detectTapGestures(
+                                onDoubleTap = {
+                                    onDoubleTap(
+                                        SelectedParticipant(
+                                            userId = participant.id,
+                                            clientId = participant.clientId,
+                                            isSelfUser = participant.isSelfUser,
+                                        )
+                                    )
+                                }
+                            )
+                        },
+                    participantTitleState = participant,
+                    isOnPiPMode = isInPictureInPictureMode,
+                    isSelfUserMuted = isSelfUserMuted,
+                    isSelfUserCameraOn = isSelfUserCameraOn,
+                    onSelfUserVideoPreviewCreated = onSelfVideoPreviewCreated,
+                    onClearSelfUserVideoPreview = onSelfClearVideoPreview,
+                    recentReaction = recentReactions[participant.id],
+                    isOnFrontCamera = isOnFrontCamera,
+                    flipCamera = flipCamera,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21283" title="WPB-21283" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21283</a>  [Android] LayoutNode Crash in Group Calls
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Crash in production: `IllegalStateException: LayoutNode should be attached to an owner`

Happens in group calls when participants join/leave or swiping between pages.

Stack trace points to `ParticipantTile.kt` in ConstraintLayout measurement.

### Causes (Optional)

`.animateItem()` on LazyGrid items + ConstraintLayout = race condition where item gets measured after being detached during animation.

Also item key had `pageIndex` which made same participant different identity on each page, causing unnecessary recreations.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
