### PR TITLE
chore: disable wire cells by default for new conversation (WPB-20190)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -122,7 +122,7 @@ class NewConversationViewModel @Inject constructor(
     private fun getWireCellFeatureState() = viewModelScope.launch {
         if (isWireCellsFeatureEnabled()) {
             groupOptionsState = groupOptionsState.copy(
-                isWireCellsEnabled = true
+                isWireCellsEnabled = false
             )
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20190" title="WPB-20190" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20190</a>  [Android] Update group and channel creation flow with additional Files info
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20190
# What's new in this PR?

Set default value for Wire Cells feature to false when creating a new group / channel.