### PR TITLE
feat: add activity extension for dynamic screen orientation setup [WPB-21393]

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,7 +86,6 @@
             android:exported="true"
             android:hardwareAccelerated="true"
             android:launchMode="singleTop"
-            android:screenOrientation="portrait"
             android:theme="@style/AppTheme" />
 
         <activity
@@ -95,7 +94,6 @@
             android:exported="true"
             android:hardwareAccelerated="true"
             android:launchMode="singleTop"
-            android:screenOrientation="portrait"
             android:supportsPictureInPicture="true"
             android:taskAffinity="wire.call"
             android:theme="@style/AppTheme" />
@@ -105,7 +103,6 @@
             android:exported="true"
             android:hardwareAccelerated="true"
             android:launchMode="singleInstance"
-            android:screenOrientation="portrait"
             android:taskAffinity="wire.call"
             android:theme="@style/AppTheme" />
 
@@ -114,7 +111,6 @@
             android:exported="true"
             android:hardwareAccelerated="true"
             android:launchMode="singleTask"
-            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.SplashScreen"
             android:windowSoftInputMode="adjustResize|stateHidden">
 

--- a/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
@@ -29,6 +29,7 @@ import com.wire.android.appLogger
 import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.MainNavHost
 import com.wire.android.navigation.rememberNavigator
+import com.wire.android.ui.common.setupOrientationForDevice
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.destinations.AppUnlockWithBiometricsScreenDestination
 import com.wire.android.ui.destinations.EnterLockCodeScreenDestination
@@ -45,6 +46,7 @@ class AppLockActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setupOrientationForDevice()
         enableEdgeToEdge()
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -81,6 +81,7 @@ import com.wire.android.ui.calling.getOutgoingCallIntent
 import com.wire.android.ui.calling.ongoing.getOngoingCallIntent
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.bottomsheet.show
+import com.wire.android.ui.common.setupOrientationForDevice
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.topappbar.CommonTopAppBar
 import com.wire.android.ui.common.topappbar.CommonTopAppBarState
@@ -180,6 +181,7 @@ class WireActivity : AppCompatActivity() {
         splashScreen.setKeepOnScreenCondition { shouldKeepSplashOpen }
 
         enableEdgeToEdge()
+        setupOrientationForDevice()
 
         lifecycleScope.launch {
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
@@ -19,11 +19,13 @@ package com.wire.android.ui.calling
 
 import android.content.Intent
 import android.os.Build
+import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.wire.android.ui.AppLockActivity
+import com.wire.android.ui.common.setupOrientationForDevice
 import com.wire.android.util.SwitchAccountObserver
 import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
 import dagger.hilt.android.AndroidEntryPoint
@@ -46,6 +48,10 @@ abstract class CallActivity : AppCompatActivity() {
     private val callActivityViewModel: CallActivityViewModel by viewModels()
     protected val qualifiedIdMapper = QualifiedIdMapperImpl(null)
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setupOrientationForDevice()
+    }
     fun switchAccountIfNeeded(userId: String?) {
         userId?.let {
             qualifiedIdMapper.fromStringToQualifiedID(it).run {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
@@ -22,9 +22,9 @@ import android.os.Build
 import android.view.WindowManager
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import com.wire.android.util.SwitchAccountObserver
 import androidx.lifecycle.lifecycleScope
 import com.wire.android.ui.AppLockActivity
+import com.wire.android.util.SwitchAccountObserver
 import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch

--- a/app/src/main/kotlin/com/wire/android/ui/calling/StartingCallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/StartingCallActivity.kt
@@ -45,6 +45,7 @@ import com.wire.android.ui.calling.common.ProximitySensorManager
 import com.wire.android.ui.calling.incoming.IncomingCallScreen
 import com.wire.android.ui.calling.ongoing.getOngoingCallIntent
 import com.wire.android.ui.calling.outgoing.OutgoingCallScreen
+import com.wire.android.ui.common.setupOrientationForDevice
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.theme.WireTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -90,6 +91,7 @@ class StartingCallActivity : CallActivity() {
     @Suppress("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setupOrientationForDevice()
 
         setUpScreenshotPreventionFlag()
         setUpCallingFlags()

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
@@ -52,6 +52,7 @@ import com.wire.android.ui.calling.CallActivity.Companion.EXTRA_SHOULD_ANSWER_CA
 import com.wire.android.ui.calling.CallActivity.Companion.EXTRA_USER_ID
 import com.wire.android.ui.calling.common.ProximitySensorManager
 import com.wire.android.ui.calling.ongoing.OngoingCallActivity.Companion.TAG
+import com.wire.android.ui.common.setupOrientationForDevice
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.theme.WireTheme
 import com.wire.kalium.logic.data.id.ConversationId
@@ -101,6 +102,7 @@ class OngoingCallActivity : CallActivity() {
     @SuppressLint("UnusedContentLambdaTargetStateParameter")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setupOrientationForDevice()
         setUpScreenshotPreventionFlag()
         setUpCallingFlags()
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/ActivityExtensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/ActivityExtensions.kt
@@ -1,0 +1,41 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.common
+
+import android.app.Activity
+import android.content.pm.ActivityInfo
+
+/**
+ * Sets up screen orientation based on device type.
+ * - Tablets (smallestScreenWidthDp >= 600dp): Can rotate freely in all orientations
+ * - Phones (smallestScreenWidthDp < 600dp): Locked to portrait orientation only
+ *
+ * This uses the same 600dp threshold that the app uses throughout its UI system
+ * for determining tablet vs phone layouts.
+ */
+fun Activity.setupOrientationForDevice() {
+    val isTablet = resources.configuration.smallestScreenWidthDp >= TABLET_MIN_SCREEN_WIDTH_DP
+    requestedOrientation = if (isTablet) {
+        ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
+    } else {
+        ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    }
+}
+
+private const val TABLET_MIN_SCREEN_WIDTH_DP = 600


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21393" title="WPB-21393" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21393</a>  [Android] Enable landscape mode for all tablets
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Instead of relying on Google to enforce it, enable it for all tablets with all Android versions in code

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
