### PR TITLE
fix: prevent double unregister calls for DynamicReceiversManager [WPB-21471]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/DynamicReceiversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/DynamicReceiversManager.kt
@@ -36,6 +36,7 @@ class DynamicReceiversManager @Inject constructor(
     @ApplicationContext val context: Context,
     private val managedConfigurationsReceiver: ManagedConfigurationsReceiver
 ) {
+    @Volatile
     private var isRegistered = false
 
     fun registerAll() {

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/DynamicReceiversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/DynamicReceiversManager.kt
@@ -36,17 +36,33 @@ class DynamicReceiversManager @Inject constructor(
     @ApplicationContext val context: Context,
     private val managedConfigurationsReceiver: ManagedConfigurationsReceiver
 ) {
+    private var isRegistered = false
+
     fun registerAll() {
         if (EMM_SUPPORT_ENABLED) {
-            appLogger.i("$TAG Registering Runtime ManagedConfigurations Broadcast receiver")
-            context.registerReceiver(managedConfigurationsReceiver, IntentFilter(Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED))
+            synchronized(this) {
+                if (!isRegistered) {
+                    appLogger.i("$TAG Registering Runtime ManagedConfigurations Broadcast receiver")
+                    context.registerReceiver(managedConfigurationsReceiver, IntentFilter(Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED))
+                    isRegistered = true
+                } else {
+                    appLogger.w("$TAG Receiver already registered, skipping")
+                }
+            }
         }
     }
 
     fun unregisterAll() {
         if (EMM_SUPPORT_ENABLED) {
-            appLogger.i("$TAG Unregistering Runtime ManagedConfigurations Broadcast receiver")
-            context.unregisterReceiver(managedConfigurationsReceiver)
+            synchronized(this) {
+                if (isRegistered) {
+                    appLogger.i("$TAG Unregistering Runtime ManagedConfigurations Broadcast receiver")
+                    context.unregisterReceiver(managedConfigurationsReceiver)
+                    isRegistered = false
+                } else {
+                    appLogger.w("$TAG Receiver not registered, skipping unregister")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21471" title="WPB-21471" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21471</a>  [Android] App crashes on stop - receiver unregister error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

  ### Issues

  This PR fixes a crash caused by attempting to unregister a broadcast receiver that was not registered or already unregistered. The crash manifests as an `IllegalArgumentException` thrown from
  `DynamicReceiversManager.unregisterAll()` when called from `WireActivity.onStop()`.

  **Stack trace:**
  Caused by java.lang.IllegalArgumentException:
    at com.wire.android.notification.broadcastreceivers.DynamicReceiversManager.unregisterAll (DynamicReceiversManager.java:49)
    at com.wire.android.ui.WireActivity.onStop (WireActivity.kt:227)

  ### Causes

  The `DynamicReceiversManager` singleton lacked registration state tracking, allowing `unregisterAll()` to be called multiple times without corresponding `registerAll()` calls. This occurs when:

  - The Activity lifecycle triggers multiple `onStop()` calls without intervening `onStart()` calls
  - Configuration changes or process death scenarios cause rapid Activity recreation
  - Multiple Activity instances interact with the same singleton without coordination

### Solutions

  Implemented thread-safe state tracking in `DynamicReceiversManager`

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
