### PR TITLE
fix: markdown heading alignment [WPB-21551]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHeading.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownHeading.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.messages.item.onBackground
 
@@ -47,6 +48,7 @@ fun MarkdownHeading(heading: MarkdownNode.Block.Heading, nodeData: NodeData, mod
         }
         MarkdownText(
             annotatedString = text,
+            textAlign = TextAlign.Start,
             style = style.copy(color = nodeData.messageStyle.onBackground()),
             onLongClick = nodeData.actions?.onLongClick,
             onOpenProfile = nodeData.actions?.onOpenProfile


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21551" title="WPB-21551" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21551</a>  [Android]Message bubble alignment bug when header style (H1) is applied
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixed markdown heading alignment 