### PR TITLE
feat: reply to multipart part 2 (WPB-16897)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
@@ -239,6 +239,11 @@ class RegularMessageMapper @Inject constructor(
                     quotedContent.locationName.orEmpty()
                 )
 
+                is MessageContent.QuotedMessageDetails.Multipart -> UIQuotedMessage.UIQuotedData.Multipart(
+                    text = quotedContent.text?.let { UIText.DynamicString(it) },
+                    attachments = emptyList()
+                )
+
                 MessageContent.QuotedMessageDetails.Deleted -> UIQuotedMessage.UIQuotedData.Deleted
                 MessageContent.QuotedMessageDetails.Invalid -> UIQuotedMessage.UIQuotedData.Invalid
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -151,19 +151,24 @@ class ConversationMessagesViewModel @Inject constructor(
         )
 
     fun navigateToReplyOriginalMessage(message: UIMessage) {
-        if (message.messageContent is UIMessageContent.TextMessage) {
-            val originalMessageId =
-                (
-                    (message.messageContent as UIMessageContent.TextMessage)
-                    .messageBody.quotedMessage as UIQuotedMessage.UIQuotedData
-                )
-                    .messageId
+        getOriginalMessageId(message)?.let { originalMessageId ->
             conversationViewState = conversationViewState.copy(
                 searchedMessageId = originalMessageId
             )
             loadPaginatedMessages()
         }
     }
+
+    private fun getOriginalMessageId(message: UIMessage) =
+        when (val content = message.messageContent) {
+            is UIMessageContent.TextMessage ->
+                (content.messageBody.quotedMessage as UIQuotedMessage.UIQuotedData).messageId
+
+            is UIMessageContent.Multipart ->
+                (content.messageBody?.quotedMessage as? UIQuotedMessage.UIQuotedData)?.messageId
+
+            else -> null
+        }
 
     private fun clearOrphanedTypingEvents() {
         viewModelScope.launch { clearUsersTypingEvents() }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -72,6 +72,7 @@ import com.wire.android.ui.theme.Accent
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.id.ConversationId
 
 private const val TEXT_QUOTE_MAX_LINES = 7
 
@@ -103,6 +104,7 @@ enum class QuotedStyle {
 
 @Composable
 internal fun QuotedMessage(
+    conversationId: ConversationId,
     messageData: UIQuotedMessage.UIQuotedData,
     clickable: Clickable?,
     style: QuotedMessageStyle,
@@ -172,10 +174,11 @@ internal fun QuotedMessage(
         )
 
         is UIQuotedMessage.UIQuotedData.Multipart -> QuotedMultipartMessage(
+            conversationId = conversationId,
+            quotedMessageId = messageData.messageId,
             senderName = messageData.senderName,
             originalDateTimeText = messageData.originalMessageDateDescription,
             text = quotedContent.text?.asString(),
-            attachments = quotedContent.attachments,
             accent = messageData.senderAccent,
             modifier = modifier,
             style = style,
@@ -187,11 +190,13 @@ internal fun QuotedMessage(
 
 @Composable
 fun QuotedMessagePreview(
+    conversationId: ConversationId,
     quotedMessageData: UIQuotedMessage.UIQuotedData,
     onCancelReply: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     QuotedMessage(
+        conversationId = conversationId,
         modifier = modifier,
         messageData = quotedMessageData,
         clickable = null,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessage.kt
@@ -74,20 +74,14 @@ fun QuotedMultipartMessage(
     accent: Accent,
     clickable: Clickable?,
     modifier: Modifier = Modifier,
-    viewModel: QuotedMultipartMessageViewModel =
-        hiltViewModel<QuotedMultipartMessageViewModel, QuotedMultipartMessageViewModel.Factory>(
-            key = conversationId.toString(),
-            creationCallback = { factory ->
-                factory.create(quotedMessageId, conversationId)
-            }
-        ),
+    viewModel: QuotedMultipartMessageViewModel = hiltViewModel(key = conversationId.toString()),
     startContent: @Composable () -> Unit = {}
 ) {
 
     var quotedMultipartMessage by remember { mutableStateOf(UIQuotedMultipartMessage()) }
 
     LaunchedEffect(quotedMessageId) {
-        viewModel.observeMultipartMessage(quotedMessageId)
+        viewModel.observeMultipartMessage(conversationId, quotedMessageId)
             .collect {
                 quotedMultipartMessage = it
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessage.kt
@@ -32,6 +32,11 @@ import androidx.compose.material.Text
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,12 +45,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.decode.VideoFrameDecoder
 import coil.request.ImageRequest
 import com.wire.android.R
 import com.wire.android.feature.cells.domain.model.AttachmentFileType
-import com.wire.android.feature.cells.domain.model.AttachmentFileType.IMAGE
 import com.wire.android.feature.cells.domain.model.AttachmentFileType.VIDEO
 import com.wire.android.feature.cells.domain.model.icon
 import com.wire.android.model.Clickable
@@ -55,64 +60,49 @@ import com.wire.android.ui.home.conversations.model.UIMultipartQuotedContent
 import com.wire.android.ui.theme.Accent
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.util.fileExtension
 
 @Composable
 fun QuotedMultipartMessage(
+    conversationId: ConversationId,
+    quotedMessageId: String,
     senderName: UIText,
     originalDateTimeText: UIText,
     text: String?,
-    attachments: List<UIMultipartQuotedContent>,
     style: QuotedMessageStyle,
     accent: Accent,
     clickable: Clickable?,
     modifier: Modifier = Modifier,
+    viewModel: QuotedMultipartMessageViewModel =
+        hiltViewModel<QuotedMultipartMessageViewModel, QuotedMultipartMessageViewModel.Factory>(
+            key = conversationId.toString(),
+            creationCallback = { factory ->
+                factory.create(quotedMessageId, conversationId)
+            }
+        ),
     startContent: @Composable () -> Unit = {}
 ) {
-    QuotedMessageContent(
-        senderName = senderName.asString(),
+
+    var quotedMultipartMessage by remember { mutableStateOf(UIQuotedMultipartMessage()) }
+
+    LaunchedEffect(quotedMessageId) {
+        viewModel.observeMultipartMessage(quotedMessageId)
+            .collect {
+                quotedMultipartMessage = it
+            }
+    }
+
+    QuotedMultipartMessageContent(
+        quotedMultipartMessage = quotedMultipartMessage,
+        senderName = senderName,
+        originalDateTimeText = originalDateTimeText,
+        text = text,
         style = style,
+        accent = accent,
+        clickable = clickable,
         modifier = modifier,
-        centerContent = {
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(
-                    dimensions().spacing4x,
-                    Alignment.CenterVertically
-                ),
-            ) {
-
-                // Message text or file name
-                when {
-                    text?.isNotEmpty() == true -> MainMarkdownText(
-                        text = text,
-                        messageStyle = style.messageStyle,
-                        accent = accent,
-                    )
-                    attachments.isSingleMediaAttachment() ->
-                        if (attachments.first().assetAvailable) {
-                            MainContentText(attachments.first().name)
-                        } else {
-                            MainContentText(stringResource(R.string.asset_message_failed_download_text))
-                        }
-                }
-
-                when {
-                    attachments.size > 1 -> MultipleAttachmentsLabel(attachments.size)
-                    attachments.isSingleFileAttachment() -> FileIconAndNameRow(attachments.first())
-                }
-            }
-        },
-        startContent = {
-            startContent()
-        },
-        endContent = {
-            if (attachments.isSingleMediaAttachment()) {
-                MediaAttachmentThumbnail(attachments.first())
-            }
-        },
-        footerContent = { QuotedMessageOriginalDate(originalDateTimeText, style) },
-        clickable = clickable
+        startContent = startContent
     )
 }
 
@@ -199,6 +189,70 @@ private fun FileIconAndNameRow(file: UIMultipartQuotedContent) {
 }
 
 @Composable
+fun QuotedMultipartMessageContent(
+    quotedMultipartMessage: UIQuotedMultipartMessage,
+    senderName: UIText,
+    originalDateTimeText: UIText,
+    text: String?,
+    style: QuotedMessageStyle,
+    accent: Accent,
+    clickable: Clickable?,
+    modifier: Modifier = Modifier,
+    startContent: @Composable () -> Unit = {}
+) {
+    QuotedMessageContent(
+        senderName = senderName.asString(),
+        style = style,
+        modifier = modifier,
+        centerContent = {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(
+                    dimensions().spacing4x,
+                    Alignment.CenterVertically
+                ),
+            ) {
+
+                // Message text or file name
+                if (text?.isNotEmpty() == true) {
+                    MainMarkdownText(
+                        text = text,
+                        messageStyle = style.messageStyle,
+                        accent = accent,
+                    )
+                } else {
+                    quotedMultipartMessage.mediaAttachment?.let { mediaAttachment ->
+                        if (mediaAttachment.assetAvailable) {
+                            MainContentText(mediaAttachment.name)
+                        } else {
+                            MainContentText(stringResource(R.string.asset_message_failed_download_text))
+                        }
+                    }
+                }
+
+                if (quotedMultipartMessage.attachmentsCount > 1) {
+                    MultipleAttachmentsLabel(quotedMultipartMessage.attachmentsCount)
+                }
+
+                quotedMultipartMessage.fileAttachment?.let { fileAttachment ->
+                    FileIconAndNameRow(fileAttachment)
+                }
+            }
+        },
+        startContent = {
+            startContent()
+        },
+        endContent = {
+            quotedMultipartMessage.mediaAttachment?.let { mediaAttachment ->
+                MediaAttachmentThumbnail(mediaAttachment)
+            }
+        },
+        footerContent = { QuotedMessageOriginalDate(originalDateTimeText, style) },
+        clickable = clickable
+    )
+}
+
+@Composable
 private fun UIMultipartQuotedContent.imageModel(): ImageRequest {
 
     val builder = ImageRequest.Builder(LocalContext.current)
@@ -215,15 +269,3 @@ private fun UIMultipartQuotedContent.imageModel(): ImageRequest {
 
     return builder.build()
 }
-
-private fun UIMultipartQuotedContent.isMediaAttachment() =
-    when (AttachmentFileType.fromMimeType(mimeType)) {
-        IMAGE, VIDEO -> true
-        else -> false
-    }
-
-private fun List<UIMultipartQuotedContent>.isSingleMediaAttachment() =
-    size == 1 && first().isMediaAttachment()
-
-private fun List<UIMultipartQuotedContent>.isSingleFileAttachment() =
-    size == 1 && !first().isMediaAttachment()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessageViewModel.kt
@@ -25,28 +25,19 @@ import com.wire.android.ui.home.conversations.model.UIMultipartQuotedContent
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.home.conversations.usecase.ObserveQuoteMessageForConversationUseCase
 import com.wire.kalium.logic.data.id.ConversationId
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
+import javax.inject.Inject
 
-@HiltViewModel(assistedFactory = QuotedMultipartMessageViewModel.Factory::class)
-class QuotedMultipartMessageViewModel @AssistedInject constructor(
-    @Assisted val conversationId: ConversationId,
-    @Assisted val messageId: String,
+@HiltViewModel
+class QuotedMultipartMessageViewModel @Inject constructor(
     private val observeQuotedMessage: ObserveQuoteMessageForConversationUseCase,
 ) : ViewModel() {
 
-    @AssistedFactory
-    interface Factory {
-        fun create(messageId: String, conversationId: ConversationId): QuotedMultipartMessageViewModel
-    }
-
-    suspend fun observeMultipartMessage(quotedMessageId: String): Flow<UIQuotedMultipartMessage> =
+    suspend fun observeMultipartMessage(conversationId: ConversationId, quotedMessageId: String): Flow<UIQuotedMultipartMessage> =
         observeQuotedMessage(conversationId, quotedMessageId)
             .mapNotNull { result -> (result as? UIQuotedMessage.UIQuotedData)?.quotedContent }
             .filterIsInstance<UIQuotedMessage.UIQuotedData.Multipart>()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessageViewModel.kt
@@ -1,0 +1,78 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.messages
+
+import androidx.lifecycle.ViewModel
+import com.wire.android.feature.cells.domain.model.AttachmentFileType
+import com.wire.android.feature.cells.domain.model.AttachmentFileType.IMAGE
+import com.wire.android.feature.cells.domain.model.AttachmentFileType.VIDEO
+import com.wire.android.ui.home.conversations.model.UIMultipartQuotedContent
+import com.wire.android.ui.home.conversations.model.UIQuotedMessage
+import com.wire.android.ui.home.conversations.usecase.ObserveQuoteMessageForConversationUseCase
+import com.wire.kalium.logic.data.id.ConversationId
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+
+@HiltViewModel(assistedFactory = QuotedMultipartMessageViewModel.Factory::class)
+class QuotedMultipartMessageViewModel @AssistedInject constructor(
+    @Assisted val conversationId: ConversationId,
+    @Assisted val messageId: String,
+    private val observeQuotedMessage: ObserveQuoteMessageForConversationUseCase,
+) : ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(messageId: String, conversationId: ConversationId): QuotedMultipartMessageViewModel
+    }
+
+    suspend fun observeMultipartMessage(quotedMessageId: String): Flow<UIQuotedMultipartMessage> =
+        observeQuotedMessage(conversationId, quotedMessageId)
+            .mapNotNull { result -> (result as? UIQuotedMessage.UIQuotedData)?.quotedContent }
+            .filterIsInstance<UIQuotedMessage.UIQuotedData.Multipart>()
+            .map { multipart ->
+                UIQuotedMultipartMessage(
+                    mediaAttachment = if (multipart.attachments.isSingleMediaAttachment()) multipart.attachments.first() else null,
+                    fileAttachment = if (multipart.attachments.isSingleFileAttachment()) multipart.attachments.first() else null,
+                    attachmentsCount = multipart.attachments.size,
+                )
+            }
+}
+
+data class UIQuotedMultipartMessage(
+    val mediaAttachment: UIMultipartQuotedContent? = null,
+    val fileAttachment: UIMultipartQuotedContent? = null,
+    val attachmentsCount: Int = 0,
+)
+
+private fun UIMultipartQuotedContent.isMediaAttachment() =
+    when (AttachmentFileType.fromMimeType(mimeType)) {
+        IMAGE, VIDEO -> true
+        else -> false
+    }
+
+private fun List<UIMultipartQuotedContent>.isSingleMediaAttachment() =
+    size == 1 && first().isMediaAttachment()
+
+private fun List<UIMultipartQuotedContent>.isSingleFileAttachment() =
+    size == 1 && !first().isMediaAttachment()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
@@ -166,6 +166,7 @@ private fun MessageContent(
                     VerticalSpace.x4()
                     when (it) {
                         is UIQuotedMessage.UIQuotedData -> QuotedMessage(
+                            conversationId = message.conversationId,
                             messageData = it,
                             style = QuotedMessageStyle(
                                 quotedStyle = QuotedStyle.COMPLETE,
@@ -205,6 +206,7 @@ private fun MessageContent(
                     VerticalSpace.x4()
                     when (it) {
                         is UIQuotedMessage.UIQuotedData -> QuotedMessage(
+                            conversationId = message.conversationId,
                             messageData = it,
                             style = QuotedMessageStyle(
                                 quotedStyle = QuotedStyle.COMPLETE,
@@ -312,6 +314,30 @@ private fun MessageContent(
 
         is UIMessageContent.Multipart ->
             Column {
+                messageContent.messageBody?.quotedMessage?.let {
+                    VerticalSpace.x4()
+                    when (it) {
+                        is UIQuotedMessage.UIQuotedData -> QuotedMessage(
+                            conversationId = message.conversationId,
+                            messageData = it,
+                            style = QuotedMessageStyle(
+                                quotedStyle = QuotedStyle.COMPLETE,
+                                messageStyle = messageStyle,
+                                selfAccent = accent
+                            ),
+                            clickable = onReplyClick
+                        )
+
+                        UIQuotedMessage.UnavailableData -> QuotedUnavailable(
+                            style = QuotedMessageStyle(
+                                quotedStyle = QuotedStyle.COMPLETE,
+                                messageStyle = messageStyle,
+                                selfAccent = accent
+                            )
+                        )
+                    }
+                    VerticalSpace.x4()
+                }
                 if (messageContent.messageBody?.message?.asString()?.isNotEmpty() == true) {
                     MessageBody(
                         messageBody = messageContent.messageBody,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewMultipartReply.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewMultipartReply.kt
@@ -22,8 +22,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.messages.QuotedMessageStyle
-import com.wire.android.ui.home.conversations.messages.QuotedMultipartMessage
+import com.wire.android.ui.home.conversations.messages.QuotedMultipartMessageContent
 import com.wire.android.ui.home.conversations.messages.QuotedStyle
+import com.wire.android.ui.home.conversations.messages.UIQuotedMultipartMessage
 import com.wire.android.ui.home.conversations.messages.item.MessageStyle
 import com.wire.android.ui.home.conversations.model.UIMultipartQuotedContent
 import com.wire.android.ui.theme.Accent
@@ -32,18 +33,18 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 
 @Composable
-private fun PreviewMultipartMessage(text: String?, attachments: List<UIMultipartQuotedContent>) {
-    QuotedMultipartMessage(
+private fun PreviewMultipartMessage(text: String?, message: UIQuotedMultipartMessage) {
+    QuotedMultipartMessageContent(
         senderName = UIText.DynamicString("Compose UI Tester"),
         originalDateTimeText = UIText.DynamicString(""),
         text = text,
-        attachments = attachments,
         style = QuotedMessageStyle(
             messageStyle = MessageStyle.NORMAL,
             quotedStyle = QuotedStyle.PREVIEW,
             selfAccent = Accent.Blue,
         ),
         accent = Accent.Blue,
+        quotedMultipartMessage = message,
         clickable = null,
     )
 }
@@ -57,8 +58,20 @@ private fun PreviewReplies() {
         ) {
             PreviewMultipartMessage(
                 text = null,
-                attachments = listOf(
-                    UIMultipartQuotedContent(
+                message = UIQuotedMultipartMessage(
+                    mediaAttachment = UIMultipartQuotedContent(
+                        name = "Test File.mp4",
+                        localPath = null,
+                        previewUrl = "https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d",
+                        mimeType = "video/mp4",
+                        assetAvailable = true,
+                    )
+                )
+            )
+            PreviewMultipartMessage(
+                text = "Testing multipart quoted message with text and image attachment.",
+                message = UIQuotedMultipartMessage(
+                    fileAttachment = UIMultipartQuotedContent(
                         name = "Test File.pdf",
                         localPath = null,
                         previewUrl = "https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d",
@@ -69,53 +82,9 @@ private fun PreviewReplies() {
             )
             PreviewMultipartMessage(
                 text = "Testing multipart quoted message with text and image attachment.",
-                attachments = listOf(
-                    UIMultipartQuotedContent(
-                        name = "Test File.pdf",
-                        localPath = null,
-                        previewUrl = "https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d",
-                        mimeType = "application/pdf",
-                        assetAvailable = true,
-                    )
-                ),
-            )
-            PreviewMultipartMessage(
-                text = "Testing multipart quoted message with text and image attachment.",
-                attachments = listOf(
-                    UIMultipartQuotedContent(
-                        name = "Test File.pdf",
-                        localPath = null,
-                        previewUrl = "https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d",
-                        mimeType = "application/pdf",
-                        assetAvailable = true,
-                    ),
-                    UIMultipartQuotedContent(
-                        name = "Test File.pdf",
-                        localPath = null,
-                        previewUrl = "https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d",
-                        mimeType = "application/pdf",
-                        assetAvailable = true,
-                    ),
-                ),
-            )
-            PreviewMultipartMessage(
-                text = null,
-                attachments = listOf(
-                    UIMultipartQuotedContent(
-                        name = "Test File.pdf",
-                        localPath = null,
-                        previewUrl = "https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d",
-                        mimeType = "application/pdf",
-                        assetAvailable = true,
-                    ),
-                    UIMultipartQuotedContent(
-                        name = "Test File.pdf",
-                        localPath = null,
-                        previewUrl = "https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d",
-                        mimeType = "application/pdf",
-                        assetAvailable = true,
-                    ),
-                ),
+                message = UIQuotedMultipartMessage(
+                    attachmentsCount = 2
+                )
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -125,6 +125,7 @@ fun ActiveMessageComposerInput(
             VerticalSpace.x4()
             Box(modifier = Modifier.padding(horizontal = dimensions().spacing8x)) {
                 QuotedMessagePreview(
+                    conversationId = conversationId,
                     quotedMessageData = quotedMessage,
                     onCancelReply = onCancelReply
                 )

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessageViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessageViewModelTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.messages
+
+import app.cash.turbine.test
+import com.wire.android.ui.home.conversations.model.UIMultipartQuotedContent
+import com.wire.android.ui.home.conversations.model.UIQuotedMessage
+import com.wire.android.ui.home.conversations.usecase.ObserveQuoteMessageForConversationUseCase
+import com.wire.android.ui.theme.Accent
+import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.user.UserId
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+
+class QuotedMultipartMessageViewModelTest {
+
+    @Test
+    fun `given a quoted message with multiple attachments when observing then valid data is returned`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withQuotedMessageContent(
+                UIQuotedMessage.UIQuotedData.Multipart(
+                    text = UIText.DynamicString("Multipart message"),
+                    attachments = listOf(videoAttachment, imageAttachment, fileAttachment)
+                )
+            )
+            .arrange()
+
+        viewModel.observeMultipartMessage("message_id").test {
+            val data = awaitItem()
+
+            assertNull(data.fileAttachment)
+            assertNull(data.mediaAttachment)
+            assertEquals(3, data.attachmentsCount)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given a quoted message with one media attachment when observing then valid data is returned`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withQuotedMessageContent(
+                UIQuotedMessage.UIQuotedData.Multipart(
+                    text = UIText.DynamicString("Multipart message"),
+                    attachments = listOf(videoAttachment)
+                )
+            )
+            .arrange()
+
+        viewModel.observeMultipartMessage("message_id").test {
+            val data = awaitItem()
+
+            assertNull(data.fileAttachment)
+            assertEquals(videoAttachment, data.mediaAttachment)
+            assertEquals(1, data.attachmentsCount)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given a quoted message with one file attachment when observing then valid data is returned`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withQuotedMessageContent(
+                UIQuotedMessage.UIQuotedData.Multipart(
+                    text = UIText.DynamicString("Multipart message"),
+                    attachments = listOf(fileAttachment)
+                )
+            )
+            .arrange()
+
+        viewModel.observeMultipartMessage("message_id").test {
+            val data = awaitItem()
+
+            assertNull(data.mediaAttachment)
+            assertEquals(fileAttachment, data.fileAttachment)
+            assertEquals(1, data.attachmentsCount)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given non-multipart quoted message no data emitted`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withQuotedMessageContent(
+                UIQuotedMessage.UIQuotedData.Text(
+                    value = UIText.DynamicString("Just a text message")
+                )
+            )
+            .arrange()
+
+        viewModel.observeMultipartMessage("message_id").test {
+            awaitComplete()
+        }
+    }
+
+    private class Arrangement {
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        @MockK
+        lateinit var observeQuotedMessage: ObserveQuoteMessageForConversationUseCase
+
+        fun withQuotedMessageContent(content: UIQuotedMessage.UIQuotedData.Content) = apply {
+            coEvery {
+                observeQuotedMessage.invoke(any(), any())
+            } returns flowOf(
+                UIQuotedMessage.UIQuotedData(
+                    messageId = "message_id",
+                    senderId = UserId("user", "domain"),
+                    senderName = UIText.DynamicString("Sender Name"),
+                    senderAccent = Accent.Unknown,
+                    originalMessageDateDescription = UIText.DynamicString("Date"),
+                    editedTimeDescription = null,
+                    quotedContent = content,
+                )
+            )
+        }
+
+        fun arrange(): Pair<Arrangement, QuotedMultipartMessageViewModel> {
+            val viewModel = QuotedMultipartMessageViewModel(
+                conversationId = QualifiedID("convo-id", "convo.domain"),
+                messageId = "test_message_id",
+                observeQuotedMessage = observeQuotedMessage
+            )
+            return this to viewModel
+        }
+    }
+
+    private companion object {
+        val videoAttachment = UIMultipartQuotedContent(
+            name = "video1.mp4",
+            localPath = null,
+            previewUrl = null,
+            mimeType = "video/mp4",
+            assetAvailable = true
+        )
+        val imageAttachment = UIMultipartQuotedContent(
+            name = "image1.png",
+            localPath = null,
+            previewUrl = null,
+            mimeType = "image/png",
+            assetAvailable = true
+        )
+        val fileAttachment = UIMultipartQuotedContent(
+            name = "document.pdf",
+            localPath = null,
+            previewUrl = null,
+            mimeType = "application/pdf",
+            assetAvailable = true
+        )
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessageViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessageViewModelTest.kt
@@ -47,7 +47,7 @@ class QuotedMultipartMessageViewModelTest {
             )
             .arrange()
 
-        viewModel.observeMultipartMessage("message_id").test {
+        viewModel.observeMultipartMessage(conversationId, "message_id").test {
             val data = awaitItem()
 
             assertNull(data.fileAttachment)
@@ -69,7 +69,7 @@ class QuotedMultipartMessageViewModelTest {
             )
             .arrange()
 
-        viewModel.observeMultipartMessage("message_id").test {
+        viewModel.observeMultipartMessage(conversationId, "message_id").test {
             val data = awaitItem()
 
             assertNull(data.fileAttachment)
@@ -91,7 +91,7 @@ class QuotedMultipartMessageViewModelTest {
             )
             .arrange()
 
-        viewModel.observeMultipartMessage("message_id").test {
+        viewModel.observeMultipartMessage(conversationId, "message_id").test {
             val data = awaitItem()
 
             assertNull(data.mediaAttachment)
@@ -112,7 +112,7 @@ class QuotedMultipartMessageViewModelTest {
             )
             .arrange()
 
-        viewModel.observeMultipartMessage("message_id").test {
+        viewModel.observeMultipartMessage(conversationId, "message_id").test {
             awaitComplete()
         }
     }
@@ -144,8 +144,6 @@ class QuotedMultipartMessageViewModelTest {
 
         fun arrange(): Pair<Arrangement, QuotedMultipartMessageViewModel> {
             val viewModel = QuotedMultipartMessageViewModel(
-                conversationId = QualifiedID("convo-id", "convo.domain"),
-                messageId = "test_message_id",
                 observeQuotedMessage = observeQuotedMessage
             )
             return this to viewModel
@@ -153,6 +151,9 @@ class QuotedMultipartMessageViewModelTest {
     }
 
     private companion object {
+
+        val conversationId = QualifiedID("convo-id", "convo.domain")
+
         val videoAttachment = UIMultipartQuotedContent(
             name = "video1.mp4",
             localPath = null,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16897" title="WPB-16897" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16897</a>  [Android] Support reply for multipart message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-16897

# What's new in this PR?

Show multipart message replies in messages list.
QuotedMultipartMessage view is using a helper QuotedMultipartMessageViewModel to observe quoted multipart data

Please review the `QuotedMultipartMessage` / `QuotedMultipartMessageViewModel` and let me know if you see issues with it and/or have a better solution.

Figma: https://www.figma.com/design/grnVU2vAihHXwYgHryu2xE/Cells---Files?node-id=9487-193420&p=f&t=hnZxJrjkkZKEAwoD-0