### PR TITLE
fix: message text typing (WPB-16897)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/MessageModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/MessageModule.kt
@@ -26,8 +26,8 @@ import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.GetPaginatedFlowOfAssetMessageByConversationIdUseCase
 import com.wire.kalium.logic.feature.asset.ObserveAssetStatusesUseCase
 import com.wire.kalium.logic.feature.asset.ObservePaginatedAssetImageMessages
-import com.wire.kalium.logic.feature.asset.upload.ScheduleNewAssetMessageUseCase
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCase
+import com.wire.kalium.logic.feature.asset.upload.ScheduleNewAssetMessageUseCase
 import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
@@ -49,7 +49,7 @@ import com.wire.kalium.logic.feature.message.SendMultipartMessageUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
 import com.wire.kalium.logic.feature.message.composite.SendButtonActionMessageUseCase
-import com.wire.kalium.logic.feature.message.draft.ObserveMessageDraftUseCase
+import com.wire.kalium.logic.feature.message.draft.GetMessageDraftUseCase
 import com.wire.kalium.logic.feature.message.draft.RemoveMessageDraftUseCase
 import com.wire.kalium.logic.feature.message.draft.SaveMessageDraftUseCase
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
@@ -218,8 +218,8 @@ class MessageModule {
 
     @ViewModelScoped
     @Provides
-    fun provideObserveMessageDraftUseCase(messageScope: MessageScope): ObserveMessageDraftUseCase =
-        messageScope.observeMessageDraftUseCase
+    fun provideGetMessageDraftUseCase(messageScope: MessageScope): GetMessageDraftUseCase =
+        messageScope.getMessageDraftUseCase
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
@@ -24,7 +24,7 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.ui.home.conversations.ConversationNavArgs
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.home.conversations.model.toUiMention
-import com.wire.android.ui.home.conversations.usecase.ObserveQuoteMessageForConversationUseCase
+import com.wire.android.ui.home.conversations.usecase.GetQuoteMessageForConversationUseCase
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
 import com.wire.android.ui.home.messagecomposer.model.toDraft
 import com.wire.android.ui.home.messagecomposer.model.update
@@ -32,20 +32,17 @@ import com.wire.android.ui.navArgs
 import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.draft.MessageDraft
-import com.wire.kalium.logic.feature.message.draft.ObserveMessageDraftUseCase
+import com.wire.kalium.logic.feature.message.draft.GetMessageDraftUseCase
 import com.wire.kalium.logic.feature.message.draft.SaveMessageDraftUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class MessageDraftViewModel @Inject constructor(
     val savedStateHandle: SavedStateHandle,
-    private val observeMessageDraft: ObserveMessageDraftUseCase,
-    private val observeQuotedMessage: ObserveQuoteMessageForConversationUseCase,
+    private val getMessageDraft: GetMessageDraftUseCase,
+    private val getQuotedMessage: GetQuoteMessageForConversationUseCase,
     private val saveMessageDraft: SaveMessageDraftUseCase,
 ) : ViewModel() {
 
@@ -56,7 +53,7 @@ class MessageDraftViewModel @Inject constructor(
         private set
 
     init {
-        observeMessageDraft()
+        loadMessageDraft()
     }
 
     fun clearDraft() {
@@ -74,34 +71,28 @@ class MessageDraftViewModel @Inject constructor(
         }
     }
 
-    private fun observeMessageDraft() = viewModelScope.launch {
-        observeMessageDraft(conversationId)
-            .flatMapLatest { draft ->
-                observeQuoted(draft?.quotedMessageId)
-                    .map { quotedMessage -> draft to quotedMessage }
-            }.collect { (draft, quotedMessage) ->
-                if (draft == null) {
-                    state.update { messageComposition ->
-                        MessageComposition(conversationId = conversationId)
-                    }
-                } else {
-                    state.update { messageComposition ->
-                        messageComposition.copy(
-                            draftText = draft.text,
-                            selectedMentions = draft.selectedMentionList.mapNotNull { it.toUiMention(draft.text) },
-                            editMessageId = draft.editMessageId,
-                            quotedMessage = quotedMessage as? UIQuotedMessage.UIQuotedData,
-                            quotedMessageId = (quotedMessage as? UIQuotedMessage.UIQuotedData)?.messageId,
-                        )
-                    }
-                }
-            }
-    }
+    private fun loadMessageDraft() = viewModelScope.launch {
+        getMessageDraft(conversationId)?.let { draft ->
 
-    private suspend fun observeQuoted(quotedMessageId: String?) =
-        quotedMessageId?.let { quotedMessageId ->
-            observeQuotedMessage(conversationId, quotedMessageId)
-        } ?: flowOf(UIQuotedMessage.UnavailableData)
+            val quotedMessage = draft.quotedMessageId?.let { quotedMessageId ->
+                getQuotedMessage(conversationId, quotedMessageId)
+            }
+
+            state.update { messageComposition ->
+                messageComposition.copy(
+                    draftText = draft.text,
+                    selectedMentions = draft.selectedMentionList.mapNotNull { it.toUiMention(draft.text) },
+                    editMessageId = draft.editMessageId,
+                    quotedMessage = quotedMessage as? UIQuotedMessage.UIQuotedData,
+                    quotedMessageId = (quotedMessage as? UIQuotedMessage.UIQuotedData)?.messageId,
+                )
+            }
+        } ?: run {
+            state.update { messageComposition ->
+                MessageComposition(conversationId = conversationId)
+            }
+        }
+    }
 
     fun saveDraft(messageDraft: MessageDraft) {
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetQuoteMessageForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetQuoteMessageForConversationUseCase.kt
@@ -1,0 +1,73 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.home.conversations.usecase
+
+import com.wire.android.mapper.MessageMapper
+import com.wire.android.ui.home.conversations.model.UIMessage
+import com.wire.android.ui.home.conversations.model.UIQuotedMessage
+import com.wire.android.ui.home.conversations.model.mapToQuotedContent
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.ui.toUIText
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class GetQuoteMessageForConversationUseCase @Inject constructor(
+    private val getMessageById: GetMessageByIdUseCase,
+    private val getUsersForMessage: GetUsersForMessageUseCase,
+    private val messageMapper: MessageMapper,
+    private val dispatchers: DispatcherProvider,
+) {
+
+    suspend operator fun invoke(conversationId: ConversationId, quotedMessageId: String): UIQuotedMessage = withContext(dispatchers.io()) {
+        when (val result = getMessageById(conversationId, quotedMessageId)) {
+            is GetMessageByIdUseCase.Result.Failure -> UIQuotedMessage.UnavailableData
+            is GetMessageByIdUseCase.Result.Success -> {
+                when (val message = result.message) {
+                    is Message.Regular -> {
+                        val usersForMessage = getUsersForMessage(message)
+                        when (val uiMessage = messageMapper.toUIMessage(usersForMessage, message)) {
+                            is UIMessage.Regular -> uiMessage.mapToQuotedContent()?.let { quotedContent ->
+                                uiMessage.header.userId?.let { senderId ->
+                                    UIQuotedMessage.UIQuotedData(
+                                        messageId = uiMessage.header.messageId,
+                                        senderId = senderId,
+                                        senderName = uiMessage.header.username,
+                                        originalMessageDateDescription = "".toUIText(),
+                                        editedTimeDescription = "".toUIText(),
+                                        quotedContent = quotedContent,
+                                        senderAccent = uiMessage.header.accent
+                                    )
+                                }
+                            } ?: UIQuotedMessage.UnavailableData
+
+                            is UIMessage.System -> UIQuotedMessage.UnavailableData
+                            null -> UIQuotedMessage.UnavailableData
+                        }
+                    }
+
+                    is Message.Signaling -> UIQuotedMessage.UnavailableData
+                    is Message.System -> UIQuotedMessage.UnavailableData
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModelTest.kt
@@ -26,13 +26,13 @@ import com.wire.android.config.mockUri
 import com.wire.android.framework.TestConversation
 import com.wire.android.ui.home.conversations.ConversationNavArgs
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
-import com.wire.android.ui.home.conversations.usecase.ObserveQuoteMessageForConversationUseCase
+import com.wire.android.ui.home.conversations.usecase.GetQuoteMessageForConversationUseCase
 import com.wire.android.ui.navArgs
 import com.wire.android.ui.theme.Accent
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.message.draft.MessageDraft
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.message.draft.ObserveMessageDraftUseCase
+import com.wire.kalium.logic.feature.message.draft.GetMessageDraftUseCase
 import com.wire.kalium.logic.feature.message.draft.SaveMessageDraftUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -40,7 +40,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -71,7 +70,7 @@ class MessageDraftViewModelTest {
         // then
         assertEquals(messageDraft.text, viewModel.state.value.draftText)
         coVerify(exactly = 1) {
-            arrangement.observeMessageDraft(any())
+            arrangement.getMessageDraft(any())
         }
     }
 
@@ -88,7 +87,7 @@ class MessageDraftViewModelTest {
         // then
         assertEquals(true, viewModel.state.value.draftText.isEmpty())
         coVerify(exactly = 1) {
-            arrangement.observeMessageDraft(any())
+            arrangement.getMessageDraft(any())
         }
     }
 
@@ -125,10 +124,10 @@ class MessageDraftViewModelTest {
         assertEquals(quotedData, viewModel.state.value.quotedMessage)
 
         coVerify(exactly = 1) {
-            arrangement.observeMessageDraft(any())
+            arrangement.getMessageDraft(any())
         }
         coVerify(exactly = 1) {
-            arrangement.observeQuoteMessageForConversation(any(), any())
+            arrangement.getQuoteMessageForConversation(any(), any())
         }
     }
 
@@ -157,10 +156,10 @@ class MessageDraftViewModelTest {
         assertEquals(null, viewModel.state.value.quotedMessageId)
 
         coVerify(exactly = 1) {
-            arrangement.observeMessageDraft(any())
+            arrangement.getMessageDraft(any())
         }
         coVerify(exactly = 1) {
-            arrangement.observeQuoteMessageForConversation(any(), any())
+            arrangement.getQuoteMessageForConversation(any(), any())
         }
     }
 
@@ -179,33 +178,33 @@ class MessageDraftViewModelTest {
         private lateinit var savedStateHandle: SavedStateHandle
 
         @MockK
-        lateinit var observeMessageDraft: ObserveMessageDraftUseCase
+        lateinit var getMessageDraft: GetMessageDraftUseCase
 
         @MockK
         lateinit var saveMessageDraft: SaveMessageDraftUseCase
 
         @MockK
-        lateinit var observeQuoteMessageForConversation: ObserveQuoteMessageForConversationUseCase
+        lateinit var getQuoteMessageForConversation: GetQuoteMessageForConversationUseCase
 
         private val viewModel by lazy {
             MessageDraftViewModel(
                 savedStateHandle,
-                observeMessageDraft,
-                observeQuoteMessageForConversation,
+                getMessageDraft,
+                getQuoteMessageForConversation,
                 saveMessageDraft,
             )
         }
 
         fun withNoMessageDraft() = apply {
-            coEvery { observeMessageDraft(any()) } returns flowOf()
+            coEvery { getMessageDraft(any()) } returns null
         }
 
         fun withMessageDraft(messageDraft: MessageDraft) = apply {
-            coEvery { observeMessageDraft(any()) } returns flowOf(messageDraft)
+            coEvery { getMessageDraft(any()) } returns messageDraft
         }
 
         fun withQuotedMessage(quotedMessage: UIQuotedMessage) = apply {
-            coEvery { observeQuoteMessageForConversation(any(), any()) } returns flowOf(quotedMessage)
+            coEvery { getQuoteMessageForConversation(any(), any()) } returns quotedMessage
         }
 
         fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetQuoteMessageForConversationUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetQuoteMessageForConversationUseCaseTest.kt
@@ -33,6 +33,7 @@ import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.ui.theme.Accent
 import com.wire.android.util.ui.toUIText
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
@@ -76,7 +77,18 @@ class GetQuoteMessageForConversationUseCaseTest {
 
         val result = useCase(CONVERSATION_ID, QUOTED_MESSAGE_ID)
 
-        assertEquals(UIQuotedMessage.UnavailableData, result)
+        assertEquals(
+            UIQuotedMessage.UIQuotedData(
+                messageId = "message_id",
+                senderId = USER_ID,
+                senderName = "User".toUIText(),
+                senderAccent = Accent.Unknown,
+                originalMessageDateDescription = "".toUIText(),
+                editedTimeDescription = "".toUIText(),
+                quotedContent = UIQuotedMessage.UIQuotedData.Text("Hello".toUIText())
+            ),
+            result
+        )
     }
 
     @Test
@@ -221,6 +233,7 @@ class GetQuoteMessageForConversationUseCaseTest {
             coEvery { messageMapper.toUIMessage(any(), any()) } returns UIMessage.Regular(
                 conversationId = CONVERSATION_ID,
                 header = MessageHeader(
+                    userId = USER_ID,
                     username = "User".toUIText(),
                     membership = Membership.Standard,
                     showLegalHoldIndicator = false,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetQuoteMessageForConversationUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetQuoteMessageForConversationUseCaseTest.kt
@@ -1,0 +1,266 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.usecase
+
+import com.wire.android.config.TestDispatcherProvider
+import com.wire.android.mapper.MessageMapper
+import com.wire.android.mapper.testOtherUser
+import com.wire.android.model.UserAvatarData
+import com.wire.android.ui.home.conversations.model.ExpirationStatus
+import com.wire.android.ui.home.conversations.model.MessageBody
+import com.wire.android.ui.home.conversations.model.MessageFlowStatus
+import com.wire.android.ui.home.conversations.model.MessageFooter
+import com.wire.android.ui.home.conversations.model.MessageHeader
+import com.wire.android.ui.home.conversations.model.MessageSource
+import com.wire.android.ui.home.conversations.model.MessageStatus
+import com.wire.android.ui.home.conversations.model.MessageTime
+import com.wire.android.ui.home.conversations.model.UIMessage
+import com.wire.android.ui.home.conversations.model.UIMessageContent
+import com.wire.android.ui.home.conversations.model.UIQuotedMessage
+import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.util.ui.toUIText
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.PlainId
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetQuoteMessageForConversationUseCaseTest {
+
+    val dispatchers = TestDispatcherProvider()
+
+    @Test
+    fun `given valid message when calling use case then data returned`() = runTest(dispatchers.main()) {
+        val (_, useCase) = Arrangement()
+            .withMappingSuccess()
+            .withMessageQueryResult(
+                GetMessageByIdUseCase.Result.Success(
+                    message = Message.Regular(
+                        id = "message-id",
+                        content = MessageContent.Text("Hello"),
+                        conversationId = CONVERSATION_ID,
+                        date = Clock.System.now(),
+                        senderUserId = USER_ID,
+                        status = Message.Status.Read(0),
+                        isSelfMessage = true,
+                        senderClientId = CLIENT_ID,
+                        editStatus = Message.EditStatus.NotEdited,
+                    )
+                )
+            )
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID, QUOTED_MESSAGE_ID)
+
+        assertEquals(UIQuotedMessage.UnavailableData, result)
+    }
+
+    @Test
+    fun `given message mapping fails when calling use case then unavailable data returned`() = runTest(dispatchers.main()) {
+        val (_, useCase) = Arrangement()
+            .withMappingFailure()
+            .withMessageQueryResult(
+                GetMessageByIdUseCase.Result.Success(
+                    message = Message.Regular(
+                        id = "message-id",
+                        content = MessageContent.Text("Hello"),
+                        conversationId = CONVERSATION_ID,
+                        date = Clock.System.now(),
+                        senderUserId = USER_ID,
+                        status = Message.Status.Read(0),
+                        isSelfMessage = true,
+                        senderClientId = CLIENT_ID,
+                        editStatus = Message.EditStatus.NotEdited,
+                    )
+                )
+            )
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID, QUOTED_MESSAGE_ID)
+
+        assertEquals(UIQuotedMessage.UnavailableData, result)
+    }
+
+    @Test
+    fun `given message mapped to system  when calling use case then unavailable data returned`() = runTest(dispatchers.main()) {
+        val (_, useCase) = Arrangement()
+            .withSystemUIMessage()
+            .withMessageQueryResult(
+                GetMessageByIdUseCase.Result.Success(
+                    message = Message.Regular(
+                        id = "message-id",
+                        content = MessageContent.Text("Hello"),
+                        conversationId = CONVERSATION_ID,
+                        date = Clock.System.now(),
+                        senderUserId = USER_ID,
+                        status = Message.Status.Read(0),
+                        isSelfMessage = true,
+                        senderClientId = CLIENT_ID,
+                        editStatus = Message.EditStatus.NotEdited,
+                    )
+                )
+            )
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID, QUOTED_MESSAGE_ID)
+
+        assertEquals(UIQuotedMessage.UnavailableData, result)
+    }
+
+    @Test
+    fun `given message query returns signalling message when calling use case then unavailable data returned`() =
+        runTest(dispatchers.main()) {
+            val (_, useCase) = Arrangement()
+                .withMessageQueryResult(
+                    GetMessageByIdUseCase.Result.Success(
+                        message = Message.Signaling(
+                            id = "message-id",
+                            content = MessageContent.Calling(
+                                value = "",
+                            ),
+                            conversationId = CONVERSATION_ID,
+                            date = Clock.System.now(),
+                            senderUserId = USER_ID,
+                            senderClientId = CLIENT_ID,
+                            status = Message.Status.Read(0),
+                            isSelfMessage = true,
+                            expirationData = null,
+                        )
+                    )
+                )
+                .arrange()
+
+            val result = useCase(CONVERSATION_ID, QUOTED_MESSAGE_ID)
+
+            assertEquals(UIQuotedMessage.UnavailableData, result)
+        }
+
+    @Test
+    fun `given message query returns system message when calling use case then unavailable data returned`() = runTest(dispatchers.main()) {
+        val (_, useCase) = Arrangement()
+            .withMessageQueryResult(
+                GetMessageByIdUseCase.Result.Success(
+                    message = Message.System(
+                        id = "message-id",
+                        content = MessageContent.MissedCall,
+                        conversationId = CONVERSATION_ID,
+                        date = Clock.System.now(),
+                        senderUserId = USER_ID,
+                        status = Message.Status.Read(0),
+                        expirationData = null,
+                    )
+                )
+            )
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID, QUOTED_MESSAGE_ID)
+
+        assertEquals(UIQuotedMessage.UnavailableData, result)
+    }
+
+    @Test
+    fun `given message query fails when calling use case then unavailable data returned`() = runTest(dispatchers.main()) {
+
+        val (_, useCase) = Arrangement()
+            .withMessageQueryResult(GetMessageByIdUseCase.Result.Failure(CoreFailure.Unknown(null)))
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID, QUOTED_MESSAGE_ID)
+
+        assertEquals(UIQuotedMessage.UnavailableData, result)
+    }
+
+    inner class Arrangement {
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        @MockK
+        lateinit var getMessageById: GetMessageByIdUseCase
+
+        @MockK
+        lateinit var getUsersForMessage: GetUsersForMessageUseCase
+
+        @MockK
+        lateinit var messageMapper: MessageMapper
+
+        @MockK
+        lateinit var messageSystem: UIMessage.System
+
+        fun withMessageQueryResult(result: GetMessageByIdUseCase.Result) = apply {
+            coEvery { getMessageById.invoke(any(), any()) } returns result
+            coEvery { getUsersForMessage(any()) } returns listOf(testOtherUser(1))
+        }
+
+        fun withMappingSuccess() = apply {
+            coEvery { messageMapper.toUIMessage(any(), any()) } returns UIMessage.Regular(
+                conversationId = CONVERSATION_ID,
+                header = MessageHeader(
+                    username = "User".toUIText(),
+                    membership = Membership.Standard,
+                    showLegalHoldIndicator = false,
+                    messageTime = MessageTime(Clock.System.now()),
+                    messageStatus = MessageStatus(
+                        flowStatus = MessageFlowStatus.Sent,
+                        expirationStatus = ExpirationStatus.NotExpirable
+                    ),
+                    messageId = "message_id",
+                    connectionState = null,
+                    isSenderDeleted = false,
+                    isSenderUnavailable = false,
+                ),
+                source = MessageSource.OtherUser,
+                userAvatarData = UserAvatarData(),
+                messageContent = UIMessageContent.TextMessage(MessageBody("Hello".toUIText())),
+                messageFooter = MessageFooter("message_id")
+            )
+        }
+
+        fun withMappingFailure() = apply {
+            coEvery { messageMapper.toUIMessage(any(), any()) } returns null
+        }
+
+        fun withSystemUIMessage() = apply {
+            coEvery { messageMapper.toUIMessage(any(), any()) } returns messageSystem
+        }
+
+        fun arrange() = this to GetQuoteMessageForConversationUseCase(
+            getMessageById = getMessageById,
+            getUsersForMessage = getUsersForMessage,
+            messageMapper = messageMapper,
+            dispatchers = dispatchers
+        )
+    }
+
+    private companion object {
+        val CONVERSATION_ID = ConversationId("conversation-id", "domain")
+        val USER_ID = QualifiedID("user-id", "domain")
+        val CLIENT_ID = PlainId("client-id")
+        const val QUOTED_MESSAGE_ID = "quoted-message-id"
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16897" title="WPB-16897" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16897</a>  [Android] Support reply for multipart message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues
Message text update is broken. After each typed character the cursor jumps to the end of the text.

### Causes (Optional)
Draft is saved after each typed character. Observing the draft updated message input text after each text update.

### Solutions
Revert the draft observation back to single get operation.
