### PR TITLE
feat: edit multipart message text (WPB-16899)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -321,6 +321,7 @@ fun ConversationScreen(
                 mentions = compositionState.selectedMentions.map {
                     it.intoMessageMention()
                 },
+                isMultipart = compositionState.isMultipart,
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
@@ -83,6 +83,7 @@ class MessageDraftViewModel @Inject constructor(
                     draftText = draft.text,
                     selectedMentions = draft.selectedMentionList.mapNotNull { it.toUiMention(draft.text) },
                     editMessageId = draft.editMessageId,
+                    isMultipart = draft.isMultipartEdit,
                     quotedMessage = quotedMessage as? UIQuotedMessage.UIQuotedData,
                     quotedMessageId = (quotedMessage as? UIQuotedMessage.UIQuotedData)?.messageId,
                 )
@@ -100,9 +101,7 @@ class MessageDraftViewModel @Inject constructor(
         }
     }
 
-    fun onMessageTextUpdate(newText: String) {
-        if (state.value.draftText != newText) {
-            saveDraft(state.value.toDraft(newText))
-        }
+    fun onMessageTextUpdate(messageDraft: MessageDraft) {
+        saveDraft(messageDraft)
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/model/MessageComposition.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/model/MessageComposition.kt
@@ -32,6 +32,7 @@ data class MessageComposition(
     val quotedMessage: UIQuotedMessage.UIQuotedData? = null,
     val quotedMessageId: String? = null,
     val selectedMentions: List<UIMention> = emptyList(),
+    val isMultipart: Boolean = false,
 ) {
     fun getSelectedMentions(newMessageText: String): List<UIMention> {
         val result = mutableSetOf<UIMention>()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
@@ -44,7 +44,7 @@ fun rememberMessageComposerStateHolder(
     draftMessageComposition: MessageComposition,
     onClearDraft: () -> Unit,
     onSaveDraft: (MessageDraft) -> Unit,
-    onMessageTextUpdate: (String) -> Unit,
+    onMessageTextUpdate: (MessageDraft) -> Unit,
     onSearchMentionQueryChanged: (String) -> Unit,
     onClearMentionSearchResult: () -> Unit,
     onTypingEvent: (Conversation.TypingIndicatorMode) -> Unit,
@@ -140,9 +140,9 @@ class MessageComposerStateHolder(
 ) {
     val messageComposition = messageCompositionHolder.value.messageComposition
 
-    fun toEdit(messageId: String, editMessageText: String, mentions: List<MessageMention>) {
-        messageCompositionHolder.value.setEditText(messageId, editMessageText, mentions)
-        messageCompositionInputStateHolder.toEdit(editMessageText)
+    fun toEdit(messageId: String, editMessageText: String, mentions: List<MessageMention>, isMultipart: Boolean) {
+        messageCompositionHolder.value.setEditText(messageId, editMessageText, mentions, isMultipart)
+        messageCompositionInputStateHolder.toEdit(editMessageText, isMultipart)
     }
 
     fun toReply(message: UIMessage.Regular) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
@@ -58,7 +58,7 @@ class MessageCompositionHolder(
     var messageTextState: TextFieldState,
     val onClearDraft: () -> Unit,
     private val onSaveDraft: (MessageDraft) -> Unit,
-    private val onMessageTextUpdate: (String) -> Unit,
+    private val onMessageTextUpdate: (MessageDraft) -> Unit,
     private val onSearchMentionQueryChanged: (String) -> Unit,
     private val onClearMentionSearchResult: () -> Unit,
     private val onTypingEvent: (TypingIndicatorMode) -> Unit,
@@ -120,7 +120,7 @@ class MessageCompositionHolder(
                 updateTypingEvent(messageText.toString())
                 updateMentionsIfNeeded(messageText.toString())
                 requestMentionSuggestionIfNeeded(messageText.toString(), selection)
-                onMessageTextUpdate(messageText.toString())
+                onMessageTextUpdate(messageComposition.value.toDraft(messageText = messageText.toString()))
             }
     }
 
@@ -242,7 +242,7 @@ class MessageCompositionHolder(
         onSaveDraft(messageComposition.value.toDraft(resultText))
     }
 
-    fun setEditText(messageId: String, editMessageText: String, mentions: List<MessageMention>) {
+    fun setEditText(messageId: String, editMessageText: String, mentions: List<MessageMention>, isMultipart: Boolean) {
         messageTextState.setTextAndPlaceCursorAtEnd(editMessageText)
         messageComposition.update {
             it.copy(
@@ -250,6 +250,7 @@ class MessageCompositionHolder(
                 editMessageId = messageId,
                 quotedMessage = null,
                 quotedMessageId = null,
+                isMultipart = isMultipart,
             )
         }
         onSaveDraft(messageComposition.value.toDraft(editMessageText))

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolder.kt
@@ -70,8 +70,11 @@ class MessageCompositionInputStateHolder(
             )
 
             is CompositionState.Editing -> InputType.Editing(
-                isEditButtonEnabled = messageTextState.text != state.originalMessageText &&
-                        messageTextState.text.isNotMarkdownBlank()
+                isEditButtonEnabled = when {
+                    messageTextState.text.isNotMarkdownBlank() && messageTextState.text != state.originalMessageText -> true
+                    !messageTextState.text.isNotMarkdownBlank() && state.allowEmptyText -> true
+                    else -> false
+                }
             )
         }
     }
@@ -104,8 +107,8 @@ class MessageCompositionInputStateHolder(
         optionsVisible = showOptions
     }
 
-    fun toEdit(editMessageText: String) {
-        compositionState = CompositionState.Editing(editMessageText)
+    fun toEdit(editMessageText: String, isMultipart: Boolean) {
+        compositionState = CompositionState.Editing(editMessageText, isMultipart)
         requestFocus()
     }
 
@@ -211,7 +214,7 @@ class MessageCompositionInputStateHolder(
 
 private sealed class CompositionState {
     data object Composing : CompositionState()
-    data class Editing(val originalMessageText: String) : CompositionState()
+    data class Editing(val originalMessageText: String, val allowEmptyText: Boolean) : CompositionState()
 }
 
 sealed class InputType {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -777,9 +777,9 @@
     <string name="profile_image_change_image_button_label">Change Picture…</string>
     <!--Conversation-->
     <string name="label_message_details">Message Details</string>
-    <string name="label_copy">Copy</string>
+    <string name="label_copy">Copy text</string>
     <string name="label_share">Share</string>
-    <string name="label_edit">Edit</string>
+    <string name="label_edit">Edit text</string>
     <string name="label_delete">Delete</string>
     <string name="info_message_copied">Message copied</string>
     <string name="conversation_banner_federated">federated users</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerStateHolderTest.kt
@@ -114,7 +114,8 @@ class MessageComposerStateHolderTest {
         state.toEdit(
             messageId = "messageId",
             editMessageText = "edit_message_text",
-            mentions = listOf()
+            mentions = listOf(),
+            isMultipart = false,
         )
 
         // then
@@ -126,7 +127,8 @@ class MessageComposerStateHolderTest {
         state.toEdit(
             messageId = "messageId",
             editMessageText = "edit_message_text",
-            mentions = listOf()
+            mentions = listOf(),
+            isMultipart = false,
         )
         assertInstanceOf(InputType.Editing::class.java, messageCompositionInputStateHolder.inputType).also {
             assertEquals(false, it.isEditButtonEnabled)
@@ -138,7 +140,8 @@ class MessageComposerStateHolderTest {
         state.toEdit(
             messageId = "messageId",
             editMessageText = "edit_message_text",
-            mentions = listOf()
+            mentions = listOf(),
+            isMultipart = false,
         )
         state.messageCompositionHolder.value.messageTextState.edit {
             append("some text")

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionInputStateHolderTest.kt
@@ -113,7 +113,22 @@ class MessageCompositionInputStateHolderTest {
         val initialText = "Hello"
         val newText = "Hello World"
         val (state, _) = Arrangement().withText(initialText).arrange()
-        state.toEdit(newText)
+        state.toEdit(newText, false)
+
+        // When
+        val result = state.inputType as InputType.Editing
+
+        // Then
+        result.isEditButtonEnabled shouldBeEqualTo true
+    }
+
+    @Test
+    fun `given text has changed and is blank when transitioning to editing state then edit button is enabled for multipart`() = runTest {
+        // Given
+        val initialText = "Hello"
+        val newText = ""
+        val (state, _) = Arrangement().withText(initialText).arrange()
+        state.toEdit(newText, true)
 
         // When
         val result = state.inputType as InputType.Editing
@@ -195,7 +210,7 @@ class MessageCompositionInputStateHolderTest {
         val (state, _) = Arrangement().withText(messageText).arrange()
 
         // When
-        state.toEdit(messageText)
+        state.toEdit(messageText, false)
 
         // Then
         state.inputType.shouldBeInstanceOf<InputType.Editing>().isEditButtonEnabled shouldBeEqualTo false


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16899" title="WPB-16899" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16899</a>  [Android] Support edit for multipart message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-16899
----

# What's new in this PR?

Editing multipart message text. Main changes:
- Allow setting empty text for multipart messages
- Hide "Copy text" menu option if multipart message has no text
- Rename "Copy"\"Edit" to "Copy text"\"Edit text"
