### PR TITLE
feat: view wire cell images in internal viewer (WPB-21325)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/CellsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/CellsModule.kt
@@ -27,7 +27,9 @@ import com.wire.kalium.cells.domain.usecase.CreateFolderUseCase
 import com.wire.kalium.cells.domain.usecase.DeleteCellAssetUseCase
 import com.wire.kalium.cells.domain.usecase.DownloadCellFileUseCase
 import com.wire.kalium.cells.domain.usecase.GetAllTagsUseCase
+import com.wire.kalium.cells.domain.usecase.GetCellFileUseCase
 import com.wire.kalium.cells.domain.usecase.GetFoldersUseCase
+import com.wire.kalium.cells.domain.usecase.GetMessageAttachmentUseCase
 import com.wire.kalium.cells.domain.usecase.GetPaginatedFilesFlowUseCase
 import com.wire.kalium.cells.domain.usecase.GetPaginatedNodesUseCase
 import com.wire.kalium.cells.domain.usecase.IsAtLeastOneCellAvailableUseCase
@@ -164,6 +166,13 @@ class CellsModule {
     @Provides
     fun provideCellAvailableUseCase(cellsScope: CellsScope): IsAtLeastOneCellAvailableUseCase = cellsScope.isCellAvailable
 
+    @ViewModelScoped
+    @Provides
+    fun provideGetAttachmentUseCase(cellsScope: CellsScope): GetMessageAttachmentUseCase = cellsScope.getMessageAttachmentUseCase
+
     @Provides
     fun provideFileNameResolver(): FileNameResolver = FileNameResolver()
+
+    @Provides
+    fun provideGetCellNodeUseCase(cellsScope: CellsScope): GetCellFileUseCase = cellsScope.getCellFileUseCase
 }

--- a/app/src/main/kotlin/com/wire/android/ui/edit/ShareAssetMenuOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/ShareAssetMenuOption.kt
@@ -36,3 +36,17 @@ fun ShareAssetMenuOption(onShareAsset: () -> Unit) {
         onItemClick = onShareAsset
     )
 }
+
+@Composable
+fun SharePublicLinkMenuOption(onShareAsset: () -> Unit) {
+    MenuBottomSheetItem(
+        leading = {
+            MenuItemIcon(
+                id = com.wire.android.ui.common.R.drawable.ic_link,
+                contentDescription = stringResource(R.string.content_description_share_the_file),
+            )
+        },
+        title = stringResource(com.wire.android.feature.cells.R.string.public_link),
+        onItemClick = onShareAsset
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -549,7 +549,7 @@ fun ConversationScreen(
                 .show(DeleteMessageDialogState(deleteForEveryone, messageId, conversationMessagesViewModel.conversationId))
         },
         onAssetItemClicked = conversationMessagesViewModel::openOrFetchAsset,
-        onImageFullScreenMode = { message, isSelfMessage ->
+        onImageFullScreenMode = { message, isSelfMessage, cellAssetId ->
             with(conversationMessagesViewModel) {
                 navigator.navigate(
                     NavigationCommand(
@@ -558,7 +558,8 @@ fun ConversationScreen(
                             messageId = message.header.messageId,
                             isSelfAsset = isSelfMessage,
                             isEphemeral = message.header.messageStatus.expirationStatus is ExpirationStatus.Expirable,
-                            messageOptionsEnabled = true
+                            messageOptionsEnabled = true,
+                            cellAssetId = cellAssetId,
                         )
                     )
                 )
@@ -887,7 +888,7 @@ private fun ConversationScreen(
     onAudioRecorded: (UriAsset) -> Unit,
     onDeleteMessage: (String, Boolean) -> Unit,
     onAssetItemClicked: (String) -> Unit,
-    onImageFullScreenMode: (UIMessage.Regular, Boolean) -> Unit,
+    onImageFullScreenMode: (UIMessage.Regular, Boolean, String?) -> Unit,
     onStartCall: () -> Unit,
     onJoinCall: () -> Unit,
     onReactionClick: (messageId: String, reactionEmoji: String) -> Unit,
@@ -1075,7 +1076,7 @@ private fun ConversationScreenContent(
     onAttachmentPicked: (UriAsset) -> Unit,
     onAudioRecorded: (UriAsset) -> Unit,
     onAssetItemClicked: (String) -> Unit,
-    onImageFullScreenMode: (UIMessage.Regular, Boolean) -> Unit,
+    onImageFullScreenMode: (UIMessage.Regular, Boolean, String?) -> Unit,
     onReactionClicked: (String, String) -> Unit,
     onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit,
     onOpenProfile: (String) -> Unit,
@@ -1660,7 +1661,7 @@ fun PreviewConversationScreen() = WireTheme {
         onPingOptionClicked = { },
         onDeleteMessage = { _, _ -> },
         onAssetItemClicked = { },
-        onImageFullScreenMode = { _, _ -> },
+        onImageFullScreenMode = { _, _, _ -> },
         onStartCall = { },
         onJoinCall = { },
         onReactionClick = { _, _ -> },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
@@ -101,7 +101,7 @@ fun ConversationMediaScreen(
     Content(
         state = state,
         onNavigationPressed = { navigator.navigateBack() },
-        onImageFullScreenMode = { conversationId, messageId, isSelfAsset ->
+        onImageFullScreenMode = { conversationId, messageId, isSelfAsset, cellAssetId ->
             navigator.navigate(
                 NavigationCommand(
                     MediaGalleryScreenDestination(
@@ -109,7 +109,8 @@ fun ConversationMediaScreen(
                         messageId = messageId,
                         isSelfAsset = isSelfAsset,
                         isEphemeral = false,
-                        messageOptionsEnabled = false
+                        messageOptionsEnabled = false,
+                        cellAssetId = cellAssetId,
                     )
                 )
             )
@@ -167,7 +168,8 @@ fun ConversationMediaScreen(
 private fun Content(
     state: ConversationAssetMessagesViewState,
     initialPage: ConversationMediaScreenTabItem = ConversationMediaScreenTabItem.PICTURES,
-    onImageFullScreenMode: (conversationId: ConversationId, messageId: String, isSelfAsset: Boolean) -> Unit = { _, _, _ -> },
+    onImageFullScreenMode:
+        (conversationId: ConversationId, messageId: String, isSelfAsset: Boolean, cellAssetId: String?) -> Unit = { _, _, _, _ -> },
     onAssetItemClicked: (String) -> Unit = {},
     onOpenAssetOptions: (messageId: String, isMyMessage: Boolean) -> Unit = { _, _ -> },
     onNavigationPressed: () -> Unit = {},
@@ -216,7 +218,9 @@ private fun Content(
                     ConversationMediaScreenTabItem.PICTURES -> ImageAssetsContent(
                         imageMessageList = state.imageMessages,
                         assetStatuses = state.assetStatuses,
-                        onImageClicked = onImageFullScreenMode,
+                        onImageClicked = { conversationId, messageId, isSelfAsset ->
+                            onImageFullScreenMode(conversationId, messageId, isSelfAsset, null)
+                        },
                         onImageLongClicked = onOpenAssetOptions
                     )
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageClickActions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageClickActions.kt
@@ -27,7 +27,7 @@ sealed class MessageClickActions {
     open val onProfileClicked: (String) -> Unit = {}
     open val onReactionClicked: (String, String) -> Unit = { _, _ -> }
     open val onAssetClicked: (String) -> Unit = {}
-    open val onImageClicked: (UIMessage.Regular, Boolean) -> Unit = { _, _ -> }
+    open val onImageClicked: (UIMessage.Regular, Boolean, String?) -> Unit = { _, _, _ -> }
     open val onLinkClicked: (String) -> Unit = {}
     open val onReplyClicked: (UIMessage.Regular) -> Unit = {}
     open val onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit = { _, _ -> }
@@ -44,7 +44,7 @@ sealed class MessageClickActions {
         override val onProfileClicked: (String) -> Unit = {},
         override val onReactionClicked: (String, String) -> Unit = { _, _ -> },
         override val onAssetClicked: (String) -> Unit = {},
-        override val onImageClicked: (UIMessage.Regular, Boolean) -> Unit = { _, _ -> },
+        override val onImageClicked: (UIMessage.Regular, Boolean, String?) -> Unit = { _, _, _ -> },
         override val onLinkClicked: (String) -> Unit = {},
         override val onReplyClicked: (UIMessage.Regular) -> Unit = {},
         override val onResetSessionClicked: (senderUserId: UserId, clientId: String?) -> Unit = { _, _ -> },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/multipart/MultipartAttachmentsView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/multipart/MultipartAttachmentsView.kt
@@ -54,6 +54,7 @@ fun MultipartAttachmentsView(
     conversationId: ConversationId,
     attachments: List<MessageAttachment>,
     messageStyle: MessageStyle,
+    onImageAttachmentClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     accent: Accent = Accent.Unknown,
     viewModel: MultipartAttachmentsViewModel = hiltViewModel<MultipartAttachmentsViewModel>(key = conversationId.value),
@@ -66,7 +67,13 @@ fun MultipartAttachmentsView(
                 item = it,
                 messageStyle = messageStyle,
                 accent = accent,
-                onClick = { viewModel.onClick(it) },
+                onClick = {
+                    if (it.mimeType.startsWith("image/")) {
+                        onImageAttachmentClick(it.uuid)
+                    } else {
+                        viewModel.onClick(it)
+                    }
+                },
             )
         }
     } else {
@@ -82,7 +89,13 @@ fun MultipartAttachmentsView(
                         AttachmentsGrid(
                             attachments = group.attachments,
                             messageStyle = messageStyle,
-                            onClick = { viewModel.onClick(it) },
+                            onClick = {
+                                if (it.mimeType.startsWith("image/")) {
+                                    onImageAttachmentClick(it.uuid)
+                                } else {
+                                    viewModel.onClick(it)
+                                }
+                            },
                         )
 
                     is MultipartAttachmentsViewModel.MultipartAttachmentGroup.Files ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryNavArgs.kt
@@ -26,7 +26,8 @@ data class MediaGalleryNavArgs(
     val messageId: String,
     val isSelfAsset: Boolean,
     val isEphemeral: Boolean,
-    val messageOptionsEnabled: Boolean
+    val messageOptionsEnabled: Boolean,
+    val cellAssetId: String?,
 )
 
 @Parcelize
@@ -34,7 +35,8 @@ data class MediaGalleryNavBackArgs(
     val messageId: String,
     val emoji: String? = null,
     val isSelfAsset: Boolean = false,
-    val mediaGalleryActionType: MediaGalleryActionType
+    val mediaGalleryActionType: MediaGalleryActionType,
+    val cellAssetId: String? = null,
 ) : Parcelable
 
 enum class MediaGalleryActionType {

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -18,48 +18,57 @@
 
 package com.wire.android.ui.home.gallery
 
+import android.content.Context
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
+import coil.annotation.ExperimentalCoilApi
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.R
-import com.wire.android.model.ImageAsset
+import com.wire.android.feature.cells.ui.destinations.PublicLinkScreenDestination
+import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.annotation.app.WireDestination
 import com.wire.android.navigation.style.PopUpNavigationAnimation
+import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
 import com.wire.android.ui.common.bottomsheet.WireSheetValue
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
-import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dialogs.PermissionPermanentlyDeniedDialog
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.visbility.rememberVisibilityState
+import com.wire.android.ui.edit.DeleteItemMenuOption
+import com.wire.android.ui.edit.DownloadAssetExternallyOption
+import com.wire.android.ui.edit.MessageDetailsMenuOption
+import com.wire.android.ui.edit.ReactionOption
+import com.wire.android.ui.edit.ReplyMessageOption
+import com.wire.android.ui.edit.ShareAssetMenuOption
+import com.wire.android.ui.edit.SharePublicLinkMenuOption
 import com.wire.android.ui.home.conversations.MediaGallerySnackbarMessages
 import com.wire.android.ui.home.conversations.PermissionPermanentlyDeniedDialogState
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
-import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogState
-import com.wire.android.ui.home.conversations.edit.assetMessageOptionsMenuItems
-import com.wire.android.ui.home.conversations.edit.assetOptionsMenuItems
 import com.wire.android.ui.home.conversations.mock.mockedPrivateAsset
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.permission.rememberWriteStoragePermissionFlow
+import com.wire.android.util.startFileShareIntent
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.SnackBarMessageHandler
 import com.wire.android.util.ui.openDownloadFolder
 
+@OptIn(ExperimentalCoilApi::class)
 @WireDestination(
     navArgsDelegate = MediaGalleryNavArgs::class,
     style = PopUpNavigationAnimation::class,
@@ -75,11 +84,9 @@ fun MediaGalleryScreen(
         rememberVisibilityState<PermissionPermanentlyDeniedDialogState>()
 
     val viewModelState = mediaGalleryViewModel.mediaGalleryViewState
-    val bottomSheetState: WireModalSheetState<Unit> = rememberWireModalSheetState()
     val context = LocalContext.current
     val onSaveImageWriteStorageRequest = rememberWriteStoragePermissionFlow(
         onPermissionGranted = {
-            bottomSheetState.hide()
             mediaGalleryViewModel.saveImageToExternalStorage()
         },
         onPermissionDenied = { /** Nothing to do **/ },
@@ -98,10 +105,6 @@ fun MediaGalleryScreen(
         hideDialog = permissionPermanentlyDeniedDialogState::dismiss
     )
 
-    LaunchedEffect(viewModelState.messageDeleted) {
-        if (viewModelState.messageDeleted) navigator.navigateBack()
-    }
-
     DeleteMessageDialog(
         dialogState = mediaGalleryViewModel.deleteMessageDialogState,
         deleteMessage = mediaGalleryViewModel::deleteMessage,
@@ -109,53 +112,18 @@ fun MediaGalleryScreen(
 
     MediaGalleryContent(
         state = viewModelState,
-        imageAsset = mediaGalleryViewModel.imageAsset,
         onCloseClick = navigator::navigateBack,
-        onOptionsClick = bottomSheetState::show,
+        onOptionsClick = mediaGalleryViewModel::onOptionsClick,
         modifier = modifier,
     )
 
-    MediaGalleryOptionsBottomSheetLayout(
-        sheetState = bottomSheetState,
-        isEphemeral = mediaGalleryViewModel.mediaGalleryViewState.isEphemeral,
-        messageBottomSheetOptionsEnabled = viewModelState.messageBottomSheetOptionsEnabled,
-        deleteAsset = {
-            with(mediaGalleryViewModel.imageAsset) {
-                mediaGalleryViewModel.deleteMessageDialogState.show(DeleteMessageDialogState(isSelfAsset, messageId, conversationId))
-            }
-        },
-        showDetails = {
-            resultNavigator.setResult(
-                MediaGalleryNavBackArgs(
-                    messageId = mediaGalleryViewModel.imageAsset.messageId,
-                    isSelfAsset = mediaGalleryViewModel.imageAsset.isSelfAsset,
-                    mediaGalleryActionType = MediaGalleryActionType.DETAIL
-                )
-            )
-            resultNavigator.navigateBack()
-        },
-        shareAsset = { mediaGalleryViewModel.shareAsset(context) },
-        reply = {
-            resultNavigator.setResult(
-                MediaGalleryNavBackArgs(
-                    messageId = mediaGalleryViewModel.imageAsset.messageId,
-                    mediaGalleryActionType = MediaGalleryActionType.REPLY
-                )
-            )
-            resultNavigator.navigateBack()
-        },
-        react = { emoji ->
-            resultNavigator.setResult(
-                MediaGalleryNavBackArgs(
-                    messageId = mediaGalleryViewModel.imageAsset.messageId,
-                    emoji = emoji,
-                    mediaGalleryActionType = MediaGalleryActionType.REACT
-                )
-            )
-            resultNavigator.navigateBack()
-        },
-        downloadAsset = onSaveImageWriteStorageRequest::launch
-    )
+    if (viewModelState.menuItems.isNotEmpty()) {
+        MediaGalleryOptionsBottomSheetLayout(
+            menuItems = viewModelState.menuItems,
+            onMenuIntent = { mediaGalleryViewModel.onMenuIntent(it) },
+            onDismiss = { mediaGalleryViewModel.onOptionsDismissed() },
+        )
+    }
 
     SnackBarMessageHandler(mediaGalleryViewModel.snackbarMessage) { messageCode ->
         when (messageCode) {
@@ -164,12 +132,70 @@ fun MediaGalleryScreen(
             }
         }
     }
+
+    HandleActions(mediaGalleryViewModel.actions) { action ->
+        when (action) {
+            is MediaGalleryAction.Share -> context.startFileShareIntent(action.path, action.assetName)
+            is MediaGalleryAction.ShowDetails -> {
+                resultNavigator.setResult(
+                    MediaGalleryNavBackArgs(
+                        messageId = action.messageId,
+                        isSelfAsset = action.isSelfAsset,
+                        mediaGalleryActionType = MediaGalleryActionType.DETAIL
+                    )
+                )
+                resultNavigator.navigateBack()
+            }
+
+            is MediaGalleryAction.React -> {
+                resultNavigator.setResult(
+                    MediaGalleryNavBackArgs(
+                        messageId = action.messageId,
+                        emoji = action.emoji,
+                        mediaGalleryActionType = MediaGalleryActionType.REACT
+                    )
+                )
+                resultNavigator.navigateBack()
+            }
+
+            is MediaGalleryAction.Reply -> {
+                resultNavigator.setResult(
+                    MediaGalleryNavBackArgs(
+                        messageId = action.messageId,
+                        mediaGalleryActionType = MediaGalleryActionType.REPLY
+                    )
+                )
+                resultNavigator.navigateBack()
+            }
+
+            MediaGalleryAction.Download -> { onSaveImageWriteStorageRequest.launch() }
+            is MediaGalleryAction.SharePublicLink -> {
+                navigator.navigate(
+                    NavigationCommand(
+                        PublicLinkScreenDestination(
+                            assetId = action.assetId,
+                            fileName = action.assetName,
+                            publicLinkId = action.publicLinkId,
+                            isFolder = false,
+                        )
+                    )
+                )
+                mediaGalleryViewModel.onOptionsDismissed()
+            }
+
+            MediaGalleryAction.ShowError -> showErrorMessage(context)
+            MediaGalleryAction.Close -> navigator.navigateBack()
+        }
+    }
+}
+
+fun showErrorMessage(context: Context) {
+    Toast.makeText(context, R.string.label_general_error, Toast.LENGTH_SHORT).show()
 }
 
 @Composable
 private fun MediaGalleryContent(
     state: MediaGalleryViewState,
-    imageAsset: ImageAsset.Remote,
     onCloseClick: () -> Unit,
     onOptionsClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -192,11 +218,13 @@ private fun MediaGalleryContent(
                     .fillMaxHeight()
                     .background(colorsScheme().surface)
             ) {
-                ZoomableImage(
-                    modifier = Modifier.align(Alignment.Center),
-                    imageAsset = imageAsset,
-                    contentDescription = stringResource(R.string.content_description_image_message)
-                )
+                state.imageAsset?.let {
+                    ZoomableImage(
+                        modifier = Modifier.align(Alignment.Center),
+                        image = it,
+                        contentDescription = stringResource(R.string.content_description_image_message)
+                    )
+                }
             }
         }
     )
@@ -204,47 +232,47 @@ private fun MediaGalleryContent(
 
 @Composable
 private fun MediaGalleryOptionsBottomSheetLayout(
-    sheetState: WireModalSheetState<Unit>,
-    isEphemeral: Boolean,
-    messageBottomSheetOptionsEnabled: Boolean,
-    deleteAsset: () -> Unit,
-    showDetails: () -> Unit,
-    shareAsset: () -> Unit,
-    reply: () -> Unit,
-    react: (String) -> Unit,
-    downloadAsset: () -> Unit,
+    menuItems: List<MediaGalleryMenuItem>,
+    onMenuIntent: (MenuIntent) -> Unit,
+    onDismiss: () -> Unit,
 ) {
-    val onDeleteClick: () -> Unit = remember { { sheetState.hide(deleteAsset) } }
-    val onShowDetailsClick: () -> Unit = remember { { sheetState.hide(showDetails) } }
-    val onShareAssetClick: () -> Unit = remember { { sheetState.hide(shareAsset) } }
-    val onReplyClick: () -> Unit = remember { { sheetState.hide(reply) } }
-    val onReactClick: (String) -> Unit = remember { { emoji -> sheetState.hide { react(emoji) } } }
+
+    val sheetState: WireModalSheetState<Unit> = rememberWireModalSheetState(WireSheetValue.Expanded(Unit))
+    val onOptionsClick: (MenuIntent) -> Unit = remember { { sheetState.hide { onMenuIntent(it) } } }
+
+    val menuItems: List<@Composable () -> Unit> = buildList {
+        menuItems.forEach { item ->
+            when (item) {
+                MediaGalleryMenuItem.REACT -> add {
+                    ReactionOption(emptySet(), { onOptionsClick(MenuIntent.React(it)) })
+                }
+                MediaGalleryMenuItem.SHOW_DETAILS -> add {
+                    MessageDetailsMenuOption { onOptionsClick(MenuIntent.ShowDetails) }
+                }
+                MediaGalleryMenuItem.REPLY -> add {
+                    ReplyMessageOption { onOptionsClick(MenuIntent.Reply) }
+                }
+                MediaGalleryMenuItem.DOWNLOAD -> add {
+                    DownloadAssetExternallyOption { onOptionsClick(MenuIntent.Download) }
+                }
+                MediaGalleryMenuItem.SHARE -> add {
+                    ShareAssetMenuOption { onOptionsClick(MenuIntent.Share) }
+                }
+                MediaGalleryMenuItem.SHARE_PUBLIC_LINK -> add {
+                    SharePublicLinkMenuOption { onOptionsClick(MenuIntent.Share) }
+                }
+                MediaGalleryMenuItem.DELETE -> add {
+                    DeleteItemMenuOption { onOptionsClick(MenuIntent.Delete) }
+                }
+            }
+        }
+    }
+
     WireModalSheetLayout(
         sheetState = sheetState,
+        onDismissRequest = onDismiss,
         sheetContent = {
-            WireMenuModalSheetContent(
-                menuItems = if (messageBottomSheetOptionsEnabled) {
-                    assetMessageOptionsMenuItems(
-                        isUploading = false,
-                        isEphemeral = isEphemeral,
-                        onReplyClick = onReplyClick,
-                        onReactionClick = onReactClick,
-                        onDetailsClick = onShowDetailsClick,
-                        onDeleteClick = onDeleteClick,
-                        onShareAsset = onShareAssetClick,
-                        onDownloadAsset = downloadAsset,
-                        ownReactions = setOf()
-                    )
-                } else {
-                    assetOptionsMenuItems(
-                        isUploading = false,
-                        isEphemeral = isEphemeral,
-                        onDeleteClick = onDeleteClick,
-                        onShareAsset = onShareAssetClick,
-                        onDownloadAsset = downloadAsset,
-                    )
-                }
-            )
+            WireMenuModalSheetContent(menuItems = menuItems)
         }
     )
 }
@@ -254,10 +282,9 @@ private fun MediaGalleryOptionsBottomSheetLayout(
 fun PreviewMediaGalleryScreen() = WireTheme {
     MediaGalleryContent(
         state = MediaGalleryViewState(
+            imageAsset = MediaGalleryImage.PrivateAsset(mockedPrivateAsset()),
             screenTitle = "Media Gallery",
-            messageBottomSheetOptionsEnabled = true,
         ),
-        imageAsset = mockedPrivateAsset(),
         onCloseClick = {},
         onOptionsClick = {}
     )
@@ -267,14 +294,8 @@ fun PreviewMediaGalleryScreen() = WireTheme {
 @Composable
 fun PreviewMediaGalleryOptionsBottomSheetLayout() = WireTheme {
      MediaGalleryOptionsBottomSheetLayout(
-        sheetState = rememberWireModalSheetState(initialValue = WireSheetValue.Expanded(Unit)),
-        isEphemeral = false,
-        messageBottomSheetOptionsEnabled = true,
-        deleteAsset = {},
-        showDetails = {},
-        shareAsset = {},
-        reply = {},
-        react = {},
-        downloadAsset = {}
-    )
+         onMenuIntent = {},
+         onDismiss = {},
+         menuItems = emptyList(),
+     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
@@ -18,25 +18,26 @@
 
 package com.wire.android.ui.home.gallery
 
-import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.model.ImageAsset
+import com.wire.android.ui.common.ActionsViewModel
 import com.wire.android.ui.common.visbility.VisibilityState
 import com.wire.android.ui.home.conversations.MediaGallerySnackbarMessages
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogState
 import com.wire.android.ui.navArgs
 import com.wire.android.util.FileManager
 import com.wire.android.util.dispatchers.DispatcherProvider
-import com.wire.android.util.startFileShareIntent
+import com.wire.kalium.cells.domain.usecase.GetCellFileUseCase
+import com.wire.kalium.cells.domain.usecase.GetMessageAttachmentUseCase
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.CellAssetContent
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult.Success
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
@@ -59,25 +60,18 @@ class MediaGalleryViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val getImageData: GetMessageAssetUseCase,
     private val fileManager: FileManager,
-    private val deleteMessage: DeleteMessageUseCase
-) : ViewModel() {
+    private val deleteMessage: DeleteMessageUseCase,
+    private val getAttachment: GetMessageAttachmentUseCase,
+    private val getCellNode: GetCellFileUseCase,
+) : ActionsViewModel<MediaGalleryAction>() {
 
     private val mediaGalleryNavArgs: MediaGalleryNavArgs = savedStateHandle.navArgs()
-    val imageAsset: ImageAsset.PrivateAsset = ImageAsset.PrivateAsset(
-        mediaGalleryNavArgs.conversationId,
-        mediaGalleryNavArgs.messageId,
-        mediaGalleryNavArgs.isSelfAsset,
-        mediaGalleryNavArgs.isEphemeral
-    )
 
-    private val messageId = imageAsset.messageId
-    private val conversationId = imageAsset.conversationId
-    var mediaGalleryViewState by mutableStateOf(
-        MediaGalleryViewState(
-            isEphemeral = imageAsset.isEphemeral,
-            messageBottomSheetOptionsEnabled = mediaGalleryNavArgs.messageOptionsEnabled
-        )
-    )
+    private val messageId = mediaGalleryNavArgs.messageId
+    private val conversationId = mediaGalleryNavArgs.conversationId
+    private val cellAssetId = mediaGalleryNavArgs.cellAssetId
+
+    var mediaGalleryViewState by mutableStateOf(MediaGalleryViewState())
         private set
 
     var deleteMessageDialogState: VisibilityState<DeleteMessageDialogState> by mutableStateOf(VisibilityState())
@@ -88,13 +82,64 @@ class MediaGalleryViewModel @Inject constructor(
 
     init {
         getConversationTitle()
+        setupImageAsset()
     }
 
-    fun shareAsset(context: Context) {
-        viewModelScope.launch {
-            assetDataPath(conversationId, messageId)?.run {
-                context.startFileShareIntent(first, second)
+    private fun setupImageAsset() = viewModelScope.launch {
+        if (cellAssetId == null) {
+            mediaGalleryViewState = mediaGalleryViewState.copy(
+                imageAsset = MediaGalleryImage.PrivateAsset(
+                    asset = ImageAsset.PrivateAsset(
+                        mediaGalleryNavArgs.conversationId,
+                        mediaGalleryNavArgs.messageId,
+                        mediaGalleryNavArgs.isSelfAsset,
+                        mediaGalleryNavArgs.isEphemeral
+                    )
+                )
+            )
+        } else {
+            getAttachment(cellAssetId).onSuccess { attachment ->
+                (attachment as? CellAssetContent)?.let { cellAsset ->
+                    val localPath = cellAsset.localPath
+                    val url = cellAsset.contentUrl ?: cellAsset.previewUrl
+
+                    if (localPath != null) {
+                        mediaGalleryViewState = mediaGalleryViewState.copy(
+                            imageAsset = MediaGalleryImage.LocalAsset(localPath)
+                        )
+                    } else if (url != null) {
+                        mediaGalleryViewState = mediaGalleryViewState.copy(
+                            imageAsset = MediaGalleryImage.UrlAsset(
+                                url = url,
+                                placeholder = cellAsset.previewUrl,
+                                contentHash = cellAsset.contentHash,
+                            )
+                        )
+                    }
+                }
             }
+        }
+    }
+
+    private fun shareAsset() = viewModelScope.launch {
+        if (cellAssetId == null) {
+            assetDataPath(conversationId, messageId)?.run {
+                sendAction(MediaGalleryAction.Share(first, second))
+            }
+        } else {
+            getCellNode(cellAssetId)
+                .onSuccess { node ->
+                    sendAction(
+                        MediaGalleryAction.SharePublicLink(
+                            assetId = node.uuid,
+                            assetName = node.name ?: cellAssetId,
+                            publicLinkId = node.publicLinkId
+                        )
+                    )
+                }
+                .onFailure {
+                    sendAction(MediaGalleryAction.ShowError)
+                }
         }
     }
 
@@ -161,6 +206,40 @@ class MediaGalleryViewModel @Inject constructor(
         onSnackbarMessage(MediaGallerySnackbarMessages.OnImageDownloadError)
     }
 
+    fun onMenuIntent(menuIntent: MenuIntent) {
+        when (menuIntent) {
+            is MenuIntent.React -> sendAction(
+                MediaGalleryAction.React(
+                    messageId = messageId,
+                    emoji = menuIntent.emoji
+                )
+            )
+
+            MenuIntent.ShowDetails -> sendAction(
+                MediaGalleryAction.ShowDetails(
+                    messageId = messageId,
+                    isSelfAsset = mediaGalleryNavArgs.isSelfAsset
+                )
+            )
+
+            MenuIntent.Reply -> sendAction(
+                MediaGalleryAction.Reply(
+                    messageId = messageId
+                )
+            )
+
+            MenuIntent.Download -> sendAction(MediaGalleryAction.Download)
+
+            MenuIntent.Share -> shareAsset()
+
+            MenuIntent.Delete -> {
+                deleteMessageDialogState.show(
+                    DeleteMessageDialogState(mediaGalleryNavArgs.isSelfAsset, messageId, conversationId)
+                )
+            }
+        }
+    }
+
     fun deleteMessage(messageId: String, deleteForEveryone: Boolean) {
         viewModelScope.launch {
             deleteMessageDialogState.update { it.copy(loading = true) }
@@ -168,9 +247,83 @@ class MediaGalleryViewModel @Inject constructor(
                 .onFailure {
                     onSnackbarMessage(MediaGallerySnackbarMessages.DeletingMessageError)
                 }.onSuccess {
-                    mediaGalleryViewState = mediaGalleryViewState.copy(messageDeleted = true)
+                    sendAction(MediaGalleryAction.Close)
                 }
             deleteMessageDialogState.dismiss()
         }
     }
+
+    private fun buildMenuOptions() = buildList {
+        if (mediaGalleryNavArgs.messageOptionsEnabled) {
+            when {
+                cellAssetId != null -> {
+                    add(MediaGalleryMenuItem.REACT)
+                    add(MediaGalleryMenuItem.SHOW_DETAILS)
+                    add(MediaGalleryMenuItem.REPLY)
+                    add(MediaGalleryMenuItem.SHARE_PUBLIC_LINK)
+                }
+
+                mediaGalleryNavArgs.isEphemeral -> {
+                    add(MediaGalleryMenuItem.SHOW_DETAILS)
+                    add(MediaGalleryMenuItem.DOWNLOAD)
+                    add(MediaGalleryMenuItem.DELETE)
+                }
+
+                else -> {
+                    add(MediaGalleryMenuItem.REACT)
+                    add(MediaGalleryMenuItem.SHOW_DETAILS)
+                    add(MediaGalleryMenuItem.REPLY)
+                    add(MediaGalleryMenuItem.DOWNLOAD)
+                    add(MediaGalleryMenuItem.SHARE)
+                    add(MediaGalleryMenuItem.DELETE)
+                }
+            }
+        } else if (cellAssetId == null) {
+            add(MediaGalleryMenuItem.DOWNLOAD)
+            if (!mediaGalleryNavArgs.isEphemeral) add(MediaGalleryMenuItem.SHARE)
+            add(MediaGalleryMenuItem.DELETE)
+        }
+    }
+
+    fun onOptionsClick() {
+        mediaGalleryViewState = mediaGalleryViewState.copy(
+            menuItems = buildMenuOptions()
+        )
+    }
+
+    fun onOptionsDismissed() {
+        mediaGalleryViewState = mediaGalleryViewState.copy(
+            menuItems = emptyList()
+        )
+    }
+}
+
+sealed interface MediaGalleryAction {
+    data class ShowDetails(val messageId: String, val isSelfAsset: Boolean) : MediaGalleryAction
+    data class Share(val path: Path, val assetName: String) : MediaGalleryAction
+    data class React(val messageId: String, val emoji: String) : MediaGalleryAction
+    data class Reply(val messageId: String) : MediaGalleryAction
+    data object Download : MediaGalleryAction
+    data class SharePublicLink(val assetId: String, val assetName: String, val publicLinkId: String?) : MediaGalleryAction
+    data object ShowError : MediaGalleryAction
+    data object Close : MediaGalleryAction
+}
+
+sealed interface MenuIntent {
+    data class React(val emoji: String) : MenuIntent
+    data object ShowDetails : MenuIntent
+    data object Reply : MenuIntent
+    data object Download : MenuIntent
+    data object Share : MenuIntent
+    data object Delete : MenuIntent
+}
+
+enum class MediaGalleryMenuItem {
+    REACT,
+    SHOW_DETAILS,
+    REPLY,
+    DOWNLOAD,
+    SHARE,
+    SHARE_PUBLIC_LINK,
+    DELETE
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewState.kt
@@ -18,9 +18,16 @@
 
 package com.wire.android.ui.home.gallery
 
+import com.wire.android.model.ImageAsset
+
 data class MediaGalleryViewState(
+    val imageAsset: MediaGalleryImage? = null,
     val screenTitle: String? = null,
-    val isEphemeral: Boolean = false,
-    val messageBottomSheetOptionsEnabled: Boolean,
-    val messageDeleted: Boolean = false,
+    val menuItems: List<MediaGalleryMenuItem> = emptyList(),
 )
+
+sealed interface MediaGalleryImage {
+    data class PrivateAsset(val asset: ImageAsset.PrivateAsset) : MediaGalleryImage
+    data class LocalAsset(val path: String) : MediaGalleryImage
+    data class UrlAsset(val url: String, val placeholder: String?, val contentHash: String?) : MediaGalleryImage
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21325" title="WPB-21325" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21325</a>  [Android]Improve image display smoothness when opening photos
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-21325

# What's new in this PR?

Opening wire cell images in internal app image viewer.

- New parameter (cellAssetId) for click listeners and MediaGalleryScreen
- Media gallery now supports showing:
   - Private encrypted images
   - Cell files downloaded to device (with local path available)
   - Cell files via URL
- New cellAssetId parameter is used to fetch additional info for showing image
- Actions menu is refactored:
  - Menu building logic is moved to view model
  - Different menu options supported to regular and wire cell images
  - Added "Share via public link" option for wire cell images

