### PR TITLE
fix: text colors for cell attachment file names and reply preview (WPB-21712)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -655,13 +656,13 @@ internal fun MainMarkdownText(text: String, messageStyle: MessageStyle, accent: 
 }
 
 @Composable
-internal fun MainContentText(text: String, fontStyle: FontStyle = FontStyle.Normal) {
+internal fun MainContentText(text: String, fontStyle: FontStyle = FontStyle.Normal, color: Color = colorsScheme().onSurfaceVariant) {
     Text(
         text = text,
         style = typography().subline01,
         maxLines = TEXT_QUOTE_MAX_LINES,
         overflow = TextOverflow.Ellipsis,
-        color = colorsScheme().onSurfaceVariant,
+        color = color,
         fontStyle = fontStyle
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -244,6 +244,11 @@ internal fun QuotedMessageContent(
         MessageStyle.BUBBLE_OTHER -> colorsScheme().otherBubble.secondary
         MessageStyle.NORMAL -> MaterialTheme.wireColorScheme.surfaceVariant
     }
+    val quoteOutlineColor = when (style.messageStyle) {
+        MessageStyle.BUBBLE_SELF -> colorsScheme().selfBubble.secondary
+        MessageStyle.BUBBLE_OTHER -> colorsScheme().otherBubble.secondary
+        MessageStyle.NORMAL -> colorsScheme().outline
+    }
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(dimensions().spacing4x),
@@ -254,7 +259,7 @@ internal fun QuotedMessageContent(
             )
             .border(
                 width = 1.dp,
-                color = MaterialTheme.wireColorScheme.outline,
+                color = quoteOutlineColor,
                 shape = quoteOutlineShape
             )
             .padding(dimensions().spacing4x)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessage.kt
@@ -54,8 +54,8 @@ import com.wire.android.feature.cells.domain.model.AttachmentFileType
 import com.wire.android.feature.cells.domain.model.AttachmentFileType.VIDEO
 import com.wire.android.feature.cells.domain.model.icon
 import com.wire.android.model.Clickable
-import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.home.conversations.messages.item.textColor
 import com.wire.android.ui.home.conversations.model.UIMultipartQuotedContent
 import com.wire.android.ui.theme.Accent
 import com.wire.android.ui.theme.wireColorScheme
@@ -141,24 +141,24 @@ private fun MediaAttachmentThumbnail(attachment: UIMultipartQuotedContent) {
 }
 
 @Composable
-private fun MultipleAttachmentsLabel(count: Int) {
+private fun MultipleAttachmentsLabel(style: QuotedMessageStyle, count: Int) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(dimensions().spacing4x)
     ) {
         Icon(
             painter = painterResource(R.drawable.ic_multiple_files),
             contentDescription = null,
-            tint = colorsScheme().secondaryText
+            tint = style.messageStyle.textColor(),
         )
         Text(
             text = pluralStringResource(R.plurals.reply_multiple_files, count, count),
-            color = colorsScheme().secondaryText
+            color = style.messageStyle.textColor(),
         )
     }
 }
 
 @Composable
-private fun FileIconAndNameRow(file: UIMultipartQuotedContent) {
+private fun FileIconAndNameRow(style: QuotedMessageStyle, file: UIMultipartQuotedContent) {
 
     val name = file.name
     val attachmentFileType = name.fileExtension()?.let { AttachmentFileType.fromExtension(it) } ?: AttachmentFileType.OTHER
@@ -177,7 +177,7 @@ private fun FileIconAndNameRow(file: UIMultipartQuotedContent) {
         )
         Text(
             text = if (file.assetAvailable) name else stringResource(R.string.asset_message_failed_download_text),
-            color = colorsScheme().secondaryText
+            color = style.messageStyle.textColor(),
         )
     }
 }
@@ -217,19 +217,25 @@ fun QuotedMultipartMessageContent(
                 } else {
                     quotedMultipartMessage.mediaAttachment?.let { mediaAttachment ->
                         if (mediaAttachment.assetAvailable) {
-                            MainContentText(mediaAttachment.name)
+                            MainContentText(
+                                text = mediaAttachment.name,
+                                color = style.messageStyle.textColor()
+                            )
                         } else {
-                            MainContentText(stringResource(R.string.asset_message_failed_download_text))
+                            MainContentText(
+                                text = stringResource(R.string.asset_message_failed_download_text),
+                                color = style.messageStyle.textColor()
+                            )
                         }
                     }
                 }
 
                 if (quotedMultipartMessage.attachmentsCount > 1) {
-                    MultipleAttachmentsLabel(quotedMultipartMessage.attachmentsCount)
+                    MultipleAttachmentsLabel(style, quotedMultipartMessage.attachmentsCount)
                 }
 
                 quotedMultipartMessage.fileAttachment?.let { fileAttachment ->
-                    FileIconAndNameRow(fileAttachment)
+                    FileIconAndNameRow(style, fileAttachment)
                 }
             }
         },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/multipart/standalone/PdfAssetPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/multipart/standalone/PdfAssetPreview.kt
@@ -47,6 +47,7 @@ import com.wire.android.ui.common.multipart.AssetSource
 import com.wire.android.ui.common.multipart.MultipartAttachmentUi
 import com.wire.android.ui.common.progress.WireLinearProgressIndicator
 import com.wire.android.ui.home.conversations.messages.item.MessageStyle
+import com.wire.android.ui.home.conversations.messages.item.textColor
 import com.wire.android.ui.home.conversations.model.messagetypes.multipart.previewAvailable
 import com.wire.android.ui.home.conversations.model.messagetypes.multipart.previewImageModel
 import com.wire.android.ui.home.conversations.model.messagetypes.multipart.transferProgressColor
@@ -128,6 +129,7 @@ internal fun PdfAssetPreview(
                     .padding(start = dimensions().spacing8x, end = dimensions().spacing8x),
                 text = it,
                 style = MaterialTheme.wireTypography.body02,
+                color = messageStyle.textColor(),
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21712" title="WPB-21712" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21712</a>  [Android] Incorrect text colors for text in file name in message view and reply preview
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-21712

# What's new in this PR?

### Issues
Fixing invalid text colors in multipart replies and file names.

<img width="300"  alt="Screenshot_20251111_164209" src="https://github.com/user-attachments/assets/490bd55f-74c2-4a9f-918f-4c8ce70974f6" />
<img width="300"  alt="Screenshot_20251111_164146" src="https://github.com/user-attachments/assets/1c49aaa4-1329-4873-a7f1-7f4819f11e29" />
<img width="300"  alt="Screenshot_20251111_164032" src="https://github.com/user-attachments/assets/e8ed038c-08a7-44b4-89ae-f03d7ee32dc3" />

