### PR TITLE
fix: correct archive button logic in ConversationOptionsModalSheetLayout [WPB-22092]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationOptionsModalSheetLayout.kt
@@ -85,7 +85,7 @@ fun ConversationOptionsModalSheetLayout(
     )
     ArchiveConversationDialog(
         dialogState = viewModel.archiveConversationDialogState,
-        onArchiveButtonClicked = { viewModel.moveToArchive(it.conversationId, !it.isArchived, !it.isMember) }
+        onArchiveButtonClicked = { viewModel.moveToArchive(it.conversationId, !it.isArchived, it.isMember) }
     )
     HandleActions(viewModel.actions) { action ->
         when (action) {
@@ -119,7 +119,7 @@ fun ConversationOptionsModalSheetLayout(
                     updateConversationArchiveStatus = {
                         sheetState.hide {
                             when {
-                                it.isArchived -> viewModel.moveToArchive(it.conversationId, false, !it.isMember)
+                                it.isArchived -> viewModel.moveToArchive(it.conversationId, false, it.isMember)
                                 else -> viewModel.archiveConversationDialogState.show(it)
                             }
                         }

--- a/app/src/test/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationOptionsMenuViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationOptionsMenuViewModelTest.kt
@@ -259,6 +259,44 @@ class ConversationOptionsMenuViewModelTest {
     }
 
     @Test
+    fun `given user is not a member, when moving to archive, then archive only locally`() = runTest(dispatcherProvider.main()) {
+        val (arrangement, viewModel) = Arrangement()
+            .withUpdateArchivedStatus(ArchiveStatusUpdateResult.Success)
+            .arrange()
+
+        viewModel.actions.test {
+            viewModel.moveToArchive(conversationId, true, false)
+
+            coVerify(exactly = 1) { arrangement.updateConversationArchivedStatus(conversationId, true, true, any()) }
+            assertIs<ConversationOptionsMenuViewAction.Message>(awaitItem()).also {
+                assertIs<HomeSnackBarMessage.UpdateArchivingStatusSuccess>(it.message).also {
+                    assertEquals(true, it.isArchiving)
+                }
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given user is not a member, when removing from archive, then unarchive only locally`() = runTest(dispatcherProvider.main()) {
+        val (arrangement, viewModel) = Arrangement()
+            .withUpdateArchivedStatus(ArchiveStatusUpdateResult.Success)
+            .arrange()
+
+        viewModel.actions.test {
+            viewModel.moveToArchive(conversationId, false, false)
+
+            coVerify(exactly = 1) { arrangement.updateConversationArchivedStatus(conversationId, false, true, any()) }
+            assertIs<ConversationOptionsMenuViewAction.Message>(awaitItem()).also {
+                assertIs<HomeSnackBarMessage.UpdateArchivingStatusSuccess>(it.message).also {
+                    assertEquals(false, it.isArchiving)
+                }
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `given success, when changing muted state, then call proper action`() = runTest(dispatcherProvider.main()) {
         val (arrangement, viewModel) = Arrangement()
             .withUpdateConversationMutedStatus(ConversationUpdateStatusResult.Success)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22092" title="WPB-22092" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22092</a>  [Android] archive a conversation is not working as expected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

archiving on android was happening only locally

### Causes (Optional)

the flag is self is a member, was flipped 

### Solutions

remove ! and add couple of tests 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
