### PR TITLE
fix: missing message content with bubble disabled [WPB-21763]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageBubbleItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageBubbleItem.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.unit.dp
 import com.wire.android.ui.common.applyIf
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.MessageStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
@@ -90,7 +89,7 @@ fun MessageBubbleItem(
         val leadingPadding = if (leading != null) {
             dimensions().spacing48x
         } else {
-            dimensions().spacing0x
+            dimensions().spacing12x
         }
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -101,12 +100,10 @@ fun MessageBubbleItem(
             },
             verticalAlignment = Alignment.Bottom
         ) {
-            if (leading != null) {
-                Box(Modifier.width(leadingPadding), contentAlignment = Alignment.BottomStart) {
+            Box(Modifier.width(leadingPadding), contentAlignment = Alignment.BottomStart) {
+                if (leading != null) {
                     leading()
                 }
-            } else {
-                HorizontalSpace.x12()
             }
             Column(
                 modifier = Modifier.applyIf(!message.decryptionFailed) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
@@ -1,6 +1,7 @@
 package com.wire.android.ui.home.conversations.messages.item
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -12,6 +13,7 @@ import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.media.audiomessage.AudioMessageArgs
 import com.wire.android.model.Clickable
+import com.wire.android.ui.common.applyIf
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.spacers.VerticalSpace
@@ -52,7 +54,6 @@ internal fun UIMessage.Regular.MessageContentAndStatus(
     onReplyClicked: (UIMessage.Regular) -> Unit,
     shouldDisplayMessageStatus: Boolean,
     conversationDetailsData: ConversationDetailsData,
-    modifier: Modifier = Modifier,
     accent: Accent = Accent.Unknown,
 ) {
     val onAssetClickable = remember(message) {
@@ -78,17 +79,16 @@ internal fun UIMessage.Regular.MessageContentAndStatus(
             onReplyClicked(message)
         }
     }
-    Column(
-        modifier
-    ) {
-        MessageContent(
-            message = message,
-            messageContent = messageContent,
-            searchQuery = searchQuery,
-            assetStatus = assetStatus,
-            onAssetClick = onAssetClickable,
-            onImageClick = onImageClickable,
-            onMultipartImageClick = onMultipartImageClickable,
+    Row {
+        Column(Modifier.applyIf(!messageStyle.isBubble()) { weight(1F) }) {
+            MessageContent(
+                message = message,
+                messageContent = messageContent,
+                searchQuery = searchQuery,
+                assetStatus = assetStatus,
+                onAssetClick = onAssetClickable,
+                onImageClick = onImageClickable,
+                onMultipartImageClick = onMultipartImageClickable,
                 onOpenProfile = onProfileClicked,
                 onLinkClick = onLinkClicked,
                 onReplyClick = onReplyClickable,
@@ -120,6 +120,7 @@ internal fun UIMessage.Regular.MessageContentAndStatus(
                 VerticalSpace.x2()
             } else {
                 VerticalSpace.x4()
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentItem.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
-import com.wire.android.ui.common.applyIf
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.spacers.VerticalSpace
@@ -101,10 +100,6 @@ fun MessageContentItem(
                     shouldDisplayMessageStatus = shouldDisplayMessageStatus,
                     conversationDetailsData = conversationDetailsData,
                     onReplyClicked = clickActions.onReplyClicked,
-                    modifier = Modifier
-                        .applyIf(!messageStyle.isBubble()) {
-                            weight(1F)
-                        }
                 )
                 if (shouldDisplayFooter && !messageStyle.isBubble()) {
                     VerticalSpace.x4()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21763" title="WPB-21763" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21763</a>  [Android] Missing message content when buble UI disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- fixed wrong column/row arrangement 
- fixed paddings for message bubble reactions for 1on1 conversation messages