### PR TITLE
fix(apps): consider protocol instead of feature flag for enabling apps interaction (WPB-21835)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -37,7 +37,6 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
-import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.type.isExternal
 import com.wire.kalium.logic.data.user.type.isTeamAdmin
 import com.wire.kalium.logic.feature.client.IsWireCellsEnabledUseCase
@@ -49,7 +48,6 @@ import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppsAllowedForUsageU
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.team.GetUpdatedSelfTeamUseCase
-import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -82,8 +80,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
     private val isMLSEnabled: IsMLSEnabledUseCase,
     refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase,
     private val isWireCellsEnabled: IsWireCellsEnabledUseCase,
-    private val observeIsAppsAllowedForUsage: ObserveIsAppsAllowedForUsageUseCase,
-    private val getDefaultProtocol: GetDefaultProtocolUseCase,
+    private val observeIsAppsAllowedForUsage: ObserveIsAppsAllowedForUsageUseCase
 ) : GroupConversationParticipantsViewModel(savedStateHandle, observeConversationMembers, refreshUsersWithoutMetadata),
     ActionsManager<GroupConversationDetailsViewAction> by ActionsManagerImpl() {
 
@@ -135,7 +132,8 @@ class GroupConversationDetailsViewModel @Inject constructor(
                 val channelPermissionType = groupDetails.getChannelPermissionType()
                 val channelAccessType = groupDetails.getChannelAccessType()
 
-                val isMLSTeam = getDefaultProtocol() == SupportedProtocol.MLS
+                // todo: WPB-21835: ignoring feature flag, and based on protocol until there is finalized apps support.
+                // isAppsUsageAllowed should be consider then.
                 val isMLSConversation = groupDetails.conversation.protocol is Conversation.ProtocolInfo.MLS
 
                 _isFetchingInitialData.value = false

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -96,6 +96,7 @@ class NewConversationViewModel @Inject constructor(
         viewModelScope.launch {
             observeIsAppsAllowedForUsage()
                 .collectLatest { appsAllowed ->
+                    // todo: WPB-21835: ignoring feature flag, and based on protocol until there is finalized apps support.
                     val isMLS = newGroupState.groupProtocol == CreateConversationParam.Protocol.MLS
                     groupOptionsState = groupOptionsState.copy(
                         isTeamAllowedToUseApps = !isMLS,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -66,7 +66,7 @@ class NewConversationViewModel @Inject constructor(
     private val getSelfUser: GetSelfUserUseCase,
     private val getDefaultProtocol: GetDefaultProtocolUseCase,
     private val isWireCellsFeatureEnabled: IsWireCellsEnabledUseCase,
-    private val observeIsAppsAllowedForUsage: ObserveIsAppsAllowedForUsageUseCase
+    private val observeIsAppsAllowedForUsage: ObserveIsAppsAllowedForUsageUseCase,
 ) : ViewModel() {
 
     var newGroupNameTextState: TextFieldState = TextFieldState()
@@ -96,9 +96,10 @@ class NewConversationViewModel @Inject constructor(
         viewModelScope.launch {
             observeIsAppsAllowedForUsage()
                 .collectLatest { appsAllowed ->
+                    val isMLS = newGroupState.groupProtocol == CreateConversationParam.Protocol.MLS
                     groupOptionsState = groupOptionsState.copy(
-                        isTeamAllowedToUseApps = appsAllowed,
-                        isAllowAppsEnabled = appsAllowed
+                        isTeamAllowedToUseApps = !isMLS,
+                        isAllowAppsEnabled = !isMLS
                     )
                 }
         }

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -366,15 +366,15 @@ class NewConversationViewModelTest {
     }
 
     @Test
-    fun `given apps are not allowed, when initializing viewModel, then state should reflect that`() = runTest {
+    fun `given apps are not allowed, when initializing, then state should ignore the feature flag and based on protocol`() = runTest {
         // Given
         val (_, viewModel) = NewConversationViewModelArrangement()
             .withGetSelfUser(isTeamMember = true)
             .withAppsAllowedResult(false)
             .arrange()
 
-        assertFalse(viewModel.groupOptionsState.isTeamAllowedToUseApps)
-        assertFalse(viewModel.groupOptionsState.isAllowAppsEnabled)
+        assertTrue(viewModel.groupOptionsState.isTeamAllowedToUseApps)
+        assertTrue(viewModel.groupOptionsState.isAllowAppsEnabled)
     }
 
     @Test


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21835" title="WPB-21835" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21835</a>  [Android] Old Bots flow disabled - consider team and conversation protocol instead of FF
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Feature flag for apps is not relevant as of now, and we need to provide support for old bots

### Causes (Optional)

Misalignment on bots and apps rollout

### Solutions

Ignore for now the feature flag and roll back to protocol based interaction of app.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution


### Attachments (Optional)
[Screen_recording_20251119_125808.webm](https://github.com/user-attachments/assets/8909c4c4-a958-4590-807b-efdf5f546e65)

[Screen_recording_20251119_125731.webm](https://github.com/user-attachments/assets/bc67b755-34b3-4ba1-847b-1f71fe784f3e)

[Screen_recording_20251119_140025.webm](https://github.com/user-attachments/assets/0862a8dd-342d-42c2-8ae3-58ca8d9036bf)

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
