### PR TITLE
feat: secure public link dialogs (WPB-20914)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/PublicLinkErrorDialog.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/PublicLinkErrorDialog.kt
@@ -1,0 +1,62 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.cells.ui.publiclink
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.DialogProperties
+import com.wire.android.feature.cells.R
+import com.wire.android.feature.cells.ui.util.PreviewMultipleThemes
+import com.wire.android.ui.common.WireDialog
+import com.wire.android.ui.common.WireDialogButtonProperties
+import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.theme.WireTheme
+
+@Composable
+internal fun PublicLinkErrorDialog(
+    title: String? = null,
+    message: String? = null,
+    onResult: (tryAgain: Boolean) -> Unit,
+) {
+    WireDialog(
+        title = title ?: stringResource(R.string.public_link_common_failure_dialog_title),
+        text = message ?: stringResource(R.string.public_link_common_failure_dialog_message),
+        onDismiss = { onResult(false) },
+        optionButton1Properties = WireDialogButtonProperties(
+            onClick = { onResult(true) },
+            text = stringResource(R.string.error_try_again_button_title),
+            type = WireDialogButtonType.Primary,
+        ),
+        dismissButtonProperties = WireDialogButtonProperties(
+            text = stringResource(id = R.string.cancel),
+            onClick = { onResult(false) },
+        ),
+        buttonsHorizontalAlignment = true,
+        properties = DialogProperties(usePlatformDefaultWidth = false, dismissOnBackPress = true, dismissOnClickOutside = true)
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+private fun PreviewErrorDialog() {
+    WireTheme {
+        PublicLinkErrorDialog(
+            onResult = {},
+        )
+    }
+}

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/PublicLinkViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/PublicLinkViewModel.kt
@@ -78,7 +78,7 @@ class PublicLinkViewModel @Inject constructor(
             }
         } else {
             publicLink?.let {
-                deletePublicLink(it.uuid)
+                sendAction(ShowRemoveConfirmation)
             }
         }
     }
@@ -92,6 +92,18 @@ class PublicLinkViewModel @Inject constructor(
                     isPasswordEnabled = isPasswordEnabled,
                 )
             )
+        }
+    }
+
+    fun onConfirmRemoval(confirmed: Boolean) {
+        if (confirmed) {
+            publicLink?.let {
+                deletePublicLink(it.uuid)
+            }
+        } else {
+            _state.update {
+                it.copy(isEnabled = true)
+            }
         }
     }
 
@@ -117,7 +129,7 @@ class PublicLinkViewModel @Inject constructor(
                 }
             }
             .onFailure {
-                sendAction(ShowError(R.string.error_create_public_link))
+                sendAction(ShowErrorDialog(PublicLinkError.Create))
                 _state.update { it.copy(isEnabled = false) }
             }
     }
@@ -159,7 +171,7 @@ class PublicLinkViewModel @Inject constructor(
                 }
             }
             .onFailure {
-                sendAction(ShowError(R.string.error_delete_public_link))
+                sendAction(ShowErrorDialog(PublicLinkError.Remove))
                 _state.update { it.copy(isEnabled = true) }
             }
     }
@@ -188,6 +200,13 @@ class PublicLinkViewModel @Inject constructor(
                     passwordSettings = PublicLinkPassword(passwordEnabled = isPasswordEnabled)
                 )
             )
+        }
+    }
+
+    internal fun retryError(error: PublicLinkError) {
+        when (error) {
+            PublicLinkError.Create -> createPublicLink()
+            PublicLinkError.Remove -> onConfirmRemoval(true)
         }
     }
 
@@ -224,5 +243,11 @@ internal data class PublicLinkExpiration(
 
 sealed interface PublicLinkViewAction
 internal data class ShowError(val message: Int, val closeScreen: Boolean = false) : PublicLinkViewAction
+internal data class ShowErrorDialog(val error: PublicLinkError) : PublicLinkViewAction
 internal data class CopyLink(val url: String) : PublicLinkViewAction
 internal data class OpenPasswordSettings(val linkUuid: String, val isPasswordEnabled: Boolean) : PublicLinkViewAction
+internal data object ShowRemoveConfirmation : PublicLinkViewAction
+
+internal enum class PublicLinkError {
+    Create, Remove
+}

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/PublicLinkConfirmationDialog.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/PublicLinkConfirmationDialog.kt
@@ -1,0 +1,91 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.cells.ui.publiclink.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.DialogProperties
+import com.wire.android.feature.cells.R
+import com.wire.android.feature.cells.ui.util.PreviewMultipleThemes
+import com.wire.android.ui.common.WireDialog
+import com.wire.android.ui.common.WireDialogButtonProperties
+import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.theme.WireTheme
+
+@Composable
+private fun PublicLinkConfirmationDialog(
+    title: String,
+    message: String,
+    actionText: String,
+    onResult: (confirmed: Boolean) -> Unit,
+) {
+    WireDialog(
+        title = title,
+        text = message,
+        onDismiss = { onResult(false) },
+        optionButton1Properties = WireDialogButtonProperties(
+            onClick = { onResult(true) },
+            text = actionText,
+            type = WireDialogButtonType.Primary,
+        ),
+        dismissButtonProperties = WireDialogButtonProperties(
+            text = stringResource(id = R.string.cancel),
+            onClick = { onResult(false) }
+        ),
+        buttonsHorizontalAlignment = false,
+        properties = DialogProperties(usePlatformDefaultWidth = false, dismissOnBackPress = true, dismissOnClickOutside = true)
+    )
+}
+
+@Composable
+internal fun RemovePasswordDialog(onResult: (confirmed: Boolean) -> Unit) =
+    PublicLinkConfirmationDialog(
+        title = stringResource(R.string.public_link_password_remove_dialog_title),
+        message = stringResource(R.string.public_link_password_remove_dialog_message),
+        actionText = stringResource(R.string.public_link_password_remove_dialog_action),
+        onResult = onResult,
+    )
+
+@Composable
+internal fun RemovePublicLinkDialog(onResult: (confirmed: Boolean) -> Unit) =
+    PublicLinkConfirmationDialog(
+        title = stringResource(R.string.public_link_remove_dialog_title),
+        message = stringResource(R.string.public_link_remove_dialog_message),
+        actionText = stringResource(R.string.public_link_remove_dialog_action),
+        onResult = onResult,
+    )
+
+@PreviewMultipleThemes
+@Composable
+private fun PreviewRemovePasswordDialog() {
+    WireTheme {
+        RemovePasswordDialog(
+            onResult = {},
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+private fun PreviewRemoveLinkDialog() {
+    WireTheme {
+        RemovePublicLinkDialog(
+            onResult = {},
+        )
+    }
+}

--- a/features/cells/src/main/res/values/strings.xml
+++ b/features/cells/src/main/res/values/strings.xml
@@ -147,4 +147,15 @@
     <string name="public_link_missing_password_dialog_title">No access to existing password</string>
     <string name="public_link_missing_password_dialog_message">After reinstalling Wire, you can’t copy the set password. Yet, it is still valid.\nIf you didn’t save the password, change it and reshare the updated link.</string>
     <string name="public_link_missing_password_dialog_message_action">Change password</string>
+    <string name="public_link_password_remove_dialog_title">Remove password?</string>
+    <string name="public_link_password_remove_dialog_message">Anyone with the link can open the file and view its contents.</string>
+    <string name="public_link_password_remove_dialog_action">Remove</string>
+    <string name="public_link_remove_dialog_title">Disable public link?</string>
+    <string name="public_link_remove_dialog_message">People can’t access the content anymore.</string>
+    <string name="public_link_remove_dialog_action">Disable</string>
+    <string name="public_link_common_failure_dialog_title">Something went wrong</string>
+    <string name="public_link_common_failure_dialog_message">Please try again.\n\nIf this error persists, contact your team administrator.</string>
+    <string name="public_link_password_create_failure_dialog_title">Unable to create password-secured link</string>
+    <string name="public_link_password_create_failure_dialog_message">Please try again.\n\nIf this error persists, contact your team administrator.</string>
+    <string name="error_try_again_button_title">Try again</string>
 </resources>

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/publiclink/PublicLinkViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/publiclink/PublicLinkViewModelTest.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -111,7 +112,21 @@ class PublicLinkViewModelTest {
     }
 
     @Test
-    fun `given public link available and loaded when disabled then link is deleted`() = runTest {
+    fun `given public link available and loaded when disabled then confirmation is shown`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withPublicLink()
+            .withLoadSuccess()
+            .withDeleteSuccess()
+            .arrange()
+
+        viewModel.actions.test {
+            viewModel.onEnabledClick()
+            assertEquals(ShowRemoveConfirmation, awaitItem())
+        }
+    }
+
+    @Test
+    fun `given public link available and loaded when disable confirmed then link is deleted`() = runTest {
         val (_, viewModel) = Arrangement()
             .withPublicLink()
             .withLoadSuccess()
@@ -120,7 +135,7 @@ class PublicLinkViewModelTest {
 
         viewModel.state.test {
 
-            viewModel.onEnabledClick()
+            viewModel.onConfirmRemoval(true)
 
             with(expectMostRecentItem()) {
                 assertFalse(isEnabled)
@@ -138,13 +153,8 @@ class PublicLinkViewModelTest {
             .arrange()
 
         viewModel.actions.test {
-
-            viewModel.onEnabledClick()
-
-            with(expectMostRecentItem()) {
-                assertTrue(this is ShowError)
-                assertFalse((this as ShowError).closeScreen)
-            }
+            viewModel.onConfirmRemoval(true)
+            assertEquals(ShowErrorDialog(PublicLinkError.Remove), awaitItem())
         }
     }
 
@@ -174,13 +184,8 @@ class PublicLinkViewModelTest {
             .arrange()
 
         viewModel.actions.test {
-
             viewModel.onEnabledClick()
-
-            with(expectMostRecentItem()) {
-                assertTrue(this is ShowError)
-                assertFalse((this as ShowError).closeScreen)
-            }
+            assertEquals(ShowErrorDialog(PublicLinkError.Create), awaitItem())
         }
     }
 

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/publiclink/settings/password/PublicLinkPasswordScreenViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/publiclink/settings/password/PublicLinkPasswordScreenViewModelTest.kt
@@ -112,14 +112,28 @@ class PublicLinkPasswordScreenViewModelTest {
     }
 
     @Test
-    fun `given link password enabled when disabled then remove use case called`() = runTest {
+    fun `given link password enabled when disabled then confirmation dialog is shown`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withPasswordEnabled(true)
+            .withPasswordRemoveSuccess()
+            .withLocalPassword("test")
+            .arrange()
+
+        viewModel.actions.test {
+            viewModel.onEnableClick()
+            assertEquals(ShowRemoveConfirmationDialog, awaitItem())
+        }
+    }
+
+    @Test
+    fun `given link password enabled when disable confirmed then remove use case called`() = runTest {
         val (arrangement, viewModel) = Arrangement()
             .withPasswordEnabled(true)
             .withPasswordRemoveSuccess()
             .withLocalPassword()
             .arrange()
 
-        viewModel.onEnableClick()
+        viewModel.onConfirmPasswordRemoval(true)
 
         coVerify(exactly = 1) {
             arrangement.updatePassword(
@@ -130,7 +144,7 @@ class PublicLinkPasswordScreenViewModelTest {
     }
 
     @Test
-    fun `given link password disabled when enabled and disabled then remove use case not called`() = runTest {
+    fun `given no link password when enabled and disabled then remove use case not called`() = runTest {
         val (arrangement, viewModel) = Arrangement()
             .withPasswordEnabled(false)
             .withPasswordRemoveSuccess()
@@ -155,8 +169,7 @@ class PublicLinkPasswordScreenViewModelTest {
 
         viewModel.state.test {
             skipItems(1)
-            viewModel.onEnableClick()
-            skipItems(1)
+            viewModel.onConfirmPasswordRemoval(true)
             val state = awaitItem()
             assertFalse(state.isEnabled)
             assertEquals(PasswordScreenState.SETUP_PASSWORD, state.screenState)
@@ -174,16 +187,14 @@ class PublicLinkPasswordScreenViewModelTest {
             .arrange()
 
         viewModel.state.test {
-            skipItems(1)
-            viewModel.onEnableClick()
-            skipItems(1)
+            viewModel.onConfirmPasswordRemoval(true)
             val state = awaitItem()
             assertTrue(state.isEnabled)
         }
     }
 
     @Test
-    fun `given remove password failure when disabled then error message is shown`() = runTest {
+    fun `given failure when remove password then error message is shown`() = runTest {
         val (_, viewModel) = Arrangement()
             .withPasswordEnabled(true)
             .withPasswordRemoveFailure()
@@ -191,8 +202,8 @@ class PublicLinkPasswordScreenViewModelTest {
             .arrange()
 
         viewModel.actions.test {
-            viewModel.onEnableClick()
-            assertTrue(awaitItem() is ShowError)
+            viewModel.onConfirmPasswordRemoval(true)
+            assertEquals(ShowPasswordError(PasswordError.RemoveFailure), awaitItem())
         }
     }
 
@@ -298,8 +309,8 @@ class PublicLinkPasswordScreenViewModelTest {
             .arrange()
 
         viewModel.actions.test {
-            viewModel.onEnableClick()
-            assertTrue(awaitItem() is ShowError)
+            viewModel.onConfirmPasswordRemoval(true)
+            assertEquals(ShowPasswordError(PasswordError.RemoveFailure), awaitItem())
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20914" title="WPB-20914" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20914</a>  [Android] Secure & Time-limited Public Links
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20914

# What's new in this PR?

Show confirmation and error dialogs for wire cell public links feature:
- Remove public link confirmation
- Remove password confirmation
- Link and password update error dialogs