### PR TITLE
fix: permissions for adding participants [WPB-22025] [WPB-20583]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -198,7 +198,6 @@ fun GroupConversationDetailsScreen(
                 else -> navigator.navigate(NavigationCommand(OtherUserProfileScreenDestination(participant.id, viewModel.conversationId)))
             }
         },
-        showAllowUserToAddParticipants = { viewModel.shouldShowAddParticipantButton() },
         onAddParticipantsPressed = {
             navigator.navigate(
                 NavigationCommand(
@@ -348,7 +347,6 @@ private fun GroupConversationDetailsContent(
     onEditSelfDeletingMessages: () -> Unit,
     onEditGroupName: () -> Unit,
     groupParticipantsState: GroupConversationParticipantsState,
-    showAllowUserToAddParticipants: () -> Boolean,
     isAbandonedOneOnOneConversation: Boolean,
     isWireCellEnabled: Boolean,
     onSearchConversationMessagesClick: () -> Unit,
@@ -466,7 +464,8 @@ private fun GroupConversationDetailsContent(
                         }
 
                         GroupConversationDetailsTabItem.PARTICIPANTS -> {
-                            val shouldShowAddParticipantsButton = showAllowUserToAddParticipants() && !isAbandonedOneOnOneConversation
+                            val shouldShowAddParticipantsButton = groupConversationOptionsState.canSelfAddParticipants
+                                    && !isAbandonedOneOnOneConversation
                             if (shouldShowAddParticipantsButton) {
                                 Box(modifier = Modifier.padding(MaterialTheme.wireDimensions.spacing16x)) {
                                     WirePrimaryButton(
@@ -624,7 +623,6 @@ fun PreviewGroupConversationDetails() {
             onEditSelfDeletingMessages = {},
             onEditGroupName = {},
             groupParticipantsState = GroupConversationParticipantsState.PREVIEW,
-            showAllowUserToAddParticipants = { true },
             isAbandonedOneOnOneConversation = false,
             isWireCellEnabled = false,
             onSearchConversationMessagesClick = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -38,6 +38,8 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.type.isExternal
+import com.wire.kalium.logic.data.user.type.isFederated
+import com.wire.kalium.logic.data.user.type.isRegularTeamMember
 import com.wire.kalium.logic.data.user.type.isTeamAdmin
 import com.wire.kalium.logic.feature.client.IsWireCellsEnabledUseCase
 import com.wire.kalium.logic.feature.conversation.ConversationUpdateReceiptModeResult
@@ -117,8 +119,10 @@ class GroupConversationDetailsViewModel @Inject constructor(
                 groupDetailsFlow,
                 observeSelfDeletionTimerSettingsForConversation(conversationId, considerSelfUserSettings = false),
             ) { groupDetails, selfDeletionTimer ->
+                val selfType = selfUser?.userType
                 val isSelfInTeamThatOwnsConversation = selfTeam?.id != null && selfTeam.id == groupDetails.conversation.teamId?.value
                 val isSelfExternalMember = selfUser?.userType?.isExternal() == true
+                val isRegularTeamMember = selfType?.isRegularTeamMember() == true
                 val isChannel = groupDetails is ConversationDetails.Group.Channel
                 val isSelfTeamAdmin = selfUser?.userType?.isTeamAdmin() == true
                 val canPerformChannelAdminTasks = isChannel && isSelfInTeamThatOwnsConversation && isSelfTeamAdmin
@@ -126,6 +130,23 @@ class GroupConversationDetailsViewModel @Inject constructor(
                 val canSelfPerformAdminTasks = (isRegularGroupAdmin) || (canPerformChannelAdminTasks)
                 val channelPermissionType = groupDetails.getChannelPermissionType()
                 val channelAccessType = groupDetails.getChannelAccessType()
+                val isExternalOrFederated =
+                    selfType?.isExternal() == true || selfType?.isFederated() == true
+                val canSelfAddParticipants =
+                    when {
+                        !isChannel -> isRegularGroupAdmin && !isExternalOrFederated
+
+                        groupOptionsState.value.isSelfTeamAdmin -> true
+
+                        canSelfPerformAdminTasks -> true
+
+                        channelPermissionType == ChannelAddPermissionType.EVERYONE &&
+                                isSelfInTeamThatOwnsConversation &&
+                                isRegularTeamMember ->
+                            true
+
+                        else -> false
+                    }
 
                 // WPB-21835: Apps availability logic controlled by feature flag
                 val isMLSConversation = groupDetails.conversation.protocol is Conversation.ProtocolInfo.MLS
@@ -162,6 +183,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
                         isWireCellEnabled = groupDetails.wireCell != null,
                         isWireCellFeatureEnabled = isWireCellsEnabled(),
                         isSelfPartOfATeam = selfTeam != null,
+                        canSelfAddParticipants = canSelfAddParticipants
                     )
                 )
             }.collect {}
@@ -198,24 +220,6 @@ class GroupConversationDetailsViewModel @Inject constructor(
         // new logic: based on feature flags
         groupDetails.conversation.isServicesAllowed()
     }
-
-    fun shouldShowAddParticipantButton(): Boolean {
-        val isSelfAdmin = groupParticipantsState.data.isSelfAnAdmin
-        val isSelfGuest = groupParticipantsState.data.isSelfGuest
-        val isSelfExternalMember = groupParticipantsState.data.isSelfExternalMember
-
-        return when {
-            groupOptionsState.value.isChannel -> {
-                val isEveryoneAllowed = groupOptionsState.value.channelAddPermissionType == ChannelAddPermissionType.EVERYONE
-                isEveryoneAllowed && !isSelfGuest || isSelfAdmin && !isSelfGuest || groupOptionsState.value.isSelfTeamAdmin
-            }
-
-            else -> {
-                isSelfAdmin && !isSelfExternalMember
-            }
-        }
-    }
-
     private fun ConversationDetails.getChannelPermissionType(): ChannelAddPermissionType? = if (this is ConversationDetails.Group.Channel) {
         this.permission.toUiEnum()
     } else {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
@@ -69,6 +69,7 @@ data class GroupConversationOptionsState(
     val isWireCellFeatureEnabled: Boolean = false,
     val isWireCellEnabled: Boolean = false,
     val isSelfPartOfATeam: Boolean = false,
+    val canSelfAddParticipants: Boolean = false
 ) {
 
     sealed interface Error {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantsState.kt
@@ -26,8 +26,6 @@ import com.wire.kalium.logic.data.user.UserId
 data class GroupConversationParticipantsState(
     val data: ConversationParticipantsData = ConversationParticipantsData()
 ) {
-    val addParticipantsEnabled: Boolean get() = data.isSelfAnAdmin && !data.isSelfExternalMember
-
     companion object {
         val PREVIEW = GroupConversationParticipantsState(
             data = ConversationParticipantsData(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupDetailsViewModelTest.kt
@@ -407,7 +407,7 @@ class GroupDetailsViewModelTest {
             val channelDetails = testChannel
                 .copy(
                     isSelfUserMember = true,
-                    permission =  ChannelAddPermission.EVERYONE
+                    permission = ChannelAddPermission.EVERYONE
                 )
 
             val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
@@ -625,8 +625,6 @@ class GroupDetailsViewModelTest {
             // Then
             assertEquals(false, viewModel.groupOptionsState.value.canSelfAddParticipants)
         }
-
-
 
     companion object {
         val dummyConversationId = ConversationId("some-dummy-value", "some.dummy.domain")

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupDetailsViewModelTest.kt
@@ -35,6 +35,9 @@ import com.wire.android.ui.navArgs
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.ConversationDetails.Group.Channel.ChannelAccess
+import com.wire.kalium.logic.data.conversation.ConversationDetails.Group.Channel.ChannelAddPermission
+import com.wire.kalium.logic.data.conversation.ConversationHistorySettings
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.TeamId
@@ -391,30 +394,31 @@ class GroupDetailsViewModelTest {
     }
 
     @Test
-    fun `Given isChannel is true and EVERYONE permission, when isSelfGuest is false, then should show addParticipants button`() {
-        // Given
-        val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
-            .arrange()
-        viewModel.groupParticipantsState = viewModel.groupParticipantsState.copy(
-            data = viewModel.groupParticipantsState.data.copy(
-                isSelfAnAdmin = false,
-                isSelfGuest = false,
-                isSelfExternalMember = false
+    fun `given channel EVERYONE and self is regular team member of owning team, then canSelfAddParticipants is true`() =
+        runTest {
+            // Given
+            val selfTeamId = TeamId("team_id")
+            val self = TestUser.SELF_USER.copy(
+                userType = UserTypeInfo.Regular(UserType.INTERNAL),
+                teamId = selfTeamId
             )
-        )
-        viewModel.updateState(
-            viewModel.groupOptionsState.value.copy(
-                isChannel = true,
-                channelAddPermissionType = ChannelAddPermissionType.EVERYONE
-            )
-        )
 
-        // When
-        val result = viewModel.shouldShowAddParticipantButton()
+            // When
+            val channelDetails = testChannel
+                .copy(
+                    isSelfUserMember = true,
+                    permission =  ChannelAddPermission.EVERYONE
+                )
 
-        // Then
-        assertEquals(true, result)
-    }
+            val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+                .withGetSelfUserReturns(self)
+                .withSelfTeamUseCaseReturns(Team(selfTeamId.value, "team_name", "icon"))
+                .withConversationDetailUpdate(channelDetails)
+                .arrange()
+
+            // Then
+            assertEquals(true, viewModel.groupOptionsState.value.canSelfAddParticipants)
+        }
 
     @Test
     fun `Given isChannel is true and EVERYONE permission, when isSelfGuest is true, then should not show addParticipants button`() {
@@ -436,36 +440,33 @@ class GroupDetailsViewModelTest {
         )
 
         // When
-        val result = viewModel.shouldShowAddParticipantButton()
+        val result = viewModel.groupOptionsState.value.canSelfAddParticipants
 
         // Then
         assertEquals(false, result)
     }
 
     @Test
-    fun `Given regular group and isSelfAdmin is true, when isSelfExternalMember is false, then should show button`() {
-        val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
-            .arrange()
-        viewModel.groupParticipantsState = viewModel.groupParticipantsState.copy(
-            data = viewModel.groupParticipantsState.data.copy(
-                isSelfAnAdmin = true,
-                isSelfGuest = false,
-                isSelfExternalMember = false
+    fun `given regular group and self is admin and not external, then canSelfAddParticipants is true`() =
+        runTest {
+            // Given
+            val details = testGroup.copy(
+                selfRole = Conversation.Member.Role.Admin
             )
-        )
-        viewModel.updateState(
-            viewModel.groupOptionsState.value.copy(
-                isChannel = false,
-                channelAddPermissionType = ChannelAddPermissionType.EVERYONE
+
+            val self = TestUser.SELF_USER.copy(
+                userType = UserTypeInfo.Regular(UserType.INTERNAL) // not EXTERNAL, not FEDERATED
             )
-        )
 
-        // When
-        val result = viewModel.shouldShowAddParticipantButton()
+            // When
+            val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+                .withConversationDetailUpdate(details)
+                .withGetSelfUserReturns(self)
+                .arrange()
 
-        // Then
-        assertEquals(true, result)
-    }
+            // Then
+            assertEquals(true, viewModel.groupOptionsState.value.canSelfAddParticipants)
+        }
 
     @Test
     fun `Given regular group and isSelfAdmin is false, when isSelfExternalMember is true, then should not show button`() {
@@ -486,7 +487,7 @@ class GroupDetailsViewModelTest {
         )
 
         // When
-        val result = viewModel.shouldShowAddParticipantButton()
+        val result = viewModel.groupOptionsState.value.canSelfAddParticipants
 
         // Then
         assertEquals(false, result)
@@ -511,37 +512,121 @@ class GroupDetailsViewModelTest {
         )
 
         // When
-        val result = viewModel.shouldShowAddParticipantButton()
+        val result = viewModel.groupOptionsState.value.canSelfAddParticipants
 
         // Then
         assertEquals(false, result)
     }
 
     @Test
-    fun `Given isChannel is true and isSelfTeamAdmin is true, then should show button`() {
-        val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
-            .arrange()
-        viewModel.groupParticipantsState = viewModel.groupParticipantsState.copy(
-            data = viewModel.groupParticipantsState.data.copy(
-                isSelfAnAdmin = false,
-                isSelfGuest = false,
-                isSelfExternalMember = true
+    fun `given channel and self is team admin of owning team, then canSelfAddParticipants is true`() =
+        runTest {
+            // Given
+            val selfTeamId = TeamId("team_id")
+            val self = TestUser.SELF_USER.copy(
+                userType = UserTypeInfo.Regular(UserType.ADMIN),
+                teamId = selfTeamId
             )
-        )
-        viewModel.updateState(
-            viewModel.groupOptionsState.value.copy(
-                isSelfTeamAdmin = true,
-                isChannel = true,
-                channelAddPermissionType = ChannelAddPermissionType.ADMINS
+
+            // When
+            val channelDetails = testChannel.copy(
+                isSelfUserMember = true,
+                selfRole = Conversation.Member.Role.Member,
+                permission = ChannelAddPermission.ADMINS,
+                access = ChannelAccess.PRIVATE
             )
-        )
 
-        // When
-        val result = viewModel.shouldShowAddParticipantButton()
+            val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+                .withGetSelfUserReturns(self)
+                .withSelfTeamUseCaseReturns(Team(selfTeamId.value, "team_name", "icon"))
+                .withConversationDetailUpdate(channelDetails)
+                .arrange()
 
-        // Then
-        assertEquals(true, result)
-    }
+            // Then
+            assertEquals(true, viewModel.groupOptionsState.value.canSelfAddParticipants)
+        }
+
+    @Test
+    fun `given channel EVERYONE and self is regular team member from other team, then canSelfAddParticipants is false`() =
+        runTest {
+            // Given
+            val selfTeamId = TeamId("other_team_id")
+            val self = TestUser.SELF_USER.copy(
+                userType = UserTypeInfo.Regular(UserType.INTERNAL),
+                teamId = selfTeamId
+            )
+
+            // When
+            val channelDetails = testChannel.copy(
+                isSelfUserMember = true,
+                permission = ChannelAddPermission.EVERYONE
+            )
+
+            val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+                .withGetSelfUserReturns(self)
+                .withSelfTeamUseCaseReturns(Team(selfTeamId.value, "team_name", "icon"))
+                .withConversationDetailUpdate(channelDetails)
+                .arrange()
+
+            assertEquals(false, viewModel.groupOptionsState.value.canSelfAddParticipants)
+        }
+
+    @Test
+    fun `given channel EVERYONE and self is guest non admin of owning team, then canSelfAddParticipants is false`() =
+        runTest {
+            // Given
+            val selfTeamId = TeamId("team_id")
+            val self = TestUser.SELF_USER.copy(
+                userType = UserTypeInfo.Regular(UserType.GUEST),
+                teamId = selfTeamId
+            )
+
+            // When
+            val channelDetails = testChannel.copy(
+                isSelfUserMember = true,
+                selfRole = Conversation.Member.Role.Member,
+                permission = ChannelAddPermission.EVERYONE
+            )
+
+            val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+                .withGetSelfUserReturns(self)
+                .withSelfTeamUseCaseReturns(Team(selfTeamId.value, "team_name", "icon"))
+                .withConversationDetailUpdate(channelDetails)
+                .arrange()
+
+            // Then
+            assertEquals(false, viewModel.groupOptionsState.value.canSelfAddParticipants)
+        }
+
+    @Test
+    fun `given channel ADMINS and self is regular member of owning team, then canSelfAddParticipants is false`() =
+        runTest {
+            // Given
+            val selfTeamId = TeamId("team_id")
+            val self = TestUser.SELF_USER.copy(
+                userType = UserTypeInfo.Regular(UserType.INTERNAL),
+                teamId = selfTeamId
+            )
+
+            // When
+            val channelDetails = testChannel.copy(
+                isSelfUserMember = true,
+                selfRole = Conversation.Member.Role.Member,
+                permission = ChannelAddPermission.ADMINS,
+                access = ChannelAccess.PRIVATE
+            )
+
+            val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+                .withGetSelfUserReturns(self)
+                .withSelfTeamUseCaseReturns(Team(selfTeamId.value, "team_name", "icon"))
+                .withConversationDetailUpdate(channelDetails)
+                .arrange()
+
+            // Then
+            assertEquals(false, viewModel.groupOptionsState.value.canSelfAddParticipants)
+        }
+
+
 
     companion object {
         val dummyConversationId = ConversationId("some-dummy-value", "some.dummy.domain")
@@ -573,6 +658,41 @@ class GroupDetailsViewModelTest {
             isSelfUserMember = true,
             selfRole = Conversation.Member.Role.Member,
             wireCell = null,
+        )
+
+        val testChannel = ConversationDetails.Group.Channel(
+            Conversation(
+                id = dummyConversationId,
+                name = "Conv Name",
+                type = Conversation.Type.Group.Channel,
+                teamId = TeamId("team_id"),
+                protocol = Conversation.ProtocolInfo.Proteus,
+                mutedStatus = MutedConversationStatus.AllAllowed,
+                removedBy = null,
+                lastNotificationDate = null,
+                lastModifiedDate = null,
+                access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
+                accessRole = Conversation.defaultGroupAccessRoles.toMutableList().apply { add(Conversation.AccessRole.GUEST) },
+                lastReadDate = Instant.parse("2022-04-04T16:11:28.388Z"),
+                creatorId = null,
+                receiptMode = Conversation.ReceiptMode.ENABLED,
+                messageTimer = null,
+                userMessageTimer = null,
+                archived = false,
+                archivedDateTime = null,
+                mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+                proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+                legalHoldStatus = Conversation.LegalHoldStatus.ENABLED
+            ),
+            hasOngoingCall = false,
+            isSelfUserMember = true,
+            selfRole = Conversation.Member.Role.Member,
+            wireCell = null,
+            isFavorite = false,
+            folder = null,
+            access = ChannelAccess.PRIVATE,
+            permission = ChannelAddPermission.EVERYONE,
+            historySharing = ConversationHistorySettings.Private,
         )
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22025" title="WPB-22025" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22025</a>  [Android] Remove UI for non-team members to add users to a channel
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Removed shouldShowAddParticipantButton() and all related UI lambdas.
- Added consolidated permission logic in the ViewModel using UserTypeInfo extensions.
- UI now relies solely on groupConversationOptionsState.canSelfAddParticipants.
- Fixed incorrect previous behavior (external/federated or non-owning-team users being allowed in channels).
