### PR TITLE
feat: open online editor (WPB-21975)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/CellsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/CellsModule.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.cells.domain.usecase.DeleteCellAssetUseCase
 import com.wire.kalium.cells.domain.usecase.DownloadCellFileUseCase
 import com.wire.kalium.cells.domain.usecase.GetAllTagsUseCase
 import com.wire.kalium.cells.domain.usecase.GetCellFileUseCase
+import com.wire.kalium.cells.domain.usecase.GetEditorUrlUseCase
 import com.wire.kalium.cells.domain.usecase.GetFoldersUseCase
 import com.wire.kalium.cells.domain.usecase.GetMessageAttachmentUseCase
 import com.wire.kalium.cells.domain.usecase.GetPaginatedFilesFlowUseCase
@@ -195,4 +196,7 @@ class CellsModule {
     @Provides
     fun provideSetPublicLinkExpirationUseCase(cellsScope: CellsScope): SetPublicLinkExpirationUseCase =
         cellsScope.setPublicLinkExpiration
+
+    @Provides
+    fun provideEditorUrlUseCase(cellsScope: CellsScope): GetEditorUrlUseCase = cellsScope.getEditorUrl
 }

--- a/features/cells/build.gradle.kts
+++ b/features/cells/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(project(":core:ui-common"))
     implementation(libs.androidx.core)
     implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.browser)
     implementation(libs.material)
     implementation(libs.ktx.immutableCollections)
     implementation(libs.ktx.serialization)

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellFileActionsMenu.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellFileActionsMenu.kt
@@ -1,0 +1,137 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.cells.ui
+
+import com.wire.android.feature.cells.ui.model.CellNodeUi
+import com.wire.android.feature.cells.ui.model.NodeBottomSheetAction
+import com.wire.android.feature.cells.ui.model.isEditSupported
+import com.wire.android.feature.cells.ui.model.localFileAvailable
+import com.wire.kalium.logic.featureFlags.KaliumConfigs
+import javax.inject.Inject
+
+class CellFileActionsMenu @Inject constructor(
+    private val featureFlags: KaliumConfigs
+) {
+    internal fun buildMenu(
+        cellNode: CellNodeUi,
+        isRecycleBin: Boolean,
+        isConversationFiles: Boolean,
+        isAllFiles: Boolean,
+        isSearching: Boolean
+    ): List<NodeBottomSheetAction> =
+        when {
+            isRecycleBin -> {
+                buildList {
+                    add(NodeBottomSheetAction.RESTORE)
+                    add(NodeBottomSheetAction.DELETE_PERMANENTLY)
+                }
+            }
+
+            isConversationFiles -> {
+                buildList {
+                    if (cellNode is CellNodeUi.File && cellNode.localFileAvailable()) {
+                        add(NodeBottomSheetAction.SHARE)
+                    }
+                    add(NodeBottomSheetAction.PUBLIC_LINK)
+                    add(NodeBottomSheetAction.DOWNLOAD)
+
+                    if (featureFlags.collaboraIntegration && cellNode.isEditSupported()) {
+                        add(NodeBottomSheetAction.EDIT)
+                    }
+
+                    // to be enabled in next PR
+//                    if (cellNode is CellNodeUi.File) {
+//                        add(NodeBottomSheetAction.VERSION_HISTORY) // todo add feature flag
+//                    }
+
+                    add(NodeBottomSheetAction.ADD_REMOVE_TAGS)
+                    add(NodeBottomSheetAction.MOVE)
+                    add(NodeBottomSheetAction.RENAME)
+                    add(NodeBottomSheetAction.DELETE)
+                }
+            }
+
+            isAllFiles || isSearching -> {
+                buildList {
+                    if (cellNode is CellNodeUi.File && cellNode.localFileAvailable()) {
+                        add(NodeBottomSheetAction.SHARE)
+                    }
+                    add(NodeBottomSheetAction.PUBLIC_LINK)
+                    add(NodeBottomSheetAction.DOWNLOAD)
+                }
+            }
+
+            else -> {
+                emptyList()
+            }
+        }
+
+    internal sealed interface MenuActionResult
+    internal data class Action(val action: CellViewAction) : MenuActionResult
+    internal data class Share(val node: CellNodeUi.File) : MenuActionResult
+    internal data class Download(val node: CellNodeUi) : MenuActionResult
+    internal data class Edit(val node: CellNodeUi) : MenuActionResult
+
+    @Suppress("CyclomaticComplexMethod")
+    internal fun onMenuItemAction(
+        conversationId: String?,
+        parentFolderUuid: String?,
+        node: CellNodeUi,
+        action: NodeBottomSheetAction,
+        onResult: (MenuActionResult) -> Unit,
+    ) {
+        val result = when (action) {
+            NodeBottomSheetAction.SHARE -> {
+                if (node is CellNodeUi.File) {
+                    Share(node)
+                } else {
+                    Action(ShowPublicLinkScreen(node))
+                }
+            }
+
+            NodeBottomSheetAction.MOVE -> conversationId?.let {
+                Action(
+                    ShowMoveToFolderScreen(
+                        currentPath = it.substringBefore("/"),
+                        nodeToMovePath = "$it/${node.name}",
+                        uuid = node.uuid
+                    )
+                )
+            } ?: return
+
+            NodeBottomSheetAction.RESTORE -> {
+                if (parentFolderUuid != null) {
+                    Action(ShowRestoreParentFolderDialog(node))
+                } else {
+                    Action(ShowRestoreConfirmation(node = node))
+                }
+            }
+
+            NodeBottomSheetAction.DELETE_PERMANENTLY -> Action(ShowDeleteConfirmation(node = node, isPermanentDelete = true))
+            NodeBottomSheetAction.ADD_REMOVE_TAGS -> Action(ShowAddRemoveTagsScreen(node))
+            NodeBottomSheetAction.PUBLIC_LINK -> Action(ShowPublicLinkScreen(node))
+            NodeBottomSheetAction.RENAME -> Action(ShowRenameScreen(node))
+            NodeBottomSheetAction.DELETE -> Action(ShowDeleteConfirmation(node = node, isPermanentDelete = false))
+            NodeBottomSheetAction.DOWNLOAD -> Download(node)
+            NodeBottomSheetAction.EDIT -> Edit(node)
+            NodeBottomSheetAction.VERSION_HISTORY -> Action(ShowVersionHistoryScreen(node))
+        }
+
+        onResult(result)
+    }
+}

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
@@ -47,6 +47,7 @@ import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import com.wire.android.feature.cells.R
 import com.wire.android.feature.cells.ui.common.LoadingScreen
+import com.wire.android.feature.cells.ui.common.WireCellErrorDialog
 import com.wire.android.feature.cells.ui.dialog.DeleteConfirmationDialog
 import com.wire.android.feature.cells.ui.dialog.NodeActionsBottomSheet
 import com.wire.android.feature.cells.ui.download.DownloadFileBottomSheet
@@ -87,6 +88,7 @@ internal fun CellScreenContent(
     isRecycleBin: Boolean,
     isSearchResult: Boolean = false,
     isFiltering: Boolean = false,
+    retryEditNodeError: (String) -> Unit = {},
     showVersionHistoryScreen: (String) -> Unit = {}
 ) {
 
@@ -97,6 +99,7 @@ internal fun CellScreenContent(
     var restoreConfirmation by remember { mutableStateOf<CellNodeUi?>(null) }
     var showRestoreError by remember { mutableStateOf<ShowUnableToRestoreDialog?>(null) }
     var restoreParentFolderConfirmation by remember { mutableStateOf<CellNodeUi?>(null) }
+    var editNodeError by remember { mutableStateOf<String?>(null) }
     var menu by remember { mutableStateOf<MenuOptions?>(null) }
 
     val downloadFile by downloadFileState.collectAsState()
@@ -195,6 +198,17 @@ internal fun CellScreenContent(
         )
     }
 
+    editNodeError?.let { nodeUuid ->
+        WireCellErrorDialog(
+            title = stringResource(R.string.cell_open_editor_failure_dialog_title),
+            message = stringResource(R.string.cell_open_editor_failure_dialog_message),
+            onResult = { tryAgain ->
+                editNodeError = null
+                if (tryAgain) retryEditNodeError(nodeUuid)
+            }
+        )
+    }
+
     HandleActions(actionsFlow) { action ->
         when (action) {
             is ShowError -> Toast.makeText(context, action.error.message, Toast.LENGTH_SHORT).show()
@@ -212,7 +226,7 @@ internal fun CellScreenContent(
             is ShowRenameScreen -> showRenameScreen(action.cellNode)
             is ShowMoveToFolderScreen -> showMoveToFolderScreen(action.currentPath, action.nodeToMovePath, action.uuid)
             is ShowAddRemoveTagsScreen -> showAddRemoveTagsScreen(action.cellNode)
-            is ShowVersionHistoryScreen -> showVersionHistoryScreen(action.uuid)
+            is ShowVersionHistoryScreen -> showVersionHistoryScreen(action.cellNode.uuid)
             is RefreshData -> pagingListItems.refresh()
             is ShowUnableToRestoreDialog -> showRestoreError = action
             is ShowRestoreParentFolderDialog -> restoreParentFolderConfirmation = action.cellNode
@@ -221,6 +235,7 @@ internal fun CellScreenContent(
             is HideDeleteConfirmation -> deleteConfirmation = null
             is ShowFileDeletedMessage -> showDeleteConfirmation(context, action.isFile, action.permanently)
             is OpenFolder -> openFolder(action.path, action.title, action.parentFolderUuid)
+            is ShowEditErrorDialog -> editNodeError = action.nodeUuid
         }
     }
 

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
@@ -27,6 +27,7 @@ import androidx.paging.cachedIn
 import androidx.paging.filter
 import androidx.paging.map
 import com.wire.android.feature.cells.R
+import com.wire.android.feature.cells.ui.edit.OnlineEditor
 import com.wire.android.feature.cells.ui.model.CellNodeUi
 import com.wire.android.feature.cells.ui.model.NodeBottomSheetAction
 import com.wire.android.feature.cells.ui.model.canOpenWithUrl
@@ -40,6 +41,7 @@ import com.wire.kalium.cells.domain.model.Node
 import com.wire.kalium.cells.domain.usecase.DeleteCellAssetUseCase
 import com.wire.kalium.cells.domain.usecase.DownloadCellFileUseCase
 import com.wire.kalium.cells.domain.usecase.GetAllTagsUseCase
+import com.wire.kalium.cells.domain.usecase.GetEditorUrlUseCase
 import com.wire.kalium.cells.domain.usecase.GetPaginatedFilesFlowUseCase
 import com.wire.kalium.cells.domain.usecase.IsAtLeastOneCellAvailableUseCase
 import com.wire.kalium.cells.domain.usecase.RestoreNodeFromRecycleBinUseCase
@@ -83,7 +85,10 @@ class CellViewModel @Inject constructor(
     private val download: DownloadCellFileUseCase,
     private val isCellAvailable: IsAtLeastOneCellAvailableUseCase,
     private val fileHelper: FileHelper,
-    private val fileNameResolver: FileNameResolver
+    private val fileNameResolver: FileNameResolver,
+    private val getEditorUrl: GetEditorUrlUseCase,
+    private val onlineEditor: OnlineEditor,
+    private val cellFileActionsMenu: CellFileActionsMenu,
 ) : ActionsViewModel<CellViewAction>() {
 
     private val navArgs: CellFilesNavArgs = savedStateHandle.navArgs()
@@ -363,94 +368,46 @@ class CellViewModel @Inject constructor(
     }
 
     private fun onItemMenuClick(cellNode: CellNodeUi) = viewModelScope.launch {
-        val list = when {
-            isRecycleBin() -> {
-                buildList {
-                    add(NodeBottomSheetAction.RESTORE)
-                    add(NodeBottomSheetAction.DELETE_PERMANENTLY)
-                }
-            }
 
-            isConversationFiles() -> {
-                buildList {
-                    if (cellNode is CellNodeUi.File && cellNode.localFileAvailable()) {
-                        add(NodeBottomSheetAction.SHARE)
-                    }
-                    add(NodeBottomSheetAction.PUBLIC_LINK)
-                    add(NodeBottomSheetAction.DOWNLOAD)
-                    // to be enabled in next PR
-//                    if (cellNode is CellNodeUi.File) {
-//                        add(NodeBottomSheetAction.VERSION_HISTORY) // todo add feature flag
-//                    }
-                    add(NodeBottomSheetAction.ADD_REMOVE_TAGS)
-                    add(NodeBottomSheetAction.MOVE)
-                    add(NodeBottomSheetAction.RENAME)
-                    add(NodeBottomSheetAction.DELETE)
-                }
-            }
-
-            isAllFiles() || isSearching() -> {
-                buildList {
-                    if (cellNode is CellNodeUi.File && cellNode.localFileAvailable()) {
-                        add(NodeBottomSheetAction.SHARE)
-                    }
-                    add(NodeBottomSheetAction.PUBLIC_LINK)
-                    add(NodeBottomSheetAction.DOWNLOAD)
-                }
-            }
-
-            else -> {
-                emptyList()
-            }
-        }
-
-        val menuOption = MenuOptions(
-            node = cellNode,
-            actions = list,
+        val menuItems = cellFileActionsMenu.buildMenu(
+            cellNode = cellNode,
+            isRecycleBin = isRecycleBin(),
+            isConversationFiles = isConversationFiles(),
+            isAllFiles = isAllFiles(),
+            isSearching = isSearching()
         )
-        _menu.emit(menuOption)
+
+        _menu.emit(MenuOptions(cellNode, menuItems))
     }
 
-    @Suppress("CyclomaticComplexMethod")
     private fun onMenuItemAction(node: CellNodeUi, action: NodeBottomSheetAction) {
-        when (action) {
-            NodeBottomSheetAction.SHARE -> {
-                if (node is CellNodeUi.File) {
-                    shareFile(node)
-                } else {
-                    sendAction(ShowPublicLinkScreen(node))
-                }
+        cellFileActionsMenu.onMenuItemAction(
+            conversationId = navArgs.conversationId,
+            parentFolderUuid = navArgs.parentFolderUuid,
+            node = node,
+            action = action,
+        ) { result ->
+            when (result) {
+                is CellFileActionsMenu.Action -> sendAction(result.action)
+                is CellFileActionsMenu.Download -> downloadNode(result.node)
+                is CellFileActionsMenu.Edit -> editNode(result.node.uuid)
+                is CellFileActionsMenu.Share -> shareFile(result.node)
             }
-
-            NodeBottomSheetAction.PUBLIC_LINK -> sendAction(ShowPublicLinkScreen(node))
-            NodeBottomSheetAction.ADD_REMOVE_TAGS -> sendAction(ShowAddRemoveTagsScreen(node))
-            NodeBottomSheetAction.MOVE -> navArgs.conversationId?.let {
-                sendAction(
-                    ShowMoveToFolderScreen(
-                        currentPath = it.substringBefore("/"),
-                        nodeToMovePath = "$it/${node.name}",
-                        uuid = node.uuid
-                    )
-                )
-            }
-
-            NodeBottomSheetAction.RENAME -> sendAction(ShowRenameScreen(node))
-            NodeBottomSheetAction.DOWNLOAD -> downloadNode(node)
-            NodeBottomSheetAction.VERSION_HISTORY -> {
-                sendAction(ShowVersionHistoryScreen(node.uuid))
-            }
-
-            NodeBottomSheetAction.RESTORE -> {
-                if (navArgs.parentFolderUuid != null) {
-                    sendAction(ShowRestoreParentFolderDialog(node))
-                } else {
-                    sendAction(ShowRestoreConfirmation(node = node))
-                }
-            }
-
-            NodeBottomSheetAction.DELETE -> sendAction(ShowDeleteConfirmation(node = node, isPermanentDelete = false))
-            NodeBottomSheetAction.DELETE_PERMANENTLY -> sendAction(ShowDeleteConfirmation(node = node, isPermanentDelete = true))
         }
+    }
+
+    internal fun editNode(nodeUuid: String) = viewModelScope.launch {
+        getEditorUrl(nodeUuid)
+            .onSuccess { url ->
+                if (url != null) {
+                    onlineEditor.open(url)
+                } else {
+                    sendAction(ShowEditErrorDialog(nodeUuid))
+                }
+            }
+            .onFailure {
+                sendAction(ShowEditErrorDialog(nodeUuid))
+            }
     }
 
     private fun shareFile(cell: CellNodeUi.File) {
@@ -582,17 +539,14 @@ internal data class ShowPublicLinkScreen(val cellNode: CellNodeUi) : CellViewAct
 internal data class ShowRenameScreen(val cellNode: CellNodeUi) : CellViewAction
 internal data class ShowAddRemoveTagsScreen(val cellNode: CellNodeUi) : CellViewAction
 internal data class ShowMoveToFolderScreen(val currentPath: String, val nodeToMovePath: String, val uuid: String) : CellViewAction
-internal data class ShowVersionHistoryScreen(val uuid: String) : CellViewAction
+internal data class ShowVersionHistoryScreen(val cellNode: CellNodeUi) : CellViewAction
 internal data class ShowUnableToRestoreDialog(val isFolder: Boolean) : CellViewAction
 internal data class ShowRestoreParentFolderDialog(val cellNode: CellNodeUi) : CellViewAction
 internal data object HideRestoreParentFolderDialog : CellViewAction
 internal data class ShowFileDeletedMessage(val isFile: Boolean, val permanently: Boolean) : CellViewAction
 internal data object RefreshData : CellViewAction
-internal data class OpenFolder(
-    val path: String,
-    val title: String,
-    val parentFolderUuid: String?
-) : CellViewAction
+internal data class OpenFolder(val path: String, val title: String, val parentFolderUuid: String?) : CellViewAction
+internal data class ShowEditErrorDialog(val nodeUuid: String) : CellViewAction
 
 internal enum class CellError(val message: Int) {
     DOWNLOAD_FAILED(R.string.cell_files_download_failure_message),

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesScreen.kt
@@ -106,8 +106,9 @@ fun ConversationFilesScreen(
         isDeleteInProgress = viewModel.isDeleteInProgress.collectAsState().value,
         isRefreshing = viewModel.isPullToRefresh.collectAsState(),
         breadcrumbs = viewModel.breadcrumbs(),
-        sendIntent = { viewModel.sendIntent(it) },
-        onRefresh = { viewModel.onPullToRefresh() },
+        sendIntent = viewModel::sendIntent,
+        onRefresh = viewModel::onPullToRefresh,
+        retryEditNodeError = viewModel::editNode
     )
 
     LaunchedEffect(Unit) {
@@ -126,6 +127,7 @@ fun ConversationFilesScreenContent(
     sendIntent: (CellViewIntent) -> Unit,
     isRefreshing: State<Boolean>,
     onRefresh: () -> Unit,
+    retryEditNodeError: (String) -> Unit,
     modifier: Modifier = Modifier,
     onBreadcrumbsFolderClick: (index: Int) -> Unit = {},
     isDeleteInProgress: Boolean = false,
@@ -305,6 +307,7 @@ fun ConversationFilesScreenContent(
                 showVersionHistoryScreen = {
                     navigator.navigate(NavigationCommand(VersionHistoryScreenDestination(it)))
                 },
+                retryEditNodeError = { retryEditNodeError(it) },
                 isRefreshing = isRefreshing,
                 onRefresh = onRefresh
             )
@@ -360,7 +363,8 @@ fun PreviewConversationFilesScreen() {
             isRecycleBin = false,
             breadcrumbs = arrayOf("Engineering", "Android"),
             isRefreshing = remember { mutableStateOf(false) },
-            onRefresh = { }
+            onRefresh = {},
+            retryEditNodeError = {},
         )
     }
 }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesWithSlideInTransitionScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesWithSlideInTransitionScreen.kt
@@ -74,7 +74,8 @@ fun ConversationFilesWithSlideInTransitionScreen(
             val stepsBack = viewModel.breadcrumbs()?.size!! - it - 1
             navigator.navigateBackAndRemoveAllConsecutiveXTimes(ConversationFilesWithSlideInTransitionScreenDestination.route, stepsBack)
         },
-        sendIntent = { viewModel.sendIntent(it) },
-        onRefresh = { viewModel.onPullToRefresh() },
+        sendIntent = viewModel::sendIntent,
+        onRefresh = viewModel::onPullToRefresh,
+        retryEditNodeError = viewModel::editNode
     )
 }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/common/WireCellErrorDialog.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/common/WireCellErrorDialog.kt
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.android.feature.cells.ui.publiclink
+package com.wire.android.feature.cells.ui.common
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
@@ -28,7 +28,7 @@ import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.theme.WireTheme
 
 @Composable
-internal fun PublicLinkErrorDialog(
+internal fun WireCellErrorDialog(
     title: String? = null,
     message: String? = null,
     onResult: (tryAgain: Boolean) -> Unit,
@@ -55,7 +55,7 @@ internal fun PublicLinkErrorDialog(
 @Composable
 private fun PreviewErrorDialog() {
     WireTheme {
-        PublicLinkErrorDialog(
+        WireCellErrorDialog(
             onResult = {},
         )
     }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/edit/OnlineEditor.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/edit/OnlineEditor.kt
@@ -1,0 +1,87 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.cells.ui.edit
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.browser.customtabs.CustomTabsClient
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_DARK
+import androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_LIGHT
+import androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_SYSTEM
+import javax.inject.Inject
+
+class OnlineEditor @Inject constructor(
+    private val context: Context,
+) {
+
+    fun open(url: String) {
+
+        val uri = Uri.parse(url)
+
+        if (isCustomTabsSupported()) {
+            runCatching {
+                openCustomTab(uri)
+            }.onFailure {
+                openInBrowser(uri)
+            }
+        } else {
+            openInBrowser(uri)
+        }
+    }
+
+    private fun openCustomTab(uri: Uri) {
+
+        val customTabsIntent = CustomTabsIntent.Builder()
+            .setCloseButtonIcon(BitmapFactory.decodeResource(context.resources, com.wire.android.ui.common.R.drawable.ic_close))
+            .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
+            .setDownloadButtonEnabled(false)
+            .setBookmarksButtonEnabled(false)
+            .setColorScheme(getColorScheme())
+            .setShowTitle(true)
+            .build().apply {
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse("android-app://" + context.packageName))
+            }
+
+        customTabsIntent.launchUrl(context, uri)
+    }
+
+    private fun openInBrowser(uri: Uri) {
+        val intent = Intent().apply {
+            action = Intent.ACTION_VIEW
+            data = uri
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+    }
+
+    private fun getColorScheme() = when (AppCompatDelegate.getDefaultNightMode()) {
+        AppCompatDelegate.MODE_NIGHT_NO -> COLOR_SCHEME_LIGHT
+        AppCompatDelegate.MODE_NIGHT_YES -> COLOR_SCHEME_DARK
+        else -> COLOR_SCHEME_SYSTEM
+    }
+
+    private fun isCustomTabsSupported(): Boolean {
+        val packageName = CustomTabsClient.getPackageName(context, mutableListOf<String?>())
+        return packageName != null
+    }
+}

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/model/CellNodeUi.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/model/CellNodeUi.kt
@@ -67,6 +67,7 @@ sealed class CellNodeUi {
         val contentUrl: String? = null,
         val previewUrl: String? = null,
         override val tags: List<String> = emptyList(),
+        val isEditSupported: Boolean = false,
     ) : CellNodeUi()
 }
 
@@ -86,6 +87,7 @@ internal fun Node.File.toUiModel() = CellNodeUi.File(
     publicLinkId = publicLinkId,
     modifiedTime = formattedModifiedTime(),
     tags = tags,
+    isEditSupported = isEditSupported,
 )
 
 internal fun Node.Folder.toUiModel() = CellNodeUi.Folder(
@@ -110,3 +112,4 @@ private fun Node.Folder.formattedModifiedTime() = modifiedTime?.let {
 
 internal fun CellNodeUi.File.localFileAvailable() = localPath != null
 internal fun CellNodeUi.File.canOpenWithUrl() = contentUrl != null && assetType in listOf(IMAGE, VIDEO, PDF)
+internal fun CellNodeUi.isEditSupported() = (this as? CellNodeUi.File)?.isEditSupported == true

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/model/NodeBottomSheetAction.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/model/NodeBottomSheetAction.kt
@@ -30,6 +30,7 @@ enum class NodeBottomSheetAction(
     MOVE(R.string.move_label, R.drawable.ic_folder),
     RENAME(R.string.rename_label, R.drawable.ic_rename),
     DOWNLOAD(R.string.download_label, R.drawable.ic_save),
+    EDIT(R.string.edit_label, com.wire.android.ui.common.R.drawable.ic_edit),
     RESTORE(R.string.restore_label, R.drawable.ic_restore),
     DELETE(R.string.delete_label, com.wire.android.ui.common.R.drawable.ic_delete, true),
     DELETE_PERMANENTLY(R.string.delete_permanently, com.wire.android.ui.common.R.drawable.ic_delete, true),

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/PublicLinkScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/PublicLinkScreen.kt
@@ -50,6 +50,7 @@ import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.ramcosta.composedestinations.result.ResultRecipient
 import com.ramcosta.composedestinations.spec.DestinationSpec
 import com.wire.android.feature.cells.R
+import com.wire.android.feature.cells.ui.common.WireCellErrorDialog
 import com.wire.android.feature.cells.ui.destinations.PublicLinkExpirationScreenDestination
 import com.wire.android.feature.cells.ui.destinations.PublicLinkPasswordScreenDestination
 import com.wire.android.feature.cells.ui.publiclink.settings.PublicLinkSettingsSection
@@ -158,7 +159,7 @@ fun PublicLinkScreen(
     }
 
     showErrorDialog?.let { error ->
-        PublicLinkErrorDialog(
+        WireCellErrorDialog(
             onResult = { tryAgain ->
                 showErrorDialog = null
                 if (tryAgain) viewModel.retryError(error)

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/expiration/PublicLinkExpirationScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/expiration/PublicLinkExpirationScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.feature.cells.R
-import com.wire.android.feature.cells.ui.publiclink.PublicLinkErrorDialog
+import com.wire.android.feature.cells.ui.common.WireCellErrorDialog
 import com.wire.android.feature.cells.ui.util.PreviewMultipleThemes
 import com.wire.android.navigation.annotation.features.cells.WireDestination
 import com.wire.android.ui.common.HandleActions
@@ -144,7 +144,7 @@ internal fun PublicLinkExpirationScreen(
     }
 
     showError?.let { error ->
-        PublicLinkErrorDialog(
+        WireCellErrorDialog(
             title = error.title?.let { stringResource(it) },
             message = error.message?.let { stringResource(it) },
             onResult = { tryAgain ->

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/password/PublicLinkPasswordScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/password/PublicLinkPasswordScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.feature.cells.R
-import com.wire.android.feature.cells.ui.publiclink.PublicLinkErrorDialog
+import com.wire.android.feature.cells.ui.common.WireCellErrorDialog
 import com.wire.android.feature.cells.ui.publiclink.settings.RemovePasswordDialog
 import com.wire.android.feature.cells.ui.util.PreviewMultipleThemes
 import com.wire.android.navigation.annotation.features.cells.WireDestination
@@ -131,7 +131,7 @@ internal fun PublicLinkPasswordScreen(
     }
 
     passwordError?.let { error ->
-        PublicLinkErrorDialog(
+        WireCellErrorDialog(
             title = error.title?.let { stringResource(it) },
             message = error.message?.let { stringResource(it) },
             onResult = { tryAgain ->

--- a/features/cells/src/main/res/values/strings.xml
+++ b/features/cells/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="add_remove_tags_label">Add or Remove Tags</string>
     <string name="move_label">Move to folder</string>
     <string name="download_label">Download</string>
+    <string name="edit_label">Edit file</string>
     <string name="copy_link">Copy Link</string>
     <string name="share_link">Share Link</string>
     <string name="see_version_history_bottom_sheet">See version history</string>
@@ -158,6 +159,8 @@
     <string name="public_link_common_failure_dialog_message">Please try again.\n\nIf this error persists, contact your team administrator.</string>
     <string name="public_link_password_create_failure_dialog_title">Unable to create password-secured link</string>
     <string name="public_link_expiration_create_failure_dialog_title">Unable to add expiration date</string>
+    <string name="cell_open_editor_failure_dialog_title">Unable to open file edit mode</string>
+    <string name="cell_open_editor_failure_dialog_message">There was a problem connecting to the server. Please try again. If the issue persists, contact support.</string>
     <string name="error_try_again_button_title">Try again</string>
     <string name="version_history_top_appbar_title">Version history</string>
     <string name="public_link_expiration_add">Add expiration</string>

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellFileActionsMenuTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellFileActionsMenuTest.kt
@@ -1,0 +1,492 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.cells.ui
+
+import com.wire.android.feature.cells.domain.model.AttachmentFileType
+import com.wire.android.feature.cells.ui.model.CellNodeUi
+import com.wire.android.feature.cells.ui.model.NodeBottomSheetAction
+import com.wire.kalium.logic.featureFlags.KaliumConfigs
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CellFileActionsMenuTest {
+
+    @Test
+    fun `GIVEN Search context AND File node with local file available WHEN onItemMenuClick called THEN emits SHARE PUBLIC_LINK DOWNLOAD actions`() =
+        runTest {
+
+            // WHEN
+            val items = buildMenu(
+                isAllFiles = true,
+                isSearching = true,
+            )
+
+            // THEN
+            assertEquals(
+                listOf(
+                    NodeBottomSheetAction.SHARE,
+                    NodeBottomSheetAction.PUBLIC_LINK,
+                    NodeBottomSheetAction.DOWNLOAD
+                ),
+                items
+            )
+        }
+
+    @Test
+    fun `GIVEN RecycleBin context WHEN onItemMenuClick called THEN emits RESTORE DELETE_PERMANENTLY actions`() = runTest {
+
+        // WHEN
+        val items = buildMenu(
+            isRecycleBin = true,
+            isConversationFiles = true,
+        )
+
+        // THEN
+        assertEquals(
+            listOf(
+                NodeBottomSheetAction.RESTORE,
+                NodeBottomSheetAction.DELETE_PERMANENTLY,
+            ),
+            items
+        )
+    }
+
+    @Test
+    fun `GIVEN Conversation context AND File node with local file available WHEN onItemMenuClick called THEN emits all conversation actions`() =
+        runTest {
+
+            // GIVEN
+            val fileWithNullLocalPath = fileNode.copy(localPath = null)
+
+            // WHEN
+            val items = buildMenu(
+                fileNode = fileWithNullLocalPath,
+                isConversationFiles = true,
+            )
+
+            // THEN
+            assertEquals(
+                listOf(
+                    NodeBottomSheetAction.PUBLIC_LINK,
+                    NodeBottomSheetAction.DOWNLOAD,
+                    NodeBottomSheetAction.ADD_REMOVE_TAGS,
+                    NodeBottomSheetAction.MOVE,
+                    NodeBottomSheetAction.RENAME,
+                    NodeBottomSheetAction.DELETE,
+                ),
+                items
+            )
+        }
+
+    @Test
+    fun `GIVEN AllFiles context AND File node with local file available WHEN onItemMenuClick called THEN emits SHARE PUBLIC_LINK DOWNLOAD actions`() =
+        runTest {
+
+            // WHEN
+            val items = buildMenu(
+                isAllFiles = true,
+            )
+
+            // THEN
+            assertEquals(
+                listOf(
+                    NodeBottomSheetAction.SHARE,
+                    NodeBottomSheetAction.PUBLIC_LINK,
+                    NodeBottomSheetAction.DOWNLOAD
+                ),
+                items
+            )
+        }
+
+    @Test
+    fun `GIVEN ConversationFiles context AND File supports edit AND collabora enabled WHEN onItemMenuClick called THEN emits correct actions`() =
+        runTest {
+
+            // WHEN
+            val items = buildMenu(
+                fileNode = fileNode.copy(isEditSupported = true),
+                withCollaboraIntegration = true,
+                isConversationFiles = true,
+            )
+
+            // THEN
+            assertEquals(
+                listOf(
+                    NodeBottomSheetAction.SHARE,
+                    NodeBottomSheetAction.PUBLIC_LINK,
+                    NodeBottomSheetAction.DOWNLOAD,
+                    NodeBottomSheetAction.EDIT,
+                    NodeBottomSheetAction.ADD_REMOVE_TAGS,
+                    NodeBottomSheetAction.MOVE,
+                    NodeBottomSheetAction.RENAME,
+                    NodeBottomSheetAction.DELETE,
+                ),
+                items
+            )
+        }
+
+    @Test
+    fun `GIVEN ConversationFiles context AND File NOT supports edit AND collabora enabled WHEN onItemMenuClick called THEN emits correct actions`() =
+        runTest {
+
+            // WHEN
+            val items = buildMenu(
+                fileNode = fileNode.copy(isEditSupported = false),
+                withCollaboraIntegration = true,
+                isConversationFiles = true,
+            )
+
+            // THEN
+            assertEquals(
+                listOf(
+                    NodeBottomSheetAction.SHARE,
+                    NodeBottomSheetAction.PUBLIC_LINK,
+                    NodeBottomSheetAction.DOWNLOAD,
+                    NodeBottomSheetAction.ADD_REMOVE_TAGS,
+                    NodeBottomSheetAction.MOVE,
+                    NodeBottomSheetAction.RENAME,
+                    NodeBottomSheetAction.DELETE,
+                ),
+                items
+            )
+        }
+
+    @Test
+    fun `GIVEN file menu WHEN share option selected called THEN correct action emitted`() =
+        runTest {
+            // GIVEN
+            val menu = actionsMenu()
+
+            // WHEN
+            menu.onMenuItemAction(
+                conversationId = null,
+                parentFolderUuid = null,
+                node = fileNode,
+                action = NodeBottomSheetAction.SHARE,
+                onResult = { result ->
+
+                    // THEN
+                    assertEquals(CellFileActionsMenu.Share(fileNode), result)
+                }
+            )
+        }
+
+    @Test
+    fun `GIVEN folder menu WHEN share option selected called THEN correct action emitted`() =
+        runTest {
+            // GIVEN
+            val menu = actionsMenu()
+
+            // WHEN
+            menu.onMenuItemAction(
+                conversationId = null,
+                parentFolderUuid = null,
+                node = folderNode,
+                action = NodeBottomSheetAction.SHARE,
+                onResult = { result ->
+
+                    // THEN
+                    assertEquals(
+                        CellFileActionsMenu.Action(ShowPublicLinkScreen(folderNode)),
+                        result
+                    )
+                }
+            )
+        }
+
+    @Test
+    fun `GIVEN file menu WHEN move option selected called THEN correct action emitted`() =
+        runTest {
+            // GIVEN
+            val menu = actionsMenu()
+
+            // WHEN
+            menu.onMenuItemAction(
+                conversationId = "conversation/path",
+                parentFolderUuid = null,
+                node = fileNode,
+                action = NodeBottomSheetAction.MOVE,
+                onResult = { result ->
+
+                    // THEN
+                    assertEquals(
+                        CellFileActionsMenu.Action(
+                            ShowMoveToFolderScreen(
+                                currentPath = "conversation",
+                                nodeToMovePath = "conversation/path/file.txt",
+                                uuid = fileNode.uuid
+                            )
+                        ),
+                        result
+                    )
+                }
+            )
+        }
+
+    @Test
+    fun `GIVEN recycle bin menu WHEN restore item in folder option selected called THEN correct action emitted`() =
+        runTest {
+            // GIVEN
+            val menu = actionsMenu()
+
+            // WHEN
+            menu.onMenuItemAction(
+                conversationId = null,
+                parentFolderUuid = "parentFolder",
+                node = fileNode,
+                action = NodeBottomSheetAction.RESTORE,
+                onResult = { result ->
+
+                    // THEN
+                    assertEquals(
+                        CellFileActionsMenu.Action(ShowRestoreParentFolderDialog(fileNode)),
+                        result
+                    )
+                }
+            )
+        }
+
+    @Test
+    fun `GIVEN recycle bin menu WHEN restore item option selected called THEN correct action emitted`() =
+        runTest {
+            // GIVEN
+            val menu = actionsMenu()
+
+            // WHEN
+            menu.onMenuItemAction(
+                conversationId = null,
+                parentFolderUuid = null,
+                node = fileNode,
+                action = NodeBottomSheetAction.RESTORE,
+                onResult = { result ->
+
+                    // THEN
+                    assertEquals(
+                        CellFileActionsMenu.Action(ShowRestoreConfirmation(fileNode)),
+                        result
+                    )
+                }
+            )
+        }
+
+    @Test
+    fun `GIVEN recycle bin menu WHEN delete item option selected called THEN correct action emitted`() =
+        runTest {
+            // GIVEN
+            val menu = actionsMenu()
+
+            // WHEN
+            menu.onMenuItemAction(
+                conversationId = null,
+                parentFolderUuid = null,
+                node = fileNode,
+                action = NodeBottomSheetAction.DELETE_PERMANENTLY,
+                onResult = { result ->
+                    // THEN
+                    assertEquals(
+                        CellFileActionsMenu.Action(ShowDeleteConfirmation(fileNode, true)),
+                        result
+                    )
+                }
+            )
+        }
+
+    @Test
+    fun `GIVEN file menu WHEN tags item option selected called THEN correct action emitted`() =
+        runTest {
+            // GIVEN
+            val menu = actionsMenu()
+
+            // WHEN
+            menu.onMenuItemAction(
+                conversationId = null,
+                parentFolderUuid = null,
+                node = fileNode,
+                action = NodeBottomSheetAction.ADD_REMOVE_TAGS,
+                onResult = { result ->
+                    // THEN
+                    assertEquals(
+                        CellFileActionsMenu.Action(ShowAddRemoveTagsScreen(fileNode)),
+                        result
+                    )
+                }
+            )
+        }
+
+    @Test
+    fun `GIVEN file menu WHEN public link option selected called THEN correct action emitted`() =
+        runTest {
+            // GIVEN
+            val menu = actionsMenu()
+
+            // WHEN
+            menu.onMenuItemAction(
+                conversationId = null,
+                parentFolderUuid = null,
+                node = fileNode,
+                action = NodeBottomSheetAction.PUBLIC_LINK,
+                onResult = { result ->
+                    // THEN
+                    assertEquals(
+                        CellFileActionsMenu.Action(ShowPublicLinkScreen(fileNode)),
+                        result
+                    )
+                }
+            )
+        }
+
+    @Test
+    fun `GIVEN file menu WHEN rename option selected called THEN correct action emitted`() =
+        runTest {
+            // GIVEN
+            val menu = actionsMenu()
+
+            // WHEN
+            menu.onMenuItemAction(
+                conversationId = null,
+                parentFolderUuid = null,
+                node = fileNode,
+                action = NodeBottomSheetAction.RENAME,
+                onResult = { result ->
+                    // THEN
+                    assertEquals(
+                        CellFileActionsMenu.Action(ShowRenameScreen(fileNode)),
+                        result
+                    )
+                }
+            )
+        }
+
+    @Test
+    fun `GIVEN file menu WHEN delete option selected called THEN correct action emitted`() =
+        runTest {
+            // GIVEN
+            val menu = actionsMenu()
+
+            // WHEN
+            menu.onMenuItemAction(
+                conversationId = null,
+                parentFolderUuid = null,
+                node = fileNode,
+                action = NodeBottomSheetAction.DELETE,
+                onResult = { result ->
+                    // THEN
+                    assertEquals(
+                        CellFileActionsMenu.Action(ShowDeleteConfirmation(fileNode, false)),
+                        result
+                    )
+                }
+            )
+        }
+
+    @Test
+    fun `GIVEN file menu WHEN download option selected called THEN correct action emitted`() =
+        runTest {
+            // GIVEN
+            val menu = actionsMenu()
+
+            // WHEN
+            menu.onMenuItemAction(
+                conversationId = null,
+                parentFolderUuid = null,
+                node = fileNode,
+                action = NodeBottomSheetAction.DOWNLOAD,
+                onResult = { result ->
+                    // THEN
+                    assertEquals(
+                        CellFileActionsMenu.Download(fileNode),
+                        result
+                    )
+                }
+            )
+        }
+
+    @Test
+    fun `GIVEN file menu WHEN edit option selected called THEN correct action emitted`() =
+        runTest {
+            // GIVEN
+            val menu = actionsMenu()
+
+            // WHEN
+            menu.onMenuItemAction(
+                conversationId = null,
+                parentFolderUuid = null,
+                node = fileNode,
+                action = NodeBottomSheetAction.EDIT,
+                onResult = { result ->
+                    // THEN
+                    assertEquals(
+                        CellFileActionsMenu.Edit(fileNode),
+                        result
+                    )
+                }
+            )
+        }
+
+    private fun actionsMenu(
+        withCollaboraIntegration: Boolean = false,
+    ) = CellFileActionsMenu(
+        featureFlags = KaliumConfigs(
+            collaboraIntegration = withCollaboraIntegration
+        )
+    )
+
+    @Suppress("LongParameterList")
+    private fun buildMenu(
+        fileNode: CellNodeUi = Companion.fileNode,
+        withCollaboraIntegration: Boolean = false,
+        isRecycleBin: Boolean = false,
+        isConversationFiles: Boolean = false,
+        isAllFiles: Boolean = false,
+        isSearching: Boolean = false,
+    ): List<NodeBottomSheetAction> =
+        CellFileActionsMenu(
+            featureFlags = KaliumConfigs(
+                collaboraIntegration = withCollaboraIntegration
+            )
+        ).buildMenu(fileNode, isRecycleBin, isConversationFiles, isAllFiles, isSearching)
+
+    private companion object {
+        val fileNode = CellNodeUi.File(
+            name = "file.txt",
+            conversationName = "Conversation",
+            downloadProgress = null,
+            uuid = "fileUuid",
+            mimeType = "video/mp4",
+            assetType = AttachmentFileType.VIDEO,
+            size = 23432532532,
+            localPath = "localPath",
+            userName = null,
+            modifiedTime = null,
+            remotePath = null,
+            contentHash = null,
+            contentUrl = null,
+            previewUrl = null,
+            publicLinkId = null
+        )
+        val folderNode = CellNodeUi.Folder(
+            name = "folder",
+            uuid = "uuid",
+            userName = "user",
+            conversationName = "conversation",
+            modifiedTime = "time",
+            size = 1
+        )
+    }
+}

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
@@ -25,9 +25,7 @@ import androidx.paging.PagingData
 import androidx.paging.testing.asSnapshot
 import app.cash.turbine.test
 import com.wire.android.config.NavigationTestExtension
-import com.wire.android.feature.cells.domain.model.AttachmentFileType
-import com.wire.android.feature.cells.ui.model.CellNodeUi
-import com.wire.android.feature.cells.ui.model.NodeBottomSheetAction
+import com.wire.android.feature.cells.ui.edit.OnlineEditor
 import com.wire.android.feature.cells.ui.model.toUiModel
 import com.wire.android.feature.cells.util.FileHelper
 import com.wire.android.feature.cells.util.FileNameResolver
@@ -35,6 +33,7 @@ import com.wire.kalium.cells.domain.model.Node
 import com.wire.kalium.cells.domain.usecase.DeleteCellAssetUseCase
 import com.wire.kalium.cells.domain.usecase.DownloadCellFileUseCase
 import com.wire.kalium.cells.domain.usecase.GetAllTagsUseCase
+import com.wire.kalium.cells.domain.usecase.GetEditorUrlUseCase
 import com.wire.kalium.cells.domain.usecase.GetPaginatedFilesFlowUseCase
 import com.wire.kalium.cells.domain.usecase.IsAtLeastOneCellAvailableUseCase
 import com.wire.kalium.cells.domain.usecase.RestoreNodeFromRecycleBinUseCase
@@ -69,23 +68,6 @@ import java.io.File
 class CellViewModelTest {
 
     private companion object {
-        val fileNode = CellNodeUi.File(
-            name = "file.txt",
-            conversationName = "Conversation",
-            downloadProgress = null,
-            uuid = "fileUuid",
-            mimeType = "video/mp4",
-            assetType = AttachmentFileType.VIDEO,
-            size = 23432532532,
-            localPath = "localPath",
-            userName = null,
-            modifiedTime = null,
-            remotePath = null,
-            contentHash = null,
-            contentUrl = null,
-            previewUrl = null,
-            publicLinkId = null
-        )
         val testFiles = listOf(
             Node.File(
                 uuid = "fileUuid",
@@ -126,7 +108,7 @@ class CellViewModelTest {
     }
 
     @Test
-    fun `given view model when files flow subscibed cell files are loaded`() = runTest {
+    fun `given view model when files flow subscribed cell files are loaded`() = runTest {
         val (arrangement, viewModel) = Arrangement()
             .withLoadSuccess()
             .arrange()
@@ -216,78 +198,6 @@ class CellViewModelTest {
     }
 
     @Test
-    fun `given view model when save menu action selected then download starts`() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withLoadSuccess()
-            .withDownloadSuccess()
-            .arrange()
-
-        val testFile = testFiles[0]
-            .toUiModel()
-            .copy(localPath = null)
-
-        viewModel.sendIntent(CellViewIntent.OnMenuItemActionSelected(testFile, NodeBottomSheetAction.DOWNLOAD))
-
-        coVerify(exactly = 1) {
-            arrangement.downloadCellFileUseCase(any(), any(), any(), any(), any())
-        }
-    }
-
-    @Test
-    fun `given view model when share menu action selected then file is shared`() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withLoadSuccess()
-            .arrange()
-
-        val testFile = testFiles[0]
-            .toUiModel()
-
-        viewModel.sendIntent(CellViewIntent.OnMenuItemActionSelected(testFile, NodeBottomSheetAction.SHARE))
-
-        coVerify(exactly = 1) {
-            arrangement.fileHelper.shareFileChooser(any(), any(), any(), any())
-        }
-    }
-
-    @Test
-    fun `given view model when public link menu action selected then public link is created`() = runTest {
-        val (_, viewModel) = Arrangement()
-            .withLoadSuccess()
-            .arrange()
-
-        val testFile = testFiles[0]
-            .toUiModel()
-
-        viewModel.actions.test {
-            viewModel.sendIntent(CellViewIntent.OnMenuItemActionSelected(testFile, NodeBottomSheetAction.PUBLIC_LINK))
-
-            with(expectMostRecentItem()) {
-                assertTrue(this is ShowPublicLinkScreen)
-                assertEquals(testFile, (this as ShowPublicLinkScreen).cellNode)
-            }
-        }
-    }
-
-    @Test
-    fun `given view model when delete menu action selected then delete confirmation is shown`() = runTest {
-        val (_, viewModel) = Arrangement()
-            .withLoadSuccess()
-            .arrange()
-
-        val testFile = testFiles[0]
-            .toUiModel()
-
-        viewModel.actions.test {
-            viewModel.sendIntent(CellViewIntent.OnMenuItemActionSelected(testFile, NodeBottomSheetAction.DELETE))
-
-            with(expectMostRecentItem()) {
-                assertTrue(this is ShowDeleteConfirmation)
-                assertEquals(testFile, (this as ShowDeleteConfirmation).node)
-            }
-        }
-    }
-
-    @Test
     fun `given view model when delete is confirmed then file is removed from the list`() = runTest {
         val (_, viewModel) = Arrangement()
             .withLoadSuccess()
@@ -342,116 +252,6 @@ class CellViewModelTest {
         }
 
     @Test
-    fun `GIVEN Search context AND File node with local file available WHEN onItemMenuClick called THEN emits SHARE PUBLIC_LINK DOWNLOAD actions`() =
-        runTest(dispatcher) {
-            // GIVEN
-            val (_, viewModel) = Arrangement().arrange()
-            viewModel.onSearchQueryUpdated("test")
-
-            viewModel.menu.test {
-                // WHEN
-                viewModel.sendIntent(CellViewIntent.OnItemMenuClick(fileNode))
-
-                // THEN
-                val emitted = awaitItem()
-                assertEquals(fileNode, emitted.node)
-                assertEquals(
-                    listOf(
-                        NodeBottomSheetAction.SHARE,
-                        NodeBottomSheetAction.PUBLIC_LINK,
-                        NodeBottomSheetAction.DOWNLOAD
-                    ),
-                    emitted.actions
-                )
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-    @Test
-    fun `GIVEN RecycleBin context WHEN onItemMenuClick called THEN emits RESTORE DELETE_PERMANENTLY actions`() = runTest {
-        // GIVEN
-        val (_, viewModel) = Arrangement()
-            .withRecycleBinArg(true)
-            .arrange()
-
-        viewModel.menu.test {
-            // WHEN
-            viewModel.sendIntent(CellViewIntent.OnItemMenuClick(fileNode))
-
-            // THEN
-            val emitted = awaitItem()
-            assertEquals(fileNode, emitted.node)
-            assertEquals(
-                listOf(
-                    NodeBottomSheetAction.RESTORE,
-                    NodeBottomSheetAction.DELETE_PERMANENTLY,
-                ),
-                emitted.actions
-            )
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `GIVEN Conversation context AND File node with local file available WHEN onItemMenuClick called THEN emits all conversation actions`() =
-        runTest {
-            // GIVEN
-            val (_, viewModel) = Arrangement()
-                .withConversationIdArg("conversationId")
-                .arrange()
-            val fileWithNullLocalPath = fileNode.copy(localPath = null)
-
-            viewModel.menu.test {
-                // WHEN
-                viewModel.sendIntent(CellViewIntent.OnItemMenuClick(fileWithNullLocalPath))
-
-                // THEN
-                val emitted = awaitItem()
-                assertEquals(fileWithNullLocalPath, emitted.node)
-                assertEquals(
-                    listOf(
-                        NodeBottomSheetAction.PUBLIC_LINK,
-                        NodeBottomSheetAction.DOWNLOAD,
-                        NodeBottomSheetAction.ADD_REMOVE_TAGS,
-                        NodeBottomSheetAction.MOVE,
-                        NodeBottomSheetAction.RENAME,
-                        NodeBottomSheetAction.DELETE,
-                    ),
-                    emitted.actions
-                )
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-    @Test
-    fun `GIVEN AllFiles context AND File node with local file available WHEN onItemMenuClick called THEN emits SHARE PUBLIC_LINK DOWNLOAD actions`() =
-        runTest(dispatcher) {
-            // GIVEN
-            val (_, viewModel) = Arrangement()
-                .withRecycleBinArg(false)
-                .withConversationIdArg(null)
-                .arrange()
-
-            viewModel.menu.test {
-                // WHEN
-                viewModel.sendIntent(CellViewIntent.OnItemMenuClick(fileNode))
-
-                // THEN
-                val emitted = awaitItem()
-                assertEquals(fileNode, emitted.node)
-                assertEquals(
-                    listOf(
-                        NodeBottomSheetAction.SHARE,
-                        NodeBottomSheetAction.PUBLIC_LINK,
-                        NodeBottomSheetAction.DOWNLOAD
-                    ),
-                    emitted.actions
-                )
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-    @Test
     fun `GIVEN no cells available WHEN ViewModel initialized THEN no load request is sent`() = runTest {
         val (arrangement, viewModel) = Arrangement()
             .withNoCellsAvailable()
@@ -494,6 +294,15 @@ class CellViewModelTest {
 
         @MockK
         lateinit var fileNameResolver: FileNameResolver
+
+        @MockK
+        lateinit var getEditorUrlUseCase: GetEditorUrlUseCase
+
+        @MockK
+        lateinit var onlineEditor: OnlineEditor
+
+        @MockK
+        lateinit var cellFileActionsMenu: CellFileActionsMenu
 
         init {
 
@@ -551,18 +360,6 @@ class CellViewModelTest {
             coEvery { deleteCellAssetUseCase(any(), any()) } returns Unit.right()
         }
 
-        fun withRecycleBinArg(isRecycleBin: Boolean) = apply {
-            every { savedStateHandle.navArgs<CellFilesNavArgs>() } returns CellFilesNavArgs(
-                isRecycleBin = isRecycleBin
-            )
-        }
-
-        fun withConversationIdArg(conversationId: String?) = apply {
-            every { savedStateHandle.navArgs<CellFilesNavArgs>() } returns CellFilesNavArgs(
-                conversationId = conversationId
-            )
-        }
-
         fun withNoCellsAvailable() = apply {
             coEvery { isCellAvailableUseCase.invoke() } returns false.right()
         }
@@ -583,7 +380,10 @@ class CellViewModelTest {
                 download = downloadCellFileUseCase,
                 isCellAvailable = isCellAvailableUseCase,
                 fileHelper = fileHelper,
-                fileNameResolver = fileNameResolver
+                fileNameResolver = fileNameResolver,
+                onlineEditor = onlineEditor,
+                getEditorUrl = getEditorUrlUseCase,
+                cellFileActionsMenu = cellFileActionsMenu,
             )
         }
     }

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/publiclink/PublicLinkViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/publiclink/PublicLinkViewModelTest.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.cells.domain.usecase.publiclink.GetPublicLinkUseCase
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.left
 import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -218,6 +219,9 @@ class PublicLinkViewModelTest {
         @MockK
         lateinit var fileHelper: FileHelper
 
+        @MockK
+        lateinit var kaliumConfigs: KaliumConfigs
+
         init {
 
             MockKAnnotations.init(this, relaxUnitFun = true)
@@ -273,12 +277,16 @@ class PublicLinkViewModelTest {
         }
 
         fun arrange(): Pair<Arrangement, PublicLinkViewModel> {
+
+            every { kaliumConfigs.securePublicLinkSettings } returns false
+
             return this to PublicLinkViewModel(
                 savedStateHandle = savedStateHandle,
                 createPublicLink = createPublicLinkUseCase,
                 getPublicLinkUseCase = getPublicLinkUseCase,
                 deletePublicLinkUseCase = deletePublicLinkUseCase,
-                fileHelper = fileHelper
+                fileHelper = fileHelper,
+                config = kaliumConfigs,
             )
         }
     }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21975" title="WPB-21975" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21975</a>  [Android] Edit file in Collabora
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

https://wearezeta.atlassian.net/browse/WPB-21975

# What's new in this PR?

- Request editor URL from server
- Opening cell file in online editor
- Refactoring CellViewModel to reduce size / complexity (moving menu logic to separate class)
- Unit tests update


https://github.com/user-attachments/assets/99cd3a43-51dd-47c6-bef2-286366a7bbe4



