### PR TITLE
ci: fix formatting of release notes to store action and staged rollout config

### DIFF
--- a/.github/workflows/build-develop-push.yml
+++ b/.github/workflows/build-develop-push.yml
@@ -35,7 +35,8 @@ jobs:
                 "type": "google-play",
                 "package-name": "com.wire.internal",
                 "track": "${{ vars.INTERNAL_APP_TRACK }}",
-                "status": "completed"
+                "status": "completed",
+                "user-fraction": 1.0
               }
             ]
           }

--- a/.github/workflows/build-main-push.yml
+++ b/.github/workflows/build-main-push.yml
@@ -34,7 +34,8 @@ jobs:
               {
                 "type": "google-play",
                 "package-name": "com.wire.android.internal",
-                "track": "${{ vars.BETA_APP_TRACK_INTERNAL }}"
+                "track": "${{ vars.BETA_APP_TRACK_INTERNAL }}",
+                "user-fraction": 1.0
               }
             ]
           }

--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -59,7 +59,8 @@ jobs:
               {
                 "type": "google-play",
                 "package-name": "com.wire",
-                "track": "${{ vars.PROD_APP_RELEASE_TRACK }}"
+                "track": "${{ vars.PROD_APP_RELEASE_TRACK }}",
+                "user-fraction": 0.1
               },
               {
                 "type": "github-release",

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -152,7 +152,8 @@ jobs:
               {
                 "type": "google-play",
                 "package-name": "com.wire",
-                "track": "${{ vars.PROD_APP_RC_TRACK }}"
+                "track": "${{ vars.PROD_APP_RC_TRACK }}",
+                "user-fraction": 0.1
               },
               {
                 "type": "github-release",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,11 @@ jobs:
         if: matrix.target.type == 'google-play'
         run: echo '${{ secrets.SERVICE_ACCOUNT_JSON }}' > service_account.json
 
+      - name: Format latest release notes
+        if: matrix.target.type == 'google-play'
+        run: |
+          python3 scripts/generate_whatsnew_notes.py
+
       - name: Deploy to Google Play
         if: matrix.target.type == 'google-play'
         uses: r0adkll/upload-google-play@v1
@@ -84,7 +89,8 @@ jobs:
           releaseFiles: ${{ inputs.artifacts-path }}bundle/${{ steps.lowercase.outputs.build-flavour }}${{ inputs.build-variant }}/*.aab
           track: ${{ matrix.target.track }}
           status: ${{ matrix.target.status || 'completed' }}
-          whatsNewDirectory: app/src/main/play/release-notes
+          whatsNewDirectory: build/whatsnew
+          userFraction: ${{ inputs.target.user-fraction }}
 
       - name: Deploy to GitHub Release
         if: matrix.target.type == 'github-release'

--- a/scripts/generate_whatsnew_notes.py
+++ b/scripts/generate_whatsnew_notes.py
@@ -1,0 +1,40 @@
+import os, re, pathlib
+
+WORKSPACE = os.environ.get('GITHUB_WORKSPACE') or str(pathlib.Path.cwd().parent)
+OUTDIR = os.path.join(WORKSPACE, 'build/whatsnew')
+SEMVER_PATTERN = re.compile(r'^\d+\.\d+\.\d+\.txt$')
+
+def is_semver_file(filename):
+    return bool(SEMVER_PATTERN.match(filename))
+
+def version_key(name: str):
+    """Convert '1.12.5.txt' → (1, 12, 5) for correct sorting"""
+    parts = re.findall(r'\d+', name)
+    return tuple(int(p) for p in parts) if parts else (0,)
+
+def list_files_recursively(path='../app/src/main/play/release-notes'):
+    latest_releases = []
+
+    for root, dirs, files in os.walk(path):
+        semver_files = [f for f in files if is_semver_file(f)]
+
+        if not semver_files:
+            continue
+            
+        latest_file = max(semver_files, key=version_key)
+        full_path = os.path.join(root, latest_file)
+
+        latest_releases.append(full_path)
+    
+    return latest_releases
+
+def main():
+    for f in list_files_recursively():
+        original_path = pathlib.Path(f)
+        dest_dir = pathlib.Path(OUTDIR)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        destination = pathlib.Path(dest_dir / f'whatsnew-{original_path.parent.name}')
+        destination.write_bytes(original_path.read_bytes())
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Add release notes format for gh action `whatsnew-LOCALE` from last release file and also add staged rollout config.

#### How to Test

Needs to be tested manually 

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
