### PR TITLE
feat: update cell file name validation (WPB-21936)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/common/CellFileNameValidation.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/common/CellFileNameValidation.kt
@@ -1,0 +1,32 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.cells.ui.common
+
+internal const val FILE_NAME_MAX_COUNT = 64
+
+internal fun CharSequence.validateFileName() = when {
+    length > FILE_NAME_MAX_COUNT -> FileNameError.NameExceedLimit
+    trim().isEmpty() -> FileNameError.NameEmpty
+    contains("/") -> FileNameError.InvalidName
+    startsWith(".") -> FileNameError.InvalidName
+    else -> null
+}
+
+enum class FileNameError {
+    NameEmpty, NameExceedLimit, NameAlreadyExist, InvalidName
+}

--- a/features/cells/src/main/res/values/strings.xml
+++ b/features/cells/src/main/res/values/strings.xml
@@ -107,7 +107,7 @@
     <string name="rename_file_renamed">File was renamed</string>
     <string name="rename_folder_renamed">Folder was renamed</string>
     <string name="rename_failure">Unable to rename</string>
-    <string name="rename_invalid_name">Use a name without "/"</string>
+    <string name="rename_invalid_name">Use a name without "/" and not starting with "."</string>
     <string name="rename_already_exist">File with this name already exists</string>
     <string name="filter_label">Filter</string>
     <string name="tags_label">Tags</string>

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/common/CellFileNameValidationTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/common/CellFileNameValidationTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.cells.ui.common
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CellFileNameValidationTest {
+
+    @Test
+    fun `given file name too long, when validating, then correct error returned`() = runTest {
+        val filename = "Long name that exceeds the limit of sixty four characters will return error."
+        val result = filename.validateFileName()
+        assertEquals(FileNameError.NameExceedLimit, result)
+    }
+
+    @Test
+    fun `given file name empty, when validating, then correct error returned`() = runTest {
+        val filename = ""
+        val result = filename.validateFileName()
+        assertEquals(FileNameError.NameEmpty, result)
+    }
+
+    @Test
+    fun `given file name contains slash, when validating, then correct error returned`() = runTest {
+        val filename = "File/Name"
+        val result = filename.validateFileName()
+        assertEquals(FileNameError.InvalidName, result)
+    }
+
+    @Test
+    fun `given file name starts with dot, when validating, then correct error returned`() = runTest {
+        val filename = ".filename"
+        val result = filename.validateFileName()
+        assertEquals(FileNameError.InvalidName, result)
+    }
+
+    @Test
+    fun `given file name only has dot, when validating, then correct error returned`() = runTest {
+        val filename = "."
+        val result = filename.validateFileName()
+        assertEquals(FileNameError.InvalidName, result)
+    }
+
+    @Test
+    fun `given file name is valid, when validating, then no error returned`() = runTest {
+        val filename = "valid file name"
+        val result = filename.validateFileName()
+        assertEquals(null, result)
+    }
+}

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/rename/RenameNodeViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/rename/RenameNodeViewModelTest.kt
@@ -19,6 +19,7 @@ package com.wire.android.feature.cells.ui.rename
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.wire.android.feature.cells.ui.common.FileNameError
 import com.wire.android.feature.cells.ui.navArgs
 import com.wire.kalium.cells.domain.usecase.RenameNodeFailure
 import com.wire.kalium.cells.domain.usecase.RenameNodeUseCase
@@ -69,7 +70,6 @@ class RenameNodeViewModelTest {
         viewModel.actions.test {
             with(expectMostRecentItem()) {
                 assertEquals(false, viewModel.viewState.loading)
-                assertEquals(RenameNodeViewState.Completed.Success, viewModel.viewState.completed)
                 assertTrue(this is RenameNodeViewModelAction.Success)
                 coVerify(exactly = 1) { arrangement.renameNodeUseCase(eq(UUID), eq(CURRENT_PATH), eq("newFileName.txt")) }
             }
@@ -105,7 +105,23 @@ class RenameNodeViewModelTest {
 
         assertFalse(viewModel.viewState.saveEnabled)
         assertEquals(
-            RenameNodeViewState.RenameError.TextFieldError.InvalidName,
+            FileNameError.InvalidName,
+            viewModel.viewState.error
+        )
+    }
+
+    @Test
+    fun `given invalid name starting with dot, when text is emitted, then InvalidNameError is set`() = runTest {
+        val invalidName = "."
+        val (_, viewModel) = Arrangement()
+            .withNodeNameReturning(invalidName)
+            .arrange()
+
+        advanceUntilIdle()
+
+        assertFalse(viewModel.viewState.saveEnabled)
+        assertEquals(
+            FileNameError.InvalidName,
             viewModel.viewState.error
         )
     }
@@ -120,7 +136,7 @@ class RenameNodeViewModelTest {
         advanceUntilIdle()
         assertFalse(viewModel.viewState.saveEnabled)
         assertEquals(
-            RenameNodeViewState.RenameError.TextFieldError.NameEmpty,
+            FileNameError.NameEmpty,
             viewModel.viewState.error
         )
     }
@@ -137,7 +153,7 @@ class RenameNodeViewModelTest {
 
         assertFalse(viewModel.viewState.saveEnabled)
         assertEquals(
-            RenameNodeViewState.RenameError.TextFieldError.NameExceedLimit,
+            FileNameError.NameExceedLimit,
             viewModel.viewState.error
         )
     }
@@ -151,7 +167,7 @@ class RenameNodeViewModelTest {
 
         assertFalse(viewModel.viewState.saveEnabled)
         assertEquals(
-            RenameNodeViewState.RenameError.None,
+            null,
             viewModel.viewState.error
         )
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21936" title="WPB-21936" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21936</a>  [Android] Prevent file/folder names starting with “.” or equal to “.”
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-21936

# What's new in this PR?

- Moved file name validation to a separate file and share in rename / create features
- Added new rule to disallow filenames starting with "."
- Refactoring file name error handling to simplify and reuse in rename / create features