### PR TITLE
feat: add triggering of faulty conversations on app launch (WPB-22180)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -62,6 +62,7 @@ class KaliumConfigsModule {
             maxRemoteSearchResultCount = BuildConfig.MAX_REMOTE_SEARCH_RESULT_COUNT,
             limitTeamMembersFetchDuringSlowSync = BuildConfig.LIMIT_TEAM_MEMBERS_FETCH_DURING_SLOW_SYNC,
             isMlsResetEnabled = BuildConfig.IS_MLS_RESET_ENABLED,
+            domainWithFaultyKeysMap = BuildConfig.DOMAIN_REMOVAL_KEYS_FOR_REPAIR
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsViewModel.kt
@@ -264,7 +264,7 @@ class DebugDataOptionsViewModelImpl
             val result = repairFaultyRemovalKeys(
                 param = TargetedRepairParam(
                     domain = domain,
-                    faultyKey = faultyKey
+                    faultyKeys = faultyKey
                 )
             )
             when (result) {
@@ -272,8 +272,8 @@ class DebugDataOptionsViewModelImpl
                 RepairResult.NoConversationsToRepair -> appLogger.i("No conversations to repair")
                 RepairResult.RepairNotNeeded -> appLogger.i("Repair not needed")
                 is RepairResult.RepairPerformed -> {
-                    _infoMessage.emit(UIText.DynamicString("Repair finalized"))
-                    appLogger.i("Repair performed: $result")
+                    _infoMessage.emit(UIText.DynamicString("Reset finalized"))
+                    appLogger.i("Repair performed: ${result.toLogString()}")
                 }
             }
             state = state.copy(mlsInfoState = state.mlsInfoState.copy(isLoadingRepair = false))

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsViewModel.kt
@@ -253,7 +253,7 @@ class DebugDataOptionsViewModelImpl
     override fun repairFaultRemovalKeys() {
         viewModelScope.launch {
             state = state.copy(mlsInfoState = state.mlsInfoState.copy(isLoadingRepair = true))
-            val (domain, faultyKey) = DOMAIN_REMOVAL_KEYS_FOR_REPAIR.entries.firstOrNull()
+            val (domain, faultyKey) = DOMAIN_REMOVAL_KEYS_FOR_REPAIR.entries.firstOrNull { it.key == currentAccount.domain }
                 ?: run {
                     appLogger.w("No faulty removal keys configured for repair")
                     _infoMessage.emit(UIText.DynamicString("No faulty removal keys configured for repair"))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1354,7 +1354,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="label_client_device_id">Proteus ID</string>
     <string name="label_key_packages_count">Key-packages count</string>
     <string name="label_mls_client_id">MLS Client ID</string>
-    <string name="label_mls_repair_faulty_keys">Repair faulty removal keys</string>
+    <string name="label_mls_repair_faulty_keys" translatable="false">Initiate reset of affected MLS groups</string>
     <string name="conversation_empty_list_description">Connect with others or create a new group to start collaborating!</string>
     <string name="favorites_empty_list_description">Select your favorite conversations, and you’ll find them here</string>
     <string name="group_empty_list_description">You are not part of any group conversation yet.\nStart a new conversation!</string>
@@ -1795,7 +1795,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="debug_settings_force_api_versioning_update" translatable="false">Force API versioning update</string>
     <string name="debug_settings_break_session" translatable="false">⚠️ Break Session</string>
     <string name="debug_settings_force_api_versioning_update_button_text" translatable="false">Update</string>
-    <string name="debug_settings_force_repair_faulty_keys" translatable="false">Repair</string>
+    <string name="debug_settings_force_repair_faulty_keys" translatable="false">Reset</string>
     <string name="debug_settings_feature_flags" translatable="false">Feature Flags</string>
 
     <!--    Personal to team migration screen-->


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22180" title="WPB-22180" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22180</a>  [Android] "Message could not be decrypted" from federated connection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Follow up on #4484

- This PR is focused on triggering the process on app start, and mark as completed.
- Change the structure of the config to be: `{"domain": ["some hex string key"]}`.
- Pass to Kalium using current Configs, so it can be triggered automatically with the data to be targeted.

IMPORTANT!
Update the env vars in the gh repository

### Issues

Conversations break if the removal key is rotated in the Backend

### Solutions

Detect MLS conversations with the faulty key and belonging to the target domain, if there is match, trigger a MLS reset flow.

### Depends on

- https://github.com/wireapp/kalium/pull/3779

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
