### PR TITLE
feat: use collabora config from cell feature config (WPB-22343)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/CellsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/CellsModule.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.cells.domain.usecase.GetFoldersUseCase
 import com.wire.kalium.cells.domain.usecase.GetMessageAttachmentUseCase
 import com.wire.kalium.cells.domain.usecase.GetPaginatedFilesFlowUseCase
 import com.wire.kalium.cells.domain.usecase.GetPaginatedNodesUseCase
+import com.wire.kalium.cells.domain.usecase.GetWireCellConfigurationUseCase
 import com.wire.kalium.cells.domain.usecase.IsAtLeastOneCellAvailableUseCase
 import com.wire.kalium.cells.domain.usecase.MoveNodeUseCase
 import com.wire.kalium.cells.domain.usecase.ObserveAttachmentDraftsUseCase
@@ -242,4 +243,8 @@ class CellsModule {
         refreshAsset = cellsScope.refreshAsset,
         featureFlags = kaliumConfigs
     )
+
+    @ViewModelScoped
+    @Provides
+    fun provideGetCellsConfigUseCase(cellsScope: CellsScope): GetWireCellConfigurationUseCase = cellsScope.getCellConfig
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/multipart/MultipartAttachmentsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/multipart/MultipartAttachmentsViewModelTest.kt
@@ -25,6 +25,7 @@ import com.wire.android.ui.common.multipart.MultipartAttachmentUi
 import com.wire.android.util.FileManager
 import com.wire.kalium.cells.domain.usecase.download.DownloadCellFileUseCase
 import com.wire.kalium.cells.domain.usecase.GetEditorUrlUseCase
+import com.wire.kalium.cells.domain.usecase.GetWireCellConfigurationUseCase
 import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
@@ -247,6 +248,9 @@ class MultipartAttachmentsViewModelTest {
         @MockK
         lateinit var kaliumConfigs: KaliumConfigs
 
+        @MockK
+        lateinit var getWireCellsConfig: GetWireCellConfigurationUseCase
+
         val kaliumFileSystem: KaliumFileSystem = FakeKaliumFileSystem()
 
         suspend fun arrange(): Pair<Arrangement, MultipartAttachmentsViewModel> {
@@ -255,6 +259,7 @@ class MultipartAttachmentsViewModelTest {
             coEvery { fileManager.openWithExternalApp(any(), any(), any(), any()) } returns Unit
             coEvery { fileManager.openUrlWithExternalApp(any(), any(), any()) } returns Unit
             coEvery { download(any(), any(), any(), any(), any()) } returns Unit.right()
+            coEvery { getWireCellsConfig() } returns null
 
             return this to MultipartAttachmentsViewModelImpl(
                 refreshHelper = refreshHelper,
@@ -264,6 +269,7 @@ class MultipartAttachmentsViewModelTest {
                 onlineEditor = onlineEditor,
                 kaliumFileSystem = kaliumFileSystem,
                 featureFlags = kaliumConfigs,
+                getWireCellsConfig = getWireCellsConfig,
             )
         }
     }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellFileActionsMenu.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellFileActionsMenu.kt
@@ -24,6 +24,7 @@ import com.wire.android.feature.cells.ui.model.localFileAvailable
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import javax.inject.Inject
 
+@Suppress("CyclomaticComplexMethod", "LongParameterList")
 class CellFileActionsMenu @Inject constructor(
     private val featureFlags: KaliumConfigs
 ) {
@@ -32,7 +33,8 @@ class CellFileActionsMenu @Inject constructor(
         isRecycleBin: Boolean,
         isConversationFiles: Boolean,
         isAllFiles: Boolean,
-        isSearching: Boolean
+        isSearching: Boolean,
+        isCollaboraEnabled: Boolean,
     ): List<NodeBottomSheetAction> =
         when {
             isRecycleBin -> {
@@ -50,7 +52,7 @@ class CellFileActionsMenu @Inject constructor(
                     add(NodeBottomSheetAction.PUBLIC_LINK)
                     add(NodeBottomSheetAction.DOWNLOAD)
 
-                    if (featureFlags.collaboraIntegration && cellNode.isEditSupported()) {
+                    if (isCollaboraEnabled && featureFlags.collaboraIntegration && cellNode.isEditSupported()) {
                         add(NodeBottomSheetAction.EDIT)
                     }
 
@@ -86,7 +88,6 @@ class CellFileActionsMenu @Inject constructor(
     internal data class Download(val node: CellNodeUi) : MenuActionResult
     internal data class Edit(val node: CellNodeUi) : MenuActionResult
 
-    @Suppress("CyclomaticComplexMethod")
     internal fun onMenuItemAction(
         conversationId: String?,
         parentFolderUuid: String?,

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/filter/FilterBottomSheet.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/filter/FilterBottomSheet.kt
@@ -67,7 +67,7 @@ fun FilterBottomSheet(
     onApply: (Set<String>) -> Unit,
     onClearAll: () -> Unit,
     onDismiss: () -> Unit,
-    onShow: suspend () -> Unit = {},
+    onShow: () -> Unit = {},
     sheetState: WireModalSheetState<Unit> = rememberWireModalSheetState<Unit>(WireSheetValue.Expanded(Unit))
 ) {
     WireModalSheetLayout(

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellFileActionsMenuTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellFileActionsMenuTest.kt
@@ -123,6 +123,7 @@ class CellFileActionsMenuTest {
                 fileNode = fileNode.copy(isEditSupported = true),
                 withCollaboraIntegration = true,
                 isConversationFiles = true,
+                isCollaboraEnabled = true,
             )
 
             // THEN
@@ -456,12 +457,13 @@ class CellFileActionsMenuTest {
         isConversationFiles: Boolean = false,
         isAllFiles: Boolean = false,
         isSearching: Boolean = false,
+        isCollaboraEnabled: Boolean = false,
     ): List<NodeBottomSheetAction> =
         CellFileActionsMenu(
             featureFlags = KaliumConfigs(
                 collaboraIntegration = withCollaboraIntegration
             )
-        ).buildMenu(fileNode, isRecycleBin, isConversationFiles, isAllFiles, isSearching)
+        ).buildMenu(fileNode, isRecycleBin, isConversationFiles, isAllFiles, isSearching, isCollaboraEnabled)
 
     private companion object {
         val fileNode = CellNodeUi.File(

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.cells.domain.usecase.download.DownloadCellFileUseCase
 import com.wire.kalium.cells.domain.usecase.GetAllTagsUseCase
 import com.wire.kalium.cells.domain.usecase.GetEditorUrlUseCase
 import com.wire.kalium.cells.domain.usecase.GetPaginatedFilesFlowUseCase
+import com.wire.kalium.cells.domain.usecase.GetWireCellConfigurationUseCase
 import com.wire.kalium.cells.domain.usecase.IsAtLeastOneCellAvailableUseCase
 import com.wire.kalium.cells.domain.usecase.RestoreNodeFromRecycleBinUseCase
 import com.wire.kalium.common.error.CoreFailure
@@ -304,6 +305,9 @@ class CellViewModelTest {
         @MockK
         lateinit var cellFileActionsMenu: CellFileActionsMenu
 
+        @MockK
+        lateinit var getWireCellsConfig: GetWireCellConfigurationUseCase
+
         init {
 
             MockKAnnotations.init(this, relaxUnitFun = true)
@@ -371,6 +375,8 @@ class CellViewModelTest {
             every { fileNameResolver.getUniqueFile(any(), any()) } returns File("")
             coEvery { Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) } returns File("")
 
+            coEvery { getWireCellsConfig() } returns null
+
             return this to CellViewModel(
                 savedStateHandle = savedStateHandle,
                 getCellFilesPaged = getCellFilesPagedUseCase,
@@ -384,6 +390,7 @@ class CellViewModelTest {
                 onlineEditor = onlineEditor,
                 getEditorUrl = getEditorUrlUseCase,
                 cellFileActionsMenu = cellFileActionsMenu,
+                getWireCellsConfig = getWireCellsConfig,
             )
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22343" title="WPB-22343" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22343</a>  [Android] Support Collabora feature flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-22343

# What's new in this PR?

Check collabora settings from feature flag to enable / disable feature. 

Current logic for enabling the online edit feature for the file:
- Feature is enabled by client feature flag (to be removed on release)
- Feature is enabled by configuration from server feature flag
- Current file format is supported by online editor