### PR TITLE
fix: arrow icon next to toggle in settings [WPB-22554]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsItem.kt
@@ -58,7 +58,6 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
-import com.wire.android.ui.common.R as commonR
 
 @Composable
 fun SettingsItem(
@@ -125,10 +124,7 @@ fun SettingsItem(
                             .padding(end = dimensions().spacing8x)
                             .clickable(onIconPressed)
                     )
-                } ?: Icon(
-                    painter = painterResource(commonR.drawable.ic_chevron_right),
-                    contentDescription = null,
-                )
+                }
             }
         },
         clickable = onRowPressed

--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewItem.kt
@@ -44,7 +44,6 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
-import com.wire.android.ui.common.R as commonR
 
 @Composable
 fun WhatsNewItem(
@@ -93,10 +92,7 @@ fun WhatsNewItem(
                         .padding(end = dimensions().spacing8x)
                         .shimmerPlaceholder(visible = isLoading)
                 )
-            } ?: Icon(
-                painter = painterResource(commonR.drawable.ic_chevron_right),
-                contentDescription = null,
-            )
+            }
         },
         clickable = onRowPressed,
         modifier = modifier


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22554" title="WPB-22554" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22554</a>  [Android] Arrow shouldn't be visible when there's a toggle in settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In settings, for rows that have a toggle, there shouldn't be an arrow icon visible, the app should either show a toggle or arrow icon.

### Causes (Optional)

This is just an outcome of actually fixing the part of code that had no sense before, as previously it was like this:
```
actions = {
    trailingIcon?.let {
        Icon(
            painter = painterResource(id = trailingIcon),
            contentDescription = "",
            tint = MaterialTheme.wireColorScheme.onSecondaryButtonEnabled,
            modifier = Modifier
                .defaultMinSize(80.dp)
                .clickable(onIconPressed)
        )
    } ?: Icons.Filled.ChevronRight
},
```
so in case of null `trailingIcon` (and it should be null when there's a toggle) it was passing the `ImageVector` but it wasn't drawing it (not wrapped in any Icon nor Image drawable) and when replacing material Icons it was actually wrapped with `Icon` because it was probably noticed that it doesn't do anything.

### Solutions

Remove creating `Icon` with arrow when `trailingIcon` is null - in this case it shouldn't have any trailing icon.

### Testing

#### How to Test

Open settings and check "lock with passcode" option, if app lock is enabled for the user and not enforced by team, so when the toggle is visible and editable.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <img width="400" src="https://github.com/user-attachments/assets/bb75844c-d3cd-44de-878d-0a928fa0e6fe" /> | <img width="400" src="https://github.com/user-attachments/assets/60bacec9-ef18-417f-b106-40f0d2cd7848" /> |


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
