### PR TITLE
ci: updating dockerfile for android-agent

### DIFF
--- a/docker-agent/AndroidAgent
+++ b/docker-agent/AndroidAgent
@@ -1,73 +1,71 @@
-FROM eclipse-temurin:17-jdk
+# Android Agent Docker Image
+#
+# Base: Ubuntu 24.04 (noble) with glibc 2.39
+# Required for core-crypto native binaries which need glibc 2.38+
+#
+# Build:
+#   docker build -t android-agent:latest .
+#
+# Test:
+#   docker run --rm android-agent:latest ldd --version | head -1
+#   # Should show: GLIBC 2.39
+
+FROM eclipse-temurin:17-jdk-noble
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get update && \
-    apt-get install -yq unzip libc6 libstdc++6 zlib1g libncurses5 build-essential libssl-dev ruby ruby-dev --no-install-recommends docker.io vim git && \
+    apt-get install -yq \
+        unzip \
+        libc6 \
+        libstdc++6 \
+        zlib1g \
+        libncurses6 \
+        build-essential \
+        libssl-dev \
+        ruby \
+        ruby-dev \
+        docker.io \
+        vim \
+        git \
+        wget \
+        --no-install-recommends && \
     apt-get clean
 
 RUN gem install bundler
 
-# Cleaning
-RUN apt-get clean
-
 ARG USER=android-agent
 ARG USER_ID=1000
 ARG GROUP_ID=1000
-RUN useradd -m ${USER} --uid=${USER_ID}
+RUN useradd -m ${USER} --uid=${USER_ID} --non-unique || true
 USER ${USER_ID}:${GROUP_ID}
 WORKDIR /home/${USER}
-ENV HOME /home/${USER}
+ENV HOME=/home/${USER}
 
-# Download and untar Android SDK tools
-RUN mkdir -p /home/${USER}/android-sdk-linux && \
-    wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -O tools.zip && \
-    unzip tools.zip -d /home/${USER}/android-sdk && \
-    rm tools.zip
+# Download Android cmdline-tools
+RUN mkdir -p /home/${USER}/android-sdk/cmdline-tools && \
+    wget -q https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O cmdline-tools.zip && \
+    unzip -q cmdline-tools.zip && \
+    mv cmdline-tools /home/${USER}/android-sdk/cmdline-tools/latest && \
+    rm cmdline-tools.zip
 
-# Download and untar Android NDK tools
-ENV ANDROID_NDK_HOME /home/${USER}/android-ndk
-ENV ANDROID_NDK_VERSION r22b
+# Download Android NDK
+ENV ANDROID_NDK_HOME=/home/${USER}/android-ndk
+ENV ANDROID_NDK_VERSION=r27b
 RUN mkdir /home/${USER}/android-ndk-tmp && \
     cd /home/${USER}/android-ndk-tmp && \
-    wget -q https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip && \
-# uncompress
-    unzip -q android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip && \
-# move to its final location
+    wget -q https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux.zip && \
+    unzip -q android-ndk-${ANDROID_NDK_VERSION}-linux.zip && \
     mv ./android-ndk-${ANDROID_NDK_VERSION} ${ANDROID_NDK_HOME} && \
-# remove temp dir
-    cd ${ANDROID_NDK_HOME} && \
     rm -rf /home/${USER}/android-ndk-tmp
 
-# Download latest cmdline-tools to fix the sdkmanager jdk11 incompatibilities
-RUN mkdir /home/${USER}/cmdline-tools-tmp && \
-    cd /home/${USER}/cmdline-tools-tmp && \
-    wget https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip && \
-# uncompress
-    unzip commandlinetools-linux-7583922_latest.zip && \
-# hackytrick as google is stupid
-    mkdir /home/${USER}/android-sdk/cmdline-tools/ && \
-# now copy the cmdlone-tools folder as the actual tools folder
-    mv cmdline-tools /home/${USER}/android-sdk/cmdline-tools/tools && \
-# remove the temp folder
-    cd /home/${USER} && \
-    rm -rf /home/${USER}/cmdline-tools-tmp
-
-# Set environment variable
-ENV ANDROID_HOME /home/${USER}/android-sdk
+ENV ANDROID_HOME=/home/${USER}/android-sdk
 ENV ANDROID_SDK=${ANDROID_HOME}
-ENV PATH ${ANDROID_HOME}/cmdline-tools/tools:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/emulator:${ANDROID_HOME}/cmdline-tools/tools/bin:$ANDROID_NDK_HOME:$PATH
+ENV PATH=${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/emulator:${ANDROID_NDK_HOME}:${PATH}
 
-#define the values to install/setup via the sdk manager
-ARG BUILD_TOOLS_VERSION=30.0.2
-ARG PLATFORMS_VERSION=android-29
-ARG ARCHITECTURE=x86
+# Accept licenses and install SDK components
+ARG BUILD_TOOLS_VERSION=35.0.0
+ARG PLATFORMS_VERSION=android-35
 
-# Make license agreement
-RUN yes | $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager --licenses
-
-# Update and install using sdkmanager
-RUN $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager "tools" "platform-tools" "build-tools;${BUILD_TOOLS_VERSION}" "platforms;${PLATFORMS_VERSION}" "system-images;${PLATFORMS_VERSION};default;${ARCHITECTURE}" "extras;android;m2repository" "extras;google;m2repository"
-
-# uncomment if you need to run the docker image standalone for testing purpose
-#CMD tail -f /dev/null
+RUN yes | sdkmanager --licenses && \
+    sdkmanager "platform-tools" "build-tools;${BUILD_TOOLS_VERSION}" "platforms;${PLATFORMS_VERSION}"

--- a/docker-agent/AndroidAgent
+++ b/docker-agent/AndroidAgent
@@ -66,6 +66,9 @@ ENV PATH=${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools
 # Accept licenses and install SDK components
 ARG BUILD_TOOLS_VERSION=35.0.0
 ARG PLATFORMS_VERSION=android-35
+ARG ARCHITECTURE=x86_64
 
 RUN yes | sdkmanager --licenses && \
-    sdkmanager "platform-tools" "build-tools;${BUILD_TOOLS_VERSION}" "platforms;${PLATFORMS_VERSION}"
+    sdkmanager "platform-tools" "build-tools;${BUILD_TOOLS_VERSION}" "platforms;${PLATFORMS_VERSION}" \
+    "system-images;${PLATFORMS_VERSION};default;${ARCHITECTURE}" \
+    "extras;android;m2repository" "extras;google;m2repository"

--- a/docker-agent/builder.sh
+++ b/docker-agent/builder.sh
@@ -38,7 +38,7 @@ fi
 if [ "$SIGN_APK" = true ] ; then
     echo "Signing APK with given details"
     clientVersion=$(sed -ne "s/.*ANDROID_CLIENT_MAJOR_VERSION = \"\([^']*\)\"/\1/p" buildSrc/src/main/kotlin/Dependencies.kt)
-   /home/android-agent/android-sdk/build-tools/30.0.2/apksigner sign --ks ${HOME}/wire-android/${KEYSTORE_PATH} --ks-key-alias ${KEYSTORE_KEY_NAME} --ks-pass pass:${KSTOREPWD} --key-pass pass:${KEYPWD} "${HOME}/wire-android/app/build/outputs/apk/wire-${CUSTOM_FLAVOR,,}-${BUILD_TYPE,,}-${clientVersion}${PATCH_VERSION}.apk"
+   /home/android-agent/android-sdk/build-tools/35.0.0/apksigner sign --ks ${HOME}/wire-android/${KEYSTORE_PATH} --ks-key-alias ${KEYSTORE_KEY_NAME} --ks-pass pass:${KSTOREPWD} --key-pass pass:${KEYPWD} "${HOME}/wire-android/app/build/outputs/apk/wire-${CUSTOM_FLAVOR,,}-${BUILD_TYPE,,}-${clientVersion}${PATCH_VERSION}.apk"
 else
    echo "Apk will not be signed by the builder script"
 fi


### PR DESCRIPTION
Update base image to eclipse-temurin:17-jdk-noble (Ubuntu 24.04)
for glibc 2.39 compatibility. core-crypto native binaries require
glibc 2.38+, which the previous Ubuntu 22.04-based image lacked.

Changes from previous image:

    Base: Ubuntu 24.04 (noble) with glibc 2.39
    NDK: r27b
    Build tools: 35.0.0
    Platform: android-35
    cmdline-tools: 11076708

