### PR TITLE
fix: crash when trying to change accent color on tablets [WPB-22627]

### DIFF
--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/StatusBarsHelper.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/theme/StatusBarsHelper.kt
@@ -18,6 +18,8 @@
 package com.wire.android.ui.theme
 
 import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.platform.LocalView
@@ -26,10 +28,16 @@ import androidx.core.view.WindowCompat
 @Composable
 fun UpdateSystemBarIconsAppearance(useDarkSystemBarIcons: Boolean) {
     val view = LocalView.current
-    if (!view.isInEditMode) {
+    val activity = view.context.getActivity()
+    if (!view.isInEditMode && activity != null) {
         SideEffect {
-            val window = (view.context as Activity).window
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = useDarkSystemBarIcons
+            WindowCompat.getInsetsController(activity.window, view).isAppearanceLightStatusBars = useDarkSystemBarIcons
         }
     }
+}
+
+private fun Context.getActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.getActivity()
+    else -> null
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22627" title="WPB-22627" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22627</a>  [Android] Crash on StatusBarHelpers playstore finding
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Opening `ChangeUserColorScreen` crashes on tablets.

### Causes (Optional)

It uses a different `WireTheme` inside the screen and on tablets this screen uses `DialogNavigation` so the `LocalContext` is wrapped with `ContextThemeWrapper` to apply `FloatingDialogWindowTheme` and then it crashes because `view.context` is of type `ContextThemeWrapper` and not `Activity`.

### Solutions

Use a recursive function to get the `Activity` from the context, or null if not possible.

### Testing

#### How to Test

Open the app on tablet and try to change the accent color (Settings -> Account Details -> User Color) - it should open the "User Color" screen as a dialog without crashing.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
