### PR TITLE
feat: add global shake to open log management [WPB-22628]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -317,9 +317,7 @@ class WireApplication : BaseApp() {
         AppLogger.init(config)
         CoreLogger.init(config)
         // 3. Initialize our internal FILE logging framework
-        if (isLoggingEnabled) {
-            logFileWriter.get().start()
-        }
+        logFileWriter.get().start()
         // 4. Everything ready, now we can log device info
         appLogger.i("Logger enabled")
         logDeviceInformation()

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -317,7 +317,9 @@ class WireApplication : BaseApp() {
         AppLogger.init(config)
         CoreLogger.init(config)
         // 3. Initialize our internal FILE logging framework
-        logFileWriter.get().start()
+        if (isLoggingEnabled) {
+            logFileWriter.get().start()
+        }
         // 4. Everything ready, now we can log device info
         appLogger.i("Logger enabled")
         logDeviceInformation()

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -96,6 +96,7 @@ import com.wire.android.ui.destinations.NewWelcomeEmptyStartScreenDestination
 import com.wire.android.ui.destinations.SelfDevicesScreenDestination
 import com.wire.android.ui.destinations.SelfUserProfileScreenDestination
 import com.wire.android.ui.destinations.WelcomeScreenDestination
+import com.wire.android.ui.destinations.LogManagementScreenDestination
 import com.wire.android.ui.e2eiEnrollment.GetE2EICertificateUI
 import com.wire.android.ui.home.E2EICertificateRevokedDialog
 import com.wire.android.ui.home.E2EIRequiredDialog
@@ -119,6 +120,7 @@ import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.LocalSyncStateObserver
 import com.wire.android.util.SwitchAccountObserver
 import com.wire.android.util.SyncStateObserver
+import com.wire.android.util.ShakeDetector
 import com.wire.android.util.debug.FeatureVisibilityFlags
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.deeplink.LoginType
@@ -166,6 +168,8 @@ class WireActivity : AppCompatActivity() {
     private val legalHoldDeactivatedViewModel: LegalHoldDeactivatedViewModel by viewModels()
 
     private val newIntents = Channel<Pair<Intent, Bundle?>>(Channel.UNLIMITED) // keep new intents until subscribed but do not replay them
+    private var navigatorRef: Navigator? = null
+    private var shakeDetector: ShakeDetector? = null
 
     // This flag is used to keep the splash screen open until the first screen is drawn.
     private var shouldKeepSplashOpen = true
@@ -182,6 +186,7 @@ class WireActivity : AppCompatActivity() {
 
         enableEdgeToEdge()
         setupOrientationForDevice()
+        shakeDetector = ShakeDetector(this, onShake = { handleLogManagementShake() })
 
         lifecycleScope.launch {
 
@@ -275,6 +280,14 @@ class WireActivity : AppCompatActivity() {
                             }
                         }
                     )
+                    DisposableEffect(navigator) {
+                        navigatorRef = navigator
+                        onDispose {
+                            if (navigatorRef === navigator) {
+                                navigatorRef = null
+                            }
+                        }
+                    }
                     val currentBackStackEntryState = navigator.navController.currentBackStackEntryAsState()
                     val backgroundType by remember {
                         derivedStateOf {
@@ -662,6 +675,7 @@ class WireActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        shakeDetector?.start()
 
         lifecycleScope.launch {
             lockCodeTimeManager.get().observeAppLock()
@@ -677,6 +691,11 @@ class WireActivity : AppCompatActivity() {
                     }
                 }
         }
+    }
+
+    override fun onPause() {
+        shakeDetector?.stop()
+        super.onPause()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -734,6 +753,16 @@ class WireActivity : AppCompatActivity() {
         } else {
             viewModel.handleDeepLink(intent)
             intent.putExtra(HANDLED_DEEPLINK_FLAG, true)
+        }
+    }
+
+    private fun handleLogManagementShake() {
+        val navigator = navigatorRef ?: return
+        runOnUiThread {
+            val currentRoute = navigator.navController.currentDestination?.route?.getBaseRoute()
+            val targetRoute = LogManagementScreenDestination.route.getBaseRoute()
+            if (currentRoute == targetRoute) return@runOnUiThread
+            navigator.navigate(NavigationCommand(LogManagementScreenDestination, BackStackMode.UPDATE_EXISTED))
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementScreen.kt
@@ -1,0 +1,72 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.debug
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.wire.android.R
+import com.wire.android.navigation.Navigator
+import com.wire.android.navigation.annotation.app.WireDestination
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.scaffold.WireScaffold
+import com.wire.android.ui.common.topappbar.NavigationIconType
+import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+
+@WireDestination
+@Composable
+fun LogManagementScreen(
+    navigator: Navigator,
+    viewModel: LogManagementViewModel = hiltViewModel()
+) {
+    val state = viewModel.state
+    val contentState = rememberDebugContentState(state.logPath)
+
+    WireScaffold(
+        topBar = {
+            WireCenterAlignedTopAppBar(
+                title = stringResource(R.string.label_logs_option_title),
+                elevation = dimensions().spacing0x,
+                navigationIconType = NavigationIconType.Close(),
+                onNavigationPressed = navigator::navigateBack
+            )
+        }
+    ) { internalPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(contentState.scrollState)
+                .padding(internalPadding)
+        ) {
+            LogOptions(
+                isLoggingEnabled = state.isLoggingEnabled,
+                onLoggingEnabledChange = viewModel::setLoggingEnabledState,
+                onDeleteLogs = viewModel::deleteLogs,
+                onShareLogs = { contentState.shareLogs(viewModel::flushLogs) },
+                isDBLoggerEnabled = false,
+                onDBLoggerEnabledChange = {},
+                isPrivateBuild = false
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementScreen.kt
@@ -37,12 +37,14 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 @Composable
 fun LogManagementScreen(
     navigator: Navigator,
+    modifier: Modifier = Modifier,
     viewModel: LogManagementViewModel = hiltViewModel()
 ) {
     val state = viewModel.state
     val contentState = rememberDebugContentState(state.logPath)
 
     WireScaffold(
+        modifier = modifier,
         topBar = {
             WireCenterAlignedTopAppBar(
                 title = stringResource(R.string.label_logs_option_title),

--- a/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementViewModel.kt
@@ -1,0 +1,84 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.debug
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.util.logging.LogFileWriter
+import com.wire.kalium.common.logger.CoreLogger
+import com.wire.kalium.logger.KaliumLogLevel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class LogManagementState(
+    val isLoggingEnabled: Boolean = false,
+    val logPath: String
+)
+
+@HiltViewModel
+class LogManagementViewModel @Inject constructor(
+    private val logFileWriter: LogFileWriter,
+    private val globalDataStore: GlobalDataStore
+) : ViewModel() {
+
+    var state by mutableStateOf(
+        LogManagementState(logPath = logFileWriter.activeLoggingFile.absolutePath)
+    )
+
+    init {
+        observeLoggingState()
+    }
+
+    fun setLoggingEnabledState(isEnabled: Boolean) {
+        viewModelScope.launch {
+            globalDataStore.setLoggingEnabled(isEnabled)
+            if (isEnabled) {
+                logFileWriter.start()
+                CoreLogger.setLoggingLevel(level = KaliumLogLevel.VERBOSE)
+            } else {
+                logFileWriter.stop()
+                CoreLogger.setLoggingLevel(level = KaliumLogLevel.DISABLED)
+            }
+        }
+    }
+
+    fun deleteLogs() {
+        logFileWriter.deleteAllLogFiles()
+    }
+
+    fun flushLogs(): Deferred<Unit> {
+        return viewModelScope.async {
+            logFileWriter.forceFlush()
+        }
+    }
+
+    private fun observeLoggingState() {
+        viewModelScope.launch {
+            globalDataStore.isLoggingEnabled().collect {
+                state = state.copy(isLoggingEnabled = it)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/debug/LogOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/LogOptions.kt
@@ -70,25 +70,23 @@ fun LogOptions(
                 onCheckedChange = onDBLoggerEnabledChange
             )
         }
-        if (isLoggingEnabled) {
-            SettingsItem(
-                text = stringResource(R.string.label_share_logs),
-                trailingIcon = R.drawable.ic_entypo_share,
-                onIconPressed = Clickable(
-                    enabled = true,
-                    onClick = onShareLogs
-                )
+        SettingsItem(
+            text = stringResource(R.string.label_share_logs),
+            trailingIcon = R.drawable.ic_entypo_share,
+            onIconPressed = Clickable(
+                enabled = true,
+                onClick = onShareLogs
             )
+        )
 
-            SettingsItem(
-                text = stringResource(R.string.label_delete_logs),
-                trailingIcon = com.wire.android.ui.common.R.drawable.ic_delete,
-                onIconPressed = Clickable(
-                    enabled = true,
-                    onClick = onDeleteLogs
-                )
+        SettingsItem(
+            text = stringResource(R.string.label_delete_logs),
+            trailingIcon = com.wire.android.ui.common.R.drawable.ic_delete,
+            onIconPressed = Clickable(
+                enabled = true,
+                onClick = onDeleteLogs
             )
-        }
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/debug/LogOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/LogOptions.kt
@@ -33,13 +33,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.model.Clickable
-import com.wire.android.ui.common.rowitem.RowItemTemplate
 import com.wire.android.ui.common.SurfaceBackgroundWrapper
 import com.wire.android.ui.common.button.WireSwitch
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.common.typography
+import com.wire.android.ui.common.rowitem.RowItemTemplate
 import com.wire.android.ui.common.rowitem.SectionHeader
+import com.wire.android.ui.common.typography
 import com.wire.android.ui.home.settings.SettingsItem
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -70,23 +70,25 @@ fun LogOptions(
                 onCheckedChange = onDBLoggerEnabledChange
             )
         }
-        SettingsItem(
-            text = stringResource(R.string.label_share_logs),
-            trailingIcon = R.drawable.ic_entypo_share,
-            onIconPressed = Clickable(
-                enabled = true,
-                onClick = onShareLogs
+        if (isLoggingEnabled) {
+            SettingsItem(
+                text = stringResource(R.string.label_share_logs),
+                trailingIcon = R.drawable.ic_entypo_share,
+                onIconPressed = Clickable(
+                    enabled = true,
+                    onClick = onShareLogs
+                )
             )
-        )
 
-        SettingsItem(
-            text = stringResource(R.string.label_delete_logs),
-            trailingIcon = com.wire.android.ui.common.R.drawable.ic_delete,
-            onIconPressed = Clickable(
-                enabled = true,
-                onClick = onDeleteLogs
+            SettingsItem(
+                text = stringResource(R.string.label_delete_logs),
+                trailingIcon = com.wire.android.ui.common.R.drawable.ic_delete,
+                onIconPressed = Clickable(
+                    enabled = true,
+                    onClick = onDeleteLogs
+                )
             )
-        )
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/util/ShakeDetector.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ShakeDetector.kt
@@ -48,20 +48,20 @@ class ShakeDetector(
     }
 
     override fun onSensorChanged(event: SensorEvent) {
-        if (event.sensor.type != Sensor.TYPE_ACCELEROMETER) return
+        if (event.sensor.type == Sensor.TYPE_ACCELEROMETER) {
+            val x = event.values[0] / SensorManager.GRAVITY_EARTH
+            val y = event.values[1] / SensorManager.GRAVITY_EARTH
+            val z = event.values[2] / SensorManager.GRAVITY_EARTH
 
-        val x = event.values[0] / SensorManager.GRAVITY_EARTH
-        val y = event.values[1] / SensorManager.GRAVITY_EARTH
-        val z = event.values[2] / SensorManager.GRAVITY_EARTH
-
-        val gForce = sqrt(x * x + y * y + z * z)
-        if (gForce < shakeThresholdGravity) return
-
-        val now = SystemClock.elapsedRealtime()
-        if (now - lastShakeTimestamp < debounceMs) return
-
-        lastShakeTimestamp = now
-        onShake()
+            val gForce = sqrt(x * x + y * y + z * z)
+            if (gForce >= shakeThresholdGravity) {
+                val now = SystemClock.elapsedRealtime()
+                if (now - lastShakeTimestamp >= debounceMs) {
+                    lastShakeTimestamp = now
+                    onShake()
+                }
+            }
+        }
     }
 
     override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit

--- a/app/src/main/kotlin/com/wire/android/util/ShakeDetector.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ShakeDetector.kt
@@ -1,0 +1,73 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.SystemClock
+import kotlin.math.sqrt
+
+class ShakeDetector(
+    context: Context,
+    private val onShake: () -> Unit,
+    private val shakeThresholdGravity: Float = DEFAULT_SHAKE_THRESHOLD_GRAVITY,
+    private val debounceMs: Long = DEFAULT_DEBOUNCE_MS
+) : SensorEventListener {
+
+    private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+    private val accelerometer = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+
+    private var lastShakeTimestamp = 0L
+
+    fun start() {
+        if (accelerometer != null) {
+            sensorManager.registerListener(this, accelerometer, SensorManager.SENSOR_DELAY_UI)
+        }
+    }
+
+    fun stop() {
+        sensorManager.unregisterListener(this)
+    }
+
+    override fun onSensorChanged(event: SensorEvent) {
+        if (event.sensor.type != Sensor.TYPE_ACCELEROMETER) return
+
+        val x = event.values[0] / SensorManager.GRAVITY_EARTH
+        val y = event.values[1] / SensorManager.GRAVITY_EARTH
+        val z = event.values[2] / SensorManager.GRAVITY_EARTH
+
+        val gForce = sqrt(x * x + y * y + z * z)
+        if (gForce < shakeThresholdGravity) return
+
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastShakeTimestamp < debounceMs) return
+
+        lastShakeTimestamp = now
+        onShake()
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+
+    companion object {
+        private const val DEFAULT_SHAKE_THRESHOLD_GRAVITY = 2.7f
+        private const val DEFAULT_DEBOUNCE_MS = 2000L
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22628" title="WPB-22628" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22628</a>  [Android] Shake device to manage logs (available anytime)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Adds a global shake gesture to open Log Management, accessible pre- and post-login.

### Issues

- No fast, global entry point for managing logs from any screen/state (especially pre-login).
- Logging toggle and log sharing were hard to access outside debug settings.

---

### Causes (Optional)

- Log Management was only reachable through the debug/settings flow.
- No lightweight, always-available entry point for logs.

---

### Solutions

- Added `ShakeDetector` in `WireActivity` with debouncing and navigation to the new Log Management screen.
- Introduced a standalone `LogManagementScreen` + `LogManagementViewModel` reachable anytime.
