### PR TITLE
feat: disable channel creation for personal users (WPB-22618)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupsearch/NewGroupConversationSearchPeopleScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupsearch/NewGroupConversationSearchPeopleScreen.kt
@@ -48,7 +48,6 @@ fun NewGroupConversationSearchPeopleScreen(
     }
 
     BackHandler(true, onBackClicked)
-    val isSelfTeamMember = newConversationViewModel.newGroupState.isSelfTeamMember ?: false
 
     val screenTitle = if (newConversationViewModel.newGroupState.isChannel) {
         stringResource(id = R.string.label_new_channel)
@@ -61,7 +60,7 @@ fun NewGroupConversationSearchPeopleScreen(
             OtherUserProfileScreenDestination(QualifiedID(contact.id, contact.domain))
                 .let { navigator.navigate(NavigationCommand(it)) }
         },
-        shouldShowChannelPromotion = !isSelfTeamMember,
+        shouldShowChannelPromotion = false,
         isUserAllowedToCreateChannels = false,
         onContactChecked = newConversationViewModel::updateSelectedContacts,
         onContinue = { navigator.navigate(NavigationCommand(NewGroupNameScreenDestination)) },

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/NewConversationSearchPeopleScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/NewConversationSearchPeopleScreen.kt
@@ -45,12 +45,10 @@ fun NewConversationSearchPeopleScreen(
     navigator: Navigator,
     newConversationViewModel: NewConversationViewModel,
 ) {
-    val isSelfTeamMember = newConversationViewModel.newGroupState.isSelfTeamMember ?: false
-    val shouldShowChannelPromotion = !isSelfTeamMember
     val showCreateTeamDialog = remember { mutableStateOf(false) }
     SearchUsersAndAppsScreen(
         searchTitle = stringResource(id = R.string.label_new_conversation),
-        shouldShowChannelPromotion = shouldShowChannelPromotion,
+        shouldShowChannelPromotion = false,
         isUserAllowedToCreateChannels = newConversationViewModel.isChannelCreationPossible,
         onOpenUserProfile = { contact ->
             OtherUserProfileScreenDestination(QualifiedID(contact.id, contact.domain))
@@ -62,12 +60,8 @@ fun NewConversationSearchPeopleScreen(
             navigator.navigate(NavigationCommand(NewGroupConversationSearchPeopleScreenDestination))
         },
         onCreateNewChannel = {
-            if (!shouldShowChannelPromotion) {
-                newConversationViewModel.setIsChannel(true)
-                navigator.navigate(NavigationCommand(NewGroupConversationSearchPeopleScreenDestination))
-            } else {
-                showCreateTeamDialog.value = true
-            }
+            newConversationViewModel.setIsChannel(true)
+            navigator.navigate(NavigationCommand(NewGroupConversationSearchPeopleScreenDestination))
         },
         isGroupSubmitVisible = newConversationViewModel.newGroupState.isGroupCreatingAllowed == true,
         onClose = navigator::navigateBack,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22618" title="WPB-22618" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22618</a>  [Android] Hide Channel options for now
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-22618

# What's new in this PR?

### Issues

Currently, personal users see the option to create a channel, but are prompted to create a team.
When they create a team, they will still not have the possibility to create channels until we have fully rolled out this feature.
Until such time we want to hide this option in the UI for personal users.