### PR TITLE
fix: missing notification (WPB-22701)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -475,7 +475,10 @@ class WireNotificationManager @Inject constructor(
                         selfUserNameState.value
                     )
                 }
-                markMessagesAsNotified(userId)
+
+                newNotifications.map { it.conversationId }.distinct().forEach { notifiedConversationId ->
+                    markMessagesAsNotified(userId, notifiedConversationId)
+                }
                 markConnectionAsNotified(userId)
             }
     }

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -1031,7 +1031,7 @@ class WireNotificationManagerTest {
                 )
             }
             coVerify(atLeast = 1) {
-                arrangement.markMessagesAsNotified(MarkMessagesAsNotifiedUseCase.UpdateTarget.AllConversations)
+                arrangement.markMessagesAsNotified(MarkMessagesAsNotifiedUseCase.UpdateTarget.SingleConversation(conversationId))
             }
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22701" title="WPB-22701" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22701</a>  [Android] Not receiving all notifications
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-22701

# What's new in this PR?

### Issues
Application sometimes skips new message notification.

### Causes
Notification handler is setting the date of the most recent message as last_notified_date for every conversation (even if the notification was shown for another conversation). Which is causing the notifications query skip some of the messages.

### Solutions
Update last_notified_date only for notified conversations.