### PR TITLE
fix: benchmarks configurations and docs on how to run them (WPB-22876)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/password/NewLoginPasswordScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/password/NewLoginPasswordScreen.kt
@@ -211,7 +211,8 @@ internal fun LoginPasswordContent(
                 PasswordInput(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(bottom = dimensions().spacing8x),
+                        .padding(bottom = dimensions().spacing8x)
+                        .testTag("PasswordInput"),
                     passwordState = passwordTextState,
                 )
                 if (serverConfig.isProxyAuthRequired) {
@@ -237,7 +238,8 @@ internal fun LoginPasswordContent(
                     onClick = onLoginButtonClick,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(bottom = dimensions().spacing8x),
+                        .padding(bottom = dimensions().spacing8x)
+                        .testTag("LoginNextButton"),
 
                     )
                 if (!serverConfig.isProxyAuthRequired) {

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,22 @@
+## App Benchmarks
+
+This is the benchmark project for the Android App. To run the benchmarks, the following prerequisites must be met:
+
+- A real Android device is used for testing (emulators are not supported).
+- There is a beta benchmark build of the app installed on the device. 
+- If using the test with login, make sure the max amount of devices registered to the account is not exceeded.
+
+### Building the benchmark APK
+To build the benchmark APK, use the following command:
+
+```shell
+./gradlew clean assembleBetaBenchmark
+```
+
+### Running the benchmarks
+To run the benchmarks, use the following command:
+```shell
+./gradlew :benchmark:connectedDebugAndroidTest
+```
+
+Alternatively, you can run the benchmarks directly from Android Studio by selecting the `benchmark` module and running the `connectedDebugAndroidTest` configuration.

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -47,3 +47,9 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.benchmark.macro.junit4)
 }
+
+kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_17.majorVersion))
+    }
+}

--- a/benchmark/src/androidTest/java/com/wire/benchmark/StartupBenchmarkWithLogin.kt
+++ b/benchmark/src/androidTest/java/com/wire/benchmark/StartupBenchmarkWithLogin.kt
@@ -63,16 +63,16 @@ class StartupBenchmarkWithLogin {
     }
 
     private fun MacrobenchmarkScope.login() {
-        device.findObject(By.res("loginButton"))?.let {
-            it.click()
-        }
         device.findObject(By.res("userIdentifierInput"))?.let {
             it.text = EMAIL
+        }
+        device.findObject(By.res("loginButton"))?.let {
+            it.click()
         }
         device.findObject(By.res("PasswordInput"))?.let {
             it.text = PASSWORD
         }
-        device.findObject(By.res("loginButton"))?.let {
+        device.findObject(By.res("LoginNextButton"))?.let {
             it.click()
         }
         device.wait(Until.hasObject(By.text("Conversations")), 30_000)

--- a/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -50,6 +50,10 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                     isMinifyEnabled = false
                     proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
                 }
+                create("benchmark") {
+                    initWith(getByName("release"))
+                    matchingFallbacks.add("release")
+                }
             }
 
             val crowdinTask = tasks.register("addEntryToCrowdinFile", AddEntryToCrowdinTask::class.java) {

--- a/build-logic/plugins/src/main/kotlin/AndroidTestLibraryConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidTestLibraryConventionPlugin.kt
@@ -65,6 +65,10 @@ class AndroidTestLibraryConventionPlugin : Plugin<Project> {
                     isMinifyEnabled = false
                     proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
                 }
+                create("benchmark") {
+                    initWith(getByName("release"))
+                    matchingFallbacks.add("release")
+                }
             }
         }
     }

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -6,16 +6,12 @@ plugins {
 
 android {
     namespace = "com.wire.android.navigation"
-    buildTypes {
-        create("benchmark") {
-        }
-    }
 }
 
 dependencies {
+    implementation(projects.core.uiCommon)
     implementation(libs.visibilityModifiers)
     implementation(libs.compose.navigation)
     implementation(libs.compose.destinations.core)
-    implementation(project(":core:ui-common"))
     implementation(libs.compose.material3)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-22876
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Running benchmarks needed some hacks in order to be run. 

### Causes (Optional)

Outdated since the last time we run, and new modules introduced.

### Solutions

- Add to the convention plugin the benchmark build type configs, so modules match the flavor.
- Add docs about how to run the benchmarks
- Fix benchmark with login, since new login was introduced last year.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- build the benchmark app as per instructions in new `benchmark/README.md`
- run the benchmarks


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
