### PR TITLE
refactor(perf): improves changes to applock non blocking check to improve startup time (WPB-22876)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
+++ b/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.runBlocking
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -160,12 +159,6 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
         context.dataStore.data.map {
             it.contains(APP_LOCK_PASSCODE)
         }
-
-    fun isAppLockPasscodeSet(): Boolean = runBlocking {
-        context.dataStore.data.map {
-            it.contains(APP_LOCK_PASSCODE)
-        }.first()
-    }
 
     suspend fun clearAppLockPasscode() {
         context.dataStore.edit {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -90,13 +90,13 @@ import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.destinations.E2EIEnrollmentScreenDestination
 import com.wire.android.ui.destinations.E2eiCertificateDetailsScreenDestination
 import com.wire.android.ui.destinations.HomeScreenDestination
+import com.wire.android.ui.destinations.LogManagementScreenDestination
 import com.wire.android.ui.destinations.LoginScreenDestination
 import com.wire.android.ui.destinations.NewLoginScreenDestination
 import com.wire.android.ui.destinations.NewWelcomeEmptyStartScreenDestination
 import com.wire.android.ui.destinations.SelfDevicesScreenDestination
 import com.wire.android.ui.destinations.SelfUserProfileScreenDestination
 import com.wire.android.ui.destinations.WelcomeScreenDestination
-import com.wire.android.ui.destinations.LogManagementScreenDestination
 import com.wire.android.ui.e2eiEnrollment.GetE2EICertificateUI
 import com.wire.android.ui.home.E2EICertificateRevokedDialog
 import com.wire.android.ui.home.E2EIRequiredDialog
@@ -118,9 +118,9 @@ import com.wire.android.ui.userprofile.self.dialog.LogoutOptionsDialog
 import com.wire.android.ui.userprofile.self.dialog.LogoutOptionsDialogState
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.LocalSyncStateObserver
+import com.wire.android.util.ShakeDetector
 import com.wire.android.util.SwitchAccountObserver
 import com.wire.android.util.SyncStateObserver
-import com.wire.android.util.ShakeDetector
 import com.wire.android.util.debug.FeatureVisibilityFlags
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.deeplink.LoginType
@@ -458,8 +458,7 @@ class WireActivity : AppCompatActivity() {
                     onConfirm = {
                         featureFlagNotificationViewModel.dismissTeamAppLockDialog()
                         if (isTeamAppLockEnabled) {
-                            val isUserAppLockSet =
-                                featureFlagNotificationViewModel.isUserAppLockSet()
+                            val isUserAppLockSet = featureFlagNotificationViewModel.featureFlagState.isUserAppLockSet
                             // No need to setup another app lock if the user already has one
                             if (!isUserAppLockSet) {
                                 Intent(this@WireActivity, AppLockActivity::class.java)

--- a/app/src/main/kotlin/com/wire/android/ui/home/FeatureFlagState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/FeatureFlagState.kt
@@ -38,7 +38,8 @@ data class FeatureFlagState(
     val e2EIResult: E2EIResult? = null,
     val isE2EILoading: Boolean = false,
     val showCallEndedBecauseOfConversationDegraded: Boolean = false,
-    val startGettingE2EICertificate: Boolean = false
+    val startGettingE2EICertificate: Boolean = false,
+    val isUserAppLockSet: Boolean = false
 ) {
 
     sealed interface FileSharingState {

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -45,6 +45,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -65,8 +66,14 @@ class FeatureFlagNotificationViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            initialSync()
-            isAppLockSet()
+            // Load local initial app lock state before collecting updates
+            val initialAppLockSet = globalDataStore.get().isAppLockPasscodeSetFlow().first()
+            featureFlagState = featureFlagState.copy(isUserAppLockSet = initialAppLockSet)
+
+            coroutineScope {
+                launch { initialSync() }
+                launch { isAppLockSet() }
+            }
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
@@ -363,7 +363,7 @@ class FeatureFlagNotificationViewModelTest {
         }
 
         fun withIsAppLockSetup(result: Boolean) = apply {
-            coEvery { globalDataStore.isAppLockPasscodeSet() } returns result
+            coEvery { globalDataStore.isAppLockPasscodeSetFlow() } returns flowOf(result)
         }
 
         fun withAppLockSource(source: AppLockSource) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
@@ -356,6 +356,7 @@ class FeatureFlagNotificationViewModelTest {
             every { coreLogic.getSessionScope(any()).markNotifyForRevokedCertificateAsNotified } returns
                     markNotifyForRevokedCertificateAsNotified
             coEvery { ppLockTeamFeatureConfigObserver() } returns flowOf(null)
+            withIsAppLockSetup(true)
         }
 
         fun withCurrentSessionsFlow(result: Flow<CurrentSessionResult>) = apply {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-22876
<!--jira-description-action-hidden-marker-end-->




----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Change/remove the usage of `isUserAppLockSet()` checks from blocking to using the flow alternative and use as a state property.

### Solutions

Use the flow version `isAppLockPasscodeSetFlow()` and collect/update the state property.

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Attachments (Optional)

**With app lock changes to flow:**
```
StartupBenchmarkWithLogin_startUpWithoutBaselineProfiler
frameCount               min    15.0,   median    23.0,   max    27.0
timeToInitialDisplayMs   min 3,500.3,   median 3,835.8,   max 4,134.4
frameDurationCpuMs       P50     14.2,   P90     82.1,   P95    142.1,   P99    301.7
frameOverrunMs           P50      1.9,   P90    141.5,   P95    352.0,   P99  1,937.5
```

**Without (current dev):**
```
StartupBenchmarkWithLogin_startUpWithoutBaselineProfiler
frameCount               min    11.0,   median    16.0,   max    19.0
timeToInitialDisplayMs   min 3,978.1,   median 5,154.1,   max 5,866.2
frameDurationCpuMs       P50     21.0,   P90    119.1,   P95    403.7,   P99    491.4
frameOverrunMs           P50     42.1,   P90    518.4,   P95    654.2,   P99  1,732.9 
```

**Summary (by AI on the results)**
```
Performance Improvements
Startup Speed (TTID)
├─ Median: 25.6% faster (1,318 ms saved!)
├─ Min:    12.0% faster (478 ms saved)
└─ Max:    29.5% faster (1,732 ms saved)
Frame Rendering Quality (CPU time per frame)
├─ P50: 32.4% faster (6.8 ms saved per frame)
├─ P90: 31.1% faster (37.0 ms saved)
├─ P95: 64.8% faster (262 ms saved!)
└─ P99: 38.6% faster (190 ms saved)
Frame Overrun (Dropped Frames / Overrun ms)
├─ P50: 95.5% reduction (40.2 ms saved – almost eliminated!)
├─ P90: 72.7% reduction (377 ms saved)
├─ P95: 46.2% reduction (302 ms saved)
└─ P99: 11.8% worse (+205 ms regression – tail became heavier)
```

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
