### PR TITLE
refactor: lazy evaluate for kalium config  [WPB-23190]

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/TestCoreLogicModule.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/TestCoreLogicModule.kt
@@ -21,6 +21,7 @@ package com.wire.android
 import android.content.Context
 import androidx.work.WorkManager
 import com.wire.android.di.CoreLogicModule
+import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.NoSession
 import com.wire.android.util.UserAgentProvider
@@ -119,4 +120,8 @@ class TestCoreLogicModule {
     @Provides
     fun provideAudioNormalizedLoudnessBuilder(@KaliumCoreLogic coreLogic: CoreLogic): AudioNormalizedLoudnessBuilder =
         coreLogic.audioNormalizedLoudnessBuilder
+
+    @DefaultWebSocketEnabledByDefault
+    @Provides
+    fun provideDefaultWebSocketEnabledByDefault(): Boolean = true
 }

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -23,6 +23,7 @@ import androidx.work.WorkManager
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.util.ImageUtil
 import com.wire.android.util.UserAgentProvider
+import com.wire.android.util.isWebsocketEnabledByDefault
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.id.FederatedIdMapper
@@ -80,6 +81,10 @@ annotation class CurrentAccount
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class NoSession
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultWebSocketEnabledByDefault
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -144,6 +149,11 @@ class CoreLogicModule {
     @Provides
     fun provideAudioNormalizedLoudnessBuilder(@KaliumCoreLogic coreLogic: CoreLogic): AudioNormalizedLoudnessBuilder =
         coreLogic.audioNormalizedLoudnessBuilder
+
+    @DefaultWebSocketEnabledByDefault
+    @Provides
+    fun provideDefaultWebSocketEnabledByDefault(@ApplicationContext context: Context): Boolean =
+        isWebsocketEnabledByDefault(context)
 }
 
 @Module

--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -18,10 +18,8 @@
 
 package com.wire.android.di
 
-import android.content.Context
 import android.os.Build
 import com.wire.android.BuildConfig
-import com.wire.android.util.isWebsocketEnabledByDefault
 import com.wire.kalium.logic.featureFlags.BuildFileRestrictionState
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import dagger.Module
@@ -34,20 +32,20 @@ import dagger.hilt.components.SingletonComponent
 class KaliumConfigsModule {
 
     @Provides
-    fun provideKaliumConfigs(context: Context): KaliumConfigs {
-        val fileRestriction: BuildFileRestrictionState = if (BuildConfig.FILE_RESTRICTION_ENABLED) {
-            BuildConfig.FILE_RESTRICTION_LIST.split(",").map { it.trim() }.let {
-                BuildFileRestrictionState.AllowSome(it)
-            }
-        } else {
-            BuildFileRestrictionState.NoRestriction
-        }
-
+    fun provideKaliumConfigs(): KaliumConfigs {
         return KaliumConfigs(
-            fileRestrictionState = fileRestriction,
+            fileRestrictionState = {
+                if (BuildConfig.FILE_RESTRICTION_ENABLED) {
+                    BuildConfig.FILE_RESTRICTION_LIST.split(",").map { it.trim() }.let {
+                        BuildFileRestrictionState.AllowSome(it)
+                    }
+                } else {
+                    BuildFileRestrictionState.NoRestriction
+                }
+            },
             forceConstantBitrateCalls = BuildConfig.FORCE_CONSTANT_BITRATE_CALLS,
             // we use upsert, available from SQL3.24, which is supported from Android API30, so for older APIs we have to use SQLCipher
-            shouldEncryptData = !BuildConfig.DEBUG || Build.VERSION.SDK_INT < Build.VERSION_CODES.R,
+            shouldEncryptData = { !BuildConfig.DEBUG || Build.VERSION.SDK_INT < Build.VERSION_CODES.R },
             lowerKeyPackageLimits = BuildConfig.LOWER_KEYPACKAGE_LIMIT,
             developmentApiEnabled = BuildConfig.DEVELOPMENT_API_ENABLED,
             ignoreSSLCertificatesForUnboundCalls = BuildConfig.IGNORE_SSL_CERTIFICATES,
@@ -57,7 +55,6 @@ class KaliumConfigsModule {
             wipeOnCookieInvalid = BuildConfig.WIPE_ON_COOKIE_INVALID,
             wipeOnDeviceRemoval = BuildConfig.WIPE_ON_DEVICE_REMOVAL,
             wipeOnRootedDevice = BuildConfig.WIPE_ON_ROOTED_DEVICE,
-            isWebSocketEnabledByDefault = isWebsocketEnabledByDefault(context),
             certPinningConfig = BuildConfig.CERTIFICATE_PINNING_CONFIG,
             maxRemoteSearchResultCount = BuildConfig.MAX_REMOTE_SEARCH_RESULT_COUNT,
             limitTeamMembersFetchDuringSlowSync = BuildConfig.LIMIT_TEAM_MEMBERS_FETCH_DURING_SLOW_SYNC,

--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -34,7 +34,7 @@ class KaliumConfigsModule {
     @Provides
     fun provideKaliumConfigs(): KaliumConfigs {
         return KaliumConfigs(
-            fileRestrictionState = {
+            fileRestrictionState = lazy {
                 if (BuildConfig.FILE_RESTRICTION_ENABLED) {
                     BuildConfig.FILE_RESTRICTION_LIST.split(",").map { it.trim() }.let {
                         BuildFileRestrictionState.AllowSome(it)

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeViewModel.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.BuildConfig
 import com.wire.android.di.ClientScopeProvider
+import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.ui.authentication.create.common.CreateAccountFlowType
 import com.wire.android.ui.authentication.create.common.CreateAccountNavArgs
@@ -58,7 +59,8 @@ class CreateAccountCodeViewModel @Inject constructor(
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val addAuthenticatedUser: AddAuthenticatedUserUseCase,
     private val clientScopeProviderFactory: ClientScopeProvider.Factory,
-    defaultServerConfig: ServerConfig.Links
+    defaultServerConfig: ServerConfig.Links,
+    @DefaultWebSocketEnabledByDefault private val defaultWebSocketEnabledByDefault: Boolean
 ) : ViewModel() {
 
     val createAccountNavArgs: CreateAccountNavArgs = savedStateHandle.navArgs()
@@ -184,6 +186,7 @@ class CreateAccountCodeViewModel @Inject constructor(
                 ssoId = registerResult.ssoID,
                 serverConfigId = registerResult.serverConfigId,
                 proxyCredentials = registerResult.proxyCredentials,
+                isPersistentWebSocketEnabled = defaultWebSocketEnabledByDefault,
                 replace = false
             ).let {
                 when (it) {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.ClientScopeProvider
+import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.ui.authentication.login.LoginNavArgs
 import com.wire.android.ui.authentication.login.LoginState
@@ -79,6 +80,7 @@ class LoginEmailViewModel @Inject constructor(
     private val resendCodeTimer: CountdownTimer,
     private val dispatchers: DispatcherProvider,
     defaultServerConfig: ServerConfig.Links,
+    @DefaultWebSocketEnabledByDefault private val defaultWebSocketEnabledByDefault: Boolean,
 ) : LoginViewModel(
     savedStateHandle,
     clientScopeProviderFactory,
@@ -206,6 +208,7 @@ class LoginEmailViewModel @Inject constructor(
                     managedBy = loginResult.managedBy,
                     serverConfigId = loginResult.serverConfigId,
                     proxyCredentials = loginResult.proxyCredentials,
+                    isPersistentWebSocketEnabled = defaultWebSocketEnabledByDefault,
                     replace = false
                 )
             }.let {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.config.DefaultServerConfig
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.ClientScopeProvider
+import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.ui.authentication.login.LoginState
 import com.wire.android.ui.authentication.login.LoginViewModel
@@ -82,7 +83,8 @@ class LoginSSOViewModel(
         @KaliumCoreLogic coreLogic: CoreLogic,
         clientScopeProviderFactory: ClientScopeProvider.Factory,
         userDataStoreProvider: UserDataStoreProvider,
-        serverConfig: ServerConfig.Links
+        serverConfig: ServerConfig.Links,
+        @DefaultWebSocketEnabledByDefault defaultWebSocketEnabledByDefault: Boolean,
     ) : this(
         savedStateHandle,
         addAuthenticatedUser,
@@ -90,7 +92,7 @@ class LoginSSOViewModel(
         coreLogic,
         clientScopeProviderFactory,
         userDataStoreProvider,
-        LoginSSOViewModelExtension(addAuthenticatedUser, coreLogic),
+        LoginSSOViewModelExtension(addAuthenticatedUser, coreLogic, defaultWebSocketEnabledByDefault),
         serverConfig
     )
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtension.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtension.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.feature.auth.sso.ValidateSSOCodeUseCase.Companion.S
 class LoginSSOViewModelExtension(
     private val addAuthenticatedUser: AddAuthenticatedUserUseCase,
     private val coreLogic: CoreLogic,
+    private val defaultWebSocketEnabledByDefault: Boolean,
 ) {
     suspend fun withAuthenticationScope(
         serverConfig: ServerConfig.Links,
@@ -100,6 +101,7 @@ class LoginSSOViewModelExtension(
                             serverConfigId = serverConfigId,
                             proxyCredentials = ssoLoginResult.proxyCredentials,
                             managedBy = ssoLoginResult.managedBy,
+                            isPersistentWebSocketEnabled = defaultWebSocketEnabledByDefault,
                             replace = false
                         ).let { authenticatedUserResult ->
                             when (authenticatedUserResult) {

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.ClientScopeProvider
+import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.ui.authentication.login.DomainClaimedByOrg
 import com.wire.android.ui.authentication.login.LoginNavArgs
@@ -91,6 +92,7 @@ class NewLoginViewModel(
         dispatchers: DispatcherProvider,
         defaultServerConfig: ServerConfig.Links,
         @Named("ssoCodeConfig") defaultSSOCodeConfig: String,
+        @DefaultWebSocketEnabledByDefault defaultWebSocketEnabledByDefault: Boolean,
     ) : this(
         validateEmailOrSSOCode,
         coreLogic,
@@ -98,7 +100,7 @@ class NewLoginViewModel(
         clientScopeProviderFactory,
         userDataStoreProvider,
         LoginViewModelExtension(clientScopeProviderFactory, userDataStoreProvider),
-        LoginSSOViewModelExtension(addAuthenticatedUser, coreLogic),
+        LoginSSOViewModelExtension(addAuthenticatedUser, coreLogic, defaultWebSocketEnabledByDefault),
         dispatchers,
         defaultServerConfig,
         defaultSSOCodeConfig

--- a/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeViewModel.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.BuildConfig
 import com.wire.android.analytics.RegistrationAnalyticsManagerUseCase
 import com.wire.android.di.ClientScopeProvider
+import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.ui.authentication.create.common.CreateAccountDataNavArgs
@@ -56,7 +57,8 @@ class CreateAccountVerificationCodeViewModel @Inject constructor(
     private val addAuthenticatedUser: AddAuthenticatedUserUseCase,
     private val registrationAnalyticsManager: RegistrationAnalyticsManagerUseCase,
     private val clientScopeProviderFactory: ClientScopeProvider.Factory,
-    defaultServerConfig: ServerConfig.Links
+    defaultServerConfig: ServerConfig.Links,
+    @DefaultWebSocketEnabledByDefault private val defaultWebSocketEnabledByDefault: Boolean,
 ) : ViewModel() {
 
     val createAccountNavArgs: CreateAccountDataNavArgs = savedStateHandle.navArgs()
@@ -164,6 +166,7 @@ class CreateAccountVerificationCodeViewModel @Inject constructor(
                 ssoId = registerResult.ssoID,
                 serverConfigId = registerResult.serverConfigId,
                 proxyCredentials = registerResult.proxyCredentials,
+                isPersistentWebSocketEnabled = defaultWebSocketEnabledByDefault,
                 replace = false
             ).let {
                 when (it) {

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -453,7 +453,7 @@ class LoginEmailViewModelTest {
         loginViewModel.userIdentifierTextState.setTextAndPlaceCursorAtEnd(email)
         loginViewModel.secondFactorVerificationCodeTextState.setTextAndPlaceCursorAtEnd(code)
         advanceUntilIdle()
-        coVerify(exactly = 0) { arrangement.addAuthenticatedUserUseCase(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { arrangement.addAuthenticatedUserUseCase(any(), any(), any(), any(), any()) }
         coVerify(exactly = 0) { arrangement.getOrRegisterClientUseCase(any()) }
         assertEquals(LoginState.Error.DialogError.Request2FAWithHandle, loginViewModel.loginState.flowState)
     }
@@ -689,7 +689,7 @@ class LoginEmailViewModelTest {
         }
         coVerify(exactly = 1) { // verify that the second login job has been started
             arrangement.loginUseCase(any(), any(), any(), any(), any())
-            arrangement.addAuthenticatedUserUseCase(any(), any(), eq(authToken2), any(), any())
+            arrangement.addAuthenticatedUserUseCase(any(), any(), eq(authToken2), any(), any(), any(), any())
         }
     }
 
@@ -880,7 +880,8 @@ class LoginEmailViewModelTest {
             coreLogic,
             countdownTimer,
             dispatcherProvider,
-            ServerConfig.STAGING
+            ServerConfig.STAGING,
+            false,
         ).also { it.autoLoginWhenFullCodeEntered = true }
 
         fun withLoginReturning(result: AuthenticationResult) = apply {
@@ -891,7 +892,7 @@ class LoginEmailViewModelTest {
 
         fun withAddAuthenticatedUserReturning(result: AddAuthenticatedUserUseCase.Result) = apply {
             coEvery {
-                addAuthenticatedUserUseCase(any(), any(), any(), any(), any())
+                addAuthenticatedUserUseCase(any(), any(), any(), any(), any(), any(), any())
             } returns result
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23190
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

all values in kalium config are calculated at app startup but will be needed way later of never
for example 

1. isWebSocketEnabledByDefaultis used only when adding a new user aka login
2. fileRestrictionState can be lazy calculated later when needed 
3. shouldEncryptData is only needed during init and no need to have it around all the time

### Solutions

1. remove isWebSocketEnabledByDefaultis since it is only used one time when logging in and it can be passed when needed
2. fileRestrictionState and shouldEncryptData as lambdaz that will be evaluated lazely

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
