### PR TITLE
feat: add support for enforcing persistent WebSocket connection via MDM [WPB-23228]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -21,6 +21,7 @@ package com.wire.android.di
 import android.content.Context
 import android.os.Build
 import com.wire.android.BuildConfig
+import com.wire.android.emm.ManagedConfigurationsManager
 import com.wire.android.util.isWebsocketEnabledByDefault
 import com.wire.kalium.logic.featureFlags.BuildFileRestrictionState
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
@@ -34,7 +35,10 @@ import dagger.hilt.components.SingletonComponent
 class KaliumConfigsModule {
 
     @Provides
-    fun provideKaliumConfigs(context: Context): KaliumConfigs {
+    fun provideKaliumConfigs(
+        context: Context,
+        managedConfigurationsManager: ManagedConfigurationsManager
+    ): KaliumConfigs {
         val fileRestriction: BuildFileRestrictionState = if (BuildConfig.FILE_RESTRICTION_ENABLED) {
             BuildConfig.FILE_RESTRICTION_LIST.split(",").map { it.trim() }.let {
                 BuildFileRestrictionState.AllowSome(it)
@@ -57,7 +61,10 @@ class KaliumConfigsModule {
             wipeOnCookieInvalid = BuildConfig.WIPE_ON_COOKIE_INVALID,
             wipeOnDeviceRemoval = BuildConfig.WIPE_ON_DEVICE_REMOVAL,
             wipeOnRootedDevice = BuildConfig.WIPE_ON_ROOTED_DEVICE,
-            isWebSocketEnabledByDefault = isWebsocketEnabledByDefault(context),
+            isWebSocketEnabledByDefault = isWebsocketEnabledByDefault(
+                context,
+                managedConfigurationsManager.persistentWebSocketEnforcedByMDM.value
+            ),
             certPinningConfig = BuildConfig.CERTIFICATE_PINNING_CONFIG,
             maxRemoteSearchResultCount = BuildConfig.MAX_REMOTE_SEARCH_RESULT_COUNT,
             limitTeamMembersFetchDuringSlowSync = BuildConfig.LIMIT_TEAM_MEMBERS_FETCH_DURING_SLOW_SYNC,

--- a/app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsKeys.kt
+++ b/app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsKeys.kt
@@ -19,7 +19,8 @@ package com.wire.android.emm
 
 enum class ManagedConfigurationsKeys {
     DEFAULT_SERVER_URLS,
-    SSO_CODE;
+    SSO_CODE,
+    KEEP_WEBSOCKET_CONNECTION;
 
     fun asKey() = name.lowercase()
 }

--- a/app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsManager.kt
+++ b/app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsManager.kt
@@ -24,6 +24,9 @@ import com.wire.android.config.ServerConfigProvider
 import com.wire.android.util.EMPTY
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.configuration.server.ServerConfig
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.util.concurrent.atomic.AtomicReference
@@ -66,6 +69,19 @@ interface ManagedConfigurationsManager {
      * empty if no config found or cleared, or failure with reason.
      */
     suspend fun refreshSSOCodeConfig(): SSOCodeConfigResult
+
+    /**
+     * Whether persistent WebSocket connection is enforced by MDM.
+     * When true, the persistent WebSocket service should always be started
+     * and users should not be able to change this setting.
+     */
+    val persistentWebSocketEnforcedByMDM: StateFlow<Boolean>
+
+    /**
+     * Refresh the persistent WebSocket configuration from managed restrictions.
+     * This should be called when the app starts or when broadcast receiver triggers.
+     */
+    suspend fun refreshPersistentWebSocketConfig()
 }
 
 internal class ManagedConfigurationsManagerImpl(
@@ -82,12 +98,16 @@ internal class ManagedConfigurationsManagerImpl(
 
     private val _currentServerConfig = AtomicReference<ServerConfig.Links?>(null)
     private val _currentSSOCodeConfig = AtomicReference(String.EMPTY)
+    private val _persistentWebSocketEnforcedByMDM = MutableStateFlow(false)
 
     override val currentServerConfig: ServerConfig.Links
         get() = _currentServerConfig.get() ?: serverConfigProvider.getDefaultServerConfig()
 
     override val currentSSOCodeConfig: String
         get() = _currentSSOCodeConfig.get()
+
+    override val persistentWebSocketEnforcedByMDM: StateFlow<Boolean>
+        get() = _persistentWebSocketEnforcedByMDM.asStateFlow()
 
     override suspend fun refreshServerConfig(): ServerConfigResult = withContext(dispatchers.io()) {
         val managedServerConfig = getServerConfig()
@@ -117,6 +137,22 @@ internal class ManagedConfigurationsManagerImpl(
             logger.i("SSO code config refreshed to: $ssoCode")
             managedSSOCodeConfig
         }
+
+    override suspend fun refreshPersistentWebSocketConfig() {
+        withContext(dispatchers.io()) {
+            val restrictions = restrictionsManager.applicationRestrictions
+            val isEnforced = if (restrictions == null || restrictions.isEmpty) {
+                false
+            } else {
+                restrictions.getBoolean(
+                    ManagedConfigurationsKeys.KEEP_WEBSOCKET_CONNECTION.asKey(),
+                    false
+                )
+            }
+            _persistentWebSocketEnforcedByMDM.value = isEnforced
+            logger.i("Persistent WebSocket enforced by MDM refreshed to: $isEnforced")
+        }
+    }
 
     private suspend fun getSSOCodeConfig(): SSOCodeConfigResult =
         withContext(dispatchers.io()) {

--- a/app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsReceiver.kt
@@ -48,6 +48,7 @@ class ManagedConfigurationsReceiver @Inject constructor(
                     logger.i("Received intent to refresh managed configurations")
                     updateServerConfig()
                     updateSSOCodeConfig()
+                    updatePersistentWebSocketConfig()
                 }
             }
 
@@ -101,6 +102,16 @@ class ManagedConfigurationsReceiver @Inject constructor(
                 )
             }
         }
+    }
+
+    private suspend fun updatePersistentWebSocketConfig() {
+        managedConfigurationsManager.refreshPersistentWebSocketConfig()
+        val isEnforced = managedConfigurationsManager.persistentWebSocketEnforcedByMDM.value
+        managedConfigurationsReporter.reportAppliedState(
+            key = ManagedConfigurationsKeys.KEEP_WEBSOCKET_CONNECTION.asKey(),
+            message = if (isEnforced) "Persistent WebSocket enforced" else "Persistent WebSocket not enforced",
+            data = isEnforced.toString()
+        )
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -224,6 +224,7 @@ class WireActivity : AppCompatActivity() {
             lifecycleScope.launch(Dispatchers.IO) {
                 managedConfigurationsManager.refreshServerConfig()
                 managedConfigurationsManager.refreshSSOCodeConfig()
+                managedConfigurationsManager.refreshPersistentWebSocketConfig()
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -49,6 +49,7 @@ fun NetworkSettingsScreen(
     NetworkSettingsScreenContent(
         onBackPressed = navigator::navigateBack,
         isWebSocketEnabled = networkSettingsViewModel.networkSettingsState.isPersistentWebSocketConnectionEnabled,
+        isEnforcedByMDM = networkSettingsViewModel.networkSettingsState.isEnforcedByMDM,
         setWebSocketState = { networkSettingsViewModel.setWebSocketState(it) },
     )
 }
@@ -57,6 +58,7 @@ fun NetworkSettingsScreen(
 fun NetworkSettingsScreenContent(
     onBackPressed: () -> Unit,
     isWebSocketEnabled: Boolean,
+    isEnforcedByMDM: Boolean,
     setWebSocketState: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -79,20 +81,26 @@ fun NetworkSettingsScreenContent(
             val isWebSocketEnforcedByDefault = remember {
                 isWebsocketEnabledByDefault(appContext)
             }
-            val switchState = remember(isWebSocketEnabled) {
-                if (isWebSocketEnforcedByDefault) {
-                    SwitchState.TextOnly(true)
-                } else {
-                    SwitchState.Enabled(
+            val switchState = remember(isWebSocketEnabled, isEnforcedByMDM) {
+                when {
+                    isEnforcedByMDM -> SwitchState.TextOnly(true)
+                    isWebSocketEnforcedByDefault -> SwitchState.TextOnly(true)
+                    else -> SwitchState.Enabled(
                         value = isWebSocketEnabled,
                         onCheckedChange = setWebSocketState
                     )
                 }
             }
 
+            val subtitle = if (isEnforcedByMDM) {
+                stringResource(R.string.settings_keep_websocket_enforced_by_organization)
+            } else {
+                stringResource(R.string.settings_keep_connection_to_websocket_description)
+            }
+
             GroupConversationOptionsItem(
                 title = stringResource(R.string.settings_keep_connection_to_websocket),
-                subtitle = stringResource(R.string.settings_keep_connection_to_websocket_description),
+                subtitle = subtitle,
                 switchState = switchState,
                 arrowType = ArrowType.NONE
             )
@@ -106,6 +114,7 @@ fun PreviewNetworkSettingsScreen() = WireTheme {
     NetworkSettingsScreenContent(
         onBackPressed = {},
         isWebSocketEnabled = true,
+        isEnforcedByMDM = false,
         setWebSocketState = {},
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsState.kt
@@ -19,5 +19,6 @@
 package com.wire.android.ui.home.settings.appsettings.networkSettings
 
 data class NetworkSettingsState(
-    val isPersistentWebSocketConnectionEnabled: Boolean = false
+    val isPersistentWebSocketConnectionEnabled: Boolean = false,
+    val isEnforcedByMDM: Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModel.kt
@@ -53,8 +53,11 @@ class NetworkSettingsViewModel
             managedConfigurationsManager.persistentWebSocketEnforcedByMDM.collect { isEnforced ->
                 networkSettingsState = networkSettingsState.copy(
                     isEnforcedByMDM = isEnforced,
-                    isPersistentWebSocketConnectionEnabled = if (isEnforced) true
-                    else networkSettingsState.isPersistentWebSocketConnectionEnabled
+                    isPersistentWebSocketConnectionEnabled = if (isEnforced) {
+                        true
+                    } else {
+                        networkSettingsState.isPersistentWebSocketConnectionEnabled
+                    }
                 )
             }
         }
@@ -72,6 +75,7 @@ class NetworkSettingsViewModel
                             is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> {
                                 appLogger.e("Failure while fetching persistent web socket status flow from network settings")
                             }
+
                             is ObservePersistentWebSocketConnectionStatusUseCase.Result.Success -> {
                                 it.persistentWebSocketStatusListFlow.collect {
                                     it.map { persistentWebSocketStatus ->
@@ -79,7 +83,7 @@ class NetworkSettingsViewModel
                                             networkSettingsState =
                                                 networkSettingsState.copy(
                                                     isPersistentWebSocketConnectionEnabled =
-                                                    persistentWebSocketStatus.isPersistentWebSocketEnabled
+                                                        persistentWebSocketStatus.isPersistentWebSocketEnabled
                                                 )
                                         }
                                     }
@@ -88,6 +92,7 @@ class NetworkSettingsViewModel
                         }
                     }
                 }
+
                 else -> {
                     // NO SESSION - Nothing to do
                 }

--- a/app/src/main/kotlin/com/wire/android/util/WebsocketHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/util/WebsocketHelper.kt
@@ -22,8 +22,16 @@ import com.wire.android.BuildConfig
 import com.wire.android.util.extension.isGoogleServicesAvailable
 
 /**
- * If [BuildConfig.WEBSOCKET_ENABLED_BY_DEFAULT] is true, the websocket should be enabled by default always.
- * Otherwise, it should be enabled by default only if Google Play Services are not available.
+ * Determines if websocket should be enabled by default.
+ *
+ * Returns true if:
+ * - MDM enforces persistent websocket, OR
+ * - [BuildConfig.WEBSOCKET_ENABLED_BY_DEFAULT] is true, OR
+ * - Google Play Services are not available
  */
-fun isWebsocketEnabledByDefault(context: Context) =
-    BuildConfig.WEBSOCKET_ENABLED_BY_DEFAULT || !context.isGoogleServicesAvailable()
+fun isWebsocketEnabledByDefault(
+    context: Context,
+    persistentWebSocketEnforcedByMDM: Boolean = false
+) = persistentWebSocketEnforcedByMDM ||
+    BuildConfig.WEBSOCKET_ENABLED_BY_DEFAULT ||
+    !context.isGoogleServicesAvailable()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1875,6 +1875,9 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="restriction_sso_code_title">SSO code configuration</string>
     <string name="restriction_server_urls_description">JSON value with the server endpoints configuration</string>
     <string name="restriction_sso_code_description">JSON value with the default SSO code configuration</string>
+    <string name="restriction_keep_websocket_title">Keep WebSocket Connection</string>
+    <string name="restriction_keep_websocket_description">Force persistent WebSocket connection for all users</string>
+    <string name="settings_keep_websocket_enforced_by_organization">This setting is managed by your organization.</string>
 
     <!--    channel not available dialog-->
     <string name="channel_not_available_dialog_title">Channels are available for team members.</string>

--- a/app/src/main/res/xml/app_restrictions.xml
+++ b/app/src/main/res/xml/app_restrictions.xml
@@ -31,4 +31,12 @@
             android:restrictionType="string"
             android:title="@string/restriction_sso_code_title" />
 
+    <!-- Keep WebSocket Connection Configuration -->
+    <restriction
+            android:key="keep_websocket_connection"
+            android:restrictionType="bool"
+            android:defaultValue="false"
+            android:title="@string/restriction_keep_websocket_title"
+            android:description="@string/restriction_keep_websocket_description" />
+
 </restrictions>

--- a/app/src/test/kotlin/com/wire/android/util/WebsocketHelperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/WebsocketHelperTest.kt
@@ -1,0 +1,49 @@
+package com.wire.android.util
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.wire.android.BuildConfig
+import io.mockk.coEvery
+import io.mockk.mockkStatic
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class WebsocketHelperTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `when MDM enforces persistent websocket, isWebsocketEnabledByDefault returns true`() {
+        mockkStatic("com.wire.android.util.extension.GoogleServicesKt")
+        coEvery { context.isGoogleServicesAvailable() } returns true
+
+        val result = isWebsocketEnabledByDefault(context, persistentWebSocketEnforcedByMDM = true)
+        assertTrue(result)
+    }
+
+    @Test
+    fun `when GMS not available and MDM not enforced, isWebsocketEnabledByDefault returns true`() {
+        mockkStatic("com.wire.android.util.extension.GoogleServicesKt")
+        coEvery { context.isGoogleServicesAvailable() } returns false
+
+        val result = isWebsocketEnabledByDefault(context, persistentWebSocketEnforcedByMDM = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun `when GMS available and MDM not enforced, isWebsocketEnabledByDefault matches BuildConfig flag`() {
+        mockkStatic("com.wire.android.util.extension.GoogleServicesKt")
+        coEvery { context.isGoogleServicesAvailable() } returns true
+
+        val result = isWebsocketEnabledByDefault(context, persistentWebSocketEnforcedByMDM = false)
+        assertEquals(BuildConfig.WEBSOCKET_ENABLED_BY_DEFAULT, result)
+    }
+}
+


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23228
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

add support for enforcing persistent WebSocket connection via MDM

### Solutions

if it is enforced via MDM then the app will ignore any other settings and force it, the settings in this case will not be able to change by users and a short explanation of why is displayed 

this PR was vibe coded by claude code and here is the prompt

```
 User Story                                                                                                                                                                                                                                      
  As an administrator for end users, with my own fleet of Android devices I want to                                                                                                                                                               
  Install Wire via MDM                                                                                                                                                                                                                            
  Configure the app settings via “App-Config”                                                                                                                                                                                                     
  Turn on the feature “Keep Connection to Websocket” to “On”                                                                                                                                                                                      
  Lock this feature, so end users cannot manipulate it                                                                                                                                                                                            
  This should be possible for                                                                                                                                                                                                                     
  Users that are not logged in yet as well as                                                                                                                                                                                                     
  Users that are already logged in                                                                                                                                                                                                                
                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                  
  when this MDM settings is enabled all uesrs or the app will have the WS persistet there are not exsiptions and the settings is turned on and greayed with and explination of why it can't be changed   
  ``` 

and the generated plan 

# MDM Control for Persistent WebSocket Feature

## Overview
Add MDM (Mobile Device Management) control to force the "Keep Connection to Websocket" feature ON and lock it so users cannot change it.

## Requirements
- MDM admins can enable and lock the persistent websocket setting via App-Config
- When enabled via MDM: forced ON for ALL users, no exceptions
- UI shows setting as ON and greyed out with explanation text
- Works for users not yet logged in AND already logged in

---

## Implementation Plan

### Phase 1: MDM Configuration Layer

#### 1.1 Update `app_restrictions.xml`
**File:** `app/src/main/res/xml/app_restrictions.xml`

Add new boolean restriction:
```xml
<restriction
    android:key="keep_websocket_connection"
    android:restrictionType="bool"
    android:defaultValue="false"
    android:title="@string/restriction_keep_websocket_title"
    android:description="@string/restriction_keep_websocket_description" />
```

#### 1.2 Add MDM Key
**File:** `app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsKeys.kt`

Add `KEEP_WEBSOCKET_CONNECTION` to the enum.

#### 1.3 Extend `ManagedConfigurationsManager`
**File:** `app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsManager.kt`

Add to interface:
```kotlin
val persistentWebSocketEnforcedByMDM: StateFlow<Boolean>
suspend fun refreshPersistentWebSocketConfig()
```

Add implementation that:
- Reads boolean restriction directly from `RestrictionsManager.applicationRestrictions.getBoolean()`
- Exposes as `StateFlow<Boolean>` (true = forced on, false = not enforced)
- Refreshes on app start and broadcast receiver trigger

#### 1.4 Update `ManagedConfigurationsReceiver`
**File:** `app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsReceiver.kt`

Call `refreshPersistentWebSocketConfig()` in `onReceive()`.

#### 1.5 Add String Resources
**File:** `app/src/main/res/values/strings.xml`

```xml
<string name="restriction_keep_websocket_title">Keep WebSocket Connection</string>
<string name="restriction_keep_websocket_description">Force persistent WebSocket connection for all users</string>
<string name="settings_keep_websocket_enforced_by_organization">This setting is managed by your organization.</string>
```

---

### Phase 2: Service Logic

#### 2.1 Update `ShouldStartPersistentWebSocketServiceUseCase`
**File:** `app/src/main/kotlin/com/wire/android/feature/ShouldStartPersistentWebSocketServiceUseCase.kt`

Inject `ManagedConfigurationsManager` and check MDM first:
```kotlin
suspend operator fun invoke(): Result {
    // MDM takes priority - if enforced, always start service
    if (managedConfigurationsManager.persistentWebSocketEnforcedByMDM.value) {
        return Result.Success(true)
    }
    // Fall back to existing per-user database logic
    // ... existing code ...
}
```

---

### Phase 3: UI Layer

#### 3.1 Update `NetworkSettingsState`
**File:** `app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsState.kt`

Add field:
```kotlin
data class NetworkSettingsState(
    val isPersistentWebSocketConnectionEnabled: Boolean = false,
    val isEnforcedByMDM: Boolean = false  // NEW
)
```

#### 3.2 Update `NetworkSettingsViewModel`
**File:** `app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModel.kt`

- Inject `ManagedConfigurationsManager`
- Observe `persistentWebSocketEnforcedByMDM` flow
- Update state with `isEnforcedByMDM`
- When enforced, set `isPersistentWebSocketConnectionEnabled = true`
- Block `setWebSocketState()` when MDM-controlled

#### 3.3 Update `NetworkSettingsScreen`
**File:** `app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt`

Pass `isEnforcedByMDM` to content and update switch state logic:
```kotlin
val switchState = when {
    isEnforcedByMDM -> SwitchState.TextOnly(true)  // MDM priority
    isWebSocketEnforcedByDefault -> SwitchState.TextOnly(true)
    else -> SwitchState.Enabled(value = isWebSocketEnabled, onCheckedChange = setWebSocketState)
}

val subtitle = if (isEnforcedByMDM) {
    stringResource(R.string.settings_keep_websocket_enforced_by_organization)
} else {
    stringResource(R.string.settings_keep_connection_to_websocket_description)
}
```

---

### Phase 4: Testing

#### Unit Tests to Add/Modify:
1. `ManagedConfigurationsManagerTest.kt` - test boolean config parsing
2. `ShouldStartPersistentWebSocketServiceUseCaseTest.kt` - test MDM override logic
3. `NetworkSettingsViewModelTest.kt` - test MDM state propagation


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
