### PR TITLE
fix: markdown parsing outside UI (empty lines + UIText resolver) [WPB-16171] [WPB-22830]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/AppModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/AppModule.kt
@@ -35,6 +35,8 @@ import com.wire.android.ui.home.conversations.MessageSharedState
 import com.wire.android.ui.home.messagecomposer.location.LocationPickerParameters
 import com.wire.android.util.dispatchers.DefaultDispatcherProvider
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.ui.AndroidUiTextResolver
+import com.wire.android.util.ui.UiTextResolver
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -67,6 +69,11 @@ object AppModule {
 
     @Provides
     fun provideMessageResourceProvider(): MessageResourceProvider = MessageResourceProvider()
+
+    @Singleton
+    @Provides
+    fun provideUiTextResolver(@ApplicationContext appContext: Context): UiTextResolver =
+        AndroidUiTextResolver(appContext)
 
     @Provides
     fun provideNotificationManagerCompat(appContext: Context): NotificationManagerCompat =

--- a/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
@@ -29,6 +29,7 @@ import com.wire.android.ui.home.conversationslist.model.ConversationInfo
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.ui.home.conversationslist.model.PlayingAudioInConversation
 import com.wire.android.ui.home.conversationslist.showLegalHoldIndicator
+import com.wire.android.util.ui.UiTextResolver
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationDetails.Connection
 import com.wire.kalium.logic.data.conversation.ConversationDetails.Group
@@ -45,6 +46,7 @@ import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 @Suppress("LongMethod")
 fun ConversationDetailsWithEvents.toConversationItem(
     userTypeMapper: UserTypeMapper,
+    uiTextResolver: UiTextResolver,
     searchQuery: String,
     selfUserTeamId: TeamId?,
     playingAudioMessage: PlayingAudioMessage
@@ -55,7 +57,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
             showLegalHoldIndicator = conversationDetails.conversation.legalHoldStatus.showLegalHoldIndicator(),
-            lastMessageContent = lastMessage.toUIPreview(unreadEventCount),
+            lastMessageContent = lastMessage.toUIPreview(unreadEventCount, uiTextResolver),
             badgeEventType = parseConversationEventType(
                 mutedStatus = conversationDetails.conversation.mutedStatus,
                 unreadEventCount = unreadEventCount
@@ -82,7 +84,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
             showLegalHoldIndicator = conversationDetails.conversation.legalHoldStatus.showLegalHoldIndicator(),
-            lastMessageContent = lastMessage.toUIPreview(unreadEventCount),
+            lastMessageContent = lastMessage.toUIPreview(unreadEventCount, uiTextResolver),
             badgeEventType = parseConversationEventType(
                 mutedStatus = conversationDetails.conversation.mutedStatus,
                 unreadEventCount = unreadEventCount
@@ -120,7 +122,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
             showLegalHoldIndicator = conversationDetails.conversation.legalHoldStatus.showLegalHoldIndicator(),
-            lastMessageContent = lastMessage.toUIPreview(unreadEventCount),
+            lastMessageContent = lastMessage.toUIPreview(unreadEventCount, uiTextResolver),
             badgeEventType = parsePrivateConversationEventType(
                 conversationDetails.otherUser.connectionStatus,
                 conversationDetails.otherUser.deleted,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -31,6 +31,7 @@ import com.wire.android.ui.home.conversations.model.messagetypes.image.VisualMed
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.messagecomposer.SelfDeletionDuration
 import com.wire.android.ui.markdown.MarkdownConstants
+import com.wire.android.ui.markdown.MarkdownNode
 import com.wire.android.ui.markdown.MarkdownPreview
 import com.wire.android.ui.theme.Accent
 import com.wire.android.util.Copyable
@@ -290,7 +291,9 @@ sealed interface UILastMessageContent {
     data class TextMessage(
         val messageBody: MessageBody,
         @Transient
-        val markdownPreview: MarkdownPreview? = null
+        val markdownPreview: MarkdownPreview? = null,
+        @Transient
+        val markdownLocaleTag: String? = null
     ) : UILastMessageContent
 
     @Serializable
@@ -299,7 +302,9 @@ sealed interface UILastMessageContent {
         val message: UIText,
         val separator: String = MarkdownConstants.NON_BREAKING_SPACE,
         @Transient
-        val markdownPreview: MarkdownPreview? = null
+        val markdownPreview: MarkdownPreview? = null,
+        @Transient
+        val markdownLocaleTag: String? = null
     ) : UILastMessageContent
 
     @Serializable
@@ -627,7 +632,9 @@ sealed interface UIMessageContent {
 @Serializable
 data class MessageBody(
     val message: UIText,
-    val quotedMessage: UIQuotedMessage? = null
+    val quotedMessage: UIQuotedMessage? = null,
+    @Transient
+    val markdownDocument: MarkdownNode.Document? = null
 )
 
 enum class MessageSource {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
@@ -28,6 +28,7 @@ import com.wire.android.mapper.toConversationItem
 import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.ui.UiTextResolver
 import com.wire.kalium.logic.data.conversation.ConversationDetailsWithEvents
 import com.wire.kalium.logic.data.conversation.ConversationFilter
 import com.wire.kalium.logic.data.conversation.ConversationQueryConfig
@@ -48,6 +49,7 @@ class GetConversationsFromSearchUseCase @Inject constructor(
     private val userTypeMapper: UserTypeMapper,
     private val dispatchers: DispatcherProvider,
     private val getSelfUser: GetSelfUserUseCase,
+    private val uiTextResolver: UiTextResolver,
 ) {
     @Suppress("LongParameterList")
     suspend operator fun invoke(
@@ -100,6 +102,7 @@ class GetConversationsFromSearchUseCase @Inject constructor(
                 pagingData.map {
                     it.toConversationItem(
                         userTypeMapper = userTypeMapper,
+                        uiTextResolver = uiTextResolver,
                         searchQuery = searchQuery,
                         selfUserTeamId = getSelfUser()?.teamId,
                         playingAudioMessage = playingAudioMessage

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -44,6 +44,7 @@ import com.wire.android.ui.home.conversationslist.model.ConversationItemType
 import com.wire.android.ui.home.conversationslist.model.ConversationSection
 import com.wire.android.ui.home.conversationslist.model.ConversationsSource
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.ui.UiTextResolver
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationFilter
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
@@ -108,6 +109,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
     @CurrentAccount val currentAccount: UserId,
     private val userTypeMapper: UserTypeMapper,
     private val getSelfUser: GetSelfUserUseCase,
+    private val uiTextResolver: UiTextResolver,
 ) : ConversationListViewModel, ViewModel() {
 
     @AssistedFactory
@@ -225,6 +227,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
                         conversations.map { conversationDetails ->
                             conversationDetails.toConversationItem(
                                 userTypeMapper = userTypeMapper,
+                                uiTextResolver = uiTextResolver,
                                 searchQuery = searchQuery,
                                 selfUserTeamId = getSelfUser()?.teamId,
                                 playingAudioMessage = playingAudioMessage

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -123,7 +123,8 @@ fun ConversationItemFactory(
                 when (val messageContent = conversation.lastMessageContent) {
                     is UILastMessageContent.TextMessage -> LastMessageSubtitle(
                         messageContent.messageBody.message,
-                        messageContent.markdownPreview
+                        messageContent.markdownPreview,
+                        messageContent.markdownLocaleTag
                     )
 
                     is UILastMessageContent.MultipleMessage -> LastMultipleMessages(messageContent.messages, messageContent.separator)
@@ -131,7 +132,8 @@ fun ConversationItemFactory(
                         messageContent.sender,
                         messageContent.message,
                         messageContent.separator,
-                        messageContent.markdownPreview
+                        messageContent.markdownPreview,
+                        messageContent.markdownLocaleTag
                     )
 
                     is UILastMessageContent.Connection -> ConnectionLabel(connectionInfo = messageContent)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
@@ -21,15 +21,14 @@ package com.wire.android.ui.home.conversationslist.common
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import com.wire.android.ui.markdown.MarkdownConstants
 import com.wire.android.ui.markdown.MarkdownInline
 import com.wire.android.ui.markdown.MarkdownPreview
+import com.wire.android.ui.markdown.MarkdownNode
 import com.wire.android.ui.markdown.MessageColors
 import com.wire.android.ui.markdown.NodeData
-import com.wire.android.ui.markdown.getFirstInlines
-import com.wire.android.ui.markdown.toMarkdownDocument
 import com.wire.android.ui.theme.Accent
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
@@ -37,13 +36,24 @@ import com.wire.android.util.ui.UIText
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
-fun LastMessageSubtitle(text: UIText, markdownPreview: MarkdownPreview? = null) {
-    LastMessageMarkdown(text = text.asString(), markdownPreview = markdownPreview)
+fun LastMessageSubtitle(text: UIText, markdownPreview: MarkdownPreview? = null, markdownLocaleTag: String? = null) {
+    LastMessageMarkdown(text = text.asString(), markdownPreview = markdownPreview, markdownLocaleTag = markdownLocaleTag)
 }
 
 @Composable
-fun LastMessageSubtitleWithAuthor(author: UIText, text: UIText, separator: String, markdownPreview: MarkdownPreview? = null) {
-    LastMessageMarkdown(text = text.asString(), leadingText = "${author.asString()}$separator", markdownPreview = markdownPreview)
+fun LastMessageSubtitleWithAuthor(
+    author: UIText,
+    text: UIText,
+    separator: String,
+    markdownPreview: MarkdownPreview? = null,
+    markdownLocaleTag: String? = null
+) {
+    LastMessageMarkdown(
+        text = text.asString(),
+        leadingText = "${author.asString()}$separator",
+        markdownPreview = markdownPreview,
+        markdownLocaleTag = markdownLocaleTag
+    )
 }
 
 @Composable
@@ -55,7 +65,8 @@ fun LastMultipleMessages(messages: List<UIText>, separator: String) {
 private fun LastMessageMarkdown(
     text: String,
     leadingText: String = "",
-    markdownPreview: MarkdownPreview? = null
+    markdownPreview: MarkdownPreview? = null,
+    markdownLocaleTag: String? = null
 ) {
     val nodeData = NodeData(
         color = MaterialTheme.wireColorScheme.secondaryText,
@@ -69,22 +80,28 @@ private fun LastMessageMarkdown(
         accent = Accent.Unknown
     )
 
-    val effectivePreview = remember(text, markdownPreview) {
-        markdownPreview ?: text.toMarkdownDocument().getFirstInlines()
-    }
+    val locales = LocalContext.current.resources.configuration.locales
+    val currentLocaleTag = if (locales.isEmpty) "" else locales[0].toLanguageTag()
+    val shouldUsePreview = markdownPreview != null && (markdownLocaleTag == null || markdownLocaleTag == currentLocaleTag)
 
-    val leadingInlines = remember(leadingText) {
-        leadingText.toMarkdownDocument().getFirstInlines()?.children ?: persistentListOf()
-    }
-
-    if (effectivePreview != null) {
+    if (shouldUsePreview) {
+        val leadingInlines = if (leadingText.isBlank()) {
+            persistentListOf()
+        } else {
+            persistentListOf(
+                MarkdownNode.Inline.Text(
+                    leadingText.replace(MarkdownConstants.NON_BREAKING_SPACE, " ")
+                )
+            )
+        }
         MarkdownInline(
-            inlines = leadingInlines.plus(effectivePreview.children),
+            inlines = leadingInlines.plus(markdownPreview.children),
             nodeData = nodeData
         )
     } else {
         Text(
-            text = leadingText.replace(MarkdownConstants.NON_BREAKING_SPACE, " ") + text,
+            text = leadingText.replace(MarkdownConstants.NON_BREAKING_SPACE, " ") +
+                text.replace(MarkdownConstants.NON_BREAKING_SPACE, " "),
             style = nodeData.style,
             color = nodeData.color,
             maxLines = 1,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
@@ -21,7 +21,7 @@ package com.wire.android.ui.home.conversationslist.common
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.style.TextOverflow
 import com.wire.android.ui.markdown.MarkdownConstants
 import com.wire.android.ui.markdown.MarkdownInline
@@ -80,7 +80,7 @@ private fun LastMessageMarkdown(
         accent = Accent.Unknown
     )
 
-    val locales = LocalContext.current.resources.configuration.locales
+    val locales = LocalConfiguration.current.locales
     val currentLocaleTag = if (locales.isEmpty) "" else locales[0].toLanguageTag()
     val shouldUsePreview = markdownPreview != null && (markdownLocaleTag == null || markdownLocaleTag == currentLocaleTag)
 

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParser.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParser.kt
@@ -18,10 +18,149 @@
 package com.wire.android.ui.markdown
 
 import org.commonmark.node.Document
+import org.commonmark.parser.IncludeSourceSpans
 import org.commonmark.parser.Parser
 
 object MarkdownParser {
-    private val parser = Parser.builder().extensions(MarkdownConstants.supportedExtensions).build()
 
-    fun parse(text: String) = (parser.parse(text) as Document).toContent() as MarkdownNode.Document
+    private val parser = Parser.builder()
+        .extensions(MarkdownConstants.supportedExtensions)
+        .includeSourceSpans(IncludeSourceSpans.BLOCKS)
+        .build()
+
+    // We preserve blank lines across *all* block types by using source spans:
+    // CommonMark collapses empty lines into block boundaries, so we count
+    // blank input lines between top-level blocks and insert spacer paragraphs
+    // (Break-only) to render the exact number of empty lines in the UI.
+    // We then disable bottom padding on blocks followed by a spacer to avoid
+    // double spacing (padding + spacer).
+    fun parse(text: String): MarkdownNode.Document {
+        val documentNode = parser.parse(text) as Document
+        val markdownChildren = mutableListOf<MarkdownNode.Block>()
+
+        // Walk top-level blocks in source order and optionally insert spacer paragraphs between them.
+        val blockNodes = collectTopLevelBlocks(documentNode)
+        val blankLineCounts = countBlankLinesBetweenBlocks(documentNode, text)
+        blockNodes.forEachIndexed { index, block ->
+            // Convert each CommonMark top-level block into our UI model.
+            markdownChildren.add(block.toContent() as MarkdownNode.Block)
+            if (index < blankLineCounts.size) {
+                val blankLines = blankLineCounts[index]
+                if (blankLines > 0) {
+                    // Insert a spacer block to render the exact number of blank lines.
+                    markdownChildren.add(createSpacerParagraph(blankLines))
+                }
+            }
+        }
+
+        return MarkdownNode.Document(
+            adjustPaddingForSpacers(markdownChildren)
+        )
+    }
+
+    private fun collectTopLevelBlocks(document: Document): List<org.commonmark.node.Node> {
+        // Collect direct children (top-level blocks) because source spans are per block.
+        val blocks = mutableListOf<org.commonmark.node.Node>()
+        var child = document.firstChild
+        while (child != null) {
+            blocks.add(child)
+            child = child.next
+        }
+        return blocks
+    }
+
+    private fun countBlankLinesBetweenBlocks(document: Document, text: String): List<Int> {
+        // Split input by lines so we can count the blank lines between block spans.
+        val lines = text.split("\n")
+        val blocks = collectTopLevelBlocks(document)
+        if (blocks.size < 2) return emptyList()
+
+        val blankCounts = mutableListOf<Int>()
+        for (index in 0 until blocks.size - 1) {
+            // Source spans point to the lines covered by each block in the original input.
+            val currentSpan = blocks[index].sourceLineRange()
+            val nextSpan = blocks[index + 1].sourceLineRange()
+            blankCounts.add(countBlankLinesBetween(lines, currentSpan, nextSpan))
+        }
+        return blankCounts
+    }
+
+    private fun countBlankLinesBetween(
+        lines: List<String>,
+        currentSpan: Pair<Int, Int>?,
+        nextSpan: Pair<Int, Int>?
+    ): Int {
+        val start = currentSpan?.second?.plus(1)
+        val end = nextSpan?.first?.minus(1)
+        val safeEnd = if (start != null && end != null) {
+            calculateSafeEnd(start, end, lines.size)
+        } else {
+            null
+        }
+
+        return if (start == null || safeEnd == null) {
+            0
+        } else {
+            lines.subList(start, safeEnd + 1).count { it.isBlank() }
+        }
+    }
+
+    private fun calculateSafeEnd(start: Int, end: Int, linesSize: Int): Int? {
+        var safeEnd: Int? = null
+        if (start <= end && start < linesSize) {
+            safeEnd = minOf(end, linesSize - 1)
+        }
+        return safeEnd
+    }
+
+    private fun org.commonmark.node.Node.sourceLineRange(): Pair<Int, Int>? {
+        // Reduce all spans to a min/max line range for the block.
+        val spans = sourceSpans
+        if (spans.isEmpty()) return null
+        var minLine = Int.MAX_VALUE
+        var maxLine = Int.MIN_VALUE
+        for (span in spans) {
+            minLine = minOf(minLine, span.lineIndex)
+            maxLine = maxOf(maxLine, span.lineIndex)
+        }
+        return if (minLine == Int.MAX_VALUE || maxLine == Int.MIN_VALUE) null else Pair(minLine, maxLine)
+    }
+
+    private fun createSpacerParagraph(blankLines: Int): MarkdownNode.Block.Paragraph {
+        val breaks = List(blankLines) { MarkdownNode.Inline.Break() }
+        return MarkdownNode.Block.Paragraph(breaks, isParentDocument = false)
+    }
+
+    private fun adjustPaddingForSpacers(children: List<MarkdownNode.Block>): List<MarkdownNode.Block> {
+        if (children.isEmpty()) return children
+        val adjusted = mutableListOf<MarkdownNode.Block>()
+        for (index in children.indices) {
+            val block = children[index]
+            // If a spacer follows, suppress padding on the current block to avoid double spacing.
+            val nextIsSpacer = index + 1 < children.size && children[index + 1].isSpacerParagraph()
+            adjusted.add(if (nextIsSpacer) block.withParentDocument(false) else block)
+        }
+        return adjusted
+    }
+
+    private fun MarkdownNode.Block.isSpacerParagraph(): Boolean {
+        return this is MarkdownNode.Block.Paragraph && children.all { it is MarkdownNode.Inline.Break }
+    }
+
+    private fun MarkdownNode.Block.withParentDocument(isParentDocument: Boolean): MarkdownNode.Block {
+        return when (this) {
+            is MarkdownNode.Block.Heading -> copy(isParentDocument = isParentDocument)
+            is MarkdownNode.Block.Paragraph -> copy(isParentDocument = isParentDocument)
+            is MarkdownNode.Block.BlockQuote -> copy(isParentDocument = isParentDocument)
+            is MarkdownNode.Block.ListBlock.Bullet -> copy(isParentDocument = isParentDocument)
+            is MarkdownNode.Block.ListBlock.Ordered -> copy(isParentDocument = isParentDocument)
+            is MarkdownNode.Block.ListItem -> copy(isParentDocument = isParentDocument)
+            is MarkdownNode.Block.IntendedCode -> copy(isParentDocument = isParentDocument)
+            is MarkdownNode.Block.FencedCode -> copy(isParentDocument = isParentDocument)
+            is MarkdownNode.Block.Table -> copy(isParentDocument = isParentDocument)
+            is MarkdownNode.Block.TableContent.Head -> copy(isParentDocument = isParentDocument)
+            is MarkdownNode.Block.TableContent.Body -> copy(isParentDocument = isParentDocument)
+            is MarkdownNode.Block.ThematicBreak -> copy(isParentDocument = isParentDocument)
+        }
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/util/ui/UiTextResolver.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/UiTextResolver.kt
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.util.ui
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.Locale
+import javax.inject.Inject
+
+interface UiTextResolver {
+
+    // Resolves UIText outside of Compose without holding Activity/Fragment context.
+    fun resolve(text: UIText): String
+
+    // Tag used to invalidate precomputed markdown when the locale changes.
+    fun localeTag(): String
+}
+
+class AndroidUiTextResolver @Inject constructor(
+    @ApplicationContext private val context: Context
+) : UiTextResolver {
+
+    override fun resolve(text: UIText): String = text.asString(context.resources)
+
+    override fun localeTag(): String {
+        val locales = context.resources.configuration.locales
+        val locale = if (locales.isEmpty) Locale.getDefault() else locales[0]
+        return locale.toLanguageTag()
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -36,6 +36,8 @@ import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.ui.home.conversations.usecase.GetConversationsFromSearchUseCase
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.ui.home.conversationslist.model.ConversationsSource
+import com.wire.android.util.ui.UiTextResolver
+import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.ConversationDetailsWithEvents
 import com.wire.kalium.logic.data.conversation.ConversationFilter
 import com.wire.kalium.logic.data.id.ConversationId
@@ -291,6 +293,9 @@ class ConversationListViewModelTest {
         @MockK
         lateinit var audioMessagePlayer: ConversationAudioMessagePlayer
 
+        @MockK
+        lateinit var uiTextResolver: UiTextResolver
+
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
             withConversationsPaginated(listOf(TestConversationItem.CONNECTION, TestConversationItem.PRIVATE, TestConversationItem.GROUP))
@@ -307,6 +312,15 @@ class ConversationListViewModelTest {
                 }
             )
             every { audioMessagePlayer.playingAudioMessageFlow } returns flowOf(PlayingAudioMessage.None)
+            coEvery { uiTextResolver.resolve(any()) } answers {
+                val text = firstArg<UIText>()
+                when (text) {
+                    is UIText.DynamicString -> text.value
+                    is UIText.StringResource -> "res_${text.resId}"
+                    is UIText.PluralResource -> "plural_${text.resId}_${text.count}"
+                }
+            }
+            coEvery { uiTextResolver.localeTag() } returns "test-locale"
             mockUri()
         }
 
@@ -344,6 +358,7 @@ class ConversationListViewModelTest {
             observeLegalHoldStateForSelfUser = observeLegalHoldStateForSelfUserUseCase,
             userTypeMapper = UserTypeMapper(),
             getSelfUser = getSelfUser,
+            uiTextResolver = uiTextResolver,
             usePagination = true,
             audioMessagePlayer = audioMessagePlayer,
         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-16171
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Markdown previews were computed in the UI layer and CommonMark collapsed empty lines, so multi‑line formatting was lost.
- After moving parsing higher (mapper/model), we could no longer resolve UIText.StringResource/PluralResource, so previews were either missing or inconsistent across locales.
- Some sender-with-message previews were built from the sender name, causing the username to appear twice (e.g., instead of “user left conversation”).
- Mention handling for markdown was duplicated in UI code.

### Causes (Optional)

- CommonMark doesn’t preserve blank lines without source‑span handling.
- Parsing outside Compose lacked access to resources to resolve UIText.
- Preview generation used userUIText in several paths rather than the message content.
- Mention markers were built ad‑hoc instead of a shared helper.

### Solutions

- Moved markdown parsing out of UI and made the parser preserve empty lines via source spans + spacer paragraphs.
- Introduced UiTextResolver (DI) so markdown parsing/preview works for both DynamicString and resource‑based UIText, with locale tagging to invalidate stale previews.
- Built previews from the actual message text for SenderWithMessage paths, fixing the duplicated‑username issue.
- Centralized mention‑marker generation in MarkdownHelper and reused it from mapper/UI.
