### PR TITLE
fix: conversation list title alignment across avatar types [WPB-22273]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -30,6 +31,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
@@ -57,6 +59,7 @@ import com.wire.android.ui.home.conversationslist.model.toUserInfoLabel
 import com.wire.android.ui.markdown.MarkdownConstants
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.toUIText
@@ -184,7 +187,9 @@ private fun GeneralConversationItem(
                             } else {
                                 ConversationAvatar.Group.Regular(conversationId)
                             }
-                            GroupConversationAvatar(avatar)
+                            ConversationLeadingAvatar {
+                                GroupConversationAvatar(avatar)
+                            }
                         }
                     },
                     title = {
@@ -229,6 +234,7 @@ private fun GeneralConversationItem(
             with(conversation) {
                 RowItemTemplate(
                     modifier = modifier.padding(start = dimensions().spacing8x),
+                    titleStartPadding = dimensions().spacing0x,
                     leadingIcon = {
                         Row {
                             if (isSelectable) {
@@ -236,7 +242,9 @@ private fun GeneralConversationItem(
                                     selectOnRadioGroup()
                                 })
                             }
-                            ConversationUserAvatar(userAvatarData)
+                            ConversationLeadingAvatar {
+                                ConversationUserAvatar(userAvatarData)
+                            }
                         }
                     },
                     title = {
@@ -275,7 +283,12 @@ private fun GeneralConversationItem(
             with(conversation) {
                 RowItemTemplate(
                     modifier = modifier.padding(start = dimensions().spacing8x),
-                    leadingIcon = { ConversationUserAvatar(userAvatarData) },
+                    titleStartPadding = dimensions().spacing0x,
+                    leadingIcon = {
+                        ConversationLeadingAvatar {
+                            ConversationUserAvatar(userAvatarData)
+                        }
+                    },
                     title = {
                         UserLabel(
                             userInfoLabel = toUserInfoLabel(),
@@ -290,6 +303,21 @@ private fun GeneralConversationItem(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun ConversationLeadingAvatar(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    val leadingSize = MaterialTheme.wireDimensions.avatarDefaultSize +
+            (MaterialTheme.wireDimensions.avatarClickablePadding * 2)
+    Box(
+        modifier = modifier.size(leadingSize),
+        contentAlignment = Alignment.Center
+    ) {
+        content()
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-22273
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Conversation list titles and subtitles were misaligned across group, channel, and 1:1 items.

### Solutions

- Removed the extra title start padding for 1:1 and connection items to match group/channel layout.
- Normalized the leading avatar container size so all conversation types reserve the same width before text.
