### PR TITLE
feat: web socket health check (WPB-21876)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/feature/IsWebSocketConnectionUnhealthyUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/IsWebSocketConnectionUnhealthyUseCase.kt
@@ -1,0 +1,84 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.feature
+
+import com.wire.android.di.KaliumCoreLogic
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.datetime.Clock
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * Use case to check if the WebSocket connection is unhealthy.
+ * A connection is considered unhealthy if any user with persistent WebSocket enabled
+ * has not received any WebSocket events in the last [UNHEALTHY_THRESHOLD].
+ *
+ * @return [Result.success] with `true` if connection is unhealthy, `false` if healthy,
+ *         or [Result.failure] if the check could not be performed.
+ */
+@Singleton
+class IsWebSocketConnectionUnhealthyUseCase @Inject constructor(
+    @KaliumCoreLogic private val coreLogic: CoreLogic
+) {
+    @Suppress("ReturnCount")
+    suspend operator fun invoke(): Result<Boolean> {
+        return coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus().let { result ->
+            when (result) {
+                is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure ->
+                    Result.failure(IllegalStateException("Failed to observe persistent WebSocket status"))
+
+                is ObservePersistentWebSocketConnectionStatusUseCase.Result.Success -> {
+                    val statusList = withTimeoutOrNull(TIMEOUT) {
+                        result.persistentWebSocketStatusListFlow.firstOrNull()
+                    }
+                    if (statusList == null) {
+                        return Result.failure(IllegalStateException("Failed to fetch WebSocket status"))
+                    }
+
+                    val usersWithPersistentWebSocket = statusList.filter { it.isPersistentWebSocketEnabled }
+                    if (usersWithPersistentWebSocket.isEmpty()) {
+                        return Result.success(false)
+                    }
+
+                    val now = Clock.System.now()
+                    val isUnhealthy = usersWithPersistentWebSocket.any { status ->
+                        val lastEventInstant = coreLogic.getSessionScope(status.userId)
+                            .getLastWebSocketEventInstant()
+                        val timeSinceLastEvent = lastEventInstant?.let { now - it }
+
+                        // Connection is unhealthy only if we received events before but threshold exceeded
+                        // null means service just started and hasn't received events yet - not unhealthy
+                        lastEventInstant != null && timeSinceLastEvent!! > UNHEALTHY_THRESHOLD
+                    }
+
+                    Result.success(isUnhealthy)
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val TIMEOUT = 10_000L
+        val UNHEALTHY_THRESHOLD = 12.hours
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/services/ServicesManager.kt
+++ b/app/src/main/kotlin/com/wire/android/services/ServicesManager.kt
@@ -134,6 +134,11 @@ class ServicesManager @Inject constructor(
         stopService(PersistentWebSocketService.newIntent(context))
     }
 
+    fun restartPersistentWebSocketService() {
+        stopPersistentWebSocketService()
+        startPersistentWebSocketService()
+    }
+
     fun isPersistentWebSocketServiceRunning(): Boolean =
         PersistentWebSocketService.isServiceStarted
 

--- a/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
@@ -23,9 +23,11 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.feature.IsWebSocketConnectionUnhealthyUseCase
 import com.wire.android.feature.StartPersistentWebsocketIfNecessaryUseCase
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
+import com.wire.android.services.ServicesManager
 import com.wire.android.sync.InitialSyncWorker
 import com.wire.android.workmanager.worker.DeleteConversationLocallyWorker
 import com.wire.android.workmanager.worker.NotificationFetchWorker
@@ -40,6 +42,8 @@ class WireWorkerFactory @Inject constructor(
     private val wireNotificationManager: WireNotificationManager,
     private val notificationChannelsManager: NotificationChannelsManager,
     private val startPersistentWebsocketIfNecessary: StartPersistentWebsocketIfNecessaryUseCase,
+    private val isWebSocketConnectionUnhealthyUseCase: IsWebSocketConnectionUnhealthyUseCase,
+    private val servicesManager: ServicesManager,
     @KaliumCoreLogic
     private val coreLogic: CoreLogic
 ) : WorkerFactory() {
@@ -58,6 +62,8 @@ class WireWorkerFactory @Inject constructor(
                     appContext,
                     workerParameters,
                     startPersistentWebsocketIfNecessary,
+                    isWebSocketConnectionUnhealthyUseCase,
+                    servicesManager,
                     notificationChannelsManager
                 )
 

--- a/app/src/test/kotlin/com/wire/android/feature/IsWebSocketConnectionUnhealthyUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/IsWebSocketConnectionUnhealthyUseCaseTest.kt
@@ -1,0 +1,282 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature
+
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.auth.PersistentWebSocketStatus
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+class IsWebSocketConnectionUnhealthyUseCaseTest {
+
+    @Test
+    fun givenObservePersistentWebSocketStatusReturnsFailure_whenInvoking_thenShouldReturnFailure() =
+        runTest {
+            // given
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusFailure()
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertTrue(result.isFailure)
+        }
+
+    @Test
+    fun givenFlowTimesOut_whenInvoking_thenShouldReturnFailure() =
+        runTest {
+            // given
+            val sharedFlow = MutableSharedFlow<List<PersistentWebSocketStatus>>()
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(sharedFlow)
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            advanceTimeBy(IsWebSocketConnectionUnhealthyUseCase.TIMEOUT + 1000L)
+            // then
+            assertTrue(result.isFailure)
+        }
+
+    @Test
+    fun givenNoUsersWithPersistentWebSocketEnabled_whenInvoking_thenShouldReturnSuccessFalse() =
+        runTest {
+            // given
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(
+                    flowOf(listOf(PersistentWebSocketStatus(userId, false)))
+                )
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertTrue(result.isSuccess)
+            assertEquals(false, result.getOrNull())
+        }
+
+    @Test
+    fun givenEmptyUserList_whenInvoking_thenShouldReturnSuccessFalse() =
+        runTest {
+            // given
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(flowOf(emptyList()))
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertTrue(result.isSuccess)
+            assertEquals(false, result.getOrNull())
+        }
+
+    @Test
+    fun givenUserWithPersistentWebSocketAndNoEventsYet_whenInvoking_thenShouldReturnSuccessFalse() =
+        runTest {
+            // given
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(
+                    flowOf(listOf(PersistentWebSocketStatus(userId, true)))
+                )
+                .withLastWebSocketEventInstant(userId, null)
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertTrue(result.isSuccess)
+            assertEquals(false, result.getOrNull())
+        }
+
+    @Test
+    fun givenUserWithPersistentWebSocketAndRecentEvent_whenInvoking_thenShouldReturnSuccessFalse() =
+        runTest {
+            // given
+            val recentInstant = Clock.System.now() - 1.hours
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(
+                    flowOf(listOf(PersistentWebSocketStatus(userId, true)))
+                )
+                .withLastWebSocketEventInstant(userId, recentInstant)
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertTrue(result.isSuccess)
+            assertEquals(false, result.getOrNull())
+        }
+
+    @Test
+    fun givenUserWithPersistentWebSocketAndEventExactlyAtThreshold_whenInvoking_thenShouldReturnSuccessFalse() =
+        runTest {
+            // given
+            // Add 1 minute buffer to account for time elapsed between test setup and use case execution
+            val thresholdInstant = Clock.System.now() - IsWebSocketConnectionUnhealthyUseCase.UNHEALTHY_THRESHOLD + 1.minutes
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(
+                    flowOf(listOf(PersistentWebSocketStatus(userId, true)))
+                )
+                .withLastWebSocketEventInstant(userId, thresholdInstant)
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertTrue(result.isSuccess)
+            assertEquals(false, result.getOrNull())
+        }
+
+    @Test
+    fun givenUserWithPersistentWebSocketAndOldEvent_whenInvoking_thenShouldReturnSuccessTrue() =
+        runTest {
+            // given
+            val oldInstant = Clock.System.now() - 13.hours
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(
+                    flowOf(listOf(PersistentWebSocketStatus(userId, true)))
+                )
+                .withLastWebSocketEventInstant(userId, oldInstant)
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertTrue(result.isSuccess)
+            assertEquals(true, result.getOrNull())
+        }
+
+    @Test
+    fun givenMultipleUsersOneWithOldEvent_whenInvoking_thenShouldReturnSuccessTrue() =
+        runTest {
+            // given
+            val recentInstant = Clock.System.now() - 1.hours
+            val oldInstant = Clock.System.now() - 13.hours
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(
+                    flowOf(
+                        listOf(
+                            PersistentWebSocketStatus(userId, true),
+                            PersistentWebSocketStatus(userId2, true)
+                        )
+                    )
+                )
+                .withLastWebSocketEventInstant(userId, recentInstant)
+                .withLastWebSocketEventInstant(userId2, oldInstant)
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertTrue(result.isSuccess)
+            assertEquals(true, result.getOrNull())
+        }
+
+    @Test
+    fun givenMultipleUsersAllWithRecentEvents_whenInvoking_thenShouldReturnSuccessFalse() =
+        runTest {
+            // given
+            val recentInstant1 = Clock.System.now() - 1.hours
+            val recentInstant2 = Clock.System.now() - 6.hours
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(
+                    flowOf(
+                        listOf(
+                            PersistentWebSocketStatus(userId, true),
+                            PersistentWebSocketStatus(userId2, true)
+                        )
+                    )
+                )
+                .withLastWebSocketEventInstant(userId, recentInstant1)
+                .withLastWebSocketEventInstant(userId2, recentInstant2)
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertTrue(result.isSuccess)
+            assertEquals(false, result.getOrNull())
+        }
+
+    @Test
+    fun givenMixOfEnabledAndDisabledUsersWithOldEventOnlyForDisabled_whenInvoking_thenShouldReturnSuccessFalse() =
+        runTest {
+            // given
+            val recentInstant = Clock.System.now() - 1.hours
+            val oldInstant = Clock.System.now() - 13.hours
+            val (_, useCase) = Arrangement()
+                .withObservePersistentWebSocketConnectionStatusSuccess(
+                    flowOf(
+                        listOf(
+                            PersistentWebSocketStatus(userId, true),
+                            PersistentWebSocketStatus(userId2, false)
+                        )
+                    )
+                )
+                .withLastWebSocketEventInstant(userId, recentInstant)
+                .withLastWebSocketEventInstant(userId2, oldInstant)
+                .arrange()
+            // when
+            val result = useCase.invoke()
+            // then
+            assertTrue(result.isSuccess)
+            assertEquals(false, result.getOrNull())
+        }
+
+    inner class Arrangement {
+
+        @MockK
+        private lateinit var coreLogic: CoreLogic
+
+        val useCase by lazy {
+            IsWebSocketConnectionUnhealthyUseCase(coreLogic)
+        }
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        fun arrange() = this to useCase
+
+        fun withObservePersistentWebSocketConnectionStatusSuccess(flow: Flow<List<PersistentWebSocketStatus>>) = apply {
+            coEvery { coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus() } returns
+                    ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(flow)
+        }
+
+        fun withObservePersistentWebSocketConnectionStatusFailure() = apply {
+            coEvery { coreLogic.getGlobalScope().observePersistentWebSocketConnectionStatus() } returns
+                    ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure.StorageFailure
+        }
+
+        fun withLastWebSocketEventInstant(userId: UserId, instant: Instant?) = apply {
+            every { coreLogic.getSessionScope(userId).getLastWebSocketEventInstant() } returns instant
+        }
+    }
+
+    companion object {
+        private val userId = UserId("userId", "domain")
+        private val userId2 = UserId("userId2", "domain")
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-21876
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-21876
----

### Issue
Users with persistent WebSocket enabled may experience silent connection failures where the service appears running but messages are not being received. The existing PersistentWebsocketCheckWorker only ensures the service is started but cannot detect or recover from stale connections.

### Causes
The periodic worker checks if the persistent WebSocket service should be running and starts it if needed, but has no visibility into whether the connection is actually healthy. A WebSocket connection can remain technically "connected" while the server has stopped sending events, resulting in missed messages until the user manually restarts the app.

### Solution
- Add IsWebSocketConnectionUnhealthyUseCase that checks if any user with persistent WebSocket enabled has not received events in the last 12 hours
- Enhance PersistentWebsocketCheckWorker to perform health checks and automatically restart the service when an unhealthy connection is detected
- Reduce the worker interval from 24 hours to 12 hours to align with the health check threshold
