### PR TITLE
feat: implement Android user context provider and managed config parser for MDM support [WPB-23327]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/ManagedConfigurationsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/ManagedConfigurationsModule.kt
@@ -21,6 +21,10 @@ import android.content.Context
 import com.wire.android.BuildConfig
 import com.wire.android.config.ServerConfigProvider
 import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.emm.AndroidUserContextProvider
+import com.wire.android.emm.AndroidUserContextProviderImpl
+import com.wire.android.emm.ManagedConfigParser
+import com.wire.android.emm.ManagedConfigParserImpl
 import com.wire.android.emm.ManagedConfigurationsManager
 import com.wire.android.emm.ManagedConfigurationsManagerImpl
 import com.wire.android.util.EMPTY
@@ -44,13 +48,31 @@ class ManagedConfigurationsModule {
 
     @Provides
     @Singleton
+    fun provideAndroidUserContextProvider(): AndroidUserContextProvider =
+        AndroidUserContextProviderImpl()
+
+    @Provides
+    @Singleton
+    fun provideManagedConfigParser(
+        userContextProvider: AndroidUserContextProvider
+    ): ManagedConfigParser = ManagedConfigParserImpl(userContextProvider)
+
+    @Provides
+    @Singleton
     fun provideManagedConfigurationsRepository(
         @ApplicationContext context: Context,
         dispatcherProvider: DispatcherProvider,
         serverConfigProvider: ServerConfigProvider,
-        globalDataStore: GlobalDataStore
+        globalDataStore: GlobalDataStore,
+        configParser: ManagedConfigParser
     ): ManagedConfigurationsManager {
-        return ManagedConfigurationsManagerImpl(context, dispatcherProvider, serverConfigProvider, globalDataStore)
+        return ManagedConfigurationsManagerImpl(
+            context,
+            dispatcherProvider,
+            serverConfigProvider,
+            globalDataStore,
+            configParser
+        )
     }
 
     @Provides

--- a/app/src/main/kotlin/com/wire/android/emm/AndroidUserContextProvider.kt
+++ b/app/src/main/kotlin/com/wire/android/emm/AndroidUserContextProvider.kt
@@ -1,0 +1,59 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.emm
+
+import android.os.Process
+
+/**
+ * Provides the current Android user context for multi-app MDM configurations.
+ *
+ * On Android, each user (including work profiles) has a unique user ID.
+ * The user ID is calculated as UID / 100000, where UID is the process UID.
+ * - User 0: Main user (UID 0-99999)
+ * - User 10: Work profile or secondary user (UID 1000000-1099999)
+ */
+interface AndroidUserContextProvider {
+    /**
+     * Returns the current Android user ID.
+     * This is calculated as Process.myUid() / 100000.
+     *
+     * @return The user ID (e.g., 0 for main user, 10 for work profile)
+     */
+    fun getCurrentAndroidUserId(): Int
+
+    /**
+     * Returns the current user ID as a string key for configuration lookup.
+     *
+     * @return The user ID as a string (e.g., "0", "10")
+     */
+    fun getCurrentUserIdKey(): String
+
+    companion object {
+        const val DEFAULT_KEY = "default"
+        internal const val UID_DIVISOR = 100_000
+    }
+}
+
+internal class AndroidUserContextProviderImpl : AndroidUserContextProvider {
+
+    override fun getCurrentAndroidUserId(): Int =
+        Process.myUid() / AndroidUserContextProvider.UID_DIVISOR
+
+    override fun getCurrentUserIdKey(): String =
+        getCurrentAndroidUserId().toString()
+}

--- a/app/src/main/kotlin/com/wire/android/emm/ManagedConfigParser.kt
+++ b/app/src/main/kotlin/com/wire/android/emm/ManagedConfigParser.kt
@@ -1,0 +1,157 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.emm
+
+import com.wire.android.appLogger
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Parser for MDM managed configurations that supports both unified and context-mapped formats.
+ *
+ * **Unified Format (backward compatible):**
+ * ```json
+ * {
+ *   "title": "Enterprise Server",
+ *   "endpoints": { ... }
+ * }
+ * ```
+ *
+ * **Context-Mapped Format (multi-app support):**
+ * ```json
+ * {
+ *   "0": { "title": "Secure Server", "endpoints": { ... } },
+ *   "default": { "title": "General Server", "endpoints": { ... } }
+ * }
+ * ```
+ *
+ * The parser automatically detects the format and resolves the appropriate configuration
+ * based on the current Android user context.
+ */
+interface ManagedConfigParser {
+    /**
+     * Parses server configuration from raw JSON string.
+     *
+     * @param rawJson The raw JSON string from MDM restrictions
+     * @return Parsed [ManagedServerConfig] or null if parsing fails or no config found
+     * @throws InvalidManagedConfig if JSON is malformed
+     */
+    fun parseServerConfig(rawJson: String): ManagedServerConfig?
+
+    /**
+     * Parses SSO code configuration from raw JSON string.
+     *
+     * @param rawJson The raw JSON string from MDM restrictions
+     * @return Parsed [ManagedSSOCodeConfig] or null if parsing fails or no config found
+     * @throws InvalidManagedConfig if JSON is malformed
+     */
+    fun parseSSOCodeConfig(rawJson: String): ManagedSSOCodeConfig?
+}
+
+internal class ManagedConfigParserImpl(
+    private val userContextProvider: AndroidUserContextProvider
+) : ManagedConfigParser {
+
+    private val json: Json = Json { ignoreUnknownKeys = true }
+    private val logger = appLogger.withTextTag(TAG)
+
+    override fun parseServerConfig(rawJson: String): ManagedServerConfig? {
+        return parseConfig(
+            rawJson = rawJson,
+            configType = "server",
+            isUnifiedFormat = ::isUnifiedServerFormat,
+            parseUnified = { json.decodeFromString<ManagedServerConfig>(rawJson) },
+            parseFromObject = { json.decodeFromJsonElement<ManagedServerConfig>(it) }
+        )
+    }
+
+    override fun parseSSOCodeConfig(rawJson: String): ManagedSSOCodeConfig? {
+        return parseConfig(
+            rawJson = rawJson,
+            configType = "SSO",
+            isUnifiedFormat = ::isUnifiedSSOFormat,
+            parseUnified = { json.decodeFromString<ManagedSSOCodeConfig>(rawJson) },
+            parseFromObject = { json.decodeFromJsonElement<ManagedSSOCodeConfig>(it) }
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private inline fun <T> parseConfig(
+        rawJson: String,
+        configType: String,
+        isUnifiedFormat: (JsonObject) -> Boolean,
+        parseUnified: () -> T,
+        parseFromObject: (JsonObject) -> T
+    ): T? {
+        return try {
+            val jsonObject = json.parseToJsonElement(rawJson).jsonObject
+
+            if (isUnifiedFormat(jsonObject)) {
+                logger.i("Detected unified $configType config format")
+                parseUnified()
+            } else {
+                logger.i("Detected context-mapped $configType config format")
+                resolveContextMappedConfig(jsonObject, parseFromObject)
+            }
+        } catch (e: Exception) {
+            throw InvalidManagedConfig("Failed to parse managed $configType config: ${e.message}")
+        }
+    }
+
+    private inline fun <T> resolveContextMappedConfig(
+        jsonObject: JsonObject,
+        parseFromObject: (JsonObject) -> T
+    ): T? {
+        val userIdKey = userContextProvider.getCurrentUserIdKey()
+        logger.i("Resolving context-mapped config for user ID key: $userIdKey")
+
+        // Try to find config by user ID key
+        val configObject = jsonObject[userIdKey]?.jsonObject
+            ?: jsonObject[AndroidUserContextProvider.DEFAULT_KEY]?.jsonObject
+
+        return if (configObject != null) {
+            val resolvedKey = if (jsonObject.containsKey(userIdKey)) userIdKey else AndroidUserContextProvider.DEFAULT_KEY
+            logger.i("Resolved config using key: $resolvedKey")
+            parseFromObject(configObject)
+        } else {
+            logger.w("No config found for user ID key '$userIdKey' and no '${AndroidUserContextProvider.DEFAULT_KEY}' fallback")
+            null
+        }
+    }
+
+    /**
+     * Unified server format has "endpoints" and "title" at the root level.
+     */
+    private fun isUnifiedServerFormat(jsonObject: JsonObject): Boolean =
+        jsonObject.containsKey(KEY_ENDPOINTS) && jsonObject.containsKey(KEY_TITLE)
+
+    /**
+     * Unified SSO format has "sso_code" at the root level.
+     */
+    private fun isUnifiedSSOFormat(jsonObject: JsonObject): Boolean =
+        jsonObject.containsKey(KEY_SSO_CODE)
+
+    companion object {
+        private const val TAG = "ManagedConfigParser"
+        private const val KEY_ENDPOINTS = "endpoints"
+        private const val KEY_TITLE = "title"
+        private const val KEY_SSO_CODE = "sso_code"
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/emm/AndroidUserContextProviderTest.kt
+++ b/app/src/test/kotlin/com/wire/android/emm/AndroidUserContextProviderTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.emm
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AndroidUserContextProviderTest {
+
+    @Test
+    fun `given UID in main user range, then user ID should be 0`() {
+        val provider = FakeAndroidUserContextProvider(uid = 10123) // UID 10123 / 100000 = 0
+        assertEquals(0, provider.getCurrentAndroidUserId())
+        assertEquals("0", provider.getCurrentUserIdKey())
+    }
+
+    @Test
+    fun `given UID in work profile range, then user ID should be 10`() {
+        val provider = FakeAndroidUserContextProvider(uid = 1010123) // UID 1010123 / 100000 = 10
+        assertEquals(10, provider.getCurrentAndroidUserId())
+        assertEquals("10", provider.getCurrentUserIdKey())
+    }
+
+    @Test
+    fun `given UID at exact boundary, then user ID should be calculated correctly`() {
+        val provider = FakeAndroidUserContextProvider(uid = 100000) // UID 100000 / 100000 = 1
+        assertEquals(1, provider.getCurrentAndroidUserId())
+        assertEquals("1", provider.getCurrentUserIdKey())
+    }
+
+    @Test
+    fun `given UID zero, then user ID should be 0`() {
+        val provider = FakeAndroidUserContextProvider(uid = 0)
+        assertEquals(0, provider.getCurrentAndroidUserId())
+        assertEquals("0", provider.getCurrentUserIdKey())
+    }
+
+    @Test
+    fun `given UID just below boundary, then user ID should be 0`() {
+        val provider = FakeAndroidUserContextProvider(uid = 99999)
+        assertEquals(0, provider.getCurrentAndroidUserId())
+        assertEquals("0", provider.getCurrentUserIdKey())
+    }
+
+    @Test
+    fun `given DEFAULT_KEY constant, then it should be 'default'`() {
+        assertEquals("default", AndroidUserContextProvider.DEFAULT_KEY)
+    }
+}
+
+/**
+ * Fake implementation for testing that allows injecting a specific UID value.
+ */
+class FakeAndroidUserContextProvider(private val uid: Int) : AndroidUserContextProvider {
+    override fun getCurrentAndroidUserId(): Int = uid / AndroidUserContextProvider.UID_DIVISOR
+    override fun getCurrentUserIdKey(): String = getCurrentAndroidUserId().toString()
+}

--- a/app/src/test/kotlin/com/wire/android/emm/ManagedConfigParserTest.kt
+++ b/app/src/test/kotlin/com/wire/android/emm/ManagedConfigParserTest.kt
@@ -1,0 +1,301 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.emm
+
+import android.app.Application
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class ManagedConfigParserTest {
+
+    // region Server Config - Unified Format
+
+    @Test
+    fun `given unified server config, then parse correctly`() {
+        val parser = createParser(userIdKey = "0")
+        val result = parser.parseServerConfig(UNIFIED_SERVER_CONFIG)
+
+        assertNotNull(result)
+        assertEquals("anta.wire.link", result!!.title)
+        assertEquals("https://account.anta.wire.link", result.endpoints.accountsURL)
+        assertEquals("https://nginz-https.anta.wire.link", result.endpoints.backendURL)
+        assertEquals("https://nginz-ssl.anta.wire.link", result.endpoints.backendWSURL)
+        assertEquals("https://disallowed-clients.anta.wire.link", result.endpoints.blackListURL)
+        assertEquals("https://teams.anta.wire.link", result.endpoints.teamsURL)
+        assertEquals("https://wire.com", result.endpoints.websiteURL)
+    }
+
+    // endregion
+
+    // region Server Config - Context-Mapped Format
+
+    @Test
+    fun `given context-mapped server config with matching user ID, then return correct config`() {
+        val parser = createParser(userIdKey = "0")
+        val result = parser.parseServerConfig(CONTEXT_MAPPED_SERVER_CONFIG)
+
+        assertNotNull(result)
+        assertEquals("Secure Server", result!!.title)
+        assertEquals("https://secure-account.wire.link", result.endpoints.accountsURL)
+    }
+
+    @Test
+    fun `given context-mapped server config with non-matching user ID, then fallback to default`() {
+        val parser = createParser(userIdKey = "99") // User ID not in config
+        val result = parser.parseServerConfig(CONTEXT_MAPPED_SERVER_CONFIG)
+
+        assertNotNull(result)
+        assertEquals("General Server", result!!.title)
+        assertEquals("https://general-account.wire.link", result.endpoints.accountsURL)
+    }
+
+    @Test
+    fun `given context-mapped server config without default and non-matching user ID, then return null`() {
+        val parser = createParser(userIdKey = "99")
+        val result = parser.parseServerConfig(CONTEXT_MAPPED_SERVER_CONFIG_NO_DEFAULT)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `given context-mapped server config with only default, then use default for any user`() {
+        val parser = createParser(userIdKey = "42")
+        val result = parser.parseServerConfig(CONTEXT_MAPPED_SERVER_CONFIG_ONLY_DEFAULT)
+
+        assertNotNull(result)
+        assertEquals("Default Server", result!!.title)
+    }
+
+    // endregion
+
+    // region SSO Config - Unified Format
+
+    @Test
+    fun `given unified SSO config, then parse correctly`() {
+        val parser = createParser(userIdKey = "0")
+        val result = parser.parseSSOCodeConfig(UNIFIED_SSO_CONFIG)
+
+        assertNotNull(result)
+        assertEquals("fd994b20-b9af-11ec-ae36-00163e9b33ca", result!!.ssoCode)
+    }
+
+    // endregion
+
+    // region SSO Config - Context-Mapped Format
+
+    @Test
+    fun `given context-mapped SSO config with matching user ID, then return correct config`() {
+        val parser = createParser(userIdKey = "0")
+        val result = parser.parseSSOCodeConfig(CONTEXT_MAPPED_SSO_CONFIG)
+
+        assertNotNull(result)
+        assertEquals("secure-sso-code-0000-0000-000000000000", result!!.ssoCode)
+    }
+
+    @Test
+    fun `given context-mapped SSO config with non-matching user ID, then fallback to default`() {
+        val parser = createParser(userIdKey = "99")
+        val result = parser.parseSSOCodeConfig(CONTEXT_MAPPED_SSO_CONFIG)
+
+        assertNotNull(result)
+        assertEquals("default-sso-code-0000-0000-000000000000", result!!.ssoCode)
+    }
+
+    @Test
+    fun `given context-mapped SSO config without default and non-matching user ID, then return null`() {
+        val parser = createParser(userIdKey = "99")
+        val result = parser.parseSSOCodeConfig(CONTEXT_MAPPED_SSO_CONFIG_NO_DEFAULT)
+
+        assertNull(result)
+    }
+
+    // endregion
+
+    // region Invalid JSON
+
+    @Test
+    fun `given invalid JSON, then throw InvalidManagedConfig`() {
+        val parser = createParser(userIdKey = "0")
+
+        assertThrows(InvalidManagedConfig::class.java) {
+            parser.parseServerConfig("invalid json")
+        }
+    }
+
+    @Test
+    fun `given empty JSON object for server config, then return null as no context matched`() {
+        val parser = createParser(userIdKey = "0")
+        // Empty JSON object {} has no keys matching user ID or "default"
+        val result = parser.parseServerConfig("{}")
+        assertNull(result)
+    }
+
+    @Test
+    fun `given malformed server config with partial unified format, then return null`() {
+        val parser = createParser(userIdKey = "0")
+        // This JSON has title but no endpoints - doesn't match unified format, falls through to context-mapped
+        // Since it has no matching context keys, returns null
+        val malformedJson = """{"title": "Test"}"""
+
+        val result = parser.parseServerConfig(malformedJson)
+        assertNull(result)
+    }
+
+    @Test
+    fun `given completely invalid JSON structure, then throw InvalidManagedConfig`() {
+        val parser = createParser(userIdKey = "0")
+        // Not a valid JSON object structure
+        assertThrows(InvalidManagedConfig::class.java) {
+            parser.parseServerConfig("not json at all")
+        }
+    }
+
+    // endregion
+
+    // region Helper Methods
+
+    private fun createParser(userIdKey: String): ManagedConfigParser {
+        return ManagedConfigParserImpl(
+            userContextProvider = object : AndroidUserContextProvider {
+                override fun getCurrentAndroidUserId(): Int = userIdKey.toIntOrNull() ?: 0
+                override fun getCurrentUserIdKey(): String = userIdKey
+            }
+        )
+    }
+
+    // endregion
+
+    companion object {
+        val UNIFIED_SERVER_CONFIG = """
+            {
+              "endpoints": {
+                "accountsURL": "https://account.anta.wire.link",
+                "backendURL": "https://nginz-https.anta.wire.link",
+                "backendWSURL": "https://nginz-ssl.anta.wire.link",
+                "blackListURL": "https://disallowed-clients.anta.wire.link",
+                "teamsURL": "https://teams.anta.wire.link",
+                "websiteURL": "https://wire.com"
+              },
+              "title": "anta.wire.link"
+            }
+        """.trimIndent()
+
+        val CONTEXT_MAPPED_SERVER_CONFIG = """
+            {
+              "0": {
+                "title": "Secure Server",
+                "endpoints": {
+                  "accountsURL": "https://secure-account.wire.link",
+                  "backendURL": "https://secure-api.wire.link",
+                  "backendWSURL": "https://secure-ws.wire.link",
+                  "blackListURL": "https://secure-blacklist.wire.link",
+                  "teamsURL": "https://secure-teams.wire.link",
+                  "websiteURL": "https://secure.wire.com"
+                }
+              },
+              "default": {
+                "title": "General Server",
+                "endpoints": {
+                  "accountsURL": "https://general-account.wire.link",
+                  "backendURL": "https://general-api.wire.link",
+                  "backendWSURL": "https://general-ws.wire.link",
+                  "blackListURL": "https://general-blacklist.wire.link",
+                  "teamsURL": "https://general-teams.wire.link",
+                  "websiteURL": "https://general.wire.com"
+                }
+              }
+            }
+        """.trimIndent()
+
+        val CONTEXT_MAPPED_SERVER_CONFIG_NO_DEFAULT = """
+            {
+              "0": {
+                "title": "Secure Server",
+                "endpoints": {
+                  "accountsURL": "https://secure-account.wire.link",
+                  "backendURL": "https://secure-api.wire.link",
+                  "backendWSURL": "https://secure-ws.wire.link",
+                  "blackListURL": "https://secure-blacklist.wire.link",
+                  "teamsURL": "https://secure-teams.wire.link",
+                  "websiteURL": "https://secure.wire.com"
+                }
+              },
+              "10": {
+                "title": "Work Profile Server",
+                "endpoints": {
+                  "accountsURL": "https://work-account.wire.link",
+                  "backendURL": "https://work-api.wire.link",
+                  "backendWSURL": "https://work-ws.wire.link",
+                  "blackListURL": "https://work-blacklist.wire.link",
+                  "teamsURL": "https://work-teams.wire.link",
+                  "websiteURL": "https://work.wire.com"
+                }
+              }
+            }
+        """.trimIndent()
+
+        val CONTEXT_MAPPED_SERVER_CONFIG_ONLY_DEFAULT = """
+            {
+              "default": {
+                "title": "Default Server",
+                "endpoints": {
+                  "accountsURL": "https://default-account.wire.link",
+                  "backendURL": "https://default-api.wire.link",
+                  "backendWSURL": "https://default-ws.wire.link",
+                  "blackListURL": "https://default-blacklist.wire.link",
+                  "teamsURL": "https://default-teams.wire.link",
+                  "websiteURL": "https://default.wire.com"
+                }
+              }
+            }
+        """.trimIndent()
+
+        val UNIFIED_SSO_CONFIG = """
+            {
+              "sso_code": "fd994b20-b9af-11ec-ae36-00163e9b33ca"
+            }
+        """.trimIndent()
+
+        val CONTEXT_MAPPED_SSO_CONFIG = """
+            {
+              "0": {
+                "sso_code": "secure-sso-code-0000-0000-000000000000"
+              },
+              "default": {
+                "sso_code": "default-sso-code-0000-0000-000000000000"
+              }
+            }
+        """.trimIndent()
+
+        val CONTEXT_MAPPED_SSO_CONFIG_NO_DEFAULT = """
+            {
+              "0": {
+                "sso_code": "secure-sso-code-0000-0000-000000000000"
+              }
+            }
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23327
<!--jira-description-action-hidden-marker-end-->

Glad you asked—this is the kind of detail that keeps PRs smooth. Here’s the template filled out for the **context‑aware MDM config** feature, with a suggested PR title and honest testing notes.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Enable enterprise MDM configurations to be resolved per Android user context so multiple Wire instances on the same device (primary user vs work profile/secure container) can use different server endpoints and SSO codes.

### Causes (Optional)

Current managed configuration parsing only supports a single unified config and does not account for Android user context, so both app instances read the same restrictions and cannot be independently configured.

### Solutions

Introduce an Android user context provider and a managed configuration parser that supports both unified and context‑mapped formats. Resolve configs by string‑matching the current Android user ID key with a `default` fallback, and apply server/SSO configs per context with validation and safe fallbacks.

### Dependencies (Optional)

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Run unit tests for EMM parsing and manager behavior, for example:  
`./gradlew test`  
Verify tests in `ManagedConfigParserTest`, `ManagedConfigurationsManagerTest`, and `AndroidUserContextProviderTest` pass.

### Notes (Optional)

Context matching is based on simple string keys of the Android user ID (`Process.myUid() / 100000`). If no matching key exists, `default` is used; otherwise server config falls back to app defaults and SSO is cleared.

### Attachments (Optional)

N/A

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.

**Suggested PR Title (meets requirements):**  
`feat(emm): If merged, this PR will support context-aware MDM config resolution #SQPIT-XXXX`