### PR TITLE
fix: pass the correct argument when navigating back after leaving/deleting the group [WPB-19133]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsNavArgs.kt
@@ -28,8 +28,6 @@ data class GroupConversationDetailsNavArgs(
 @Parcelize
 data class GroupConversationDetailsNavBackArgs(
     val groupConversationActionType: GroupConversationActionType,
-    val hasLeftGroup: Boolean = false,
-    val isGroupDeleted: Boolean = false,
     val conversationName: String,
 ) : Parcelable
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -266,8 +266,7 @@ fun GroupConversationDetailsScreen(
         onLeftConversation = {
             resultNavigator.navigateBack(
                 GroupConversationDetailsNavBackArgs(
-                    groupConversationActionType = GroupConversationActionType.DELETE_GROUP,
-                    isGroupDeleted = true,
+                    groupConversationActionType = GroupConversationActionType.LEAVE_GROUP,
                     conversationName = groupOptions.groupName
                 )
             )
@@ -275,8 +274,7 @@ fun GroupConversationDetailsScreen(
         onDeletedConversation = {
             resultNavigator.navigateBack(
                 GroupConversationDetailsNavBackArgs(
-                    groupConversationActionType = GroupConversationActionType.LEAVE_GROUP,
-                    hasLeftGroup = true,
+                    groupConversationActionType = GroupConversationActionType.DELETE_GROUP,
                     conversationName = groupOptions.groupName
                 )
             )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-19133
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

pass the correct argument when navigating back after leaving/deleting the group

### Solutions

now the correct you left is showing

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
