### PR TITLE
refactor: load default protocol in init and resetState methods [WPB-23210]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -79,17 +79,20 @@ class NewConversationViewModel @Inject constructor(
     var createGroupState: CreateGroupState by mutableStateOf(CreateGroupState.Default)
 
     init {
-        initNewGroupState()
+        loadDefaultProtocol()
         observeAllowanceOfAppsUsageInitialState()
         setConversationCreationParam()
         observeChannelCreationPermission()
         getWireCellFeatureState()
     }
 
-    private fun initNewGroupState() = viewModelScope.launch {
-        val defaultProtocol = CreateConversationParam
-            .Protocol.fromSupportedProtocolToConversationOptionsProtocol(getDefaultProtocol())
-        newGroupState = newGroupState.copy(groupProtocol = defaultProtocol)
+    private fun loadDefaultProtocol() {
+        viewModelScope.launch {
+            val defaultProtocol = CreateConversationParam
+                .Protocol
+                .fromSupportedProtocolToConversationOptionsProtocol(getDefaultProtocol())
+            newGroupState = newGroupState.copy(groupProtocol = defaultProtocol)
+        }
     }
 
     private fun observeAllowanceOfAppsUsageInitialState() {
@@ -118,16 +121,10 @@ class NewConversationViewModel @Inject constructor(
         appsAllowed
     }
 
-    fun resetState() = viewModelScope.launch {
+    fun resetState() {
         newGroupNameTextState.clearText()
-        newGroupState = GroupMetadataState().let {
-            val defaultProtocol = CreateConversationParam
-                .Protocol
-                .fromSupportedProtocolToConversationOptionsProtocol(getDefaultProtocol())
-            it.copy(
-                groupProtocol = defaultProtocol
-            )
-        }
+        newGroupState = GroupMetadataState()
+        loadDefaultProtocol()
         observeAllowanceOfAppsUsageInitialState()
         createGroupState = CreateGroupState.Default
         setConversationCreationParam()

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -408,6 +408,7 @@ class NewConversationViewModelTest {
 
         // When
         viewModel.resetState()
+        advanceUntilIdle()
 
         assertTrue(viewModel.groupOptionsState.isTeamAllowedToUseApps)
         assertTrue(viewModel.groupOptionsState.isAllowAppsEnabled)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23210
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

removing user scoped pref mad all functions suspend

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
