### PR TITLE
feat: support for separate mdm configurations (WPB-23327)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/ManagedConfigurationsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/ManagedConfigurationsModule.kt
@@ -23,6 +23,7 @@ import com.wire.android.config.ServerConfigProvider
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.emm.ManagedConfigurationsManager
 import com.wire.android.emm.ManagedConfigurationsManagerImpl
+import com.wire.android.feature.IsSecureFolderUseCase
 import com.wire.android.util.EMPTY
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.configuration.server.ServerConfig
@@ -48,9 +49,10 @@ class ManagedConfigurationsModule {
         @ApplicationContext context: Context,
         dispatcherProvider: DispatcherProvider,
         serverConfigProvider: ServerConfigProvider,
-        globalDataStore: GlobalDataStore
+        globalDataStore: GlobalDataStore,
+        isSecureFolderUseCase: IsSecureFolderUseCase
     ): ManagedConfigurationsManager {
-        return ManagedConfigurationsManagerImpl(context, dispatcherProvider, serverConfigProvider, globalDataStore)
+        return ManagedConfigurationsManagerImpl(context, dispatcherProvider, serverConfigProvider, globalDataStore, isSecureFolderUseCase)
     }
 
     @Provides

--- a/app/src/main/kotlin/com/wire/android/feature/IsSecureFolderUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/IsSecureFolderUseCase.kt
@@ -1,0 +1,39 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature
+
+import android.os.Process
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Determines whether the app is running inside a Secure Folder (Samsung) or a work profile.
+ *
+ * On Android, each user space is assigned a range of 100 000 UIDs.
+ * Primary user space UIDs fall in the range 0–99 999 (user ID 0),
+ * while secondary spaces (Secure Folder, work profiles) start at 100 000+.
+ */
+@Singleton
+class IsSecureFolderUseCase @Inject constructor() {
+    operator fun invoke(): Boolean = Process.myUid() / PER_USER_RANGE != PRIMARY_USER_ID
+
+    companion object {
+        private const val PER_USER_RANGE = 100_000
+        private const val PRIMARY_USER_ID = 0
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/feature/IsSecureFolderUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/IsSecureFolderUseCaseTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature
+
+import android.app.Application
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowProcess
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class IsSecureFolderUseCaseTest {
+
+    private val useCase = IsSecureFolderUseCase()
+
+    @Test
+    fun `given UID zero, then returns false`() {
+        ShadowProcess.setUid(0)
+        assertEquals(false, useCase())
+    }
+
+    @Test
+    fun `given primary user UID, then returns false`() {
+        ShadowProcess.setUid(10_042)
+        assertEquals(false, useCase())
+    }
+
+    @Test
+    fun `given secondary user UID (secure folder), then returns true`() {
+        ShadowProcess.setUid(100_042)
+        assertEquals(true, useCase())
+    }
+
+    @Test
+    fun `given UID at exact boundary of secondary user, then returns true`() {
+        ShadowProcess.setUid(100_000)
+        assertEquals(true, useCase())
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23327
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-23327
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

###  Summary

  - Add context-mapped MDM config support so two Wire instances on the same device (primary + Samsung Secure Folder) can receive different server and SSO configurations from a single MDM restriction payload
  - Extract secure folder detection into IsSecureFolderUseCase with unit tests
  - Existing unified JSON format continues to work unchanged (backward compatible)

###  Context-mapped JSON format

  Admins can now push a JSON object with "regular", "secure", and/or "default" keys. Resolution order:
  1. Exact context key ("regular" for primary user, "secure" for Secure Folder/work profile)
  2. "default" fallback
  3. No match and no default → app defaults (server config) / empty string (SSO code)
  4. No context keys detected → treat as unified format (backward compatible)
