### PR TITLE
refactor: previews not building for network screen because of cotext usage [WPB-23588]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -25,12 +25,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.preview.MultipleThemePreviews
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
@@ -38,7 +37,6 @@ import com.wire.android.ui.home.conversations.details.options.ArrowType
 import com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsItem
 import com.wire.android.ui.home.settings.SwitchState
 import com.wire.android.ui.theme.WireTheme
-import com.wire.android.util.isWebsocketEnabledByDefault
 
 @WireRootDestination
 @Composable
@@ -50,6 +48,7 @@ fun NetworkSettingsScreen(
         onBackPressed = navigator::navigateBack,
         isWebSocketEnabled = networkSettingsViewModel.networkSettingsState.isPersistentWebSocketConnectionEnabled,
         isEnforcedByMDM = networkSettingsViewModel.networkSettingsState.isEnforcedByMDM,
+        isWebSocketEnforcedByDefault = networkSettingsViewModel.networkSettingsState.isWebSocketEnforcedByDefault,
         setWebSocketState = { networkSettingsViewModel.setWebSocketState(it) },
     )
 }
@@ -59,6 +58,7 @@ fun NetworkSettingsScreenContent(
     onBackPressed: () -> Unit,
     isWebSocketEnabled: Boolean,
     isEnforcedByMDM: Boolean,
+    isWebSocketEnforcedByDefault: Boolean,
     setWebSocketState: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -67,7 +67,7 @@ fun NetworkSettingsScreenContent(
         topBar = {
             WireCenterAlignedTopAppBar(
                 onNavigationPressed = onBackPressed,
-                elevation = 0.dp,
+                elevation = dimensions().spacing0x,
                 title = stringResource(id = R.string.settings_network_settings_label)
             )
         }
@@ -77,11 +77,7 @@ fun NetworkSettingsScreenContent(
                 .fillMaxSize()
                 .padding(internalPadding)
         ) {
-            val appContext = LocalContext.current.applicationContext
-            val isWebSocketEnforcedByDefault = remember {
-                isWebsocketEnabledByDefault(appContext)
-            }
-            val switchState = remember(isWebSocketEnabled, isEnforcedByMDM) {
+            val switchState = remember(isWebSocketEnabled, isEnforcedByMDM, isWebSocketEnforcedByDefault) {
                 when {
                     isEnforcedByMDM -> SwitchState.TextOnly(true)
                     isWebSocketEnforcedByDefault -> SwitchState.TextOnly(true)
@@ -110,11 +106,48 @@ fun NetworkSettingsScreenContent(
 
 @Composable
 @MultipleThemePreviews
-fun PreviewNetworkSettingsScreen() = WireTheme {
+fun PreviewNetworkSettingsScreenWebSocketEnabled() = WireTheme {
     NetworkSettingsScreenContent(
         onBackPressed = {},
         isWebSocketEnabled = true,
         isEnforcedByMDM = false,
+        isWebSocketEnforcedByDefault = false,
+        setWebSocketState = {},
+    )
+}
+
+@Composable
+@MultipleThemePreviews
+fun PreviewNetworkSettingsScreenWebSocketDisabled() = WireTheme {
+    NetworkSettingsScreenContent(
+        onBackPressed = {},
+        isWebSocketEnabled = false,
+        isEnforcedByMDM = false,
+        isWebSocketEnforcedByDefault = false,
+        setWebSocketState = {},
+    )
+}
+
+@Composable
+@MultipleThemePreviews
+fun PreviewNetworkSettingsScreenEnforcedByMDM() = WireTheme {
+    NetworkSettingsScreenContent(
+        onBackPressed = {},
+        isWebSocketEnabled = true,
+        isEnforcedByMDM = true,
+        isWebSocketEnforcedByDefault = false,
+        setWebSocketState = {},
+    )
+}
+
+@Composable
+@MultipleThemePreviews
+fun PreviewNetworkSettingsScreenEnforcedByDefault() = WireTheme {
+    NetworkSettingsScreenContent(
+        onBackPressed = {},
+        isWebSocketEnabled = true,
+        isEnforcedByMDM = false,
+        isWebSocketEnforcedByDefault = true,
         setWebSocketState = {},
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsState.kt
@@ -20,5 +20,6 @@ package com.wire.android.ui.home.settings.appsettings.networkSettings
 
 data class NetworkSettingsState(
     val isPersistentWebSocketConnectionEnabled: Boolean = false,
-    val isEnforcedByMDM: Boolean = false
+    val isEnforcedByMDM: Boolean = false,
+    val isWebSocketEnforcedByDefault: Boolean = false
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModel.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.ui.home.settings.appsettings.networkSettings
 
+import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -25,11 +26,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.emm.ManagedConfigurationsManager
+import com.wire.android.util.isWebsocketEnabledByDefault
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import com.wire.kalium.logic.feature.user.webSocketStatus.PersistPersistentWebSocketConnectionStatusUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -39,13 +42,21 @@ class NetworkSettingsViewModel
     private val persistPersistentWebSocketConnectionStatus: PersistPersistentWebSocketConnectionStatusUseCase,
     private val observePersistentWebSocketConnectionStatus: ObservePersistentWebSocketConnectionStatusUseCase,
     private val currentSession: CurrentSessionUseCase,
-    private val managedConfigurationsManager: ManagedConfigurationsManager
+    private val managedConfigurationsManager: ManagedConfigurationsManager,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
     var networkSettingsState by mutableStateOf(NetworkSettingsState())
 
     init {
+        checkWebSocketEnforcedByDefault()
         observePersistentWebSocketConnection()
         observeMDMEnforcement()
+    }
+
+    private fun checkWebSocketEnforcedByDefault() {
+        networkSettingsState = networkSettingsState.copy(
+            isWebSocketEnforcedByDefault = isWebsocketEnabledByDefault(context)
+        )
     }
 
     private fun observeMDMEnforcement() {

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModelTest.kt
@@ -56,7 +56,7 @@ class NetworkSettingsViewModelTest {
     fun setup() {
         MockKAnnotations.init(this, relaxUnitFun = true)
         mockkStatic(::isWebsocketEnabledByDefault)
-        
+
         context = mockk(relaxed = true)
         persistPersistentWebSocketConnectionStatus = mockk()
         observePersistentWebSocketConnectionStatus = mockk()

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModelTest.kt
@@ -1,0 +1,261 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.settings.appsettings.networkSettings
+
+import android.content.Context
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.emm.ManagedConfigurationsManager
+import com.wire.android.util.isWebsocketEnabledByDefault
+import com.wire.kalium.logic.data.auth.AccountInfo
+import com.wire.kalium.logic.data.auth.PersistentWebSocketStatus
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
+import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
+import com.wire.kalium.logic.feature.user.webSocketStatus.PersistPersistentWebSocketConnectionStatusUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(CoroutineTestExtension::class)
+class NetworkSettingsViewModelTest {
+
+    private lateinit var viewModel: NetworkSettingsViewModel
+    private lateinit var context: Context
+    private lateinit var persistPersistentWebSocketConnectionStatus: PersistPersistentWebSocketConnectionStatusUseCase
+    private lateinit var observePersistentWebSocketConnectionStatus: ObservePersistentWebSocketConnectionStatusUseCase
+    private lateinit var currentSession: CurrentSessionUseCase
+    private lateinit var managedConfigurationsManager: ManagedConfigurationsManager
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        mockkStatic(::isWebsocketEnabledByDefault)
+        
+        context = mockk(relaxed = true)
+        persistPersistentWebSocketConnectionStatus = mockk()
+        observePersistentWebSocketConnectionStatus = mockk()
+        currentSession = mockk()
+        managedConfigurationsManager = mockk()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        io.mockk.unmockkStatic(::isWebsocketEnabledByDefault)
+    }
+
+    @Test
+    fun `given websocket is enabled by default, when ViewModel initializes, then state reflects it`() = runTest {
+        // given
+        every { isWebsocketEnabledByDefault(context) } returns true
+        coEvery { currentSession() } returns CurrentSessionResult.Success(
+            AccountInfo.Valid(userId = QualifiedID("user", "domain"))
+        )
+        coEvery { observePersistentWebSocketConnectionStatus() } returns
+            ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(
+                flowOf(emptyList())
+            )
+        every { managedConfigurationsManager.persistentWebSocketEnforcedByMDM } returns flowOf(false).stateIn(this)
+
+        // when
+        viewModel = createViewModel()
+
+        // then
+        assertEquals(true, viewModel.networkSettingsState.isWebSocketEnforcedByDefault)
+    }
+
+    @Test
+    fun `given websocket is not enabled by default, when ViewModel initializes, then state reflects it`() = runTest {
+        // given
+        every { isWebsocketEnabledByDefault(context) } returns false
+        coEvery { currentSession() } returns CurrentSessionResult.Success(
+            AccountInfo.Valid(userId = QualifiedID("user", "domain"))
+        )
+        coEvery { observePersistentWebSocketConnectionStatus() } returns
+            ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(
+                flowOf(emptyList())
+            )
+        every { managedConfigurationsManager.persistentWebSocketEnforcedByMDM } returns flowOf(false).stateIn(this)
+
+        // when
+        viewModel = createViewModel()
+
+        // then
+        assertEquals(false, viewModel.networkSettingsState.isWebSocketEnforcedByDefault)
+    }
+
+    @Test
+    fun `given websocket is enabled, when ViewModel observes status, then state reflects it`() = runTest {
+        // given
+        val userId = QualifiedID("user", "domain")
+        every { isWebsocketEnabledByDefault(context) } returns false
+        coEvery { currentSession() } returns CurrentSessionResult.Success(AccountInfo.Valid(userId = userId))
+        coEvery { observePersistentWebSocketConnectionStatus() } returns
+            ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(
+                flowOf(listOf(PersistentWebSocketStatus(userId, true)))
+            )
+        every { managedConfigurationsManager.persistentWebSocketEnforcedByMDM } returns flowOf(false).stateIn(this)
+
+        // when
+        viewModel = createViewModel()
+
+        // then
+        assertEquals(true, viewModel.networkSettingsState.isPersistentWebSocketConnectionEnabled)
+    }
+
+    @Test
+    fun `given websocket is disabled, when ViewModel observes status, then state reflects it`() = runTest {
+        // given
+        val userId = QualifiedID("user", "domain")
+        every { isWebsocketEnabledByDefault(context) } returns false
+        coEvery { currentSession() } returns CurrentSessionResult.Success(AccountInfo.Valid(userId = userId))
+        coEvery { observePersistentWebSocketConnectionStatus() } returns
+            ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(
+                flowOf(listOf(PersistentWebSocketStatus(userId, false)))
+            )
+        every { managedConfigurationsManager.persistentWebSocketEnforcedByMDM } returns flowOf(false).stateIn(this)
+
+        // when
+        viewModel = createViewModel()
+
+        // then
+        assertEquals(false, viewModel.networkSettingsState.isPersistentWebSocketConnectionEnabled)
+    }
+
+    @Test
+    fun `given MDM enforces websocket, when ViewModel observes MDM state, then state reflects it`() = runTest {
+        // given
+        every { isWebsocketEnabledByDefault(context) } returns false
+        coEvery { currentSession() } returns CurrentSessionResult.Success(
+            AccountInfo.Valid(userId = QualifiedID("user", "domain"))
+        )
+        coEvery { observePersistentWebSocketConnectionStatus() } returns
+            ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(
+                flowOf(emptyList())
+            )
+        every { managedConfigurationsManager.persistentWebSocketEnforcedByMDM } returns flowOf(true).stateIn(this)
+
+        // when
+        viewModel = createViewModel()
+
+        // then
+        assertEquals(true, viewModel.networkSettingsState.isEnforcedByMDM)
+        assertEquals(true, viewModel.networkSettingsState.isPersistentWebSocketConnectionEnabled)
+    }
+
+    @Test
+    fun `given MDM does not enforce websocket, when ViewModel observes MDM state, then state reflects it`() = runTest {
+        // given
+        every { isWebsocketEnabledByDefault(context) } returns false
+        coEvery { currentSession() } returns CurrentSessionResult.Success(
+            AccountInfo.Valid(userId = QualifiedID("user", "domain"))
+        )
+        coEvery { observePersistentWebSocketConnectionStatus() } returns
+            ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(
+                flowOf(emptyList())
+            )
+        every { managedConfigurationsManager.persistentWebSocketEnforcedByMDM } returns flowOf(false).stateIn(this)
+
+        // when
+        viewModel = createViewModel()
+
+        // then
+        assertEquals(false, viewModel.networkSettingsState.isEnforcedByMDM)
+    }
+
+    @Test
+    fun `given websocket is not enforced by MDM, when setting websocket state to enabled, then persist is called`() = runTest {
+        // given
+        every { isWebsocketEnabledByDefault(context) } returns false
+        coEvery { currentSession() } returns CurrentSessionResult.Success(
+            AccountInfo.Valid(userId = QualifiedID("user", "domain"))
+        )
+        coEvery { observePersistentWebSocketConnectionStatus() } returns
+            ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(
+                flowOf(emptyList())
+            )
+        every { managedConfigurationsManager.persistentWebSocketEnforcedByMDM } returns flowOf(false).stateIn(this)
+        coEvery { persistPersistentWebSocketConnectionStatus(true) } returns Unit
+
+        viewModel = createViewModel()
+
+        // when
+        viewModel.setWebSocketState(true)
+
+        // then
+        coEvery { persistPersistentWebSocketConnectionStatus(true) }
+    }
+
+    @Test
+    fun `given websocket is enforced by MDM, when attempting to set websocket state, then persist is not called`() = runTest {
+        // given
+        every { isWebsocketEnabledByDefault(context) } returns false
+        coEvery { currentSession() } returns CurrentSessionResult.Success(
+            AccountInfo.Valid(userId = QualifiedID("user", "domain"))
+        )
+        coEvery { observePersistentWebSocketConnectionStatus() } returns
+            ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(
+                flowOf(emptyList())
+            )
+        every { managedConfigurationsManager.persistentWebSocketEnforcedByMDM } returns flowOf(true).stateIn(this)
+
+        viewModel = createViewModel()
+
+        // when
+        viewModel.setWebSocketState(false)
+
+        // then - persist should not be called
+        coEvery { persistPersistentWebSocketConnectionStatus(any()) } returns Unit
+    }
+
+    @Test
+    fun `given no current session, when ViewModel initializes, then state has default values`() = runTest {
+        // given
+        every { isWebsocketEnabledByDefault(context) } returns false
+        coEvery { currentSession() } returns CurrentSessionResult.Failure.SessionNotFound
+        coEvery { observePersistentWebSocketConnectionStatus() } returns
+            ObservePersistentWebSocketConnectionStatusUseCase.Result.Success(
+                flowOf(emptyList())
+            )
+        every { managedConfigurationsManager.persistentWebSocketEnforcedByMDM } returns flowOf(false).stateIn(this)
+
+        // when
+        viewModel = createViewModel()
+
+        // then
+        assertEquals(false, viewModel.networkSettingsState.isPersistentWebSocketConnectionEnabled)
+    }
+
+    private fun createViewModel() = NetworkSettingsViewModel(
+        persistPersistentWebSocketConnectionStatus = persistPersistentWebSocketConnectionStatus,
+        observePersistentWebSocketConnectionStatus = observePersistentWebSocketConnectionStatus,
+        currentSession = currentSession,
+        managedConfigurationsManager = managedConfigurationsManager,
+        context = context
+    )
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23588
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

network settings screen preview not rendering and the ViewModel have no tests  

### Solutions

refactor it to not use the app context this fixed the preview 
add tests to the ViewModel  

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
