### PR TITLE
fix: R8 keep rules for JNA and AVS/WebRTC to prevent login crash 

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -46,6 +46,22 @@
 -dontwarn java.awt.GraphicsEnvironment
 -dontwarn java.awt.HeadlessException
 -dontwarn java.awt.Window
+-keep class com.sun.jna.** { *; }
+-keep class * extends com.sun.jna.** { *; }
+-keepclassmembers class com.sun.jna.Pointer { long peer; }
+
+# AVS/WebRTC classes are accessed from native code (FlowManager_attach).
+# Keep concrete names and members to avoid NoSuchMethodError/ClassNotFoundException at runtime.
+-keep class org.webrtc.** { *; }
+-keep class com.waz.call.FlowManager { *; }
+-keep class com.waz.avs.VideoRenderer { *; }
+-keep class com.waz.call.CaptureDevice { *; }
+-keep class com.waz.media.manager.** { *; }
+-keep class com.waz.service.call.** { *; }
+-keep class com.waz.soundlink.SoundLinkAPI { *; }
+-dontwarn org.webrtc.CalledByNative
+-dontwarn org.webrtc.JniCommon
+-dontwarn org.webrtc.audio.AudioDeviceModule
 
 # Room/WorkManager instantiate generated DB classes via reflection.
 # Keep *_Impl classes (including constructors) to avoid startup crash


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
This PR fixes a release-only login crash caused by R8 shrinking/obfuscating classes used from native AVS/JNA code.

What was happening:
- During login/call initialization, native `FlowManager_attach` tried to access Java classes/methods by name.
- R8 removed/renamed required symbols, which led to `NoSuchMethodError` / `ClassNotFoundException` in `com.waz.media.manager.*`, then a native crash in `libavs.so`.
- Previously seen JNA init issues were also covered by explicit JNA keep rules.

What was changed:
- Added explicit ProGuard/R8 keep rules in `proguard-rules.pro` for:
  - `com.sun.jna.**` (+ `Pointer.peer`)
  - AVS/WebRTC classes used from native (`com.waz.*`, `org.webrtc.*`)
- Added required WebRTC `-dontwarn` entries to let R8 complete.

Result:
- `internalCompatrelease` builds and installs successfully.
- Login no longer crashes on device.