### PR TITLE
fix: maintain worker class name stability for minification compatibility [WPB-20393]

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -67,3 +67,11 @@
 # Keep *_Impl classes (including constructors) to avoid startup crash
 # when R8 strips default constructors.
 -keep class **_Impl extends androidx.room.RoomDatabase { *; }
+
+# WrapperWorkerFactory resolves inner workers by class name from input data.
+# Keep names stable so existing enqueued work remains resolvable after minification.
+# See docs/minification-workmanager-compat.md
+-keepnames class com.wire.kalium.logic.sync.PendingMessagesSenderWorker
+-keepnames class com.wire.kalium.logic.sync.periodic.UserConfigSyncWorker
+-keepnames class com.wire.kalium.logic.sync.periodic.UpdateApiVersionsWorker
+-keepnames class com.wire.kalium.logic.sync.receiver.asset.AudioNormalizedLoudnessWorker


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-20393
<!--jira-description-action-hidden-marker-end-->

#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability

----

# What's new in this PR?

### Issues

- App crashes in minified builds because some Kalium/worker classes are not stable after obfuscation.
- Existing queued WorkManager jobs can fail with `ClassNotFoundException` after upgrade/minification.

### Causes (Optional)

- With AGP 9 / Gradle 9 + composite Kalium build, consumer ProGuard rules are not always propagated transitively like before.
- Worker dispatch previously depended on class-name strings stored in WorkManager input data.

### Solutions

- Added app-level keep/keepnames rules for affected classes (media manager + worker class names).
- Added compatibility layer in `WrapperWorkerFactory`:
  - stable `worker_type` key for new work
  - legacy class-name aliases for old enqueued work
  - safe fallback worker instead of crashing process

### Dependencies (Optional)

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Build a minified variant (`internalRelease` / `betaDebug` with minify).
- Launch app and verify no startup/worker `ClassNotFoundException` crash.
- Verify queued work still runs after upgrading from a previous install.

### Notes (Optional)

- Full workspace compile currently has an unrelated `kalium/domain/userstorage` compile issue in this branch; this PR focuses on runtime minification compatibility.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
