### PR TITLE
chore: update get cert button text (WPB-23618)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
@@ -35,6 +35,7 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.settings.devices.button.GetE2eiCertificateButton
 import com.wire.android.ui.settings.devices.button.ShowE2eiCertificateButton
+import com.wire.android.ui.settings.devices.button.UpdateE2eiCertificateButton
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -119,11 +120,19 @@ fun EndToEndIdentityCertificateItem(
                     }
                 }
                 if (isCurrentDevice) {
-                    GetE2eiCertificateButton(
-                        enabled = true,
-                        isLoading = isLoadingCertificate,
-                        onGetCertificateClicked = enrollE2eiCertificate
-                    )
+                    if (mlsClientIdentity.e2eiStatus == MLSClientE2EIStatus.NOT_ACTIVATED) {
+                        GetE2eiCertificateButton(
+                            enabled = true,
+                            isLoading = isLoadingCertificate,
+                            onGetCertificateClicked = enrollE2eiCertificate
+                        )
+                    } else {
+                        UpdateE2eiCertificateButton(
+                            enabled = true,
+                            isLoading = isLoadingCertificate,
+                            onUpdateCertificateClicked = enrollE2eiCertificate
+                        )
+                    }
                 }
                 ShowE2eiCertificateButton(
                     enabled = true,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23618
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-23618
----

Follow-up for: https://wearezeta.atlassian.net/browse/WPB-23317

# What's new in this PR?

Show correct text for the update certificate button:
- Certificate status NOT ACTIVATED: Get certificate
- Other status: Update certificate

Reusing existing `UpdateE2eiCertificateButton` button.