### PR TITLE
chore: adjust memory allocation for CI assemble and bundle tasks [WPB-8645]

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -223,6 +223,7 @@ jobs:
           DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           ENABLE_SIGNING: ${{ secrets.ENABLE_SIGNING }}
           DOMAIN_REMOVAL_KEYS_FOR_REPAIR: ${{ secrets.DOMAIN_REMOVAL_KEYS_FOR_REPAIR }}
+          GRADLE_OPTS: "-Xmx6G -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g"
 
       - name: Build AAB
         if: matrix.build-type == 'bundle' || matrix.build-type == 'both'
@@ -233,6 +234,7 @@ jobs:
           DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           ENABLE_SIGNING: ${{ secrets.ENABLE_SIGNING }}
           DOMAIN_REMOVAL_KEYS_FOR_REPAIR: ${{ secrets.DOMAIN_REMOVAL_KEYS_FOR_REPAIR }}
+          GRADLE_OPTS: "-Xmx6G -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g"
 
       - name: Move version file for consistent artifact structure
         if: matrix.generate-version-file == true

--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -223,7 +223,6 @@ jobs:
           DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           ENABLE_SIGNING: ${{ secrets.ENABLE_SIGNING }}
           DOMAIN_REMOVAL_KEYS_FOR_REPAIR: ${{ secrets.DOMAIN_REMOVAL_KEYS_FOR_REPAIR }}
-          GRADLE_OPTS: "-Xmx6G -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g"
 
       - name: Build AAB
         if: matrix.build-type == 'bundle' || matrix.build-type == 'both'
@@ -234,7 +233,6 @@ jobs:
           DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           ENABLE_SIGNING: ${{ secrets.ENABLE_SIGNING }}
           DOMAIN_REMOVAL_KEYS_FOR_REPAIR: ${{ secrets.DOMAIN_REMOVAL_KEYS_FOR_REPAIR }}
-          GRADLE_OPTS: "-Xmx6G -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g"
 
       - name: Move version file for consistent artifact structure
         if: matrix.generate-version-file == true

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-org.gradle.jvmargs=-Xmx10g -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx6G -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g
 android.useAndroidX=true
 kotlin.code.style=official
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

“Release” variant builds fail on CI - the runner is canceled when executing `:app:minify{Flavor}{Variant}WithR8`.
Error only says that `The operation was canceled.`

### Causes (Optional)

According to this article: https://blog.jakelee.co.uk/gradle-build-freezing-on-github-ci/#cause--resolution it can happen due to requesting too much RAM - in that case the runner can be canceled due to high usage and it can happen without any indication of OOM, just exactly like in our case.

### Solutions

Limit the RAM usage in `gradle.properties`.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
