### PR TITLE
fix: keep WorkManager input mergers for reflection [WPB-23616]

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -75,3 +75,8 @@
 -keepnames class com.wire.kalium.logic.sync.periodic.UserConfigSyncWorker
 -keepnames class com.wire.kalium.logic.sync.periodic.UpdateApiVersionsWorker
 -keepnames class com.wire.kalium.logic.sync.receiver.asset.AudioNormalizedLoudnessWorker
+
+# WorkManager reflection
+# InputMerger is created reflectively via getDeclaredConstructor() and may lose a visible no-arg ctor after shrinking.
+-keep class androidx.work.OverwritingInputMerger { <init>(); *; }
+-keep class androidx.work.ArrayCreatingInputMerger { <init>(); *; }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23616
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- `NotificationFetchWorker` jobs were failing repeatedly.
- WorkManager could not instantiate `androidx.work.OverwritingInputMerger` at runtime (`NoSuchMethodException`).

### Causes (Optional)

- Input mergers are instantiated reflectively by WorkManager.
- After minification, constructor/metadata needed for reflective creation was not preserved.

### Solutions

- Added explicit R8 keep rules for WorkManager input mergers in `/Users/jakub.zerko/Documents/projects/wire-android/app/proguard-rules.pro`:
  - `androidx.work.OverwritingInputMerger`
  - `androidx.work.ArrayCreatingInputMerger`
- Kept constructors and class members needed for reflective instantiation.