### PR TITLE
feat: call details button with low network state [WPB-23579]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
@@ -213,4 +213,9 @@ class CallsModule {
     @Provides
     fun provideObserveInCallReactionsUseCase(callsScope: CallsScope) =
         callsScope.observeInCallReactions
+
+    @ViewModelScoped
+    @Provides
+    fun provideObserveCallQualityDataUseCase(callsScope: CallsScope) =
+        callsScope.observeCallQualityData
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/CallDetailsButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/CallDetailsButton.kt
@@ -1,0 +1,112 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.calling.ongoing
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandIn
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.shrinkOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import com.wire.android.R
+import com.wire.android.ui.common.OverlapDirection
+import com.wire.android.ui.common.OverlappingCirclesRow
+import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.ui.PreviewMultipleThemes
+import com.wire.kalium.logic.data.call.CallQuality
+
+@Composable
+fun CallDetailsButton(callQuality: CallQuality, modifier: Modifier = Modifier) {
+    IconButton(
+        modifier = modifier,
+        onClick = { /* TODO */ },
+        content = {
+            OverlappingCirclesRow(
+                overlapSize = dimensions().spacing4x,
+                overlapCutoutSize = dimensions().spacing1x,
+                overlapDirection = OverlapDirection.StartOnTop,
+                items = listOf(
+                    { LowNetworkItem(callQuality = callQuality) },
+                    { InfoItem() }
+                )
+            )
+        },
+    )
+}
+
+@Composable
+private fun LowNetworkItem(callQuality: CallQuality) {
+    AnimatedVisibility(
+        visible = callQuality.isLowQuality,
+        enter = fadeIn() + scaleIn() + expandIn(expandFrom = Alignment.Center),
+        exit = fadeOut() + scaleOut() + shrinkOut(shrinkTowards = Alignment.Center)
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(dimensions().wireIconButtonSize)
+                .clip(CircleShape)
+                .background(color = colorsScheme().warning, shape = CircleShape)
+                .padding(horizontal = dimensions().spacing2x, vertical = dimensions().spacing4x),
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_network),
+                contentDescription = stringResource(R.string.content_description_call_low_network_quality),
+                tint = colorsScheme().onWarning,
+            )
+        }
+    }
+}
+
+@Composable
+private fun InfoItem() {
+    Icon(
+        painter = painterResource(id = R.drawable.ic_info),
+        contentDescription = stringResource(R.string.content_description_call_open_calling_details),
+        tint = colorsScheme().onBackground,
+        modifier = Modifier.size(dimensions().wireIconButtonSize)
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+fun CallDetailsButtonPreview() = WireTheme {
+    CallDetailsButton(callQuality = CallQuality.NORMAL)
+}
+
+@PreviewMultipleThemes
+@Composable
+fun CallDetailsButtonWithLowNetworkPreview() = WireTheme {
+    CallDetailsButton(callQuality = CallQuality.POOR)
+}

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -103,6 +103,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.PreviewMultipleThemesForLandscape
 import com.wire.android.util.ui.PreviewMultipleThemesForPortrait
 import com.wire.android.util.ui.PreviewMultipleThemesForSquare
+import com.wire.kalium.logic.data.call.CallQuality
 import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
@@ -211,6 +212,7 @@ fun OngoingCallScreen(
         participants = sharedCallingViewModel.participantsState,
         inPictureInPictureMode = inPictureInPictureMode,
         recentReactions = sharedCallingViewModel.recentReactions,
+        callQuality = ongoingCallViewModel.state.callQualityData.quality
     )
     ObserveRotation(sharedCallingViewModel::setUIRotation)
 
@@ -324,6 +326,7 @@ private fun OngoingCallContent(
     participants: PersistentList<UICallParticipant>,
     recentReactions: Map<UserId, String>,
     inPictureInPictureMode: Boolean,
+    callQuality: CallQuality,
     initialShowInCallReactionsPanel: Boolean = false, // for preview purposes
 ) {
     var shouldOpenFullScreen by remember { mutableStateOf(false) }
@@ -345,7 +348,8 @@ private fun OngoingCallContent(
                     onCollapse = onCollapse,
                     protocolInfo = callState.protocolInfo,
                     mlsVerificationStatus = callState.mlsVerificationStatus,
-                    proteusVerificationStatus = callState.proteusVerificationStatus
+                    proteusVerificationStatus = callState.proteusVerificationStatus,
+                    callQuality = callQuality
                 )
             }
         }
@@ -507,6 +511,7 @@ private fun OngoingCallTopBar(
     protocolInfo: Conversation.ProtocolInfo?,
     mlsVerificationStatus: Conversation.VerificationStatus?,
     proteusVerificationStatus: Conversation.VerificationStatus?,
+    callQuality: CallQuality,
     onCollapse: () -> Unit
 ) {
     Column {
@@ -534,7 +539,9 @@ private fun OngoingCallTopBar(
             },
             navigationIconType = NavigationIconType.Collapse,
             elevation = 0.dp,
-            actions = {}
+            actions = {
+                CallDetailsButton(callQuality = callQuality)
+            }
         )
         if (isCbrEnabled) {
             Text(
@@ -644,6 +651,7 @@ fun PreviewOngoingCallContent(participants: PersistentList<UICallParticipant>, i
         selectedParticipantForFullScreen = SelectedParticipant(),
         recentReactions = emptyMap(),
         initialShowInCallReactionsPanel = inCallReactionsPanelVisible,
+        callQuality = CallQuality.NORMAL
     )
 }
 
@@ -685,7 +693,13 @@ fun PreviewOngoingCallScreenConnecting() = WireTheme {
 @PreviewMultipleThemes
 @Composable
 fun PreviewOngoingCallTopBar() = WireTheme {
-    OngoingCallTopBar("Default", true, null, null, null) { }
+    OngoingCallTopBar("Default", true, null, null, null, CallQuality.NORMAL) { }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewOngoingCallTopBarWithPoorQuality() = WireTheme {
+    OngoingCallTopBar("Default", true, null, null, null, CallQuality.POOR) { }
 }
 
 fun buildPreviewParticipantsList(count: Int = 10) = buildList {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallState.kt
@@ -17,8 +17,17 @@
  */
 package com.wire.android.ui.calling.ongoing
 
+import com.wire.kalium.logic.data.call.CallQuality
+import com.wire.kalium.logic.data.call.CallQualityData
+
 data class OngoingCallState(
-    val flowState: FlowState = FlowState.Default
+    val flowState: FlowState = FlowState.Default,
+    val callQualityData: CallQualityData = CallQualityData(
+        quality = CallQuality.UNKNOWN,
+        roundTripTimeInMilliseconds = -1,
+        upstreamPacketLossPercentage = -1,
+        downstreamPacketLossPercentage = -1,
+    ),
 ) {
     sealed interface FlowState {
         object Default : FlowState

--- a/app/src/main/res/drawable/ic_network.xml
+++ b/app/src/main/res/drawable/ic_network.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Wire
+  ~ Copyright (C) 2026 Wire Swiss GmbH
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see http://www.gnu.org/licenses/.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="11dp"
+    android:height="8dp"
+    android:viewportWidth="11"
+    android:viewportHeight="8">
+  <path
+      android:pathData="M1.025,3.362L0,2.3C0.74,1.558 1.584,0.99 2.533,0.594C3.482,0.198 4.471,0 5.5,0C6.529,0 7.518,0.198 8.467,0.594C9.416,0.99 10.26,1.558 11,2.3L9.975,3.362C9.372,2.763 8.684,2.302 7.912,1.981C7.14,1.66 6.336,1.5 5.5,1.5C4.664,1.5 3.86,1.66 3.088,1.981C2.316,2.302 1.628,2.763 1.025,3.362ZM3.064,5.475L2.05,4.425C2.525,3.967 3.058,3.615 3.649,3.369C4.24,3.123 4.857,3 5.5,3C6.143,3 6.76,3.123 7.351,3.369C7.942,3.615 8.475,3.967 8.95,4.425L7.936,5.475C7.599,5.158 7.223,4.917 6.809,4.75C6.395,4.583 5.958,4.5 5.5,4.5C5.042,4.5 4.605,4.583 4.191,4.75C3.777,4.917 3.401,5.158 3.064,5.475ZM5.5,8C5.235,8 5.007,7.902 4.819,7.706C4.63,7.51 4.535,7.275 4.535,7C4.535,6.725 4.63,6.49 4.819,6.294C5.007,6.098 5.235,6 5.5,6C5.765,6 5.993,6.098 6.181,6.294C6.37,6.49 6.465,6.725 6.465,7C6.465,7.275 6.37,7.51 6.181,7.706C5.993,7.902 5.765,8 5.5,8Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -161,6 +161,8 @@
     <string name="content_description_calling_turn_speaker_off">Turn speaker off</string>
     <string name="content_description_calling_in_call_reactions_show">Show in call reactions panel</string>
     <string name="content_description_calling_in_call_reactions_hide">Hide in call reactions panel</string>
+    <string name="content_description_call_open_calling_details">Open calling details</string>
+    <string name="content_description_call_low_network_quality">Low network quality</string>
     <string name="content_description_reply_to_messge">Reply to the message</string>
     <string name="content_description_reply_cancel">Cancel message reply</string>
     <string name="content_description_ping_message">Ping message</string>

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/OverlappingCirclesRow.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/OverlappingCirclesRow.kt
@@ -1,0 +1,218 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toSize
+import com.wire.android.ui.theme.Accent
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.ui.theme.withAccent
+import com.wire.android.util.PreviewMultipleThemes
+import kotlin.math.max
+
+@Composable
+fun OverlappingCirclesRow(
+    overlapSize: Dp,
+    overlapCutoutSize: Dp,
+    overlapDirection: OverlapDirection,
+    items: List<@Composable () -> Unit>,
+    modifier: Modifier = Modifier
+) {
+    if (items.isEmpty()) return
+    Layout(
+        modifier = modifier,
+        content = {
+            var sizeAndPositionList by remember(items) {
+                mutableStateOf(List(items.size) { SizeAndPosition(Size.Zero, Offset.Zero) })
+            }
+            items.forEachIndexed { index, item ->
+                Box(
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .onGloballyPositioned {
+                            sizeAndPositionList = sizeAndPositionList.toMutableList().also { list ->
+                                list[index] = SizeAndPosition(size = it.size.toSize(), position = it.positionInParent())
+                            }
+                        }
+                        .drawWithContent { // this cuts out previous items in the overlap area if overlapCutoutBorderSize is set
+                            with(drawContext.canvas.nativeCanvas) {
+                                val checkPoint = saveLayer(null, null)
+                                drawContent() // draw the original content first so that we can cut it out with the overlap area
+                                if (overlapCutoutSize > 0.dp) {
+                                    // find all item indexes that overlap the current item based on the overlap direction
+                                    val overlappingIndexes = when (overlapDirection) {
+                                        OverlapDirection.StartOnTop -> 0 until index
+                                        OverlapDirection.EndOnTop -> (index + 1) until sizeAndPositionList.size
+                                    }
+                                    overlappingIndexes.forEach { overlappingIndex ->
+                                        val (overlapping, current) = sizeAndPositionList[overlappingIndex] to sizeAndPositionList[index]
+                                        // cut out the overlap area from the current item by drawing a rounded rect with BlendMode.Clear
+                                        drawRoundRect(
+                                            color = Color.Black,
+                                            cornerRadius = CornerRadius(
+                                                x = overlapping.size.minDimension,
+                                                y = overlapping.size.minDimension
+                                            ),
+                                            size = overlapping.size.withBorder(overlapCutoutSize.toPx()),
+                                            topLeft = overlapping.position.withBorder(overlapCutoutSize.toPx()).minus(current.position),
+                                            blendMode = BlendMode.Clear
+                                        )
+                                    }
+                                }
+                                restoreToCount(checkPoint)
+                            }
+                        },
+                    content = {
+                        item()
+                    }
+                )
+            }
+        },
+        measurePolicy = { measurables, constraints ->
+            val placeables = measurables.map { it.measure(constraints) }
+            val height = placeables.maxOf { it.height }
+            val width = placeables.filter { it.width > 0 }.let { nonEmptyPlaceables ->
+                nonEmptyPlaceables.mapIndexed { index, item ->
+                    when (index) {
+                        nonEmptyPlaceables.lastIndex -> max(item.width, overlapSize.roundToPx())
+                        else -> (item.width - overlapSize.roundToPx()).coerceAtLeast(0)
+                    }
+                }
+            }.sum()
+            layout(width, height) {
+                var x = 0
+                for (i in placeables.indices) {
+                    val y = (height - placeables[i].height) / 2
+                    val zIndex = if (overlapDirection == OverlapDirection.EndOnTop) i else placeables.size - i
+                    placeables[i].placeRelative(x, y, zIndex.toFloat())
+                    x += (placeables[i].width - overlapSize.roundToPx()).coerceAtLeast(0)
+                }
+            }
+        }
+    )
+}
+
+enum class OverlapDirection { StartOnTop, EndOnTop }
+private data class SizeAndPosition(val size: Size, val position: Offset)
+
+private fun Size.withBorder(borderWidth: Float) = if (isEmpty()) this else Size(width + (2 * borderWidth), height + (2 * borderWidth))
+private fun Offset.withBorder(borderWidth: Float) = Offset(x - borderWidth, y - borderWidth)
+
+@Composable
+private fun OverlappingCirclesRowPreview(
+    overlapCutoutBorderSize: Dp,
+    overlapDirection: OverlapDirection,
+    layoutDirection: LayoutDirection,
+    count: Int = 6
+) = WireTheme {
+    CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
+        OverlappingCirclesRow(
+            overlapSize = dimensions().spacing10x,
+            overlapCutoutSize = overlapCutoutBorderSize,
+            overlapDirection = overlapDirection,
+            items = List(count) { index ->
+                @Composable {
+                    val accent = Accent.entries[index % Accent.entries.size]
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .size(dimensions().spacing32x)
+                            .background(color = colorsScheme().withAccent(accent).primary, shape = CircleShape)
+                            .padding(dimensions().spacing4x),
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_input_mandatory),
+                            contentDescription = "",
+                            tint = colorsScheme().withAccent(accent).onPrimary,
+                            modifier = Modifier.size(dimensions().spacing16x)
+                        )
+                    }
+                }
+            }
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun OverlappingCirclesRow_WithCutout_StartOnTop_LTR_Preview() =
+    OverlappingCirclesRowPreview(dimensions().spacing2x, OverlapDirection.StartOnTop, LayoutDirection.Ltr)
+
+@PreviewMultipleThemes
+@Composable
+fun OverlappingCirclesRow_WithCutout_StartOnTop_RTL_Preview() =
+    OverlappingCirclesRowPreview(dimensions().spacing2x, OverlapDirection.StartOnTop, LayoutDirection.Rtl)
+
+@PreviewMultipleThemes
+@Composable
+fun OverlappingCirclesRow_WithCutout_EndOnTop_LTR_Preview() =
+    OverlappingCirclesRowPreview(dimensions().spacing2x, OverlapDirection.EndOnTop, LayoutDirection.Ltr)
+
+@PreviewMultipleThemes
+@Composable
+fun OverlappingCirclesRow_WithCutout_EndOnTop_RTL_Preview() =
+    OverlappingCirclesRowPreview(dimensions().spacing2x, OverlapDirection.EndOnTop, LayoutDirection.Rtl)
+
+@PreviewMultipleThemes
+@Composable
+fun OverlappingCirclesRow_WithoutCutout_StartOnTop_LTR_Preview() =
+    OverlappingCirclesRowPreview(dimensions().spacing0x, OverlapDirection.StartOnTop, LayoutDirection.Ltr)
+
+@PreviewMultipleThemes
+@Composable
+fun OverlappingCirclesRow_WithoutCutout_StartOnTop_RTL_Preview() =
+    OverlappingCirclesRowPreview(dimensions().spacing0x, OverlapDirection.StartOnTop, LayoutDirection.Rtl)
+
+@PreviewMultipleThemes
+@Composable
+fun OverlappingCirclesRow_WithoutCutout_EndOnTop_LTR_Preview() =
+    OverlappingCirclesRowPreview(dimensions().spacing0x, OverlapDirection.EndOnTop, LayoutDirection.Ltr)
+
+@PreviewMultipleThemes
+@Composable
+fun OverlappingCirclesRow_WithoutCutout_EndOnTop_RTL_Preview() =
+    OverlappingCirclesRowPreview(dimensions().spacing0x, OverlapDirection.EndOnTop, LayoutDirection.Rtl)

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/avatar/UserProfileAvatarsRow.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/avatar/UserProfileAvatarsRow.kt
@@ -18,8 +18,6 @@
 package com.wire.android.ui.common.avatar
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
@@ -29,6 +27,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
+import com.wire.android.ui.common.OverlapDirection
+import com.wire.android.ui.common.OverlappingCirclesRow
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireTheme
@@ -43,24 +43,27 @@ fun UserProfileAvatarsRow(
     borderWidth: Dp = dimensions().spacing1x,
     borderColor: Color = colorsScheme().surfaceVariant,
 ) {
-    Row(
+    OverlappingCirclesRow(
+        overlapSize = overlapSize,
+        overlapCutoutSize = dimensions().spacing0x,
+        overlapDirection = OverlapDirection.EndOnTop,
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(-overlapSize)
-    ) {
-        avatars.forEach { avatarData ->
-            UserProfileAvatar(
-                avatarData = avatarData,
-                size = avatarSize,
-                avatarBorderWidth = borderWidth,
-                avatarBorderColor = borderColor,
-                modifier = Modifier
-                    .clip(CircleShape)
-                    .background(borderColor),
-                padding = dimensions().spacing0x,
-                type = UserProfileAvatarType.WithoutIndicators,
-            )
+        items = avatars.map { avatarData ->
+            {
+                UserProfileAvatar(
+                    avatarData = avatarData,
+                    size = avatarSize,
+                    avatarBorderWidth = borderWidth,
+                    avatarBorderColor = borderColor,
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .background(borderColor),
+                    padding = dimensions().spacing0x,
+                    type = UserProfileAvatarType.WithoutIndicators,
+                )
+            }
         }
-    }
+    )
 }
 
 private val mockAvatars = listOf(


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23579
<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

For users that face network issues, we will provide a button named Call details that periodically indicates a users network quality.
- updated kalium to version that contains use case to observe call quality data
- created `OverlappingCirclesRow` which is responsible for showing circular items that overlap each other with the option to adjust the direction, overlap size, or cutout border size between them; it works properly for both LTR and RTL languages
- changed existing `UserProfileAvatarsRow` to also make use of this new composable
- created `CallDetailsButton` with info and low network icons that overlap each other and animation to show/hide low network icon when needed
- added logic to `OngoingCallViewModel` for passing quality data into that button

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Start a call and make the device to drop the network quality, or just turn off the network for a couple of seconds.

### Attachments (Optional)

#### OverlappingCirclesRow
<img width="600" src="https://github.com/user-attachments/assets/2f6c73f5-59d3-4317-afdc-1e962c7cf3de" />

#### OngoingCallTopBar with CallDetailsButton
<img width="600" src="https://github.com/user-attachments/assets/7b62872b-c719-4c31-a679-3f8d044d2e64" />

#### Demo
https://github.com/user-attachments/assets/caa118e5-781d-4bbf-839f-13326d82b655

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
