### PR TITLE
feat(nomad profiles): login and log out intent (WPB-23837)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -318,6 +318,13 @@
         <receiver
                 android:name=".notification.broadcastreceivers.StopAudioMessageReceiver"
                 android:exported="false" />
+        <receiver
+            android:name=".notification.broadcastreceivers.LogoutReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.wire.ACTION_LOGOUT" />
+            </intent-filter>
+        </receiver>
 
         <service
             android:name=".services.WireFirebaseMessagingService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -319,7 +319,7 @@
                 android:name=".notification.broadcastreceivers.StopAudioMessageReceiver"
                 android:exported="false" />
         <receiver
-            android:name=".notification.broadcastreceivers.LogoutReceiver"
+            android:name=".notification.broadcastreceivers.NomadLogoutReceiver"
             android:exported="true">
             <intent-filter>
                 <action android:name="com.wire.ACTION_LOGOUT" />

--- a/app/src/main/kotlin/com/wire/android/config/NomadProfilesFeatureConfig.kt
+++ b/app/src/main/kotlin/com/wire/android/config/NomadProfilesFeatureConfig.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.config
+
+import com.wire.android.BuildConfig
+import javax.inject.Inject
+
+class NomadProfilesFeatureConfig @Inject constructor() {
+    fun isEnabled(): Boolean = BuildConfig.NOMAD_PROFILES_ENABLED
+}

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/LogoutReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/LogoutReceiver.kt
@@ -20,6 +20,7 @@ package com.wire.android.notification.broadcastreceivers
 import android.content.Context
 import android.content.Intent
 import com.wire.android.appLogger
+import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
@@ -30,6 +31,10 @@ import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -48,11 +53,22 @@ class LogoutReceiver : CoroutineReceiver() {
     @Inject
     lateinit var accountSwitch: AccountSwitchUseCase
 
+    @Inject
+    @ApplicationScope
+    lateinit var coroutineScope: CoroutineScope
+
     override suspend fun receive(context: Context, intent: Intent) {
         if (intent.action != ACTION_LOGOUT) return
 
         appLogger.i("$TAG Received logout broadcast")
 
+        val appContext = context.applicationContext
+        coroutineScope.launch {
+            performLogout(appContext)
+        }
+    }
+
+    private suspend fun performLogout(context: Context) {
         when (val session = currentSession()) {
             is CurrentSessionResult.Success -> {
                 val userId = session.accountInfo.userId
@@ -63,7 +79,9 @@ class LogoutReceiver : CoroutineReceiver() {
                 val wireActivityIntent = Intent(context, WireActivity::class.java).apply {
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
                 }
-                context.startActivity(wireActivityIntent)
+                withContext(Dispatchers.Main.immediate) {
+                    context.startActivity(wireActivityIntent)
+                }
             }
 
             is CurrentSessionResult.Failure.SessionNotFound ->

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/LogoutReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/LogoutReceiver.kt
@@ -19,6 +19,7 @@ package com.wire.android.notification.broadcastreceivers
 
 import android.content.Context
 import android.content.Intent
+import com.wire.android.BuildConfig
 import com.wire.android.appLogger
 import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
@@ -58,6 +59,7 @@ class LogoutReceiver : CoroutineReceiver() {
     lateinit var coroutineScope: CoroutineScope
 
     override suspend fun receive(context: Context, intent: Intent) {
+        if (!BuildConfig.NOMAD_PROFILES_ENABLED) return
         if (intent.action != ACTION_LOGOUT) return
 
         appLogger.i("$TAG Received logout broadcast")

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/LogoutReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/LogoutReceiver.kt
@@ -1,0 +1,81 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.notification.broadcastreceivers
+
+import android.content.Context
+import android.content.Intent
+import com.wire.android.appLogger
+import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.feature.AccountSwitchUseCase
+import com.wire.android.feature.SwitchAccountParam
+import com.wire.android.ui.WireActivity
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
+import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class LogoutReceiver : CoroutineReceiver() {
+
+    @Inject
+    @KaliumCoreLogic
+    lateinit var coreLogic: CoreLogic
+
+    @Inject
+    lateinit var currentSession: CurrentSessionUseCase
+
+    @Inject
+    lateinit var deleteSession: DeleteSessionUseCase
+
+    @Inject
+    lateinit var accountSwitch: AccountSwitchUseCase
+
+    override suspend fun receive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_LOGOUT) return
+
+        appLogger.i("$TAG Received logout broadcast")
+
+        when (val session = currentSession()) {
+            is CurrentSessionResult.Success -> {
+                val userId = session.accountInfo.userId
+                appLogger.i("$TAG Logging out user: ${userId.toLogString()}")
+                coreLogic.getSessionScope(userId).logout(LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
+                deleteSession(userId)
+                accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount)
+                val wireActivityIntent = Intent(context, WireActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                }
+                context.startActivity(wireActivityIntent)
+            }
+
+            is CurrentSessionResult.Failure.SessionNotFound ->
+                appLogger.i("$TAG No active session found, nothing to logout")
+
+            is CurrentSessionResult.Failure.Generic ->
+                appLogger.e("$TAG Failed to get current session")
+        }
+    }
+
+    companion object {
+        const val ACTION_LOGOUT = "com.wire.ACTION_LOGOUT"
+        private const val TAG = "LogoutReceiver"
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/LogoutReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/LogoutReceiver.kt
@@ -19,8 +19,8 @@ package com.wire.android.notification.broadcastreceivers
 
 import android.content.Context
 import android.content.Intent
-import com.wire.android.BuildConfig
 import com.wire.android.appLogger
+import com.wire.android.config.NomadProfilesFeatureConfig
 import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.AccountSwitchUseCase
@@ -58,8 +58,11 @@ class LogoutReceiver : CoroutineReceiver() {
     @ApplicationScope
     lateinit var coroutineScope: CoroutineScope
 
+    @Inject
+    lateinit var nomadProfilesFeatureConfig: NomadProfilesFeatureConfig
+
     override suspend fun receive(context: Context, intent: Intent) {
-        if (!BuildConfig.NOMAD_PROFILES_ENABLED) return
+        if (!nomadProfilesFeatureConfig.isEnabled()) return
         if (intent.action != ACTION_LOGOUT) return
 
         appLogger.i("$TAG Received logout broadcast")

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
@@ -21,7 +21,6 @@ import android.content.Context
 import android.content.Intent
 import com.wire.android.appLogger
 import com.wire.android.config.NomadProfilesFeatureConfig
-import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
@@ -32,14 +31,13 @@ import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class LogoutReceiver : CoroutineReceiver() {
+class NomadLogoutReceiver : CoroutineReceiver() {
 
     @Inject
     @KaliumCoreLogic
@@ -55,10 +53,6 @@ class LogoutReceiver : CoroutineReceiver() {
     lateinit var accountSwitch: AccountSwitchUseCase
 
     @Inject
-    @ApplicationScope
-    lateinit var coroutineScope: CoroutineScope
-
-    @Inject
     lateinit var nomadProfilesFeatureConfig: NomadProfilesFeatureConfig
 
     override suspend fun receive(context: Context, intent: Intent) {
@@ -67,9 +61,13 @@ class LogoutReceiver : CoroutineReceiver() {
 
         appLogger.i("$TAG Received logout broadcast")
 
-        val appContext = context.applicationContext
-        coroutineScope.launch {
-            performLogout(appContext)
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            performLogout(context.applicationContext)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Exception) {
+            appLogger.e("$TAG Logout failed", t)
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -385,7 +385,7 @@ class WireActivity : AppCompatActivity() {
                     .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
                     .collectLatest { (intent, savedInstanceState) ->
                         currentKeyboardController?.hide()
-                        handleDeepLink(currentNavigator, intent, savedInstanceState)
+                        handleDeepLinkOrIntent(currentNavigator, intent, savedInstanceState)
                     }
             }
         }
@@ -730,7 +730,7 @@ class WireActivity : AppCompatActivity() {
     /*
      * This method is responsible for handling deep links from given intent
      */
-    private fun handleDeepLink(
+    private suspend fun handleDeepLinkOrIntent(
         navigator: Navigator,
         intent: Intent?,
         savedInstanceState: Bundle? = null
@@ -742,19 +742,23 @@ class WireActivity : AppCompatActivity() {
         }
         val originalIntent = savedInstanceState.getOriginalIntent()
         if (intent == null
-            || intent.action == Intent.ACTION_MAIN // This is the case when the app is opened from launcher so no deep link to handle
+            || intent.action == Intent.ACTION_MAIN // The app is opened from launcher so no deep link to handle, only start intents if any
             || intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY != 0
             || originalIntent == intent // This is the case when the activity is recreated and already handled
             || intent.getBooleanExtra(HANDLED_DEEPLINK_FLAG, false)
         ) {
-            if (navigator.isEmptyWelcomeStartDestination()) {
-                // no deep link to handle so if "welcome empty start" screen then switch "start" screen to login by navigating to it
-                navigator.navigate(NavigationCommand(NewLoginScreenDestination(), BackStackMode.CLEAR_WHOLE))
+            val handled = viewModel.handleIntentsThatAreNotDeepLinks(intent)
+            if (!handled && navigator.isEmptyWelcomeStartDestination()) {
+                // nothing to handle so if "welcome empty start" screen then switch "start" screen to login by navigating to it
+                navigate(NavigationCommand(NewLoginScreenDestination(), BackStackMode.CLEAR_WHOLE))
             }
             return
         } else {
-            viewModel.handleDeepLink(intent)
-            intent.putExtra(HANDLED_DEEPLINK_FLAG, true)
+            val handled = viewModel.handleIntentsThatAreNotDeepLinks(intent)
+            if (!handled) {
+                viewModel.handleDeepLink(intent)
+                intent.putExtra(HANDLED_DEEPLINK_FLAG, true)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -730,7 +730,7 @@ class WireActivity : AppCompatActivity() {
     /*
      * This method is responsible for handling deep links from given intent
      */
-    private suspend fun handleDeepLinkOrIntent(
+    private fun handleDeepLinkOrIntent(
         navigator: Navigator,
         intent: Intent?,
         savedInstanceState: Bundle? = null

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityActionsHandler.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityActionsHandler.kt
@@ -20,6 +20,7 @@ package com.wire.android.ui
 import android.content.Context
 import android.widget.Toast
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import com.ramcosta.composedestinations.utils.destination
 import com.wire.android.R
@@ -28,6 +29,7 @@ import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.authentication.login.PreFilledUserIdentifierType
+import com.wire.android.ui.authentication.login.SSOCodeAutoLogin
 import com.wire.android.ui.common.HandleActions
 import com.ramcosta.composedestinations.generated.app.destinations.ConversationScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.HomeScreenDestination
@@ -35,16 +37,21 @@ import com.ramcosta.composedestinations.generated.app.destinations.ImportMediaSc
 import com.ramcosta.composedestinations.generated.app.destinations.LoginScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.NewLoginScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.OtherUserProfileScreenDestination
+import com.wire.android.ui.authentication.login.LoginPasswordPath
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun HandleViewActions(actions: Flow<WireActivityViewAction>, navigator: Navigator, loginTypeSelector: LoginTypeSelector) {
 
     val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
     HandleActions(actions) { action ->
         when (action) {
             is OnAuthorizationNeeded -> onAuthorizationNeeded(context, navigator)
             is OnMigrationLogin -> onMigration(navigator, loginTypeSelector, action)
+            is OnAutomaticLogin -> onAutomaticLogin(coroutineScope, navigator, loginTypeSelector, action)
             is OnOpenUserProfile -> openUserProfile(action, navigator)
             is OnSSOLogin -> openSsoLogin(navigator, action)
             is OnShowImportMediaScreen -> openImportMediaScreen(navigator)
@@ -90,9 +97,16 @@ private fun openSsoLogin(navigator: Navigator, action: OnSSOLogin) {
         NavigationCommand(
             when (navigator.navController.currentBackStackEntry?.destination()?.baseRoute) {
                 // if SSO login started from new login screen then go back to the new login flow
-                NewLoginScreenDestination.baseRoute -> NewLoginScreenDestination(
-                    ssoLoginResult = action.result
-                )
+                NewLoginScreenDestination.baseRoute -> {
+                    val existingLoginPasswordPath = navigator.navController.currentBackStackEntry
+                        ?.savedStateHandle
+                        ?.let { NewLoginScreenDestination.argsFrom(it) }
+                        ?.loginPasswordPath
+                    NewLoginScreenDestination(
+                        ssoLoginResult = action.result,
+                        loginPasswordPath = existingLoginPasswordPath,
+                    )
+                }
 
                 else -> LoginScreenDestination(
                     ssoLoginResult = action.result
@@ -143,6 +157,47 @@ private fun onMigration(
             },
         )
     )
+}
+
+private fun onAutomaticLogin(
+    coroutineScope: CoroutineScope,
+    navigator: Navigator,
+    loginTypeSelector: LoginTypeSelector,
+    action: OnAutomaticLogin
+) {
+    // Auto-apply backend config AND navigate with SSO code pre-filled
+    val serverLinks = action.serverLinks
+    val ssoCode = action.ssoCode
+    val ssoCodeAutoLogin = ssoCode?.let { SSOCodeAutoLogin(ssoCode = it, autoInitiateLogin = true) }
+
+    coroutineScope.launch {
+        val useNewLogin = loginTypeSelector.canUseNewLogin(serverLinks)
+
+        val destination = when (useNewLogin) {
+            true -> {
+                NewLoginScreenDestination(
+                    loginPasswordPath = LoginPasswordPath(serverLinks),
+                    ssoCodeAutoLogin = ssoCodeAutoLogin
+                )
+            }
+            false -> {
+                LoginScreenDestination(
+                    loginPasswordPath = LoginPasswordPath(serverLinks),
+                    ssoCodeAutoLogin = ssoCodeAutoLogin
+                )
+            }
+        }
+
+        navigator.navigate(
+            NavigationCommand(
+                destination = destination,
+                backStackMode = when (navigator.shouldReplaceWelcomeLoginStartDestination()) {
+                    true -> BackStackMode.CLEAR_WHOLE
+                    else -> BackStackMode.UPDATE_EXISTED
+                }
+            )
+        )
+    }
 }
 
 private fun onAuthorizationNeeded(context: Context, navigator: Navigator) {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -57,6 +57,8 @@ import com.wire.android.util.deeplink.LoginType
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.UIText
 import com.wire.android.emm.ManagedConfigurationsManager
+import com.wire.android.util.lifecycle.AutomatedLoginManager
+import com.wire.android.util.lifecycle.IntentsProcessor
 import com.wire.android.workmanager.worker.cancelPeriodicPersistentWebsocketCheckWorker
 import com.wire.android.workmanager.worker.enqueuePeriodicPersistentWebsocketCheckWorker
 import com.wire.kalium.logic.CoreLogic
@@ -117,6 +119,7 @@ class WireActivityViewModel @Inject constructor(
     private val doesValidSessionExist: Lazy<DoesValidSessionExistUseCase>,
     private val getServerConfigUseCase: Lazy<GetServerConfigUseCase>,
     private val deepLinkProcessor: Lazy<DeepLinkProcessor>,
+    private val intentsProcessor: Lazy<IntentsProcessor>,
     private val observeSessions: Lazy<ObserveSessionsUseCase>,
     private val accountSwitch: Lazy<AccountSwitchUseCase>,
     private val servicesManager: Lazy<ServicesManager>,
@@ -135,6 +138,7 @@ class WireActivityViewModel @Inject constructor(
     private val observeSelfUserFactory: ObserveSelfUserUseCaseProvider.Factory,
     private val monitorSyncWorkUseCase: MonitorSyncWorkUseCase,
     private val managedConfigurationsManager: ManagedConfigurationsManager,
+    private val automatedLoginManager: AutomatedLoginManager,
 ) : ActionsViewModel<WireActivityViewAction>() {
 
     var globalAppState: GlobalAppState by mutableStateOf(GlobalAppState())
@@ -339,6 +343,16 @@ class WireActivityViewModel @Inject constructor(
         }
     }
 
+    // Returns whether an intent was handled, or if there was nothing to do
+    fun handleIntentsThatAreNotDeepLinks(intent: Intent?): Boolean {
+        val result = intentsProcessor.get().invoke(intent)
+        if (result != null) {
+            onAutomaticLoginParameters(result.backendConfig, result.ssoCode)
+            return true
+        }
+        return false
+    }
+
     @Suppress("ComplexMethod")
     fun handleDeepLink(intent: Intent?) {
         viewModelScope.launch(dispatchers.io()) {
@@ -365,6 +379,22 @@ class WireActivityViewModel @Inject constructor(
                     sendAction(OnUnknownDeepLink)
                     appLogger.e("unknown deeplink result $result")
                 }
+            }
+        }
+    }
+
+    private fun onAutomaticLoginParameters(backendConfigUrl: String?, ssoCode: String?) {
+        viewModelScope.launch(dispatchers.io()) {
+            // Load backend config
+            val serverLinks = backendConfigUrl?.let { loadServerConfig(it) }
+
+            val backendConfigLoadFailed = backendConfigUrl != null && serverLinks == null
+            val nothingProvided = backendConfigUrl == null && ssoCode == null
+            if (backendConfigLoadFailed || nothingProvided) {
+                sendAction(OnUnknownDeepLink)
+            } else {
+                automatedLoginManager.pendingMoveToBackgroundAfterSync = true
+                sendAction(OnAutomaticLogin(serverLinks, ssoCode))
             }
         }
     }
@@ -661,6 +691,7 @@ internal data object OnShowImportMediaScreen : WireActivityViewAction
 internal data object OnAuthorizationNeeded : WireActivityViewAction
 internal data object OnUnknownDeepLink : WireActivityViewAction
 internal data class OnMigrationLogin(val result: DeepLinkResult.MigrationLogin) : WireActivityViewAction
+internal data class OnAutomaticLogin(val serverLinks: ServerConfig.Links?, val ssoCode: String?) : WireActivityViewAction
 internal data class OnOpenUserProfile(val result: DeepLinkResult.OpenOtherUserProfile) : WireActivityViewAction
 internal data class OnSSOLogin(val result: DeepLinkResult.SSOLogin) : WireActivityViewAction
 internal data class ShowToast(val messageResId: Int) : WireActivityViewAction

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -28,6 +28,7 @@ import androidx.work.WorkManager
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.appLogger
+import com.wire.android.config.NomadProfilesFeatureConfig
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.IsProfileQRCodeEnabledUseCaseProvider
 import com.wire.android.di.KaliumCoreLogic
@@ -139,6 +140,7 @@ class WireActivityViewModel @Inject constructor(
     private val monitorSyncWorkUseCase: MonitorSyncWorkUseCase,
     private val managedConfigurationsManager: ManagedConfigurationsManager,
     private val automatedLoginManager: AutomatedLoginManager,
+    private val nomadProfilesFeatureConfig: NomadProfilesFeatureConfig,
 ) : ActionsViewModel<WireActivityViewAction>() {
 
     var globalAppState: GlobalAppState by mutableStateOf(GlobalAppState())
@@ -343,9 +345,10 @@ class WireActivityViewModel @Inject constructor(
         }
     }
 
+    @Suppress("ReturnCount")
     // Returns whether an intent was handled, or if there was nothing to do
     fun handleIntentsThatAreNotDeepLinks(intent: Intent?): Boolean {
-        if (!BuildConfig.NOMAD_PROFILES_ENABLED) return false
+        if (!nomadProfilesFeatureConfig.isEnabled()) return false
         val result = intentsProcessor.get().invoke(intent)
         if (result != null) {
             onAutomaticLoginParameters(result.backendConfig, result.ssoCode)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -345,6 +345,7 @@ class WireActivityViewModel @Inject constructor(
 
     // Returns whether an intent was handled, or if there was nothing to do
     fun handleIntentsThatAreNotDeepLinks(intent: Intent?): Boolean {
+        if (!BuildConfig.NOMAD_PROFILES_ENABLED) return false
         val result = intentsProcessor.get().invoke(intent)
         if (result != null) {
             onAutomaticLoginParameters(result.backendConfig, result.ssoCode)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -36,6 +36,7 @@ import com.wire.android.di.ObserveIfE2EIRequiredDuringLoginUseCaseProvider
 import com.wire.android.di.ObserveScreenshotCensoringConfigUseCaseProvider
 import com.wire.android.di.ObserveSelfUserUseCaseProvider
 import com.wire.android.di.ObserveSyncStateUseCaseProvider
+import com.wire.android.emm.ManagedConfigurationsManager
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountActions
 import com.wire.android.feature.SwitchAccountParam
@@ -56,10 +57,9 @@ import com.wire.android.util.deeplink.DeepLinkProcessor
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.deeplink.LoginType
 import com.wire.android.util.dispatchers.DispatcherProvider
-import com.wire.android.util.ui.UIText
-import com.wire.android.emm.ManagedConfigurationsManager
 import com.wire.android.util.lifecycle.AutomatedLoginManager
 import com.wire.android.util.lifecycle.IntentsProcessor
+import com.wire.android.util.ui.UIText
 import com.wire.android.workmanager.worker.cancelPeriodicPersistentWebsocketCheckWorker
 import com.wire.android.workmanager.worker.enqueuePeriodicPersistentWebsocketCheckWorker
 import com.wire.kalium.logic.CoreLogic
@@ -95,12 +95,12 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
@@ -345,18 +345,6 @@ class WireActivityViewModel @Inject constructor(
         }
     }
 
-    @Suppress("ReturnCount")
-    // Returns whether an intent was handled, or if there was nothing to do
-    fun handleIntentsThatAreNotDeepLinks(intent: Intent?): Boolean {
-        if (!nomadProfilesFeatureConfig.isEnabled()) return false
-        val result = intentsProcessor.get().invoke(intent)
-        if (result != null) {
-            onAutomaticLoginParameters(result.backendConfig, result.ssoCode)
-            return true
-        }
-        return false
-    }
-
     @Suppress("ComplexMethod")
     fun handleDeepLink(intent: Intent?) {
         viewModelScope.launch(dispatchers.io()) {
@@ -385,6 +373,18 @@ class WireActivityViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    // Returns whether an intent was handled, or if there was nothing to do
+    @Suppress("ReturnCount")
+    fun handleIntentsThatAreNotDeepLinks(intent: Intent?): Boolean {
+        if (!nomadProfilesFeatureConfig.isEnabled()) return false
+        val result = intentsProcessor.get().invoke(intent)
+        if (result != null) {
+            onAutomaticLoginParameters(result.backendConfig, result.ssoCode)
+            return true
+        }
+        return false
     }
 
     private fun onAutomaticLoginParameters(backendConfigUrl: String?, ssoCode: String?) {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginNavArgs.kt
@@ -26,6 +26,13 @@ data class LoginNavArgs(
     val userHandle: PreFilledUserIdentifierType.PreFilled? = null,
     val ssoLoginResult: DeepLinkResult.SSOLogin? = null,
     val loginPasswordPath: LoginPasswordPath? = null,
+    val ssoCodeAutoLogin: SSOCodeAutoLogin? = null,
+)
+
+@Serializable
+data class SSOCodeAutoLogin(
+    val ssoCode: String,
+    val autoInitiateLogin: Boolean = true
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -107,7 +107,6 @@ fun LoginScreen(
         },
         loginEmailViewModel = loginEmailViewModel,
         ssoLoginResult = loginNavArgs.ssoLoginResult,
-//        ssoUrlConfigHolder = ssoUrlConfigHolder,
     )
 }
 
@@ -140,7 +139,6 @@ private fun LoginContent(
                     onRemoveDeviceNeeded = onRemoveDeviceNeeded,
                     loginEmailViewModel = loginEmailViewModel,
                     ssoLoginResult = ssoLoginResult,
-//                    ssoUrlConfigHolder = ssoUrlConfigHolder
                 )
             }
         }
@@ -227,7 +225,6 @@ private fun MainLoginContent(
                         onSuccess,
                         onRemoveDeviceNeeded,
                         ssoLoginResult,
-//                        ssoUrlConfigHolder
                     )
                 }
             }
@@ -259,7 +256,6 @@ private fun PreviewLoginScreen() = WireTheme {
             onRemoveDeviceNeeded = {},
             loginEmailViewModel = hiltViewModel(),
             ssoLoginResult = null,
-//            ssoUrlConfigHolder = SSOUrlConfigHolderPreview,
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -107,6 +107,7 @@ fun LoginScreen(
         },
         loginEmailViewModel = loginEmailViewModel,
         ssoLoginResult = loginNavArgs.ssoLoginResult,
+        ssoCodeAutoLogin = loginNavArgs.ssoCodeAutoLogin
     )
 }
 
@@ -117,6 +118,7 @@ private fun LoginContent(
     onRemoveDeviceNeeded: () -> Unit,
     loginEmailViewModel: LoginEmailViewModel,
     ssoLoginResult: DeepLinkResult.SSOLogin?,
+    ssoCodeAutoLogin: SSOCodeAutoLogin?,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         /*
@@ -153,11 +155,17 @@ private fun MainLoginContent(
     onRemoveDeviceNeeded: () -> Unit,
     loginEmailViewModel: LoginEmailViewModel,
     ssoLoginResult: DeepLinkResult.SSOLogin?,
+    ssoCodeAutoLogin: SSOCodeAutoLogin?,
 ) {
 
     val scope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
-    val initialPageIndex = if (ssoLoginResult == null) LoginTabItem.EMAIL.ordinal else LoginTabItem.SSO.ordinal
+    // Show SSO tab if we have either ssoLoginResult or ssoCodeAutoLogin
+    val initialPageIndex = if (ssoLoginResult != null || ssoCodeAutoLogin != null) {
+        LoginTabItem.SSO.ordinal
+    } else {
+        LoginTabItem.EMAIL.ordinal
+    }
     val pagerState = rememberPagerState(
         initialPage = initialPageIndex,
         pageCount = { LoginTabItem.values().size }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -234,7 +234,7 @@ private fun MainLoginContent(
                         onSuccess,
                         onRemoveDeviceNeeded,
                         ssoLoginResult,
-//                        ssoUrlConfigHolder
+                        ssoCodeAutoLogin,
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -141,6 +141,7 @@ private fun LoginContent(
                     onRemoveDeviceNeeded = onRemoveDeviceNeeded,
                     loginEmailViewModel = loginEmailViewModel,
                     ssoLoginResult = ssoLoginResult,
+                    ssoCodeAutoLogin = ssoCodeAutoLogin
                 )
             }
         }
@@ -233,6 +234,7 @@ private fun MainLoginContent(
                         onSuccess,
                         onRemoveDeviceNeeded,
                         ssoLoginResult,
+//                        ssoUrlConfigHolder
                     )
                 }
             }
@@ -264,6 +266,7 @@ private fun PreviewLoginScreen() = WireTheme {
             onRemoveDeviceNeeded = {},
             loginEmailViewModel = hiltViewModel(),
             ssoLoginResult = null,
+            ssoCodeAutoLogin = null
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -64,6 +65,7 @@ fun LoginSSOScreen(
     onSuccess: (initialSyncCompleted: Boolean, isE2EIRequired: Boolean) -> Unit,
     onRemoveDeviceNeeded: () -> Unit,
     ssoLoginResult: DeepLinkResult.SSOLogin?,
+    ssoCodeAutoLogin: com.wire.android.ui.authentication.login.SSOCodeAutoLogin?,
     loginSSOViewModel: LoginSSOViewModel = hiltViewModel(),
     scrollState: ScrollState = rememberScrollState()
 ) {
@@ -74,6 +76,19 @@ fun LoginSSOScreen(
         loginSSOViewModel.handleSSOResult(
             ssoLoginResult,
         )
+    }
+
+    // Handle SSO code auto-login from intent parameter
+    LaunchedEffect(ssoCodeAutoLogin) {
+        ssoCodeAutoLogin?.let {
+            // Pre-fill the SSO code
+            loginSSOViewModel.ssoTextState.setTextAndPlaceCursorAtEnd(it.ssoCode)
+
+            // Auto-initiate login if flag is set
+            if (it.autoInitiateLogin) {
+                loginSSOViewModel.login()
+            }
+        }
     }
     LoginSSOContent(
         scrollState = scrollState,

--- a/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncScreen.kt
@@ -20,12 +20,17 @@ package com.wire.android.ui.initialsync
 
 import com.wire.android.navigation.annotation.app.WireRootDestination
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.SettingUpWireScreenContent
 import com.ramcosta.composedestinations.generated.app.destinations.HomeScreenDestination
+import com.wire.android.ui.LocalActivity
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @WireRootDestination
 @Composable
@@ -33,9 +38,22 @@ fun InitialSyncScreen(
     navigator: Navigator,
     viewModel: InitialSyncViewModel = hiltViewModel()
 ) {
+    val activity = LocalActivity.current
+
     SettingUpWireScreenContent()
 
     if (viewModel.isSyncCompleted) {
         navigator.navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
+
+        // If started with SSO intent, move app to background after sync completes
+        if (viewModel.shouldMoveToBackground) {
+            LaunchedEffect(Unit) {
+                delay(250) // Small delay to let navigation complete
+                activity.moveTaskToBack(false)
+            }
+        }
     }
+
+
+
 }

--- a/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncScreen.kt
@@ -18,18 +18,21 @@
 
 package com.wire.android.ui.initialsync
 
-import com.wire.android.navigation.annotation.app.WireRootDestination
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.lifecycleScope
+import com.ramcosta.composedestinations.generated.app.destinations.HomeScreenDestination
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
-import com.wire.android.ui.common.SettingUpWireScreenContent
-import com.ramcosta.composedestinations.generated.app.destinations.HomeScreenDestination
+import com.wire.android.navigation.annotation.app.WireRootDestination
+import com.wire.android.navigation.baseRoute
+import com.wire.android.navigation.getBaseRoute
 import com.wire.android.ui.LocalActivity
-import kotlinx.coroutines.delay
+import com.wire.android.ui.common.SettingUpWireScreenContent
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 @WireRootDestination
@@ -42,18 +45,18 @@ fun InitialSyncScreen(
 
     SettingUpWireScreenContent()
 
-    if (viewModel.isSyncCompleted) {
-        navigator.navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
+    LaunchedEffect(viewModel.isSyncCompleted, viewModel.shouldMoveToBackground) {
+        if (!viewModel.isSyncCompleted) return@LaunchedEffect
 
-        // If started with SSO intent, move app to background after sync completes
         if (viewModel.shouldMoveToBackground) {
-            LaunchedEffect(Unit) {
-                delay(250) // Small delay to let navigation complete
+            activity.lifecycleScope.launch {
+                navigator.navController.currentBackStackEntryFlow
+                    .map { it.destination.route?.getBaseRoute() }
+                    .first { it == HomeScreenDestination.baseRoute }
                 activity.moveTaskToBack(false)
             }
         }
+
+        navigator.navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
     }
-
-
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncViewModel.kt
@@ -28,6 +28,7 @@ import com.wire.android.appLogger
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.CurrentAccount
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.lifecycle.AutomatedLoginManager
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
@@ -44,9 +45,13 @@ class InitialSyncViewModel @Inject constructor(
     private val userDataStoreProvider: UserDataStoreProvider,
     @CurrentAccount private val userId: UserId,
     private val dispatchers: DispatcherProvider,
+    private val automatedLoginManager: AutomatedLoginManager,
 ) : ViewModel() {
 
     internal var isSyncCompleted: Boolean by mutableStateOf(false)
+        private set
+
+    internal var shouldMoveToBackground: Boolean by mutableStateOf(false)
         private set
 
     init {
@@ -61,6 +66,10 @@ class InitialSyncViewModel @Inject constructor(
                     userDataStoreProvider.getOrCreate(userId).setInitialSyncCompleted()
                 }
             }?.let {
+                if (automatedLoginManager.pendingMoveToBackgroundAfterSync) {
+                    automatedLoginManager.pendingMoveToBackgroundAfterSync = false
+                    shouldMoveToBackground = true
+                }
                 isSyncCompleted = true
             } ?: run {
                 appLogger.e("InitialSyncViewModel: SyncState is null")

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -68,6 +69,7 @@ import com.wire.android.ui.authentication.login.LoginPasswordPath
 import com.wire.android.ui.authentication.login.PreFilledUserIdentifierType
 import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
 import com.wire.android.ui.authentication.login.toLoginDialogErrorData
+import com.ramcosta.composedestinations.spec.Direction
 import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
@@ -123,13 +125,7 @@ fun NewLoginScreen(
             }
 
             is NewLoginAction.Success -> {
-                val destination = when (newLoginAction.nextStep) {
-                    NewLoginAction.Success.NextStep.None -> HomeScreenDestination
-                    NewLoginAction.Success.NextStep.E2EIEnrollment -> E2EIEnrollmentScreenDestination
-                    NewLoginAction.Success.NextStep.InitialSync -> InitialSyncScreenDestination
-                    NewLoginAction.Success.NextStep.TooManyDevices -> RemoveDeviceScreenDestination
-                }
-                navigator.navigate(NavigationCommand(destination, BackStackMode.CLEAR_WHOLE))
+                navigator.navigate(NavigationCommand(newLoginAction.nextStep.toDestination(), BackStackMode.CLEAR_WHOLE))
             }
 
             is NewLoginAction.EnterpriseLoginNotSupported -> {
@@ -148,6 +144,19 @@ fun NewLoginScreen(
             viewModel.handleSSOResult(
                 navArgs.ssoLoginResult,
             )
+        }
+    }
+
+    // Handle SSO code auto-login from intent parameter
+    LaunchedEffect(navArgs.ssoCodeAutoLogin) {
+        navArgs.ssoCodeAutoLogin?.let {
+            // Pre-fill the SSO code in the user identifier field
+            viewModel.userIdentifierTextState.setTextAndPlaceCursorAtEnd(it.ssoCode)
+
+            // Auto-initiate login if flag is set
+            if (it.autoInitiateLogin) {
+                viewModel.onLoginStarted()
+            }
         }
     }
     (viewModel.state.flowState as? NewLoginFlowState.CustomConfigDialog)?.let { customServerDialogState ->
@@ -174,6 +183,13 @@ fun NewLoginScreen(
     )
 
     HandleActions(viewModel.actions, handleNewLoginAction)
+}
+
+private fun NewLoginAction.Success.NextStep.toDestination(): Direction = when (this) {
+    NewLoginAction.Success.NextStep.None -> HomeScreenDestination
+    NewLoginAction.Success.NextStep.E2EIEnrollment -> E2EIEnrollmentScreenDestination
+    NewLoginAction.Success.NextStep.InitialSync -> InitialSyncScreenDestination
+    NewLoginAction.Success.NextStep.TooManyDevices -> RemoveDeviceScreenDestination
 }
 
 @OptIn(ExperimentalComposeUiApi::class)

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
@@ -119,7 +119,6 @@ fun NewLoginScreen(
 
             is NewLoginAction.SSO -> {
                 currentKeyboardController?.hide()
-//                ssoUrlConfigHolder.set(newLoginAction.config)
                 CustomTabsHelper.launchUrl(context, newLoginAction.url)
             }
 
@@ -148,7 +147,6 @@ fun NewLoginScreen(
         if (navArgs.ssoLoginResult != null) {
             viewModel.handleSSOResult(
                 navArgs.ssoLoginResult,
-//                ssoUrlConfigHolder.get()
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/AutomatedLoginManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/AutomatedLoginManager.kt
@@ -1,0 +1,34 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util.lifecycle
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Tracks whether the app was started via an automated login intent,
+ * so that the app can move to the background once initial sync completes.
+ *
+ * Intentionally in-memory only: if the process is killed mid-flow the flag
+ * resets naturally, preventing the app from unexpectedly backgrounding itself
+ * on a future normal launch.
+ */
+@Singleton
+class AutomatedLoginManager @Inject constructor() {
+    var pendingMoveToBackgroundAfterSync: Boolean = false
+}

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/IntentsProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/IntentsProcessor.kt
@@ -1,0 +1,64 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util.lifecycle
+
+import android.content.Intent
+import java.net.URI
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class AutomatedLoginViaSSO(
+    val backendConfig: String? = null,
+    val ssoCode: String? = null
+) {
+    val isEmpty = backendConfig == null && ssoCode == null
+}
+
+@Singleton
+class IntentsProcessor @Inject constructor() {
+
+    companion object {
+        private const val AUTOMATED_LOGIN = "automated_login"
+    }
+
+    operator fun invoke(intent: Intent?): AutomatedLoginViaSSO? {
+        @Serializable
+        data class Parameters(
+            val backendConfig: String? = null,
+            val ssoCode: String? = null
+        )
+
+        val automatedLoginParameter = intent?.getStringExtra(AUTOMATED_LOGIN) ?: return null
+        return runCatching {
+            val parsed = Json.decodeFromString<Parameters>(automatedLoginParameter)
+            AutomatedLoginViaSSO(parsed.backendConfig, parsed.ssoCode)
+        }.getOrNull()
+            ?.takeIf { !it.isEmpty }
+            ?.takeIf { params ->
+                params.backendConfig == null || isValidHttpsUrl(params.backendConfig)
+            }
+    }
+
+    private fun isValidHttpsUrl(url: String): Boolean {
+        // Validate that backendConfig is a valid HTTPS URL (HTTP is not allowed for security)
+        val uri = runCatching { URI(url) }.getOrNull()
+        return uri?.scheme?.lowercase() == "https" && !uri.host.isNullOrEmpty()
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/LogoutReceiverTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/LogoutReceiverTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.notification.broadcastreceivers
+
+import android.content.Context
+import android.content.Intent
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.feature.AccountSwitchUseCase
+import com.wire.android.feature.SwitchAccountParam
+import com.wire.android.feature.SwitchAccountResult
+import com.wire.android.ui.WireActivity
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.auth.AccountInfo
+import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
+import com.wire.kalium.logic.feature.auth.LogoutUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
+import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.any
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import io.mockk.withArg
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+
+@ExtendWith(CoroutineTestExtension::class)
+class LogoutReceiverTest {
+
+    @Test
+    fun `when logout broadcast received then work is handed off before logout sequence runs`() = runTest {
+        val userId = UserId("user", "domain")
+        val arrangement = Arrangement(this)
+            .withCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(userId)))
+            .arrange()
+
+        arrangement.receiver.receive(arrangement.context, Intent().setAction(LogoutReceiver.ACTION_LOGOUT))
+
+        coVerify(exactly = 0) {
+            arrangement.currentSession()
+            arrangement.logoutUseCase(any(), any())
+            arrangement.deleteSession(any())
+            arrangement.accountSwitch(any())
+        }
+        verify(exactly = 0) { arrangement.context.startActivity(any()) }
+
+        advanceUntilIdle()
+
+        verify(exactly = 1) { arrangement.coreLogic.getSessionScope(userId) }
+        coVerifyOrder {
+            arrangement.currentSession()
+            arrangement.logoutUseCase(LogoutReason.SELF_HARD_LOGOUT, true)
+            arrangement.deleteSession(userId)
+            arrangement.accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount)
+        }
+        verify(exactly = 1) {
+            arrangement.context.startActivity(withArg { startedIntent ->
+                assertEquals(WireActivity::class.java.name, startedIntent.component?.className)
+                assertEquals(
+                    Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK,
+                    startedIntent.flags and (Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                )
+            })
+        }
+    }
+
+    @Test
+    fun `when no current session exists then receiver does not continue logout flow`() = runTest {
+        val arrangement = Arrangement(this)
+            .withCurrentSession(CurrentSessionResult.Failure.SessionNotFound)
+            .arrange()
+
+        arrangement.receiver.receive(arrangement.context, Intent().setAction(LogoutReceiver.ACTION_LOGOUT))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { arrangement.currentSession() }
+        verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
+        coVerify(exactly = 0) {
+            arrangement.logoutUseCase(any(), any())
+            arrangement.deleteSession(any())
+            arrangement.accountSwitch(any())
+        }
+        verify(exactly = 0) { arrangement.context.startActivity(any()) }
+    }
+
+    private class Arrangement(
+        private val coroutineScope: CoroutineScope
+    ) {
+
+        @MockK
+        lateinit var coreLogic: CoreLogic
+
+        @MockK
+        lateinit var currentSession: CurrentSessionUseCase
+
+        @MockK
+        lateinit var deleteSession: DeleteSessionUseCase
+
+        @MockK
+        lateinit var accountSwitch: AccountSwitchUseCase
+
+        @MockK
+        lateinit var userSessionScope: UserSessionScope
+
+        @MockK
+        lateinit var logoutUseCase: LogoutUseCase
+
+        val context = mockk<Context>(relaxed = true)
+        val receiver = LogoutReceiver()
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+
+            every { context.applicationContext } returns context
+            every { context.packageName } returns "com.wire.android"
+            every { context.startActivity(any()) } just runs
+
+            every { userSessionScope.logout } returns logoutUseCase
+            coEvery { logoutUseCase(any(), any()) } returns Unit
+            coEvery { deleteSession(any()) } returns DeleteSessionUseCase.Result.Success
+            coEvery { accountSwitch(any()) } returns SwitchAccountResult.NoOtherAccountToSwitch
+            every { coreLogic.getSessionScope(any()) } returns userSessionScope
+        }
+
+        fun arrange(): Arrangement {
+            receiver.coreLogic = coreLogic
+            receiver.currentSession = currentSession
+            receiver.deleteSession = deleteSession
+            receiver.accountSwitch = accountSwitch
+            receiver.coroutineScope = coroutineScope
+            return this
+        }
+
+        fun withCurrentSession(result: CurrentSessionResult) = apply {
+            coEvery { currentSession() } returns result
+        }
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/LogoutReceiverTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/LogoutReceiverTest.kt
@@ -20,6 +20,7 @@ package com.wire.android.notification.broadcastreceivers
 import android.content.Context
 import android.content.Intent
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.NomadProfilesFeatureConfig
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
 import com.wire.android.feature.SwitchAccountResult
@@ -43,14 +44,14 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
-import io.mockk.verify
 import io.mockk.withArg
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import kotlin.test.assertEquals
 
 @ExtendWith(CoroutineTestExtension::class)
 class LogoutReceiverTest {
@@ -82,13 +83,36 @@ class LogoutReceiverTest {
             arrangement.accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount)
         }
         verify(exactly = 1) {
-            arrangement.context.startActivity(withArg { startedIntent ->
-                assertEquals(WireActivity::class.java.name, startedIntent.component?.className)
-                assertEquals(
-                    Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK,
-                    startedIntent.flags and (Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                )
-            })
+            arrangement.context.startActivity(
+                withArg { startedIntent ->
+                    assertEquals(WireActivity::class.java.name, startedIntent.component?.className)
+                    assertEquals(
+                        Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK,
+                        startedIntent.flags and (Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    )
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `when nomad profiles are disabled then logout broadcast is ignored`() = runTest {
+        val arrangement = Arrangement(this)
+            .withNomadProfilesEnabled(false)
+            .arrange()
+
+        arrangement.receiver.receive(arrangement.context, Intent().setAction(LogoutReceiver.ACTION_LOGOUT))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            arrangement.currentSession()
+            arrangement.logoutUseCase(any(), any())
+            arrangement.deleteSession(any())
+            arrangement.accountSwitch(any())
+        }
+        verify(exactly = 0) {
+            arrangement.coreLogic.getSessionScope(any())
+            arrangement.context.startActivity(any())
         }
     }
 
@@ -133,6 +157,9 @@ class LogoutReceiverTest {
         @MockK
         lateinit var logoutUseCase: LogoutUseCase
 
+        @MockK
+        lateinit var nomadProfilesFeatureConfig: NomadProfilesFeatureConfig
+
         val context = mockk<Context>(relaxed = true)
         val receiver = LogoutReceiver()
 
@@ -148,6 +175,7 @@ class LogoutReceiverTest {
             coEvery { deleteSession(any()) } returns DeleteSessionUseCase.Result.Success
             coEvery { accountSwitch(any()) } returns SwitchAccountResult.NoOtherAccountToSwitch
             every { coreLogic.getSessionScope(any()) } returns userSessionScope
+            every { nomadProfilesFeatureConfig.isEnabled() } returns true
         }
 
         fun arrange(): Arrangement {
@@ -156,11 +184,16 @@ class LogoutReceiverTest {
             receiver.deleteSession = deleteSession
             receiver.accountSwitch = accountSwitch
             receiver.coroutineScope = coroutineScope
+            receiver.nomadProfilesFeatureConfig = nomadProfilesFeatureConfig
             return this
         }
 
         fun withCurrentSession(result: CurrentSessionResult) = apply {
             coEvery { currentSession() } returns result
+        }
+
+        fun withNomadProfilesEnabled(enabled: Boolean) = apply {
+            every { nomadProfilesFeatureConfig.isEnabled() } returns enabled
         }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiverTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiverTest.kt
@@ -44,9 +44,8 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
-import io.mockk.withArg
 import io.mockk.verify
-import kotlinx.coroutines.CoroutineScope
+import io.mockk.withArg
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -54,26 +53,16 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(CoroutineTestExtension::class)
-class LogoutReceiverTest {
+class NomadLogoutReceiverTest {
 
     @Test
-    fun `when logout broadcast received then work is handed off before logout sequence runs`() = runTest {
+    fun `when logout broadcast received then logout sequence runs within receiver`() = runTest {
         val userId = UserId("user", "domain")
-        val arrangement = Arrangement(this)
+        val arrangement = Arrangement()
             .withCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(userId)))
             .arrange()
 
-        arrangement.receiver.receive(arrangement.context, Intent().setAction(LogoutReceiver.ACTION_LOGOUT))
-
-        coVerify(exactly = 0) {
-            arrangement.currentSession()
-            arrangement.logoutUseCase(any(), any())
-            arrangement.deleteSession(any())
-            arrangement.accountSwitch(any())
-        }
-        verify(exactly = 0) { arrangement.context.startActivity(any()) }
-
-        advanceUntilIdle()
+        arrangement.receiver.receive(arrangement.context, Intent().setAction(NomadLogoutReceiver.ACTION_LOGOUT))
 
         verify(exactly = 1) { arrangement.coreLogic.getSessionScope(userId) }
         coVerifyOrder {
@@ -97,11 +86,11 @@ class LogoutReceiverTest {
 
     @Test
     fun `when nomad profiles are disabled then logout broadcast is ignored`() = runTest {
-        val arrangement = Arrangement(this)
+        val arrangement = Arrangement()
             .withNomadProfilesEnabled(false)
             .arrange()
 
-        arrangement.receiver.receive(arrangement.context, Intent().setAction(LogoutReceiver.ACTION_LOGOUT))
+        arrangement.receiver.receive(arrangement.context, Intent().setAction(NomadLogoutReceiver.ACTION_LOGOUT))
         advanceUntilIdle()
 
         coVerify(exactly = 0) {
@@ -118,11 +107,11 @@ class LogoutReceiverTest {
 
     @Test
     fun `when no current session exists then receiver does not continue logout flow`() = runTest {
-        val arrangement = Arrangement(this)
+        val arrangement = Arrangement()
             .withCurrentSession(CurrentSessionResult.Failure.SessionNotFound)
             .arrange()
 
-        arrangement.receiver.receive(arrangement.context, Intent().setAction(LogoutReceiver.ACTION_LOGOUT))
+        arrangement.receiver.receive(arrangement.context, Intent().setAction(NomadLogoutReceiver.ACTION_LOGOUT))
         advanceUntilIdle()
 
         coVerify(exactly = 1) { arrangement.currentSession() }
@@ -135,9 +124,7 @@ class LogoutReceiverTest {
         verify(exactly = 0) { arrangement.context.startActivity(any()) }
     }
 
-    private class Arrangement(
-        private val coroutineScope: CoroutineScope
-    ) {
+    private class Arrangement {
 
         @MockK
         lateinit var coreLogic: CoreLogic
@@ -161,7 +148,7 @@ class LogoutReceiverTest {
         lateinit var nomadProfilesFeatureConfig: NomadProfilesFeatureConfig
 
         val context = mockk<Context>(relaxed = true)
-        val receiver = LogoutReceiver()
+        val receiver = NomadLogoutReceiver()
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
@@ -183,7 +170,6 @@ class LogoutReceiverTest {
             receiver.currentSession = currentSession
             receiver.deleteSession = deleteSession
             receiver.accountSwitch = accountSwitch
-            receiver.coroutineScope = coroutineScope
             receiver.nomadProfilesFeatureConfig = nomadProfilesFeatureConfig
             return this
         }

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -22,7 +22,7 @@ package com.wire.android.ui
 
 import android.content.Intent
 import androidx.work.WorkManager
-import androidx.work.impl.OperationImpl
+import androidx.work.Operation
 import app.cash.turbine.test
 import com.wire.android.BuildConfig
 import com.wire.android.assertions.shouldBeEqualTo
@@ -51,6 +51,9 @@ import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.deeplink.DeepLinkProcessor
 import com.wire.android.util.deeplink.DeepLinkResult
+import com.wire.android.util.lifecycle.AutomatedLoginManager
+import com.wire.android.util.lifecycle.AutomatedLoginViaSSO
+import com.wire.android.util.lifecycle.IntentsProcessor
 import com.wire.android.util.newServerConfig
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.CoreLogic
@@ -770,6 +773,19 @@ class WireActivityViewModelTest {
         }
 
     @Test
+    fun `given valid automated_login intent, when handling intents, then automated login manager pending flag is set`() = runTest {
+        val ssoCode = "wire-b6261497-5b7d-4a57-8f4d-3a94e936b2c0"
+        val (arrangement, viewModel) = Arrangement()
+            .withAutomatedLoginIntent(ssoCode = ssoCode)
+            .arrange()
+
+        viewModel.handleIntentsThatAreNotDeepLinks(mockedIntent())
+        advanceUntilIdle()
+
+        assertTrue(arrangement.automatedLoginManager.pendingMoveToBackgroundAfterSync)
+    }
+
+    @Test
     fun `given no valid session, when checking number of sessions, then return true`() = runTest {
         // given
         val (_, viewModel) = Arrangement()
@@ -818,6 +834,7 @@ class WireActivityViewModelTest {
 
         val managedConfigurationsManager: ManagedConfigurationsManager = mockk(relaxed = true)
         private val persistentWebSocketEnforcedByMDMFlow = MutableStateFlow(false)
+        val automatedLoginManager = AutomatedLoginManager()
 
         init {
             // Tests setup
@@ -829,6 +846,7 @@ class WireActivityViewModelTest {
             coEvery { currentSessionFlow() } returns flowOf()
             coEvery { getServerConfigUseCase(any()) } returns GetServerConfigResult.Success(newServerConfig(1).links)
             coEvery { deepLinkProcessor(any(), any()) } returns DeepLinkResult.Unknown
+            every { intentsProcessor(any()) } returns null
             coEvery { observeSessionsUseCase.invoke() } returns flowOf(GetAllSessionsResult.Failure.NoSessionFound)
             every { observeSyncStateUseCaseProviderFactory.create(any()).observeSyncState } returns observeSyncStateUseCase
             every { observeSyncStateUseCase() } returns emptyFlow()
@@ -843,8 +861,8 @@ class WireActivityViewModelTest {
                 observeIfE2EIRequiredDuringLoginUseCaseProviderFactory.create(any()).observeIfE2EIIsRequiredDuringLogin()
             } returns
                     flowOf(false)
-            every { workManager.cancelAllWorkByTag(any()) } returns OperationImpl()
-            every { workManager.enqueueUniquePeriodicWork(any(), any(), any()) } returns OperationImpl()
+            every { workManager.cancelAllWorkByTag(any()) } returns mockk<Operation>()
+            every { workManager.enqueueUniquePeriodicWork(any(), any(), any()) } returns mockk<Operation>()
             val observeSelfUserUseCase = mockk<ObserveSelfUserUseCase>()
             every { observeSelfUserFactory.create(any()).observeSelfUser } returns observeSelfUserUseCase
             coEvery { observeSelfUserUseCase() } returns flowOf(SELF_USER)
@@ -862,6 +880,9 @@ class WireActivityViewModelTest {
 
         @MockK
         lateinit var deepLinkProcessor: DeepLinkProcessor
+
+        @MockK
+        lateinit var intentsProcessor: IntentsProcessor
 
         @MockK
         lateinit var observeSessionsUseCase: ObserveSessionsUseCase
@@ -928,6 +949,7 @@ class WireActivityViewModelTest {
                 doesValidSessionExist = { doesValidSessionExist },
                 getServerConfigUseCase = { getServerConfigUseCase },
                 deepLinkProcessor = { deepLinkProcessor },
+                intentsProcessor = { intentsProcessor },
                 observeSessions = { observeSessionsUseCase },
                 accountSwitch = { switchAccount },
                 servicesManager = { servicesManager },
@@ -944,6 +966,7 @@ class WireActivityViewModelTest {
                 observeSelfUserFactory = observeSelfUserFactory,
                 monitorSyncWorkUseCase = monitorSyncWorkUseCase,
                 managedConfigurationsManager = managedConfigurationsManager,
+                automatedLoginManager = automatedLoginManager,
             )
         }
 
@@ -1071,6 +1094,10 @@ class WireActivityViewModelTest {
             val useCase = mockk<IsProfileQRCodeEnabledUseCase>()
             coEvery { isProfileQRCodeEnabledFactory.create(any()).isProfileQRCodeEnabled } returns useCase
             coEvery { useCase() } returns isEnabled
+        }
+
+        fun withAutomatedLoginIntent(ssoCode: String): Arrangement = apply {
+            every { intentsProcessor(any()) } returns AutomatedLoginViaSSO(ssoCode = ssoCode)
         }
 
         fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -27,6 +27,7 @@ import app.cash.turbine.test
 import com.wire.android.BuildConfig
 import com.wire.android.assertions.shouldBeEqualTo
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.NomadProfilesFeatureConfig
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.datastore.GlobalDataStore
@@ -89,11 +90,13 @@ import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotC
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import io.mockk.MockKAnnotations
+import io.mockk.any
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -779,10 +782,39 @@ class WireActivityViewModelTest {
             .withAutomatedLoginIntent(ssoCode = ssoCode)
             .arrange()
 
-        viewModel.handleIntentsThatAreNotDeepLinks(mockedIntent())
+        val handled = viewModel.handleIntentsThatAreNotDeepLinks(mockedIntent())
         advanceUntilIdle()
 
+        assertTrue(handled)
         assertTrue(arrangement.automatedLoginManager.pendingMoveToBackgroundAfterSync)
+    }
+
+    @Test
+    fun `given nomad profiles disabled, when handling non deep link intents, then intent is ignored`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .withNomadProfilesEnabled(false)
+            .withAutomatedLoginIntent(ssoCode = "wire-b6261497-5b7d-4a57-8f4d-3a94e936b2c0")
+            .arrange()
+
+        val handled = viewModel.handleIntentsThatAreNotDeepLinks(mockedIntent())
+        advanceUntilIdle()
+
+        assertEquals(false, handled)
+        assertEquals(false, arrangement.automatedLoginManager.pendingMoveToBackgroundAfterSync)
+        verify(exactly = 0) { arrangement.intentsProcessor(any()) }
+    }
+
+    @Test
+    fun `given nomad profiles disabled, when handling sharing intent, then import media screen is still shown`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withNomadProfilesEnabled(false)
+            .withDeepLinkResult(DeepLinkResult.SharingIntent)
+            .arrange()
+
+        viewModel.actions.test {
+            viewModel.handleDeepLink(mockedIntent())
+            assertEquals(OnShowImportMediaScreen, expectMostRecentItem())
+        }
     }
 
     @Test
@@ -867,6 +899,7 @@ class WireActivityViewModelTest {
             every { observeSelfUserFactory.create(any()).observeSelfUser } returns observeSelfUserUseCase
             coEvery { observeSelfUserUseCase() } returns flowOf(SELF_USER)
             every { managedConfigurationsManager.persistentWebSocketEnforcedByMDM } returns persistentWebSocketEnforcedByMDMFlow
+            every { nomadProfilesFeatureConfig.isEnabled() } returns true
         }
 
         @MockK
@@ -941,6 +974,9 @@ class WireActivityViewModelTest {
         @MockK
         lateinit var monitorSyncWorkUseCase: MonitorSyncWorkUseCase
 
+        @MockK
+        lateinit var nomadProfilesFeatureConfig: NomadProfilesFeatureConfig
+
         private val viewModel by lazy {
             WireActivityViewModel(
                 coreLogic = { coreLogic },
@@ -967,6 +1003,7 @@ class WireActivityViewModelTest {
                 monitorSyncWorkUseCase = monitorSyncWorkUseCase,
                 managedConfigurationsManager = managedConfigurationsManager,
                 automatedLoginManager = automatedLoginManager,
+                nomadProfilesFeatureConfig = nomadProfilesFeatureConfig,
             )
         }
 
@@ -1098,6 +1135,10 @@ class WireActivityViewModelTest {
 
         fun withAutomatedLoginIntent(ssoCode: String): Arrangement = apply {
             every { intentsProcessor(any()) } returns AutomatedLoginViaSSO(ssoCode = ssoCode)
+        }
+
+        fun withNomadProfilesEnabled(enabled: Boolean): Arrangement = apply {
+            every { nomadProfilesFeatureConfig.isEnabled() } returns enabled
         }
 
         fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -110,7 +110,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
-@Suppress("MaxLineLength")
+@Suppress("MaxLineLength", "LargeClass")
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
 class WireActivityViewModelTest {

--- a/app/src/test/kotlin/com/wire/android/ui/initialsync/InitialSyncViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/initialsync/InitialSyncViewModelTest.kt
@@ -23,6 +23,7 @@ import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.datastore.UserDataStoreProvider
+import com.wire.android.util.lifecycle.AutomatedLoginManager
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
@@ -73,6 +74,36 @@ class InitialSyncViewModelTest {
         assertFalse(viewModel.isSyncCompleted)
     }
 
+    @Test
+    fun `given automated login pending, when sync completes, then shouldMoveToBackground is true and flag is cleared`() = runTest {
+        // given
+        val (viewModel, arrangement) = Arrangement()
+            .withAutomatedLoginPending()
+            .withSyncState(SyncState.Live)
+            .arrange()
+
+        advanceUntilIdle()
+
+        // then
+        assertTrue(viewModel.isSyncCompleted)
+        assertTrue(viewModel.shouldMoveToBackground)
+        assertFalse(arrangement.automatedLoginManager.pendingMoveToBackgroundAfterSync)
+    }
+
+    @Test
+    fun `given no automated login pending, when sync completes, then shouldMoveToBackground is false`() = runTest {
+        // given
+        val (viewModel, _) = Arrangement()
+            .withSyncState(SyncState.Live)
+            .arrange()
+
+        advanceUntilIdle()
+
+        // then
+        assertTrue(viewModel.isSyncCompleted)
+        assertFalse(viewModel.shouldMoveToBackground)
+    }
+
     private class Arrangement {
 
         @MockK
@@ -85,8 +116,10 @@ class InitialSyncViewModelTest {
         lateinit var userDataStore: UserDataStore
         val userId = UserId("id", "domain")
 
+        val automatedLoginManager = AutomatedLoginManager()
+
         val viewModel by lazy {
-            InitialSyncViewModel(observeSyncState, userDataStoreProvider, userId, TestDispatcherProvider())
+            InitialSyncViewModel(observeSyncState, userDataStoreProvider, userId, TestDispatcherProvider(), automatedLoginManager)
         }
 
         private val syncStateChannel = Channel<SyncState>(capacity = Channel.UNLIMITED)
@@ -96,13 +129,17 @@ class InitialSyncViewModelTest {
             MockKAnnotations.init(this, relaxUnitFun = true)
             // Default empty values
             mockUri()
-           coEvery { userDataStoreProvider.getOrCreate(any()) } returns userDataStore
+            coEvery { userDataStoreProvider.getOrCreate(any()) } returns userDataStore
         }
 
         suspend fun withSyncState(syncState: SyncState): Arrangement {
             every { observeSyncState.invoke() } returns syncStateChannel.consumeAsFlow()
             syncStateChannel.send(syncState)
             return this
+        }
+
+        fun withAutomatedLoginPending(): Arrangement = apply {
+            automatedLoginManager.pendingMoveToBackgroundAfterSync = true
         }
 
         fun arrange() = viewModel to this

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/IntentsProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/IntentsProcessorTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util.lifecycle
+
+import android.content.Intent
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class IntentsProcessorTest {
+
+    @Test
+    fun `given null intent, returns null`() {
+        val (_, intentsProcessor) = Arrangement().arrange()
+        assertNull(intentsProcessor(null))
+    }
+
+    @Test
+    fun `given intent without automated_login extra, returns null`() {
+        val (arrangement, intentsProcessor) = Arrangement()
+            .withAutomatedLoginExtra(null)
+            .arrange()
+        assertNull(intentsProcessor(arrangement.intent))
+    }
+
+    @Test
+    fun `given valid JSON with both backendConfig and ssoCode, returns AutomatedLoginViaSSO`() {
+        val (arrangement, intentsProcessor) = Arrangement()
+            .withAutomatedLoginExtra("""{"backendConfig":"$FAKE_BACKEND_CONFIG","ssoCode":"$FAKE_SSO_CODE"}""")
+            .arrange()
+        assertEquals(
+            AutomatedLoginViaSSO(backendConfig = FAKE_BACKEND_CONFIG, ssoCode = FAKE_SSO_CODE),
+            intentsProcessor(arrangement.intent)
+        )
+    }
+
+    @Test
+    fun `given valid JSON with only ssoCode, returns AutomatedLoginViaSSO`() {
+        val (arrangement, intentsProcessor) = Arrangement()
+            .withAutomatedLoginExtra("""{"ssoCode":"$FAKE_SSO_CODE"}""")
+            .arrange()
+        assertEquals(
+            AutomatedLoginViaSSO(ssoCode = FAKE_SSO_CODE),
+            intentsProcessor(arrangement.intent)
+        )
+    }
+
+    @Test
+    fun `given valid JSON with only backendConfig using HTTPS, returns AutomatedLoginViaSSO`() {
+        val (arrangement, intentsProcessor) = Arrangement()
+            .withAutomatedLoginExtra("""{"backendConfig":"$FAKE_BACKEND_CONFIG"}""")
+            .arrange()
+        assertEquals(
+            AutomatedLoginViaSSO(backendConfig = FAKE_BACKEND_CONFIG),
+            intentsProcessor(arrangement.intent)
+        )
+    }
+
+    @Test
+    fun `given JSON with both fields null, returns null`() {
+        val (arrangement, intentsProcessor) = Arrangement()
+            .withAutomatedLoginExtra("""{}""")
+            .arrange()
+        assertNull(intentsProcessor(arrangement.intent))
+    }
+
+    @Test
+    fun `given invalid JSON string, returns null`() {
+        val (arrangement, intentsProcessor) = Arrangement()
+            .withAutomatedLoginExtra("not-valid-json")
+            .arrange()
+        assertNull(intentsProcessor(arrangement.intent))
+    }
+
+    @Test
+    fun `given backendConfig with HTTP instead of HTTPS, returns null`() {
+        val (arrangement, intentsProcessor) = Arrangement()
+            .withAutomatedLoginExtra("""{"backendConfig":"http://insecure.wire.com/deeplink.json"}""")
+            .arrange()
+        assertNull(intentsProcessor(arrangement.intent))
+    }
+
+    @Test
+    fun `given backendConfig with empty host, returns null`() {
+        val (arrangement, intentsProcessor) = Arrangement()
+            .withAutomatedLoginExtra("""{"backendConfig":"https:///path"}""")
+            .arrange()
+        assertNull(intentsProcessor(arrangement.intent))
+    }
+
+    @Test
+    fun `given backendConfig with malformed URI, returns null`() {
+        val (arrangement, intentsProcessor) = Arrangement()
+            .withAutomatedLoginExtra("""{"backendConfig":"not a url"}""")
+            .arrange()
+        assertNull(intentsProcessor(arrangement.intent))
+    }
+
+    class Arrangement {
+        internal val intent: Intent = mockk()
+
+        init {
+            every { intent.getStringExtra(any()) } returns null
+        }
+
+        fun arrange() = this to IntentsProcessor()
+
+        fun withAutomatedLoginExtra(json: String?) = apply {
+            every { intent.getStringExtra("automated_login") } returns json
+        }
+    }
+
+    private companion object {
+        const val FAKE_BACKEND_CONFIG = "https://example.com/deeplink.json"
+        const val FAKE_SSO_CODE = "wire-87080ee2-7855-47e2-a60a-4b3def45bbd4"
+    }
+}

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -143,5 +143,7 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
 
     COLLABORA_INTEGRATION_ENABLED("collabora_integration", ConfigType.BOOLEAN),
 
-    DB_INVALIDATION_CONTROL_ENABLED("db_invalidation_control_enabled", ConfigType.BOOLEAN)
+    DB_INVALIDATION_CONTROL_ENABLED("db_invalidation_control_enabled", ConfigType.BOOLEAN),
+
+    NOMAD_PROFILES_ENABLED("nomad_profiles_enabled", ConfigType.BOOLEAN)
 }

--- a/default.json
+++ b/default.json
@@ -37,7 +37,8 @@
             "meetings_enabled": true,
             "use_async_flush_logging": true,
             "conversation_feeder_enabled": true,
-            "db_invalidation_control_enabled": true
+            "db_invalidation_control_enabled": true,
+            "nomad_profiles_enabled": true
         },
         "staging": {
             "application_id": "com.waz.zclient.dev",
@@ -163,5 +164,6 @@
     "background_notification_stay_alive_seconds": 3,
     "is_bubble_ui_enabled": true,
     "collabora_integration": true,
-    "db_invalidation_control_enabled": false
+    "db_invalidation_control_enabled": false,
+    "nomad_profiles_enabled": false
 }


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23837
<!--jira-description-action-hidden-marker-end-->


# What's new in this PR?

- Adding the ability to receive SSO code and backend URL from intent. If both are received, the application switches to the backend specified in the URL, and starts the SSO flow with the given code. Both happen without waiting for user confirmation.
- Adding a log out intent