### PR TITLE
Remove Support menu item from hamburger menu

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModel.kt
@@ -100,7 +100,6 @@ class HomeDrawerViewModel @Inject constructor(
                             )
                         )
                     }
-                    add(DrawerUiItem.RegularItem(destination = HomeDestination.Support))
                 }
             }.collect {
                 drawerState = drawerState.copy(items = it)


### PR DESCRIPTION
## Summary
- Removed the Support menu item from the hamburger menu's bottom items list

## Changes
- Modified `HomeDrawerViewModel.kt` to exclude the Support menu item from the drawer navigation

## Details
The Support menu item has been removed from line 103 in the `buildDrawerItems()` function. The hamburger menu will no longer display the Support option in its bottom section.