### PR TITLE
fix: allow sharing bug-report logs via non-email apps [WPB-20336]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
@@ -28,6 +28,7 @@ import com.wire.android.R
 import com.wire.android.util.EmailComposer
 import com.wire.android.util.getDeviceIdString
 import com.wire.android.util.getGitBuildId
+import com.wire.android.util.getMimeType
 import com.wire.android.util.getUrisOfFilesInDirectory
 import com.wire.android.util.logging.LogFileWriter
 import com.wire.android.util.multipleFileSharingIntent
@@ -119,7 +120,11 @@ object ReportBugDestination : IntentDirection {
                 context.getGitBuildId()
             )
         )
-        intent.type = "message/rfc822"
+        val mimeTypes = logsUris.mapNotNull { it.getMimeType(context) }.toSet()
+        if (mimeTypes.isNotEmpty()) {
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes.toTypedArray())
+        }
+        intent.type = "*/*"
         return Intent.createChooser(intent, context.getString(R.string.send_feedback_choose_email))
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-20336
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When using **Preferences → Fehler melden (Report issue)** on Android, logs could not be shared via Wire because Wire was missing from the system share targets.

### Causes (Optional)

The bug-report share intent used MIME type `message/rfc822`, which narrows available targets mostly to email clients.

### Solutions

Updated `ReportBugDestination` to use a generic share MIME type:
- changed intent type from `message/rfc822` to `*/*`
- added `Intent.EXTRA_MIME_TYPES` based on actual log file MIME types

This restores visibility of non-email targets (including Wire) in the share chooser.