### PR TITLE
fix: align guest link password fields with design labels and placeholders [WPB-11364]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordProtectedGuestLinkScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordProtectedGuestLinkScreen.kt
@@ -190,7 +190,10 @@ fun CreatePasswordProtectedGuestLinkScreenContent(
                         textState = passwordTextState,
                         labelMandatoryIcon = true,
                         labelText = stringResource(
-                            R.string.conversation_options_create_password_protected_guest_link_button_placeholder_text
+                            R.string.conversation_options_create_password_protected_guest_link_password_label
+                        ),
+                        placeholderText = stringResource(
+                            id = R.string.conversation_options_create_password_protected_guest_link_button_placeholder_text
                         ),
                         descriptionText = stringResource(
                             R.string.conversation_options_create_password_protected_guest_link_password_description


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-11364
<!--jira-description-action-hidden-marker-end-->


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

**Commit**
`fix(android): align guest link password fields with design labels and placeholders`

**PR title**
`[Android] Align guest-link password form labels/placeholders with design`

# What's new in this PR?

Updated `CreatePasswordProtectedGuestLinkScreen` so the two password fields are consistent with design:
- first field label changed to `SET PASSWORD`
- second field label remains `CONFIRM PASSWORD`
- both fields now display the same placeholder (`Enter password`) inside the input area
