### PR TITLE
fix: failure message for adding user with no mls client (WPB-17105)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
@@ -274,6 +274,7 @@ class SystemMessageContentMapper @Inject constructor(
                     FailedToAdd.Type.Federation -> UIMessageContent.SystemMessage.MemberFailedToAdd.Type.Federation
                     FailedToAdd.Type.LegalHold -> UIMessageContent.SystemMessage.MemberFailedToAdd.Type.LegalHold
                     FailedToAdd.Type.Unknown -> UIMessageContent.SystemMessage.MemberFailedToAdd.Type.Unknown
+                    FailedToAdd.Type.MissingKeyPackages -> UIMessageContent.SystemMessage.MemberFailedToAdd.Type.MissingKeyPackages
                 }
             )
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SystemMessageItem.kt
@@ -476,6 +476,7 @@ private fun SystemMessage.buildContent(isWireCellsEnabled: Boolean) = when (this
             Type.Federation -> R.string.url_message_details_offline_backends_learn_more
             Type.LegalHold -> R.string.url_legal_hold_learn_more
             Type.Unknown -> null
+            Type.MissingKeyPackages -> R.string.url_mls_learn_more
         }
     ) { expanded ->
         val markdownTextStyle = DefaultMarkdownTextStyle.copy(
@@ -492,6 +493,7 @@ private fun SystemMessage.buildContent(isWireCellsEnabled: Boolean) = when (this
                 Type.Federation -> R.plurals.label_system_message_conversation_failed_add_members_details_federation
                 Type.LegalHold -> R.plurals.label_system_message_conversation_failed_add_members_details_legal_hold
                 Type.Unknown -> R.plurals.label_system_message_conversation_failed_add_members_details_unknown
+                Type.MissingKeyPackages -> R.plurals.label_system_message_conversation_failed_add_members_details_missing_key_packages
             },
             count = memberNames.size,
             formatArgs = arrayOf(memberNames.limitList(expanded).toListMarkdownString())

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -567,7 +567,7 @@ sealed interface UIMessageContent {
             val memberNames: List<UIText>,
             val type: Type,
         ) : SystemMessage {
-            enum class Type { Federation, LegalHold, Unknown; }
+            enum class Type { Federation, LegalHold, Unknown, MissingKeyPackages; }
         }
 
         @Serializable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,7 @@
     <string name="url_learn_about_search" translatable="false">https://support.wire.com/hc/articles/203121850</string>
     <string name="url_legal_hold_learn_more" translatable="false">https://support.wire.com/hc/articles/360002018278</string>
     <string name="url_message_details_offline_backends_learn_more" translatable="false">https://support.wire.com/hc/articles/9357718008093</string>
+    <string name="url_mls_learn_more" translatable="false">https://support.wire.com/hc/en-us/articles/12434725011485-Messaging-Layer-Security-MLS</string>
     <string name="url_message_details_reactions_learn_more" translatable="false">https://support.wire.com/hc/articles/212053645</string>
     <string name="url_message_details_read_receipts_learn_more" translatable="false">https://support.wire.com/hc/articles/360000665277</string>
     <string name="url_self_client_fingerprint_learn_more" translatable="false">https://support.wire.com/hc/articles/207692235</string>
@@ -872,6 +873,10 @@
     <plurals name="label_system_message_conversation_failed_add_members_details_unknown">
         <item quantity="one">%1$s could not be added to the conversation.</item>
         <item quantity="other">%1$s could not be added to the conversation.</item>
+    </plurals>
+    <plurals name="label_system_message_conversation_failed_add_members_details_missing_key_packages">
+        <item quantity="one">%1$s could not be added to the conversation. They may not have an MLS-capable client.</item>
+        <item quantity="other">%1$s could not be added to the conversation. They may not have MLS-capable clients.</item>
     </plurals>
     <string name="label_system_message_conversation_degraded_mls">This conversation is no longer verified, as at least one participant started using a new device or has an invalid certificate.</string>
     <string name="label_system_message_conversation_degraded_proteus">This conversation is no longer verified, as at least one participant started using a new device or has an invalid certificate.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,7 +276,7 @@
     <string name="url_learn_about_search" translatable="false">https://support.wire.com/hc/articles/203121850</string>
     <string name="url_legal_hold_learn_more" translatable="false">https://support.wire.com/hc/articles/360002018278</string>
     <string name="url_message_details_offline_backends_learn_more" translatable="false">https://support.wire.com/hc/articles/9357718008093</string>
-    <string name="url_mls_learn_more" translatable="false">https://support.wire.com/hc/en-us/articles/12434725011485-Messaging-Layer-Security-MLS</string>
+    <string name="url_mls_learn_more" translatable="false">https://support.wire.com/hc/articles/12434725011485</string>
     <string name="url_message_details_reactions_learn_more" translatable="false">https://support.wire.com/hc/articles/212053645</string>
     <string name="url_message_details_read_receipts_learn_more" translatable="false">https://support.wire.com/hc/articles/360000665277</string>
     <string name="url_self_client_fingerprint_learn_more" translatable="false">https://support.wire.com/hc/articles/207692235</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-17105
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-17105
----

# What's new in this PR?

### Issues
When adding user with no MLS client application is showing Federation error and support page in conversation.

### Causes (Optional)
MissingKeyPackages error is always mapped to Federation error.

### Solutions
Using new MissingKeyPackages error to show correct system message.