### PR TITLE
refactor: move participants and reactions to OngoingCallViewModel [WPB-23581]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/SharedCallingViewModel.kt
@@ -21,39 +21,26 @@ package com.wire.android.ui.calling.common
 import android.view.View
 import androidx.camera.core.impl.ImageOutputConfig.RotationValue
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
-import com.wire.android.di.CurrentAccount
-import com.wire.android.mapper.UICallParticipantMapper
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.calling.model.CallState
-import com.wire.android.ui.calling.model.InCallReaction
-import com.wire.android.ui.calling.model.ReactionSender
-import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.model.getConversationName
-import com.wire.android.ui.calling.ongoing.incallreactions.InCallReactions
 import com.wire.android.ui.calling.usecase.HangUpCallUseCase
 import com.wire.android.ui.common.ActionsViewModel
-import com.wire.android.util.ExpiringMap
 import com.wire.android.util.dispatchers.DispatcherProvider
-import com.wire.android.util.extension.withDelayAfterFirst
-import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.ConversationTypeForCall
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.QualifiedID
-import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.FlipToBackCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.FlipToFrontCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
-import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveLastActiveCallWithSortedParticipantsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveSpeakerUseCase
 import com.wire.kalium.logic.feature.call.usecase.SetUIRotationUseCase
@@ -62,29 +49,21 @@ import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
-import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
-import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
 import com.wire.kalium.logic.util.PlatformRotation
 import com.wire.kalium.logic.util.PlatformView
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 
@@ -92,7 +71,6 @@ import kotlinx.coroutines.launch
 @HiltViewModel(assistedFactory = SharedCallingViewModel.Factory::class)
 class SharedCallingViewModel @AssistedInject constructor(
     @Assisted val conversationId: ConversationId,
-    @CurrentAccount private val selfUserId: UserId,
     private val conversationDetails: ObserveConversationDetailsUseCase,
     private val observeLastActiveCallWithSortedParticipants: ObserveLastActiveCallWithSortedParticipantsUseCase,
     private val hangUpCall: HangUpCallUseCase,
@@ -106,26 +84,11 @@ class SharedCallingViewModel @AssistedInject constructor(
     private val flipToFrontCamera: FlipToFrontCameraUseCase,
     private val flipToBackCamera: FlipToBackCameraUseCase,
     private val observeSpeaker: ObserveSpeakerUseCase,
-    private val observeInCallReactionsUseCase: ObserveInCallReactionsUseCase,
-    private val sendInCallReactionUseCase: SendInCallReactionUseCase,
-    private val getCurrentClientId: ObserveCurrentClientIdUseCase,
-    private val uiCallParticipantMapper: UICallParticipantMapper,
     private val userTypeMapper: UserTypeMapper,
     private val dispatchers: DispatcherProvider
 ) : ActionsViewModel<SharedCallingViewActions>() {
 
     var callState by mutableStateOf(CallState(conversationId))
-
-    var participantsState by mutableStateOf(persistentListOf<UICallParticipant>())
-
-    private val _inCallReactions = Channel<InCallReaction>(
-        capacity = 300, // Max reactions to keep in queue
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
-
-    val inCallReactions = _inCallReactions.receiveAsFlow().withDelayAfterFirst(InCallReactions.reactionsThrottleDelayMs)
-
-    val recentReactions = recentInCallReactionMap()
 
     init {
         viewModelScope.launch {
@@ -139,13 +102,7 @@ class SharedCallingViewModel @AssistedInject constructor(
                 observeCallState(callSharedFlow)
             }
             launch {
-                observeParticipants(callSharedFlow)
-            }
-            launch {
                 observeOnSpeaker(this)
-            }
-            launch {
-                observeInCallReactions()
             }
         }
     }
@@ -209,19 +166,6 @@ class SharedCallingViewModel @AssistedInject constructor(
                     isCbrEnabled = call.isCbrEnabled && call.conversationType == Conversation.Type.OneOnOne
                 )
             }
-    }
-
-    private suspend fun observeParticipants(sharedFlow: SharedFlow<Call?>) {
-        combine(
-            getCurrentClientId().filterNotNull(),
-            sharedFlow.filterNotNull(),
-        ) { clientId, call ->
-            call.participants.map {
-                uiCallParticipantMapper.toUICallParticipant(it, clientId)
-            }.toPersistentList()
-        }.collectLatest {
-            participantsState = it
-        }
     }
 
     fun hangUpCall() {
@@ -309,47 +253,11 @@ class SharedCallingViewModel @AssistedInject constructor(
         }
     }
 
-    private suspend fun observeInCallReactions() {
-        observeInCallReactionsUseCase(conversationId).collect { message ->
-
-            val sender = participantsState.senderName(message.senderUserId)?.let { name ->
-                ReactionSender.Other(name)
-            } ?: ReactionSender.Unknown
-
-            message.emojis.forEach { emoji ->
-                _inCallReactions.send(InCallReaction(emoji, sender))
-            }
-
-            if (message.emojis.isNotEmpty()) {
-                recentReactions.put(message.senderUserId, message.emojis.last())
-            }
-        }
-    }
-
-    fun onReactionClick(emoji: String) {
-        viewModelScope.launch {
-            sendInCallReactionUseCase(conversationId, emoji).toEither()
-                .onSuccess {
-                    _inCallReactions.send(InCallReaction(emoji, ReactionSender.You))
-                    recentReactions[selfUserId] = emoji
-                }
-        }
-    }
-
-    private fun recentInCallReactionMap(): MutableMap<UserId, String> =
-        ExpiringMap<UserId, String>(
-            scope = viewModelScope,
-            expirationMs = InCallReactions.recentReactionShowDurationMs,
-            delegate = mutableStateMapOf<UserId, String>()
-        )
-
     @AssistedFactory
     interface Factory {
         fun create(conversationId: ConversationId): SharedCallingViewModel
     }
 }
-
-private fun List<UICallParticipant>.senderName(userId: QualifiedID) = firstOrNull { it.id.value == userId.value }?.name
 
 sealed interface SharedCallingViewActions {
     data class HungUpCall(val conversationId: ConversationId) : SharedCallingViewActions

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -158,7 +158,7 @@ fun OngoingCallScreen(
     }
 
     LaunchedEffect(Unit) {
-        sharedCallingViewModel.inCallReactions.collectLatest { reaction ->
+        ongoingCallViewModel.inCallReactions.collectLatest { reaction ->
             inCallReactionsState.runAnimation(reaction)
         }
     }
@@ -196,7 +196,7 @@ fun OngoingCallScreen(
     OngoingCallContent(
         callState = sharedCallingViewModel.callState,
         inCallReactionsState = inCallReactionsState,
-        shouldShowDoubleTapToast = ongoingCallViewModel.shouldShowDoubleTapToast,
+        shouldShowDoubleTapToast = ongoingCallViewModel.state.shouldShowDoubleTapToast,
         toggleSpeaker = sharedCallingViewModel::toggleSpeaker,
         toggleMute = sharedCallingViewModel::toggleMute,
         hangUpCall = sharedCallingViewModel::hangUpCall,
@@ -207,13 +207,13 @@ fun OngoingCallScreen(
         onCollapse = onCollapse,
         requestVideoStreams = ongoingCallViewModel::requestVideoStreams,
         onSelectedParticipant = ongoingCallViewModel::onSelectedParticipant,
-        selectedParticipantForFullScreen = ongoingCallViewModel.selectedParticipant,
+        selectedParticipantForFullScreen = ongoingCallViewModel.state.selectedParticipant,
         hideDoubleTapToast = ongoingCallViewModel::hideDoubleTapToast,
         onCameraPermissionPermanentlyDenied = onCameraPermissionPermanentlyDenied,
-        onReactionClick = sharedCallingViewModel::onReactionClick,
-        participants = sharedCallingViewModel.participantsState,
+        onReactionClick = ongoingCallViewModel::onReactionClick,
+        participants = ongoingCallViewModel.state.participants,
         inPictureInPictureMode = inPictureInPictureMode,
-        recentReactions = sharedCallingViewModel.recentReactions,
+        recentReactions = ongoingCallViewModel.recentReactions,
         callQuality = ongoingCallViewModel.state.callQualityData.quality,
         onOpenCallDetails = {
             callDetailsBottomSheetState.show(CallDetailsSheetState.Details)

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallState.kt
@@ -17,11 +17,18 @@
  */
 package com.wire.android.ui.calling.ongoing
 
+import com.wire.android.ui.calling.model.UICallParticipant
+import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
 import com.wire.kalium.logic.data.call.CallQualityData
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 
 data class OngoingCallState(
     val flowState: FlowState = FlowState.Default,
+    val participants: PersistentList<UICallParticipant> = persistentListOf(),
+    val selectedParticipant: SelectedParticipant = SelectedParticipant(),
     val callQualityData: CallQualityData = CallQualityData(),
+    val shouldShowDoubleTapToast: Boolean = false,
 ) {
     sealed interface FlowState {
         object Default : FlowState

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -20,6 +20,7 @@ package com.wire.android.ui.calling.ongoing
 
 import android.os.CountDownTimer
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
@@ -27,55 +28,91 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.CurrentAccount
+import com.wire.android.mapper.UICallParticipantMapper
+import com.wire.android.ui.calling.model.InCallReaction
+import com.wire.android.ui.calling.model.ReactionSender
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
+import com.wire.android.ui.calling.ongoing.incallreactions.InCallReactions
+import com.wire.android.util.ExpiringMap
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.extension.withDelayAfterFirst
+import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.call.CallResolutionQuality
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.ObserveCallQualityDataUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveLastActiveCallWithSortedParticipantsUseCase
 import com.wire.kalium.logic.feature.call.usecase.RequestVideoStreamsUseCase
 import com.wire.kalium.logic.feature.call.usecase.SetCallQualityIntervalUseCase
 import com.wire.kalium.logic.feature.call.usecase.video.SetVideoSendStateUseCase
+import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
+import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel(assistedFactory = OngoingCallViewModel.Factory::class)
 class OngoingCallViewModel @AssistedInject constructor(
-    @Assisted
-    val conversationId: ConversationId,
-    @CurrentAccount
-    val currentUserId: UserId,
+    @Assisted val conversationId: ConversationId,
+    @CurrentAccount val currentUserId: UserId,
     private val globalDataStore: GlobalDataStore,
     private val observeLastActiveCall: ObserveLastActiveCallWithSortedParticipantsUseCase,
     private val requestVideoStreams: RequestVideoStreamsUseCase,
     private val setVideoSendState: SetVideoSendStateUseCase,
     private val observeCallQualityData: ObserveCallQualityDataUseCase,
     private val setCallQualityInterval: SetCallQualityIntervalUseCase,
+    private val getCurrentClientId: ObserveCurrentClientIdUseCase,
+    private val observeInCallReactionsUseCase: ObserveInCallReactionsUseCase,
+    private val sendInCallReactionUseCase: SendInCallReactionUseCase,
+    private val uiCallParticipantMapper: UICallParticipantMapper,
+    private val dispatchers: DispatcherProvider
 ) : ViewModel() {
-    var shouldShowDoubleTapToast: Boolean by mutableStateOf(false)
-        private set
     private var doubleTapIndicatorCountDownTimer: CountDownTimer? = null
 
     var state by mutableStateOf(OngoingCallState())
         private set
-    var selectedParticipant by mutableStateOf(SelectedParticipant())
-        private set
+
+    private val _inCallReactions = Channel<InCallReaction>(
+        capacity = 300, // Max reactions to keep in queue
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val inCallReactions = _inCallReactions.receiveAsFlow().withDelayAfterFirst(InCallReactions.reactionsThrottleDelayMs)
+    val recentReactions = recentInCallReactionMap()
 
     init {
-        observeCurrentCallFlowState()
-        observeCallQuality()
-        showDoubleTapToast()
+        viewModelScope.launch {
+            val callSharedFlow = observeLastActiveCall(conversationId)
+                .flowOn(dispatchers.default()).shareIn(this, started = SharingStarted.Lazily)
+
+            observeCurrentCallFlowState(callSharedFlow)
+            observeParticipants(callSharedFlow)
+            observeInCallReactions()
+            observeCallQuality()
+            showDoubleTapToast()
+        }
     }
 
     fun startSendingVideoFeed() {
@@ -96,9 +133,9 @@ class OngoingCallViewModel @AssistedInject constructor(
         }
     }
 
-    private fun observeCurrentCallFlowState() {
+    private fun observeCurrentCallFlowState(sharedFlow: SharedFlow<Call?>) {
         viewModelScope.launch {
-            observeLastActiveCall(conversationId)
+            sharedFlow
                 .map { it != null }
                 .distinctUntilChanged()
                 .map { isActive ->
@@ -120,6 +157,57 @@ class OngoingCallViewModel @AssistedInject constructor(
             }
         }
     }
+
+    private fun observeParticipants(sharedFlow: SharedFlow<Call?>) {
+        viewModelScope.launch {
+            combine(
+                getCurrentClientId().filterNotNull(),
+                sharedFlow.filterNotNull(),
+            ) { clientId, call ->
+                call.participants.map {
+                    uiCallParticipantMapper.toUICallParticipant(it, clientId)
+                }.toPersistentList()
+            }.collectLatest {
+                state = state.copy(participants = it)
+            }
+        }
+    }
+
+    private fun observeInCallReactions() {
+        viewModelScope.launch {
+            observeInCallReactionsUseCase(conversationId).collect { message ->
+
+                val sender = state.participants.senderName(message.senderUserId)?.let { name ->
+                    ReactionSender.Other(name)
+                } ?: ReactionSender.Unknown
+
+                message.emojis.forEach { emoji ->
+                    _inCallReactions.send(InCallReaction(emoji, sender))
+                }
+
+                if (message.emojis.isNotEmpty()) {
+                    recentReactions[message.senderUserId] = message.emojis.last()
+                }
+            }
+        }
+    }
+
+    fun onReactionClick(emoji: String) {
+        viewModelScope.launch {
+            sendInCallReactionUseCase(conversationId, emoji).toEither()
+                .onSuccess {
+                    _inCallReactions.send(InCallReaction(emoji, ReactionSender.You))
+                    recentReactions[currentUserId] = emoji
+                }
+        }
+    }
+
+    private fun recentInCallReactionMap(): MutableMap<UserId, String> =
+        ExpiringMap<UserId, String>(
+            scope = viewModelScope,
+            expirationMs = InCallReactions.recentReactionShowDurationMs,
+            delegate = mutableStateMapOf<UserId, String>()
+        )
 
     fun requestVideoStreams(participants: List<UICallParticipant>) {
         viewModelScope.launch {
@@ -143,7 +231,7 @@ class OngoingCallViewModel @AssistedInject constructor(
     }
 
     private fun mapQualityStream(uiParticipant: UICallParticipant): CallResolutionQuality {
-        return if (uiParticipant.clientId == selectedParticipant.clientId) {
+        return if (uiParticipant.clientId == state.selectedParticipant.clientId) {
             CallResolutionQuality.HIGH
         } else {
             CallResolutionQuality.LOW
@@ -159,7 +247,7 @@ class OngoingCallViewModel @AssistedInject constructor(
                 }
 
                 override fun onFinish() {
-                    shouldShowDoubleTapToast = false
+                    state = state.copy(shouldShowDoubleTapToast = false)
                     viewModelScope.launch {
                         globalDataStore.setShouldShowDoubleTapToastStatus(
                             currentUserId.toString(),
@@ -174,16 +262,15 @@ class OngoingCallViewModel @AssistedInject constructor(
     private fun showDoubleTapToast() {
         viewModelScope.launch {
             delay(DELAY_TO_SHOW_DOUBLE_TAP_TOAST)
-            shouldShowDoubleTapToast =
-                globalDataStore.getShouldShowDoubleTapToast(currentUserId.toString())
-            if (shouldShowDoubleTapToast) {
+            state = state.copy(shouldShowDoubleTapToast = globalDataStore.getShouldShowDoubleTapToast(currentUserId.toString()))
+            if (state.shouldShowDoubleTapToast) {
                 startDoubleTapToastDisplayCountDown()
             }
         }
     }
 
     fun hideDoubleTapToast() {
-        shouldShowDoubleTapToast = false
+        state = state.copy(shouldShowDoubleTapToast = false)
         viewModelScope.launch {
             globalDataStore.setShouldShowDoubleTapToastStatus(currentUserId.toString(), false)
         }
@@ -191,7 +278,7 @@ class OngoingCallViewModel @AssistedInject constructor(
 
     fun onSelectedParticipant(selectedParticipant: SelectedParticipant) {
         appLogger.d("$TAG - Selected participant: ${selectedParticipant.toLogString()}")
-        this.selectedParticipant = selectedParticipant
+        state = state.copy(selectedParticipant = selectedParticipant)
     }
 
     fun setQualityInterval(interval: QualityInterval) {
@@ -218,3 +305,5 @@ class OngoingCallViewModel @AssistedInject constructor(
         fun create(conversationId: ConversationId): OngoingCallViewModel
     }
 }
+
+private fun List<UICallParticipant>.senderName(userId: QualifiedID) = firstOrNull { it.id.value == userId.value }?.name

--- a/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
@@ -18,49 +18,72 @@
 
 package com.wire.android.ui.calling
 
+import app.cash.turbine.test
+import com.wire.android.assertIs
+import com.wire.android.assertions.shouldBeEqualTo
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.framework.TestUser
+import com.wire.android.mapper.UICallParticipantMapper
+import com.wire.android.mapper.UserTypeMapper
+import com.wire.android.ui.calling.model.ReactionSender
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.ongoing.OngoingCallState
 import com.wire.android.ui.calling.ongoing.OngoingCallViewModel
 import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
 import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.call.CallQualityData
 import com.wire.kalium.logic.data.call.CallResolutionQuality
 import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.call.InCallReactionMessage
+import com.wire.kalium.logic.data.call.Participant
 import com.wire.kalium.logic.data.call.VideoState
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.data.user.type.UserTypeInfo
 import com.wire.kalium.logic.feature.call.usecase.ObserveCallQualityDataUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveLastActiveCallWithSortedParticipantsUseCase
 import com.wire.kalium.logic.feature.call.usecase.RequestVideoStreamsUseCase
 import com.wire.kalium.logic.feature.call.usecase.SetCallQualityIntervalUseCase
 import com.wire.kalium.logic.feature.call.usecase.video.SetVideoSendStateUseCase
+import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
+import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
+import com.wire.kalium.logic.feature.message.MessageOperationResult
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
 class OngoingCallViewModelTest {
+    private val dispatchers = TestDispatcherProvider()
 
     @Test
-    fun givenAnOngoingCall_WhenTurningOnCamera_ThenSetVideoSendStateToStarted() = runTest {
+    fun givenAnOngoingCall_WhenTurningOnCamera_ThenSetVideoSendStateToStarted() = runTest(dispatchers.main()) {
         val (arrangement, ongoingCallViewModel) = Arrangement()
             .withLastActiveCall(provideCall())
             .withShouldShowDoubleTapToastReturning(false)
@@ -73,7 +96,7 @@ class OngoingCallViewModelTest {
     }
 
     @Test
-    fun givenAnOngoingCall_WhenTurningOffCamera_ThenSetVideoSendStateToStopped() = runTest {
+    fun givenAnOngoingCall_WhenTurningOffCamera_ThenSetVideoSendStateToStopped() = runTest(dispatchers.main()) {
         val (arrangement, ongoingCallViewModel) = Arrangement()
             .withLastActiveCall(provideCall())
             .withShouldShowDoubleTapToastReturning(false)
@@ -87,10 +110,10 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenParticipantsList_WhenRequestingVideoStream_ThenRequestItForOnlyParticipantsWithVideoEnabled() =
-        runTest {
+        runTest(dispatchers.main()) {
             val expectedClients = listOf(
-                CallClient(participant1.id.toString(), participant1.clientId),
-                CallClient(participant3.id.toString(), participant3.clientId)
+                CallClient(uiParticipant1.id.toString(), uiParticipant1.clientId),
+                CallClient(uiParticipant3.id.toString(), uiParticipant3.clientId)
             )
 
             val (arrangement, ongoingCallViewModel) = Arrangement()
@@ -100,7 +123,7 @@ class OngoingCallViewModelTest {
                 .withRequestVideoStreams(conversationId, expectedClients)
                 .arrange()
 
-            ongoingCallViewModel.requestVideoStreams(participants)
+            ongoingCallViewModel.requestVideoStreams(uiParticipants)
 
             coVerify(exactly = 1) {
                 arrangement.requestVideoStreams(
@@ -111,7 +134,7 @@ class OngoingCallViewModelTest {
         }
 
     @Test
-    fun givenDoubleTabIndicatorIsDisplayed_whenUserTapsOnIt_thenHideIt() = runTest {
+    fun givenDoubleTabIndicatorIsDisplayed_whenUserTapsOnIt_thenHideIt() = runTest(dispatchers.main()) {
         val (arrangement, ongoingCallViewModel) = Arrangement()
             .withLastActiveCall(provideCall())
             .withShouldShowDoubleTapToastReturning(false)
@@ -121,7 +144,7 @@ class OngoingCallViewModelTest {
 
         ongoingCallViewModel.hideDoubleTapToast()
 
-        assertEquals(false, ongoingCallViewModel.shouldShowDoubleTapToast)
+        assertEquals(false, ongoingCallViewModel.state.shouldShowDoubleTapToast)
         coVerify(exactly = 1) {
             arrangement.globalDataStore.setShouldShowDoubleTapToastStatus(
                 currentUserId.toString(),
@@ -132,7 +155,7 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenSetVideoSendStateUseCase_whenStartSendingVideoFeedIsCalled_thenInvokeUseCaseWithStartedStateOnce() =
-        runTest {
+        runTest(dispatchers.main()) {
             val (arrangement, ongoingCallViewModel) = Arrangement()
                 .withLastActiveCall(provideCall())
                 .withShouldShowDoubleTapToastReturning(false)
@@ -148,7 +171,7 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenSetVideoSendStateUseCase_whenPauseSendingVideoFeedIsCalled_thenInvokeUseCaseWithPausedStateOnce() =
-        runTest {
+        runTest(dispatchers.main()) {
             val (arrangement, ongoingCallViewModel) = Arrangement()
                 .withLastActiveCall(provideCall())
                 .withShouldShowDoubleTapToastReturning(false)
@@ -164,7 +187,7 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenSetVideoSendStateUseCase_whenStopSendingVideoFeedIsCalled_thenInvokeUseCaseWithStoppedState() =
-        runTest {
+        runTest(dispatchers.main()) {
             val (arrangement, ongoingCallViewModel) = Arrangement()
                 .withLastActiveCall(provideCall().copy(isCameraOn = true))
                 .withShouldShowDoubleTapToastReturning(false)
@@ -180,7 +203,7 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenAUserIsSelected_whenRequestedFullScreen_thenSetTheUserAsSelected() =
-        runTest {
+        runTest(dispatchers.main()) {
             val (_, ongoingCallViewModel) = Arrangement()
                 .withLastActiveCall(provideCall().copy(isCameraOn = true))
                 .withShouldShowDoubleTapToastReturning(false)
@@ -189,15 +212,15 @@ class OngoingCallViewModelTest {
 
             ongoingCallViewModel.onSelectedParticipant(selectedParticipant3)
 
-            assertEquals(selectedParticipant3, ongoingCallViewModel.selectedParticipant)
+            assertEquals(selectedParticipant3, ongoingCallViewModel.state.selectedParticipant)
         }
 
     @Test
     fun givenParticipantsList_WhenRequestingVideoStreamForFullScreenParticipant_ThenRequestItInHighQuality() =
-        runTest {
+        runTest(dispatchers.main()) {
             val expectedClients = listOf(
-                CallClient(participant1.id.toString(), participant1.clientId, false, CallResolutionQuality.LOW),
-                CallClient(participant3.id.toString(), participant3.clientId, false, CallResolutionQuality.HIGH)
+                CallClient(uiParticipant1.id.toString(), uiParticipant1.clientId, false, CallResolutionQuality.LOW),
+                CallClient(uiParticipant3.id.toString(), uiParticipant3.clientId, false, CallResolutionQuality.HIGH)
             )
 
             val (arrangement, ongoingCallViewModel) = Arrangement()
@@ -208,7 +231,7 @@ class OngoingCallViewModelTest {
                 .arrange()
 
             ongoingCallViewModel.onSelectedParticipant(selectedParticipant3)
-            ongoingCallViewModel.requestVideoStreams(participants)
+            ongoingCallViewModel.requestVideoStreams(uiParticipants)
 
             coVerify(exactly = 1) {
                 arrangement.requestVideoStreams(
@@ -220,10 +243,10 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenParticipantsList_WhenRequestingVideoStreamForAllParticipant_ThenRequestItInLowQuality() =
-        runTest {
+        runTest(dispatchers.main()) {
             val expectedClients = listOf(
-                CallClient(participant1.id.toString(), participant1.clientId, false, CallResolutionQuality.LOW),
-                CallClient(participant3.id.toString(), participant3.clientId, false, CallResolutionQuality.LOW)
+                CallClient(uiParticipant1.id.toString(), uiParticipant1.clientId, false, CallResolutionQuality.LOW),
+                CallClient(uiParticipant3.id.toString(), uiParticipant3.clientId, false, CallResolutionQuality.LOW)
             )
 
             val (arrangement, ongoingCallViewModel) = Arrangement()
@@ -234,7 +257,7 @@ class OngoingCallViewModelTest {
                 .arrange()
 
             ongoingCallViewModel.onSelectedParticipant(SelectedParticipant())
-            ongoingCallViewModel.requestVideoStreams(participants)
+            ongoingCallViewModel.requestVideoStreams(uiParticipants)
 
             coVerify(exactly = 1) {
                 arrangement.requestVideoStreams(
@@ -245,7 +268,7 @@ class OngoingCallViewModelTest {
         }
 
     @Test
-    fun givenActiveOngoingCall_WhenObservingState_ThenStateShouldBeSetToDefault() = runTest {
+    fun givenActiveOngoingCall_WhenObservingState_ThenStateShouldBeSetToDefault() = runTest(dispatchers.main()) {
         val (_, ongoingCallViewModel) = Arrangement()
             .withLastActiveCall(provideCall())
             .withShouldShowDoubleTapToastReturning(false)
@@ -257,7 +280,7 @@ class OngoingCallViewModelTest {
     }
 
     @Test
-    fun givenClosedOngoingCall_WhenObservingState_ThenStateShouldBeSetToCallClosed() = runTest {
+    fun givenClosedOngoingCall_WhenObservingState_ThenStateShouldBeSetToCallClosed() = runTest(dispatchers.main()) {
         val (_, ongoingCallViewModel) = Arrangement()
             .withNoLastActiveCall()
             .withShouldShowDoubleTapToastReturning(false)
@@ -269,7 +292,7 @@ class OngoingCallViewModelTest {
     }
 
     @Test
-    fun givenCallQualityChanges_WhenObservingQualityState_ThenStateIsUpdated() = runTest {
+    fun givenCallQualityChanges_WhenObservingQualityState_ThenStateIsUpdated() = runTest(dispatchers.main()) {
         val initialQuality = CallQualityData(quality = CallQualityData.Quality.NORMAL, ping = 0)
         val callQualityFlow = MutableStateFlow(initialQuality)
         val (_, ongoingCallViewModel) = Arrangement()
@@ -288,7 +311,7 @@ class OngoingCallViewModelTest {
     }
 
     @Test
-    fun givenCall_WhenChangingCallQualityInterval_ThenSetIntervalProperly() = runTest {
+    fun givenCall_WhenChangingCallQualityInterval_ThenSetIntervalProperly() = runTest(dispatchers.main()) {
         val (arrangement, ongoingCallViewModel) = Arrangement()
             .withLastActiveCall(provideCall())
             .withShouldShowDoubleTapToastReturning(false)
@@ -303,7 +326,147 @@ class OngoingCallViewModelTest {
         }
     }
 
-    private class Arrangement {
+    @Test
+    fun givenAnOngoingCall_WhenInCallReactionIsReceived_ThenNewEmojiIsEmitted() = runTest(dispatchers.main()) {
+        val (arrangement, ongoingCallViewModel) = Arrangement().arrange()
+
+        ongoingCallViewModel.inCallReactions.test {
+
+            // when
+            arrangement.reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍", "🎉")))
+
+            val reaction1 = awaitItem()
+            val reaction2 = awaitItem()
+
+            // then
+            assertEquals("👍", reaction1.emoji)
+            assertIs<ReactionSender.Unknown>(reaction1.sender)
+            assertEquals("🎉", reaction2.emoji)
+            assertIs<ReactionSender.Unknown>(reaction2.sender)
+        }
+    }
+
+    @Test
+    fun givenAnOngoingCall_WhenInCallReactionIsReceived_ThenNewRecentReactionEmitted() = runTest(dispatchers.main()) {
+        val (arrangement, ongoingCallViewModel) = Arrangement().arrange()
+
+        // when
+        arrangement.reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍")))
+
+        val recentReaction = ongoingCallViewModel.recentReactions.getValue(TestUser.USER_ID)
+
+        // then
+        assertEquals("👍", recentReaction)
+    }
+
+    @Test
+    fun givenAnOngoingCall_WhenNewInCallReactionIsReceived_ThenRecentReactionUpdated() = runTest(dispatchers.main()) {
+        val (arrangement, ongoingCallViewModel) = Arrangement().arrange()
+
+        // when
+        arrangement.reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍", "🎉")))
+
+        val recentReaction = ongoingCallViewModel.recentReactions.getValue(TestUser.USER_ID)
+
+        // then
+        assertEquals("🎉", recentReaction)
+    }
+
+    @Test
+    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenReactionMessageIsSent() = runTest(dispatchers.main()) {
+
+        // given
+        val (arrangement, ongoingCallViewModel) = Arrangement()
+            .withSendInCallReactionUseCaseReturning(MessageOperationResult.Success)
+            .arrange()
+
+        // when
+        ongoingCallViewModel.onReactionClick("👍")
+
+        // then
+        coVerify(exactly = 1) {
+            arrangement.sendInCallReactionUseCase(conversationId, "👍")
+        }
+    }
+
+    @Test
+    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenNewEmojiIsEmitted() = runTest(dispatchers.main()) {
+
+        // given
+        val (_, ongoingCallViewModel) = Arrangement()
+            .withSendInCallReactionUseCaseReturning(MessageOperationResult.Success)
+            .arrange()
+
+        ongoingCallViewModel.inCallReactions.test {
+            // when
+            ongoingCallViewModel.onReactionClick("👍")
+
+            val reaction = awaitItem()
+
+            // then
+            assertEquals("👍", reaction.emoji)
+            assertIs<ReactionSender.You>(reaction.sender)
+        }
+    }
+
+    @Test
+    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenReactionMessageIsSentAndAddedToRecentReactions() =
+        runTest(dispatchers.main()) {
+
+            // given
+            val (arrangement, ongoingCallViewModel) = Arrangement()
+                .withSendInCallReactionUseCaseReturning(MessageOperationResult.Success)
+                .arrange()
+
+            // when
+            ongoingCallViewModel.onReactionClick("👌")
+
+            // then
+            coVerify(exactly = 1) {
+                arrangement.sendInCallReactionUseCase(conversationId, "👌")
+            }
+            assertTrue(ongoingCallViewModel.recentReactions.containsValue("👌"))
+        }
+
+    @Test
+    fun givenAnOngoingCall_WhenInCallReactionSentFails_ThenNoEmojiIsEmitted() = runTest(dispatchers.main()) {
+        // given
+        val (_, ongoingCallViewModel) = Arrangement()
+            .withSendInCallReactionUseCaseReturning(
+                MessageOperationResult.Failure(
+                    NetworkFailure.NoNetworkConnection(
+                        IllegalStateException()
+                    )
+                )
+            )
+            .arrange()
+
+        ongoingCallViewModel.inCallReactions.test {
+            // when
+            ongoingCallViewModel.onReactionClick("👍")
+
+            // then
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun givenActiveCall_whenParticipantsChange_thenParticipantsStateIsUpdated() = runTest(dispatchers.main()) {
+        val callFlow = MutableSharedFlow<Call?>()
+        val (_, ongoingCallViewModel) = Arrangement()
+            .withLastActiveCallFlow(callFlow)
+            .arrange()
+
+        callFlow.emit(provideCall().copy(status = CallStatus.ANSWERED, participants = emptyList()))
+        advanceUntilIdle()
+        ongoingCallViewModel.state.participants shouldBeEqualTo persistentListOf()
+
+        callFlow.emit(provideCall().copy(status = CallStatus.ESTABLISHED, participants = participants))
+        advanceUntilIdle()
+        ongoingCallViewModel.state.participants shouldBeEqualTo uiParticipants.toPersistentList()
+    }
+
+    private inner class Arrangement {
 
         @MockK
         private lateinit var observeLastActiveCall: ObserveLastActiveCallWithSortedParticipantsUseCase
@@ -321,7 +484,18 @@ class OngoingCallViewModelTest {
         lateinit var setCallQualityInterval: SetCallQualityIntervalUseCase
 
         @MockK
+        lateinit var observeInCallReactionsUseCase: ObserveInCallReactionsUseCase
+
+        @MockK
+        lateinit var sendInCallReactionUseCase: SendInCallReactionUseCase
+
+        @MockK
+        lateinit var getCurrentClientId: ObserveCurrentClientIdUseCase
+
+        @MockK
         lateinit var globalDataStore: GlobalDataStore
+
+        val reactionsFlow = MutableSharedFlow<InCallReactionMessage>()
 
         private val ongoingCallViewModel by lazy {
             OngoingCallViewModel(
@@ -332,7 +506,12 @@ class OngoingCallViewModelTest {
                 setVideoSendState = setVideoSendState,
                 globalDataStore = globalDataStore,
                 observeCallQualityData = observeCallQualityData,
-                setCallQualityInterval = setCallQualityInterval
+                setCallQualityInterval = setCallQualityInterval,
+                observeInCallReactionsUseCase = observeInCallReactionsUseCase,
+                sendInCallReactionUseCase = sendInCallReactionUseCase,
+                getCurrentClientId = getCurrentClientId,
+                uiCallParticipantMapper = UICallParticipantMapper(UserTypeMapper()),
+                dispatchers = dispatchers
             )
         }
 
@@ -340,6 +519,9 @@ class OngoingCallViewModelTest {
             MockKAnnotations.init(this)
             coEvery { observeCallQualityData(any()) } returns emptyFlow()
             coEvery { setCallQualityInterval(any()) } returns Unit
+            coEvery { observeInCallReactionsUseCase(any()) } returns reactionsFlow
+            coEvery { getCurrentClientId() } returns flowOf(currentClientId)
+            coEvery { observeLastActiveCall.invoke(any()) } returns emptyFlow()
         }
 
         fun arrange() = this to ongoingCallViewModel
@@ -350,6 +532,10 @@ class OngoingCallViewModelTest {
 
         fun withLastActiveCall(call: Call) = apply {
             coEvery { observeLastActiveCall(any()) } returns flowOf(call)
+        }
+
+        fun withLastActiveCallFlow(callFlow: Flow<Call?>) = apply {
+            coEvery { observeLastActiveCall(any()) } returns callFlow
         }
 
         fun withShouldShowDoubleTapToastReturning(shouldShow: Boolean) = apply {
@@ -377,52 +563,54 @@ class OngoingCallViewModelTest {
         fun withCallQualityDataFlow(callQualityDataFlow: Flow<CallQualityData>) = apply {
             coEvery { observeCallQualityData(any()) } returns callQualityDataFlow
         }
+
+        fun withSendInCallReactionUseCaseReturning(result: MessageOperationResult) = apply {
+            coEvery { sendInCallReactionUseCase(conversationId, any()) } returns result
+        }
     }
 
     companion object {
         val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
         val currentUserId = UserId("userId", "some.dummy.domain")
-        private val participant1 = UICallParticipant(
-            id = QualifiedID("value1", "domain"),
-            clientId = "client-id1",
-            isSelfUser = false,
-            name = "name1",
-            isMuted = false,
-            isSpeaking = false,
-            isCameraOn = true,
-            isSharingScreen = false,
-            membership = Membership.None,
-            hasEstablishedAudio = true,
-            accentId = -1
-        )
-        private val participant2 = UICallParticipant(
-            id = QualifiedID("value2", "domain"),
-            clientId = "client-id2",
-            isSelfUser = false,
-            name = "name2",
-            isMuted = false,
-            isSpeaking = false,
-            isCameraOn = false,
-            isSharingScreen = false,
-            membership = Membership.None,
-            hasEstablishedAudio = true,
-            accentId = -1
-        )
-        private val participant3 = UICallParticipant(
-            id = QualifiedID("value3", "domain"),
-            clientId = "client-id3",
-            isSelfUser = false,
-            name = "name3",
-            isMuted = false,
-            isSpeaking = false,
-            isCameraOn = true,
-            isSharingScreen = true,
-            membership = Membership.None,
-            hasEstablishedAudio = true,
-            accentId = -1
-        )
+        private val currentClientId = ClientId("current_client_id")
+        private val uiParticipant1 = provideUICallParticipant(index = 1, isSelfUser = false, isCameraOn = true, isSharingScreen = false)
+        private val uiParticipant2 = provideUICallParticipant(index = 2, isSelfUser = false, isCameraOn = false, isSharingScreen = false)
+        private val uiParticipant3 = provideUICallParticipant(index = 3, isSelfUser = false, isCameraOn = true, isSharingScreen = true)
+        private val participant1 = provideParticipant(index = 1, isCameraOn = true, isSharingScreen = false)
+        private val participant2 = provideParticipant(index = 2, isCameraOn = false, isSharingScreen = false)
+        private val participant3 = provideParticipant(index = 3, isCameraOn = true, isSharingScreen = true)
+        val uiParticipants = listOf(uiParticipant1, uiParticipant2, uiParticipant3)
         val participants = listOf(participant1, participant2, participant3)
-        val selectedParticipant3 = SelectedParticipant(participant3.id, participant3.clientId, false)
+        val selectedParticipant3 = SelectedParticipant(uiParticipant3.id, uiParticipant3.clientId, false)
+
+        fun provideUICallParticipant(index: Int, isSelfUser: Boolean, isCameraOn: Boolean, isSharingScreen: Boolean) = UICallParticipant(
+            id = QualifiedID("value$index", "domain"),
+            clientId = "client-id$index",
+            name = "name$index",
+            isMuted = false,
+            isCameraOn = isCameraOn,
+            hasEstablishedAudio = true,
+            isSpeaking = false,
+            isSharingScreen = isSharingScreen,
+            avatar = null,
+            membership = Membership.None,
+            isSelfUser = isSelfUser,
+            accentId = -1
+        )
+
+        fun provideParticipant(index: Int, isCameraOn: Boolean, isSharingScreen: Boolean) = Participant(
+            id = QualifiedID("value$index", "domain"),
+            clientId = "client-id$index",
+            name = "name$index",
+            isMuted = false,
+            isCameraOn = isCameraOn,
+            hasEstablishedAudio = true,
+            isSpeaking = false,
+            isSharingScreen = isSharingScreen,
+            avatarAssetId = null,
+            userType = UserTypeInfo.Regular(UserType.NONE),
+            accentId = -1
+        )
     }
 
     private fun provideCall(

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -21,22 +21,17 @@ package com.wire.android.ui.calling
 import android.view.Surface
 import android.view.View
 import app.cash.turbine.test
-import com.wire.android.assertIs
 import com.wire.android.assertions.shouldBeEqualTo
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.TestUser
-import com.wire.android.mapper.UICallParticipantMapper
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.ui.calling.common.SharedCallingViewActions
 import com.wire.android.ui.calling.common.SharedCallingViewModel
-import com.wire.android.ui.calling.model.ReactionSender
 import com.wire.android.ui.calling.usecase.HangUpCallUseCase
-import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallStatus
-import com.wire.kalium.logic.data.call.InCallReactionMessage
 import com.wire.kalium.logic.data.call.Participant
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -47,7 +42,6 @@ import com.wire.kalium.logic.data.user.type.UserTypeInfo
 import com.wire.kalium.logic.feature.call.usecase.FlipToBackCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.FlipToFrontCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
-import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveLastActiveCallWithSortedParticipantsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveSpeakerUseCase
 import com.wire.kalium.logic.feature.call.usecase.SetUIRotationUseCase
@@ -56,23 +50,17 @@ import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
-import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
-import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
-import com.wire.kalium.logic.feature.message.MessageOperationResult
 import com.wire.kalium.logic.util.PlatformRotation
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -223,144 +211,18 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsReceived_ThenNewEmojiIsEmitted() = runTest(dispatchers.main()) {
-        val (arrangement, sharedCallingViewModel) = Arrangement().arrange()
-
-        sharedCallingViewModel.inCallReactions.test {
-
-            // when
-            arrangement.reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍", "🎉")))
-
-            val reaction1 = awaitItem()
-            val reaction2 = awaitItem()
-
-            // then
-            assertEquals("👍", reaction1.emoji)
-            assertIs<ReactionSender.Unknown>(reaction1.sender)
-            assertEquals("🎉", reaction2.emoji)
-            assertIs<ReactionSender.Unknown>(reaction2.sender)
-        }
-    }
-
-    @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsReceived_ThenNewRecentReactionEmitted() = runTest(dispatchers.main()) {
-        val (arrangement, sharedCallingViewModel) = Arrangement().arrange()
-
-        // when
-        arrangement.reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍")))
-
-        val recentReaction = sharedCallingViewModel.recentReactions.getValue(TestUser.USER_ID)
-
-        // then
-        assertEquals("👍", recentReaction)
-    }
-
-    @Test
-    fun givenAnOngoingCall_WhenNewInCallReactionIsReceived_ThenRecentReactionUpdated() = runTest(dispatchers.main()) {
-        val (arrangement, sharedCallingViewModel) = Arrangement().arrange()
-
-        // when
-        arrangement.reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍", "🎉")))
-
-        val recentReaction = sharedCallingViewModel.recentReactions.getValue(TestUser.USER_ID)
-
-        // then
-        assertEquals("🎉", recentReaction)
-    }
-
-    @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenReactionMessageIsSent() = runTest(dispatchers.main()) {
-
-        // given
-        val (arrangement, sharedCallingViewModel) = Arrangement().arrange()
-
-        // when
-        sharedCallingViewModel.onReactionClick("👍")
-
-        // then
-        coVerify(exactly = 1) {
-            arrangement.sendInCallReactionUseCase(OngoingCallViewModelTest.conversationId, "👍")
-        }
-    }
-
-    @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenNewEmojiIsEmitted() = runTest(dispatchers.main()) {
-
-        // given
-        val (_, sharedCallingViewModel) = Arrangement()
-            .withSendInCallReactionUseCaseReturning(MessageOperationResult.Success)
-            .arrange()
-
-        sharedCallingViewModel.inCallReactions.test {
-            // when
-            sharedCallingViewModel.onReactionClick("👍")
-
-            val reaction = awaitItem()
-
-            // then
-            assertEquals("👍", reaction.emoji)
-            assertIs<ReactionSender.You>(reaction.sender)
-        }
-    }
-
-    @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenReactionMessageIsSentAndAddedToRecentReactions() =
-        runTest(dispatchers.main()) {
-
-            // given
-            val (arrangement, sharedCallingViewModel) = Arrangement()
-                .withSendInCallReactionUseCaseReturning(MessageOperationResult.Success)
-                .arrange()
-
-            // when
-            sharedCallingViewModel.onReactionClick("👌")
-
-            // then
-            coVerify(exactly = 1) {
-                arrangement.sendInCallReactionUseCase(OngoingCallViewModelTest.conversationId, "👌")
-            }
-            assertTrue(sharedCallingViewModel.recentReactions.containsValue("👌"))
-        }
-
-    @Test
-    fun givenAnOngoingCall_WhenInCallReactionSentFails_ThenNoEmojiIsEmitted() = runTest(dispatchers.main()) {
-        // given
-        val (_, sharedCallingViewModel) = Arrangement()
-            .withSendInCallReactionUseCaseReturning(
-                MessageOperationResult.Failure(
-                    NetworkFailure.NoNetworkConnection(
-                        IllegalStateException()
-                    )
-                )
-            )
-            .arrange()
-
-        sharedCallingViewModel.inCallReactions.test {
-            // when
-            sharedCallingViewModel.onReactionClick("👍")
-
-            // then
-            expectNoEvents()
-        }
-    }
-
-    @Test
-    fun givenActiveCall_whenCallStateChanges_thenCallAndParticipantStatesAreUpdated() = runTest(dispatchers.main()) {
+    fun givenActiveCall_whenCallStateChanges_thenCallStateIsUpdated() = runTest(dispatchers.main()) {
         val (arrangement, sharedCallingViewModel) = Arrangement().arrange()
 
         arrangement.callFlow.emit(call.copy(status = CallStatus.ANSWERED, participants = emptyList()))
         advanceUntilIdle()
         sharedCallingViewModel.callState.conversationId shouldBeEqualTo call.conversationId
         sharedCallingViewModel.callState.callStatus shouldBeEqualTo CallStatus.ANSWERED
-        sharedCallingViewModel.participantsState shouldBeEqualTo persistentListOf()
 
         arrangement.callFlow.emit(call.copy(status = CallStatus.ESTABLISHED, participants = listOf(selfParticipant)))
         advanceUntilIdle()
         sharedCallingViewModel.callState.conversationId shouldBeEqualTo call.conversationId
         sharedCallingViewModel.callState.callStatus shouldBeEqualTo CallStatus.ESTABLISHED
-        sharedCallingViewModel.participantsState shouldBeEqualTo persistentListOf(
-            arrangement.uiCallParticipantMapper.toUICallParticipant(selfParticipant, ClientId(selfParticipant.clientId))
-        )
     }
 
     @Test
@@ -416,15 +278,6 @@ class SharedCallingViewModelTest {
         lateinit var observeSpeaker: ObserveSpeakerUseCase
 
         @MockK
-        lateinit var observeInCallReactionsUseCase: ObserveInCallReactionsUseCase
-
-        @MockK
-        lateinit var sendInCallReactionUseCase: SendInCallReactionUseCase
-
-        @MockK
-        lateinit var getCurrentClientId: ObserveCurrentClientIdUseCase
-
-        @MockK
         lateinit var setUIRotationUseCase: SetUIRotationUseCase
 
         @MockK
@@ -433,11 +286,6 @@ class SharedCallingViewModelTest {
         @MockK
         lateinit var userTypeMapper: UserTypeMapper
 
-        val uiCallParticipantMapper: UICallParticipantMapper by lazy {
-            UICallParticipantMapper(userTypeMapper)
-        }
-
-        val reactionsFlow = MutableSharedFlow<InCallReactionMessage>()
         val callFlow = MutableSharedFlow<Call?>()
 
         init {
@@ -445,13 +293,10 @@ class SharedCallingViewModelTest {
             coEvery { observeLastActiveCall.invoke(any()) } returns callFlow
             coEvery { observeConversationDetails.invoke(any()) } returns emptyFlow()
             coEvery { observeSpeaker.invoke() } returns emptyFlow()
-            coEvery { observeInCallReactionsUseCase(any()) } returns reactionsFlow
-            coEvery { getCurrentClientId() } returns flowOf(currentClientId)
         }
 
         fun arrange() = this to SharedCallingViewModel(
             conversationId = conversationId,
-            selfUserId = TestUser.SELF_USER_ID,
             conversationDetails = observeConversationDetails,
             observeLastActiveCallWithSortedParticipants = observeLastActiveCall,
             hangUpCall = hangUpCall,
@@ -465,17 +310,9 @@ class SharedCallingViewModelTest {
             turnLoudSpeakerOff = turnLoudSpeakerOff,
             turnLoudSpeakerOn = turnLoudSpeakerOn,
             observeSpeaker = observeSpeaker,
-            uiCallParticipantMapper = uiCallParticipantMapper,
             userTypeMapper = userTypeMapper,
-            observeInCallReactionsUseCase = observeInCallReactionsUseCase,
-            sendInCallReactionUseCase = sendInCallReactionUseCase,
-            getCurrentClientId = getCurrentClientId,
             dispatchers = dispatchers,
         )
-
-        fun withSendInCallReactionUseCaseReturning(result: MessageOperationResult) = apply {
-            coEvery { sendInCallReactionUseCase(conversationId, any()) } returns result
-        }
     }
 
     companion object {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23581
<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Currently, participants and reactions are part of SharedCallViewModel which isn't correct because both should be available only when the call is established. So we have participants list in SharedCallViewModel view model, but selected participant in OngoingCallViewModel. With that, it would be also hard to implement disabling videos because video handling is in OngoingCallViewModel, but participants list is in SharedCallViewModel. So we have logic related to only ongoing call spread into two ViewModels.
This PR moves participants and reactions to OngoingCallViewModel. Thanks to that, it will be easier to maintain logic for ongoing call and it will make it possible to easily implement logic of disabling videos.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
