### PR TITLE
feat: turn off others videos [WPB-23581]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/SharedCallingViewModel.kt
@@ -21,39 +21,26 @@ package com.wire.android.ui.calling.common
 import android.view.View
 import androidx.camera.core.impl.ImageOutputConfig.RotationValue
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
-import com.wire.android.di.CurrentAccount
-import com.wire.android.mapper.UICallParticipantMapper
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.calling.model.CallState
-import com.wire.android.ui.calling.model.InCallReaction
-import com.wire.android.ui.calling.model.ReactionSender
-import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.model.getConversationName
-import com.wire.android.ui.calling.ongoing.incallreactions.InCallReactions
 import com.wire.android.ui.calling.usecase.HangUpCallUseCase
 import com.wire.android.ui.common.ActionsViewModel
-import com.wire.android.util.ExpiringMap
 import com.wire.android.util.dispatchers.DispatcherProvider
-import com.wire.android.util.extension.withDelayAfterFirst
-import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.ConversationTypeForCall
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.QualifiedID
-import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.FlipToBackCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.FlipToFrontCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
-import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveLastActiveCallWithSortedParticipantsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveSpeakerUseCase
 import com.wire.kalium.logic.feature.call.usecase.SetUIRotationUseCase
@@ -62,29 +49,21 @@ import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
-import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
-import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
 import com.wire.kalium.logic.util.PlatformRotation
 import com.wire.kalium.logic.util.PlatformView
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 
@@ -92,7 +71,6 @@ import kotlinx.coroutines.launch
 @HiltViewModel(assistedFactory = SharedCallingViewModel.Factory::class)
 class SharedCallingViewModel @AssistedInject constructor(
     @Assisted val conversationId: ConversationId,
-    @CurrentAccount private val selfUserId: UserId,
     private val conversationDetails: ObserveConversationDetailsUseCase,
     private val observeLastActiveCallWithSortedParticipants: ObserveLastActiveCallWithSortedParticipantsUseCase,
     private val hangUpCall: HangUpCallUseCase,
@@ -106,26 +84,11 @@ class SharedCallingViewModel @AssistedInject constructor(
     private val flipToFrontCamera: FlipToFrontCameraUseCase,
     private val flipToBackCamera: FlipToBackCameraUseCase,
     private val observeSpeaker: ObserveSpeakerUseCase,
-    private val observeInCallReactionsUseCase: ObserveInCallReactionsUseCase,
-    private val sendInCallReactionUseCase: SendInCallReactionUseCase,
-    private val getCurrentClientId: ObserveCurrentClientIdUseCase,
-    private val uiCallParticipantMapper: UICallParticipantMapper,
     private val userTypeMapper: UserTypeMapper,
     private val dispatchers: DispatcherProvider
 ) : ActionsViewModel<SharedCallingViewActions>() {
 
     var callState by mutableStateOf(CallState(conversationId))
-
-    var participantsState by mutableStateOf(persistentListOf<UICallParticipant>())
-
-    private val _inCallReactions = Channel<InCallReaction>(
-        capacity = 300, // Max reactions to keep in queue
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
-
-    val inCallReactions = _inCallReactions.receiveAsFlow().withDelayAfterFirst(InCallReactions.reactionsThrottleDelayMs)
-
-    val recentReactions = recentInCallReactionMap()
 
     init {
         viewModelScope.launch {
@@ -139,13 +102,7 @@ class SharedCallingViewModel @AssistedInject constructor(
                 observeCallState(callSharedFlow)
             }
             launch {
-                observeParticipants(callSharedFlow)
-            }
-            launch {
                 observeOnSpeaker(this)
-            }
-            launch {
-                observeInCallReactions()
             }
         }
     }
@@ -209,19 +166,6 @@ class SharedCallingViewModel @AssistedInject constructor(
                     isCbrEnabled = call.isCbrEnabled && call.conversationType == Conversation.Type.OneOnOne
                 )
             }
-    }
-
-    private suspend fun observeParticipants(sharedFlow: SharedFlow<Call?>) {
-        combine(
-            getCurrentClientId().filterNotNull(),
-            sharedFlow.filterNotNull(),
-        ) { clientId, call ->
-            call.participants.map {
-                uiCallParticipantMapper.toUICallParticipant(it, clientId)
-            }.toPersistentList()
-        }.collectLatest {
-            participantsState = it
-        }
     }
 
     fun hangUpCall() {
@@ -309,47 +253,11 @@ class SharedCallingViewModel @AssistedInject constructor(
         }
     }
 
-    private suspend fun observeInCallReactions() {
-        observeInCallReactionsUseCase(conversationId).collect { message ->
-
-            val sender = participantsState.senderName(message.senderUserId)?.let { name ->
-                ReactionSender.Other(name)
-            } ?: ReactionSender.Unknown
-
-            message.emojis.forEach { emoji ->
-                _inCallReactions.send(InCallReaction(emoji, sender))
-            }
-
-            if (message.emojis.isNotEmpty()) {
-                recentReactions.put(message.senderUserId, message.emojis.last())
-            }
-        }
-    }
-
-    fun onReactionClick(emoji: String) {
-        viewModelScope.launch {
-            sendInCallReactionUseCase(conversationId, emoji).toEither()
-                .onSuccess {
-                    _inCallReactions.send(InCallReaction(emoji, ReactionSender.You))
-                    recentReactions[selfUserId] = emoji
-                }
-        }
-    }
-
-    private fun recentInCallReactionMap(): MutableMap<UserId, String> =
-        ExpiringMap<UserId, String>(
-            scope = viewModelScope,
-            expirationMs = InCallReactions.recentReactionShowDurationMs,
-            delegate = mutableStateMapOf<UserId, String>()
-        )
-
     @AssistedFactory
     interface Factory {
         fun create(conversationId: ConversationId): SharedCallingViewModel
     }
 }
-
-private fun List<UICallParticipant>.senderName(userId: QualifiedID) = firstOrNull { it.id.value == userId.value }?.name
 
 sealed interface SharedCallingViewActions {
     data class HungUpCall(val conversationId: ConversationId) : SharedCallingViewActions

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -128,10 +129,10 @@ fun OngoingCallScreen(
         creationCallback = { factory -> factory.create(conversationId = conversationId) }
     ),
     sharedCallingViewModel: SharedCallingViewModel =
-    hiltViewModel<SharedCallingViewModel, SharedCallingViewModel.Factory>(
-        key = "shared_$conversationId",
-        creationCallback = { factory -> factory.create(conversationId = conversationId) }
-    )
+        hiltViewModel<SharedCallingViewModel, SharedCallingViewModel.Factory>(
+            key = "shared_$conversationId",
+            creationCallback = { factory -> factory.create(conversationId = conversationId) }
+        )
 ) {
     val permissionPermanentlyDeniedDialogState = rememberVisibilityState<PermissionPermanentlyDeniedDialogState>()
     val inCallReactionsState = rememberInCallReactionsState()
@@ -217,7 +218,8 @@ fun OngoingCallScreen(
         callQuality = ongoingCallViewModel.state.callQualityData.quality,
         onOpenCallDetails = {
             callDetailsBottomSheetState.show(CallDetailsSheetState.Details)
-        }
+        },
+        othersVideosDisabled = ongoingCallViewModel.state.othersVideosDisabled,
     )
     ObserveRotation(sharedCallingViewModel::setUIRotation)
 
@@ -269,6 +271,8 @@ fun OngoingCallScreen(
     CallDetailsBottomSheet(
         sheetState = callDetailsBottomSheetState,
         callQualityData = ongoingCallViewModel.state.callQualityData,
+        othersVideosDisabled = ongoingCallViewModel.state.othersVideosDisabled,
+        setOthersVideosDisabled = ongoingCallViewModel::setOthersVideosDisabled,
     )
     HandleQualityIntervals(
         sheetValue = callDetailsBottomSheetState.currentValue,
@@ -355,16 +359,15 @@ private fun OngoingCallContent(
     onCameraPermissionPermanentlyDenied: () -> Unit,
     onReactionClick: (String) -> Unit,
     requestVideoStreams: (participants: List<UICallParticipant>) -> Unit,
-    onSelectedParticipant: (selectedParticipant: SelectedParticipant) -> Unit,
-    selectedParticipantForFullScreen: SelectedParticipant,
+    onSelectedParticipant: (selectedParticipant: SelectedParticipant?) -> Unit,
+    selectedParticipantForFullScreen: SelectedParticipant?,
     participants: PersistentList<UICallParticipant>,
     recentReactions: Map<UserId, String>,
     inPictureInPictureMode: Boolean,
     callQuality: CallQualityData.Quality,
+    othersVideosDisabled: Boolean,
     initialShowInCallReactionsPanel: Boolean = false, // for preview purposes
 ) {
-    var shouldOpenFullScreen by remember { mutableStateOf(false) }
-
     var showInCallReactionsPanel by remember { mutableStateOf(initialShowInCallReactionsPanel) }
     val emojiPickerState = rememberWireModalSheetState<Unit>(skipPartiallyExpanded = false)
     val isConnecting = participants.isEmpty()
@@ -427,39 +430,41 @@ private fun OngoingCallContent(
                                 enabled = !inPictureInPictureMode,
                             )
                     ) {
-
-                        // if there is only one in the call, do not allow full screen
-                        if (participants.size == 1) {
-                            shouldOpenFullScreen = false
+                        val uiCallParticipantToShowOnFullScreen by remember(participants, selectedParticipantForFullScreen) {
+                            derivedStateOf {
+                                participants
+                                    .takeIf { it.size > 1 } // if there is only one in the call, do not allow full screen
+                                    ?.find { participant -> participant.id == selectedParticipantForFullScreen?.userId }
+                            }
                         }
 
-                        // if we are on full screen, and that user left the call, then we leave the full screen
-                        if (participants.find { user -> user.id == selectedParticipantForFullScreen.userId } == null) {
-                            shouldOpenFullScreen = false
+                        LaunchedEffect(selectedParticipantForFullScreen, uiCallParticipantToShowOnFullScreen) {
+                            // if we have user for full screen selected, but that user left the call, then we leave the full screen
+                            if (selectedParticipantForFullScreen != null && uiCallParticipantToShowOnFullScreen == null) {
+                                onSelectedParticipant(null)
+                            }
                         }
 
-                        if (shouldOpenFullScreen) {
+                        uiCallParticipantToShowOnFullScreen?.let { uiCallParticipantToShowOnFullScreen ->
                             hideDoubleTapToast()
                             FullScreenTile(
                                 callState = callState,
-                                selectedParticipant = selectedParticipantForFullScreen,
-                                height = this@BoxWithConstraints.maxHeight - dimensions().spacing4x,
+                                selectedParticipant = uiCallParticipantToShowOnFullScreen,
+                                height = this@BoxWithConstraints.maxHeight,
                                 closeFullScreen = {
-                                    onSelectedParticipant(SelectedParticipant())
-                                    shouldOpenFullScreen = !shouldOpenFullScreen
+                                    onSelectedParticipant(null)
                                 },
                                 onBackButtonClicked = {
-                                    onSelectedParticipant(SelectedParticipant())
-                                    shouldOpenFullScreen = !shouldOpenFullScreen
+                                    onSelectedParticipant(null)
                                 },
                                 requestVideoStreams = requestVideoStreams,
                                 setVideoPreview = setVideoPreview,
                                 clearVideoPreview = clearVideoPreview,
-                                participants = participants,
                                 isOnFrontCamera = callState.isOnFrontCamera,
                                 flipCamera = flipCamera,
+                                othersVideosDisabled = othersVideosDisabled,
                             )
-                        } else {
+                        } ?: run {
                             VerticalCallingPager(
                                 participants = participants,
                                 isSelfUserCameraOn = callState.isCameraOn,
@@ -472,11 +477,9 @@ private fun OngoingCallContent(
                                 onSelfClearVideoPreview = clearVideoPreview,
                                 requestVideoStreams = requestVideoStreams,
                                 recentReactions = recentReactions,
-                                onDoubleTap = { selectedParticipant ->
-                                    onSelectedParticipant(selectedParticipant)
-                                    shouldOpenFullScreen = !shouldOpenFullScreen
-                                },
+                                onDoubleTap = onSelectedParticipant,
                                 flipCamera = flipCamera,
+                                othersVideosDisabled = othersVideosDisabled,
                             )
                             DoubleTapToast(
                                 modifier = Modifier.align(Alignment.TopCenter),
@@ -496,6 +499,7 @@ private fun OngoingCallContent(
                                 onSelfUserVideoPreviewCreated = setVideoPreview,
                                 onClearSelfUserVideoPreview = clearVideoPreview,
                                 flipCamera = flipCamera,
+                                othersVideosDisabled = othersVideosDisabled,
                             )
                         }
                     }
@@ -686,11 +690,12 @@ fun PreviewOngoingCallContent(participants: PersistentList<UICallParticipant>, i
         participants = participants,
         inPictureInPictureMode = false,
         onSelectedParticipant = {},
-        selectedParticipantForFullScreen = SelectedParticipant(),
+        selectedParticipantForFullScreen = null,
         recentReactions = emptyMap(),
         initialShowInCallReactionsPanel = inCallReactionsPanelVisible,
         callQuality = CallQualityData.Quality.NORMAL,
-        onOpenCallDetails = {}
+        onOpenCallDetails = {},
+        othersVideosDisabled = true,
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -158,7 +158,7 @@ fun OngoingCallScreen(
     }
 
     LaunchedEffect(Unit) {
-        sharedCallingViewModel.inCallReactions.collectLatest { reaction ->
+        ongoingCallViewModel.inCallReactions.collectLatest { reaction ->
             inCallReactionsState.runAnimation(reaction)
         }
     }
@@ -196,7 +196,7 @@ fun OngoingCallScreen(
     OngoingCallContent(
         callState = sharedCallingViewModel.callState,
         inCallReactionsState = inCallReactionsState,
-        shouldShowDoubleTapToast = ongoingCallViewModel.shouldShowDoubleTapToast,
+        shouldShowDoubleTapToast = ongoingCallViewModel.state.shouldShowDoubleTapToast,
         toggleSpeaker = sharedCallingViewModel::toggleSpeaker,
         toggleMute = sharedCallingViewModel::toggleMute,
         hangUpCall = sharedCallingViewModel::hangUpCall,
@@ -207,13 +207,13 @@ fun OngoingCallScreen(
         onCollapse = onCollapse,
         requestVideoStreams = ongoingCallViewModel::requestVideoStreams,
         onSelectedParticipant = ongoingCallViewModel::onSelectedParticipant,
-        selectedParticipantForFullScreen = ongoingCallViewModel.selectedParticipant,
+        selectedParticipantForFullScreen = ongoingCallViewModel.state.selectedParticipant,
         hideDoubleTapToast = ongoingCallViewModel::hideDoubleTapToast,
         onCameraPermissionPermanentlyDenied = onCameraPermissionPermanentlyDenied,
-        onReactionClick = sharedCallingViewModel::onReactionClick,
-        participants = sharedCallingViewModel.participantsState,
+        onReactionClick = ongoingCallViewModel::onReactionClick,
+        participants = ongoingCallViewModel.state.participants,
         inPictureInPictureMode = inPictureInPictureMode,
-        recentReactions = sharedCallingViewModel.recentReactions,
+        recentReactions = ongoingCallViewModel.recentReactions,
         callQuality = ongoingCallViewModel.state.callQualityData.quality,
         onOpenCallDetails = {
             callDetailsBottomSheetState.show(CallDetailsSheetState.Details)

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallState.kt
@@ -17,11 +17,18 @@
  */
 package com.wire.android.ui.calling.ongoing
 
+import com.wire.android.ui.calling.model.UICallParticipant
+import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
 import com.wire.kalium.logic.data.call.CallQualityData
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 
 data class OngoingCallState(
     val flowState: FlowState = FlowState.Default,
+    val participants: PersistentList<UICallParticipant> = persistentListOf(),
+    val selectedParticipant: SelectedParticipant = SelectedParticipant(),
     val callQualityData: CallQualityData = CallQualityData(),
+    val shouldShowDoubleTapToast: Boolean = false,
 ) {
     sealed interface FlowState {
         object Default : FlowState

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallState.kt
@@ -26,9 +26,10 @@ import kotlinx.collections.immutable.persistentListOf
 data class OngoingCallState(
     val flowState: FlowState = FlowState.Default,
     val participants: PersistentList<UICallParticipant> = persistentListOf(),
-    val selectedParticipant: SelectedParticipant = SelectedParticipant(),
+    val selectedParticipant: SelectedParticipant? = null,
     val callQualityData: CallQualityData = CallQualityData(),
     val shouldShowDoubleTapToast: Boolean = false,
+    val othersVideosDisabled: Boolean = false,
 ) {
     sealed interface FlowState {
         object Default : FlowState

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -221,7 +221,7 @@ class OngoingCallViewModel @AssistedInject constructor(
         viewModelScope.launch {
             participants
                 .filter {
-                    it.isCameraOn || it.isSharingScreen
+                    (it.isCameraOn || it.isSharingScreen) && !state.othersVideosDisabled
                 }
                 .also {
                     val clients: List<CallClient> = it.map { uiParticipant ->

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -20,6 +20,7 @@ package com.wire.android.ui.calling.ongoing
 
 import android.os.CountDownTimer
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
@@ -27,55 +28,91 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.CurrentAccount
+import com.wire.android.mapper.UICallParticipantMapper
+import com.wire.android.ui.calling.model.InCallReaction
+import com.wire.android.ui.calling.model.ReactionSender
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
+import com.wire.android.ui.calling.ongoing.incallreactions.InCallReactions
+import com.wire.android.util.ExpiringMap
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.extension.withDelayAfterFirst
+import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.call.CallResolutionQuality
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.ObserveCallQualityDataUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveLastActiveCallWithSortedParticipantsUseCase
 import com.wire.kalium.logic.feature.call.usecase.RequestVideoStreamsUseCase
 import com.wire.kalium.logic.feature.call.usecase.SetCallQualityIntervalUseCase
 import com.wire.kalium.logic.feature.call.usecase.video.SetVideoSendStateUseCase
+import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
+import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel(assistedFactory = OngoingCallViewModel.Factory::class)
 class OngoingCallViewModel @AssistedInject constructor(
-    @Assisted
-    val conversationId: ConversationId,
-    @CurrentAccount
-    val currentUserId: UserId,
+    @Assisted val conversationId: ConversationId,
+    @CurrentAccount val currentUserId: UserId,
     private val globalDataStore: GlobalDataStore,
     private val observeLastActiveCall: ObserveLastActiveCallWithSortedParticipantsUseCase,
     private val requestVideoStreams: RequestVideoStreamsUseCase,
     private val setVideoSendState: SetVideoSendStateUseCase,
     private val observeCallQualityData: ObserveCallQualityDataUseCase,
     private val setCallQualityInterval: SetCallQualityIntervalUseCase,
+    private val getCurrentClientId: ObserveCurrentClientIdUseCase,
+    private val observeInCallReactionsUseCase: ObserveInCallReactionsUseCase,
+    private val sendInCallReactionUseCase: SendInCallReactionUseCase,
+    private val uiCallParticipantMapper: UICallParticipantMapper,
+    private val dispatchers: DispatcherProvider
 ) : ViewModel() {
-    var shouldShowDoubleTapToast: Boolean by mutableStateOf(false)
-        private set
     private var doubleTapIndicatorCountDownTimer: CountDownTimer? = null
 
     var state by mutableStateOf(OngoingCallState())
         private set
-    var selectedParticipant by mutableStateOf(SelectedParticipant())
-        private set
+
+    private val _inCallReactions = Channel<InCallReaction>(
+        capacity = 300, // Max reactions to keep in queue
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val inCallReactions = _inCallReactions.receiveAsFlow().withDelayAfterFirst(InCallReactions.reactionsThrottleDelayMs)
+    val recentReactions = recentInCallReactionMap()
 
     init {
-        observeCurrentCallFlowState()
-        observeCallQuality()
-        showDoubleTapToast()
+        viewModelScope.launch {
+            val callSharedFlow = observeLastActiveCall(conversationId)
+                .flowOn(dispatchers.default()).shareIn(this, started = SharingStarted.Lazily)
+
+            observeCurrentCallFlowState(callSharedFlow)
+            observeParticipants(callSharedFlow)
+            observeInCallReactions()
+            observeCallQuality()
+            showDoubleTapToast()
+        }
     }
 
     fun startSendingVideoFeed() {
@@ -96,9 +133,9 @@ class OngoingCallViewModel @AssistedInject constructor(
         }
     }
 
-    private fun observeCurrentCallFlowState() {
+    private fun observeCurrentCallFlowState(sharedFlow: SharedFlow<Call?>) {
         viewModelScope.launch {
-            observeLastActiveCall(conversationId)
+            sharedFlow
                 .map { it != null }
                 .distinctUntilChanged()
                 .map { isActive ->
@@ -120,6 +157,57 @@ class OngoingCallViewModel @AssistedInject constructor(
             }
         }
     }
+
+    private fun observeParticipants(sharedFlow: SharedFlow<Call?>) {
+        viewModelScope.launch {
+            combine(
+                getCurrentClientId().filterNotNull(),
+                sharedFlow.filterNotNull(),
+            ) { clientId, call ->
+                call.participants.map {
+                    uiCallParticipantMapper.toUICallParticipant(it, clientId)
+                }.toPersistentList()
+            }.collectLatest {
+                state = state.copy(participants = it)
+            }
+        }
+    }
+
+    private fun observeInCallReactions() {
+        viewModelScope.launch {
+            observeInCallReactionsUseCase(conversationId).collect { message ->
+
+                val sender = state.participants.senderName(message.senderUserId)?.let { name ->
+                    ReactionSender.Other(name)
+                } ?: ReactionSender.Unknown
+
+                message.emojis.forEach { emoji ->
+                    _inCallReactions.send(InCallReaction(emoji, sender))
+                }
+
+                if (message.emojis.isNotEmpty()) {
+                    recentReactions[message.senderUserId] = message.emojis.last()
+                }
+            }
+        }
+    }
+
+    fun onReactionClick(emoji: String) {
+        viewModelScope.launch {
+            sendInCallReactionUseCase(conversationId, emoji).toEither()
+                .onSuccess {
+                    _inCallReactions.send(InCallReaction(emoji, ReactionSender.You))
+                    recentReactions[currentUserId] = emoji
+                }
+        }
+    }
+
+    private fun recentInCallReactionMap(): MutableMap<UserId, String> =
+        ExpiringMap<UserId, String>(
+            scope = viewModelScope,
+            expirationMs = InCallReactions.recentReactionShowDurationMs,
+            delegate = mutableStateMapOf<UserId, String>()
+        )
 
     fun requestVideoStreams(participants: List<UICallParticipant>) {
         viewModelScope.launch {
@@ -143,7 +231,7 @@ class OngoingCallViewModel @AssistedInject constructor(
     }
 
     private fun mapQualityStream(uiParticipant: UICallParticipant): CallResolutionQuality {
-        return if (uiParticipant.clientId == selectedParticipant.clientId) {
+        return if (uiParticipant.clientId == state.selectedParticipant.clientId) {
             CallResolutionQuality.HIGH
         } else {
             CallResolutionQuality.LOW
@@ -159,7 +247,7 @@ class OngoingCallViewModel @AssistedInject constructor(
                 }
 
                 override fun onFinish() {
-                    shouldShowDoubleTapToast = false
+                    state = state.copy(shouldShowDoubleTapToast = false)
                     viewModelScope.launch {
                         globalDataStore.setShouldShowDoubleTapToastStatus(
                             currentUserId.toString(),
@@ -174,16 +262,15 @@ class OngoingCallViewModel @AssistedInject constructor(
     private fun showDoubleTapToast() {
         viewModelScope.launch {
             delay(DELAY_TO_SHOW_DOUBLE_TAP_TOAST)
-            shouldShowDoubleTapToast =
-                globalDataStore.getShouldShowDoubleTapToast(currentUserId.toString())
-            if (shouldShowDoubleTapToast) {
+            state = state.copy(shouldShowDoubleTapToast = globalDataStore.getShouldShowDoubleTapToast(currentUserId.toString()))
+            if (state.shouldShowDoubleTapToast) {
                 startDoubleTapToastDisplayCountDown()
             }
         }
     }
 
     fun hideDoubleTapToast() {
-        shouldShowDoubleTapToast = false
+        state = state.copy(shouldShowDoubleTapToast = false)
         viewModelScope.launch {
             globalDataStore.setShouldShowDoubleTapToastStatus(currentUserId.toString(), false)
         }
@@ -191,7 +278,7 @@ class OngoingCallViewModel @AssistedInject constructor(
 
     fun onSelectedParticipant(selectedParticipant: SelectedParticipant) {
         appLogger.d("$TAG - Selected participant: ${selectedParticipant.toLogString()}")
-        this.selectedParticipant = selectedParticipant
+        state = state.copy(selectedParticipant = selectedParticipant)
     }
 
     fun setQualityInterval(interval: QualityInterval) {
@@ -218,3 +305,5 @@ class OngoingCallViewModel @AssistedInject constructor(
         fun create(conversationId: ConversationId): OngoingCallViewModel
     }
 }
+
+private fun List<UICallParticipant>.senderName(userId: QualifiedID) = firstOrNull { it.id.value == userId.value }?.name

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -41,6 +41,7 @@ import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.call.CallResolutionQuality
+import com.wire.kalium.logic.data.call.CallingParticipantsOrderType
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -61,12 +62,14 @@ import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -102,9 +105,14 @@ class OngoingCallViewModel @AssistedInject constructor(
     val inCallReactions = _inCallReactions.receiveAsFlow().withDelayAfterFirst(InCallReactions.reactionsThrottleDelayMs)
     val recentReactions = recentInCallReactionMap()
 
+    private val orderTypeStateFlow = MutableStateFlow(state.currentOrderType())
+
     init {
         viewModelScope.launch {
-            val callSharedFlow = observeLastActiveCall(conversationId)
+            val callSharedFlow = orderTypeStateFlow
+                .flatMapLatest { orderType ->
+                    observeLastActiveCall(conversationId = conversationId, orderType = orderType)
+                }
                 .flowOn(dispatchers.default()).shareIn(this, started = SharingStarted.Lazily)
 
             observeCurrentCallFlowState(callSharedFlow)
@@ -216,22 +224,20 @@ class OngoingCallViewModel @AssistedInject constructor(
                     it.isCameraOn || it.isSharingScreen
                 }
                 .also {
-                    if (it.isNotEmpty()) {
-                        val clients: List<CallClient> = it.map { uiParticipant ->
-                            CallClient(
-                                userId = uiParticipant.id.toString(),
-                                clientId = uiParticipant.clientId,
-                                quality = mapQualityStream(uiParticipant)
-                            )
-                        }
-                        requestVideoStreams(conversationId, clients)
+                    val clients: List<CallClient> = it.map { uiParticipant ->
+                        CallClient(
+                            userId = uiParticipant.id.toString(),
+                            clientId = uiParticipant.clientId,
+                            quality = mapQualityStream(uiParticipant)
+                        )
                     }
+                    requestVideoStreams(conversationId, clients)
                 }
         }
     }
 
     private fun mapQualityStream(uiParticipant: UICallParticipant): CallResolutionQuality {
-        return if (uiParticipant.clientId == state.selectedParticipant.clientId) {
+        return if (uiParticipant.clientId == state.selectedParticipant?.clientId) {
             CallResolutionQuality.HIGH
         } else {
             CallResolutionQuality.LOW
@@ -276,9 +282,14 @@ class OngoingCallViewModel @AssistedInject constructor(
         }
     }
 
-    fun onSelectedParticipant(selectedParticipant: SelectedParticipant) {
-        appLogger.d("$TAG - Selected participant: ${selectedParticipant.toLogString()}")
+    fun onSelectedParticipant(selectedParticipant: SelectedParticipant?) {
+        appLogger.d("$TAG - Selected participant: ${selectedParticipant?.toLogString()}")
         state = state.copy(selectedParticipant = selectedParticipant)
+    }
+
+    fun setOthersVideosDisabled(othersVideosDisabled: Boolean) {
+        state = state.copy(othersVideosDisabled = othersVideosDisabled)
+        orderTypeStateFlow.value = state.currentOrderType() // update order type based on current state to trigger participants reordering
     }
 
     fun setQualityInterval(interval: QualityInterval) {
@@ -307,3 +318,8 @@ class OngoingCallViewModel @AssistedInject constructor(
 }
 
 private fun List<UICallParticipant>.senderName(userId: QualifiedID) = firstOrNull { it.id.value == userId.value }?.name
+
+private fun OngoingCallState.currentOrderType(): CallingParticipantsOrderType = when (othersVideosDisabled) {
+    true -> CallingParticipantsOrderType.ALPHABETICALLY
+    false -> CallingParticipantsOrderType.VIDEOS_FIRST
+}

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallDetailsBottomSheet.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallDetailsBottomSheet.kt
@@ -34,6 +34,8 @@ import kotlinx.serialization.Serializable
 fun CallDetailsBottomSheet(
     sheetState: WireModalSheetState<CallDetailsSheetState>,
     callQualityData: CallQualityData,
+    othersVideosDisabled: Boolean,
+    setOthersVideosDisabled: (othersVideosDisabled: Boolean) -> Unit,
 ) {
     WireModalSheetLayout(
         sheetState = sheetState,
@@ -56,6 +58,8 @@ fun CallDetailsBottomSheet(
                         onOpenNetworkQuality = {
                             sheetState.show(CallDetailsSheetState.Quality)
                         },
+                        othersVideosDisabled = othersVideosDisabled,
+                        onOthersVideosDisabledChanged = setOthersVideosDisabled,
                     )
 
                     CallDetailsSheetState.Quality -> CallNetworkQualitySheetContent(
@@ -93,6 +97,8 @@ private fun CallDetailsBottomSheetPreview(callDetailsSheetState: CallDetailsShee
                 video = CallQualityData.VideoJitter(up = 15, down = 25),
             ),
         ),
+        othersVideosDisabled = true,
+        setOthersVideosDisabled = {},
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallDetailsSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallDetailsSheetContent.kt
@@ -28,10 +28,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -54,6 +50,8 @@ import com.wire.android.ui.common.R as commonR
 fun CallDetailsSheetContent(
     callQuality: CallQualityData.Quality,
     onOpenNetworkQuality: () -> Unit,
+    othersVideosDisabled: Boolean,
+    onOthersVideosDisabledChanged: (othersVideosDisabled: Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -67,7 +65,10 @@ fun CallDetailsSheetContent(
             onOpenNetworkQuality = onOpenNetworkQuality
         )
         WireDivider()
-        TurnOffOtherVideosItem()
+        TurnOffOtherVideosItem(
+            othersVideosDisabled = othersVideosDisabled,
+            onOthersVideosDisabledChanged = onOthersVideosDisabledChanged,
+        )
     }
 }
 
@@ -125,7 +126,10 @@ private fun NetworkQualityItem(
 }
 
 @Composable
-private fun TurnOffOtherVideosItem() {
+private fun TurnOffOtherVideosItem(
+    othersVideosDisabled: Boolean,
+    onOthersVideosDisabledChanged: (othersVideosDisabled: Boolean) -> Unit,
+) {
     Column(
         verticalArrangement = Arrangement.spacedBy(dimensions().spacing8x),
         modifier = Modifier
@@ -143,12 +147,9 @@ private fun TurnOffOtherVideosItem() {
                 color = colorsScheme().onSurface,
                 modifier = Modifier.weight(1f, fill = true)
             )
-            var checked by remember { mutableStateOf(false) } // TODO: get this value from the view model
             WireSwitch(
-                checked = checked,
-                onCheckedChange = {
-                    checked = it // TODO: implement the logic of turning off other videos in the view model and call it here
-                },
+                checked = othersVideosDisabled,
+                onCheckedChange = onOthersVideosDisabledChanged,
             )
         }
         Text(
@@ -166,6 +167,8 @@ private fun TurnOffOtherVideosItem() {
 fun CallDetailsSheetContentPreview() = WireTheme {
     CallDetailsSheetContent(
         callQuality = CallQualityData.Quality.NORMAL,
-        onOpenNetworkQuality = {}
+        onOpenNetworkQuality = {},
+        othersVideosDisabled = true,
+        onOthersVideosDisabledChanged = {},
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
@@ -47,14 +47,12 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.id.ConversationId
-import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.delay
 
 @Composable
 fun FullScreenTile(
     callState: CallState,
-    participants: PersistentList<UICallParticipant>,
-    selectedParticipant: SelectedParticipant,
+    selectedParticipant: UICallParticipant,
     height: Dp,
     closeFullScreen: (offset: Offset) -> Unit,
     onBackButtonClicked: () -> Unit,
@@ -63,6 +61,7 @@ fun FullScreenTile(
     clearVideoPreview: () -> Unit,
     isOnFrontCamera: Boolean,
     flipCamera: () -> Unit,
+    othersVideosDisabled: Boolean,
     modifier: Modifier = Modifier,
     contentPadding: Dp = dimensions().spacing4x,
 ) {
@@ -72,9 +71,7 @@ fun FullScreenTile(
         onBackButtonClicked()
     }
 
-    participants.find {
-        it.id == selectedParticipant.userId && it.clientId == selectedParticipant.clientId
-    }?.let {
+    selectedParticipant.let {
         Box(modifier = modifier) {
             ParticipantTile(
                 modifier = Modifier
@@ -104,6 +101,7 @@ fun FullScreenTile(
                 onClearSelfUserVideoPreview = clearVideoPreview,
                 isOnFrontCamera = isOnFrontCamera,
                 flipCamera = flipCamera,
+                othersVideosDisabled = othersVideosDisabled,
             )
             LaunchedEffect(Unit) {
                 delay(200)
@@ -120,8 +118,8 @@ fun FullScreenTile(
             )
         }
 
-        LaunchedEffect(selectedParticipant.userId) {
-            requestVideoStreams(listOf(it))
+        LaunchedEffect(selectedParticipant.id, othersVideosDisabled) {
+            requestVideoStreams(if (othersVideosDisabled) emptyList() else listOf(it))
         }
     }
 }
@@ -129,24 +127,19 @@ fun FullScreenTile(
 @PreviewMultipleThemes
 @Composable
 fun PreviewFullScreenTile() = WireTheme {
-    val participants = buildPreviewParticipantsList(1)
     FullScreenTile(
         callState = CallState(
             conversationId = ConversationId("id", "domain"),
         ),
-        selectedParticipant = SelectedParticipant(
-            userId = participants.first().id,
-            clientId = participants.first().clientId,
-            isSelfUser = false,
-        ),
+        selectedParticipant = buildPreviewParticipantsList(1).first(),
         height = 800.dp,
         closeFullScreen = {},
         onBackButtonClicked = {},
         setVideoPreview = {},
         requestVideoStreams = {},
         clearVideoPreview = {},
-        participants = participants,
         isOnFrontCamera = false,
         flipCamera = {},
+        othersVideosDisabled = false,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/FullScreenTile.kt
@@ -118,8 +118,8 @@ fun FullScreenTile(
             )
         }
 
-        LaunchedEffect(selectedParticipant.id, othersVideosDisabled) {
-            requestVideoStreams(if (othersVideosDisabled) emptyList() else listOf(it))
+        LaunchedEffect(selectedParticipant, othersVideosDisabled) {
+            requestVideoStreams(listOf(it))
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/SelectedParticipant.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/fullscreen/SelectedParticipant.kt
@@ -21,9 +21,9 @@ import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.user.UserId
 
 data class SelectedParticipant(
-    val userId: UserId = UserId("", ""),
-    val clientId: String = "",
-    val isSelfUser: Boolean = false
+    val userId: UserId,
+    val clientId: String,
+    val isSelfUser: Boolean
 ) {
 
     fun toLogString(): String {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/FloatingSelfUserTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/FloatingSelfUserTile.kt
@@ -64,6 +64,7 @@ fun FloatingSelfUserTile(
     onSelfUserVideoPreviewCreated: (view: View) -> Unit,
     onClearSelfUserVideoPreview: () -> Unit,
     flipCamera: () -> Unit,
+    othersVideosDisabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
     var selfVideoTileHeight by remember {
@@ -173,6 +174,7 @@ fun FloatingSelfUserTile(
             onClearSelfUserVideoPreview = onClearSelfUserVideoPreview,
             isOnFrontCamera = isOnFrontCamera,
             flipCamera = flipCamera,
+            othersVideosDisabled = othersVideosDisabled,
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
@@ -63,6 +63,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -96,15 +98,16 @@ fun ParticipantTile(
     isSelfUserMuted: Boolean,
     isSelfUserCameraOn: Boolean,
     onSelfUserVideoPreviewCreated: (view: View) -> Unit,
+    onClearSelfUserVideoPreview: () -> Unit,
     isOnFrontCamera: Boolean,
     flipCamera: () -> Unit,
+    othersVideosDisabled: Boolean,
     modifier: Modifier = Modifier,
     isOnPiPMode: Boolean = false,
     shouldFillSelfUserCameraPreview: Boolean = false,
     shouldFillOthersVideoPreview: Boolean = true,
     isZoomingEnabled: Boolean = false,
     recentReaction: String? = null,
-    onClearSelfUserVideoPreview: () -> Unit,
 ) {
     Surface(
         modifier = modifier
@@ -131,15 +134,16 @@ fun ParticipantTile(
                     isCameraOn = participantTitleState.isCameraOn,
                     isSharingScreen = participantTitleState.isSharingScreen,
                     shouldFill = shouldFillOthersVideoPreview,
-                    isZoomingEnabled = isZoomingEnabled
+                    isZoomingEnabled = isZoomingEnabled,
+                    othersVideosDisabled = othersVideosDisabled,
                 )
             }
 
             // Layer 2: Avatar centered (only show when video is off)
-            val shouldShowAvatar = if (participantTitleState.isSelfUser) {
-                !isSelfUserCameraOn
-            } else {
-                !participantTitleState.isCameraOn && !participantTitleState.isSharingScreen
+            val shouldShowAvatar = when {
+                participantTitleState.isSelfUser -> !isSelfUserCameraOn // for self user show avatar when self camera is off
+                othersVideosDisabled -> true // if others videos are disabled, show avatar because their videos will be off anyway
+                else -> !participantTitleState.isCameraOn && !participantTitleState.isSharingScreen // otherwise show avatar if no video
             }
 
             if (shouldShowAvatar) {
@@ -244,7 +248,7 @@ private fun BottomRow(
         content = {
             MicrophoneTile(
                 modifier = Modifier
-                    .padding(end = dimensions().spacing8x)
+                    .padding(end = dimensions().spacing6x)
                     .layoutId("muteIcon"),
                 isMuted = if (participantTitleState.isSelfUser) isSelfUserMuted else participantTitleState.isMuted,
                 hasEstablishedAudio = participantTitleState.hasEstablishedAudio
@@ -338,7 +342,8 @@ private fun OthersVideoRenderer(
     isCameraOn: Boolean,
     isSharingScreen: Boolean,
     shouldFill: Boolean,
-    isZoomingEnabled: Boolean
+    isZoomingEnabled: Boolean,
+    othersVideosDisabled: Boolean,
 ) {
     var size by remember { mutableStateOf(IntSize.Zero) }
     var zoom by remember { mutableStateOf(1f) }
@@ -347,7 +352,7 @@ private fun OthersVideoRenderer(
 
     val context = LocalContext.current
     val rendererFillColor = (darkColorsScheme().surfaceContainer.value shr 32).toLong()
-    if (isCameraOn || isSharingScreen) {
+    if ((isCameraOn || isSharingScreen) && !othersVideosDisabled) {
 
         val videoRenderer = remember {
             VideoRenderer(
@@ -489,33 +494,50 @@ private fun MicrophoneTile(
     }
 }
 
-private enum class PreviewTileShape(val width: Dp, val height: Dp) {
+enum class PreviewTileShape(val width: Dp, val height: Dp) {
     Regular(width = 175.dp, height = 140.dp),
     Tall(width = 140.dp, height = 175.dp),
     Wide(width = 175.dp, height = 80.dp),
 }
 
+enum class PreviewName(val userName: String) {
+    Short("user name"),
+    Long("Long name to be displayed in participant tile during a call")
+}
+
+data class PreviewParams(val name: PreviewName, val shape: PreviewTileShape)
+
+private class PreviewParamsProvider : PreviewParameterProvider<PreviewParams> {
+    private val valuesMap = PreviewName.entries.flatMap { previewName ->
+        PreviewTileShape.entries.map { previewTileShape ->
+            PreviewParams(previewName, previewTileShape)
+        }
+    }.associateBy { (nameEntry, shape) -> "${nameEntry.name} name - ${shape.name} shape" }
+    override val values = valuesMap.values.asSequence()
+    override fun getDisplayName(index: Int): String? = valuesMap.keys.elementAtOrNull(index)
+}
+
 @Composable
 private fun PreviewParticipantTile(
-    longName: Boolean = false,
+    params: PreviewParams,
     isMuted: Boolean = false,
+    othersVideosDisabled: Boolean = false,
     isSpeaking: Boolean = false,
     hasEstablishedAudio: Boolean = true,
-    shape: PreviewTileShape = PreviewTileShape.Wide,
     recentReaction: String? = null,
     isSelfUser: Boolean = false,
-    isSelfCameraOn: Boolean = false,
-) {
+    isCameraOn: Boolean = false,
+) = WireTheme {
     ParticipantTile(
-        modifier = Modifier.size(width = shape.width, height = shape.height),
+        modifier = Modifier.size(width = params.shape.width, height = params.shape.height),
         participantTitleState = UICallParticipant(
             id = QualifiedID("", ""),
             clientId = "client-id",
             isSelfUser = isSelfUser,
-            name = if (longName) "long user name to be displayed in participant tile during a call" else "user name",
-            isMuted = isMuted,
+            name = params.name.userName,
+            isMuted = !isSelfUser && isMuted,
             isSpeaking = isSpeaking,
-            isCameraOn = false,
+            isCameraOn = !isSelfUser && isCameraOn,
             isSharingScreen = false,
             avatar = null,
             membership = Membership.Admin,
@@ -524,113 +546,36 @@ private fun PreviewParticipantTile(
         ),
         onClearSelfUserVideoPreview = {},
         onSelfUserVideoPreviewCreated = {},
-        isSelfUserMuted = false,
-        isSelfUserCameraOn = isSelfCameraOn,
+        isSelfUserMuted = isSelfUser && isMuted,
+        isSelfUserCameraOn = isSelfUser && isCameraOn,
         recentReaction = recentReaction,
         isOnFrontCamera = false,
         flipCamera = { },
-    )
-}
-
-// ------ connecting ------
-
-@PreviewMultipleThemes
-@Composable
-fun PreviewParticipantConnecting() = WireTheme {
-    PreviewParticipantTile(shape = PreviewTileShape.Regular, hasEstablishedAudio = false)
-}
-
-@PreviewMultipleThemes
-@Composable
-fun PreviewParticipantLongNameConnecting() = WireTheme {
-    PreviewParticipantTile(
-        shape = PreviewTileShape.Regular,
-        hasEstablishedAudio = false,
-        longName = true
+        othersVideosDisabled = othersVideosDisabled,
     )
 }
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewParticipantTallLongNameConnecting() = WireTheme {
-    PreviewParticipantTile(shape = PreviewTileShape.Tall, hasEstablishedAudio = false)
-}
+fun PreviewParticipantConnecting(@PreviewParameter(PreviewParamsProvider::class) params: PreviewParams) =
+    PreviewParticipantTile(params = params, hasEstablishedAudio = false)
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewParticipantWideLongNameConnecting() = WireTheme {
-    PreviewParticipantTile(shape = PreviewTileShape.Wide, hasEstablishedAudio = false)
-}
-
-// ------ muted ------
+fun PreviewParticipantMuted(@PreviewParameter(PreviewParamsProvider::class) params: PreviewParams) =
+    PreviewParticipantTile(params = params, isMuted = true)
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewParticipantMuted() = WireTheme {
-    PreviewParticipantTile(shape = PreviewTileShape.Regular, isMuted = true)
-}
+fun PreviewParticipantTalking(@PreviewParameter(PreviewParamsProvider::class) params: PreviewParams) =
+    PreviewParticipantTile(params = params, isSpeaking = true)
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewParticipantLongNameMuted() = WireTheme {
-    PreviewParticipantTile(shape = PreviewTileShape.Regular, isMuted = true, longName = true)
-}
+fun PreviewParticipantTalkingReaction(@PreviewParameter(PreviewParamsProvider::class) params: PreviewParams) =
+    PreviewParticipantTile(params = params, isSpeaking = true, recentReaction = InCallReactions.defaultReactions[2])
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewParticipantTallLongNameMuted() = WireTheme {
-    PreviewParticipantTile(shape = PreviewTileShape.Tall, isMuted = true)
-}
-
-@PreviewMultipleThemes
-@Composable
-fun PreviewParticipantWideLongNameMuted() = WireTheme {
-    PreviewParticipantTile(shape = PreviewTileShape.Wide, isMuted = true)
-}
-
-// ------ talking ------
-
-@PreviewMultipleThemes
-@Composable
-fun PreviewParticipantTalking() = WireTheme {
-    PreviewParticipantTile(shape = PreviewTileShape.Regular, isSpeaking = true)
-}
-
-@PreviewMultipleThemes
-@Composable
-fun PreviewParticipantLongNameTalking() = WireTheme {
-    PreviewParticipantTile(shape = PreviewTileShape.Regular, isSpeaking = true, longName = true)
-}
-
-@PreviewMultipleThemes
-@Composable
-fun PreviewParticipantTallLongNameTalking() = WireTheme {
-    PreviewParticipantTile(shape = PreviewTileShape.Tall, isSpeaking = true)
-}
-
-@PreviewMultipleThemes
-@Composable
-fun PreviewParticipantWideLongNameTalking() = WireTheme {
-    PreviewParticipantTile(shape = PreviewTileShape.Wide, isSpeaking = true)
-}
-
-@PreviewMultipleThemes
-@Composable
-fun PreviewParticipantTalkingReaction() = WireTheme {
-    PreviewParticipantTile(
-        shape = PreviewTileShape.Regular,
-        isSpeaking = true,
-        recentReaction = InCallReactions.defaultReactions[2],
-    )
-}
-
-@PreviewMultipleThemes
-@Composable
-fun PreviewParticipantCameraButton() = WireTheme {
-    PreviewParticipantTile(
-        shape = PreviewTileShape.Regular,
-        recentReaction = InCallReactions.defaultReactions[2],
-        isSelfUser = true,
-        isSelfCameraOn = true,
-    )
-}
+fun PreviewParticipantCameraButton(@PreviewParameter(PreviewParamsProvider::class) params: PreviewParams) =
+    PreviewParticipantTile(params = params, recentReaction = InCallReactions.defaultReactions[2], isSelfUser = true, isCameraOn = true)

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
@@ -65,8 +65,9 @@ fun VerticalCallingPager(
     requestVideoStreams: (participants: List<UICallParticipant>) -> Unit,
     onDoubleTap: (selectedParticipant: SelectedParticipant) -> Unit,
     flipCamera: () -> Unit,
-    gridParams: CallingGridParams = CallingGridParams.fromScreenDimensions(width = contentWidth, height = contentHeight),
+    othersVideosDisabled: Boolean,
     modifier: Modifier = Modifier,
+    gridParams: CallingGridParams = CallingGridParams.fromScreenDimensions(width = contentWidth, height = contentHeight),
 ) {
     Column(
         modifier = modifier
@@ -107,14 +108,16 @@ fun VerticalCallingPager(
                         recentReactions = recentReactions,
                         isOnFrontCamera = isOnFrontCamera,
                         flipCamera = flipCamera,
+                        othersVideosDisabled = othersVideosDisabled,
                     )
 
                     LaunchedEffect(
                         participantsWithCameraOn, // Request video stream when someone turns camera on/off
                         participantsWithScreenShareOn, // Request video stream when someone starts sharing screen
-                        pagerState.currentPage // Request video stream when swiping to a different page on the grid
+                        pagerState.currentPage, // Request video stream when swiping to a different page on the grid
+                        othersVideosDisabled, // Request video stream when the current user enables/disables others' videos
                     ) {
-                        requestVideoStreams(participantsPages[pagerState.currentPage])
+                        requestVideoStreams(if (othersVideosDisabled) emptyList() else participantsPages[pagerState.currentPage])
                     }
                 }
             }
@@ -156,6 +159,7 @@ private fun PreviewVerticalCallingPager(participants: List<UICallParticipant>) {
         isInPictureInPictureMode = false,
         recentReactions = emptyMap(),
         isOnFrontCamera = false,
+        othersVideosDisabled = false,
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
@@ -143,7 +143,6 @@ private fun rememberParticipantsWithoutPip(participants: List<UICallParticipant>
         }
     }
 
-
 @Composable
 private fun PreviewVerticalCallingPager(participants: List<UICallParticipant>) {
     VerticalCallingPager(

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
@@ -20,7 +20,6 @@ package com.wire.android.ui.calling.ongoing.participantsview
 
 import android.view.View
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -108,7 +107,7 @@ fun VerticalCallingPager(
                         pagerState.currentPage, // Request video stream when swiping to a different page on the grid
                         othersVideosDisabled, // Request video stream when the current user enables/disables others' videos
                     ) {
-                        requestVideoStreams(if (othersVideosDisabled) emptyList() else participantsPages[pagerState.currentPage])
+                        requestVideoStreams(participantsPages[pagerState.currentPage])
                     }
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/VerticalCallingPager.kt
@@ -69,30 +69,21 @@ fun VerticalCallingPager(
     modifier: Modifier = Modifier,
     gridParams: CallingGridParams = CallingGridParams.fromScreenDimensions(width = contentWidth, height = contentHeight),
 ) {
-    Column(
+    Box(
         modifier = modifier
             .size(width = contentWidth, height = contentHeight)
     ) {
-        // if PiP is enabled and more than one participant is present,
-        // we need to remove the first participant(self user) from the list
-        val participantsWithoutPip =
-            if (BuildConfig.PICTURE_IN_PICTURE_ENABLED && participants.size > 1) {
-                participants.subList(1, participants.size)
-            } else {
-                participants
-            }
+        val participantsWithoutPip = rememberParticipantsWithoutPip(participants)
         val participantsPages = remember(participantsWithoutPip, gridParams.maxItemsPerPage) {
             participantsWithoutPip.chunked(gridParams.maxItemsPerPage)
         }
-
         val pagerState = rememberPagerState(pageCount = { participantsPages.size })
 
-        Box {
+        if (participants.isNotEmpty()) {
             VerticalPager(
                 state = pagerState,
                 modifier = Modifier.fillMaxSize()
             ) { pageIndex ->
-                if (participants.isNotEmpty()) {
                     val participantsWithCameraOn by rememberUpdatedState(participantsWithoutPip.count { it.isCameraOn })
                     val participantsWithScreenShareOn by rememberUpdatedState(participantsWithoutPip.count { it.isSharingScreen })
                     GroupCallGrid(
@@ -137,11 +128,22 @@ fun VerticalCallingPager(
                         spacing = dimensions().spacing6x,
                         indicatorShape = CircleShape
                     )
-                }
             }
         }
     }
 }
+
+@Composable
+private fun rememberParticipantsWithoutPip(participants: List<UICallParticipant>): List<UICallParticipant> =
+    remember(BuildConfig.PICTURE_IN_PICTURE_ENABLED, participants) {
+        // if PiP is enabled and more than one participant is present, we need to remove the first participant(self user) from the list
+        if (BuildConfig.PICTURE_IN_PICTURE_ENABLED && participants.size > 1) {
+            participants.subList(1, participants.size)
+        } else {
+            participants
+        }
+    }
+
 
 @Composable
 private fun PreviewVerticalCallingPager(participants: List<UICallParticipant>) {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/gridview/CallingGridView.kt
@@ -63,6 +63,7 @@ fun GroupCallGrid(
     flipCamera: () -> Unit,
     isInPictureInPictureMode: Boolean,
     recentReactions: Map<UserId, String>,
+    othersVideosDisabled: Boolean,
     modifier: Modifier = Modifier,
     contentPadding: Dp = dimensions().spacing4x,
     spacedBy: Dp = dimensions().spacing2x,
@@ -114,6 +115,7 @@ fun GroupCallGrid(
                 recentReaction = recentReactions[participant.id],
                 isOnFrontCamera = isOnFrontCamera,
                 flipCamera = flipCamera,
+                othersVideosDisabled = othersVideosDisabled,
             )
         }
     }
@@ -127,7 +129,7 @@ private fun getContentType(
 @Composable
 private fun PreviewGroupCallGrid(participants: List<UICallParticipant>, modifier: Modifier = Modifier) {
     Box(modifier = modifier.padding(top = 60.dp, bottom = 80.dp)) { // paddings to simulate top and bottom bars
-        BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             GroupCallGrid(
                 gridParams = CallingGridParams.fromScreenDimensions(maxWidth, maxHeight),
                 participants = participants,
@@ -141,6 +143,7 @@ private fun PreviewGroupCallGrid(participants: List<UICallParticipant>, modifier
                 recentReactions = emptyMap(),
                 isOnFrontCamera = false,
                 flipCamera = {},
+                othersVideosDisabled = false,
             )
         }
     }

--- a/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
@@ -18,49 +18,72 @@
 
 package com.wire.android.ui.calling
 
+import app.cash.turbine.test
+import com.wire.android.assertIs
+import com.wire.android.assertions.shouldBeEqualTo
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.framework.TestUser
+import com.wire.android.mapper.UICallParticipantMapper
+import com.wire.android.mapper.UserTypeMapper
+import com.wire.android.ui.calling.model.ReactionSender
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.calling.ongoing.OngoingCallState
 import com.wire.android.ui.calling.ongoing.OngoingCallViewModel
 import com.wire.android.ui.calling.ongoing.fullscreen.SelectedParticipant
 import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.call.CallQualityData
 import com.wire.kalium.logic.data.call.CallResolutionQuality
 import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.call.InCallReactionMessage
+import com.wire.kalium.logic.data.call.Participant
 import com.wire.kalium.logic.data.call.VideoState
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.data.user.type.UserTypeInfo
 import com.wire.kalium.logic.feature.call.usecase.ObserveCallQualityDataUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveLastActiveCallWithSortedParticipantsUseCase
 import com.wire.kalium.logic.feature.call.usecase.RequestVideoStreamsUseCase
 import com.wire.kalium.logic.feature.call.usecase.SetCallQualityIntervalUseCase
 import com.wire.kalium.logic.feature.call.usecase.video.SetVideoSendStateUseCase
+import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
+import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
+import com.wire.kalium.logic.feature.message.MessageOperationResult
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
 class OngoingCallViewModelTest {
+    private val dispatchers = TestDispatcherProvider()
 
     @Test
-    fun givenAnOngoingCall_WhenTurningOnCamera_ThenSetVideoSendStateToStarted() = runTest {
+    fun givenAnOngoingCall_WhenTurningOnCamera_ThenSetVideoSendStateToStarted() = runTest(dispatchers.main()) {
         val (arrangement, ongoingCallViewModel) = Arrangement()
             .withLastActiveCall(provideCall())
             .withShouldShowDoubleTapToastReturning(false)
@@ -73,7 +96,7 @@ class OngoingCallViewModelTest {
     }
 
     @Test
-    fun givenAnOngoingCall_WhenTurningOffCamera_ThenSetVideoSendStateToStopped() = runTest {
+    fun givenAnOngoingCall_WhenTurningOffCamera_ThenSetVideoSendStateToStopped() = runTest(dispatchers.main()) {
         val (arrangement, ongoingCallViewModel) = Arrangement()
             .withLastActiveCall(provideCall())
             .withShouldShowDoubleTapToastReturning(false)
@@ -87,10 +110,10 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenParticipantsList_WhenRequestingVideoStream_ThenRequestItForOnlyParticipantsWithVideoEnabled() =
-        runTest {
+        runTest(dispatchers.main()) {
             val expectedClients = listOf(
-                CallClient(participant1.id.toString(), participant1.clientId),
-                CallClient(participant3.id.toString(), participant3.clientId)
+                CallClient(uiParticipant1.id.toString(), uiParticipant1.clientId),
+                CallClient(uiParticipant3.id.toString(), uiParticipant3.clientId)
             )
 
             val (arrangement, ongoingCallViewModel) = Arrangement()
@@ -100,7 +123,7 @@ class OngoingCallViewModelTest {
                 .withRequestVideoStreams(conversationId, expectedClients)
                 .arrange()
 
-            ongoingCallViewModel.requestVideoStreams(participants)
+            ongoingCallViewModel.requestVideoStreams(uiParticipants)
 
             coVerify(exactly = 1) {
                 arrangement.requestVideoStreams(
@@ -111,7 +134,7 @@ class OngoingCallViewModelTest {
         }
 
     @Test
-    fun givenDoubleTabIndicatorIsDisplayed_whenUserTapsOnIt_thenHideIt() = runTest {
+    fun givenDoubleTabIndicatorIsDisplayed_whenUserTapsOnIt_thenHideIt() = runTest(dispatchers.main()) {
         val (arrangement, ongoingCallViewModel) = Arrangement()
             .withLastActiveCall(provideCall())
             .withShouldShowDoubleTapToastReturning(false)
@@ -121,7 +144,7 @@ class OngoingCallViewModelTest {
 
         ongoingCallViewModel.hideDoubleTapToast()
 
-        assertEquals(false, ongoingCallViewModel.shouldShowDoubleTapToast)
+        assertEquals(false, ongoingCallViewModel.state.shouldShowDoubleTapToast)
         coVerify(exactly = 1) {
             arrangement.globalDataStore.setShouldShowDoubleTapToastStatus(
                 currentUserId.toString(),
@@ -132,7 +155,7 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenSetVideoSendStateUseCase_whenStartSendingVideoFeedIsCalled_thenInvokeUseCaseWithStartedStateOnce() =
-        runTest {
+        runTest(dispatchers.main()) {
             val (arrangement, ongoingCallViewModel) = Arrangement()
                 .withLastActiveCall(provideCall())
                 .withShouldShowDoubleTapToastReturning(false)
@@ -148,7 +171,7 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenSetVideoSendStateUseCase_whenPauseSendingVideoFeedIsCalled_thenInvokeUseCaseWithPausedStateOnce() =
-        runTest {
+        runTest(dispatchers.main()) {
             val (arrangement, ongoingCallViewModel) = Arrangement()
                 .withLastActiveCall(provideCall())
                 .withShouldShowDoubleTapToastReturning(false)
@@ -164,7 +187,7 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenSetVideoSendStateUseCase_whenStopSendingVideoFeedIsCalled_thenInvokeUseCaseWithStoppedState() =
-        runTest {
+        runTest(dispatchers.main()) {
             val (arrangement, ongoingCallViewModel) = Arrangement()
                 .withLastActiveCall(provideCall().copy(isCameraOn = true))
                 .withShouldShowDoubleTapToastReturning(false)
@@ -180,7 +203,7 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenAUserIsSelected_whenRequestedFullScreen_thenSetTheUserAsSelected() =
-        runTest {
+        runTest(dispatchers.main()) {
             val (_, ongoingCallViewModel) = Arrangement()
                 .withLastActiveCall(provideCall().copy(isCameraOn = true))
                 .withShouldShowDoubleTapToastReturning(false)
@@ -189,15 +212,15 @@ class OngoingCallViewModelTest {
 
             ongoingCallViewModel.onSelectedParticipant(selectedParticipant3)
 
-            assertEquals(selectedParticipant3, ongoingCallViewModel.selectedParticipant)
+            assertEquals(selectedParticipant3, ongoingCallViewModel.state.selectedParticipant)
         }
 
     @Test
     fun givenParticipantsList_WhenRequestingVideoStreamForFullScreenParticipant_ThenRequestItInHighQuality() =
-        runTest {
+        runTest(dispatchers.main()) {
             val expectedClients = listOf(
-                CallClient(participant1.id.toString(), participant1.clientId, false, CallResolutionQuality.LOW),
-                CallClient(participant3.id.toString(), participant3.clientId, false, CallResolutionQuality.HIGH)
+                CallClient(uiParticipant1.id.toString(), uiParticipant1.clientId, false, CallResolutionQuality.LOW),
+                CallClient(uiParticipant3.id.toString(), uiParticipant3.clientId, false, CallResolutionQuality.HIGH)
             )
 
             val (arrangement, ongoingCallViewModel) = Arrangement()
@@ -208,7 +231,7 @@ class OngoingCallViewModelTest {
                 .arrange()
 
             ongoingCallViewModel.onSelectedParticipant(selectedParticipant3)
-            ongoingCallViewModel.requestVideoStreams(participants)
+            ongoingCallViewModel.requestVideoStreams(uiParticipants)
 
             coVerify(exactly = 1) {
                 arrangement.requestVideoStreams(
@@ -220,10 +243,10 @@ class OngoingCallViewModelTest {
 
     @Test
     fun givenParticipantsList_WhenRequestingVideoStreamForAllParticipant_ThenRequestItInLowQuality() =
-        runTest {
+        runTest(dispatchers.main()) {
             val expectedClients = listOf(
-                CallClient(participant1.id.toString(), participant1.clientId, false, CallResolutionQuality.LOW),
-                CallClient(participant3.id.toString(), participant3.clientId, false, CallResolutionQuality.LOW)
+                CallClient(uiParticipant1.id.toString(), uiParticipant1.clientId, false, CallResolutionQuality.LOW),
+                CallClient(uiParticipant3.id.toString(), uiParticipant3.clientId, false, CallResolutionQuality.LOW)
             )
 
             val (arrangement, ongoingCallViewModel) = Arrangement()
@@ -234,7 +257,7 @@ class OngoingCallViewModelTest {
                 .arrange()
 
             ongoingCallViewModel.onSelectedParticipant(SelectedParticipant())
-            ongoingCallViewModel.requestVideoStreams(participants)
+            ongoingCallViewModel.requestVideoStreams(uiParticipants)
 
             coVerify(exactly = 1) {
                 arrangement.requestVideoStreams(
@@ -245,7 +268,7 @@ class OngoingCallViewModelTest {
         }
 
     @Test
-    fun givenActiveOngoingCall_WhenObservingState_ThenStateShouldBeSetToDefault() = runTest {
+    fun givenActiveOngoingCall_WhenObservingState_ThenStateShouldBeSetToDefault() = runTest(dispatchers.main()) {
         val (_, ongoingCallViewModel) = Arrangement()
             .withLastActiveCall(provideCall())
             .withShouldShowDoubleTapToastReturning(false)
@@ -257,7 +280,7 @@ class OngoingCallViewModelTest {
     }
 
     @Test
-    fun givenClosedOngoingCall_WhenObservingState_ThenStateShouldBeSetToCallClosed() = runTest {
+    fun givenClosedOngoingCall_WhenObservingState_ThenStateShouldBeSetToCallClosed() = runTest(dispatchers.main()) {
         val (_, ongoingCallViewModel) = Arrangement()
             .withNoLastActiveCall()
             .withShouldShowDoubleTapToastReturning(false)
@@ -269,7 +292,7 @@ class OngoingCallViewModelTest {
     }
 
     @Test
-    fun givenCallQualityChanges_WhenObservingQualityState_ThenStateIsUpdated() = runTest {
+    fun givenCallQualityChanges_WhenObservingQualityState_ThenStateIsUpdated() = runTest(dispatchers.main()) {
         val initialQuality = CallQualityData(quality = CallQualityData.Quality.NORMAL, ping = 0)
         val callQualityFlow = MutableStateFlow(initialQuality)
         val (_, ongoingCallViewModel) = Arrangement()
@@ -288,7 +311,7 @@ class OngoingCallViewModelTest {
     }
 
     @Test
-    fun givenCall_WhenChangingCallQualityInterval_ThenSetIntervalProperly() = runTest {
+    fun givenCall_WhenChangingCallQualityInterval_ThenSetIntervalProperly() = runTest(dispatchers.main()) {
         val (arrangement, ongoingCallViewModel) = Arrangement()
             .withLastActiveCall(provideCall())
             .withShouldShowDoubleTapToastReturning(false)
@@ -303,7 +326,147 @@ class OngoingCallViewModelTest {
         }
     }
 
-    private class Arrangement {
+    @Test
+    fun givenAnOngoingCall_WhenInCallReactionIsReceived_ThenNewEmojiIsEmitted() = runTest(dispatchers.main()) {
+        val (arrangement, ongoingCallViewModel) = Arrangement().arrange()
+
+        ongoingCallViewModel.inCallReactions.test {
+
+            // when
+            arrangement.reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍", "🎉")))
+
+            val reaction1 = awaitItem()
+            val reaction2 = awaitItem()
+
+            // then
+            assertEquals("👍", reaction1.emoji)
+            assertIs<ReactionSender.Unknown>(reaction1.sender)
+            assertEquals("🎉", reaction2.emoji)
+            assertIs<ReactionSender.Unknown>(reaction2.sender)
+        }
+    }
+
+    @Test
+    fun givenAnOngoingCall_WhenInCallReactionIsReceived_ThenNewRecentReactionEmitted() = runTest(dispatchers.main()) {
+        val (arrangement, ongoingCallViewModel) = Arrangement().arrange()
+
+        // when
+        arrangement.reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍")))
+
+        val recentReaction = ongoingCallViewModel.recentReactions.getValue(TestUser.USER_ID)
+
+        // then
+        assertEquals("👍", recentReaction)
+    }
+
+    @Test
+    fun givenAnOngoingCall_WhenNewInCallReactionIsReceived_ThenRecentReactionUpdated() = runTest(dispatchers.main()) {
+        val (arrangement, ongoingCallViewModel) = Arrangement().arrange()
+
+        // when
+        arrangement.reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍", "🎉")))
+
+        val recentReaction = ongoingCallViewModel.recentReactions.getValue(TestUser.USER_ID)
+
+        // then
+        assertEquals("🎉", recentReaction)
+    }
+
+    @Test
+    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenReactionMessageIsSent() = runTest(dispatchers.main()) {
+
+        // given
+        val (arrangement, ongoingCallViewModel) = Arrangement()
+            .withSendInCallReactionUseCaseReturning(MessageOperationResult.Success)
+            .arrange()
+
+        // when
+        ongoingCallViewModel.onReactionClick("👍")
+
+        // then
+        coVerify(exactly = 1) {
+            arrangement.sendInCallReactionUseCase(conversationId, "👍")
+        }
+    }
+
+    @Test
+    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenNewEmojiIsEmitted() = runTest(dispatchers.main()) {
+
+        // given
+        val (_, ongoingCallViewModel) = Arrangement()
+            .withSendInCallReactionUseCaseReturning(MessageOperationResult.Success)
+            .arrange()
+
+        ongoingCallViewModel.inCallReactions.test {
+            // when
+            ongoingCallViewModel.onReactionClick("👍")
+
+            val reaction = awaitItem()
+
+            // then
+            assertEquals("👍", reaction.emoji)
+            assertIs<ReactionSender.You>(reaction.sender)
+        }
+    }
+
+    @Test
+    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenReactionMessageIsSentAndAddedToRecentReactions() =
+        runTest(dispatchers.main()) {
+
+            // given
+            val (arrangement, ongoingCallViewModel) = Arrangement()
+                .withSendInCallReactionUseCaseReturning(MessageOperationResult.Success)
+                .arrange()
+
+            // when
+            ongoingCallViewModel.onReactionClick("👌")
+
+            // then
+            coVerify(exactly = 1) {
+                arrangement.sendInCallReactionUseCase(conversationId, "👌")
+            }
+            assertTrue(ongoingCallViewModel.recentReactions.containsValue("👌"))
+        }
+
+    @Test
+    fun givenAnOngoingCall_WhenInCallReactionSentFails_ThenNoEmojiIsEmitted() = runTest(dispatchers.main()) {
+        // given
+        val (_, ongoingCallViewModel) = Arrangement()
+            .withSendInCallReactionUseCaseReturning(
+                MessageOperationResult.Failure(
+                    NetworkFailure.NoNetworkConnection(
+                        IllegalStateException()
+                    )
+                )
+            )
+            .arrange()
+
+        ongoingCallViewModel.inCallReactions.test {
+            // when
+            ongoingCallViewModel.onReactionClick("👍")
+
+            // then
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun givenActiveCall_whenParticipantsChange_thenParticipantsStateIsUpdated() = runTest(dispatchers.main()) {
+        val callFlow = MutableSharedFlow<Call?>()
+        val (_, ongoingCallViewModel) = Arrangement()
+            .withLastActiveCallFlow(callFlow)
+            .arrange()
+
+        callFlow.emit(provideCall().copy(status = CallStatus.ANSWERED, participants = emptyList()))
+        advanceUntilIdle()
+        ongoingCallViewModel.state.participants shouldBeEqualTo persistentListOf()
+
+        callFlow.emit(provideCall().copy(status = CallStatus.ESTABLISHED, participants = participants))
+        advanceUntilIdle()
+        ongoingCallViewModel.state.participants shouldBeEqualTo uiParticipants.toPersistentList()
+    }
+
+    private inner class Arrangement {
 
         @MockK
         private lateinit var observeLastActiveCall: ObserveLastActiveCallWithSortedParticipantsUseCase
@@ -321,7 +484,18 @@ class OngoingCallViewModelTest {
         lateinit var setCallQualityInterval: SetCallQualityIntervalUseCase
 
         @MockK
+        lateinit var observeInCallReactionsUseCase: ObserveInCallReactionsUseCase
+
+        @MockK
+        lateinit var sendInCallReactionUseCase: SendInCallReactionUseCase
+
+        @MockK
+        lateinit var getCurrentClientId: ObserveCurrentClientIdUseCase
+
+        @MockK
         lateinit var globalDataStore: GlobalDataStore
+
+        val reactionsFlow = MutableSharedFlow<InCallReactionMessage>()
 
         private val ongoingCallViewModel by lazy {
             OngoingCallViewModel(
@@ -332,7 +506,12 @@ class OngoingCallViewModelTest {
                 setVideoSendState = setVideoSendState,
                 globalDataStore = globalDataStore,
                 observeCallQualityData = observeCallQualityData,
-                setCallQualityInterval = setCallQualityInterval
+                setCallQualityInterval = setCallQualityInterval,
+                observeInCallReactionsUseCase = observeInCallReactionsUseCase,
+                sendInCallReactionUseCase = sendInCallReactionUseCase,
+                getCurrentClientId = getCurrentClientId,
+                uiCallParticipantMapper = UICallParticipantMapper(UserTypeMapper()),
+                dispatchers = dispatchers
             )
         }
 
@@ -340,6 +519,9 @@ class OngoingCallViewModelTest {
             MockKAnnotations.init(this)
             coEvery { observeCallQualityData(any()) } returns emptyFlow()
             coEvery { setCallQualityInterval(any()) } returns Unit
+            coEvery { observeInCallReactionsUseCase(any()) } returns reactionsFlow
+            coEvery { getCurrentClientId() } returns flowOf(currentClientId)
+            coEvery { observeLastActiveCall.invoke(any()) } returns emptyFlow()
         }
 
         fun arrange() = this to ongoingCallViewModel
@@ -350,6 +532,10 @@ class OngoingCallViewModelTest {
 
         fun withLastActiveCall(call: Call) = apply {
             coEvery { observeLastActiveCall(any()) } returns flowOf(call)
+        }
+
+        fun withLastActiveCallFlow(callFlow: Flow<Call?>) = apply {
+            coEvery { observeLastActiveCall(any()) } returns callFlow
         }
 
         fun withShouldShowDoubleTapToastReturning(shouldShow: Boolean) = apply {
@@ -377,52 +563,54 @@ class OngoingCallViewModelTest {
         fun withCallQualityDataFlow(callQualityDataFlow: Flow<CallQualityData>) = apply {
             coEvery { observeCallQualityData(any()) } returns callQualityDataFlow
         }
+
+        fun withSendInCallReactionUseCaseReturning(result: MessageOperationResult) = apply {
+            coEvery { sendInCallReactionUseCase(conversationId, any()) } returns result
+        }
     }
 
     companion object {
         val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
         val currentUserId = UserId("userId", "some.dummy.domain")
-        private val participant1 = UICallParticipant(
-            id = QualifiedID("value1", "domain"),
-            clientId = "client-id1",
-            isSelfUser = false,
-            name = "name1",
-            isMuted = false,
-            isSpeaking = false,
-            isCameraOn = true,
-            isSharingScreen = false,
-            membership = Membership.None,
-            hasEstablishedAudio = true,
-            accentId = -1
-        )
-        private val participant2 = UICallParticipant(
-            id = QualifiedID("value2", "domain"),
-            clientId = "client-id2",
-            isSelfUser = false,
-            name = "name2",
-            isMuted = false,
-            isSpeaking = false,
-            isCameraOn = false,
-            isSharingScreen = false,
-            membership = Membership.None,
-            hasEstablishedAudio = true,
-            accentId = -1
-        )
-        private val participant3 = UICallParticipant(
-            id = QualifiedID("value3", "domain"),
-            clientId = "client-id3",
-            isSelfUser = false,
-            name = "name3",
-            isMuted = false,
-            isSpeaking = false,
-            isCameraOn = true,
-            isSharingScreen = true,
-            membership = Membership.None,
-            hasEstablishedAudio = true,
-            accentId = -1
-        )
+        private val currentClientId = ClientId("current_client_id")
+        private val uiParticipant1 = provideUICallParticipant(index = 1, isSelfUser = false, isCameraOn = true, isSharingScreen = false)
+        private val uiParticipant2 = provideUICallParticipant(index = 2, isSelfUser = false, isCameraOn = false, isSharingScreen = false)
+        private val uiParticipant3 = provideUICallParticipant(index = 3, isSelfUser = false, isCameraOn = true, isSharingScreen = true)
+        private val participant1 = provideParticipant(index = 1, isCameraOn = true, isSharingScreen = false)
+        private val participant2 = provideParticipant(index = 2, isCameraOn = false, isSharingScreen = false)
+        private val participant3 = provideParticipant(index = 3, isCameraOn = true, isSharingScreen = true)
+        val uiParticipants = listOf(uiParticipant1, uiParticipant2, uiParticipant3)
         val participants = listOf(participant1, participant2, participant3)
-        val selectedParticipant3 = SelectedParticipant(participant3.id, participant3.clientId, false)
+        val selectedParticipant3 = SelectedParticipant(uiParticipant3.id, uiParticipant3.clientId, false)
+
+        fun provideUICallParticipant(index: Int, isSelfUser: Boolean, isCameraOn: Boolean, isSharingScreen: Boolean) = UICallParticipant(
+            id = QualifiedID("value$index", "domain"),
+            clientId = "client-id$index",
+            name = "name$index",
+            isMuted = false,
+            isCameraOn = isCameraOn,
+            hasEstablishedAudio = true,
+            isSpeaking = false,
+            isSharingScreen = isSharingScreen,
+            avatar = null,
+            membership = Membership.None,
+            isSelfUser = isSelfUser,
+            accentId = -1
+        )
+
+        fun provideParticipant(index: Int, isCameraOn: Boolean, isSharingScreen: Boolean) = Participant(
+            id = QualifiedID("value$index", "domain"),
+            clientId = "client-id$index",
+            name = "name$index",
+            isMuted = false,
+            isCameraOn = isCameraOn,
+            hasEstablishedAudio = true,
+            isSpeaking = false,
+            isSharingScreen = isSharingScreen,
+            avatarAssetId = null,
+            userType = UserTypeInfo.Regular(UserType.NONE),
+            accentId = -1
+        )
     }
 
     private fun provideCall(

--- a/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
@@ -246,6 +246,25 @@ class OngoingCallViewModelTest {
     @Test
     fun givenParticipantsList_WhenRequestingVideoStreamForAllParticipant_ThenRequestItInLowQuality() =
         runTest(dispatchers.main()) {
+            val (arrangement, ongoingCallViewModel) = Arrangement()
+                .withLastActiveCall(provideCall().copy(participants = participants))
+                .withShouldShowDoubleTapToastReturning(false)
+                .withSetVideoSendState()
+                .withRequestVideoStreams(conversationId, emptyList())
+                .arrange()
+
+            ongoingCallViewModel.setOthersVideosDisabled(true)
+            ongoingCallViewModel.onSelectedParticipant(null)
+            ongoingCallViewModel.requestVideoStreams(uiParticipants)
+
+            coVerify(exactly = 1) {
+                arrangement.requestVideoStreams(conversationId, emptyList())
+            }
+        }
+
+    @Test
+    fun givenParticipantsListAndOthersVideosDisabled_WhenRequestingVideoStreamForAllParticipant_ThenRequestEmptyList() =
+        runTest(dispatchers.main()) {
             val expectedClients = listOf(
                 CallClient(uiParticipant1.id.toString(), uiParticipant1.clientId, false, CallResolutionQuality.LOW),
                 CallClient(uiParticipant3.id.toString(), uiParticipant3.clientId, false, CallResolutionQuality.LOW)

--- a/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/OngoingCallViewModelTest.kt
@@ -16,6 +16,8 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
+@file:Suppress("UnusedFlow")
+
 package com.wire.android.ui.calling
 
 import app.cash.turbine.test
@@ -39,6 +41,7 @@ import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.call.CallQualityData
 import com.wire.kalium.logic.data.call.CallResolutionQuality
 import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.call.CallingParticipantsOrderType
 import com.wire.kalium.logic.data.call.InCallReactionMessage
 import com.wire.kalium.logic.data.call.Participant
 import com.wire.kalium.logic.data.call.VideoState
@@ -77,8 +80,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
-@OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(CoroutineTestExtension::class)
+@OptIn(ExperimentalCoroutinesApi::class)@ExtendWith(CoroutineTestExtension::class)
 class OngoingCallViewModelTest {
     private val dispatchers = TestDispatcherProvider()
 
@@ -256,7 +258,7 @@ class OngoingCallViewModelTest {
                 .withRequestVideoStreams(conversationId, expectedClients)
                 .arrange()
 
-            ongoingCallViewModel.onSelectedParticipant(SelectedParticipant())
+            ongoingCallViewModel.onSelectedParticipant(null)
             ongoingCallViewModel.requestVideoStreams(uiParticipants)
 
             coVerify(exactly = 1) {
@@ -466,10 +468,57 @@ class OngoingCallViewModelTest {
         ongoingCallViewModel.state.participants shouldBeEqualTo uiParticipants.toPersistentList()
     }
 
+    @Test
+    fun givenCall_WhenDisablingOthersVideos_ThenStateIsUpdated() = runTest(dispatchers.main()) {
+        val (_, ongoingCallViewModel) = Arrangement()
+            .withLastActiveCall(provideCall())
+            .withShouldShowDoubleTapToastReturning(false)
+            .withSetVideoSendState()
+            .arrange()
+        advanceUntilIdle()
+
+        ongoingCallViewModel.setOthersVideosDisabled(true)
+        advanceUntilIdle()
+        assertEquals(true, ongoingCallViewModel.state.othersVideosDisabled)
+
+        ongoingCallViewModel.setOthersVideosDisabled(false)
+        advanceUntilIdle()
+        assertEquals(false, ongoingCallViewModel.state.othersVideosDisabled)
+    }
+
+    @Test
+    fun givenCall_WhenDisablingOthersVideos_ThenParticipantsOrderIsUpdated() = runTest(dispatchers.main()) {
+        val participantsVideosFirst = listOf(participant3, participant1, participant2)
+        val participantsAlphabetically = listOf(participant1, participant2, participant3)
+        val (arrangement, ongoingCallViewModel) = Arrangement()
+            .withLastActiveCall(provideCall().copy(participants = participantsVideosFirst), CallingParticipantsOrderType.VIDEOS_FIRST)
+            .withLastActiveCall(provideCall().copy(participants = participantsAlphabetically), CallingParticipantsOrderType.ALPHABETICALLY)
+            .withShouldShowDoubleTapToastReturning(false)
+            .withSetVideoSendState()
+            .arrange()
+        advanceUntilIdle()
+
+        ongoingCallViewModel.setOthersVideosDisabled(false)
+        advanceUntilIdle()
+        val expectedVideosFirst = listOf(uiParticipant3, uiParticipant1, uiParticipant2)
+        assertEquals(expectedVideosFirst, ongoingCallViewModel.state.participants)
+        coVerify(exactly = 1) {
+            arrangement.observeLastActiveCall(any(), eq(CallingParticipantsOrderType.VIDEOS_FIRST))
+        }
+
+        ongoingCallViewModel.setOthersVideosDisabled(true)
+        advanceUntilIdle()
+        val expectedAlphabetically = listOf(uiParticipant1, uiParticipant2, uiParticipant3)
+        assertEquals(expectedAlphabetically, ongoingCallViewModel.state.participants)
+        coVerify(exactly = 1) {
+            arrangement.observeLastActiveCall(any(), eq(CallingParticipantsOrderType.ALPHABETICALLY))
+        }
+    }
+
     private inner class Arrangement {
 
         @MockK
-        private lateinit var observeLastActiveCall: ObserveLastActiveCallWithSortedParticipantsUseCase
+        lateinit var observeLastActiveCall: ObserveLastActiveCallWithSortedParticipantsUseCase
 
         @MockK
         lateinit var requestVideoStreams: RequestVideoStreamsUseCase
@@ -527,15 +576,15 @@ class OngoingCallViewModelTest {
         fun arrange() = this to ongoingCallViewModel
 
         fun withNoLastActiveCall() = apply {
-            coEvery { observeLastActiveCall(any()) } returns flowOf(null)
+            coEvery { observeLastActiveCall(any(), any()) } returns flowOf(null)
         }
 
-        fun withLastActiveCall(call: Call) = apply {
-            coEvery { observeLastActiveCall(any()) } returns flowOf(call)
+        fun withLastActiveCall(call: Call, orderType: CallingParticipantsOrderType? = null) = apply {
+            coEvery { observeLastActiveCall(any(), (orderType ?: any())) } returns flowOf(call)
         }
 
         fun withLastActiveCallFlow(callFlow: Flow<Call?>) = apply {
-            coEvery { observeLastActiveCall(any()) } returns callFlow
+            coEvery { observeLastActiveCall(any(), any()) } returns callFlow
         }
 
         fun withShouldShowDoubleTapToastReturning(shouldShow: Boolean) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -21,22 +21,17 @@ package com.wire.android.ui.calling
 import android.view.Surface
 import android.view.View
 import app.cash.turbine.test
-import com.wire.android.assertIs
 import com.wire.android.assertions.shouldBeEqualTo
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.TestUser
-import com.wire.android.mapper.UICallParticipantMapper
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.ui.calling.common.SharedCallingViewActions
 import com.wire.android.ui.calling.common.SharedCallingViewModel
-import com.wire.android.ui.calling.model.ReactionSender
 import com.wire.android.ui.calling.usecase.HangUpCallUseCase
-import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallStatus
-import com.wire.kalium.logic.data.call.InCallReactionMessage
 import com.wire.kalium.logic.data.call.Participant
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -47,7 +42,6 @@ import com.wire.kalium.logic.data.user.type.UserTypeInfo
 import com.wire.kalium.logic.feature.call.usecase.FlipToBackCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.FlipToFrontCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
-import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveLastActiveCallWithSortedParticipantsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveSpeakerUseCase
 import com.wire.kalium.logic.feature.call.usecase.SetUIRotationUseCase
@@ -56,23 +50,17 @@ import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
-import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
-import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
-import com.wire.kalium.logic.feature.message.MessageOperationResult
 import com.wire.kalium.logic.util.PlatformRotation
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -223,144 +211,18 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsReceived_ThenNewEmojiIsEmitted() = runTest(dispatchers.main()) {
-        val (arrangement, sharedCallingViewModel) = Arrangement().arrange()
-
-        sharedCallingViewModel.inCallReactions.test {
-
-            // when
-            arrangement.reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍", "🎉")))
-
-            val reaction1 = awaitItem()
-            val reaction2 = awaitItem()
-
-            // then
-            assertEquals("👍", reaction1.emoji)
-            assertIs<ReactionSender.Unknown>(reaction1.sender)
-            assertEquals("🎉", reaction2.emoji)
-            assertIs<ReactionSender.Unknown>(reaction2.sender)
-        }
-    }
-
-    @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsReceived_ThenNewRecentReactionEmitted() = runTest(dispatchers.main()) {
-        val (arrangement, sharedCallingViewModel) = Arrangement().arrange()
-
-        // when
-        arrangement.reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍")))
-
-        val recentReaction = sharedCallingViewModel.recentReactions.getValue(TestUser.USER_ID)
-
-        // then
-        assertEquals("👍", recentReaction)
-    }
-
-    @Test
-    fun givenAnOngoingCall_WhenNewInCallReactionIsReceived_ThenRecentReactionUpdated() = runTest(dispatchers.main()) {
-        val (arrangement, sharedCallingViewModel) = Arrangement().arrange()
-
-        // when
-        arrangement.reactionsFlow.emit(InCallReactionMessage(conversationId, TestUser.USER_ID, setOf("👍", "🎉")))
-
-        val recentReaction = sharedCallingViewModel.recentReactions.getValue(TestUser.USER_ID)
-
-        // then
-        assertEquals("🎉", recentReaction)
-    }
-
-    @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenReactionMessageIsSent() = runTest(dispatchers.main()) {
-
-        // given
-        val (arrangement, sharedCallingViewModel) = Arrangement().arrange()
-
-        // when
-        sharedCallingViewModel.onReactionClick("👍")
-
-        // then
-        coVerify(exactly = 1) {
-            arrangement.sendInCallReactionUseCase(OngoingCallViewModelTest.conversationId, "👍")
-        }
-    }
-
-    @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenNewEmojiIsEmitted() = runTest(dispatchers.main()) {
-
-        // given
-        val (_, sharedCallingViewModel) = Arrangement()
-            .withSendInCallReactionUseCaseReturning(MessageOperationResult.Success)
-            .arrange()
-
-        sharedCallingViewModel.inCallReactions.test {
-            // when
-            sharedCallingViewModel.onReactionClick("👍")
-
-            val reaction = awaitItem()
-
-            // then
-            assertEquals("👍", reaction.emoji)
-            assertIs<ReactionSender.You>(reaction.sender)
-        }
-    }
-
-    @Test
-    fun givenAnOngoingCall_WhenInCallReactionIsSent_ThenReactionMessageIsSentAndAddedToRecentReactions() =
-        runTest(dispatchers.main()) {
-
-            // given
-            val (arrangement, sharedCallingViewModel) = Arrangement()
-                .withSendInCallReactionUseCaseReturning(MessageOperationResult.Success)
-                .arrange()
-
-            // when
-            sharedCallingViewModel.onReactionClick("👌")
-
-            // then
-            coVerify(exactly = 1) {
-                arrangement.sendInCallReactionUseCase(OngoingCallViewModelTest.conversationId, "👌")
-            }
-            assertTrue(sharedCallingViewModel.recentReactions.containsValue("👌"))
-        }
-
-    @Test
-    fun givenAnOngoingCall_WhenInCallReactionSentFails_ThenNoEmojiIsEmitted() = runTest(dispatchers.main()) {
-        // given
-        val (_, sharedCallingViewModel) = Arrangement()
-            .withSendInCallReactionUseCaseReturning(
-                MessageOperationResult.Failure(
-                    NetworkFailure.NoNetworkConnection(
-                        IllegalStateException()
-                    )
-                )
-            )
-            .arrange()
-
-        sharedCallingViewModel.inCallReactions.test {
-            // when
-            sharedCallingViewModel.onReactionClick("👍")
-
-            // then
-            expectNoEvents()
-        }
-    }
-
-    @Test
-    fun givenActiveCall_whenCallStateChanges_thenCallAndParticipantStatesAreUpdated() = runTest(dispatchers.main()) {
+    fun givenActiveCall_whenCallStateChanges_thenCallStateIsUpdated() = runTest(dispatchers.main()) {
         val (arrangement, sharedCallingViewModel) = Arrangement().arrange()
 
         arrangement.callFlow.emit(call.copy(status = CallStatus.ANSWERED, participants = emptyList()))
         advanceUntilIdle()
         sharedCallingViewModel.callState.conversationId shouldBeEqualTo call.conversationId
         sharedCallingViewModel.callState.callStatus shouldBeEqualTo CallStatus.ANSWERED
-        sharedCallingViewModel.participantsState shouldBeEqualTo persistentListOf()
 
         arrangement.callFlow.emit(call.copy(status = CallStatus.ESTABLISHED, participants = listOf(selfParticipant)))
         advanceUntilIdle()
         sharedCallingViewModel.callState.conversationId shouldBeEqualTo call.conversationId
         sharedCallingViewModel.callState.callStatus shouldBeEqualTo CallStatus.ESTABLISHED
-        sharedCallingViewModel.participantsState shouldBeEqualTo persistentListOf(
-            arrangement.uiCallParticipantMapper.toUICallParticipant(selfParticipant, ClientId(selfParticipant.clientId))
-        )
     }
 
     @Test
@@ -416,15 +278,6 @@ class SharedCallingViewModelTest {
         lateinit var observeSpeaker: ObserveSpeakerUseCase
 
         @MockK
-        lateinit var observeInCallReactionsUseCase: ObserveInCallReactionsUseCase
-
-        @MockK
-        lateinit var sendInCallReactionUseCase: SendInCallReactionUseCase
-
-        @MockK
-        lateinit var getCurrentClientId: ObserveCurrentClientIdUseCase
-
-        @MockK
         lateinit var setUIRotationUseCase: SetUIRotationUseCase
 
         @MockK
@@ -433,11 +286,6 @@ class SharedCallingViewModelTest {
         @MockK
         lateinit var userTypeMapper: UserTypeMapper
 
-        val uiCallParticipantMapper: UICallParticipantMapper by lazy {
-            UICallParticipantMapper(userTypeMapper)
-        }
-
-        val reactionsFlow = MutableSharedFlow<InCallReactionMessage>()
         val callFlow = MutableSharedFlow<Call?>()
 
         init {
@@ -445,13 +293,10 @@ class SharedCallingViewModelTest {
             coEvery { observeLastActiveCall.invoke(any()) } returns callFlow
             coEvery { observeConversationDetails.invoke(any()) } returns emptyFlow()
             coEvery { observeSpeaker.invoke() } returns emptyFlow()
-            coEvery { observeInCallReactionsUseCase(any()) } returns reactionsFlow
-            coEvery { getCurrentClientId() } returns flowOf(currentClientId)
         }
 
         fun arrange() = this to SharedCallingViewModel(
             conversationId = conversationId,
-            selfUserId = TestUser.SELF_USER_ID,
             conversationDetails = observeConversationDetails,
             observeLastActiveCallWithSortedParticipants = observeLastActiveCall,
             hangUpCall = hangUpCall,
@@ -465,17 +310,9 @@ class SharedCallingViewModelTest {
             turnLoudSpeakerOff = turnLoudSpeakerOff,
             turnLoudSpeakerOn = turnLoudSpeakerOn,
             observeSpeaker = observeSpeaker,
-            uiCallParticipantMapper = uiCallParticipantMapper,
             userTypeMapper = userTypeMapper,
-            observeInCallReactionsUseCase = observeInCallReactionsUseCase,
-            sendInCallReactionUseCase = sendInCallReactionUseCase,
-            getCurrentClientId = getCurrentClientId,
             dispatchers = dispatchers,
         )
-
-        fun withSendInCallReactionUseCaseReturning(result: MessageOperationResult) = apply {
-            coEvery { sendInCallReactionUseCase(conversationId, any()) } returns result
-        }
     }
 
     companion object {

--- a/default.json
+++ b/default.json
@@ -64,7 +64,8 @@
             "analytics_app_key": "8ffae535f1836ed5f58fd5c8a11c00eca07c5438",
             "analytics_server_url": "https://wire.count.ly/",
             "enable_new_registration": true,
-            "enforce_configuration_signature": true
+            "enforce_configuration_signature": true,
+            "call_quality_menu_enabled": true
         },
         "beta": {
             "application_id": "com.wire.android.internal",
@@ -77,7 +78,8 @@
             "analytics_server_url": "https://wire.count.ly/",
             "enable_new_registration": true,
             "enforce_configuration_signature": true,
-            "use_async_flush_logging": true
+            "use_async_flush_logging": true,
+            "call_quality_menu_enabled": true
         },
         "internal": {
             "application_id": "com.wire.internal",
@@ -93,7 +95,8 @@
             "use_strict_mls_filter": false,
             "use_async_flush_logging": true,
             "conversation_feeder_enabled": true,
-            "db_invalidation_control_enabled": false
+            "db_invalidation_control_enabled": false,
+            "call_quality_menu_enabled": true
         },
         "fdroid": {
             "application_id": "com.wire",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23581
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Implemented the logic for the option to turn off other videos for a user with bad connection quality.
Added new parameter `othersVideosDisabled` which is also used to determine which videos should be requested in AVS.
Used updated `ObserveLastActiveCallWithSortedParticipantsUseCase` which takes also `orderType` parameter.
Simplified logic for opening fullscreen to rely on a single state parameter instead of having two (`shouldOpenFullScreen` removed), and `FullscreenTile` takes only one parameter `selectedParticipant` which is already a `UICallParticipant`, instead of taking two `SelectedParticipant` and list of all participants and then filtering the proper one inside, which is unnecessary and can cause some unwanted recompositions.
Cleaned-up previews for `ParticipantTile` to make use of `PreviewParameter` and thanks to that previews are grouped together and redundant code is reduced.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/3978
- https://github.com/wireapp/wire-android/pull/4666

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Open dev build, start or join a call, make other participants to enable video, open call details and turn off other videos.

### Attachments (Optional)

https://github.com/user-attachments/assets/6c89af80-a2b2-4c71-abe6-af1f46b08d99

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
