### PR TITLE
feat: feature flag for in-call reactions [WPB-24190]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/InCallReactionsButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/InCallReactionsButton.kt
@@ -33,13 +33,10 @@ fun InCallReactionsButton(
     WireCallControlButton(
         isEnabled = isEnabled,
         isSelected = isSelected,
-        iconResId = when (isSelected) {
-            true -> R.drawable.ic_incall_reactions
-            false -> R.drawable.ic_incall_reactions
-        },
+        iconResId = R.drawable.ic_incall_reactions,
         contentDescription = when (isSelected) {
-            true -> R.string.content_description_calling_unmute_call
-            false -> R.string.content_description_calling_mute_call
+            true -> R.string.content_description_calling_in_call_reactions_hide
+            false -> R.string.content_description_calling_in_call_reactions_show
         },
         onClick = onInCallReactionsClick,
         modifier = modifier

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -157,9 +157,11 @@ fun OngoingCallScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
-        ongoingCallViewModel.inCallReactions.collectLatest { reaction ->
-            inCallReactionsState.runAnimation(reaction)
+    LaunchedEffect(BuildConfig.CALL_REACTIONS_ENABLED) {
+        if (BuildConfig.CALL_REACTIONS_ENABLED) {
+            ongoingCallViewModel.inCallReactions.collectLatest { reaction ->
+                inCallReactionsState.runAnimation(reaction)
+            }
         }
     }
 
@@ -361,11 +363,12 @@ private fun OngoingCallContent(
     recentReactions: Map<UserId, String>,
     inPictureInPictureMode: Boolean,
     callQuality: CallQualityData.Quality,
+    inCallReactionsEnabled: Boolean = BuildConfig.CALL_REACTIONS_ENABLED,
     initialShowInCallReactionsPanel: Boolean = false, // for preview purposes
 ) {
     var shouldOpenFullScreen by remember { mutableStateOf(false) }
 
-    var showInCallReactionsPanel by remember { mutableStateOf(initialShowInCallReactionsPanel) }
+    var showInCallReactionsPanel by remember { mutableStateOf(initialShowInCallReactionsPanel && inCallReactionsEnabled) }
     val emojiPickerState = rememberWireModalSheetState<Unit>(skipPartiallyExpanded = false)
     val isConnecting = participants.isEmpty()
 
@@ -424,7 +427,7 @@ private fun OngoingCallContent(
                             .fillMaxSize()
                             .drawInCallReactions(
                                 state = inCallReactionsState,
-                                enabled = !inPictureInPictureMode,
+                                enabled = !inPictureInPictureMode && inCallReactionsEnabled,
                             )
                     ) {
 
@@ -503,7 +506,7 @@ private fun OngoingCallContent(
             }
 
             if (!inPictureInPictureMode) {
-                if (showInCallReactionsPanel) {
+                if (showInCallReactionsPanel && inCallReactionsEnabled) {
                     InCallReactionsPanel(
                         onReactionClick = onReactionClick,
                         onMoreClick = { emojiPickerState.show(Unit) },
@@ -517,6 +520,7 @@ private fun OngoingCallContent(
                     isSpeakerOn = callState.isSpeakerOn,
                     isShowingCallReactions = showInCallReactionsPanel,
                     isConnecting = isConnecting,
+                    inCallReactionsEnabled = inCallReactionsEnabled,
                     toggleSpeaker = toggleSpeaker,
                     toggleMute = toggleMute,
                     onHangUpCall = hangUpCall,
@@ -605,6 +609,7 @@ private fun CallingControls(
     isSpeakerOn: Boolean,
     isShowingCallReactions: Boolean,
     isConnecting: Boolean,
+    inCallReactionsEnabled: Boolean,
     toggleSpeaker: () -> Unit,
     toggleMute: () -> Unit,
     onHangUpCall: () -> Unit,
@@ -638,11 +643,13 @@ private fun CallingControls(
                 onSpeakerButtonClicked = toggleSpeaker
             )
 
-            InCallReactionsButton(
-                isSelected = isShowingCallReactions,
-                isEnabled = !isConnecting,
-                onInCallReactionsClick = onCallReactionsClick
-            )
+            if (inCallReactionsEnabled) {
+                InCallReactionsButton(
+                    isSelected = isShowingCallReactions,
+                    isEnabled = !isConnecting,
+                    onInCallReactionsClick = onCallReactionsClick
+                )
+            }
 
             HangUpOngoingButton(
                 onHangUpButtonClicked = onHangUpCall
@@ -688,6 +695,7 @@ fun PreviewOngoingCallContent(participants: PersistentList<UICallParticipant>, i
         onSelectedParticipant = {},
         selectedParticipantForFullScreen = SelectedParticipant(),
         recentReactions = emptyMap(),
+        inCallReactionsEnabled = true,
         initialShowInCallReactionsPanel = inCallReactionsPanelVisible,
         callQuality = CallQualityData.Quality.NORMAL,
         onOpenCallDetails = {}

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.BuildConfig
 import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.CurrentAccount
@@ -109,7 +110,7 @@ class OngoingCallViewModel @AssistedInject constructor(
 
             observeCurrentCallFlowState(callSharedFlow)
             observeParticipants(callSharedFlow)
-            observeInCallReactions()
+            if (BuildConfig.CALL_REACTIONS_ENABLED) observeInCallReactions()
             observeCallQuality()
             showDoubleTapToast()
         }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
@@ -73,6 +73,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import com.waz.avs.CameraPreviewBuilder
 import com.waz.avs.VideoRenderer
+import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
@@ -183,7 +184,7 @@ fun ParticipantTile(
                 modifier = Modifier
                     .align(Alignment.TopStart)
                     .padding(dimensions().spacing12x),
-                visible = recentReaction != null,
+                visible = recentReaction != null && BuildConfig.CALL_REACTIONS_ENABLED,
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
@@ -109,6 +109,7 @@ fun ParticipantTile(
     shouldFillOthersVideoPreview: Boolean = true,
     isZoomingEnabled: Boolean = false,
     recentReaction: String? = null,
+    inCallReactionsEnabled: Boolean = BuildConfig.CALL_REACTIONS_ENABLED,
 ) {
     Surface(
         modifier = modifier
@@ -184,29 +185,14 @@ fun ParticipantTile(
             }
 
             // Layer 4: Reaction emoji (top-left)
-            AnimatedVisibility(
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(dimensions().spacing12x),
-                visible = recentReaction != null && BuildConfig.CALL_REACTIONS_ENABLED,
-                enter = fadeIn(),
-                exit = fadeOut(),
-            ) {
-                Box(
+            if (BuildConfig.CALL_REACTIONS_ENABLED) {
+                ReactionEmoji(
                     modifier = Modifier
-                        .size(dimensions().inCallReactionRecentReactionSize)
-                        .background(
-                            color = colorsScheme().emojiBackgroundColor,
-                            shape = RoundedCornerShape(dimensions().corner6x)
-                        ),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = recentReaction ?: "",
-                        textAlign = TextAlign.Center,
-                        style = typography().inCallReactionRecentEmoji,
-                    )
-                }
+                        .align(Alignment.TopStart)
+                        .padding(dimensions().spacing12x),
+                    recentReaction = recentReaction,
+                    inCallReactionsEnabled = inCallReactionsEnabled
+                )
             }
 
             // Layer 5: Flip camera button (top-right)
@@ -217,6 +203,36 @@ fun ParticipantTile(
                     flipCamera = flipCamera,
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun ReactionEmoji(
+    modifier: Modifier = Modifier,
+    recentReaction: String? = null,
+    inCallReactionsEnabled: Boolean = true,
+) {
+    AnimatedVisibility(
+        modifier = modifier,
+        visible = recentReaction != null && inCallReactionsEnabled,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(dimensions().inCallReactionRecentReactionSize)
+                .background(
+                    color = colorsScheme().emojiBackgroundColor,
+                    shape = RoundedCornerShape(dimensions().corner6x)
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = recentReaction ?: "",
+                textAlign = TextAlign.Center,
+                style = typography().inCallReactionRecentEmoji,
+            )
         }
     }
 }

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -152,5 +152,7 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
 
     NOMAD_PROFILES_ENABLED("nomad_profiles_enabled", ConfigType.BOOLEAN),
 
-    CALL_QUALITY_MENU_ENABLED("call_quality_menu_enabled", ConfigType.BOOLEAN)
+    CALL_QUALITY_MENU_ENABLED("call_quality_menu_enabled", ConfigType.BOOLEAN),
+
+    CALL_REACTIONS_ENABLED("call_reactions_enabled", ConfigType.BOOLEAN)
 }

--- a/default.json
+++ b/default.json
@@ -178,5 +178,6 @@
     ],
     "enforce_configuration_signature": true,
     "nomad_profiles_enabled": false,
-    "call_quality_menu_enabled": false
+    "call_quality_menu_enabled": false,
+    "call_reactions_enabled": false
 }

--- a/default.json
+++ b/default.json
@@ -179,5 +179,5 @@
     "enforce_configuration_signature": true,
     "nomad_profiles_enabled": false,
     "call_quality_menu_enabled": false,
-    "call_reactions_enabled": false
+    "call_reactions_enabled": true
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24190
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

For some specific builds, the in-call reactions need to be disabled, so this PR adds a dedicated feature flag.
Also, noticed wrong content description for reactions button so fixed that as well.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
