### PR TITLE
feat: feature flag for in-call reactions 🍒 [WPB-24190]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/SharedCallingViewModel.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
+import com.wire.android.BuildConfig
 import com.wire.android.appLogger
 import com.wire.android.di.CurrentAccount
 import com.wire.android.mapper.UICallParticipantMapper
@@ -144,8 +145,11 @@ class SharedCallingViewModel @AssistedInject constructor(
             launch {
                 observeOnSpeaker(this)
             }
-            launch {
-                observeInCallReactions()
+
+            if (BuildConfig.CALL_REACTIONS_ENABLED) {
+                launch {
+                    observeInCallReactions()
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/InCallReactionsButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlbuttons/InCallReactionsButton.kt
@@ -33,13 +33,10 @@ fun InCallReactionsButton(
     WireCallControlButton(
         isEnabled = isEnabled,
         isSelected = isSelected,
-        iconResId = when (isSelected) {
-            true -> R.drawable.ic_incall_reactions
-            false -> R.drawable.ic_incall_reactions
-        },
+        iconResId = R.drawable.ic_incall_reactions,
         contentDescription = when (isSelected) {
-            true -> R.string.content_description_calling_unmute_call
-            false -> R.string.content_description_calling_mute_call
+            true -> R.string.content_description_calling_in_call_reactions_hide
+            false -> R.string.content_description_calling_in_call_reactions_show
         },
         onClick = onInCallReactionsClick,
         modifier = modifier

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -154,9 +154,11 @@ fun OngoingCallScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
-        sharedCallingViewModel.inCallReactions.collectLatest { reaction ->
-            inCallReactionsState.runAnimation(reaction)
+    LaunchedEffect(BuildConfig.CALL_REACTIONS_ENABLED) {
+        if (BuildConfig.CALL_REACTIONS_ENABLED) {
+            sharedCallingViewModel.inCallReactions.collectLatest { reaction ->
+                inCallReactionsState.runAnimation(reaction)
+            }
         }
     }
 
@@ -324,11 +326,12 @@ private fun OngoingCallContent(
     participants: PersistentList<UICallParticipant>,
     recentReactions: Map<UserId, String>,
     inPictureInPictureMode: Boolean,
+    inCallReactionsEnabled: Boolean = BuildConfig.CALL_REACTIONS_ENABLED,
     initialShowInCallReactionsPanel: Boolean = false, // for preview purposes
 ) {
     var shouldOpenFullScreen by remember { mutableStateOf(false) }
 
-    var showInCallReactionsPanel by remember { mutableStateOf(initialShowInCallReactionsPanel) }
+    var showInCallReactionsPanel by remember { mutableStateOf(initialShowInCallReactionsPanel && inCallReactionsEnabled) }
     val emojiPickerState = rememberWireModalSheetState<Unit>(skipPartiallyExpanded = false)
     val isConnecting = participants.isEmpty()
 
@@ -385,7 +388,7 @@ private fun OngoingCallContent(
                             .fillMaxSize()
                             .drawInCallReactions(
                                 state = inCallReactionsState,
-                                enabled = !inPictureInPictureMode,
+                                enabled = !inPictureInPictureMode && inCallReactionsEnabled,
                             )
                     ) {
 
@@ -464,7 +467,7 @@ private fun OngoingCallContent(
             }
 
             if (!inPictureInPictureMode) {
-                if (showInCallReactionsPanel) {
+                if (showInCallReactionsPanel && inCallReactionsEnabled) {
                     InCallReactionsPanel(
                         onReactionClick = onReactionClick,
                         onMoreClick = { emojiPickerState.show(Unit) },
@@ -478,6 +481,7 @@ private fun OngoingCallContent(
                     isSpeakerOn = callState.isSpeakerOn,
                     isShowingCallReactions = showInCallReactionsPanel,
                     isConnecting = isConnecting,
+                    inCallReactionsEnabled = inCallReactionsEnabled,
                     toggleSpeaker = toggleSpeaker,
                     toggleMute = toggleMute,
                     onHangUpCall = hangUpCall,
@@ -560,6 +564,7 @@ private fun CallingControls(
     isSpeakerOn: Boolean,
     isShowingCallReactions: Boolean,
     isConnecting: Boolean,
+    inCallReactionsEnabled: Boolean,
     toggleSpeaker: () -> Unit,
     toggleMute: () -> Unit,
     onHangUpCall: () -> Unit,
@@ -593,11 +598,13 @@ private fun CallingControls(
                 onSpeakerButtonClicked = toggleSpeaker
             )
 
-            InCallReactionsButton(
-                isSelected = isShowingCallReactions,
-                isEnabled = !isConnecting,
-                onInCallReactionsClick = onCallReactionsClick
-            )
+            if (inCallReactionsEnabled) {
+                InCallReactionsButton(
+                    isSelected = isShowingCallReactions,
+                    isEnabled = !isConnecting,
+                    onInCallReactionsClick = onCallReactionsClick
+                )
+            }
 
             HangUpOngoingButton(
                 onHangUpButtonClicked = onHangUpCall
@@ -643,6 +650,7 @@ fun PreviewOngoingCallContent(participants: PersistentList<UICallParticipant>, i
         onSelectedParticipant = {},
         selectedParticipantForFullScreen = SelectedParticipant(),
         recentReactions = emptyMap(),
+        inCallReactionsEnabled = true,
         initialShowInCallReactionsPanel = inCallReactionsPanelVisible,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantsview/ParticipantTile.kt
@@ -74,6 +74,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import com.waz.avs.CameraPreviewBuilder
 import com.waz.avs.VideoRenderer
+import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
@@ -105,6 +106,7 @@ fun ParticipantTile(
     shouldFillOthersVideoPreview: Boolean = true,
     isZoomingEnabled: Boolean = false,
     recentReaction: String? = null,
+    inCallReactionsEnabled: Boolean = BuildConfig.CALL_REACTIONS_ENABLED,
     onClearSelfUserVideoPreview: () -> Unit,
 ) {
     val alpha =
@@ -182,30 +184,13 @@ fun ParticipantTile(
             }
 
             // Layer 4: Reaction emoji (top-left)
-            AnimatedVisibility(
+            ReactionEmoji(
                 modifier = Modifier
                     .align(Alignment.TopStart)
                     .padding(dimensions().spacing12x),
-                visible = recentReaction != null,
-                enter = fadeIn(),
-                exit = fadeOut(),
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(dimensions().inCallReactionRecentReactionSize)
-                        .background(
-                            color = colorsScheme().emojiBackgroundColor,
-                            shape = RoundedCornerShape(dimensions().corner6x)
-                        ),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = recentReaction ?: "",
-                        textAlign = TextAlign.Center,
-                        style = typography().inCallReactionRecentEmoji,
-                    )
-                }
-            }
+                recentReaction = recentReaction,
+                inCallReactionsEnabled = inCallReactionsEnabled
+            )
 
             // Layer 5: Flip camera button (top-right)
             if (participantTitleState.isSelfUser && isSelfUserCameraOn) {
@@ -215,6 +200,36 @@ fun ParticipantTile(
                     flipCamera = flipCamera,
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun ReactionEmoji(
+    modifier: Modifier = Modifier,
+    recentReaction: String? = null,
+    inCallReactionsEnabled: Boolean = true,
+) {
+    AnimatedVisibility(
+        modifier = modifier,
+        visible = recentReaction != null && inCallReactionsEnabled,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(dimensions().inCallReactionRecentReactionSize)
+                .background(
+                    color = colorsScheme().emojiBackgroundColor,
+                    shape = RoundedCornerShape(dimensions().corner6x)
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = recentReaction ?: "",
+                textAlign = TextAlign.Center,
+                style = typography().inCallReactionRecentEmoji,
+            )
         }
     }
 }

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -143,5 +143,7 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
 
     COLLABORA_INTEGRATION_ENABLED("collabora_integration", ConfigType.BOOLEAN),
 
-    DB_INVALIDATION_CONTROL_ENABLED("db_invalidation_control_enabled", ConfigType.BOOLEAN)
+    DB_INVALIDATION_CONTROL_ENABLED("db_invalidation_control_enabled", ConfigType.BOOLEAN),
+
+    CALL_REACTIONS_ENABLED("call_reactions_enabled", ConfigType.BOOLEAN)
 }

--- a/default.json
+++ b/default.json
@@ -163,5 +163,6 @@
     "background_notification_stay_alive_seconds": 3,
     "is_bubble_ui_enabled": true,
     "collabora_integration": true,
-    "db_invalidation_control_enabled": false
+    "db_invalidation_control_enabled": false,
+    "call_reactions_enabled": true
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24190
<!--jira-description-action-hidden-marker-end-->
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Cherry-pick: https://github.com/wireapp/wire-android/pull/4670

For some specific builds, the in-call reactions need to be disabled, so this PR adds a dedicated feature flag.
Also, noticed wrong content description for reactions button so fixed that as well.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.