### PR TITLE
fix: unable to login via intent in nomad environment [WPB-8645]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityActionsHandler.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityActionsHandler.kt
@@ -38,7 +38,10 @@ import com.ramcosta.composedestinations.generated.app.destinations.NewLoginScree
 import com.ramcosta.composedestinations.generated.app.destinations.OtherUserProfileScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.WelcomeScreenDestination
 import com.wire.android.ui.authentication.login.LoginPasswordPath
+import com.wire.android.ui.newauthentication.login.NewLoginViewModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 @Composable
 internal fun HandleViewActions(actions: Flow<WireActivityViewAction>, navigator: Navigator, loginTypeSelector: LoginTypeSelector) {
@@ -91,28 +94,22 @@ private fun openImportMediaScreen(navigator: Navigator) {
 }
 
 private fun openSsoLogin(navigator: Navigator, action: OnSSOLogin) {
-    navigator.navigate(
-        NavigationCommand(
-            when (navigator.navController.currentBackStackEntry?.destination()?.baseRoute) {
-                // if SSO login started from new login screen then go back to the new login flow
-                NewLoginScreenDestination.baseRoute -> {
-                    val existingLoginPasswordPath = navigator.navController.currentBackStackEntry
-                        ?.savedStateHandle
-                        ?.let { NewLoginScreenDestination.argsFrom(it) }
-                        ?.loginPasswordPath
-                    NewLoginScreenDestination(
-                        ssoLoginResult = action.result,
-                        loginPasswordPath = existingLoginPasswordPath,
-                    )
-                }
+    when (navigator.navController.currentBackStackEntry?.destination()?.baseRoute) {
+        // if SSO login started from new login screen, deliver result via savedStateHandle
+        // to avoid recreating the ViewModel (which would happen with UPDATE_EXISTED + new nav args)
+        NewLoginScreenDestination.baseRoute -> {
+            navigator.navController.currentBackStackEntry
+                ?.savedStateHandle
+                ?.set(NewLoginViewModel.SSO_LOGIN_RESULT_KEY, Json.encodeToString(action.result))
+        }
 
-                else -> LoginScreenDestination(
-                    ssoLoginResult = action.result
-                )
-            },
-            BackStackMode.UPDATE_EXISTED,
+        else -> navigator.navigate(
+            NavigationCommand(
+                LoginScreenDestination(ssoLoginResult = action.result),
+                BackStackMode.UPDATE_EXISTED,
+            )
         )
-    )
+    }
 }
 
 private fun openUserProfile(action: OnOpenUserProfile, navigator: Navigator) {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -417,7 +417,6 @@ class WireActivityViewModel @Inject constructor(
             if (backendConfigLoadFailed || nothingProvided) {
                 sendAction(OnUnknownDeepLink)
             } else {
-                automatedLoginManager.markPendingMoveToBackgroundAfterSync()
                 sendAction(
                     OnAutomaticLogin(
                         serverLinks = serverLinks,

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -417,6 +417,7 @@ class WireActivityViewModel @Inject constructor(
             if (backendConfigLoadFailed || nothingProvided) {
                 sendAction(OnUnknownDeepLink)
             } else {
+                automatedLoginManager.markPendingMoveToBackgroundAfterSync()
                 sendAction(
                     OnAutomaticLogin(
                         serverLinks = serverLinks,

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
@@ -139,12 +139,9 @@ fun NewLoginScreen(
         }
     }
 
-    LaunchedEffect(navArgs.ssoLoginResult) {
-        if (navArgs.ssoLoginResult != null) {
-            viewModel.handleSSOResult(
-                navArgs.ssoLoginResult,
-            )
-        }
+    LaunchedEffect(Unit) {
+        navigator.navController.currentBackStackEntry?.savedStateHandle
+            ?.let { viewModel.observeSSOResult(it) }
     }
 
     // Handle SSO code auto-login from intent parameter

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -64,7 +64,10 @@ import com.wire.kalium.logic.feature.client.RegisterClientResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -303,6 +306,18 @@ class NewLoginViewModel(
             )
         }
 
+    fun observeSSOResult(backStackSavedState: SavedStateHandle) {
+        viewModelScope.launch {
+            backStackSavedState
+                .getStateFlow<String?>(SSO_LOGIN_RESULT_KEY, null)
+                .filterNotNull()
+                .collect { json ->
+                    handleSSOResult(Json.decodeFromString(json))
+                    backStackSavedState.remove<String>(SSO_LOGIN_RESULT_KEY)
+                }
+        }
+    }
+
     fun handleSSOResult(ssoLoginResult: DeepLinkResult.SSOLogin) {
         updateLoginFlowState(NewLoginFlowState.Loading)
         when (ssoLoginResult) {
@@ -433,6 +448,7 @@ class NewLoginViewModel(
 
     companion object {
         private const val TAG = "[NewLoginViewModel]"
+        const val SSO_LOGIN_RESULT_KEY = "sso_login_result_json"
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Unable to login via intent in nomad environment

```[NewLoginViewModel] No default SSO code configured for this server```

### Causes (Optional)

 The ViewModel is instantiated twice because the navigation to NewLoginScreen happens twice with different nav args.
First with `ssoCodeAutoLogin` to trigger SSO, and second with `ssoLoginResult` to handle the SSO callback. 
Each nav args change produces a new SavedStateHandle and thus a new ViewModel.
This causees to have a null nomad url on the second instance of viewmodel


### Solutions

instead of navigating to `NewLoginScreenDestination` again with `ssoLoginResult` (which recreates the ViewModel via UPDATE_EXISTED), write the result directly to the existing NavBackStackEntry's savedStateHandle and observe it in the screen composable. This keeps the same ViewModel instance alive.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
