### PR TITLE
feat(nomad devices): verify automated login signature against wire and nomad URLs [WPB-24293]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/IntentsProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/IntentsProcessor.kt
@@ -28,11 +28,7 @@ data class AutomatedLoginViaSSO(
     val backendConfig: String? = null,
     val ssoCode: String? = null,
     val nomadProfilesHost: String? = null,
-) {
-    val isEmpty = backendConfig.isNullOrEmpty() &&
-        ssoCode.isNullOrEmpty() &&
-        nomadProfilesHost.isNullOrEmpty()
-}
+)
 
 @Singleton
 class IntentsProcessor @Inject internal constructor(
@@ -64,11 +60,15 @@ class IntentsProcessor @Inject internal constructor(
             return null
         }
 
-        if (!nomadIntentSignatureValidator.isValid(parsed.nomadProfilesHost, parsed.signatureNomadProfilesHost)) {
+        if (parsed.ssoCode.isNullOrEmpty() || parsed.backendConfig.isNullOrEmpty()) {
             return null
         }
 
-        if (parsed.ssoCode.isNullOrEmpty() || parsed.backendConfig.isNullOrEmpty()) {
+        val signedPayload = createSignedPayload(
+            backendConfig = parsed.backendConfig,
+            nomadProfilesHost = parsed.nomadProfilesHost
+        )
+        if (!nomadIntentSignatureValidator.isValid(signedPayload, parsed.signatureNomadProfilesHost)) {
             return null
         }
 
@@ -76,10 +76,8 @@ class IntentsProcessor @Inject internal constructor(
             parsed.backendConfig,
             parsed.ssoCode,
             parsed.nomadProfilesHost,
-        )
-            .takeIf { !it.isEmpty }
-            ?.takeIf {
-                val validBackend = parsed.backendConfig == null || isValidHttpsUrl(parsed.backendConfig)
+        ).takeIf {
+                val validBackend = isValidHttpsUrl(parsed.backendConfig)
                 val validNomadProfileHost = isValidHttpsUrl(parsed.nomadProfilesHost)
                 validBackend && validNomadProfileHost
             }
@@ -90,4 +88,9 @@ class IntentsProcessor @Inject internal constructor(
         val uri = runCatching { URI(url) }.getOrNull()
         return uri?.scheme?.lowercase() == "https" && !uri.host.isNullOrEmpty()
     }
+
+    private fun createSignedPayload(
+        backendConfig: String,
+        nomadProfilesHost: String
+    ): String = "wire=$backendConfig,nomad=$nomadProfilesHost"
 }

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/NomadIntentSignatureValidator.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/NomadIntentSignatureValidator.kt
@@ -26,7 +26,7 @@ import kotlin.io.encoding.Base64
 
 @Singleton
 class NomadIntentSignatureValidator internal constructor(
-    private val configurationSignatureKeys: List<String>,
+    private val configurationSignatureKeys: Map<String, String>,
     private val isConfigurationSignatureEnforced: Boolean
 ) {
 
@@ -53,7 +53,7 @@ class NomadIntentSignatureValidator internal constructor(
             Base64.decode(signature).toUByteArray()
         }.getOrElse { return false }
         // Any of the available keys can verify this signature.
-        return configurationSignatureKeys.any { b64DerKey ->
+        return prioritizedConfigurationSignatureKeys().any { b64DerKey ->
             runCatching {
                 // DER-encoded Ed25519 public key: 12 bytes ASN.1 header + 32 bytes raw key.
                 val decodedKey = Base64.decode(b64DerKey.replace("\\s".toRegex(), ""))
@@ -76,8 +76,21 @@ class NomadIntentSignatureValidator internal constructor(
         }
     }
 
+    private fun prioritizedConfigurationSignatureKeys(): List<String> =
+        buildList {
+            configurationSignatureKeys[PRIMARY_KEY_INDEX]?.let(::add)
+            configurationSignatureKeys[SECONDARY_KEY_INDEX]?.let(::add)
+            configurationSignatureKeys
+                .filterKeys { it != PRIMARY_KEY_INDEX && it != SECONDARY_KEY_INDEX }
+                .toSortedMap()
+                .values
+                .forEach(::add)
+        }
+
     companion object {
         internal const val SKIP_SIGNATURE_VERIFICATION_TOKEN = "skip"
+        private const val PRIMARY_KEY_INDEX = "0"
+        private const val SECONDARY_KEY_INDEX = "1"
         private const val ED25519_DER_PUBLIC_KEY_HEADER_LENGTH = 12
         private const val ED25519_PUBLIC_KEY_LENGTH = 32
         private val ED25519_DER_PUBLIC_KEY_HEADER = byteArrayOf(

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/IntentsProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/IntentsProcessorTest.kt
@@ -421,7 +421,7 @@ class IntentsProcessorTest {
 
     class Arrangement {
         internal val intent: Intent = mockk()
-        private var configurationSignatureKeys: List<String>? = null
+        private var configurationSignatureKeys: Map<String, String>? = null
         private var isConfigurationSignatureEnforced = false
 
         init {
@@ -431,7 +431,7 @@ class IntentsProcessorTest {
         fun arrange() = this to (
             IntentsProcessor(
                 nomadIntentSignatureValidator = NomadIntentSignatureValidator(
-                    configurationSignatureKeys = configurationSignatureKeys ?: emptyList(),
+                    configurationSignatureKeys = configurationSignatureKeys ?: emptyMap(),
                     isConfigurationSignatureEnforced = isConfigurationSignatureEnforced
                 )
             )
@@ -442,7 +442,7 @@ class IntentsProcessorTest {
         }
 
         fun withConfigurationSignatureKey(vararg key: String) = apply {
-            configurationSignatureKeys = key.toList()
+            configurationSignatureKeys = key.mapIndexed { index, value -> index.toString() to value }.toMap()
         }
 
         fun withConfigurationSignatureEnforced(isEnforced: Boolean) = apply {

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/IntentsProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/IntentsProcessorTest.kt
@@ -108,8 +108,8 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given real Ed25519 signature, verifies nomadProfilesHost with configured key`() {
-        val signedValue = SignedValue.sign(FAKE_NOMAD_PROFILES_HOST)
+    fun `given real Ed25519 signature, verifies backendConfig and nomadProfilesHost with configured key`() {
+        val signedValue = SignedValue.sign(signedIntentPayload())
         val (arrangement, intentsProcessor) = Arrangement()
             .withConfigurationSignatureKey(signedValue.publicKeyDerBase64)
             .withAutomatedLoginExtra(
@@ -133,7 +133,7 @@ class IntentsProcessorTest {
 
     @Test
     fun `given invalid Ed25519 signature, returns null`() {
-        val signedValue = SignedValue.sign(FAKE_NOMAD_PROFILES_HOST)
+        val signedValue = SignedValue.sign(signedIntentPayload())
         val invalidSignature = Base64.getEncoder()
             .encodeToString(
                 Base64.getDecoder().decode(signedValue.signatureBase64).apply {
@@ -144,6 +144,8 @@ class IntentsProcessorTest {
             .withConfigurationSignatureKey(signedValue.publicKeyDerBase64)
             .withAutomatedLoginExtra(
                 automatedLoginJson(
+                    "backendConfig" to FAKE_BACKEND_CONFIG,
+                    "ssoCode" to FAKE_SSO_CODE,
                     "nomadProfilesHost" to FAKE_NOMAD_PROFILES_HOST,
                     "signatureNomadProfilesHost" to invalidSignature
                 )
@@ -154,14 +156,16 @@ class IntentsProcessorTest {
 
     @Test
     fun `given configured key with invalid raw key length, returns null`() {
-        val signedValue = SignedValue.sign(FAKE_NOMAD_PROFILES_HOST)
+        val signedValue = SignedValue.sign(signedIntentPayload())
         val invalidLengthKey = Base64.getEncoder().encodeToString(ByteArray(12 + 31))
         val (arrangement, intentsProcessor) = Arrangement()
             .withConfigurationSignatureKey(invalidLengthKey)
             .withAutomatedLoginExtra(
                 automatedLoginJson(
+                    "backendConfig" to FAKE_BACKEND_CONFIG,
+                    "ssoCode" to FAKE_SSO_CODE,
                     "nomadProfilesHost" to FAKE_NOMAD_PROFILES_HOST,
-                    "sigNomadProfilesHost" to signedValue.signatureBase64
+                    "signatureNomadProfilesHost" to signedValue.signatureBase64
                 )
             )
             .arrange()
@@ -170,7 +174,7 @@ class IntentsProcessorTest {
 
     @Test
     fun `given configured key with invalid der header, returns null`() {
-        val signedValue = SignedValue.sign(FAKE_NOMAD_PROFILES_HOST)
+        val signedValue = SignedValue.sign(signedIntentPayload())
         val invalidHeaderKey = Base64.getEncoder()
             .encodeToString(
                 Base64.getDecoder().decode(signedValue.publicKeyDerBase64).apply {
@@ -181,8 +185,10 @@ class IntentsProcessorTest {
             .withConfigurationSignatureKey(invalidHeaderKey)
             .withAutomatedLoginExtra(
                 automatedLoginJson(
+                    "backendConfig" to FAKE_BACKEND_CONFIG,
+                    "ssoCode" to FAKE_SSO_CODE,
                     "nomadProfilesHost" to FAKE_NOMAD_PROFILES_HOST,
-                    "sigNomadProfilesHost" to signedValue.signatureBase64
+                    "signatureNomadProfilesHost" to signedValue.signatureBase64
                 )
             )
             .arrange()
@@ -227,6 +233,40 @@ class IntentsProcessorTest {
     }
 
     @Test
+    fun `given backendConfig changed after signing, returns null`() {
+        val signedValue = SignedValue.sign(signedIntentPayload())
+        val (arrangement, intentsProcessor) = Arrangement()
+            .withConfigurationSignatureKey(signedValue.publicKeyDerBase64)
+            .withAutomatedLoginExtra(
+                automatedLoginJson(
+                    "backendConfig" to "https://tampered.example.com/deeplink.json",
+                    "ssoCode" to FAKE_SSO_CODE,
+                    "nomadProfilesHost" to FAKE_NOMAD_PROFILES_HOST,
+                    "signatureNomadProfilesHost" to signedValue.signatureBase64
+                )
+            )
+            .arrange()
+        assertNull(intentsProcessor(arrangement.intent))
+    }
+
+    @Test
+    fun `given nomadProfilesHost changed after signing, returns null`() {
+        val signedValue = SignedValue.sign(signedIntentPayload())
+        val (arrangement, intentsProcessor) = Arrangement()
+            .withConfigurationSignatureKey(signedValue.publicKeyDerBase64)
+            .withAutomatedLoginExtra(
+                automatedLoginJson(
+                    "backendConfig" to FAKE_BACKEND_CONFIG,
+                    "ssoCode" to FAKE_SSO_CODE,
+                    "nomadProfilesHost" to "https://tampered.nomad.example.com",
+                    "signatureNomadProfilesHost" to signedValue.signatureBase64
+                )
+            )
+            .arrange()
+        assertNull(intentsProcessor(arrangement.intent))
+    }
+
+    @Test
     fun `given JSON with all fields null, returns null`() {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(automatedLoginJson())
@@ -261,8 +301,9 @@ class IntentsProcessorTest {
             .withAutomatedLoginExtra(
                 automatedLoginJson(
                     "backendConfig" to "http://insecure.wire.com/deeplink.json",
+                    "ssoCode" to FAKE_SSO_CODE,
                     "nomadProfilesHost" to FAKE_NOMAD_PROFILES_HOST,
-                    "sigNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
+                    "signatureNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
                 )
             )
             .arrange()
@@ -275,8 +316,9 @@ class IntentsProcessorTest {
             .withAutomatedLoginExtra(
                 automatedLoginJson(
                     "backendConfig" to "https:///path",
+                    "ssoCode" to FAKE_SSO_CODE,
                     "nomadProfilesHost" to FAKE_NOMAD_PROFILES_HOST,
-                    "sigNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
+                    "signatureNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
                 )
             )
             .arrange()
@@ -289,8 +331,9 @@ class IntentsProcessorTest {
             .withAutomatedLoginExtra(
                 automatedLoginJson(
                     "backendConfig" to "not a url",
+                    "ssoCode" to FAKE_SSO_CODE,
                     "nomadProfilesHost" to FAKE_NOMAD_PROFILES_HOST,
-                    "sigNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
+                    "signatureNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
                 )
             )
             .arrange()
@@ -302,8 +345,10 @@ class IntentsProcessorTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
+                    "backendConfig" to FAKE_BACKEND_CONFIG,
+                    "ssoCode" to FAKE_SSO_CODE,
                     "nomadProfilesHost" to "http://insecure.nomad.example.com",
-                    "sigNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
+                    "signatureNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
                 )
             )
             .arrange()
@@ -315,8 +360,10 @@ class IntentsProcessorTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
+                    "backendConfig" to FAKE_BACKEND_CONFIG,
+                    "ssoCode" to FAKE_SSO_CODE,
                     "nomadProfilesHost" to "https:///path",
-                    "sigNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
+                    "signatureNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
                 )
             )
             .arrange()
@@ -328,8 +375,10 @@ class IntentsProcessorTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
+                    "backendConfig" to FAKE_BACKEND_CONFIG,
+                    "ssoCode" to FAKE_SSO_CODE,
                     "nomadProfilesHost" to "not a url",
-                    "sigNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
+                    "signatureNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
                 )
             )
             .arrange()
@@ -342,13 +391,20 @@ class IntentsProcessorTest {
             .withConfigurationSignatureEnforced(true)
             .withAutomatedLoginExtra(
                 automatedLoginJson(
+                    "backendConfig" to FAKE_BACKEND_CONFIG,
+                    "ssoCode" to FAKE_SSO_CODE,
                     "nomadProfilesHost" to FAKE_NOMAD_PROFILES_HOST,
-                    "sigNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
+                    "signatureNomadProfilesHost" to IntentsProcessor.SKIP_SIGNATURE_VERIFICATION_TOKEN
                 )
             )
             .arrange()
         assertNull(intentsProcessor(arrangement.intent))
     }
+
+    private fun signedIntentPayload(
+        backendConfig: String = FAKE_BACKEND_CONFIG,
+        nomadProfilesHost: String = FAKE_NOMAD_PROFILES_HOST
+    ): String = "wire=$backendConfig,nomad=$nomadProfilesHost"
 
     private fun automatedLoginJson(vararg entries: Pair<String, String>): String =
         if (entries.isEmpty()) {

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/NomadIntentSignatureValidatorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/NomadIntentSignatureValidatorTest.kt
@@ -163,7 +163,7 @@ class NomadIntentSignatureValidatorTest {
     }
 
     private class Arrangement {
-        private var configurationSignatureKeys: List<String> = emptyList()
+        private var configurationSignatureKeys: Map<String, String> = emptyMap()
         private var isConfigurationSignatureEnforced = false
 
         fun arrange() = NomadIntentSignatureValidator(
@@ -172,7 +172,7 @@ class NomadIntentSignatureValidatorTest {
         )
 
         fun withConfigurationSignatureKey(vararg key: String) = apply {
-            configurationSignatureKeys = key.toList()
+            configurationSignatureKeys = key.mapIndexed { index, value -> index.toString() to value }.toMap()
         }
 
         fun withConfigurationSignatureEnforced(isEnforced: Boolean) = apply {

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -21,6 +21,7 @@ enum class ConfigType(val type: String) {
     STRING("String"),
     BOOLEAN("Boolean"),
     INT("int"),
+    MapOfStrings("java.util.HashMap<String, String>"),
     MapOfStringToListOfStrings("java.util.HashMap<String, java.util.List<String>>"),
     ListOfStrings("java.util.List<String>")
 }
@@ -146,7 +147,7 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
 
     DB_INVALIDATION_CONTROL_ENABLED("db_invalidation_control_enabled", ConfigType.BOOLEAN),
 
-    CONFIGURATION_SIGNATURE_KEYS("configuration_signature_keys", ConfigType.ListOfStrings),
+    CONFIGURATION_SIGNATURE_KEYS("configuration_signature_keys", ConfigType.MapOfStrings),
 
     ENFORCE_CONFIGURATION_SIGNATURE("enforce_configuration_signature", ConfigType.BOOLEAN),
 

--- a/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
@@ -205,6 +205,21 @@ android {
                     )
                 }
 
+                ConfigType.MapOfStrings -> {
+                    val map = flavorMap[flavor.name]?.get(configs.value) as? Map<*, *>
+                    val mapString = map?.map { (key, value) ->
+                        "\"$key\", \"$value\"".let {
+                            "put($it);"
+                        }
+                    }?.joinToString("\n") ?: ""
+                    buildNonStringConfig(
+                        flavor,
+                        configs.configType.type,
+                        configs.name,
+                        "new java.util.HashMap<String, String>() {{\n$mapString\n}}"
+                    )
+                }
+
                 ConfigType.MapOfStringToListOfStrings -> {
                     val map = flavorMap[flavor.name]?.get(configs.value) as? Map<*, *>
                     val mapString = map?.map { (key, value) ->

--- a/default.json
+++ b/default.json
@@ -175,10 +175,10 @@
     "is_bubble_ui_enabled": true,
     "collabora_integration": true,
     "db_invalidation_control_enabled": false,
-    "configuration_signature_keys": [
-        "MCowBQYDK2VwAyEAFbodixhcegKs4NkpPjjzJYHAxKLlye04SuZ2JNJ9RCc=",
-        "MCowBQYDK2VwAyEAkAH9FXpKfjp1PX0HeVo5JeYi6h/zDUNwkURIuEZ+7FY="
-    ],
+    "configuration_signature_keys": {
+        "0": "MCowBQYDK2VwAyEAs+61FW9LNh1nrbKyyjiWLfGmu1zNq2JvpQY2gHZwkUg=",
+        "1": "MCowBQYDK2VwAyEADxZHnqshgLAjIOvSMPVdwRxAcPh4QzvchnaVUDMseBc="
+    },
     "enforce_configuration_signature": true,
     "nomad_profiles_enabled": false,
     "call_quality_menu_enabled": false,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24293
<!--jira-description-action-hidden-marker-end-->
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability

----

# What's new in this PR?

### Issues

The automated login intent signature verification only covered `nomadProfilesHost`, which meant `backendConfig` was not protected by the same signature.

### Solutions

Updated automated login intent verification to validate a combined canonical payload built from the decoded JSON values in this exact format:

`wire={wire_url},nomad={nomad_url}`

This change ensures the signature now covers both:
- `backendConfig`
- `nomadProfilesHost`

Also updated automated tests to cover:
- valid combined signature verification
- tampering of `backendConfig`
- tampering of `nomadProfilesHost`

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

This change was tested with focused unit tests covering the automated login intent parser and signature validator.

Command used:
```bash
./gradlew :app:testDevDebugUnitTest --tests com.wire.android.util.lifecycle.IntentsProcessorTest --tests com.wire.android.util.lifecycle.NomadIntentSignatureValidatorTest
```

Result:
- `BUILD SUCCESSFUL`

### Notes

Expected signed payload format is now:

`wire={backendConfig},nomad={nomadProfilesHost}`

using the exact decoded JSON string values and this exact field order.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue

----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
