### PR TITLE
fix(nomad): App remains in foreground after logout via intent (WPB-24308)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
@@ -24,6 +24,7 @@ import com.wire.android.config.NomadProfilesFeatureConfig
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
+import com.wire.android.util.SwitchAccountObserver
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
@@ -50,6 +51,9 @@ class NomadLogoutReceiver : CoroutineReceiver() {
     lateinit var accountSwitch: AccountSwitchUseCase
 
     @Inject
+    lateinit var switchAccountObserver: SwitchAccountObserver
+
+    @Inject
     lateinit var nomadProfilesFeatureConfig: NomadProfilesFeatureConfig
 
     public override suspend fun receive(context: Context, intent: Intent) {
@@ -74,8 +78,8 @@ class NomadLogoutReceiver : CoroutineReceiver() {
                 val userId = session.accountInfo.userId
                 appLogger.i("$TAG Logging out user: ${userId.toLogString()}")
                 coreLogic.getSessionScope(userId).logout(LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
-                deleteSession(userId)
-                accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount)
+                coreLogic.getGlobalScope().deleteSession(userId)
+                accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount).callAction(switchAccountObserver)
             }
 
             is CurrentSessionResult.Failure.SessionNotFound ->
@@ -88,6 +92,6 @@ class NomadLogoutReceiver : CoroutineReceiver() {
 
     companion object {
         const val ACTION_LOGOUT = "com.wire.ACTION_LOGOUT"
-        private const val TAG = "LogoutReceiver"
+        private const val TAG = "NomadLogoutReceiver"
     }
 }

--- a/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiverTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiverTest.kt
@@ -24,6 +24,7 @@ import com.wire.android.config.NomadProfilesFeatureConfig
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
 import com.wire.android.feature.SwitchAccountResult
+import com.wire.android.util.SwitchAccountObserver
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.logout.LogoutReason
@@ -68,6 +69,7 @@ class NomadLogoutReceiverTest {
             arrangement.deleteSession(userId)
             arrangement.accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount)
         }
+        verify(exactly = 1) { arrangement.switchAccountObserver.noOtherAccountToSwitch() }
     }
 
     @Test
@@ -127,6 +129,9 @@ class NomadLogoutReceiverTest {
         lateinit var accountSwitch: AccountSwitchUseCase
 
         @MockK
+        lateinit var switchAccountObserver: SwitchAccountObserver
+
+        @MockK
         lateinit var userSessionScope: UserSessionScope
 
         @MockK
@@ -148,6 +153,7 @@ class NomadLogoutReceiverTest {
             every { userSessionScope.logout } returns logoutUseCase
             coEvery { logoutUseCase(any(), any()) } returns Unit
             coEvery { deleteSession(any()) } returns DeleteSessionUseCase.Result.Success
+            every { coreLogic.getGlobalScope().deleteSession } returns deleteSession
             coEvery { accountSwitch(any()) } returns SwitchAccountResult.NoOtherAccountToSwitch
             every { coreLogic.getSessionScope(any()) } returns userSessionScope
             every { nomadProfilesFeatureConfig.isEnabled() } returns true
@@ -158,6 +164,7 @@ class NomadLogoutReceiverTest {
             receiver.currentSession = currentSession
             receiver.deleteSession = deleteSession
             receiver.accountSwitch = accountSwitch
+            receiver.switchAccountObserver = switchAccountObserver
             receiver.nomadProfilesFeatureConfig = nomadProfilesFeatureConfig
             return this
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24308
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a Nomad logout happens, the app logs the user out and clears the session, but doesn’t navigate anywhere—so the screen stays stuck.

### Causes (Optional)

This is because normal logout (from the UI) handles navigation itself, and `WireActivityViewModel` ignores logout events assuming that already happened. But Nomad logout comes from the background, so no navigation is triggered.

### Solutions

Use the existing `SwitchAccountObserver`, which connects background events to the UI. By calling it from `NomadLogoutReceiver`, the app can properly redirect the user to the login screen right after logout.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
