### PR TITLE
fix(nomad): hide session expired modal after another successful login (WPB-24304)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -234,8 +234,14 @@ class WireActivityViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             observeCurrentAccountInfo
                 .collect {
-                    if (it is AccountInfo.Invalid) {
-                        handleInvalidSession(it.logoutReason)
+                    when (it) {
+                        is AccountInfo.Invalid -> handleInvalidSession(it.logoutReason)
+                        is AccountInfo.Valid -> withContext(dispatchers.main()) {
+                            globalAppState = globalAppState.copy(blockUserUI = null)
+                        }
+
+                        null -> {}
+                        // No account info, user is not logged in, do nothing
                     }
                 }
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24304
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Session expired modal stays visible even after another successful login on device 

### Causes (Optional)

We don't hide the the dialog when there is valid accountsInfo

### Solutions

Observe account info and update dialog state

#### How to Test

- Login on device A via intent
- Login on device B via intent with same account, and do not dismiss "expired session" dialog on device A
- Login again on device A with intent with same account

Actual:
"expired session" dialog stays visible, and once you click on it you will be navigated to login screen
Expected:
"expired session" dialog is dismissed after login

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
