### PR TITLE
fix(nomad): Crash on logout while logging in (WPB-24402)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -354,6 +354,7 @@ class LoginSSOViewModel(
         }
     }
 
+    @Suppress("ThrowsCount", "TooGenericExceptionCaught")
     private suspend fun revertSSOSession(userId: UserId) {
         try {
             coreLogic.getSessionScope(userId).logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -57,12 +57,16 @@ import com.wire.kalium.logic.feature.auth.sso.SSOInitiateLoginResult
 import com.wire.kalium.logic.feature.auth.sso.SSOLoginSessionResult
 import com.wire.kalium.logic.feature.backup.RestoreCryptoStateResult
 import com.wire.kalium.logic.feature.client.RegisterClientResult
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import android.database.sqlite.SQLiteException
+import java.io.IOException
 import javax.inject.Inject
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -257,29 +261,7 @@ class LoginSSOViewModel(
                         registerClientAndUpdateState(storedUserId, setLastDeviceId = false)
                     } else {
                         appLogger.i("$TAG Nomad enabled, attempting crypto state restore")
-                        when (
-                            withContext(dispatchers.io()) {
-                                coreLogic.getSessionScope(storedUserId).backup.restoreCryptoState()
-                            }
-                        ) {
-                            is RestoreCryptoStateResult.Success -> {
-                                updateSSOFlowState(LoginState.Success(isInitialSyncCompleted(storedUserId), false))
-                            }
-
-                            is RestoreCryptoStateResult.NoBackupAvailable -> {
-                                registerClientAndUpdateState(storedUserId, setLastDeviceId = true)
-                            }
-
-                            is RestoreCryptoStateResult.Failure -> {
-                                appLogger.e("$TAG Failed to restore crypto state during SSO login")
-                                revertSSOSession(storedUserId)
-                                updateSSOFlowState(
-                                    LoginState.Error.DialogError.GenericError(
-                                        CoreFailure.Unknown(Exception("Failed to restore crypto state"))
-                                    )
-                                )
-                            }
-                        }
+                        restoreCryptoStateAndContinue(storedUserId)
                     }
                 }
             )
@@ -330,9 +312,62 @@ class LoginSSOViewModel(
         }
     }
 
+    private suspend fun isSessionStillValid(userId: UserId): Boolean =
+        (coreLogic.getGlobalScope().doesValidSessionExist(userId) as? DoesValidSessionExistResult.Success)
+            ?.doesValidSessionExist == true
+
+    private suspend fun restoreCryptoStateAndContinue(storedUserId: UserId) {
+        val restoreResult = try {
+            withContext(dispatchers.io()) {
+                coreLogic.getSessionScope(storedUserId).backup.restoreCryptoState()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            when (e) {
+                is IllegalStateException, is IOException, is SQLiteException -> {
+                    if (isSessionStillValid(storedUserId)) throw e
+                    appLogger.w("$TAG Crypto restore interrupted by concurrent logout: ${e.message}")
+                    return
+                }
+                else -> throw e
+            }
+        }
+
+        when (restoreResult) {
+            is RestoreCryptoStateResult.Success -> {
+                updateSSOFlowState(LoginState.Success(isInitialSyncCompleted(storedUserId), false))
+            }
+            is RestoreCryptoStateResult.NoBackupAvailable -> {
+                registerClientAndUpdateState(storedUserId, setLastDeviceId = true)
+            }
+            is RestoreCryptoStateResult.Failure -> {
+                appLogger.e("$TAG Failed to restore crypto state during SSO login")
+                revertSSOSession(storedUserId)
+                updateSSOFlowState(
+                    LoginState.Error.DialogError.GenericError(
+                        CoreFailure.Unknown(Exception("Failed to restore crypto state"))
+                    )
+                )
+            }
+        }
+    }
+
     private suspend fun revertSSOSession(userId: UserId) {
-        coreLogic.getSessionScope(userId).logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
-        coreLogic.getGlobalScope().deleteSession(userId)
+        try {
+            coreLogic.getSessionScope(userId).logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
+            coreLogic.getGlobalScope().deleteSession(userId)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            when (e) {
+                is IllegalStateException, is IOException, is SQLiteException -> {
+                    if (isSessionStillValid(userId)) throw e
+                    appLogger.w("$TAG Failed to revert SSO session, may have been already logged out: ${e.message}")
+                }
+                else -> throw e
+            }
+        }
     }
 
     private fun openWebUrl(url: String, customServerConfig: ServerConfig.Links) {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -316,6 +316,7 @@ class LoginSSOViewModel(
         (coreLogic.getGlobalScope().doesValidSessionExist(userId) as? DoesValidSessionExistResult.Success)
             ?.doesValidSessionExist == true
 
+    @Suppress("ThrowsCount", "TooGenericExceptionCaught")
     private suspend fun restoreCryptoStateAndContinue(storedUserId: UserId) {
         val restoreResult = try {
             withContext(dispatchers.io()) {

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -76,7 +76,7 @@ import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Named
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
 class NewLoginViewModel(
     private val validateEmailOrSSOCode: ValidateEmailOrSSOCodeUseCase,
@@ -347,6 +347,7 @@ class NewLoginViewModel(
                     )
                 }
             }
+
             is DeepLinkResult.SSOLogin.Failure -> {
                 updateLoginFlowState(NewLoginFlowState.Error.DialogError.SSOResultFailure(ssoLoginResult.ssoError))
             }
@@ -443,6 +444,7 @@ class NewLoginViewModel(
         }
     }
 
+    @Suppress("ThrowsCount", "TooGenericExceptionCaught")
     private suspend fun revertSSOSession(userId: UserId) {
         try {
             coreLogic.getSessionScope(userId).logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -396,6 +396,7 @@ class NewLoginViewModel(
         (coreLogic.getGlobalScope().doesValidSessionExist(userId) as? DoesValidSessionExistResult.Success)
             ?.doesValidSessionExist == true
 
+    @Suppress("ThrowsCount", "TooGenericExceptionCaught")
     private suspend fun restoreCryptoStateAndContinue(storedUserId: UserId) {
         val restoreResult = try {
             withContext(dispatchers.io()) {

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.ui.newauthentication.login
 
+import android.database.sqlite.SQLiteException
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
@@ -61,15 +62,17 @@ import com.wire.kalium.logic.feature.auth.sso.SSOInitiateLoginResult
 import com.wire.kalium.logic.feature.auth.sso.SSOLoginSessionResult
 import com.wire.kalium.logic.feature.backup.RestoreCryptoStateResult
 import com.wire.kalium.logic.feature.client.RegisterClientResult
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.onEach
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -338,35 +341,7 @@ class NewLoginViewModel(
                                 appLogger.i("$TAG Nomad not enabled, proceeding with regular login")
                                 registerClientAndUpdateState(storedUserId, setLastDeviceId = false)
                             } else {
-                                when (
-                                    withContext(dispatchers.io()) {
-                                        coreLogic.getSessionScope(storedUserId).backup.restoreCryptoState()
-                                    }
-                                ) {
-                                    is RestoreCryptoStateResult.Success -> {
-                                        withContext(dispatchers.main()) {
-                                            when (loginExtension.isInitialSyncCompleted(storedUserId)) {
-                                                true -> sendAction(NewLoginAction.Success(NewLoginAction.Success.NextStep.None))
-                                                false -> sendAction(NewLoginAction.Success(NewLoginAction.Success.NextStep.InitialSync))
-                                            }
-                                            updateLoginFlowState(NewLoginFlowState.Default)
-                                        }
-                                    }
-                                    is RestoreCryptoStateResult.NoBackupAvailable -> {
-                                        registerClientAndUpdateState(storedUserId, setLastDeviceId = true)
-                                    }
-                                    is RestoreCryptoStateResult.Failure -> {
-                                        appLogger.e("$TAG Failed to restore crypto state during SSO login")
-                                        revertSSOSession(storedUserId)
-                                        withContext(dispatchers.main()) {
-                                            updateLoginFlowState(
-                                                NewLoginFlowState.Error.DialogError.GenericError(
-                                                    CoreFailure.Unknown(Exception("Failed to restore crypto state"))
-                                                )
-                                            )
-                                        }
-                                    }
-                                }
+                                restoreCryptoStateAndContinue(storedUserId)
                             }
                         }
                     )
@@ -416,9 +391,74 @@ class NewLoginViewModel(
         }
     }
 
+    private suspend fun isSessionStillValid(userId: UserId): Boolean =
+        (coreLogic.getGlobalScope().doesValidSessionExist(userId) as? DoesValidSessionExistResult.Success)
+            ?.doesValidSessionExist == true
+
+    private suspend fun restoreCryptoStateAndContinue(storedUserId: UserId) {
+        val restoreResult = try {
+            withContext(dispatchers.io()) {
+                coreLogic.getSessionScope(storedUserId).backup.restoreCryptoState()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            when (e) {
+                is IllegalStateException, is IOException, is SQLiteException -> {
+                    if (isSessionStillValid(storedUserId)) throw e
+                    appLogger.w("$TAG Crypto restore interrupted by concurrent logout: ${e.message}")
+                    return
+                }
+
+                else -> throw e
+            }
+        }
+
+        when (restoreResult) {
+            is RestoreCryptoStateResult.Success -> {
+                withContext(dispatchers.main()) {
+                    when (loginExtension.isInitialSyncCompleted(storedUserId)) {
+                        true -> sendAction(NewLoginAction.Success(NewLoginAction.Success.NextStep.None))
+                        false -> sendAction(NewLoginAction.Success(NewLoginAction.Success.NextStep.InitialSync))
+                    }
+                    updateLoginFlowState(NewLoginFlowState.Default)
+                }
+            }
+
+            is RestoreCryptoStateResult.NoBackupAvailable -> {
+                registerClientAndUpdateState(storedUserId, setLastDeviceId = true)
+            }
+
+            is RestoreCryptoStateResult.Failure -> {
+                appLogger.e("$TAG Failed to restore crypto state during SSO login")
+                revertSSOSession(storedUserId)
+                withContext(dispatchers.main()) {
+                    updateLoginFlowState(
+                        NewLoginFlowState.Error.DialogError.GenericError(
+                            CoreFailure.Unknown(Exception("Failed to restore crypto state"))
+                        )
+                    )
+                }
+            }
+        }
+    }
+
     private suspend fun revertSSOSession(userId: UserId) {
-        coreLogic.getSessionScope(userId).logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
-        coreLogic.getGlobalScope().deleteSession(userId)
+        try {
+            coreLogic.getSessionScope(userId).logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
+            coreLogic.getGlobalScope().deleteSession(userId)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            when (e) {
+                is IllegalStateException, is IOException, is SQLiteException -> {
+                    if (isSessionStillValid(userId)) throw e
+                    appLogger.w("$TAG Failed to revert SSO session, may have been already logged out: ${e.message}")
+                }
+
+                else -> throw e
+            }
+        }
     }
 
     /**

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
@@ -70,6 +70,8 @@ import com.wire.kalium.logic.feature.client.ClientScope
 import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -83,6 +85,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import android.database.sqlite.SQLiteException
 import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -889,6 +892,130 @@ class LoginSSOViewModelTest {
             loginViewModel.loginState.flowState.shouldBeInstanceOf<LoginState.Error.DialogError.GenericError>()
         }
 
+    @Test
+    fun `given Nomad enabled and crypto restore throws IllegalStateException with session gone, when establishSSOSession succeeds, then abort silently without reverting`() =
+        runTest {
+            val expectedCookie = "some-cookie"
+            val (arrangement, loginViewModel) = Arrangement()
+                .withEstablishSSOSession(expectedCookie)
+                .withNomadEnabled(true)
+                .withRestoreCryptoStateThrowing(IllegalStateException("attempt to re-open an already-closed object"))
+                .withSessionStillValid(false)
+                .arrange()
+
+            loginViewModel.establishSSOSession(expectedCookie, SERVER_CONFIG.id)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                arrangement.ssoExtension.establishSSOSession(
+                    eq(expectedCookie),
+                    eq(SERVER_CONFIG.id),
+                    any(),
+                    any(),
+                    capture(onAuthScopeFailureSlot),
+                    capture(onSSOLoginFailureSlot),
+                    capture(onAddAuthenticatedUserFailureSlot),
+                    capture(onSuccessEstablishSSOSessionSlot)
+                )
+            }
+            onSuccessEstablishSSOSessionSlot.captured.invoke(TestUser.USER_ID)
+            coVerify(exactly = 0) { arrangement.logoutUseCase(any(), any()) }
+            coVerify(exactly = 0) { arrangement.deleteSessionUseCase(any()) }
+        }
+
+    @Test
+    fun `given Nomad enabled and crypto restore throws IOException with session gone, when establishSSOSession succeeds, then abort silently without reverting`() =
+        runTest {
+            val expectedCookie = "some-cookie"
+            val (arrangement, loginViewModel) = Arrangement()
+                .withEstablishSSOSession(expectedCookie)
+                .withNomadEnabled(true)
+                .withRestoreCryptoStateThrowing(IOException("session files deleted"))
+                .withSessionStillValid(false)
+                .arrange()
+
+            loginViewModel.establishSSOSession(expectedCookie, SERVER_CONFIG.id)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                arrangement.ssoExtension.establishSSOSession(
+                    eq(expectedCookie),
+                    eq(SERVER_CONFIG.id),
+                    any(),
+                    any(),
+                    capture(onAuthScopeFailureSlot),
+                    capture(onSSOLoginFailureSlot),
+                    capture(onAddAuthenticatedUserFailureSlot),
+                    capture(onSuccessEstablishSSOSessionSlot)
+                )
+            }
+            onSuccessEstablishSSOSessionSlot.captured.invoke(TestUser.USER_ID)
+            coVerify(exactly = 0) { arrangement.logoutUseCase(any(), any()) }
+            coVerify(exactly = 0) { arrangement.deleteSessionUseCase(any()) }
+        }
+
+    @Test
+    fun `given Nomad enabled and crypto restore throws SQLiteException with session gone, when establishSSOSession succeeds, then abort silently without reverting`() =
+        runTest {
+            val expectedCookie = "some-cookie"
+            val (arrangement, loginViewModel) = Arrangement()
+                .withEstablishSSOSession(expectedCookie)
+                .withNomadEnabled(true)
+                .withRestoreCryptoStateThrowing(SQLiteException("database is locked"))
+                .withSessionStillValid(false)
+                .arrange()
+
+            loginViewModel.establishSSOSession(expectedCookie, SERVER_CONFIG.id)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                arrangement.ssoExtension.establishSSOSession(
+                    eq(expectedCookie),
+                    eq(SERVER_CONFIG.id),
+                    any(),
+                    any(),
+                    capture(onAuthScopeFailureSlot),
+                    capture(onSSOLoginFailureSlot),
+                    capture(onAddAuthenticatedUserFailureSlot),
+                    capture(onSuccessEstablishSSOSessionSlot)
+                )
+            }
+            onSuccessEstablishSSOSessionSlot.captured.invoke(TestUser.USER_ID)
+            coVerify(exactly = 0) { arrangement.logoutUseCase(any(), any()) }
+            coVerify(exactly = 0) { arrangement.deleteSessionUseCase(any()) }
+        }
+
+    @Test
+    fun `given Nomad enabled and restore failure and revert throws with session gone, when establishSSOSession succeeds, then show error without crashing`() =
+        runTest {
+            val expectedCookie = "some-cookie"
+            val (arrangement, loginViewModel) = Arrangement()
+                .withEstablishSSOSession(expectedCookie)
+                .withNomadEnabled(true)
+                .withRestoreCryptoStateReturning(RestoreCryptoStateResult.Failure)
+                .withSessionStillValid(false)
+                .apply { coEvery { logoutUseCase(any(), any()) } throws IllegalStateException("already closed") }
+                .arrange()
+
+            loginViewModel.establishSSOSession(expectedCookie, SERVER_CONFIG.id)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                arrangement.ssoExtension.establishSSOSession(
+                    eq(expectedCookie),
+                    eq(SERVER_CONFIG.id),
+                    any(),
+                    any(),
+                    capture(onAuthScopeFailureSlot),
+                    capture(onSSOLoginFailureSlot),
+                    capture(onAddAuthenticatedUserFailureSlot),
+                    capture(onSuccessEstablishSSOSessionSlot)
+                )
+            }
+            onSuccessEstablishSSOSessionSlot.captured.invoke(TestUser.USER_ID)
+            loginViewModel.loginState.flowState.shouldBeInstanceOf<LoginState.Error.DialogError.GenericError>()
+        }
+
     private class Arrangement {
 
         @MockK
@@ -947,6 +1074,9 @@ class LoginSSOViewModelTest {
 
         @MockK
         lateinit var setLastDeviceIdUseCase: SetLastDeviceIdUseCase
+
+        @MockK
+        lateinit var doesValidSessionExistUseCase: DoesValidSessionExistUseCase
 
         init {
             MockKAnnotations.init(this)
@@ -1049,6 +1179,16 @@ class LoginSSOViewModelTest {
         fun withRevertSSOSessionSuccess() = apply {
             coEvery { logoutUseCase(any(), any()) } returns Unit
             coEvery { deleteSessionUseCase(any()) } returns DeleteSessionUseCase.Result.Success
+        }
+
+        fun withRestoreCryptoStateThrowing(exception: Throwable) = apply {
+            every { coreLogic.getSessionScope(any()).backup.restoreCryptoState } returns restoreCryptoStateUseCase
+            coEvery { restoreCryptoStateUseCase() } throws exception
+        }
+
+        fun withSessionStillValid(valid: Boolean) = apply {
+            every { coreLogic.getGlobalScope().doesValidSessionExist } returns doesValidSessionExistUseCase
+            coEvery { doesValidSessionExistUseCase(any()) } returns DoesValidSessionExistResult.Success(valid)
         }
 
         fun withNomadAutoLogin(nomadServiceUrl: String) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -44,8 +44,12 @@ import com.wire.kalium.logic.feature.backup.RestoreCryptoStateResult
 import com.wire.kalium.logic.feature.backup.RestoreCryptoStateUseCase
 import com.wire.kalium.logic.feature.backup.SetLastDeviceIdResult
 import com.wire.kalium.logic.feature.backup.SetLastDeviceIdUseCase
+import android.database.sqlite.SQLiteException
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
+import java.io.IOException
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -650,6 +654,9 @@ class NewLoginViewModelTest {
         lateinit var deleteSessionUseCase: DeleteSessionUseCase
 
         @MockK
+        lateinit var doesValidSessionExistUseCase: DoesValidSessionExistUseCase
+
+        @MockK
         lateinit var setLastDeviceIdUseCase: SetLastDeviceIdUseCase
 
         init {
@@ -871,6 +878,16 @@ class NewLoginViewModelTest {
         fun withRevertSSOSessionSuccess() = apply {
             coEvery { logoutUseCase(any(), any()) } returns Unit
             coEvery { deleteSessionUseCase(any()) } returns DeleteSessionUseCase.Result.Success
+        }
+
+        fun withRestoreCryptoStateThrowing(exception: Throwable) = apply {
+            every { coreLogic.getSessionScope(any()).backup.restoreCryptoState } returns restoreCryptoStateUseCase
+            coEvery { restoreCryptoStateUseCase() } throws exception
+        }
+
+        fun withSessionStillValid(valid: Boolean) = apply {
+            every { coreLogic.getGlobalScope().doesValidSessionExist } returns doesValidSessionExistUseCase
+            coEvery { doesValidSessionExistUseCase(any()) } returns DoesValidSessionExistResult.Success(valid)
         }
 
         private var defaultSSOCodeConfig: String = String.EMPTY
@@ -1227,6 +1244,85 @@ class NewLoginViewModelTest {
                 assertInstanceOf<NewLoginFlowState.Error.DialogError.GenericError>(viewModel.state.flowState)
                 coVerify(exactly = 1) { arrangement.logoutUseCase(LogoutReason.SELF_HARD_LOGOUT, true) }
                 coVerify(exactly = 1) { arrangement.deleteSessionUseCase(userId) }
+            }
+        }
+
+    @Test
+    fun `given Nomad enabled and crypto restore throws IllegalStateException with session gone, when handling SSO result, then abort silently without reverting`() =
+        runTest(dispatchers.main()) {
+            val ssoDeepLinkResult = DeepLinkResult.SSOLogin.Success("cookie", "server-config-id")
+            val userId = UserId("user-id", "domain")
+            val (arrangement, viewModel) = Arrangement()
+                .withEstablishSSOSessionSuccess(userId)
+                .withNomadEnabled(true)
+                .withRestoreCryptoStateThrowing(IllegalStateException("attempt to re-open an already-closed object"))
+                .withSessionStillValid(false)
+                .arrange()
+
+            viewModel.handleSSOResult(ssoDeepLinkResult)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { arrangement.logoutUseCase(any(), any()) }
+            coVerify(exactly = 0) { arrangement.deleteSessionUseCase(any()) }
+        }
+
+    @Test
+    fun `given Nomad enabled and crypto restore throws IOException with session gone, when handling SSO result, then abort silently without reverting`() =
+        runTest(dispatchers.main()) {
+            val ssoDeepLinkResult = DeepLinkResult.SSOLogin.Success("cookie", "server-config-id")
+            val userId = UserId("user-id", "domain")
+            val (arrangement, viewModel) = Arrangement()
+                .withEstablishSSOSessionSuccess(userId)
+                .withNomadEnabled(true)
+                .withRestoreCryptoStateThrowing(IOException("session files deleted"))
+                .withSessionStillValid(false)
+                .arrange()
+
+            viewModel.handleSSOResult(ssoDeepLinkResult)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { arrangement.logoutUseCase(any(), any()) }
+            coVerify(exactly = 0) { arrangement.deleteSessionUseCase(any()) }
+        }
+
+    @Test
+    fun `given Nomad enabled and crypto restore throws SQLiteException with session gone, when handling SSO result, then abort silently without reverting`() =
+        runTest(dispatchers.main()) {
+            val ssoDeepLinkResult = DeepLinkResult.SSOLogin.Success("cookie", "server-config-id")
+            val userId = UserId("user-id", "domain")
+            val (arrangement, viewModel) = Arrangement()
+                .withEstablishSSOSessionSuccess(userId)
+                .withNomadEnabled(true)
+                .withRestoreCryptoStateThrowing(SQLiteException("database is locked"))
+                .withSessionStillValid(false)
+                .arrange()
+
+            viewModel.handleSSOResult(ssoDeepLinkResult)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { arrangement.logoutUseCase(any(), any()) }
+            coVerify(exactly = 0) { arrangement.deleteSessionUseCase(any()) }
+        }
+
+    @Test
+    fun `given Nomad enabled and restore failure and revert throws with session gone, when handling SSO result, then show error without crashing`() =
+        runTest(dispatchers.main()) {
+            val ssoDeepLinkResult = DeepLinkResult.SSOLogin.Success("cookie", "server-config-id")
+            val userId = UserId("user-id", "domain")
+            val (_, viewModel) = Arrangement()
+                .withEstablishSSOSessionSuccess(userId)
+                .withNomadEnabled(true)
+                .withRestoreCryptoStateReturning(RestoreCryptoStateResult.Failure)
+                .withSessionStillValid(false)
+                .apply { coEvery { logoutUseCase(any(), any()) } throws IllegalStateException("already closed") }
+                .arrange()
+
+            viewModel.actions.test {
+                viewModel.handleSSOResult(ssoDeepLinkResult)
+                advanceUntilIdle()
+
+                expectNoEvents()
+                assertInstanceOf<NewLoginFlowState.Error.DialogError.GenericError>(viewModel.state.flowState)
             }
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24402
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App is crashing when trying to logout while the app is logging in via Intent

### Solutions

Catch `IllegalStateException`, `IOException` and `SQLiteException` and if there is no valid session, then ignore, otherwise throw exception

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Send login intent
- While the app is logging in, send a logout intent

Actual: 
- App is crashing
Expected:
- App should not crash, but should go to login screen

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
