### PR TITLE
feat(nomad devices): Block nomad intent for Wire production backends and restrict logout intent to nomad sessions [WPB-24366]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
@@ -62,6 +62,11 @@ class NomadLogoutReceiver : CoroutineReceiver() {
 
         appLogger.i("$TAG Received logout broadcast")
 
+        if (!coreLogic.getGlobalScope().doesValidNomadAccountExist()) {
+            appLogger.i("$TAG Logout ignored: current session is not a nomad account")
+            return
+        }
+
         @Suppress("TooGenericExceptionCaught")
         try {
             performLogout()

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
@@ -57,26 +57,34 @@ class NomadLogoutReceiver : CoroutineReceiver() {
     lateinit var nomadProfilesFeatureConfig: NomadProfilesFeatureConfig
 
     public override suspend fun receive(context: Context, intent: Intent) {
-        if (!nomadProfilesFeatureConfig.isEnabled()) return
-        if (intent.action != ACTION_LOGOUT) return
-
-        appLogger.i("$TAG Received logout broadcast")
-
-        if (!coreLogic.getGlobalScope().doesValidNomadAccountExist()) {
-            appLogger.i("$TAG Logout ignored: current session is not a nomad account")
-            return
-        }
-
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            performLogout()
-            CoroutineScope(Dispatchers.Default).launch {
-                AppBackgroundManager.moveAppToBackground()
+        when {
+            intent.action != ACTION_LOGOUT -> {
+                appLogger.i("$TAG not a logout intent is passed ignore")
             }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (t: Exception) {
-            appLogger.e("$TAG Logout failed", t)
+
+            !nomadProfilesFeatureConfig.isEnabled() -> {
+                appLogger.i("$TAG nomadProfilesFeatureConfig is not enabled ignoring")
+            }
+
+            !coreLogic.getGlobalScope().doesValidNomadAccountExist() -> {
+                appLogger.i("$TAG Logout ignored: current session is not a nomad account")
+            }
+
+            else -> {
+                appLogger.i("$TAG Received logout broadcast")
+
+                @Suppress("TooGenericExceptionCaught")
+                try {
+                    performLogout()
+                    CoroutineScope(Dispatchers.Default).launch {
+                        AppBackgroundManager.moveAppToBackground()
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (t: Exception) {
+                    appLogger.e("$TAG Logout failed", t)
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
@@ -66,7 +66,7 @@ class NomadLogoutReceiver : CoroutineReceiver() {
                 appLogger.i("$TAG nomadProfilesFeatureConfig is not enabled ignoring")
             }
 
-            !coreLogic.getGlobalScope().doesValidNomadAccountExist() -> {
+            !coreLogic.getGlobalScope().isCurrentSessionNomadAccount() -> {
                 appLogger.i("$TAG Logout ignored: current session is not a nomad account")
             }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -404,6 +404,11 @@ class WireActivityViewModel @Inject constructor(
                     return@launch
                 }
 
+                if (serverLinks?.isProductionApi() == true) {
+                    appLogger.w("Nomad login ignored: resolved backend is Wire production")
+                    return@launch
+                }
+
                 if (!isNomadProfilesFlowEnabled(serverLinks)) {
                     return@launch
                 }
@@ -803,3 +808,7 @@ internal data class OnCustomBackendLogin(
 internal data class OnOpenUserProfile(val result: DeepLinkResult.OpenOtherUserProfile) : WireActivityViewAction
 internal data class OnSSOLogin(val result: DeepLinkResult.SSOLogin) : WireActivityViewAction
 internal data class ShowToast(val messageResId: Int) : WireActivityViewAction
+
+// TODO: replace with the kalium `ServerConfig.isProductionApi()` once it is made public and supports `Links`
+internal fun ServerConfig.Links.isProductionApi(): Boolean =
+    ServerConfig.PRODUCTION.api.contains(java.net.URI(api).host ?: "")

--- a/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiverTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiverTest.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.logic.feature.auth.LogoutUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
+import com.wire.kalium.logic.feature.session.DoesValidNomadAccountExistUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -114,6 +115,26 @@ class NomadLogoutReceiverTest {
         verify(exactly = 0) { arrangement.context.startActivity(any()) }
     }
 
+    @Test
+    fun `when current session is not a nomad account then logout broadcast is ignored`() = runTest {
+        val userId = UserId("user", "domain")
+        val arrangement = Arrangement()
+            .withCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(userId)))
+            .withValidNomadAccountExists(false)
+            .arrange()
+
+        val intent = mockk<Intent> { every { action } returns NomadLogoutReceiver.ACTION_LOGOUT }
+        arrangement.receiver.receive(arrangement.context, intent)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            arrangement.currentSession()
+            arrangement.logoutUseCase(any(), any())
+            arrangement.deleteSession(any())
+            arrangement.accountSwitch(any())
+        }
+    }
+
     private class Arrangement {
 
         @MockK
@@ -140,6 +161,9 @@ class NomadLogoutReceiverTest {
         @MockK
         lateinit var nomadProfilesFeatureConfig: NomadProfilesFeatureConfig
 
+        @MockK
+        lateinit var doesValidNomadAccountExist: DoesValidNomadAccountExistUseCase
+
         val context = mockk<Context>(relaxed = true)
         val receiver = NomadLogoutReceiver()
 
@@ -154,6 +178,8 @@ class NomadLogoutReceiverTest {
             coEvery { logoutUseCase(any(), any()) } returns Unit
             coEvery { deleteSession(any()) } returns DeleteSessionUseCase.Result.Success
             every { coreLogic.getGlobalScope().deleteSession } returns deleteSession
+            every { coreLogic.getGlobalScope().doesValidNomadAccountExist } returns doesValidNomadAccountExist
+            coEvery { doesValidNomadAccountExist() } returns true
             coEvery { accountSwitch(any()) } returns SwitchAccountResult.NoOtherAccountToSwitch
             every { coreLogic.getSessionScope(any()) } returns userSessionScope
             every { nomadProfilesFeatureConfig.isEnabled() } returns true
@@ -174,6 +200,10 @@ class NomadLogoutReceiverTest {
 
         fun withNomadProfilesEnabled(enabled: Boolean) = apply {
             every { nomadProfilesFeatureConfig.isEnabled() } returns enabled
+        }
+
+        fun withValidNomadAccountExists(exists: Boolean) = apply {
+            coEvery { doesValidNomadAccountExist() } returns exists
         }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiverTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiverTest.kt
@@ -34,7 +34,7 @@ import com.wire.kalium.logic.feature.auth.LogoutUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
-import com.wire.kalium.logic.feature.session.DoesValidNomadAccountExistUseCase
+import com.wire.kalium.logic.feature.session.IsCurrentSessionNomadAccountUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -120,7 +120,7 @@ class NomadLogoutReceiverTest {
         val userId = UserId("user", "domain")
         val arrangement = Arrangement()
             .withCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(userId)))
-            .withValidNomadAccountExists(false)
+            .withCurrentSessionNomadAccount(false)
             .arrange()
 
         val intent = mockk<Intent> { every { action } returns NomadLogoutReceiver.ACTION_LOGOUT }
@@ -162,7 +162,7 @@ class NomadLogoutReceiverTest {
         lateinit var nomadProfilesFeatureConfig: NomadProfilesFeatureConfig
 
         @MockK
-        lateinit var doesValidNomadAccountExist: DoesValidNomadAccountExistUseCase
+        lateinit var isCurrentSessionNomadAccount: IsCurrentSessionNomadAccountUseCase
 
         val context = mockk<Context>(relaxed = true)
         val receiver = NomadLogoutReceiver()
@@ -178,8 +178,8 @@ class NomadLogoutReceiverTest {
             coEvery { logoutUseCase(any(), any()) } returns Unit
             coEvery { deleteSession(any()) } returns DeleteSessionUseCase.Result.Success
             every { coreLogic.getGlobalScope().deleteSession } returns deleteSession
-            every { coreLogic.getGlobalScope().doesValidNomadAccountExist } returns doesValidNomadAccountExist
-            coEvery { doesValidNomadAccountExist() } returns true
+            every { coreLogic.getGlobalScope().isCurrentSessionNomadAccount } returns isCurrentSessionNomadAccount
+            coEvery { isCurrentSessionNomadAccount() } returns true
             coEvery { accountSwitch(any()) } returns SwitchAccountResult.NoOtherAccountToSwitch
             every { coreLogic.getSessionScope(any()) } returns userSessionScope
             every { nomadProfilesFeatureConfig.isEnabled() } returns true
@@ -202,8 +202,8 @@ class NomadLogoutReceiverTest {
             every { nomadProfilesFeatureConfig.isEnabled() } returns enabled
         }
 
-        fun withValidNomadAccountExists(exists: Boolean) = apply {
-            coEvery { doesValidNomadAccountExist() } returns exists
+        fun withCurrentSessionNomadAccount(isNomad: Boolean) = apply {
+            coEvery { isCurrentSessionNomadAccount() } returns isNomad
         }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/IsProductionApiTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/IsProductionApiTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui
+
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class IsProductionApiTest {
+
+    @Test
+    fun `given production API URL, then returns true`() {
+        val links = serverLinks(api = ServerConfig.PRODUCTION.api)
+        assertTrue(links.isProductionApi())
+    }
+
+    @Test
+    fun `given production API URL with trailing path, then returns true`() {
+        val links = serverLinks(api = "https://prod-nginz-https.wire.com/some/path")
+        assertTrue(links.isProductionApi())
+    }
+
+    @Test
+    fun `given custom on-premises API URL, then returns false`() {
+        val links = serverLinks(api = "https://custom-backend.example.com")
+        assertFalse(links.isProductionApi())
+    }
+
+    @Test
+    fun `given staging API URL, then returns false`() {
+        val links = serverLinks(api = ServerConfig.STAGING.api)
+        assertFalse(links.isProductionApi())
+    }
+
+    @Test
+    fun `given URL with production host as substring, then returns false`() {
+        val links = serverLinks(api = "https://not-prod-nginz-https.wire.com.evil.com")
+        assertFalse(links.isProductionApi())
+    }
+
+    private fun serverLinks(api: String) = ServerConfig.Links(
+        api = api,
+        accounts = "https://accounts.example.com",
+        webSocket = "https://ws.example.com",
+        blackList = "https://blacklist.example.com",
+        teams = "https://teams.example.com",
+        website = "https://example.com",
+        title = "test",
+        isOnPremises = false,
+        apiProxy = null
+    )
+}

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -82,6 +82,7 @@ import com.wire.kalium.logic.feature.client.IsProfileQRCodeEnabledUseCase
 import com.wire.kalium.logic.feature.client.NewClientResult
 import com.wire.kalium.logic.feature.client.ObserveNewClientsUseCase
 import com.wire.kalium.logic.feature.conversation.CheckConversationInviteCodeUseCase
+import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
@@ -900,6 +901,27 @@ class WireActivityViewModelTest {
     }
 
     @Test
+    fun `given resolved backend is Wire production, when handling nomad intent, then login is ignored`() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .withAutomatedLoginIntent(
+                ssoCode = "wire-b6261497-5b7d-4a57-8f4d-3a94e936b2c0",
+                backendConfig = "url"
+            )
+            .withProductionServerConfig()
+            .arrange()
+
+        viewModel.actions.test {
+            val handled = viewModel.handleIntentsThatAreNotDeepLinks(mockedIntent())
+            advanceUntilIdle()
+
+            assertTrue(handled)
+            assertFalse(arrangement.automatedLoginManager.pendingMoveToBackgroundAfterSync)
+            coVerify(exactly = 0) { arrangement.isNomadProfilesEnabledUseCase.invoke() }
+            expectNoEvents()
+        }
+    }
+
+    @Test
     fun `given nomad profiles disabled, when handling sharing intent, then import media screen is still shown`() = runTest {
         val (_, viewModel) = Arrangement()
             .withNomadProfilesEnabled(false)
@@ -1296,6 +1318,10 @@ class WireActivityViewModelTest {
 
         fun withCanUseNewLogin(canUseNewLogin: Boolean): Arrangement = apply {
             coEvery { loginTypeSelector.canUseNewLogin(any()) } returns canUseNewLogin
+        }
+
+        fun withProductionServerConfig(): Arrangement = apply {
+            coEvery { getServerConfigUseCase(any()) } returns GetServerConfigResult.Success(ServerConfig.PRODUCTION)
         }
 
         fun arrange() = this to viewModel


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24366
<!--jira-description-action-hidden-marker-end-->
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability

---

# What's new in this PR?

### Issues

- Nomad intents should not be processed when the resolved backend API points to Wire's production infrastructure, as nomad is intended for on-premises deployments only.
- The nomad logout broadcast receiver logs out any active session regardless of whether it was created via the nomad flow.

### Solutions

- Added a production API check in `WireActivityViewModel.handleIntentsThatAreNotDeepLinks()` that rejects the nomad intent if the resolved `ServerConfig.Links.api` host matches Wire's production backend. This uses the same logic as kalium's internal `isProductionApi()` (with a TODO to consolidate once the kalium function is made public).
- Added a nomad account check in `NomadLogoutReceiver` using the existing `DoesValidNomadAccountExistUseCase`. The logout broadcast is now ignored if the current session is not a nomad session.

### Testing

#### Test Coverage

- [x] I have added automated tests to this contribution

#### How to Test

1. **Production backend block:** Verify that a nomad intent whose `backendConfig` resolves to `prod-nginz-https.wire.com` is silently rejected (log: `"Nomad login ignored: resolved backend is Wire production"`).
2. **Nomad-only logout:** Verify that sending `com.wire.ACTION_LOGOUT` broadcast when logged in via a non-nomad session does nothing. When logged in via a nomad session, the logout proceeds as before.