### PR TITLE
fix: lib sodium crash on logiin intent [WPB-24366] [WPB-24440]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -185,7 +185,7 @@ dependencies {
     implementation("com.wire.kalium:kalium-logic")
     implementation("com.wire.kalium:kalium-util")
     implementation("com.wire.kalium:kalium-cells")
-    implementation(libs.libsodiumBindingsMP)
+    implementation("com.wire.kalium:kalium-core-libsodium")
     androidTestImplementation("com.wire.kalium:kalium-mocks")
     androidTestImplementation("com.wire.kalium:kalium-network")
 
@@ -319,7 +319,6 @@ dependencies {
     testImplementation(libs.turbine)
     testImplementation(libs.okio.fakeFileSystem)
     testImplementation(libs.robolectric)
-    testRuntimeOnly(libs.libsodiumBindingsJvm)
     testRuntimeOnly(libs.junit5.vintage.engine)
     testRuntimeOnly(libs.junit5.engine)
     testImplementation(libs.androidx.paging.testing)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -186,6 +186,7 @@ dependencies {
     implementation("com.wire.kalium:kalium-util")
     implementation("com.wire.kalium:kalium-cells")
     implementation("com.wire.kalium:kalium-core-libsodium")
+    testRuntimeOnly(libs.libsodium.bindings.jvm)
     androidTestImplementation("com.wire.kalium:kalium-mocks")
     androidTestImplementation("com.wire.kalium:kalium-network")
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -703,7 +703,7 @@ class WireActivity : BaseActivity() {
     /*
      * This method is responsible for handling deep links from given intent
      */
-    private fun handleDeepLinkOrIntent(
+    private suspend fun handleDeepLinkOrIntent(
         navigator: Navigator,
         intent: Intent?,
         savedInstanceState: Bundle? = null

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -389,7 +389,7 @@ class WireActivityViewModel @Inject constructor(
 
     // Returns whether an intent was handled, or if there was nothing to do
     @Suppress("ReturnCount")
-    fun handleIntentsThatAreNotDeepLinks(intent: Intent?): Boolean {
+    suspend fun handleIntentsThatAreNotDeepLinks(intent: Intent?): Boolean {
         val result = intentsProcessor.get().invoke(intent)
         if (result != null) {
             if (!nomadProfilesFeatureConfig.isEnabled()) {

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/IntentsProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/IntentsProcessor.kt
@@ -41,7 +41,7 @@ class IntentsProcessor @Inject internal constructor(
     }
 
     @Suppress("ReturnCount")
-    operator fun invoke(intent: Intent?): AutomatedLoginViaSSO? {
+    suspend operator fun invoke(intent: Intent?): AutomatedLoginViaSSO? {
         @Serializable
         data class Parameters(
             val backendConfig: String? = null,

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/NomadIntentSignatureValidator.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/NomadIntentSignatureValidator.kt
@@ -17,9 +17,9 @@
  */
 package com.wire.android.util.lifecycle
 
-import com.ionspin.kotlin.crypto.LibsodiumInitializer
 import com.ionspin.kotlin.crypto.signature.Signature
 import com.wire.android.BuildConfig
+import com.wire.kalium.cryptography.LibsodiumInitializer
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.io.encoding.Base64
@@ -36,7 +36,7 @@ class NomadIntentSignatureValidator internal constructor(
         isConfigurationSignatureEnforced = BuildConfig.ENFORCE_CONFIGURATION_SIGNATURE
     )
 
-    fun isValid(parameter: String?, signature: String?): Boolean {
+    suspend fun isValid(parameter: String?, signature: String?): Boolean {
         return when {
             parameter == null -> signature == null
             signature == SKIP_SIGNATURE_VERIFICATION_TOKEN && !isConfigurationSignatureEnforced -> true
@@ -46,8 +46,8 @@ class NomadIntentSignatureValidator internal constructor(
     }
 
     @OptIn(ExperimentalUnsignedTypes::class)
-    private fun verifySignatureWithAvailableKeys(parameter: String, signature: String): Boolean {
-        if (!LibsodiumInitializer.isInitialized()) LibsodiumInitializer.initializeWithCallback {}
+    private suspend fun verifySignatureWithAvailableKeys(parameter: String, signature: String): Boolean {
+        LibsodiumInitializer.initializeLibsodiumIfNeeded()
         val messageBytes = parameter.toByteArray().toUByteArray()
         val signatureBytes = runCatching {
             Base64.decode(signature).toUByteArray()

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -102,7 +102,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -871,7 +870,7 @@ class WireActivityViewModelTest {
 
             assertEquals(true, handled)
             assertEquals(false, arrangement.automatedLoginManager.pendingMoveToBackgroundAfterSync)
-            verify(exactly = 1) { arrangement.intentsProcessor(any()) }
+            coVerify(exactly = 1) { arrangement.intentsProcessor(any()) }
             coVerify(exactly = 0) { arrangement.isNomadProfilesEnabledUseCase.invoke() }
             coVerify(exactly = 0) { arrangement.observeSessionsUseCase.invoke() }
             expectNoEvents()
@@ -1021,7 +1020,7 @@ class WireActivityViewModelTest {
             coEvery { currentSessionFlow() } returns flowOf()
             coEvery { getServerConfigUseCase(any()) } returns GetServerConfigResult.Success(newServerConfig(1).links)
             coEvery { deepLinkProcessor(any(), any()) } returns DeepLinkResult.Unknown
-            every { intentsProcessor(any()) } returns null
+            coEvery { intentsProcessor(any()) } returns null
             coEvery { observeSessionsUseCase.invoke() } returns flowOf(GetAllSessionsResult.Failure.NoSessionFound)
             every { observeSyncStateUseCaseProviderFactory.create(any()).observeSyncState } returns observeSyncStateUseCase
             every { observeSyncStateUseCase() } returns emptyFlow()
@@ -1298,7 +1297,7 @@ class WireActivityViewModelTest {
             ssoCode: String? = null,
             backendConfig: String? = null,
         ): Arrangement = apply {
-            every { intentsProcessor(any()) } returns when {
+            coEvery { intentsProcessor(any()) } returns when {
                 ssoCode == null || backendConfig == null -> null
                 else -> AutomatedLoginViaSSO(
                     ssoCode = ssoCode,

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/IntentsProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/IntentsProcessorTest.kt
@@ -20,6 +20,7 @@ package com.wire.android.util.lifecycle
 import android.content.Intent
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -31,13 +32,13 @@ import java.util.Base64
 class IntentsProcessorTest {
 
     @Test
-    fun `given null intent, returns null`() {
+    fun `given null intent, returns null`() = runTest {
         val (_, intentsProcessor) = Arrangement().arrange()
         assertNull(intentsProcessor(null))
     }
 
     @Test
-    fun `given intent without automated_login extra, returns null`() {
+    fun `given intent without automated_login extra, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(null)
             .arrange()
@@ -45,7 +46,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given valid JSON with backendConfig, ssoCode and nomadProfilesHost, returns AutomatedLoginViaSSO`() {
+    fun `given valid JSON with backendConfig, ssoCode and nomadProfilesHost, returns AutomatedLoginViaSSO`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -67,7 +68,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given valid JSON with ssoCode and nomadProfilesHost but no backendConfig, returns null`() {
+    fun `given valid JSON with ssoCode and nomadProfilesHost but no backendConfig, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -81,7 +82,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given valid JSON with only backendConfig and nomadProfilesHost, returns null`() {
+    fun `given valid JSON with only backendConfig and nomadProfilesHost, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -95,7 +96,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given valid JSON with only nomadProfilesHost, returns null`() {
+    fun `given valid JSON with only nomadProfilesHost, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -108,7 +109,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given real Ed25519 signature, verifies backendConfig and nomadProfilesHost with configured key`() {
+    fun `given real Ed25519 signature, verifies backendConfig and nomadProfilesHost with configured key`() = runTest {
         val signedValue = SignedValue.sign(signedIntentPayload())
         val (arrangement, intentsProcessor) = Arrangement()
             .withConfigurationSignatureKey(signedValue.publicKeyDerBase64)
@@ -132,7 +133,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given invalid Ed25519 signature, returns null`() {
+    fun `given invalid Ed25519 signature, returns null`() = runTest {
         val signedValue = SignedValue.sign(signedIntentPayload())
         val invalidSignature = Base64.getEncoder()
             .encodeToString(
@@ -155,7 +156,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given configured key with invalid raw key length, returns null`() {
+    fun `given configured key with invalid raw key length, returns null`() = runTest {
         val signedValue = SignedValue.sign(signedIntentPayload())
         val invalidLengthKey = Base64.getEncoder().encodeToString(ByteArray(12 + 31))
         val (arrangement, intentsProcessor) = Arrangement()
@@ -173,7 +174,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given configured key with invalid der header, returns null`() {
+    fun `given configured key with invalid der header, returns null`() = runTest {
         val signedValue = SignedValue.sign(signedIntentPayload())
         val invalidHeaderKey = Base64.getEncoder()
             .encodeToString(
@@ -196,7 +197,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given valid signed intent, returns AutomatedLoginViaSSO`() {
+    fun `given valid signed intent, returns AutomatedLoginViaSSO`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -218,7 +219,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given invalid signature, returns null before processing the rest of the intent`() {
+    fun `given invalid signature, returns null before processing the rest of the intent`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -233,7 +234,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given backendConfig changed after signing, returns null`() {
+    fun `given backendConfig changed after signing, returns null`() = runTest {
         val signedValue = SignedValue.sign(signedIntentPayload())
         val (arrangement, intentsProcessor) = Arrangement()
             .withConfigurationSignatureKey(signedValue.publicKeyDerBase64)
@@ -250,7 +251,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given nomadProfilesHost changed after signing, returns null`() {
+    fun `given nomadProfilesHost changed after signing, returns null`() = runTest {
         val signedValue = SignedValue.sign(signedIntentPayload())
         val (arrangement, intentsProcessor) = Arrangement()
             .withConfigurationSignatureKey(signedValue.publicKeyDerBase64)
@@ -267,7 +268,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given JSON with all fields null, returns null`() {
+    fun `given JSON with all fields null, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(automatedLoginJson())
             .arrange()
@@ -275,7 +276,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given JSON without nomadProfilesHost, returns null`() {
+    fun `given JSON without nomadProfilesHost, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -288,7 +289,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given invalid JSON string, returns null`() {
+    fun `given invalid JSON string, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra("not-valid-json")
             .arrange()
@@ -296,7 +297,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given backendConfig with HTTP instead of HTTPS, returns null`() {
+    fun `given backendConfig with HTTP instead of HTTPS, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -311,7 +312,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given backendConfig with empty host, returns null`() {
+    fun `given backendConfig with empty host, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -326,7 +327,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given backendConfig with malformed URI, returns null`() {
+    fun `given backendConfig with malformed URI, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -341,7 +342,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given nomadProfilesHost with HTTP instead of HTTPS, returns null`() {
+    fun `given nomadProfilesHost with HTTP instead of HTTPS, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -356,7 +357,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given nomadProfilesHost with empty host, returns null`() {
+    fun `given nomadProfilesHost with empty host, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -371,7 +372,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given nomadProfilesHost with malformed URI, returns null`() {
+    fun `given nomadProfilesHost with malformed URI, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withAutomatedLoginExtra(
                 automatedLoginJson(
@@ -386,7 +387,7 @@ class IntentsProcessorTest {
     }
 
     @Test
-    fun `given skip token when signature enforcement is enabled, returns null`() {
+    fun `given skip token when signature enforcement is enabled, returns null`() = runTest {
         val (arrangement, intentsProcessor) = Arrangement()
             .withConfigurationSignatureEnforced(true)
             .withAutomatedLoginExtra(

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/NomadIntentSignatureValidatorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/NomadIntentSignatureValidatorTest.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.android.util.lifecycle
 
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -28,28 +29,28 @@ import java.util.Base64
 class NomadIntentSignatureValidatorTest {
 
     @Test
-    fun `given null parameter and null signature, returns true`() {
+    fun `given null parameter and null signature, returns true`() = runTest {
         val validator = Arrangement().arrange()
 
         assertTrue(validator.isValid(parameter = null, signature = null))
     }
 
     @Test
-    fun `given null parameter and non-null signature, returns false`() {
+    fun `given null parameter and non-null signature, returns false`() = runTest {
         val validator = Arrangement().arrange()
 
         assertFalse(validator.isValid(parameter = null, signature = "signature"))
     }
 
     @Test
-    fun `given non-null parameter and null signature, returns false`() {
+    fun `given non-null parameter and null signature, returns false`() = runTest {
         val validator = Arrangement().arrange()
 
         assertFalse(validator.isValid(parameter = FAKE_NOMAD_PROFILES_HOST, signature = null))
     }
 
     @Test
-    fun `given skip token when signature enforcement is disabled, returns true`() {
+    fun `given skip token when signature enforcement is disabled, returns true`() = runTest {
         val validator = Arrangement().arrange()
 
         assertTrue(
@@ -61,7 +62,7 @@ class NomadIntentSignatureValidatorTest {
     }
 
     @Test
-    fun `given skip token when signature enforcement is enabled, returns false`() {
+    fun `given skip token when signature enforcement is enabled, returns false`() = runTest {
         val validator = Arrangement()
             .withConfigurationSignatureEnforced(true)
             .arrange()
@@ -75,7 +76,7 @@ class NomadIntentSignatureValidatorTest {
     }
 
     @Test
-    fun `given valid Ed25519 signature, returns true`() {
+    fun `given valid Ed25519 signature, returns true`() = runTest {
         val signedValue = SignedValue.sign(FAKE_NOMAD_PROFILES_HOST)
         val validator = Arrangement()
             .withConfigurationSignatureKey(signedValue.publicKeyDerBase64)
@@ -90,7 +91,7 @@ class NomadIntentSignatureValidatorTest {
     }
 
     @Test
-    fun `given invalid Ed25519 signature, returns false`() {
+    fun `given invalid Ed25519 signature, returns false`() = runTest {
         val signedValue = SignedValue.sign(FAKE_NOMAD_PROFILES_HOST)
         val invalidSignature = Base64.getEncoder()
             .encodeToString(
@@ -111,7 +112,7 @@ class NomadIntentSignatureValidatorTest {
     }
 
     @Test
-    fun `given malformed base64 signature, returns false`() {
+    fun `given malformed base64 signature, returns false`() = runTest {
         val signedValue = SignedValue.sign(FAKE_NOMAD_PROFILES_HOST)
         val validator = Arrangement()
             .withConfigurationSignatureKey(signedValue.publicKeyDerBase64)
@@ -126,7 +127,7 @@ class NomadIntentSignatureValidatorTest {
     }
 
     @Test
-    fun `given configured key with invalid raw key length, returns false`() {
+    fun `given configured key with invalid raw key length, returns false`() = runTest {
         val signedValue = SignedValue.sign(FAKE_NOMAD_PROFILES_HOST)
         val invalidLengthKey = Base64.getEncoder().encodeToString(ByteArray(12 + 31))
         val validator = Arrangement()
@@ -142,7 +143,7 @@ class NomadIntentSignatureValidatorTest {
     }
 
     @Test
-    fun `given configured key with invalid der header, returns false`() {
+    fun `given configured key with invalid der header, returns false`() = runTest {
         val signedValue = SignedValue.sign(FAKE_NOMAD_PROFILES_HOST)
         val invalidHeaderKey = Base64.getEncoder()
             .encodeToString(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 # Gradle - Remind to change in `gradle-wrapper.properties` file as well!
 androidJunit5 = "1.14.0.0"
-libsodiumBindings = "0.9.5"
 
 # Kotlin
 grgitCore = "5.3.2"
@@ -152,8 +151,6 @@ wire-versionizer = { id = "com.wire.android.versionizer" }
 [libraries]
 # Kotlin Gradle Plugin
 android-junit5 = { module = "de.mannodermaus.gradle.plugins:android-junit5", version.ref = "androidJunit5" }
-libsodiumBindingsMP = { module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings", version.ref = "libsodiumBindings" }
-libsodiumBindingsJvm = { module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings-jvm", version.ref = "libsodiumBindings" }
 grgit-core = { module = "org.ajoberstar.grgit:grgit-core", version.ref = "grgitCore" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-gradlePlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ ktx-immutableCollections = "0.3.8"
 ktx-serialization = "1.8.1"
 koin = "3.5.3"
 datafaker = "1.9.0"
+libsodiumBindings = "0.9.5"
 
 # Android Core / Architecture
 detekt = "1.23.8"
@@ -163,6 +164,7 @@ kover-gradlePlugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", ver
 ktx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "ktx-serialization" }
 ktx-dateTime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "ktx-dateTime" }
 ktx-immutableCollections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "ktx-immutableCollections" }
+libsodium-bindings-jvm = { module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings-jvm", version.ref = "libsodiumBindings" }
 
 ksp-symbol-processing-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 ksp-symbol-processing-plugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }

--- a/include_builds.gradle.kts
+++ b/include_builds.gradle.kts
@@ -23,6 +23,7 @@ includeBuild("kalium") {
         substitute(module("com.wire.kalium:kalium-data")).using(project(":core:data"))
         substitute(module("com.wire.kalium:kalium-common")).using(project(":core:common"))
         substitute(module("com.wire.kalium:kalium-cells")).using(project(":domain:cells"))
+        substitute(module("com.wire.kalium:kalium-core-libsodium")).using(project(":core:libsodium"))
         // test modules
         substitute(module("com.wire.kalium:kalium-mocks")).using(project(":test:mocks"))
         substitute(module("com.wire.kalium:kalium-network")).using(project(":data:network"))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24366
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

lib sodium randomly crashes during init

### Causes (Optional)

the crash is when the init return code 1 (aka already initialized).

### Solutions

instead of using the kotlin bindings directly use kalium :core:libsodium module
