### PR TITLE
fix: hide debug fcm options for prod builds [WPB-23925]

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   # Inline simple quality check jobs for better check names
   lint:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ubuntu-24.04
     # Override JVM args from gradle.properties which sets 10GB heap
     steps:
       - name: Checkout
@@ -37,7 +37,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -120,7 +120,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   generate-screenshots:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ubuntu-24.04
 
     if: github.ref == 'refs/heads/develop'
 
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   ui-tests:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg
     strategy:
       matrix:
         api-level: [ 29 ]
@@ -40,7 +40,7 @@ jobs:
           df -h
 
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -50,7 +50,7 @@ jobs:
         uses: gradle/actions/wrapper-validation@v5
 
       - name: AVD cache
-        uses: buildjet/cache@v4
+        uses: actions/cache@v4
         id: avd-cache
         with:
           path: |

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
   coverage:
     env:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=2g -Xmx4G"'
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/qa-runner-health-check.yml
+++ b/.github/workflows/qa-runner-health-check.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Java 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "temurin"

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/SharedCallingViewModel.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
-import com.wire.android.BuildConfig
 import com.wire.android.appLogger
 import com.wire.android.di.CurrentAccount
 import com.wire.android.mapper.UICallParticipantMapper

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugToolsOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugToolsOptions.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.BuildConfig
@@ -39,7 +38,6 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
-import com.wire.android.util.extension.isGoogleServicesAvailable
 
 @Preview
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugToolsOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugToolsOptions.kt
@@ -81,8 +81,6 @@ internal fun DebugToolsOptions(
                 onEnableAsyncNotificationsChange = onEnableAsyncNotificationsChange,
                 onResendFCMToken = onResendFCMToken,
             )
-        } else {
-            ProductionDebugToolsOptions(onResendFCMToken = onResendFCMToken)
         }
     }
 }
@@ -109,18 +107,6 @@ private fun PrivateBuildDebugToolsOptions(
         ForceUpdateApiVersionsButton(onClick = onForceUpdateApiVersions)
         EnableAsyncNotifications(isAsyncNotificationsEnabled, onEnableAsyncNotificationsChange)
         RegisterFCMPushTokenButton(onClick = onResendFCMToken)
-    }
-}
-
-@Composable
-private fun ProductionDebugToolsOptions(
-    onResendFCMToken: () -> Unit,
-) {
-    if (LocalContext.current.isGoogleServicesAvailable()) {
-        Column {
-            SectionHeader(stringResource(R.string.label_debug_tools_title))
-            RegisterFCMPushTokenButton(onClick = onResendFCMToken)
-        }
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23925
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Hides RegisterFCMPushTokenButton for prod builds