### PR TITLE
fix: call quality details accessibility issues [WPB-24422]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallDetailsSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallDetailsSheetContent.kt
@@ -32,6 +32,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.text.style.TextAlign
 import com.wire.android.R
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
@@ -102,8 +105,11 @@ private fun NetworkQualityItem(
     callQuality: CallQualityData.Quality,
     onOpenNetworkQuality: () -> Unit
 ) {
+    val title = stringResource(R.string.calling_details_network_quality_title)
+    val clickLabel = stringResource(R.string.content_description_call_network_quality_view_details)
+    val value = callQuality.toCallQualityIndicatorValue().text
     MenuBottomSheetItem(
-        title = stringResource(R.string.calling_details_network_quality_title),
+        title = title,
         trailing = {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -121,7 +127,11 @@ private fun NetworkQualityItem(
                 )
             }
         },
-        onItemClick = onOpenNetworkQuality
+        onItemClick = onOpenNetworkQuality,
+        modifier = Modifier.clearAndSetSemantics {
+            contentDescription = "$title: $value"
+            onClick(label = clickLabel, action = null)
+        }
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallNetworkQualitySheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallNetworkQualitySheetContent.kt
@@ -26,8 +26,11 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.shrinkOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
@@ -40,12 +43,16 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
 import com.wire.android.R
 import com.wire.android.ui.common.ArrowLeftIcon
+import com.wire.android.ui.common.bottomsheet.BuildMenuSheetItems
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
 import com.wire.android.ui.common.bottomsheet.MenuItemTitle
-import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
-import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
+import com.wire.android.ui.common.bottomsheet.ModalSheetHeaderItem
+import com.wire.android.ui.common.bottomsheet.ModalSheetHeaderTitle
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireTheme
@@ -61,35 +68,59 @@ fun CallNetworkQualitySheetContent(
     modifier: Modifier = Modifier,
 ) {
     BackHandler(onBack = onBackPressed)
-    WireMenuModalSheetContent(
-        modifier = modifier,
-        header = MenuModalSheetHeader.Visible(
-            title = stringResource(R.string.calling_details_network_quality_title),
-            titleFillsRemainingSpace = false,
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(colorsScheme().surface)
+    ) {
+        ModalSheetHeaderItem(
+            title = {
+                val title = stringResource(R.string.calling_details_network_quality_title)
+                val value = callQualityData.quality.toCallQualityIndicatorValue().text
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .clearAndSetSemantics {
+                            contentDescription = "$title: $value"
+                        }
+                        .padding(vertical = dimensions().modalBottomSheetHeaderVerticalPadding)
+
+                ) {
+                    ModalSheetHeaderTitle(title = stringResource(R.string.calling_details_network_quality_title))
+                    CallQualityIndicator(
+                        callQuality = callQualityData.quality,
+                        modifier = Modifier
+                            .weight(1f, fill = true)
+                            .padding(horizontal = dimensions().spacing16x)
+                    )
+                }
+            },
             leadingIcon = {
-                IconButton(onClick = onBackPressed) {
+                val backButtonLabel = stringResource(R.string.content_description_back_button)
+                val clickLabel = stringResource(R.string.content_description_call_network_quality_close_details)
+                IconButton(
+                    onClick = onBackPressed,
+                    modifier = Modifier.clearAndSetSemantics {
+                        contentDescription = backButtonLabel
+                        onClick(label = clickLabel, action = null)
+                    },
+                ) {
                     ArrowLeftIcon(modifier = Modifier.size(dimensions().spacing16x))
                 }
             },
-            trailingIcon = {
-                CallQualityIndicator(
-                    callQuality = callQualityData.quality,
-                    modifier = Modifier
-                        .weight(1f, fill = true)
-                        .padding(horizontal = dimensions().spacing16x)
-                )
-            },
-            customVerticalPadding = dimensions().spacing0x,
-        ),
-        menuItems = listOf(
-            { PeerValueItem(callQualityData.peer) },
-            { ConnectionValueItem(callQualityData.connection) },
-            { PacketLossValueItem(callQualityData.packetLoss) },
-            { PingValueItem(callQualityData.ping) },
-            { JitterValueItem(callQualityData.jitter) },
-            { LearnMoreItem() },
+            verticalPadding = dimensions().spacing0x,
         )
-    )
+        BuildMenuSheetItems(
+            items = listOf(
+                { PeerValueItem(callQualityData.peer) },
+                { ConnectionValueItem(callQualityData.connection) },
+                { PacketLossValueItem(callQualityData.packetLoss) },
+                { PingValueItem(callQualityData.ping) },
+                { JitterValueItem(callQualityData.jitter) },
+                { LearnMoreItem() },
+            )
+        )
+    }
 }
 
 @Composable
@@ -169,6 +200,9 @@ private fun JitterValueItem(jitter: CallQualityData.Jitter) = QualityValueItem(
 private fun QualityValueItem(title: String, value: String, indicator: CallQualityIndicatorValue = CallQualityIndicatorValue.GOOD) {
     MenuBottomSheetItem(
         title = title,
+        modifier = Modifier.clearAndSetSemantics {
+            contentDescription = "$title: $value"
+        },
         trailing = {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 MenuItemTitle(

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallQualityIndicator.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallQualityIndicator.kt
@@ -47,14 +47,7 @@ internal fun CallQualityIndicator(
 ) {
     val callQualityIndicatorValue by remember(callQuality) {
         derivedStateOf {
-            when (callQuality) { // mapped to a simpler enum to reduce recompositions and make the animations smoother
-                CallQualityData.Quality.UNKNOWN,
-                CallQualityData.Quality.NORMAL -> CallQualityIndicatorValue.GOOD
-                CallQualityData.Quality.MEDIUM -> CallQualityIndicatorValue.FAIR
-                CallQualityData.Quality.POOR,
-                CallQualityData.Quality.NETWORK_PROBLEM,
-                CallQualityData.Quality.RECONNECTING -> CallQualityIndicatorValue.POOR
-            }
+            callQuality.toCallQualityIndicatorValue() // mapped to a simpler enum to reduce recompositions and make the animations smoother
         }
     }
     AnimatedContent(
@@ -92,4 +85,13 @@ enum class CallQualityIndicatorValue {
         FAIR -> stringResource(R.string.calling_details_network_quality_fair)
         POOR -> stringResource(R.string.calling_details_network_quality_poor)
     }
+}
+
+fun CallQualityData.Quality.toCallQualityIndicatorValue(): CallQualityIndicatorValue = when (this) {
+    CallQualityData.Quality.UNKNOWN,
+    CallQualityData.Quality.NORMAL -> CallQualityIndicatorValue.GOOD
+    CallQualityData.Quality.MEDIUM -> CallQualityIndicatorValue.FAIR
+    CallQualityData.Quality.POOR,
+    CallQualityData.Quality.NETWORK_PROBLEM,
+    CallQualityData.Quality.RECONNECTING -> CallQualityIndicatorValue.POOR
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,6 +163,8 @@
     <string name="content_description_calling_in_call_reactions_hide">Hide in call reactions panel</string>
     <string name="content_description_call_open_calling_details">Open calling details</string>
     <string name="content_description_call_low_network_quality">Low network quality</string>
+    <string name="content_description_call_network_quality_view_details">View details</string>
+    <string name="content_description_call_network_quality_close_details">Close details</string>
     <string name="content_description_reply_to_messge">Reply to the message</string>
     <string name="content_description_reply_cancel">Cancel message reply</string>
     <string name="content_description_ping_message">Ping message</string>

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/ModalSheetHeaderItem.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/bottomsheet/ModalSheetHeaderItem.kt
@@ -50,31 +50,48 @@ fun ModalSheetHeaderItem(
         }
 
         is MenuModalSheetHeader.Visible -> {
-            CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onSurface) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = modifier.padding(
-                        vertical = header.customVerticalPadding ?: dimensions().modalBottomSheetHeaderVerticalPadding
+            ModalSheetHeaderItem(
+                title = {
+                    ModalSheetHeaderTitle(
+                        title = header.title,
+                        modifier = if (header.titleFillsRemainingSpace) Modifier.weight(1f) else Modifier
                     )
-                ) {
-                    header.leadingIcon?.invoke(this) ?: Spacer(Modifier.width(dimensions().modalBottomSheetHeaderHorizontalPadding))
-                    Text(
-                        text = header.title,
-                        style = header.customTitleStyle ?: typography().title02,
-                        modifier = Modifier
-                            .semantics { heading() }
-                            .apply {
-                                if (header.titleFillsRemainingSpace) weight(weight = 1f, fill = true)
-                            }
-                    )
-                    header.trailingIcon?.invoke(this) ?: Spacer(Modifier.width(dimensions().modalBottomSheetHeaderHorizontalPadding))
-                }
-                if (header.includeDivider) {
-                    WireDivider()
-                }
-            }
+                },
+                modifier = modifier.semantics { heading() },
+                leadingIcon = header.leadingIcon,
+                trailingIcon = header.trailingIcon,
+                verticalPadding = header.customVerticalPadding ?: dimensions().modalBottomSheetHeaderVerticalPadding,
+                includeDivider = header.includeDivider
+            )
         }
     }
+}
+
+@Composable
+fun ModalSheetHeaderItem(
+    title: @Composable RowScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    leadingIcon: (@Composable RowScope.() -> Unit)? = null,
+    trailingIcon: (@Composable RowScope.() -> Unit)? = null,
+    verticalPadding: Dp = dimensions().modalBottomSheetHeaderVerticalPadding,
+    includeDivider: Boolean = true,
+) {
+    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onSurface) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier.padding(vertical = verticalPadding)
+        ) {
+            leadingIcon?.invoke(this) ?: Spacer(Modifier.width(dimensions().modalBottomSheetHeaderHorizontalPadding))
+            title()
+            trailingIcon?.invoke(this) ?: Spacer(Modifier.width(dimensions().modalBottomSheetHeaderHorizontalPadding))
+        }
+        if (includeDivider) WireDivider()
+    }
+}
+
+@Composable
+fun ModalSheetHeaderTitle(title: String, modifier: Modifier = Modifier) {
+    Text(text = title, style = typography().title02, modifier = modifier)
 }
 
 sealed class MenuModalSheetHeader {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24422
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- On the Call Details screen, after the Network Quality status, the button should be read as “View details” as per the Figma design. However, TalkBack currently reads it as “Double tap to activate”, which is not descriptive and does not match the expected label.
- On the Network Quality Dashboard, the back button is currently read as “Go Back” by TalkBack. As per the design and context, it should be read as “Close Details” to provide clearer meaning to the user.
- TalkBack does not read the Ping and Jitter values correctly. The announced values are either incorrect or not updated to reflect the latest values shown on the screen, which can lead to confusion for users relying on accessibility.

### Solutions

Use `clearAndSetSemantics` to override the semantics of the descendant nodes and make it so that the whole row is  considered to be a single element for the talkback.
"Double tap to activate" is a native system's info about how to click something when the talkback is enabled and it cannot be removed, but it can be slightly customized by providing a label to a click action, so that in this case it will become "double tap to view details". Similarly with the back button, it needs to have some name and action name, so after these changes it will be "back button" and "double tap to close details".
For particular values like ping and jitter, by default talkback only reads the value initially, after using `clearAndSetSemantics` it will always read the current value.

### Testing

#### How to Test

Enable talkback and navigate through elements of call details bottom sheet.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
