### PR TITLE
chore: update dependabot configuration to increase PR limits and add cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,17 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps): [WPB-9777] "
 
   - package-ecosystem: "github-actions"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 2
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

increase the limit of open PRs for dependencies to 5 and 2 for actions 
add 1 week cooldown for dependencies.