### PR TITLE
fix: use pendingNomadServiceUrl to decide wither to register a new client or restore crypto state from nomad service [WPB-24663]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -50,7 +50,6 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthenticationScope
 import com.wire.kalium.logic.feature.auth.DomainLookupUseCase
-import com.wire.kalium.logic.feature.auth.IsNomadProfilesEnabledUseCase
 import com.wire.kalium.logic.feature.auth.ValidateEmailUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
 import com.wire.kalium.logic.feature.auth.sso.SSOInitiateLoginResult
@@ -234,13 +233,13 @@ class LoginSSOViewModel(
         }
     }
 
-    @Suppress("ComplexMethod", "LongMethod")
     @VisibleForTesting
     fun establishSSOSession(
         cookie: String,
         serverConfigId: String,
     ) {
         updateSSOFlowState(LoginState.Loading)
+        val isNomadFlow = pendingNomadServiceUrl != null
         viewModelScope.launch {
             ssoExtension.establishSSOSession(
                 cookie = cookie,
@@ -251,16 +250,11 @@ class LoginSSOViewModel(
                 onSSOLoginFailure = { updateSSOFlowState(it.toLoginError()) },
                 onAddAuthenticatedUserFailure = { updateSSOFlowState(it.toLoginError()) },
                 onSuccess = { storedUserId ->
-                    appLogger.i("$TAG SSO session established successfully for userId: $storedUserId, checking Nomad status")
-                    val isNomadEnabled = withContext(dispatchers.io()) {
-                        val result = coreLogic.getSessionScope(storedUserId).authenticationScope.isNomadProfilesEnabled()
-                        result is IsNomadProfilesEnabledUseCase.Result.Success && result.isEnabled
-                    }
-                    if (!isNomadEnabled) {
-                        appLogger.i("$TAG Nomad not enabled, proceeding with regular login")
+                    if (!isNomadFlow) {
+                        appLogger.i("$TAG Not a nomad flow, proceeding with regular login")
                         registerClientAndUpdateState(storedUserId, setLastDeviceId = false)
                     } else {
-                        appLogger.i("$TAG Nomad enabled, attempting crypto state restore")
+                        appLogger.i("$TAG Nomad flow, attempting crypto state restore")
                         restoreCryptoStateAndContinue(storedUserId)
                     }
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -54,7 +54,6 @@ import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.EnterpriseLoginResult
-import com.wire.kalium.logic.feature.auth.IsNomadProfilesEnabledUseCase
 import com.wire.kalium.logic.feature.auth.LoginRedirectPath
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
 import com.wire.kalium.logic.feature.auth.sso.FetchSSOSettingsUseCase
@@ -325,6 +324,7 @@ class NewLoginViewModel(
         updateLoginFlowState(NewLoginFlowState.Loading)
         when (ssoLoginResult) {
             is DeepLinkResult.SSOLogin.Success -> {
+                val isNomadFlow = pendingNomadServiceUrl != null
                 viewModelScope.launch(dispatchers.io()) {
                     ssoExtension.establishSSOSession(
                         cookie = ssoLoginResult.cookie,
@@ -335,12 +335,11 @@ class NewLoginViewModel(
                         onSSOLoginFailure = { updateLoginFlowState(it.toLoginError()) },
                         onAddAuthenticatedUserFailure = { updateLoginFlowState(it.toLoginError()) },
                         onSuccess = { storedUserId ->
-                            val result = coreLogic.getSessionScope(storedUserId).authenticationScope.isNomadProfilesEnabled()
-                            val isNomadEnabled = result is IsNomadProfilesEnabledUseCase.Result.Success && result.isEnabled
-                            if (!isNomadEnabled) {
-                                appLogger.i("$TAG Nomad not enabled, proceeding with regular login")
+                            if (!isNomadFlow) {
+                                appLogger.i("$TAG Not a nomad flow, proceeding with regular login")
                                 registerClientAndUpdateState(storedUserId, setLastDeviceId = false)
                             } else {
+                                appLogger.i("$TAG Nomad flow, attempting crypto state restore")
                                 restoreCryptoStateAndContinue(storedUserId)
                             }
                         }

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
@@ -53,7 +53,6 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthenticationScope
 import com.wire.kalium.logic.feature.auth.DomainLookupUseCase
-import com.wire.kalium.logic.feature.auth.IsNomadProfilesEnabledUseCase
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
 import com.wire.kalium.logic.feature.auth.ValidateEmailUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
@@ -766,7 +765,7 @@ class LoginSSOViewModelTest {
             val expectedCookie = "some-cookie"
             val (arrangement, loginViewModel) = Arrangement()
                 .withEstablishSSOSession(expectedCookie)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateReturning(RestoreCryptoStateResult.Success)
                 .withIsSyncCompletedReturning(true)
                 .arrange()
@@ -799,7 +798,7 @@ class LoginSSOViewModelTest {
             val expectedCookie = "some-cookie"
             val (arrangement, loginViewModel) = Arrangement()
                 .withEstablishSSOSession(expectedCookie)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateReturning(RestoreCryptoStateResult.Success)
                 .withIsSyncCompletedReturning(false)
                 .arrange()
@@ -832,7 +831,7 @@ class LoginSSOViewModelTest {
             val expectedCookie = "some-cookie"
             val (arrangement, loginViewModel) = Arrangement()
                 .withEstablishSSOSession(expectedCookie)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateReturning(RestoreCryptoStateResult.NoBackupAvailable)
                 .withRegisterClientReturning(RegisterClientResult.Success(TestClient.CLIENT))
                 .withIsSyncCompletedReturning(true)
@@ -866,7 +865,7 @@ class LoginSSOViewModelTest {
             val expectedCookie = "some-cookie"
             val (arrangement, loginViewModel) = Arrangement()
                 .withEstablishSSOSession(expectedCookie)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateReturning(RestoreCryptoStateResult.Failure)
                 .withRevertSSOSessionSuccess()
                 .arrange()
@@ -898,7 +897,7 @@ class LoginSSOViewModelTest {
             val expectedCookie = "some-cookie"
             val (arrangement, loginViewModel) = Arrangement()
                 .withEstablishSSOSession(expectedCookie)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateThrowing(IllegalStateException("attempt to re-open an already-closed object"))
                 .withSessionStillValid(false)
                 .arrange()
@@ -929,7 +928,7 @@ class LoginSSOViewModelTest {
             val expectedCookie = "some-cookie"
             val (arrangement, loginViewModel) = Arrangement()
                 .withEstablishSSOSession(expectedCookie)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateThrowing(IOException("session files deleted"))
                 .withSessionStillValid(false)
                 .arrange()
@@ -960,7 +959,7 @@ class LoginSSOViewModelTest {
             val expectedCookie = "some-cookie"
             val (arrangement, loginViewModel) = Arrangement()
                 .withEstablishSSOSession(expectedCookie)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateThrowing(SQLiteException("database is locked"))
                 .withSessionStillValid(false)
                 .arrange()
@@ -991,7 +990,7 @@ class LoginSSOViewModelTest {
             val expectedCookie = "some-cookie"
             val (arrangement, loginViewModel) = Arrangement()
                 .withEstablishSSOSession(expectedCookie)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateReturning(RestoreCryptoStateResult.Failure)
                 .withSessionStillValid(false)
                 .apply { coEvery { logoutUseCase(any(), any()) } throws IllegalStateException("already closed") }
@@ -1061,9 +1060,6 @@ class LoginSSOViewModelTest {
         lateinit var ssoExtension: LoginSSOViewModelExtension
 
         @MockK
-        lateinit var isNomadProfilesEnabledUseCase: IsNomadProfilesEnabledUseCase
-
-        @MockK
         lateinit var restoreCryptoStateUseCase: RestoreCryptoStateUseCase
 
         @MockK
@@ -1098,10 +1094,6 @@ class LoginSSOViewModelTest {
             every { authenticationScope.ssoLoginScope.getLoginSession } returns getSSOLoginSessionUseCase
             every { coreLogic.versionedAuthenticationScope(any()) } returns autoVersionAuthScopeUseCase
             every { authenticationScope.ssoLoginScope.fetchSSOSettings } returns fetchSSOSettings
-            every {
-                coreLogic.getSessionScope(any()).authenticationScope.isNomadProfilesEnabled
-            } returns isNomadProfilesEnabledUseCase
-            coEvery { isNomadProfilesEnabledUseCase() } returns IsNomadProfilesEnabledUseCase.Result.Success(false)
             every { coreLogic.getGlobalScope().deleteSession } returns deleteSessionUseCase
             every { coreLogic.getSessionScope(any()).logout } returns logoutUseCase
             withFetchSSOSettings()
@@ -1160,10 +1152,6 @@ class LoginSSOViewModelTest {
 
         fun withValidateEmailReturning(result: Boolean) = apply {
             every { validateEmailUseCase(any()) } returns result
-        }
-
-        fun withNomadEnabled(enabled: Boolean) = apply {
-            coEvery { isNomadProfilesEnabledUseCase() } returns IsNomadProfilesEnabledUseCase.Result.Success(enabled)
         }
 
         fun withRestoreCryptoStateReturning(result: RestoreCryptoStateResult) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -32,7 +32,6 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthenticationScope
 import com.wire.kalium.logic.feature.auth.EnterpriseLoginResult
-import com.wire.kalium.logic.feature.auth.IsNomadProfilesEnabledUseCase
 import com.wire.kalium.logic.feature.auth.LoginRedirectPath
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
@@ -642,9 +641,6 @@ class NewLoginViewModelTest {
         val validateEmailOrSSOCodeUseCase: ValidateEmailOrSSOCodeUseCase = mockk()
 
         @MockK
-        lateinit var isNomadProfilesEnabledUseCase: IsNomadProfilesEnabledUseCase
-
-        @MockK
         lateinit var restoreCryptoStateUseCase: RestoreCryptoStateUseCase
 
         @MockK
@@ -670,10 +666,6 @@ class NewLoginViewModelTest {
             every {
                 savedStateHandle.navArgs<LoginNavArgs>()
             } returns LoginNavArgs()
-            every {
-                coreLogic.getSessionScope(any()).authenticationScope.isNomadProfilesEnabled
-            } returns isNomadProfilesEnabledUseCase
-            coEvery { isNomadProfilesEnabledUseCase() } returns IsNomadProfilesEnabledUseCase.Result.Success(false)
             every { coreLogic.getGlobalScope().deleteSession } returns deleteSessionUseCase
             every { coreLogic.getSessionScope(any()).logout } returns logoutUseCase
         }
@@ -859,10 +851,6 @@ class NewLoginViewModelTest {
                     customServerConfig = ServerConfig.STAGING
                 )
             )
-        }
-
-        fun withNomadEnabled(enabled: Boolean) = apply {
-            coEvery { isNomadProfilesEnabledUseCase() } returns IsNomadProfilesEnabledUseCase.Result.Success(enabled)
         }
 
         fun withRestoreCryptoStateReturning(result: RestoreCryptoStateResult) = apply {
@@ -1165,7 +1153,7 @@ class NewLoginViewModelTest {
             val userId = UserId("user-id", "domain")
             val (_, viewModel) = Arrangement()
                 .withEstablishSSOSessionSuccess(userId)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateReturning(RestoreCryptoStateResult.Success)
                 .withIsInitialSyncCompletedReturning(true)
                 .arrange()
@@ -1186,7 +1174,7 @@ class NewLoginViewModelTest {
             val userId = UserId("user-id", "domain")
             val (_, viewModel) = Arrangement()
                 .withEstablishSSOSessionSuccess(userId)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateReturning(RestoreCryptoStateResult.Success)
                 .withIsInitialSyncCompletedReturning(false)
                 .arrange()
@@ -1206,7 +1194,7 @@ class NewLoginViewModelTest {
             val userId = UserId("user-id", "domain")
             val (arrangement, viewModel) = Arrangement()
                 .withEstablishSSOSessionSuccess(userId)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateReturning(RestoreCryptoStateResult.NoBackupAvailable)
                 .withRegisterClientReturning(RegisterClientResult.Success(TestClient.CLIENT))
                 .withIsInitialSyncCompletedReturning(true)
@@ -1231,7 +1219,7 @@ class NewLoginViewModelTest {
             val userId = UserId("user-id", "domain")
             val (arrangement, viewModel) = Arrangement()
                 .withEstablishSSOSessionSuccess(userId)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateReturning(RestoreCryptoStateResult.Failure)
                 .withRevertSSOSessionSuccess()
                 .arrange()
@@ -1254,7 +1242,7 @@ class NewLoginViewModelTest {
             val userId = UserId("user-id", "domain")
             val (arrangement, viewModel) = Arrangement()
                 .withEstablishSSOSessionSuccess(userId)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateThrowing(IllegalStateException("attempt to re-open an already-closed object"))
                 .withSessionStillValid(false)
                 .arrange()
@@ -1273,7 +1261,7 @@ class NewLoginViewModelTest {
             val userId = UserId("user-id", "domain")
             val (arrangement, viewModel) = Arrangement()
                 .withEstablishSSOSessionSuccess(userId)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateThrowing(IOException("session files deleted"))
                 .withSessionStillValid(false)
                 .arrange()
@@ -1292,7 +1280,7 @@ class NewLoginViewModelTest {
             val userId = UserId("user-id", "domain")
             val (arrangement, viewModel) = Arrangement()
                 .withEstablishSSOSessionSuccess(userId)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateThrowing(SQLiteException("database is locked"))
                 .withSessionStillValid(false)
                 .arrange()
@@ -1311,7 +1299,7 @@ class NewLoginViewModelTest {
             val userId = UserId("user-id", "domain")
             val (_, viewModel) = Arrangement()
                 .withEstablishSSOSessionSuccess(userId)
-                .withNomadEnabled(true)
+                .withNomadAutoLogin("https://nomad.example.com/service")
                 .withRestoreCryptoStateReturning(RestoreCryptoStateResult.Failure)
                 .withSessionStillValid(false)
                 .apply { coEvery { logoutUseCase(any(), any()) } throws IllegalStateException("already closed") }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24663
<!--jira-description-action-hidden-marker-end-->
---

#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability

---

# What's new in this PR?

### Issues

- SSO login on servers with Nomad profiles enabled was broken. The login flow was querying the backend to check if Nomad profiles are enabled (`isNomadProfilesEnabled()`) to decide whether to restore crypto state or register a new client. This meant that **any** SSO login on a Nomad-enabled backend would attempt crypto state restoration, even for non-Nomad login flows.

### Causes

The `establishSSOSession` success callback in both `LoginSSOViewModel` and `NewLoginViewModel` called `coreLogic.getSessionScope(storedUserId).authenticationScope.isNomadProfilesEnabled()` to determine the post-login path. This checks a backend feature flag rather than whether the current login flow was actually initiated as a Nomad flow (i.e., with a `nomadServiceUrl`).

### Solutions

Replaced the backend feature flag check with a local check: `val isNomadFlow = pendingNomadServiceUrl != null`, captured before calling `establishSSOSession` (since `pendingNomadServiceUrl` is consumed/nulled during that call). This correctly determines whether the current SSO login was initiated as a Nomad flow based on the presence of a Nomad service URL in the deep link parameters.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

1. Perform an SSO login on a backend that has Nomad profiles enabled but without a Nomad deep link — should proceed with regular client registration (not crypto state restore).
2. Perform a Nomad SSO login (via deep link with `nomadServiceUrl`) — should attempt crypto state restore as before.
3. Verify existing SSO login flows still work on backends without Nomad support.
