### PR TITLE
fix: Conversation rename field resets while receiving message(s) (WPB-24637)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationMetadataViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationMetadataViewModel.kt
@@ -26,11 +26,11 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.ui.common.groupname.GroupMetadataState
 import com.wire.android.ui.common.groupname.GroupNameMode
 import com.wire.android.ui.common.groupname.GroupNameValidator
 import com.wire.android.ui.common.textfield.textAsFlow
-import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -38,14 +38,11 @@ import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseC
 import com.wire.kalium.logic.feature.conversation.RenameConversationUseCase
 import com.wire.kalium.logic.feature.conversation.RenamingResult
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -66,25 +63,22 @@ class EditConversationMetadataViewModel @Inject constructor(
         private set
 
     init {
-        observeConversationDetails()
+        getConversationDetails()
         observeConversationNameChanges()
     }
 
-    private fun observeConversationDetails() {
+    private fun getConversationDetails() {
         viewModelScope.launch {
-            observeConversationDetails(conversationId)
+            val conversationDetails = observeConversationDetails(conversationId)
                 .filterIsInstance<ObserveConversationDetailsUseCase.Result.Success>()
                 .map { it.conversationDetails }
-                .distinctUntilChanged()
-                .flowOn(dispatcher.io())
-                .shareIn(this, SharingStarted.WhileSubscribed(), 1)
-                .collectLatest {
-                    editConversationNameTextState.setTextAndPlaceCursorAtEnd(it.conversation.name.orEmpty())
-                    editConversationState = editConversationState.copy(
-                        originalGroupName = it.conversation.name.orEmpty(),
-                        isChannel = it.conversation.type == Conversation.Type.Group.Channel,
-                    )
-                }
+                .first()
+
+            editConversationNameTextState.setTextAndPlaceCursorAtEnd(conversationDetails.conversation.name.orEmpty())
+            editConversationState = editConversationState.copy(
+                originalGroupName = conversationDetails.conversation.name.orEmpty(),
+                isChannel = conversationDetails.conversation.type == Conversation.Type.Group.Channel,
+            )
         }
     }
 
@@ -93,8 +87,8 @@ class EditConversationMetadataViewModel @Inject constructor(
             editConversationNameTextState.textAsFlow()
                 .dropWhile { it.isEmpty() } // ignore first empty value to not show the error before the user typed anything
                 .collectLatest {
-                editConversationState = GroupNameValidator.onGroupNameChange(it.toString(), editConversationState)
-            }
+                    editConversationState = GroupNameValidator.onGroupNameChange(it.toString(), editConversationState)
+                }
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24637
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Renaming a conversation is not possible while messages are received.

### Causes (Optional)

We are observing the details of the conversation

### Solutions

This operation should not observe, so just pick the original value and not update.


### Attachments (Optional)

**Before**

https://github.com/user-attachments/assets/fc0ec845-1ed1-45d8-b9ef-00bba2933148

**After**
<img width="580" height="765" alt="Screenshot 2026-04-09 at 12 15 17" src="https://github.com/user-attachments/assets/d3fbef20-dbe3-4bb3-858b-6b19d9bcc29e" />

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
