### PR TITLE
fix: open proper video tile in fullscreen [WPB-24666]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -437,7 +437,10 @@ private fun OngoingCallContent(
                             derivedStateOf {
                                 participants
                                     .takeIf { it.size > 1 } // if there is only one in the call, do not allow full screen
-                                    ?.find { participant -> participant.id == selectedParticipantForFullScreen?.userId }
+                                    ?.find { participant ->
+                                        participant.id == selectedParticipantForFullScreen?.userId
+                                                && participant.clientId == selectedParticipantForFullScreen.clientId
+                                    }
                             }
                         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24666
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a given user has two clients in a call, then when you try to open them on fullscreen, it always opens the first one from the list, even if the second one was double-tapped.

### Causes (Optional)

Only checking user id and not also client id.

### Solutions

Check also client id when finding data of fullscreen participant.

### Testing

#### How to Test

- join a call where someone has at least two clients with video
- double-tap on their second client on a list

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/user-attachments/assets/9ae08112-2c2e-4a96-a811-e5501b24a790"/> | <video width="400" src="https://github.com/user-attachments/assets/106d6327-1729-4b67-8f03-68bf3b5c2f29"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
