### PR TITLE
feat: add GetConversationEpochFromCC use case and integrate into debug conversation screen [WPB-24877]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/DebugModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/DebugModule.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.debug.BreakSessionUseCase
 import com.wire.kalium.logic.feature.debug.DebugScope
 import com.wire.kalium.logic.feature.debug.GetFeatureConfigUseCase
+import com.wire.kalium.logic.feature.debug.GetConversationEpochFromCCUseCase
 import com.wire.kalium.logic.feature.debug.RepairFaultyRemovalKeysUseCase
 import dagger.Module
 import dagger.Provides
@@ -78,6 +79,11 @@ class DebugModule {
     @ViewModelScoped
     @Provides
     fun provideFeatureConfigUseCase(debugScope: DebugScope): GetFeatureConfigUseCase = debugScope.getFeatureConfig
+
+    @ViewModelScoped
+    @Provides
+    fun provideGetConversationEpochFromCCUseCase(debugScope: DebugScope): GetConversationEpochFromCCUseCase =
+        debugScope.getConversationEpochFromCC
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/debug/conversation/DebugConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/conversation/DebugConversationScreen.kt
@@ -103,7 +103,11 @@ fun DebugConversationScreen(
 
                 state.mlsProtocolInfo?.let {
                     SectionHeader("MLS")
-                    MlsDetailsView(it)
+                    MlsDetailsView(
+                        state = state,
+                        mlsProtocolInfo = it,
+                        onRefreshCcEpoch = viewModel::refreshConversationEpochFromCC,
+                    )
                 }
 
                 SectionHeader("Actions")
@@ -227,7 +231,11 @@ private fun ConversationDetailsView(state: DebugConversationViewState) {
 }
 
 @Composable
-private fun MlsDetailsView(mlsProtocolInfo: Conversation.ProtocolInfo.MLS) {
+private fun MlsDetailsView(
+    state: DebugConversationViewState,
+    mlsProtocolInfo: Conversation.ProtocolInfo.MLSCapable,
+    onRefreshCcEpoch: () -> Unit,
+) {
 
     val clipboard = LocalClipboardManager.current
 
@@ -249,8 +257,32 @@ private fun MlsDetailsView(mlsProtocolInfo: Conversation.ProtocolInfo.MLS) {
         text = mlsProtocolInfo.groupState.toString(),
     )
     SettingsItem(
-        title = "Epoch",
+        title = "Epoch (deprecated)",
         text = mlsProtocolInfo.epoch.toString(),
+    )
+    RowItemTemplate(
+        title = {
+            Text(
+                style = MaterialTheme.wireTypography.label01,
+                color = MaterialTheme.wireColorScheme.secondaryText,
+                text = "CC Epoch",
+                modifier = Modifier.padding(start = dimensions().spacing8x)
+            )
+            Text(
+                style = MaterialTheme.wireTypography.body01,
+                color = MaterialTheme.wireColorScheme.onBackground,
+                text = state.ccEpoch?.toString() ?: if (state.isRefreshingCCEpoch) "Loading..." else "-",
+                modifier = Modifier.padding(start = dimensions().spacing8x)
+            )
+        },
+        actions = {
+            WirePrimaryButton(
+                onClick = onRefreshCcEpoch,
+                text = "Refresh",
+                fillMaxWidth = false,
+                loading = state.isRefreshingCCEpoch,
+            )
+        }
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/debug/conversation/DebugConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/conversation/DebugConversationViewModel.kt
@@ -31,6 +31,8 @@ import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseC
 import com.wire.kalium.logic.feature.debug.DebugFeedConfig
 import com.wire.kalium.logic.feature.debug.DebugFeedConversationUseCase
 import com.wire.kalium.logic.feature.debug.DebugFeedResult
+import com.wire.kalium.logic.feature.debug.GetConversationEpochFromCCResult
+import com.wire.kalium.logic.feature.debug.GetConversationEpochFromCCUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -44,6 +46,7 @@ class DebugConversationViewModel @Inject constructor(
     private val resetMLSConversation: ResetMLSConversationUseCase,
     private val fetchConversation: FetchConversationUseCase,
     private val feedConversation: DebugFeedConversationUseCase,
+    private val getConversationEpochFromCC: GetConversationEpochFromCCUseCase,
     savedStateHandle: SavedStateHandle,
 ) : ActionsViewModel<DebugConversationScreenAction>() {
 
@@ -53,6 +56,7 @@ class DebugConversationViewModel @Inject constructor(
 
     private val _state = MutableStateFlow(DebugConversationViewState())
     val state = _state.asStateFlow()
+    private var hasRequestedInitialCCEpoch = false
 
     init {
         loadConversationDetails()
@@ -67,8 +71,16 @@ class DebugConversationViewModel @Inject constructor(
                             conversationId = conversationId.toString(),
                             conversationName = result.conversationDetails.conversation.name,
                             teamId = result.conversationDetails.conversation.teamId?.value,
-                            mlsProtocolInfo = result.conversationDetails.conversation.protocol as? Conversation.ProtocolInfo.MLS,
+                            mlsProtocolInfo = result.conversationDetails.conversation.protocol as? Conversation.ProtocolInfo.MLSCapable,
                         )
+                    }
+
+                    if (
+                        !hasRequestedInitialCCEpoch &&
+                        result.conversationDetails.conversation.protocol is Conversation.ProtocolInfo.MLSCapable
+                    ) {
+                        hasRequestedInitialCCEpoch = true
+                        refreshConversationEpochFromCC()
                     }
                 }
             }
@@ -93,6 +105,32 @@ class DebugConversationViewModel @Inject constructor(
             .onFailure { error ->
                 appLogger.e("MLS conversation fetch failed: $error")
             }
+    }
+
+    fun refreshConversationEpochFromCC() = viewModelScope.launch {
+        _state.update { it.copy(isRefreshingCCEpoch = true) }
+
+        when (val result = getConversationEpochFromCC(conversationId)) {
+            is GetConversationEpochFromCCResult.Success -> {
+                _state.update {
+                    it.copy(
+                        ccEpoch = result.epoch,
+                        isRefreshingCCEpoch = false
+                    )
+                }
+            }
+
+            GetConversationEpochFromCCResult.Failure.NotMlsConversation -> {
+                _state.update { it.copy(isRefreshingCCEpoch = false) }
+                sendAction(ShowMessage("CC epoch is only available for MLS conversations."))
+            }
+
+            is GetConversationEpochFromCCResult.Failure.Generic -> {
+                appLogger.e("Fetching conversation epoch from CC failed: ${result.coreFailure}")
+                _state.update { it.copy(isRefreshingCCEpoch = false) }
+                sendAction(ShowMessage("Failed to refresh CC epoch."))
+            }
+        }
     }
 
     /**
@@ -191,7 +229,9 @@ data class DebugConversationViewState(
     val conversationId: String? = null,
     val conversationName: String? = null,
     val teamId: String? = null,
-    val mlsProtocolInfo: Conversation.ProtocolInfo.MLS? = null,
+    val mlsProtocolInfo: Conversation.ProtocolInfo.MLSCapable? = null,
+    val ccEpoch: ULong? = null,
+    val isRefreshingCCEpoch: Boolean = false,
     val feedConfig: DebugFeedConfigUiState = DebugFeedConfigUiState(),
 )
 

--- a/app/src/test/kotlin/com/wire/android/ui/debug/conversation/DebugConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/debug/conversation/DebugConversationViewModelTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.wire.android.ui.debug.conversation
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.ramcosta.composedestinations.generated.app.navArgs
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.NavigationTestExtension
+import com.wire.android.framework.TestConversation
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
+import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.debug.DebugFeedConversationUseCase
+import com.wire.kalium.logic.feature.debug.GetConversationEpochFromCCResult
+import com.wire.kalium.logic.feature.debug.GetConversationEpochFromCCUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(CoroutineTestExtension::class)
+@ExtendWith(NavigationTestExtension::class)
+class DebugConversationViewModelTest {
+
+    @Test
+    fun givenMLSConversation_whenInitialising_thenLoadCCEpochFromUseCase() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .withConversationDetails(mlsConversationDetails())
+            .withCCEpochResult(GetConversationEpochFromCCResult.Success(CC_EPOCH))
+            .arrange()
+
+        advanceUntilIdle()
+
+        assertEquals(TestConversation.MLS_PROTOCOL_INFO, viewModel.state.value.mlsProtocolInfo)
+        assertEquals(CC_EPOCH, viewModel.state.value.ccEpoch)
+        coVerify(exactly = 1) {
+            arrangement.getConversationEpochFromCCUseCase(arrangement.conversationId)
+        }
+    }
+
+    @Test
+    fun givenCCEpochFetchFailure_whenRefreshing_thenShowErrorMessageAndKeepEpochUnset() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .withConversationDetails(mlsConversationDetails())
+            .withCCEpochResults(
+                GetConversationEpochFromCCResult.Success(CC_EPOCH),
+                GetConversationEpochFromCCResult.Failure.Generic(CoreFailure.MissingClientRegistration),
+            )
+            .arrange()
+
+        advanceUntilIdle()
+
+        viewModel.actions.test {
+            viewModel.refreshConversationEpochFromCC()
+            assertEquals(ShowMessage("Failed to refresh CC epoch."), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertEquals(CC_EPOCH, viewModel.state.value.ccEpoch)
+        assertEquals(false, viewModel.state.value.isRefreshingCCEpoch)
+        coVerify(exactly = 2) {
+            arrangement.getConversationEpochFromCCUseCase(arrangement.conversationId)
+        }
+    }
+}
+
+private class Arrangement {
+
+    @MockK
+    lateinit var savedStateHandle: SavedStateHandle
+
+    @MockK
+    lateinit var observeConversationDetailsUseCase: ObserveConversationDetailsUseCase
+
+    @MockK
+    lateinit var resetMLSConversationUseCase: ResetMLSConversationUseCase
+
+    @MockK
+    lateinit var fetchConversationUseCase: FetchConversationUseCase
+
+    @MockK
+    lateinit var debugFeedConversationUseCase: DebugFeedConversationUseCase
+
+    @MockK
+    lateinit var getConversationEpochFromCCUseCase: GetConversationEpochFromCCUseCase
+
+    val conversationId = ConversationId("debug-conversation-id", "wire.com")
+
+    init {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        every {
+            savedStateHandle.navArgs<DebugConversationScreenNavArgs>()
+        } returns DebugConversationScreenNavArgs(conversationId)
+        coEvery { observeConversationDetailsUseCase(any()) } returns flowOf<ObserveConversationDetailsUseCase.Result>()
+        coEvery { getConversationEpochFromCCUseCase(any()) } returns GetConversationEpochFromCCResult.Failure.NotMlsConversation
+    }
+
+    suspend fun withConversationDetails(conversationDetails: ConversationDetails) = apply {
+        coEvery { observeConversationDetailsUseCase(any()) } returns flowOf(
+            ObserveConversationDetailsUseCase.Result.Success(conversationDetails)
+        )
+    }
+
+    suspend fun withCCEpochResult(result: GetConversationEpochFromCCResult) = apply {
+        coEvery { getConversationEpochFromCCUseCase(any()) } returns result
+    }
+
+    suspend fun withCCEpochResults(vararg results: GetConversationEpochFromCCResult) = apply {
+        coEvery { getConversationEpochFromCCUseCase(any()) } returnsMany results.toList()
+    }
+
+    fun arrange() = this to DebugConversationViewModel(
+        conversationDetails = observeConversationDetailsUseCase,
+        resetMLSConversation = resetMLSConversationUseCase,
+        fetchConversation = fetchConversationUseCase,
+        feedConversation = debugFeedConversationUseCase,
+        getConversationEpochFromCC = getConversationEpochFromCCUseCase,
+        savedStateHandle = savedStateHandle,
+    )
+}
+
+private fun mlsConversationDetails(): ConversationDetails.Group.Regular =
+    ConversationDetails.Group.Regular(
+        conversation = TestConversation.GROUP(TestConversation.MLS_PROTOCOL_INFO),
+        isSelfUserMember = true,
+        selfRole = Conversation.Member.Role.Member,
+        wireCell = null,
+    )
+
+private const val CC_EPOCH = 42UL


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24877
<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

The debug inspect conversation screen showed the epoch from the local conversation object, which is not reliable enough for debugging.

### Solutions

- Kept the existing local epoch visible and marked it as deprecated.
- Added a new debug use case to fetch the conversation epoch from CC.
- Added a small refresh action because the CC epoch is fetched on demand and not exposed as a flow.
- Displayed the CC epoch as a separate line in the inspect conversation screen.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

- Verified the new Kalium use case with unit tests.
- Verified the debug conversation ViewModel with unit tests.
- Ran static analysis successfully.

### Notes

The CC epoch is only available for MLS conversations.