### PR TITLE
fix: Sent images appearing blank in conversation (WPB-24681)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/AssetLocalPathViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/AssetLocalPathViewModel.kt
@@ -75,7 +75,8 @@ internal class AssetLocalPathViewModelImpl @AssistedInject constructor(
         val shouldResolve = when {
             downloadIfNeeded ->
                 transferStatus == AssetTransferStatus.NOT_DOWNLOADED ||
-                transferStatus == AssetTransferStatus.SAVED_INTERNALLY
+                transferStatus == AssetTransferStatus.SAVED_INTERNALLY ||
+                transferStatus == AssetTransferStatus.UPLOADED
             else -> transferStatus == AssetTransferStatus.SAVED_INTERNALLY
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/item/AssetLocalPathViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/item/AssetLocalPathViewModelTest.kt
@@ -1,0 +1,197 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.home.conversations.messages.item
+
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.TestDispatcherProvider
+import com.wire.kalium.logic.data.asset.AssetTransferStatus
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
+import com.wire.kalium.logic.feature.asset.MessageAssetResult
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(CoroutineTestExtension::class)
+class AssetLocalPathViewModelTest {
+
+    @Test
+    fun givenUploadedStatus_whenResolveIfNeededWithDownloadIfNeeded_thenPathIsResolved() = runTest {
+        // given
+        val expectedPath = "/local/path/image.jpg"
+        val (arrangement, viewModel) = Arrangement()
+            .withGetMessageAssetSuccess(expectedPath)
+            .arrange()
+
+        // when
+        viewModel.resolveIfNeeded(transferStatus = AssetTransferStatus.UPLOADED, downloadIfNeeded = true)
+
+        // then
+        assertEquals(expectedPath, viewModel.localAssetPath)
+        coVerify(exactly = 1) { arrangement.getMessageAsset(any(), any()) }
+    }
+
+    @Test
+    fun givenNotDownloadedStatus_whenResolveIfNeededWithDownloadIfNeeded_thenPathIsResolved() = runTest {
+        // given
+        val expectedPath = "/local/path/image.jpg"
+        val (arrangement, viewModel) = Arrangement()
+            .withGetMessageAssetSuccess(expectedPath)
+            .arrange()
+
+        // when
+        viewModel.resolveIfNeeded(transferStatus = AssetTransferStatus.NOT_DOWNLOADED, downloadIfNeeded = true)
+
+        // then
+        assertEquals(expectedPath, viewModel.localAssetPath)
+        coVerify(exactly = 1) { arrangement.getMessageAsset(any(), any()) }
+    }
+
+    @Test
+    fun givenSavedInternallyStatus_whenResolveIfNeeded_thenPathIsResolved() = runTest {
+        // given
+        val expectedPath = "/local/path/image.jpg"
+        val (arrangement, viewModel) = Arrangement()
+            .withGetMessageAssetSuccess(expectedPath)
+            .arrange()
+
+        // when
+        viewModel.resolveIfNeeded(transferStatus = AssetTransferStatus.SAVED_INTERNALLY, downloadIfNeeded = false)
+
+        // then
+        assertEquals(expectedPath, viewModel.localAssetPath)
+        coVerify(exactly = 1) { arrangement.getMessageAsset(any(), any()) }
+    }
+
+    @Test
+    fun givenUploadInProgressStatus_whenResolveIfNeededWithDownloadIfNeeded_thenPathIsNotResolved() = runTest {
+        // given
+        val (arrangement, viewModel) = Arrangement()
+            .arrange()
+
+        // when
+        viewModel.resolveIfNeeded(transferStatus = AssetTransferStatus.UPLOAD_IN_PROGRESS, downloadIfNeeded = true)
+
+        // then
+        assertNull(viewModel.localAssetPath)
+        coVerify(exactly = 0) { arrangement.getMessageAsset(any(), any()) }
+    }
+
+    @Test
+    fun givenUploadedStatusButDownloadIfNeededFalse_whenResolveIfNeeded_thenPathIsNotResolved() = runTest {
+        // given
+        val (arrangement, viewModel) = Arrangement()
+            .arrange()
+
+        // when
+        viewModel.resolveIfNeeded(transferStatus = AssetTransferStatus.UPLOADED, downloadIfNeeded = false)
+
+        // then
+        assertNull(viewModel.localAssetPath)
+        coVerify(exactly = 0) { arrangement.getMessageAsset(any(), any()) }
+    }
+
+    @Test
+    fun givenPathAlreadyResolved_whenResolveIfNeededCalledAgain_thenGetAssetIsNotCalledAgain() = runTest {
+        // given
+        val expectedPath = "/local/path/image.jpg"
+        val (arrangement, viewModel) = Arrangement()
+            .withGetMessageAssetSuccess(expectedPath)
+            .arrange()
+
+        viewModel.resolveIfNeeded(transferStatus = AssetTransferStatus.UPLOADED, downloadIfNeeded = true)
+        assertEquals(expectedPath, viewModel.localAssetPath)
+
+        // when - call again
+        viewModel.resolveIfNeeded(transferStatus = AssetTransferStatus.UPLOADED, downloadIfNeeded = true)
+
+        // then - use case is only called once
+        coVerify(exactly = 1) { arrangement.getMessageAsset(any(), any()) }
+    }
+
+    @Test
+    fun givenGetAssetFails_whenResolveIfNeeded_thenLocalPathRemainsNull() = runTest {
+        // given
+        val (_, viewModel) = Arrangement()
+            .withGetMessageAssetFailure()
+            .arrange()
+
+        // when
+        viewModel.resolveIfNeeded(transferStatus = AssetTransferStatus.UPLOADED, downloadIfNeeded = true)
+
+        // then
+        assertNull(viewModel.localAssetPath)
+    }
+
+    private class Arrangement {
+
+        @MockK
+        lateinit var getMessageAsset: GetMessageAssetUseCase
+
+        private val conversationId = ConversationId("conv-value", "conv-domain")
+        private val messageId = "test-message-id"
+        private val dispatchers = TestDispatcherProvider()
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+        }
+
+        fun withGetMessageAssetSuccess(path: String) = apply {
+            coEvery { getMessageAsset(any(), any()) } returns CompletableDeferred(
+                MessageAssetResult.Success(
+                    decodedAssetPath = path.toPath(normalize = true),
+                    assetSize = 1024L,
+                    assetName = "image.jpg"
+                )
+            )
+        }
+
+        fun withGetMessageAssetFailure() = apply {
+            coEvery { getMessageAsset(any(), any()) } returns CompletableDeferred(
+                MessageAssetResult.Failure(
+                    coreFailure = com.wire.kalium.common.error.CoreFailure.Unknown(null),
+                    isRetryNeeded = false
+                )
+            )
+        }
+
+        fun arrange(): Pair<Arrangement, AssetLocalPathViewModelImpl> {
+            val viewModel = AssetLocalPathViewModelImpl(
+                getMessageAsset = getMessageAsset,
+                dispatchers = dispatchers,
+                args = AssetLocalPathArgs(
+                    conversationId = conversationId,
+                    messageId = messageId,
+                )
+            )
+            return this to viewModel
+        }
+    }
+}
+

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/item/AssetLocalPathViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/item/AssetLocalPathViewModelTest.kt
@@ -194,4 +194,3 @@ class AssetLocalPathViewModelTest {
         }
     }
 }
-


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24681
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After sending an image, the message appeared empty. When a user sends an image, Kalium sets its transfer status to `UPLOADED` once the upload completes. 
However, `AssetLocalPathViewModel` only resolved the local asset path for `NOT_DOWNLOADED` and `SAVED_INTERNALLY` statuses — leaving `UPLOADED` unhandled. This meant `localAssetPath` stayed `null` on the sender's side, rendering a blank image.

### Solutions

Add `AssetTransferStatus.UPLOADED` to the `shouldResolve` condition in the `downloadIfNeeded = true` branch, so that sent images (which never go through the download lifecycle) are also resolved via `GetMessageAssetUseCase`.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
