### PR TITLE
fix: unify call quality accessibility descriptions [WPB-24422]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallDetailsSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallDetailsSheetContent.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextAlign
 import com.wire.android.R
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
@@ -121,7 +122,7 @@ private fun NetworkQualityItem(
                 )
                 Icon(
                     painter = painterResource(id = R.drawable.ic_arrow_right),
-                    contentDescription = "",
+                    contentDescription = stringResource(R.string.content_description_call_network_quality_view_details),
                     tint = MaterialTheme.wireColorScheme.onSecondaryButtonEnabled,
                     modifier = Modifier.size(dimensions().spacing16x)
                 )
@@ -129,8 +130,9 @@ private fun NetworkQualityItem(
         },
         onItemClick = onOpenNetworkQuality,
         modifier = Modifier.clearAndSetSemantics {
-            contentDescription = "$title: $value"
-            onClick(label = clickLabel, action = null)
+            contentDescription = clickLabel
+            stateDescription = "$title: $value"
+            onClick(action = null)
         }
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallDetailsSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallDetailsSheetContent.kt
@@ -32,9 +32,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextAlign
 import com.wire.android.R
@@ -132,6 +134,7 @@ private fun NetworkQualityItem(
         modifier = Modifier.clearAndSetSemantics {
             contentDescription = clickLabel
             stateDescription = "$title: $value"
+            role = Role.Button
             onClick(action = null)
         }
     )

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallNetworkQualitySheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallNetworkQualitySheetContent.kt
@@ -44,8 +44,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.stateDescription
 import com.wire.android.R
 import com.wire.android.ui.common.ArrowLeftIcon
 import com.wire.android.ui.common.bottomsheet.BuildMenuSheetItems
@@ -81,7 +80,7 @@ fun CallNetworkQualitySheetContent(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .clearAndSetSemantics {
-                            contentDescription = "$title: $value"
+                            stateDescription = "$title: $value"
                         }
                         .padding(vertical = dimensions().modalBottomSheetHeaderVerticalPadding)
 
@@ -96,16 +95,11 @@ fun CallNetworkQualitySheetContent(
                 }
             },
             leadingIcon = {
-                val backButtonLabel = stringResource(R.string.content_description_back_button)
-                val clickLabel = stringResource(R.string.content_description_call_network_quality_close_details)
-                IconButton(
-                    onClick = onBackPressed,
-                    modifier = Modifier.clearAndSetSemantics {
-                        contentDescription = backButtonLabel
-                        onClick(label = clickLabel, action = null)
-                    },
-                ) {
-                    ArrowLeftIcon(modifier = Modifier.size(dimensions().spacing16x))
+                IconButton(onClick = onBackPressed) {
+                    ArrowLeftIcon(
+                        modifier = Modifier.size(dimensions().spacing16x),
+                        contentDescription = R.string.content_description_call_network_quality_close_details
+                    )
                 }
             },
             verticalPadding = dimensions().spacing0x,
@@ -201,7 +195,7 @@ private fun QualityValueItem(title: String, value: String, indicator: CallQualit
     MenuBottomSheetItem(
         title = title,
         modifier = Modifier.clearAndSetSemantics {
-            contentDescription = "$title: $value"
+            stateDescription = "$title: $value"
         },
         trailing = {
             Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/kotlin/com/wire/android/ui/common/ArrowIcon.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/ArrowIcon.kt
@@ -44,11 +44,12 @@ fun ArrowRightIcon(
 
 @Composable
 fun ArrowLeftIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    @StringRes contentDescription: Int = R.string.content_description_left_arrow,
 ) {
     ArrowIcon(
         arrowIcon = R.drawable.ic_arrow_left,
-        contentDescription = R.string.content_description_left_arrow,
+        contentDescription = contentDescription,
         modifier = modifier
     )
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24422
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Talkback reads some call quality dashboard button actions as "double tap to activate" and for others is more specific with "double tap to view details". We want all buttons to have unified description - the action is the same so the description also should be the same.

### Solutions

Remove custom action names for click labels.
Add the button name as `contentDescription` and move the part related to the state that changes to `stateDescription` - thanks to that state is read again when it changes, and the content is read only once after reading the state, but before "double tap to activate". So for the "view details" row with quality state, talkback reads it as: "network quality: good, view details, double tap to activate".

### Testing

#### How to Test

Join/start a call, open call details, enable talkback and let it read the content.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
