### PR TITLE
test:  stabilization flaky UI tests[wpb-24795]

### DIFF
--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/AccountManagement.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/AccountManagement.kt
@@ -67,9 +67,6 @@ class AccountManagement : BaseUiTest() {
 
     @After
     fun tearDown() {
-        UiAutomatorSetup.stopApp()
-        // To delete team member
-       // runCatching { registeredUser?.deleteTeamMember(backendClient, teamMember?.getUserId().orEmpty()) }
         // To delete team
         runCatching { registeredUser?.deleteTeam(backendClient) }
     }
@@ -92,6 +89,7 @@ class AccountManagement : BaseUiTest() {
                     backendClient,
                     context
                 )
+                registeredUser = teamHelper.usersManager.findUserBy("user1Name", ClientUserManager.FindBy.NAME_ALIAS)
 
                 teamHelper.userXAddsUsersToTeam(
                     "user1Name",
@@ -110,7 +108,6 @@ class AccountManagement : BaseUiTest() {
                     "AccountManagement"
                 )
 
-                registeredUser = teamHelper.usersManager.findUserBy("user1Name", ClientUserManager.FindBy.NAME_ALIAS)
                 teamMember = teamHelper.usersManager.findUserBy("user2Name", ClientUserManager.FindBy.NAME_ALIAS)
                 newEmail = teamHelper.usersManager.findUserBy("user4Name", ClientUserManager.FindBy.NAME_ALIAS)
             }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/FileSharingBetweenTeams.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/FileSharingBetweenTeams.kt
@@ -322,9 +322,10 @@ class FileSharingBetweenTeams : BaseUiTest() {
 
         step("Play video file and verify it opens outside Wire") {
             pages.conversationViewPage.apply {
-                tapToPlayVideoFile()
-                clickOpenButtonOnDownloadModal()
-                assertWireAppIsNotInForeground()
+//                 Commented out until this bug is fixed: https://wearezeta.atlassian.net/browse/WPB-24809
+//                tapToPlayVideoFile()
+//                clickOpenButtonOnDownloadModal()
+//                assertWireAppIsNotInForeground()
             }
         }
     }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/FileSharingBetweenTeams.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/FileSharingBetweenTeams.kt
@@ -218,10 +218,8 @@ class FileSharingBetweenTeams : BaseUiTest() {
             pages.conversationViewPage.apply {
                 tapDownloadButton()
                 assertFileActionModalIsVisible()
-                tapSaveButtonOnModal()
-                assertFileSavedToastContain(
-                    "The file AudioFile( ?\\([0-9]+\\))?\\.mp3 was saved successfully to the Downloads folder"
-                )
+                clickSaveButtonOnDownloadModal()
+                assertFileSavedToast("The file AudioFile.mp3 was saved successfully to the Downloads folder")
             }
         }
 
@@ -247,9 +245,7 @@ class FileSharingBetweenTeams : BaseUiTest() {
             pages.conversationViewPage.apply {
                 waitForPreviousFileSavedToastToDisappear()
                 clickSaveButtonOnDownloadModal()
-                assertFileSavedToastContain(
-                    "The file ImageFile( ?\\([0-9]+\\))?\\.jpg was saved successfully to the Downloads folder"
-                )
+                assertFileSavedToast("The file ImageFile.jpg was saved successfully to the Downloads folder")
             }
         }
 
@@ -275,9 +271,7 @@ class FileSharingBetweenTeams : BaseUiTest() {
             pages.conversationViewPage.apply {
                 waitForPreviousFileSavedToastToDisappear()
                 clickSaveButtonOnDownloadModal()
-                assertFileSavedToastContain(
-                    "The file TextFile( ?\\([0-9]+\\))?\\.txt was saved successfully to the Downloads folder"
-                )
+                assertFileSavedToast("The file TextFile.txt was saved successfully to the Downloads folder")
             }
         }
 
@@ -314,9 +308,7 @@ class FileSharingBetweenTeams : BaseUiTest() {
             pages.conversationViewPage.apply {
                 waitForPreviousFileSavedToastToDisappear()
                 clickSaveButtonOnDownloadModal()
-                assertFileSavedToastContain(
-                    "The file VideoFile( ?\\([0-9]+\\))?\\.mp4 was saved successfully to the Downloads folder"
-                )
+                assertFileSavedToast("The file VideoFile.mp4 was saved successfully to the Downloads folder")
             }
         }
 

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupVideoCall.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupVideoCall.kt
@@ -193,6 +193,7 @@ class GroupVideoCall : BaseUiTest() {
             }
         }
 
+
         step("And I verify GroupVideoCall conversation is visible and start new conversation flow") {
             pages.conversationListPage.apply {
                 assertGroupConversationVisible("GroupVideoCall")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupVideoCall.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupVideoCall.kt
@@ -147,7 +147,7 @@ class GroupVideoCall : BaseUiTest() {
             }
         }
 
-        step("And conference calling is enabled for WeLikeCalls and IJoinCalls via backdoor") {
+        step("And conference calling is enabled for WeLikeCalls and IJoinCalls via backend") {
             runBlocking {
                 callHelper.enableConferenceCallingFeatureViaBackdoorTeam(
                     "user1Name",
@@ -189,7 +189,6 @@ class GroupVideoCall : BaseUiTest() {
                 clickDeclineShareDataAlert()
             }
         }
-
 
         step("And I verify GroupVideoCall conversation is visible and start new conversation flow") {
             pages.conversationListPage.apply {

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupVideoCall.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupVideoCall.kt
@@ -99,6 +99,10 @@ class GroupVideoCall : BaseUiTest() {
                 backendClient,
                 context
             )
+            teamOwnerA = teamHelper.usersManager.findUserBy(
+                "user1Name",
+                ClientUserManager.FindBy.NAME_ALIAS
+            )
 
             teamHelper.userXAddsUsersToTeam(
                 "user1Name",
@@ -117,6 +121,10 @@ class GroupVideoCall : BaseUiTest() {
                 true,
                 backendClient,
                 context
+            )
+            teamOwnerB = teamHelper.usersManager.findUserBy(
+                "user4Name",
+                ClientUserManager.FindBy.NAME_ALIAS
             )
         }
 
@@ -137,17 +145,6 @@ class GroupVideoCall : BaseUiTest() {
                     usersSetUniqueUsername("user3Name")
                 }
             }
-        }
-
-        step("And team owners for WeLikeCalls and IJoinCalls are resolved") {
-            teamOwnerA = teamHelper.usersManager.findUserBy(
-                "user1Name",
-                ClientUserManager.FindBy.NAME_ALIAS
-            )
-            teamOwnerB = teamHelper.usersManager.findUserBy(
-                "user4Name",
-                ClientUserManager.FindBy.NAME_ALIAS
-            )
         }
 
         step("And conference calling is enabled for WeLikeCalls and IJoinCalls via backdoor") {

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/NewMemberMessaging.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/NewMemberMessaging.kt
@@ -81,6 +81,7 @@ class NewMemberMessaging : BaseUiTest() {
                 backendClient,
                 context
             )
+            teamOwner = teamHelper.usersManager.findUserBy("user1Name", ClientUserManager.FindBy.NAME_ALIAS)
 
             teamHelper.userXAddsUsersToTeam(
                 "user1Name",
@@ -92,7 +93,6 @@ class NewMemberMessaging : BaseUiTest() {
                 true
             )
 
-            teamOwner = teamHelper.usersManager.findUserBy("user1Name", ClientUserManager.FindBy.NAME_ALIAS)
             member1 = teamHelper.usersManager.findUserBy("user2Name", ClientUserManager.FindBy.NAME_ALIAS)
 
             testServiceHelper.apply {

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/SSODeviceBackup.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/SSODeviceBackup.kt
@@ -89,15 +89,15 @@ class SSODeviceBackup : BaseUiTest() {
                     "Messaging",
                     oktaApiClient
                 )
+                teamOwner = teamHelper.usersManager.findUserBy(
+                    "user1Name",
+                    ClientUserManager.FindBy.NAME_ALIAS
+                )
 
                 testServiceHelper.userAddsOktaUser("user1Name", "user2Name", oktaApiClient)
 
                 testServiceHelper.userXIsMe("user2Name")
 
-                teamOwner = teamHelper.usersManager.findUserBy(
-                    "user1Name",
-                    ClientUserManager.FindBy.NAME_ALIAS
-                )
                 member1 = teamHelper.usersManager.findUserBy(
                     "user2Name",
                     ClientUserManager.FindBy.NAME_ALIAS

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationViewPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationViewPage.kt
@@ -81,13 +81,7 @@ data class ConversationViewPage(private val device: UiDevice) {
         UiSelectorParams(textContains = "Layer Security (MLS) protocol"),
         UiSelectorParams(textContains = "latest version of Wire on your devices")
     )
-
-    private val mlsUpgradeMessageSelectors = listOf(
-        UiSelectorParams(textContains = "This conversation now uses the new Messaging"),
-        UiSelectorParams(textContains = "Layer Security (MLS) protocol"),
-        UiSelectorParams(textContains = "latest version of Wire on your devices")
-    )
-
+    
     private fun selfDeleteOption(label: String): UiSelectorParams {
         return UiSelectorParams(text = label, className = "android.widget.TextView")
     }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationViewPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationViewPage.kt
@@ -30,11 +30,13 @@ import org.junit.Assert
 import uiautomatorutils.UiSelectorParams
 import uiautomatorutils.UiWaitUtils
 import uiautomatorutils.UiWaitUtils.findElementOrNull
-import java.util.regex.Pattern
 import kotlin.test.DefaultAsserter.assertTrue
 import kotlin.test.assertEquals
 
 data class ConversationViewPage(private val device: UiDevice) {
+    private val fileSavedToastPrefix = "The file "
+    private val fileSavedToastMessage = "was saved successfully to the Downloads folder"
+
     private fun displayedUserName(userName: String) = UiSelectorParams(text = userName)
     private val typeMessageField = UiSelectorParams(description = " Type a message")
     private val sentQRImage = UiSelectorParams(description = "Image message")
@@ -50,8 +52,6 @@ data class ConversationViewPage(private val device: UiDevice) {
     private val downloadButton = UiSelectorParams(text = "Download")
 
     private val modalTextLocator = UiSelectorParams(textContains = "save it to your device")
-
-    private val saveButtonLocator = UiSelectorParams(text = "Save")
 
     private val saveButton = UiSelectorParams(text = "Save")
 
@@ -186,7 +186,7 @@ data class ConversationViewPage(private val device: UiDevice) {
     }
 
     fun assertFileActionModalIsVisible(timeoutMs: Long = 8_000): ConversationViewPage {
-        val modalAnchors = listOf(modalTextLocator, saveButtonLocator, openButton, cancelButton)
+        val modalAnchors = listOf(modalTextLocator, saveButton, openButton, cancelButton)
         val deadline = SystemClock.uptimeMillis() + timeoutMs
 
         while (SystemClock.uptimeMillis() < deadline) {
@@ -203,11 +203,6 @@ data class ConversationViewPage(private val device: UiDevice) {
         }
 
         throw AssertionError("The file action modal was not visible within ${timeoutMs}ms.")
-    }
-
-    fun tapSaveButtonOnModal(): ConversationViewPage {
-        UiWaitUtils.waitElement(saveButtonLocator).click()
-        return this
     }
 
     fun assertImageFileWithNameIsVisible(fileName: String): ConversationViewPage {
@@ -275,24 +270,48 @@ data class ConversationViewPage(private val device: UiDevice) {
     fun waitForPreviousFileSavedToastToDisappear(timeoutMillis: Long = 7_000): ConversationViewPage {
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         uiDevice.wait(
-            Until.gone(By.textContains("was saved successfully to the Downloads folder")),
+            Until.gone(By.textContains(fileSavedToastMessage)),
             timeoutMillis
         )
         return this
     }
 
-    fun assertFileSavedToastContain(partialText: String): ConversationViewPage {
-        val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    fun assertFileSavedToast(
+        expectedMessage: String,
+        timeoutMs: Long = 7_000
+    ): ConversationViewPage {
+        val toastPattern = buildSavedFileToastPattern(expectedMessage)
 
-        // Toasts are short-lived; wait for regex match by presence.
-        val toast = uiDevice.wait(Until.findObject(By.text(Pattern.compile(partialText))), 7_000)
-
-        Assert.assertTrue(
-            "Toast message matching regex '$partialText' is not displayed.",
-            toast != null
+        UiWaitUtils.waitUntilVisible(
+            params = UiSelectorParams(
+                textMatches = toastPattern
+            ),
+            timeoutMs = timeoutMs,
+            errorMessage = "Toast '$expectedMessage' was not displayed within ${timeoutMs}ms."
         )
-
         return this
+    }
+
+    private fun buildSavedFileToastPattern(expectedMessage: String): String {
+        val suffix = " $fileSavedToastMessage"
+
+        if (!expectedMessage.startsWith(fileSavedToastPrefix) || !expectedMessage.endsWith(suffix)) {
+            return Regex.escape(expectedMessage)
+        }
+
+        val fileWithExtension = expectedMessage
+            .removePrefix(fileSavedToastPrefix)
+            .removeSuffix(suffix)
+
+        val lastDotIndex = fileWithExtension.lastIndexOf('.')
+        if (lastDotIndex <= 0 || lastDotIndex == fileWithExtension.lastIndex) {
+            return Regex.escape(expectedMessage)
+        }
+
+        val fileName = fileWithExtension.substring(0, lastDotIndex)
+        val extension = fileWithExtension.substring(lastDotIndex + 1)
+
+        return "${Regex.escape(fileSavedToastPrefix)}${Regex.escape(fileName)}(?: \\([0-9]+\\))?\\.${Regex.escape(extension)}${Regex.escape(suffix)}"
     }
 
     fun scrollToBottomOfConversationScreen() {

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationViewPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationViewPage.kt
@@ -337,8 +337,9 @@ data class ConversationViewPage(private val device: UiDevice) {
     }
 
     fun typeMessageInInputField(message: String): ConversationViewPage {
-        UiWaitUtils.waitElement(messageInputField).click()
-        device.type(message)
+        val field = UiWaitUtils.waitElement(messageInputField)
+        field.click()
+        field.text = message
         return this
     }
 

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationViewPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationViewPage.kt
@@ -24,7 +24,6 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import androidx.test.uiautomator.type
 import junit.framework.TestCase.assertFalse
 import org.junit.Assert
 import uiautomatorutils.UiSelectorParams
@@ -81,7 +80,7 @@ data class ConversationViewPage(private val device: UiDevice) {
         UiSelectorParams(textContains = "Layer Security (MLS) protocol"),
         UiSelectorParams(textContains = "latest version of Wire on your devices")
     )
-    
+
     private fun selfDeleteOption(label: String): UiSelectorParams {
         return UiSelectorParams(text = label, className = "android.widget.TextView")
     }
@@ -292,6 +291,7 @@ data class ConversationViewPage(private val device: UiDevice) {
         return this
     }
 
+    @Suppress("ReturnCount")
     private fun buildSavedFileToastPattern(expectedMessage: String): String {
         val suffix = " $fileSavedToastMessage"
 
@@ -311,7 +311,13 @@ data class ConversationViewPage(private val device: UiDevice) {
         val fileName = fileWithExtension.substring(0, lastDotIndex)
         val extension = fileWithExtension.substring(lastDotIndex + 1)
 
-        return "${Regex.escape(fileSavedToastPrefix)}${Regex.escape(fileName)}(?: \\([0-9]+\\))?\\.${Regex.escape(extension)}${Regex.escape(suffix)}"
+        return buildString {
+            append(Regex.escape(fileSavedToastPrefix))
+            append(Regex.escape(fileName))
+            append("(?: \\([0-9]+\\))?\\.")
+            append(Regex.escape(extension))
+            append(Regex.escape(suffix))
+        }
     }
 
     fun scrollToBottomOfConversationScreen() {

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SearchPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SearchPage.kt
@@ -18,7 +18,6 @@
 package com.wire.android.tests.core.pages
 
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.type
 import backendUtils.team.TeamHelper
 import uiautomatorutils.UiSelectorParams
 import uiautomatorutils.UiWaitUtils
@@ -63,8 +62,8 @@ data class SearchPage(private val device: UiDevice) {
         )
         val field = UiWaitUtils.waitElement(searchFieldSearchPeople)
         field.click()
-        val toType = uniqueUserName.uniqueUsername.orEmpty().replace(" ", "%s")
-        device.type(toType)
+        UiWaitUtils.waitElement(UiSelectorParams(className = "android.widget.EditText")).text =
+            uniqueUserName.uniqueUsername.orEmpty()
         return this
     }
 
@@ -77,8 +76,9 @@ data class SearchPage(private val device: UiDevice) {
             alias,
             ClientUserManager.FindBy.NAME_ALIAS
         )
-         UiWaitUtils.waitElement(searchFieldSearchPeople).click()
-        device.type(userName)
+        val field = UiWaitUtils.waitElement(searchFieldSearchPeople)
+        field.click()
+        UiWaitUtils.waitElement(UiSelectorParams(className = "android.widget.EditText")).text = userName
         return this
     }
 }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/tests/PersonalUserRegistrationTest.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/tests/PersonalUserRegistrationTest.kt
@@ -97,7 +97,6 @@ class PersonalUserRegistrationTest : BaseUiTest() {
                 closeKeyboardIfOpened()
             }
         }
-
         step("Accept anonymous usage data option and continue") {
             pages.registrationPage.apply {
                 checkIAgreeToShareAnonymousUsageData()

--- a/tests/testsSupport/src/main/call/CallingManager.kt
+++ b/tests/testsSupport/src/main/call/CallingManager.kt
@@ -67,7 +67,7 @@ class CallingManager(private val usersManager: ClientUserManager) {
         private const val FLOWCHECK_POLLING_MS = 2000L
 
         private const val CHROME_SUPPORT_VERSION = "102.0.5005.115"
-        private const val CHROME_CURRENT_VERSION = "103.0.5060.53"
+        private const val CHROME_CURRENT_VERSION = "128.0.6613.137"
     }
 
     private val client = CallingServiceClient()

--- a/tests/testsSupport/src/main/uiautomatorutils/KeyboardUtils.kt
+++ b/tests/testsSupport/src/main/uiautomatorutils/KeyboardUtils.kt
@@ -17,13 +17,29 @@
  */
 package uiautomatorutils
 
+import android.os.SystemClock
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 
 object KeyboardUtils {
+    private const val keyboardSettleDelayMs = 300L
+
     fun closeKeyboardIfOpened() {
-        val d = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        d.executeShellCommand("ime reset")
-        d.waitForIdle()
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        if (isKeyboardVisible(device)) {
+            device.pressBack()
+            device.waitForIdle()
+            SystemClock.sleep(keyboardSettleDelayMs)
+        }
+    }
+
+    private fun isKeyboardVisible(device: UiDevice): Boolean {
+        val dump = runCatching {
+            device.executeShellCommand("dumpsys input_method")
+        }.getOrDefault("")
+
+        return dump.contains("mInputShown=true") ||
+            dump.contains("isInputViewShown=true") ||
+            dump.contains("imeVisible=true")
     }
 }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24795
<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Refined download success toasts to be asserted through one helper, including support for Android-generated      duplicate filenames like File (1).ext).

- Added an explicit wait for the previous download-success toast to disappear before asserting the next one.

- Replaced flaky keyboard typing in conversation and search flows with direct text assignment on the target input fields.

- Updated the keyboard utility to only dismiss the IME when it is actually visible, then wait for the UI to settle before continuing.

- Moved team-owner lookup earlier in affected flows so cleanup objects are available when needed and setup is less timing-sensitive.

- Cleaned up duplicate logic in ConversationViewPage to keep the test helpers simpler and easier to maintain.

- Bumped the Chrome version used by calling test support to match the current environment.

- Temporarily disabled the video-open foreground assertion in FileSharingBetweenTeams and linked it to WPB-24809.

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
