### PR TITLE
chore: update runner images to warp-ubuntu in CI workflows [WPB-8645]

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   # Inline simple quality check jobs for better check names
   lint:
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-2404-x64-8x
     # Override JVM args from gradle.properties which sets 10GB heap
     steps:
       - name: Checkout
@@ -57,7 +57,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   style:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-2x
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   generate-screenshots:
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-2404-x64-8x
 
     if: github.ref == 'refs/heads/develop'
 

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   ui-tests:
-    runs-on: warp-ubuntu-2404-x64-8x
+    runs-on: warp-ubuntu-latest-arm64-8x
     strategy:
       matrix:
         api-level: [ 29 ]
@@ -56,7 +56,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+          key: avd-arm64-${{ matrix.api-level }}
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -64,7 +64,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           target: google_apis
-          arch: x86_64
+          arch: arm64-v8a
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
@@ -75,7 +75,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           target: google_apis
-          arch: x86_64
+          arch: arm64-v8a
           script: ./gradlew runAcceptanceTests
         env:
           GITHUB_USER: ${{ github.actor }}

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   ui-tests:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg
+    runs-on: warp-ubuntu-latest-x64-8x
     strategy:
       matrix:
         api-level: [ 29 ]
@@ -48,6 +48,12 @@ jobs:
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v6
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: AVD cache
         uses: actions/cache@v5

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   ui-tests:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg
+    runs-on: warp-ubuntu-2404-x64-8x
     strategy:
       matrix:
         api-level: [ 29 ]

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   ui-tests:
-    runs-on: warp-ubuntu-latest-arm64-8x
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg
     strategy:
       matrix:
         api-level: [ 29 ]
@@ -56,7 +56,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-arm64-${{ matrix.api-level }}
+          key: avd-${{ matrix.api-level }}
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -64,7 +64,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           target: google_apis
-          arch: arm64-v8a
+          arch: x86_64
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
@@ -75,7 +75,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           target: google_apis
-          arch: arm64-v8a
+          arch: x86_64
           script: ./gradlew runAcceptanceTests
         env:
           GITHUB_USER: ${{ github.actor }}

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
   coverage:
     env:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=2g -Xmx4G"'
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-2404-x64-8x
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

gh runners are slow buildsJet closed, so we switched to warpBuild
