### PR TITLE
fix: handle proteus bots when apps are disabled [WPB-24956]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -224,7 +224,8 @@ fun GroupConversationDetailsScreen(
                         conversationId = viewModel.conversationId,
                         isConversationAppsEnabled = groupOptions.isAppsAllowed,
                         isSelfPartOfATeam = groupOptions.isSelfPartOfATeam,
-                        protocolInfo = groupOptions.protocolInfo
+                        protocolInfo = groupOptions.protocolInfo,
+                        shouldUseNewAppsUi = groupOptions.shouldUseNewAppsUi
                     )
                 )
             )
@@ -251,7 +252,8 @@ fun GroupConversationDetailsScreen(
                         viewModel.conversationId,
                         UpdateAppsAccessParams(
                             isGuestAllowed = groupOptions.isGuestAllowed,
-                            isAppsAllowed = groupOptions.isAppsAllowed
+                            isAppsAllowed = groupOptions.isAppsAllowed,
+                            shouldUseNewAppsUi = groupOptions.shouldUseNewAppsUi
                         )
                     )
                 )
@@ -536,7 +538,8 @@ private fun GroupConversationDetailsContent(
                         GroupConversationDetailsTabItem.PARTICIPANTS -> GroupConversationParticipants(
                             groupParticipantsState = groupParticipantsState,
                             onProfilePressed = onProfilePressed,
-                            lazyListState = lazyListStates[pageIndex]
+                            lazyListState = lazyListStates[pageIndex],
+                            shouldUseNewAppsUi = groupConversationOptionsState.shouldUseNewAppsUi
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -539,7 +539,6 @@ private fun GroupConversationDetailsContent(
                             groupParticipantsState = groupParticipantsState,
                             onProfilePressed = onProfilePressed,
                             lazyListState = lazyListStates[pageIndex],
-                            shouldUseNewAppsUi = groupConversationOptionsState.shouldUseNewAppsUi
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -30,6 +30,7 @@ import com.wire.android.ui.home.newconversation.channelaccess.ChannelAccessType
 import com.wire.android.ui.home.newconversation.channelaccess.ChannelAddPermissionType
 import com.wire.android.ui.home.newconversation.channelaccess.toUiEnum
 import com.ramcosta.composedestinations.generated.app.navArgs
+import com.wire.android.util.AppsUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -43,6 +44,8 @@ import com.wire.kalium.logic.feature.client.IsWireCellsEnabledUseCase
 import com.wire.kalium.logic.feature.conversation.ConversationUpdateReceiptModeResult
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReceiptModeUseCase
+import com.wire.kalium.logic.feature.featureConfig.AppsAllowedResult
+import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppsAllowedForUsageUseCase
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserWithTeamUseCase
@@ -71,6 +74,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
     private val observeSelfUserWithTeam: ObserveSelfUserWithTeamUseCase,
     private val updateConversationReceiptMode: UpdateConversationReceiptModeUseCase,
     private val observeSelfDeletionTimerSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase,
+    private val observeIsAppsAllowedForUsage: ObserveIsAppsAllowedForUsageUseCase,
     savedStateHandle: SavedStateHandle,
     private val isMLSEnabled: IsMLSEnabledUseCase,
     refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase,
@@ -110,12 +114,16 @@ class GroupConversationDetailsViewModel @Inject constructor(
             val selfWithTeamFlow = observeSelfUserWithTeam()
                 .flowOn(dispatcher.io())
                 .shareIn(this, SharingStarted.WhileSubscribed(), 1)
+            val appsAllowedResultFlow = observeIsAppsAllowedForUsage()
+                .flowOn(dispatcher.io())
+                .shareIn(this, SharingStarted.WhileSubscribed(), 1)
 
             combine(
                 groupDetailsFlow,
                 selfWithTeamFlow,
+                appsAllowedResultFlow,
                 observeSelfDeletionTimerSettingsForConversation(conversationId, considerSelfUserSettings = false),
-            ) { groupDetails, (selfUser, selfTeam), selfDeletionTimer ->
+            ) { groupDetails, (selfUser, selfTeam), appsAllowedResult, selfDeletionTimer ->
                 val selfType = selfUser.userType
                 val isSelfInTeamThatOwnsConversation = selfTeam?.id != null && selfTeam.id == groupDetails.conversation.teamId?.value
                 val isSelfExternalMember = selfUser.userType.isExternal()
@@ -143,11 +151,12 @@ class GroupConversationDetailsViewModel @Inject constructor(
                             true
 
                         else -> false
-                    }
+                }
 
-                val isAppsAllowedForConversation = computeAppsEnabledStatus(groupDetails)
+                val shouldUseNewAppsUi = computeShouldUseNewAppsUi(groupDetails, appsAllowedResult)
+                val isAppsAllowedForConversation = computeAppsEnabledStatus(groupDetails, appsAllowedResult)
                 val isUpdatingAppsAllowedForConversation =
-                    computeAppsAllowedStatus(canSelfPerformAdminTasks, isSelfInTeamThatOwnsConversation)
+                    computeAppsAllowedStatus(canSelfPerformAdminTasks, isSelfInTeamThatOwnsConversation, groupDetails, appsAllowedResult)
 
                 _isFetchingInitialData.value = false
 
@@ -167,6 +176,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
                         isUpdatingGuestAllowed = canSelfPerformAdminTasks && isSelfInTeamThatOwnsConversation,
                         isUpdatingChannelAccessAllowed = canSelfPerformAdminTasks && isSelfInTeamThatOwnsConversation,
                         isAppsAllowed = isAppsAllowedForConversation,
+                        shouldUseNewAppsUi = shouldUseNewAppsUi,
                         isUpdatingAppsAllowed = isUpdatingAppsAllowedForConversation,
                         isUpdatingReadReceiptAllowed = canSelfPerformAdminTasks && groupDetails.conversation.isTeamGroup(),
                         isUpdatingSelfDeletingAllowed = canSelfPerformAdminTasks,
@@ -198,16 +208,37 @@ class GroupConversationDetailsViewModel @Inject constructor(
      */
     private fun computeAppsAllowedStatus(
         canSelfPerformAdminTasks: Boolean,
-        isSelfInTeamThatOwnsConversation: Boolean
-    ) = canSelfPerformAdminTasks && isSelfInTeamThatOwnsConversation
+        isSelfInTeamThatOwnsConversation: Boolean,
+        groupDetails: ConversationDetails.Group,
+        appsAllowedResult: AppsAllowedResult
+    ) = canSelfPerformAdminTasks &&
+        isSelfInTeamThatOwnsConversation &&
+        isServicesSupportedForConversation(groupDetails.conversation.protocol, appsAllowedResult)
 
     /**
      * Determine apps visibility based on feature flag and team settings
      * Or just should be protocol based in case of current logic
      */
     private fun computeAppsEnabledStatus(
-        groupDetails: ConversationDetails.Group
-    ) = groupDetails.conversation.isServicesAllowed()
+        groupDetails: ConversationDetails.Group,
+        appsAllowedResult: AppsAllowedResult
+    ) = groupDetails.conversation.isServicesAllowed() &&
+        isServicesSupportedForConversation(groupDetails.conversation.protocol, appsAllowedResult)
+
+    private fun isServicesSupportedForConversation(
+        protocolInfo: Conversation.ProtocolInfo,
+        appsAllowedResult: AppsAllowedResult
+    ) = appsAllowedResult is AppsAllowedResult.Enabled &&
+        when (protocolInfo) {
+            is Conversation.ProtocolInfo.MLS -> AppsUtil.isAppsAllowed(appsAllowedResult, protocolInfo)
+            is Conversation.ProtocolInfo.Proteus -> true
+            is Conversation.ProtocolInfo.Mixed -> AppsUtil.isAppsAllowed(appsAllowedResult, protocolInfo)
+        }
+
+    private fun computeShouldUseNewAppsUi(
+        groupDetails: ConversationDetails.Group,
+        appsAllowedResult: AppsAllowedResult
+    ) = AppsUtil.isAppsAllowed(appsAllowedResult, groupDetails.conversation.protocol)
 
     private fun ConversationDetails.getChannelPermissionType(): ChannelAddPermissionType? = if (this is ConversationDetails.Group.Channel) {
         this.permission.toUiEnum()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
@@ -48,6 +48,7 @@ data class GroupConversationOptionsState(
     val areAccessOptionsAvailable: Boolean = false,
     val isGuestAllowed: Boolean = false,
     val isAppsAllowed: Boolean = false,
+    val shouldUseNewAppsUi: Boolean = false,
     val isReadReceiptAllowed: Boolean = false,
     val isUpdatingNameAllowed: Boolean = false,
     val isUpdatingGuestAllowed: Boolean = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationAllParticipantsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationAllParticipantsScreen.kt
@@ -125,7 +125,6 @@ private fun GroupConversationAllParticipantsContent(
                     groupParticipantsState,
                     onProfilePressed,
                     participantsExpansionState,
-                    shouldUseNewAppsUi = true
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationAllParticipantsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationAllParticipantsScreen.kt
@@ -124,7 +124,8 @@ private fun GroupConversationAllParticipantsContent(
                     context,
                     groupParticipantsState,
                     onProfilePressed,
-                    participantsExpansionState
+                    participantsExpansionState,
+                    shouldUseNewAppsUi = true
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
@@ -35,7 +35,8 @@ fun LazyListScope.participantsFoldersWithElements(
     context: Context,
     state: GroupConversationParticipantsState,
     onRowItemClicked: (UIParticipant) -> Unit,
-    participantsExpansionState: ParticipantsExpansionState
+    participantsExpansionState: ParticipantsExpansionState,
+    shouldUseNewAppsUi: Boolean
 ) {
     sectionWithElements(
         header = context.getString(R.string.conversation_details_conversation_admins, state.data.allAdminsCount),
@@ -51,7 +52,14 @@ fun LazyListScope.participantsFoldersWithElements(
     )
     if (state.data.allAppsCount > 0) {
         sectionWithElements(
-            header = context.getString(R.string.conversation_details_conversation_apps, state.data.allAppsCount),
+            header = context.getString(
+                if (shouldUseNewAppsUi) {
+                    R.string.conversation_details_conversation_apps
+                } else {
+                    R.string.conversation_details_conversation_bots
+                },
+                state.data.allAppsCount
+            ),
             items = state.data.apps,
             onRowItemClicked = onRowItemClicked,
             sectionActions = participantsExpansionState.appsActions

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
@@ -53,11 +53,7 @@ fun LazyListScope.participantsFoldersWithElements(
     if (state.data.allAppsCount > 0) {
         sectionWithElements(
             header = context.getString(
-                if (shouldUseNewAppsUi) {
-                    R.string.conversation_details_conversation_apps
-                } else {
-                    R.string.conversation_details_conversation_bots
-                },
+                R.string.conversation_details_conversation_apps,
                 state.data.allAppsCount
             ),
             items = state.data.apps,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantList.kt
@@ -36,7 +36,6 @@ fun LazyListScope.participantsFoldersWithElements(
     state: GroupConversationParticipantsState,
     onRowItemClicked: (UIParticipant) -> Unit,
     participantsExpansionState: ParticipantsExpansionState,
-    shouldUseNewAppsUi: Boolean
 ) {
     sectionWithElements(
         header = context.getString(R.string.conversation_details_conversation_admins, state.data.allAdminsCount),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipants.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipants.kt
@@ -52,6 +52,7 @@ fun GroupConversationParticipants(
     onProfilePressed: (UIParticipant) -> Unit,
     groupParticipantsState: GroupConversationParticipantsState,
     lazyListState: LazyListState,
+    shouldUseNewAppsUi: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -80,7 +81,13 @@ fun GroupConversationParticipants(
                     }
                 }
             }
-            participantsFoldersWithElements(context, groupParticipantsState, onProfilePressed, participantsExpansionState)
+            participantsFoldersWithElements(
+                context = context,
+                state = groupParticipantsState,
+                onRowItemClicked = onProfilePressed,
+                participantsExpansionState = participantsExpansionState,
+                shouldUseNewAppsUi = shouldUseNewAppsUi
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipants.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipants.kt
@@ -52,7 +52,6 @@ fun GroupConversationParticipants(
     onProfilePressed: (UIParticipant) -> Unit,
     groupParticipantsState: GroupConversationParticipantsState,
     lazyListState: LazyListState,
-    shouldUseNewAppsUi: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -86,7 +85,6 @@ fun GroupConversationParticipants(
                 state = groupParticipantsState,
                 onRowItemClicked = onProfilePressed,
                 participantsExpansionState = participantsExpansionState,
-                shouldUseNewAppsUi = shouldUseNewAppsUi
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessParams.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessParams.kt
@@ -23,4 +23,5 @@ import kotlinx.serialization.Serializable
 data class UpdateAppsAccessParams(
     val isGuestAllowed: Boolean,
     val isAppsAllowed: Boolean,
+    val shouldUseNewAppsUi: Boolean,
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessScreen.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.android.ui.home.conversations.details.updateappsaccess
 
-import com.wire.android.navigation.annotation.app.WireRootDestination
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -31,9 +30,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
+import com.wire.android.navigation.annotation.app.WireRootDestination
+import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.ui.common.rememberTopBarElevationState
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
@@ -62,7 +62,6 @@ fun UpdateAppsAccessScreen(
         onDisableAppsConfirm = updateAppsAccessViewModel::onServiceDialogConfirm,
         onDisableAppsDismiss = updateAppsAccessViewModel::onAppsDialogDismiss,
         state = updateAppsAccessViewModel.updateAppsAccessState,
-        shouldUseNewAppsUi = updateAppsAccessViewModel.shouldUseNewAppsUi,
     )
 }
 
@@ -73,7 +72,6 @@ private fun UpdateAppsAccessContent(
     onDisableAppsConfirm: () -> Unit,
     onDisableAppsDismiss: () -> Unit,
     state: UpdateAppsAccessState,
-    shouldUseNewAppsUi: Boolean,
     modifier: Modifier = Modifier
 ) {
     val snackbarHostState = LocalSnackbarHostState.current
@@ -82,18 +80,13 @@ private fun UpdateAppsAccessContent(
     WireScaffold(
         modifier = modifier,
         topBar = {
-            val title = stringResource(
-                id = if (shouldUseNewAppsUi) {
-                    R.string.apps_edit_apps_option_title
-                } else {
-                    R.string.bots_edit_bots_option_title
-                }
-            )
             WireCenterAlignedTopAppBar(
                 elevation = scrollState.rememberTopBarElevationState().value,
                 navigationIconType = NavigationIconType.Back(R.string.content_description_edit_apps_option_back_btn),
                 onNavigationPressed = onNavigateBack,
-                title = title
+                title = stringResource(
+                    id = R.string.apps_edit_apps_option_title
+                )
             )
         }
     ) { internalPadding ->
@@ -106,16 +99,6 @@ private fun UpdateAppsAccessContent(
                     .fillMaxSize()
             ) {
                 item {
-                    val servicesTitleResId = if (shouldUseNewAppsUi) {
-                        R.string.conversation_options_services_label
-                    } else {
-                        R.string.conversation_options_bots_label
-                    }
-                    val servicesDescriptionResId = if (shouldUseNewAppsUi) {
-                        R.string.conversation_options_services_description
-                    } else {
-                        R.string.conversation_options_bots_description
-                    }
                     with(state) {
                         GroupOptionWithSwitch(
                             switchClickable = isUpdatingAppAccessAllowed,
@@ -123,8 +106,8 @@ private fun UpdateAppsAccessContent(
                             switchState = isAppAccessAllowed,
                             onClick = onChangeAppAccess,
                             isLoading = isLoadingAppsOption,
-                            title = servicesTitleResId,
-                            subTitle = servicesDescriptionResId
+                            title = R.string.conversation_options_services_label,
+                            subTitle = R.string.conversation_options_services_description
                         )
                     }
                 }
@@ -141,7 +124,6 @@ private fun UpdateAppsAccessContent(
         DisableServicesConfirmationDialog(
             onConfirm = onDisableAppsConfirm,
             onDialogDismiss = onDisableAppsDismiss,
-            shouldUseNewAppsUi = shouldUseNewAppsUi
         )
     }
 
@@ -159,19 +141,10 @@ private fun UpdateAppsAccessContent(
 private fun DisableServicesConfirmationDialog(
     onConfirm: () -> Unit,
     onDialogDismiss: () -> Unit,
-    shouldUseNewAppsUi: Boolean
 ) {
     DisableConfirmationDialog(
-        title = if (shouldUseNewAppsUi) {
-            R.string.disable_services_dialog_title
-        } else {
-            R.string.disable_bots_dialog_title
-        },
-        text = if (shouldUseNewAppsUi) {
-            R.string.disable_services_dialog_text
-        } else {
-            R.string.disable_bots_dialog_text
-        },
+        title = R.string.disable_services_dialog_title,
+        text = R.string.disable_services_dialog_text,
         onDismiss = onDialogDismiss,
         onConfirm = onConfirm
     )
@@ -191,7 +164,6 @@ fun UpdateAppsAccessEnabledPreview() = WireTheme {
             isLoadingAppsOption = false,
             shouldShowDisableAppsConfirmationDialog = false
         ),
-        shouldUseNewAppsUi = true,
     )
 }
 
@@ -209,6 +181,5 @@ fun UpdateAppsAccessDisabledPreview() = WireTheme {
             isLoadingAppsOption = false,
             shouldShowDisableAppsConfirmationDialog = false
         ),
-        shouldUseNewAppsUi = true,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessScreen.kt
@@ -62,6 +62,7 @@ fun UpdateAppsAccessScreen(
         onDisableAppsConfirm = updateAppsAccessViewModel::onServiceDialogConfirm,
         onDisableAppsDismiss = updateAppsAccessViewModel::onAppsDialogDismiss,
         state = updateAppsAccessViewModel.updateAppsAccessState,
+        shouldUseNewAppsUi = updateAppsAccessViewModel.shouldUseNewAppsUi,
     )
 }
 
@@ -72,6 +73,7 @@ private fun UpdateAppsAccessContent(
     onDisableAppsConfirm: () -> Unit,
     onDisableAppsDismiss: () -> Unit,
     state: UpdateAppsAccessState,
+    shouldUseNewAppsUi: Boolean,
     modifier: Modifier = Modifier
 ) {
     val snackbarHostState = LocalSnackbarHostState.current
@@ -80,7 +82,13 @@ private fun UpdateAppsAccessContent(
     WireScaffold(
         modifier = modifier,
         topBar = {
-            val title = stringResource(id = R.string.apps_edit_apps_option_title)
+            val title = stringResource(
+                id = if (shouldUseNewAppsUi) {
+                    R.string.apps_edit_apps_option_title
+                } else {
+                    R.string.bots_edit_bots_option_title
+                }
+            )
             WireCenterAlignedTopAppBar(
                 elevation = scrollState.rememberTopBarElevationState().value,
                 navigationIconType = NavigationIconType.Back(R.string.content_description_edit_apps_option_back_btn),
@@ -98,6 +106,16 @@ private fun UpdateAppsAccessContent(
                     .fillMaxSize()
             ) {
                 item {
+                    val servicesTitleResId = if (shouldUseNewAppsUi) {
+                        R.string.conversation_options_services_label
+                    } else {
+                        R.string.conversation_options_bots_label
+                    }
+                    val servicesDescriptionResId = if (shouldUseNewAppsUi) {
+                        R.string.conversation_options_services_description
+                    } else {
+                        R.string.conversation_options_bots_description
+                    }
                     with(state) {
                         GroupOptionWithSwitch(
                             switchClickable = isUpdatingAppAccessAllowed,
@@ -105,8 +123,8 @@ private fun UpdateAppsAccessContent(
                             switchState = isAppAccessAllowed,
                             onClick = onChangeAppAccess,
                             isLoading = isLoadingAppsOption,
-                            title = R.string.conversation_options_services_label,
-                            subTitle = R.string.conversation_options_services_description
+                            title = servicesTitleResId,
+                            subTitle = servicesDescriptionResId
                         )
                     }
                 }
@@ -122,7 +140,8 @@ private fun UpdateAppsAccessContent(
     if (state.shouldShowDisableAppsConfirmationDialog) {
         DisableServicesConfirmationDialog(
             onConfirm = onDisableAppsConfirm,
-            onDialogDismiss = onDisableAppsDismiss
+            onDialogDismiss = onDisableAppsDismiss,
+            shouldUseNewAppsUi = shouldUseNewAppsUi
         )
     }
 
@@ -137,10 +156,22 @@ private fun UpdateAppsAccessContent(
 }
 
 @Composable
-private fun DisableServicesConfirmationDialog(onConfirm: () -> Unit, onDialogDismiss: () -> Unit) {
+private fun DisableServicesConfirmationDialog(
+    onConfirm: () -> Unit,
+    onDialogDismiss: () -> Unit,
+    shouldUseNewAppsUi: Boolean
+) {
     DisableConfirmationDialog(
-        title = R.string.disable_services_dialog_title,
-        text = R.string.disable_services_dialog_text,
+        title = if (shouldUseNewAppsUi) {
+            R.string.disable_services_dialog_title
+        } else {
+            R.string.disable_bots_dialog_title
+        },
+        text = if (shouldUseNewAppsUi) {
+            R.string.disable_services_dialog_text
+        } else {
+            R.string.disable_bots_dialog_text
+        },
         onDismiss = onDialogDismiss,
         onConfirm = onConfirm
     )
@@ -160,6 +191,7 @@ fun UpdateAppsAccessEnabledPreview() = WireTheme {
             isLoadingAppsOption = false,
             shouldShowDisableAppsConfirmationDialog = false
         ),
+        shouldUseNewAppsUi = true,
     )
 }
 
@@ -177,5 +209,6 @@ fun UpdateAppsAccessDisabledPreview() = WireTheme {
             isLoadingAppsOption = false,
             shouldShowDisableAppsConfirmationDialog = false
         ),
+        shouldUseNewAppsUi = true,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessViewModel.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
 import com.ramcosta.composedestinations.generated.app.navArgs
+import com.wire.android.util.AppsUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
@@ -64,6 +65,7 @@ class UpdateAppsAccessViewModel @Inject constructor(
     private val updateAppsAccessNavArgs: UpdateAppsAccessNavArgs = savedStateHandle.navArgs()
     private val conversationId: QualifiedID = updateAppsAccessNavArgs.conversationId
     private val currentAccessParams = updateAppsAccessNavArgs.updateAppsAccessParams
+    val shouldUseNewAppsUi: Boolean = currentAccessParams.shouldUseNewAppsUi
 
     var updateAppsAccessState by mutableStateOf(
         UpdateAppsAccessState(
@@ -110,7 +112,7 @@ class UpdateAppsAccessViewModel @Inject constructor(
                 // WPB-21835: Apps availability logic controlled by feature flag
                 val isAppAccessAllowed = computeAppsEnabledStatus(conversationDetails, isAppsAllowedResult)
                 val isUpdatingAppAccessAllowed =
-                    computeAppsAllowedStatus(canSelfPerformAdminActions, isAppsAllowedResult)
+                    computeAppsAllowedStatus(canSelfPerformAdminActions, conversationDetails, isAppsAllowedResult)
 
                 updateAppsAccessState = updateAppsAccessState.copy(
                     isUpdatingAppAccessAllowed = isUpdatingAppAccessAllowed,
@@ -129,7 +131,8 @@ class UpdateAppsAccessViewModel @Inject constructor(
     private fun computeAppsEnabledStatus(
         conversationDetails: ConversationDetails,
         appsAllowedResult: AppsAllowedResult
-    ) = conversationDetails.conversation.isServicesAllowed() && appsAllowedResult is AppsAllowedResult.Enabled
+    ) = conversationDetails.conversation.isServicesAllowed() &&
+        isServicesSupportedForConversation(conversationDetails.conversation.protocol, appsAllowedResult)
 
     /**
      * Determine apps visibility based on feature flag and team settings
@@ -137,8 +140,20 @@ class UpdateAppsAccessViewModel @Inject constructor(
      */
     private fun computeAppsAllowedStatus(
         canSelfPerformAdminActions: Boolean,
+        conversationDetails: ConversationDetails,
         appsAllowedResult: AppsAllowedResult
-    ) = canSelfPerformAdminActions && appsAllowedResult is AppsAllowedResult.Enabled
+    ) = canSelfPerformAdminActions &&
+        isServicesSupportedForConversation(conversationDetails.conversation.protocol, appsAllowedResult)
+
+    private fun isServicesSupportedForConversation(
+        protocolInfo: Conversation.ProtocolInfo,
+        appsAllowedResult: AppsAllowedResult
+    ) = appsAllowedResult is AppsAllowedResult.Enabled &&
+        when (protocolInfo) {
+            is Conversation.ProtocolInfo.MLS -> AppsUtil.isAppsAllowed(appsAllowedResult, protocolInfo)
+            is Conversation.ProtocolInfo.Proteus -> true
+            is Conversation.ProtocolInfo.Mixed -> AppsUtil.isAppsAllowed(appsAllowedResult, protocolInfo)
+        }
 
     private data class CombineFour(
         val appsAllowedResult: AppsAllowedResult,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/AddMembersSearchNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/AddMembersSearchNavArgs.kt
@@ -24,5 +24,6 @@ data class AddMembersSearchNavArgs(
     val conversationId: ConversationId,
     val isConversationAppsEnabled: Boolean,
     val isSelfPartOfATeam: Boolean,
-    val protocolInfo: Conversation.ProtocolInfo
+    val protocolInfo: Conversation.ProtocolInfo,
+    val shouldUseNewAppsUi: Boolean = true
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/adddembertoconversation/AddMembersSearchScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/adddembertoconversation/AddMembersSearchScreen.kt
@@ -59,7 +59,7 @@ fun AddMembersSearchScreen(
         isGroupSubmitVisible = true,
         onClose = navigator::navigateBack,
         onAppClicked = { contact: Contact ->
-            val serviceId = when (navArgs.isConversationAppsEnabled) {
+            val serviceId = when (navArgs.shouldUseNewAppsUi) {
                 true -> ServiceDetailsNavArgs.Id.AppId(UserId(contact.id, contact.domain))
                 false -> ServiceDetailsNavArgs.Id.BotServiceId(BotService(contact.id, contact.domain))
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsScreen.kt
@@ -165,11 +165,11 @@ private fun rememberAppsContentState(
     result: ImmutableList<Contact>
 ): State<AppsContentState> = remember(isConversationAppsEnabled, isLoading, appsAllowedResult, searchQuery, result) {
     derivedStateOf {
+        if (isLoading) return@derivedStateOf AppsContentState.LOADING
         if (appsAllowedResult is AppsAllowedResult.Disabled) return@derivedStateOf AppsContentState.TEAM_NOT_ALLOWED
         if (!isConversationAppsEnabled) return@derivedStateOf AppsContentState.APPS_NOT_ENABLED_FOR_CONVERSATION
 
         when {
-            isLoading -> AppsContentState.LOADING
             searchQuery.isBlank() && result.isEmpty() -> AppsContentState.EMPTY_SEARCH
             searchQuery.isNotBlank() && result.isEmpty() -> AppsContentState.EMPTY_SEARCH
             else -> AppsContentState.SHOW_RESULTS

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModel.kt
@@ -75,15 +75,27 @@ class SearchAppsViewModel @AssistedInject constructor(
             ) { selfUser, isEnabledResult, query ->
                 Triple(selfUser, isEnabledResult, query)
             }.debounce(DEFAULT_SEARCH_QUERY_DEBOUNCE).collectLatest { (selfUser, isEnabledResult, query) ->
-                state = state.copy(isTeamAllowedToUseApps = isEnabledResult, isSelfATeamAdmin = selfUser.userType.isTeamAdmin())
-                if (isEnabledResult is AppsAllowedResult.Enabled) {
-                    search(query, isEnabledResult)
+                val protocolAwareResult = resolveProtocolAwareAppsAllowedResult(isEnabledResult)
+                state = state.copy(isTeamAllowedToUseApps = protocolAwareResult, isSelfATeamAdmin = selfUser.userType.isTeamAdmin())
+                if (protocolAwareResult is AppsAllowedResult.Enabled) {
+                    search(query, protocolAwareResult)
                 } else {
                     state = state.copy(isLoading = false, result = persistentListOf())
                 }
             }
         }
     }
+
+    private fun resolveProtocolAwareAppsAllowedResult(appsAllowedResult: AppsAllowedResult): AppsAllowedResult =
+        if (
+            appsAllowedResult is AppsAllowedResult.Enabled &&
+            protocolInfo is Conversation.ProtocolInfo.MLS &&
+            !AppsUtil.isAppsAllowed(appsAllowedResult, protocolInfo)
+        ) {
+            AppsAllowedResult.Disabled
+        } else {
+            appsAllowedResult
+        }
 
     fun searchQueryChanged(searchQuery: String) {
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/util/AppsUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/AppsUtil.kt
@@ -32,7 +32,8 @@ object AppsUtil {
             AppsAllowedProtocol.MLS -> true
             AppsAllowedProtocol.PROTEUS -> false
             is AppsAllowedProtocol.MIXED -> when (conversationProtocol) {
-                is Conversation.ProtocolInfo.MLS -> true
+                is Conversation.ProtocolInfo.MLS ->
+                    (appsAllowedResult.protocol as AppsAllowedProtocol.MIXED).defaultProtocol == SupportedProtocol.MLS
                 is Conversation.ProtocolInfo.Proteus -> false
                 null, is Conversation.ProtocolInfo.Mixed ->
                     (appsAllowedResult.protocol as AppsAllowedProtocol.MIXED).defaultProtocol == SupportedProtocol.MLS

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -632,7 +632,6 @@
     <string name="conversation_details_conversation_admins">ADMINS (%d)</string>
     <string name="conversation_details_conversation_members">MEMBERS (%d)</string>
     <string name="conversation_details_conversation_apps">APPS (%d)</string>
-    <string name="conversation_details_conversation_bots">BOTS (%d)</string>
     <string name="conversation_details_participants_info">This conversation has %s participants.\nUp to 500 people can join a conversation.</string>
     <string name="conversation_details_participants_count">%s participants</string>
     <string name="conversation_details_show_all_participants">Show all participants (%d)</string>
@@ -651,16 +650,11 @@
     <string name="conversation_options_services_label">Apps</string>
     <string name="conversation_details_apps_description">When this is ON, you open this conversation to apps.</string>
     <string name="conversation_options_services_description">Turn this option ON to open this conversation to apps.</string>
-    <string name="conversation_options_bots_label">Bots</string>
-    <string name="conversation_details_bots_description">When this is ON, you open this conversation to bots.</string>
-    <string name="conversation_options_bots_description">Turn this option ON to open this conversation to bots.</string>
     <string name="conversation_options_renamed">Conversation renamed</string>
     <string name="disable_guest_dialog_title">Disable guest access?</string>
     <string name="disable_guest_dialog_text">Current guests will be removed from the conversation. New guests will not be allowed.</string>
     <string name="disable_services_dialog_title">Disable app access?</string>
     <string name="disable_services_dialog_text">Current apps will be removed from the conversation. New apps will not be allowed.</string>
-    <string name="disable_bots_dialog_title">Disable bot access?</string>
-    <string name="disable_bots_dialog_text">Current bots will be removed from the conversation. New bots will not be allowed.</string>
     <string name="leave_conversation_menu_item">Leave Conversation…</string>
     <string name="leave_conversation_dialog_title">Leave “%s”?</string>
     <string name="leave_conversation_dialog_description">You will then no longer be able to send or read messages in this conversation on any device.</string>
@@ -1943,10 +1937,8 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="apps_upgrade_teams_for_apps_banner_title">Your team doesn\'t use apps yet</string>
     <string name="apps_upgrade_teams_for_apps_banner_content">To improve your workflow with apps, your team needs configuration. Please contact your team admin.</string>
     <string name="apps_edit_apps_option_title">Apps</string>
-    <string name="bots_edit_bots_option_title">Bots</string>
     <string name="content_description_edit_apps_option_back_btn">Go back to conversation details</string>
     <string name="content_description_conversation_details_apps_action">adjust apps access</string>
-    <string name="content_description_conversation_details_bots_action">adjust bots access</string>
     <string name="search_results_apps_empty_title">Your team hasn\'t added apps yet</string>
     <string name="search_results_apps_empty_description_team_admin">Apps are helpers that can improve your workflow. As a team admin, you can add them in team management.</string>
     <string name="search_results_apps_empty_description_non_team_admin">Apps are helpers that can improve your workflow. To use them, ask your team admin.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -632,6 +632,7 @@
     <string name="conversation_details_conversation_admins">ADMINS (%d)</string>
     <string name="conversation_details_conversation_members">MEMBERS (%d)</string>
     <string name="conversation_details_conversation_apps">APPS (%d)</string>
+    <string name="conversation_details_conversation_bots">BOTS (%d)</string>
     <string name="conversation_details_participants_info">This conversation has %s participants.\nUp to 500 people can join a conversation.</string>
     <string name="conversation_details_participants_count">%s participants</string>
     <string name="conversation_details_show_all_participants">Show all participants (%d)</string>
@@ -650,11 +651,16 @@
     <string name="conversation_options_services_label">Apps</string>
     <string name="conversation_details_apps_description">When this is ON, you open this conversation to apps.</string>
     <string name="conversation_options_services_description">Turn this option ON to open this conversation to apps.</string>
+    <string name="conversation_options_bots_label">Bots</string>
+    <string name="conversation_details_bots_description">When this is ON, you open this conversation to bots.</string>
+    <string name="conversation_options_bots_description">Turn this option ON to open this conversation to bots.</string>
     <string name="conversation_options_renamed">Conversation renamed</string>
     <string name="disable_guest_dialog_title">Disable guest access?</string>
     <string name="disable_guest_dialog_text">Current guests will be removed from the conversation. New guests will not be allowed.</string>
     <string name="disable_services_dialog_title">Disable app access?</string>
     <string name="disable_services_dialog_text">Current apps will be removed from the conversation. New apps will not be allowed.</string>
+    <string name="disable_bots_dialog_title">Disable bot access?</string>
+    <string name="disable_bots_dialog_text">Current bots will be removed from the conversation. New bots will not be allowed.</string>
     <string name="leave_conversation_menu_item">Leave Conversation…</string>
     <string name="leave_conversation_dialog_title">Leave “%s”?</string>
     <string name="leave_conversation_dialog_description">You will then no longer be able to send or read messages in this conversation on any device.</string>
@@ -1937,8 +1943,10 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="apps_upgrade_teams_for_apps_banner_title">Your team doesn\'t use apps yet</string>
     <string name="apps_upgrade_teams_for_apps_banner_content">To improve your workflow with apps, your team needs configuration. Please contact your team admin.</string>
     <string name="apps_edit_apps_option_title">Apps</string>
+    <string name="bots_edit_bots_option_title">Bots</string>
     <string name="content_description_edit_apps_option_back_btn">Go back to conversation details</string>
     <string name="content_description_conversation_details_apps_action">adjust apps access</string>
+    <string name="content_description_conversation_details_bots_action">adjust bots access</string>
     <string name="search_results_apps_empty_title">Your team hasn\'t added apps yet</string>
     <string name="search_results_apps_empty_description_team_admin">Apps are helpers that can improve your workflow. As a team admin, you can add them in team management.</string>
     <string name="search_results_apps_empty_description_non_team_admin">Apps are helpers that can improve your workflow. To use them, ask your team admin.</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupDetailsViewModelTest.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
 import com.wire.android.config.TestDispatcherProvider
+import com.wire.android.framework.TestConversation
 import com.wire.android.framework.TestTeam
 import com.wire.android.framework.TestUser
 import com.wire.android.mapper.testUIParticipant
@@ -44,6 +45,7 @@ import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.data.user.type.UserTypeInfo
 import com.wire.kalium.logic.feature.client.IsWireCellsEnabledUseCase
@@ -213,6 +215,50 @@ class GroupDetailsViewModelTest {
 
         // When - Then
         assertEquals(false, viewModel.groupOptionsState.value.isUpdatingGuestAllowed)
+    }
+
+    @Test
+    fun `given mixed team falls back to Proteus, when conversation is Proteus, then details stay on legacy bots mode`() = runTest {
+        val details = testGroup.copy(
+            conversation = testGroup.conversation.copy(
+                accessRole = listOf(Conversation.AccessRole.SERVICE),
+                protocol = Conversation.ProtocolInfo.Proteus
+            ),
+            selfRole = Conversation.Member.Role.Admin
+        )
+        val selfTeam = Team("team_id", "team_name", "icon")
+
+        val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+            .withConversationDetailUpdate(details)
+            .withAppsAllowedResult(AppsAllowedResult.Enabled(AppsAllowedProtocol.MIXED(SupportedProtocol.PROTEUS)))
+            .withSelfTeamUseCaseReturns(selfTeam)
+            .arrange()
+
+        assertEquals(true, viewModel.groupOptionsState.value.isAppsAllowed)
+        assertEquals(false, viewModel.groupOptionsState.value.shouldUseNewAppsUi)
+        assertEquals(true, viewModel.groupOptionsState.value.isUpdatingAppsAllowed)
+    }
+
+    @Test
+    fun `given mixed team falls back to Proteus, when conversation is MLS, then apps are disabled`() = runTest {
+        val details = testGroup.copy(
+            conversation = testGroup.conversation.copy(
+                accessRole = listOf(Conversation.AccessRole.SERVICE),
+                protocol = TestConversation.MLS_PROTOCOL_INFO
+            ),
+            selfRole = Conversation.Member.Role.Admin
+        )
+        val selfTeam = Team("team_id", "team_name", "icon")
+
+        val (_, viewModel) = GroupConversationDetailsViewModelArrangement()
+            .withConversationDetailUpdate(details)
+            .withAppsAllowedResult(AppsAllowedResult.Enabled(AppsAllowedProtocol.MIXED(SupportedProtocol.PROTEUS)))
+            .withSelfTeamUseCaseReturns(selfTeam)
+            .arrange()
+
+        assertEquals(false, viewModel.groupOptionsState.value.isAppsAllowed)
+        assertEquals(false, viewModel.groupOptionsState.value.shouldUseNewAppsUi)
+        assertEquals(false, viewModel.groupOptionsState.value.isUpdatingAppsAllowed)
     }
 
     @Test
@@ -748,6 +794,7 @@ internal class GroupConversationDetailsViewModelArrangement {
             observeConversationDetails = observeConversationDetails,
             observeConversationMembers = observeParticipantsForConversationUseCase,
             observeSelfUserWithTeam = observeSelfUserWithTeam,
+            observeIsAppsAllowedForUsage = observeIsAppsAllowedForUsage,
             savedStateHandle = savedStateHandle,
             updateConversationReceiptMode = updateConversationReceiptMode,
             isMLSEnabled = isMLSEnabledUseCase,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessViewModelTest.kt
@@ -31,7 +31,10 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.logic.data.mls.CipherSuite
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUseCase
 import com.wire.kalium.logic.feature.conversation.apps.ChangeAccessForAppsInConversationUseCase
@@ -201,15 +204,22 @@ class UpdateAppsAccessViewModelTest {
     }
 
     @Test
-    fun `given isAppsAllowed for team and conversation has SERVICE role, then state should reflect this to allow`() = runTest {
+    fun `given apps are enabled for current conversation protocol and conversation has SERVICE role, then state should reflect this to allow`() = runTest {
         // Given
         val conversationParticipantsData = ConversationParticipantsData(isSelfAnAdmin = true)
         val conversation = TestConversation.GROUP().copy(
-            accessRole = listOf(Conversation.AccessRole.SERVICE)
+            accessRole = listOf(Conversation.AccessRole.SERVICE),
+            protocol = Conversation.ProtocolInfo.MLS(
+                groupId = GroupID("group-id"),
+                groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+                epoch = 1UL,
+                keyingMaterialLastUpdate = Instant.parse("2022-04-04T16:11:28.388Z"),
+                cipherSuite = CipherSuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256
+            )
         )
 
         val (_, viewModel) = UpdateAppsAccessViewModelArrangement()
-            .withAppsAllowedResult(AppsAllowedResult.Enabled(AppsAllowedProtocol.PROTEUS))
+            .withAppsAllowedResult(AppsAllowedResult.Enabled(AppsAllowedProtocol.MLS))
             .withConversationDetailUpdate(TestConversationDetails.GROUP.copy(conversation = conversation))
             .withConversationMembersUpdate(conversationParticipantsData)
             .arrange()
@@ -260,19 +270,76 @@ class UpdateAppsAccessViewModelTest {
     }
 
     @Test
-    fun `when onAppsDialogDismiss is called, then dialog is hidden and state is reverted`() = runTest {
-        // Given
+    fun `given mixed team falls back to Proteus, when conversation is Proteus with SERVICE role, then bots access is enabled`() = runTest {
         val conversationParticipantsData = ConversationParticipantsData(isSelfAnAdmin = true)
         val details = testGroup.copy(
             conversation = testGroup.conversation.copy(
-                accessRole = listOf(Conversation.AccessRole.SERVICE, Conversation.AccessRole.TEAM_MEMBER)
+                accessRole = listOf(Conversation.AccessRole.SERVICE),
+                protocol = Conversation.ProtocolInfo.Proteus
             )
         )
 
         val (_, viewModel) = UpdateAppsAccessViewModelArrangement()
             .withConversationDetailUpdate(details)
             .withConversationMembersUpdate(conversationParticipantsData)
-            .withAppsAllowedResult(AppsAllowedResult.Enabled(AppsAllowedProtocol.PROTEUS))
+            .withAppsAllowedResult(AppsAllowedResult.Enabled(AppsAllowedProtocol.MIXED(SupportedProtocol.PROTEUS)))
+            .arrange()
+
+        advanceUntilIdle()
+
+        assertEquals(true, viewModel.updateAppsAccessState.isAppAccessAllowed)
+        assertEquals(true, viewModel.updateAppsAccessState.isUpdatingAppAccessAllowed)
+    }
+
+    @Test
+    fun `given mixed team falls back to Proteus, when conversation is MLS, then apps access is disabled`() = runTest {
+        val conversationParticipantsData = ConversationParticipantsData(isSelfAnAdmin = true)
+        val details = testGroup.copy(
+            conversation = testGroup.conversation.copy(
+                accessRole = listOf(Conversation.AccessRole.SERVICE),
+                protocol = Conversation.ProtocolInfo.MLS(
+                    groupId = GroupID("group-id"),
+                    groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+                    epoch = 1UL,
+                    keyingMaterialLastUpdate = Instant.parse("2022-04-04T16:11:28.388Z"),
+                    cipherSuite = CipherSuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256
+                )
+            )
+        )
+
+        val (_, viewModel) = UpdateAppsAccessViewModelArrangement()
+            .withConversationDetailUpdate(details)
+            .withConversationMembersUpdate(conversationParticipantsData)
+            .withAppsAllowedResult(AppsAllowedResult.Enabled(AppsAllowedProtocol.MIXED(SupportedProtocol.PROTEUS)))
+            .arrange()
+
+        advanceUntilIdle()
+
+        assertEquals(false, viewModel.updateAppsAccessState.isAppAccessAllowed)
+        assertEquals(false, viewModel.updateAppsAccessState.isUpdatingAppAccessAllowed)
+    }
+
+    @Test
+    fun `when onAppsDialogDismiss is called, then dialog is hidden and state is reverted`() = runTest {
+        // Given
+        val conversationParticipantsData = ConversationParticipantsData(isSelfAnAdmin = true)
+        val details = testGroup.copy(
+            conversation = testGroup.conversation.copy(
+                accessRole = listOf(Conversation.AccessRole.SERVICE, Conversation.AccessRole.TEAM_MEMBER),
+                protocol = Conversation.ProtocolInfo.MLS(
+                    groupId = GroupID("group-id"),
+                    groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+                    epoch = 1UL,
+                    keyingMaterialLastUpdate = Instant.parse("2022-04-04T16:11:28.388Z"),
+                    cipherSuite = CipherSuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256
+                )
+            )
+        )
+
+        val (_, viewModel) = UpdateAppsAccessViewModelArrangement()
+            .withConversationDetailUpdate(details)
+            .withConversationMembersUpdate(conversationParticipantsData)
+            .withAppsAllowedResult(AppsAllowedResult.Enabled(AppsAllowedProtocol.MLS))
             .arrange()
 
         advanceUntilIdle()
@@ -373,7 +440,8 @@ internal class UpdateAppsAccessViewModelArrangement {
             conversationId = conversationId,
             updateAppsAccessParams = UpdateAppsAccessParams(
                 isGuestAllowed = true,
-                isAppsAllowed = true
+                isAppsAllowed = true,
+                shouldUseNewAppsUi = true
             )
         )
 
@@ -389,7 +457,8 @@ internal class UpdateAppsAccessViewModelArrangement {
             conversationId = conversationId,
             updateAppsAccessParams = UpdateAppsAccessParams(
                 isGuestAllowed = false,
-                isAppsAllowed = true
+                isAppsAllowed = true,
+                shouldUseNewAppsUi = true
             )
         )
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModelTest.kt
@@ -137,6 +137,32 @@ class SearchAppsViewModelTest {
         }
 
     @Test
+    fun `given AppsAllowedProtocol is MIXED with Proteus fallback, when MLS conversation, then apps are disabled for team`() =
+        runTest {
+            // given
+            val (arrangement, viewModel) = Arrangement()
+                .withAppsAllowedForUsage(AppsAllowedResult.Enabled(AppsAllowedProtocol.MIXED(SupportedProtocol.PROTEUS)))
+                .withGetAllApps(listOf(SERVICE_DETAILS, SERVICE_DETAILS2))
+                .withGetAllServices(listOf(SERVICE_DETAILS, SERVICE_DETAILS2))
+                .arrange(protocolInfo = TestConversation.MLS_PROTOCOL_INFO)
+
+            // when
+            // viewModel is initialized
+            advanceUntilIdle()
+
+            // then
+            coVerify(exactly = 0) {
+                arrangement.getAllApps()
+            }
+            coVerify(exactly = 0) {
+                arrangement.getAllServices()
+            }
+            assertEquals(AppsAllowedResult.Disabled, viewModel.state.isTeamAllowedToUseApps)
+            assertTrue(viewModel.state.result.isEmpty())
+            assertFalse(viewModel.state.isLoading)
+        }
+
+    @Test
     fun `given AppsAllowedProtocol is MIXED, when init view model, then load existing Apps based on conversation protocol (Proteus)`() =
         runTest {
             // given


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24956
<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

- Proteus conversations in mixed MLS-default teams showed the new Apps UI when Apps were disabled.
- Bots could be toggled on but still appear disabled after the conversation updated.
- Adding a legacy bot opened the new App details route and failed to load bot data.
- MLS conversations showed app results even when Apps were disabled for the team.

### Causes (Optional)

The UI reused the same boolean for Apps wording, conversation-level service access, and App-vs-Bot routing. Mixed-protocol fallback also did not distinguish MLS conversations from Proteus bot fallback.

### Solutions

- Split new Apps UI mode from conversation-level bot/app access.
- Route Proteus fallback additions through `BotServiceId`.
- Treat `MIXED(PROTEUS)` as Bots-enabled for Proteus conversations and Apps-disabled for MLS conversations.
- Update Kalium apps config fallback through the linked submodule PR.

### Dependencies (Optional)

Needs releases with:

- [x] https://github.com/wireapp/kalium/pull/4068

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Ran targeted unit tests for conversation details, apps access, app/bot search, add-members routing, and service details. Also ran static analysis.

### Notes (Optional)

Verified that unrelated local files were not included in this commit.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
