### PR TITLE
fix: image failed UI alignment and self error color [WPB-24957]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentItem.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -29,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
+import com.wire.android.ui.common.applyIf
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.spacers.VerticalSpace
@@ -148,7 +150,9 @@ fun MessageContentItem(
             ) {
                 VerticalSpace.x4()
                 Row(
-                    Modifier.padding(innerPadding),
+                    modifier = Modifier
+                        .padding(innerPadding)
+                        .applyIf(hasAssetParams) { fillMaxWidth() },
                     horizontalArrangement = if (source == MessageSource.Self) Arrangement.End else Arrangement.Start,
                     verticalAlignment = Alignment.CenterVertically
                 ) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageStyle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageStyle.kt
@@ -89,7 +89,7 @@ fun MessageStyle.onNodeBackground(): Color = when (this) {
 
 @Composable
 fun MessageStyle.error(): Color = when (this) {
-    MessageStyle.BUBBLE_SELF -> MaterialTheme.wireColorScheme.onPrimary
+    MessageStyle.BUBBLE_SELF -> colorsScheme().selfBubble.onPrimary
     MessageStyle.BUBBLE_OTHER -> MaterialTheme.wireColorScheme.error
     MessageStyle.NORMAL -> MaterialTheme.wireColorScheme.error
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewMesssageBubbleTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewMesssageBubbleTypes.kt
@@ -38,6 +38,7 @@ import com.wire.android.ui.home.conversations.mock.mockMessageWithMarkdownTables
 import com.wire.android.ui.home.conversations.mock.mockMessageWithMarkdownTextAndLinks
 import com.wire.android.ui.home.conversations.mock.mockMessageWithText
 import com.wire.android.ui.home.conversations.mock.mockMessageWithTextContent
+import com.wire.android.ui.home.conversations.mock.mockedImageUIMessage
 import com.wire.android.ui.home.conversations.mock.mockedMultipartMessage
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.MessageEditStatus
@@ -46,6 +47,7 @@ import com.wire.android.ui.theme.Accent
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.data.asset.AssetTransferStatus
 import com.wire.kalium.logic.data.message.Message
 import kotlinx.datetime.Instant
 import kotlin.time.DurationUnit
@@ -434,6 +436,22 @@ fun PreviewMessageBubbleOtherWithMultipartAsset() {
         Box(modifier = Modifier.background(color = colorsScheme().surface)) {
             RegularMessageItem(
                 message = mockedMultipartMessage(source = MessageSource.OtherUser),
+                conversationDetailsData = ConversationDetailsData.None(null),
+                clickActions = MessageClickActions.Content(),
+                isBubbleUiEnabled = true
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewBubbleSelfImageFailedDownload() {
+    WireTheme {
+        Box(modifier = Modifier.background(color = colorsScheme().surface)) {
+            RegularMessageItem(
+                message = mockedImageUIMessage(source = MessageSource.Self),
+                assetStatus = AssetTransferStatus.FAILED_DOWNLOAD,
                 conversationDetailsData = ConversationDetailsData.None(null),
                 clickActions = MessageClickActions.Content(),
                 isBubbleUiEnabled = true

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -64,6 +64,7 @@ import com.wire.android.ui.home.conversations.model.messagetypes.image.AsyncImag
 import com.wire.android.ui.home.conversations.model.messagetypes.image.DisplayableImageMessage
 import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMessageFailed
 import com.wire.android.ui.home.conversations.model.messagetypes.image.ImageMessageInProgress
+import com.wire.android.ui.home.conversations.model.messagetypes.image.MaxBounds
 import com.wire.android.ui.home.conversations.model.messagetypes.image.VisualMediaParams
 import com.wire.android.ui.home.conversations.model.messagetypes.image.size
 import com.wire.android.ui.markdown.DisplayMention
@@ -225,7 +226,16 @@ fun MessageImage(
     modifier: Modifier = Modifier,
     assetPath: Path? = null,
 ) {
-    val imageSize = imgParams.normalizedSize().size()
+    val imageSize = if (messageStyle.isBubble()) {
+        imgParams.normalizedSize(
+            maxBounds = MaxBounds.ScreenFraction(
+                maxWFraction = dimensions().messageVisualMaxFractionWidth,
+                maxHFraction = dimensions().messageVisualMaxFractionHeight
+            )
+        ).size()
+    } else {
+        imgParams.normalizedSize().size()
+    }
     Box(
         modifier
             .applyIf(!messageStyle.isBubble()) {
@@ -385,7 +395,7 @@ fun MediaAssetImage(
                 ImageMessageFailed(
                     size = size,
                     isDownloadFailure = true,
-                    errorColor = colorsScheme().error
+                    errorColor = messageStyle.error()
                 )
             }
 
@@ -393,7 +403,7 @@ fun MediaAssetImage(
                 ImageMessageFailed(
                     size = size,
                     isDownloadFailure = true,
-                    errorColor = colorsScheme().error
+                    errorColor = messageStyle.error()
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/image/ImageMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/image/ImageMessageTypes.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -158,30 +159,35 @@ fun ImageMessageInProgress(
 
 @Composable
 fun ImageMessageFailed(size: DpSize, isDownloadFailure: Boolean, errorColor: Color, modifier: Modifier = Modifier) {
-    Column(
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
+    Box(
         modifier = modifier
             .requiredSize(size)
             .padding(MaterialTheme.wireDimensions.spacing8x)
     ) {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_gallery),
-            contentDescription = null,
-            tint = errorColor,
-            modifier = Modifier
-        )
-        Spacer(modifier = Modifier.height(MaterialTheme.wireDimensions.spacing8x))
-        Text(
-            text = stringResource(
-                id = if (isDownloadFailure) {
-                    R.string.error_downloading_image_message
-                } else {
-                    R.string.error_uploading_image_message
-                }
-            ),
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.wireTypography.subline01.copy(color = errorColor)
-        )
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_gallery),
+                contentDescription = null,
+                tint = errorColor,
+                modifier = Modifier
+            )
+            Spacer(modifier = Modifier.height(MaterialTheme.wireDimensions.spacing8x))
+            Text(
+                text = stringResource(
+                    id = if (isDownloadFailure) {
+                        R.string.error_downloading_image_message
+                    } else {
+                        R.string.error_uploading_image_message
+                    }
+                ),
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.wireTypography.subline01.copy(color = errorColor)
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/multipart/standalone/VideoAssetPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/multipart/standalone/VideoAssetPreview.kt
@@ -89,7 +89,7 @@ internal fun VideoAssetPreview(
     )
 
     val fileNameColor = when (messageStyle) {
-        MessageStyle.BUBBLE_SELF -> colorsScheme().onPrimary
+        MessageStyle.BUBBLE_SELF -> colorsScheme().selfBubble.onPrimary
         MessageStyle.BUBBLE_OTHER -> colorsScheme().onSurface
         MessageStyle.NORMAL -> colorsScheme().onSurface
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24957
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- `Image download failed` in self bubble messages was not visually centered.
- Footer (time/status) in media bubbles could be misaligned.
- Failure text/icon color in self bubble could be wrong in dark mode.

### Causes (Optional)

- Bubble width and image overlay size were calculated with different bounds.
- Failure color logic was duplicated and inconsistent with message style tokens.

### Solutions

- Unified image size calculation for bubble media to match bubble width bounds.
- Kept failed image placeholder centered in the full media area.
- Aligned media footer row width with asset bubble width.
- Unified failure color handling via `messageStyle.error()`.
- Set `MessageStyle.error()` for `BUBBLE_SELF` to `selfBubble.onPrimary`.
- Fixed self video attachment filename color to use `selfBubble.onPrimary`.


### Attachments (Optional)
<img width="379" height="477" alt="alignement_fix" src="https://github.com/user-attachments/assets/90c6fce4-9eab-4d0c-9164-1ead00446612" />
<img width="375" height="380" alt="color_fix" src="https://github.com/user-attachments/assets/199b525d-2338-4c08-bc98-c9b5f428f4ac" />

