### PR TITLE
feat: implement SyncServicesUseCase to sync services from backend and update ObserveAllServicesUseCase to avoid network calls [WPB-25762]

### DIFF
--- a/.github/workflows/jira-lint-and-link.yml
+++ b/.github/workflows/jira-lint-and-link.yml
@@ -17,9 +17,12 @@ jobs:
     steps:
       - name: Get version name from source
         id: version
+        env:
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          VERSION=$(curl -s https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/build-logic/plugins/src/main/kotlin/AndroidCoordinates.kt | grep 'const val versionName' | sed -E 's/.*"([^"]+)".*/\1/')
-          echo "version_name=$VERSION" >> $GITHUB_OUTPUT
+          VERSION=$(curl -s "https://raw.githubusercontent.com/${REPO}/${BRANCH}/build-logic/plugins/src/main/kotlin/AndroidCoordinates.kt" | grep 'const val versionName' | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "version_name=$VERSION" >> "$GITHUB_OUTPUT"
 
   add-jira-description:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}

--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/ServicesModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/ServicesModule.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.feature.service.ObserveAllServicesUseCase
 import com.wire.kalium.logic.feature.service.ObserveIsServiceMemberUseCase
 import com.wire.kalium.logic.feature.service.SearchServicesByNameUseCase
 import com.wire.kalium.logic.feature.service.ServiceScope
+import com.wire.kalium.logic.feature.service.SyncServicesUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -57,6 +58,11 @@ class ServicesModule {
     @Provides
     fun provideObserveAllServicesUseCase(serviceScope: ServiceScope): ObserveAllServicesUseCase =
         serviceScope.observeAllServices
+
+    @ViewModelScoped
+    @Provides
+    fun provideSyncServicesUseCase(serviceScope: ServiceScope): SyncServicesUseCase =
+        serviceScope.syncServices
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModel.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.feature.featureConfig.AppsAllowedResult
 import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppsAllowedForUsageUseCase
 import com.wire.kalium.logic.feature.service.ObserveAllServicesUseCase
 import com.wire.kalium.logic.feature.service.SearchServicesByNameUseCase
+import com.wire.kalium.logic.feature.service.SyncServicesUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -55,6 +56,7 @@ import kotlinx.coroutines.launch
 class SearchAppsViewModel @AssistedInject constructor(
     @Assisted val protocolInfo: Conversation.ProtocolInfo?,
     private val getAllServices: ObserveAllServicesUseCase,
+    private val syncServices: SyncServicesUseCase,
     private val getAllApps: ObserveAllAppsUseCase,
     private val contactMapper: ContactMapper,
     private val searchServicesByName: SearchServicesByNameUseCase,
@@ -63,6 +65,7 @@ class SearchAppsViewModel @AssistedInject constructor(
     private val observeSelfUser: ObserveSelfUserUseCase
 ) : ViewModel() {
     private val searchQueryTextFlow = MutableStateFlow(String.EMPTY)
+    private var servicesSynced = false
     var state: SearchServicesState by mutableStateOf(SearchServicesState(isLoading = true))
         private set
 
@@ -113,6 +116,10 @@ class SearchAppsViewModel @AssistedInject constructor(
             val result = if (showNewApps) {
                 if (query.isEmpty()) getAllApps() else searchAppsByName(query)
             } else {
+                if (!servicesSynced) {
+                    servicesSynced = true
+                    launch { syncServices() }
+                }
                 if (query.isEmpty()) getAllServices() else searchServicesByName(query)
             }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModelTest.kt
@@ -39,7 +39,6 @@ import com.wire.kalium.logic.feature.featureConfig.AppsAllowedProtocol
 import com.wire.kalium.logic.feature.featureConfig.AppsAllowedResult
 import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppsAllowedForUsageUseCase
 import com.wire.kalium.common.error.NetworkFailure
-import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.feature.service.ObserveAllServicesUseCase
 import com.wire.kalium.logic.feature.service.SearchServicesByNameUseCase
 import com.wire.kalium.logic.feature.service.SyncServicesUseCase

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModelTest.kt
@@ -38,8 +38,11 @@ import com.wire.kalium.logic.feature.app.SearchAppsByNameUseCase
 import com.wire.kalium.logic.feature.featureConfig.AppsAllowedProtocol
 import com.wire.kalium.logic.feature.featureConfig.AppsAllowedResult
 import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppsAllowedForUsageUseCase
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.feature.service.ObserveAllServicesUseCase
 import com.wire.kalium.logic.feature.service.SearchServicesByNameUseCase
+import com.wire.kalium.logic.feature.service.SyncServicesUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -267,6 +270,66 @@ class SearchAppsViewModelTest {
         }
 
     @Test
+    fun `given services branch is used across multiple searches, when init view model, then syncServices is called exactly once`() =
+        runTest {
+            // given
+            val query = "Service Name"
+            val (arrangement, viewModel) = Arrangement()
+                .withAppsAllowedForUsage(AppsAllowedResult.Enabled(AppsAllowedProtocol.PROTEUS))
+                .withGetAllServices(listOf(SERVICE_DETAILS))
+                .withSearchServicesByName(query, listOf(SERVICE_DETAILS))
+                .arrange(protocolInfo = null)
+
+            // when
+            advanceUntilIdle()
+            viewModel.searchQueryChanged(query)
+            advanceUntilIdle()
+            viewModel.searchQueryChanged(String.EMPTY)
+            advanceUntilIdle()
+
+            // then
+            coVerify(exactly = 1) {
+                arrangement.syncServices()
+            }
+        }
+
+    @Test
+    fun `given apps branch is used, when init view model, then syncServices is never called`() =
+        runTest {
+            // given
+            val (arrangement, _) = Arrangement()
+                .withAppsAllowedForUsage(AppsAllowedResult.Enabled(AppsAllowedProtocol.MLS))
+                .withGetAllApps(listOf(SERVICE_DETAILS))
+                .arrange(protocolInfo = null)
+
+            // when
+            advanceUntilIdle()
+
+            // then
+            coVerify(exactly = 0) {
+                arrangement.syncServices()
+            }
+        }
+
+    @Test
+    fun `given syncServices fails, when services branch is used, then observed services are still emitted`() =
+        runTest {
+            // given
+            val (_, viewModel) = Arrangement()
+                .withAppsAllowedForUsage(AppsAllowedResult.Enabled(AppsAllowedProtocol.PROTEUS))
+                .withGetAllServices(listOf(SERVICE_DETAILS, SERVICE_DETAILS2))
+                .withSyncServicesFailing()
+                .arrange(protocolInfo = null)
+
+            // when
+            advanceUntilIdle()
+
+            // then
+            assertEquals(2, viewModel.state.result.size)
+            assertFalse(viewModel.state.isLoading)
+        }
+
+    @Test
     fun `given Apps feature flag is PROTEUS enabled, when searching for Apps by name, then load searched Services`() =
         runTest {
             // given
@@ -341,6 +404,9 @@ class SearchAppsViewModelTest {
         lateinit var getAllServices: ObserveAllServicesUseCase
 
         @MockK
+        lateinit var syncServices: SyncServicesUseCase
+
+        @MockK
         lateinit var getAllApps: ObserveAllAppsUseCase
 
         @MockK
@@ -362,6 +428,7 @@ class SearchAppsViewModelTest {
             MockKAnnotations.init(this, relaxUnitFun = true)
 
             coEvery { getAllServices() } returns flowOf(emptyList())
+            coEvery { syncServices() } returns Either.Right(Unit)
             coEvery { getAllApps() } returns flowOf(emptyList())
             coEvery { searchServicesByName(any()) } returns flowOf(emptyList())
             coEvery { searchAppsByName(any()) } returns flowOf(emptyList())
@@ -375,6 +442,7 @@ class SearchAppsViewModelTest {
         fun arrange(protocolInfo: Conversation.ProtocolInfo?) = this to SearchAppsViewModel(
             protocolInfo = protocolInfo,
             getAllServices = getAllServices,
+            syncServices = syncServices,
             getAllApps = getAllApps,
             contactMapper = contactMapper,
             searchServicesByName = searchServicesByName,
@@ -401,6 +469,10 @@ class SearchAppsViewModelTest {
 
         fun withSearchServicesByName(query: String, result: List<ServiceDetails>) = apply {
             coEvery { searchServicesByName(query) } returns flowOf(result)
+        }
+
+        fun withSyncServicesFailing() = apply {
+            coEvery { syncServices() } returns Either.Left(NetworkFailure.NoNetworkConnection(cause = null))
         }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModelTest.kt
@@ -428,7 +428,7 @@ class SearchAppsViewModelTest {
             MockKAnnotations.init(this, relaxUnitFun = true)
 
             coEvery { getAllServices() } returns flowOf(emptyList())
-            coEvery { syncServices() } returns Either.Right(Unit)
+            coEvery { syncServices() } returns SyncServicesUseCase.Result.Success
             coEvery { getAllApps() } returns flowOf(emptyList())
             coEvery { searchServicesByName(any()) } returns flowOf(emptyList())
             coEvery { searchAppsByName(any()) } returns flowOf(emptyList())
@@ -472,7 +472,7 @@ class SearchAppsViewModelTest {
         }
 
         fun withSyncServicesFailing() = apply {
-            coEvery { syncServices() } returns Either.Left(NetworkFailure.NoNetworkConnection(cause = null))
+            coEvery { syncServices() } returns SyncServicesUseCase.Result.Failure(NetworkFailure.NoNetworkConnection(cause = null))
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25762
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

ObserveAllServicesUseCase only return after a remote API update even tho the list of bots is 

### Causes (Optional)

the use case will update first and then return

### Solutions

split it into ObserveAllServicesUseCase and SyncServicesUseCase and call SyncServicesUseCase from the view model when needed to update 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
