### PR TITLE
fix: crash on force logout while using the security banner composable (WPB-25036)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/banner/SecurityClassificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/banner/SecurityClassificationViewModel.kt
@@ -23,17 +23,20 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.AssistedViewModelFactory
 import com.wire.android.di.ViewModelScopedPreview
+import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.conversation.ObserveOtherUserSecurityClassificationLabelUseCase
-import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
 
 @ViewModelScopedPreview
@@ -43,8 +46,7 @@ interface SecurityClassificationViewModel {
 
 @HiltViewModel(assistedFactory = SecurityClassificationViewModelImpl.Factory::class)
 class SecurityClassificationViewModelImpl @AssistedInject constructor(
-    private val observeSecurityClassificationLabel: ObserveSecurityClassificationLabelUseCase,
-    private val observeOtherUserSecurityClassificationLabel: ObserveOtherUserSecurityClassificationLabelUseCase,
+    @KaliumCoreLogic private val coreLogic: CoreLogic,
     @Assisted private val args: SecurityClassificationArgs
 ) : SecurityClassificationViewModel, ViewModel() {
 
@@ -53,24 +55,36 @@ class SecurityClassificationViewModelImpl @AssistedInject constructor(
     override fun state(): SecurityClassificationType = state
 
     init {
-        when (args) {
-            is SecurityClassificationArgs.Conversation -> fetchConversationClassificationType(args.id)
-            is SecurityClassificationArgs.User -> fetchUserClassificationType(args.id)
+        viewModelScope.launch {
+            coreLogic.getGlobalScope().session.currentSessionFlow()
+                .flatMapLatest { currentSession ->
+                    when (currentSession) {
+                        is CurrentSessionResult.Success -> when (args) {
+                            is SecurityClassificationArgs.Conversation -> observeConversationClassificationType(
+                                currentSession.accountInfo.userId,
+                                args.id
+                            )
+
+                            is SecurityClassificationArgs.User -> observeUserClassificationType(
+                                currentSession.accountInfo.userId,
+                                args.id
+                            )
+                        }
+
+                        is CurrentSessionResult.Failure -> flowOf(SecurityClassificationType.NONE)
+                    }
+                }
+                .collect { classificationType ->
+                    state = classificationType
+                }
         }
     }
 
-    private fun fetchConversationClassificationType(conversationId: ConversationId) = viewModelScope.launch {
-        observeSecurityClassificationLabel.invoke(conversationId)
-            .collect { classificationType ->
-                state = classificationType
-            }
-    }
+    private suspend fun observeConversationClassificationType(currentUserId: UserId, conversationId: ConversationId) =
+        coreLogic.getSessionScope(currentUserId).observeSecurityClassificationLabel(conversationId)
 
-    private fun fetchUserClassificationType(userId: UserId) = viewModelScope.launch {
-        observeOtherUserSecurityClassificationLabel(userId).collect { classificationType ->
-            state = classificationType
-        }
-    }
+    private suspend fun observeUserClassificationType(currentUserId: UserId, userId: UserId) =
+        coreLogic.getSessionScope(currentUserId).getOtherUserSecurityClassificationLabel(userId)
 
     @AssistedFactory
     interface Factory : AssistedViewModelFactory<SecurityClassificationViewModelImpl, SecurityClassificationArgs> {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/banner/SecurityClassificationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/banner/SecurityClassificationViewModelTest.kt
@@ -21,17 +21,22 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
 import com.wire.android.ui.common.banner.SecurityClassificationArgs
 import com.wire.android.ui.common.banner.SecurityClassificationViewModelImpl
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.conversation.ObserveOtherUserSecurityClassificationLabelUseCase
-import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
+import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -57,10 +62,6 @@ class SecurityClassificationViewModelTest {
 
         // Then
         assertEquals(SecurityClassificationType.CLASSIFIED, viewModel.state())
-
-        coVerify(exactly = 0) {
-            arrangement.getOtherUserSecurityClassificationLabel(any())
-        }
     }
 
     @Test
@@ -78,9 +79,45 @@ class SecurityClassificationViewModelTest {
 
         // Then
         assertEquals(SecurityClassificationType.CLASSIFIED, viewModel.state())
+    }
 
+    @Test
+    fun `given logout while observing classification, when current session disappears, then should reset state to none`() = runTest {
+        // Given
+        val arrangement = Arrangement(
+            conversationId = CONVERSATION_ID,
+            userId = null
+        )
+        arrangement.withCurrentSessionsFlow(arrangement.currentSessionStateFlow)
+        val (_, viewModel) = arrangement.arrange()
+
+        // When
+        arrangement.currentSessionStateFlow.emit(CurrentSessionResult.Success(AccountInfo.Valid(USER_ID)))
+        arrangement.classificationChannel.send(SecurityClassificationType.CLASSIFIED)
+        advanceUntilIdle()
+        arrangement.currentSessionStateFlow.emit(CurrentSessionResult.Failure.SessionNotFound)
+        advanceUntilIdle()
+
+        // Then
+        assertEquals(SecurityClassificationType.NONE, viewModel.state())
+    }
+
+    @Test
+    fun `given no current session, when creating view model, then should stay in none state without querying session scope`() = runTest {
+        // Given
+        val (arrangement, viewModel) = Arrangement(
+            conversationId = CONVERSATION_ID,
+            userId = null
+        )
+            .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Failure.SessionNotFound))
+            .arrange()
+
+        advanceUntilIdle()
+
+        // Then
+        assertEquals(SecurityClassificationType.NONE, viewModel.state())
         coVerify(exactly = 0) {
-            arrangement.observeSecurityClassificationLabel(any())
+            arrangement.coreLogic.getSessionScope(any()).observeSecurityClassificationLabel(any())
         }
     }
 
@@ -95,32 +132,38 @@ class SecurityClassificationViewModelTest {
     ) {
 
         @MockK
-        lateinit var observeSecurityClassificationLabel: ObserveSecurityClassificationLabelUseCase
+        lateinit var coreLogic: CoreLogic
 
         @MockK
-        lateinit var getOtherUserSecurityClassificationLabel: ObserveOtherUserSecurityClassificationLabelUseCase
+        lateinit var currentSessionFlowUseCase: CurrentSessionFlowUseCase
 
         val classificationChannel = Channel<SecurityClassificationType>(capacity = Channel.UNLIMITED)
         val classificationUserChannel = Channel<SecurityClassificationType>(capacity = Channel.UNLIMITED)
-        private val navArg: SecurityClassificationArgs
-
-        init {
-            navArg = when {
-                conversationId != null -> SecurityClassificationArgs.Conversation(conversationId)
-                userId != null -> SecurityClassificationArgs.User(userId)
-                else -> throw IllegalArgumentException("Either conversationId or userId must be provided")
-            }
-            MockKAnnotations.init(this, relaxUnitFun = true)
-            coEvery { observeSecurityClassificationLabel(any()) } returns classificationChannel.consumeAsFlow()
-            coEvery { getOtherUserSecurityClassificationLabel(any()) } returns classificationUserChannel.consumeAsFlow()
+        val currentSessionStateFlow = MutableSharedFlow<CurrentSessionResult>(replay = 1)
+        private val navArg: SecurityClassificationArgs = when {
+            conversationId != null -> SecurityClassificationArgs.Conversation(conversationId)
+            userId != null -> SecurityClassificationArgs.User(userId)
+            else -> throw IllegalArgumentException("Either conversationId or userId must be provided")
         }
 
-        val viewModel = SecurityClassificationViewModelImpl(
-            observeSecurityClassificationLabel,
-            getOtherUserSecurityClassificationLabel,
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+            every { coreLogic.getGlobalScope().session.currentSessionFlow } returns currentSessionFlowUseCase
+            coEvery { currentSessionFlowUseCase() } returns flowOf(CurrentSessionResult.Success(AccountInfo.Valid(USER_ID)))
+            coEvery {
+                coreLogic.getSessionScope(any()).observeSecurityClassificationLabel(any())
+            } returns classificationChannel.consumeAsFlow()
+            coEvery { coreLogic.getSessionScope(any()).getOtherUserSecurityClassificationLabel(any()) } returns
+                classificationUserChannel.consumeAsFlow()
+        }
+
+        fun withCurrentSessionsFlow(result: kotlinx.coroutines.flow.Flow<CurrentSessionResult>) = apply {
+            coEvery { currentSessionFlowUseCase() } returns result
+        }
+
+        fun arrange() = this to SecurityClassificationViewModelImpl(
+            coreLogic,
             navArg
         )
-
-        fun arrange() = this to viewModel
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25036
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When inside a conversation, displaying the security banner or not (VS-NfD/Unclassified or Nothing) the app crashes if a hard logout is triggered.

### Causes (Optional)

The composable tries to recompose and recompose the  viewmodel when a hard logout is made, because there's no session at that point.

### Solutions

Move the observability of currentSessionFlow() of the banner inside the viewmodel by injecting it, making it depend on it.
Falling back to `SecurityClassificationType.NONE` when no session available (triggered by this case of hard logout).

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- Go inside a conversation
- Force the logout externally (i.e. nomad)
- The app should not crash, nor logs about this  **java.lang.IllegalStateException: no current session was found** should be present.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
