### PR TITLE
test: stabilize Okta SSO backup flow [WPB-25072]

### DIFF
--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/SSODeviceBackup.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/SSODeviceBackup.kt
@@ -72,7 +72,7 @@ class SSODeviceBackup : BaseUiTest() {
     fun tearDown() {
         cleanupCreatedUsers(backendClient, teamHelper.usersManager)
         deleteDownloadedFilesContaining("Wire")
-        oktaApiClient.cleanUp()
+        runCatching { oktaApiClient.cleanUp() }
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
@@ -103,9 +103,8 @@ class SSODeviceBackup : BaseUiTest() {
                 )
             }
 
-            step("Get SSO code and wait for Okta app assignment sync") {
+            step("Get SSO code and start the SSO login flow") {
                 val ssoCode = SSOServiceHelper.getSSOCode()
-                waitFor(20) // Delay added to allow Okta app assignment to fully sync and avoid 403 error
 
                 step("Start SSO login flow using SSO code") {
                     pages.registrationPage.apply {

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationListPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationListPage.kt
@@ -196,13 +196,16 @@ data class ConversationListPage(private val device: UiDevice) {
             className = "android.view.View",
             description = "Close new conversation view"
         )
-        UiWaitUtils.waitUntilVisibleOrThrow(
-            params = closeButton,
-            timeoutMs = timeoutMs,
-            errorMessage = "Close button not found within ${timeoutMs}ms"
-        )
-        val close = UiWaitUtils.waitElement(closeButton)
-        close.click()
+
+        val closed = UiWaitUtils.retryUntilTimeout(timeoutMs = timeoutMs, pollingIntervalMs = 150) {
+            runCatching {
+                UiWaitUtils.waitElement(closeButton, timeoutMillis = 200).click()
+            }
+            UiWaitUtils.findElementOrNull(conversationListHeading)?.let { !it.visibleBounds.isEmpty } == true
+        }
+        if (!closed) {
+            throw AssertionError("Conversation list was not visible again within ${timeoutMs}ms")
+        }
 
         return this
     }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/RegistrationPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/RegistrationPage.kt
@@ -226,24 +226,13 @@ class RegistrationPage(private val device: UiDevice) {
         return this
     }
 
-    fun clickAllowNotificationButton(timeoutMs: Long = 15_000): RegistrationPage {
-        val deadline = SystemClock.uptimeMillis() + timeoutMs
-
-        while (SystemClock.uptimeMillis() < deadline) {
-            val button = allowNotificationButtons
-                .asSequence()
-                .mapNotNull(UiWaitUtils::findElementOrNull)
-                .firstOrNull { !it.visibleBounds.isEmpty && it.isEnabled }
-
-            if (button != null) {
-                button.click()
-                return this
-            }
-
-            SystemClock.sleep(200)
-        }
-
-        // On some devices/runs the permission is already granted and this dialog never appears.
+    // Fallback for runs where the PermissionUtils pre-grant does not suppress the Android notification permission dialog.
+    fun clickAllowNotificationButton(): RegistrationPage {
+        allowNotificationButtons
+            .asSequence()
+            .mapNotNull(UiWaitUtils::findElementOrNull)
+            .firstOrNull { !it.visibleBounds.isEmpty && it.isEnabled }
+            ?.let { runCatching { it.click() } }
         return this
     }
 

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/RegistrationPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/RegistrationPage.kt
@@ -238,16 +238,11 @@ class RegistrationPage(private val device: UiDevice) {
     @Suppress("MagicNumber")
     fun clickDeclineShareDataAlert(timeoutMs: Long = 10_000): RegistrationPage {
         val dismissed = UiWaitUtils.retryUntilTimeout(timeoutMs = timeoutMs, pollingIntervalMs = 150) {
-            val decline = UiWaitUtils.findElementOrNull(declineButton)
-            if (decline != null && !decline.visibleBounds.isEmpty && decline.isEnabled) {
-                val bounds = decline.visibleBounds
-                runCatching { decline.click() }
-                val stillVisibleAfterClick = UiWaitUtils.findElementOrNull(declineButton)?.let { !it.visibleBounds.isEmpty } == true
-                if (stillVisibleAfterClick && !bounds.isEmpty) {
-                    device.click(bounds.centerX(), bounds.centerY())
-                }
-                device.waitForIdle(300)
-            }
+            UiWaitUtils.clickWhenClickable(
+                params = declineButton,
+                timeoutMs = 200,
+                pollingIntervalMs = 100
+            )
 
             val dialogVisible = UiWaitUtils.findElementOrNull(consentDialogTitle)?.let { !it.visibleBounds.isEmpty } == true
             val declineVisible = UiWaitUtils.findElementOrNull(declineButton)?.let { !it.visibleBounds.isEmpty } == true

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SettingsPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SettingsPage.kt
@@ -156,23 +156,6 @@ fun openBackupAndRestoreConversationsMenu(timeoutMs: Long = 10_000): SettingsPag
     }
 
     return this
-}
-        val deadline = SystemClock.uptimeMillis() + timeoutMs
-
-        while (SystemClock.uptimeMillis() < deadline) {
-            val menu = UiWaitUtils.findElementOrNull(backUpMenuButton)
-            if (menu != null && !menu.visibleBounds.isEmpty && menu.isEnabled) {
-                runCatching { menu.click() }
-
-                if (isBackupPageOpen()) {
-                    return this
-                }
-            }
-
-            SystemClock.sleep(200)
-        }
-
-        throw AssertionError("Could not open 'Back up & Restore Conversations' within ${timeoutMs}ms.")
     }
 
     private fun isBackupPageOpen(): Boolean {

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SettingsPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SettingsPage.kt
@@ -143,9 +143,28 @@ data class SettingsPage(private val device: UiDevice) {
         return this
     }
 
-    fun openBackupAndRestoreConversationsMenu(): SettingsPage {
-        UiWaitUtils.waitElement(backUpMenuButton).click()
-        return this
+    fun openBackupAndRestoreConversationsMenu(timeoutMs: Long = 10_000): SettingsPage {
+        val deadline = SystemClock.uptimeMillis() + timeoutMs
+
+        while (SystemClock.uptimeMillis() < deadline) {
+            val menu = UiWaitUtils.findElementOrNull(backUpMenuButton)
+            if (menu != null && !menu.visibleBounds.isEmpty && menu.isEnabled) {
+                runCatching { menu.click() }
+
+                if (isBackupPageOpen()) {
+                    return this
+                }
+            }
+
+            SystemClock.sleep(200)
+        }
+
+        throw AssertionError("Could not open 'Back up & Restore Conversations' within ${timeoutMs}ms.")
+    }
+
+    private fun isBackupPageOpen(): Boolean {
+        return UiWaitUtils.findElementOrNull(restoreBackupButton)?.let { !it.visibleBounds.isEmpty } == true ||
+            UiWaitUtils.findElementOrNull(createBackupButton)?.let { !it.visibleBounds.isEmpty } == true
     }
 
     fun clickRestoreBackupButton(): SettingsPage {

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SettingsPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SettingsPage.kt
@@ -141,7 +141,22 @@ data class SettingsPage(private val device: UiDevice) {
         return this
     }
 
-    fun openBackupAndRestoreConversationsMenu(timeoutMs: Long = 10_000): SettingsPage {
+fun openBackupAndRestoreConversationsMenu(timeoutMs: Long = 10_000): SettingsPage {
+    val opened = UiWaitUtils.retryUntilTimeout(timeoutMs = timeoutMs, pollingIntervalMs = 200) {
+        UiWaitUtils.clickWhenClickable(
+            params = backUpMenuButton,
+            timeoutMs = 200,
+            pollingIntervalMs = 100
+        )
+        isBackupPageOpen()
+    }
+
+    if (!opened) {
+        throw AssertionError("Could not open 'Back up & Restore Conversations' within ${timeoutMs}ms.")
+    }
+
+    return this
+}
         val deadline = SystemClock.uptimeMillis() + timeoutMs
 
         while (SystemClock.uptimeMillis() < deadline) {

--- a/tests/testsSupport/src/androidTest/kotlin/com/wire/android/tests/support/UiAutomatorSetup.kt
+++ b/tests/testsSupport/src/androidTest/kotlin/com/wire/android/tests/support/UiAutomatorSetup.kt
@@ -17,9 +17,11 @@
  */
 package com.wire.android.tests.support
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
@@ -27,6 +29,7 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert.assertThat
+import uiautomatorutils.PermissionUtils.grantRuntimePermsForApp
 
 const val TIMEOUT_IN_MILLISECONDS = 20_000L
 
@@ -47,6 +50,8 @@ object UiAutomatorSetup {
         if (clearData) {
             device.executeShellCommand("pm clear $appPackage")
         }
+
+        grantNotificationPermissionIfSupported(appPackage)
 
         device.executeShellCommand("settings put secure show_ime_with_hard_keyboard 0")
         device.executeShellCommand("settings put global window_animation_scale 0")
@@ -99,5 +104,16 @@ object UiAutomatorSetup {
     fun stopApp() {
         val device = getDevice()
         device.executeShellCommand("am force-stop $appPackage")
+    }
+
+    // Setup-level wrapper that pre-grants notifications on Android 13+ via PermissionUtils.
+    private fun grantNotificationPermissionIfSupported(appPackage: String) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return
+        }
+
+        runCatching {
+            grantRuntimePermsForApp(appPackage, Manifest.permission.POST_NOTIFICATIONS)
+        }
     }
 }

--- a/tests/testsSupport/src/main/okta/OktaApiClient.kt
+++ b/tests/testsSupport/src/main/okta/OktaApiClient.kt
@@ -55,18 +55,34 @@ class OktaApiClient {
         private val retries: Int = 3
     ) {
         fun run(
-            block: () -> Pair<Int, String>,
+            block: () -> Triple<Int, String, Long?>,
             acceptable: IntArray
         ): String {
             var err: Throwable? = null
-            repeat(max(1, retries)) {
-                try {
-                    val (code, body) = block()
-                    verify(code, acceptable, body)
-                    return body
+            // Okta assignment/setup can hit transient 429s, so retry only retryable failures.
+            repeat(max(1, retries)) { attempt ->
+                val (code, body, retryAfterMs) = try {
+                    block()
                 } catch (t: Throwable) {
                     err = t
+                    return@repeat
                 }
+
+                if (acceptable.any { it == code }) {
+                    return body
+                }
+
+                if (code == 429 && attempt < retries - 1) {
+                    val waitMs = retryAfterMs ?: (2_000L * (attempt + 1))
+                    try {
+                        Thread.sleep(waitMs)
+                    } catch (_: InterruptedException) {
+                    }
+                    return@repeat
+                }
+
+                verify(code, acceptable, body)
+                return body
             }
             throw err ?: IllegalStateException("Request failed after $retries attempts")
         }
@@ -109,21 +125,15 @@ class OktaApiClient {
             val code = conn.responseCode
             val text = (if (code in acceptableCodes) conn.inputStream else conn.errorStream)
                 ?.bufferedReader()?.use(BufferedReader::readText).orEmpty()
+            val retryAfterMs = conn.getHeaderField("Retry-After")?.toLongOrNull()?.times(1000L)
             conn.disconnect()
-            code to text
+            Triple(code, text, retryAfterMs)
         },
         acceptable = acceptableCodes
     )
 
     private fun readRawResource(context: Context, resId: Int): String =
         context.resources.openRawResource(resId).bufferedReader().use { it.readText() }
-
-    private fun hardSleep(ms: Long) {
-        try {
-            Thread.sleep(ms)
-        } catch (_: InterruptedException) {
-        }
-    }
 
     fun createApplication(label: String, finalizeUrl: String, context: Context): String {
         val template = readRawResource(context, R.raw.app_creation)
@@ -151,13 +161,6 @@ class OktaApiClient {
         applicationId = response.getString("id")
         val groupId = fetchGroupId("Everyone")
         assignApplicationToGroup(requireNotNull(applicationId), groupId)
-
-        // NEW: wait until the assignment is visible to GETs (propagation)
-        waitForAppGroupLink(requireNotNull(applicationId), groupId)
-
-        // Tiny grace period (Okta can still be warming up)
-        hardSleep(1200)
-
         return requireNotNull(applicationId)
     }
 
@@ -186,26 +189,6 @@ class OktaApiClient {
         )
     }
 
-    // poll for the app-group link to be visible
-    private fun waitForAppGroupLink(appId: String, groupId: String, timeoutMs: Long = 30_000) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        var lastErr: Throwable? = null
-        while (System.currentTimeMillis() < deadline) {
-            try {
-                httpRequest(
-                    path = "api/v1/apps/$appId/groups/$groupId",
-                    method = "GET",
-                    acceptableCodes = intArrayOf(HttpURLConnection.HTTP_OK)
-                )
-                return // success
-            } catch (t: Throwable) {
-                lastErr = t
-                hardSleep(700)
-            }
-        }
-        throw lastErr ?: IllegalStateException("Timed out waiting for app $appId to link group $groupId")
-    }
-
     fun getApplicationMetadata(): String {
         val appId = applicationId ?: error("Application ID is not set. Create an application first.")
         return httpRequest(
@@ -216,7 +199,8 @@ class OktaApiClient {
         )
     }
 
-    fun createUser(name: String, email: String, password: String) {
+    @Suppress("LongMethod")
+    fun createUser(name: String, email: String, password: String): String {
         val requestBody = JSONObject().apply {
             put(
                 "profile",
@@ -265,16 +249,30 @@ class OktaApiClient {
                 }
             )
         }
-
         val output = httpRequest(
             path = "api/v1/users?activate=true",
             method = "POST",
             body = requestBody.toString(),
             acceptableCodes = intArrayOf(HttpURLConnection.HTTP_OK)
         )
-        val response = JSONObject(output)
-        userIds.add(response.getString("id"))
-        network.WireTestLogger.getLog("LogginUserId").info("User id is ${response.getString("id")}")
+        return JSONObject(output).getString("id").also { userId ->
+            userIds.add(userId)
+            network.WireTestLogger.getLog("LogginUserId").info("User id is $userId")
+        }
+    }
+
+    // Assigns the created Okta user directly to the current Okta application used for SSO login.
+    fun assignUserToApplication(userId: String) {
+        val appId = applicationId ?: error("Application ID is not set. Create an application first.")
+        val requestBody = JSONObject().apply {
+            put("id", userId)
+        }
+        httpRequest(
+            path = "api/v1/apps/$appId/users",
+            method = "POST",
+            body = requestBody.toString(),
+            acceptableCodes = intArrayOf(HttpURLConnection.HTTP_OK)
+        )
     }
 
     fun deleteUser(userId: String) {

--- a/tests/testsSupport/src/main/service/SSOServiceHelper.kt
+++ b/tests/testsSupport/src/main/service/SSOServiceHelper.kt
@@ -80,7 +80,8 @@ object SSOServiceHelper {
             // set backend for added okta users
             user.backendName = ownerBackendName
 
-            oktaApiClient.createUser(user.name.orEmpty(), user.email.orEmpty(), user.password.orEmpty())
+            val userId = oktaApiClient.createUser(user.name.orEmpty(), user.email.orEmpty(), user.password.orEmpty())
+            oktaApiClient.assignUserToApplication(userId)
         }
     }
 

--- a/tests/testsSupport/src/main/uiautomatorutils/PermissionUtils.kt
+++ b/tests/testsSupport/src/main/uiautomatorutils/PermissionUtils.kt
@@ -22,13 +22,18 @@ import androidx.test.uiautomator.UiDevice
 
 object PermissionUtils {
 
-    fun grantRuntimePermsForForegroundApp(device: UiDevice, vararg permissions: String) {
-        val inst = InstrumentationRegistry.getInstrumentation()
-        val pkg = device.currentPackageName
-        val ui = inst.uiAutomation
+    // Grants runtime permissions directly to a known app package.
+    fun grantRuntimePermsForApp(pkg: String, vararg permissions: String) {
+        val ui = InstrumentationRegistry.getInstrumentation().uiAutomation
 
         permissions.forEach { perm ->
             ui.executeShellCommand("pm grant $pkg $perm").close()
         }
+    }
+
+    // Grants runtime permissions to whichever app is currently in the foreground.
+    fun grantRuntimePermsForForegroundApp(device: UiDevice, vararg permissions: String) {
+        val pkg = device.currentPackageName
+        grantRuntimePermsForApp(pkg, *permissions)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25072
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Fix the Okta SSO backup setup flow by using the same shared OktaApiClient throughout app creation, user creation, and assignment.

- Update OktaApiClient.createUser(...) to return the created Okta user id so the test flow can use it immediately.

- Add direct Okta app assignment with assignUserToApplication(userId) instead of relying on indirect propagation.

- Remove the old indirect Okta propagation wait by deleting waitForAppGroupLink(...) and the extra warm-up sleep.

- Tighten Okta retry handling so we only retry retryable failures, especially transient 429 responses, and respect Retry-After.

- Make Okta cleanup in SSODeviceBackup best-effort with runCatching { oktaApiClient.cleanUp() } so teardown is less hard.

- Pre-grant Android 13+ notification permission during test setup through PermissionUtils, while keeping the notification dialog tap as a fallback if the dialog still appears.

- Keep the backup settings navigation more resilient by retrying the menu click until the backup page is detected.

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

- Stabilized the Android SSO backup test flow by fixing the Okta setup path: created Okta users are now assigned directly to the Okta app, and the old propagation wait/sleep logic was removed.

- Improved test reliability around first-time setup by pre-granting Android notification permission during setup, keeping the UI permission tap as a fallback, and making the backup settings navigation and Okta cleanup less hard.

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
