### PR TITLE
fix: unknown user accent fallback [WPB-24378]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageAuthorRow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageAuthorRow.kt
@@ -82,17 +82,20 @@ fun MessageAuthorRow(
 
 @Composable
 private fun Username(username: String, accent: Accent, messageStyle: MessageStyle, modifier: Modifier = Modifier) {
+    val fallbackColor = if (messageStyle.isBubble()) {
+        if (accent == Accent.Unknown) {
+            MaterialTheme.wireColorScheme.wireAccentColors.get(Accent.Unknown)
+        } else {
+            MaterialTheme.wireColorScheme.primary
+        }
+    } else {
+        MaterialTheme.wireColorScheme.onBackground
+    }
+
     Text(
         text = username,
         style = MaterialTheme.wireTypography.body02,
-        color = MaterialTheme.wireColorScheme.wireAccentColors.getOrDefault(
-            accent,
-            if (messageStyle.isBubble()) {
-                MaterialTheme.wireColorScheme.primary
-            } else {
-                MaterialTheme.wireColorScheme.onBackground
-            }
-        ),
+        color = MaterialTheme.wireColorScheme.wireAccentColors.getOrDefault(accent, fallbackColor),
         modifier = modifier,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/avatar/UserProfileAvatar.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/avatar/UserProfileAvatar.kt
@@ -311,10 +311,7 @@ private fun DefaultInitialsAvatar(
                         colorsScheme().outline
                     )
                 } else {
-                    colorsScheme().wireAccentColors.getOrDefault(
-                        Accent.fromAccentId(nameBasedAvatar.accentColor),
-                        colorsScheme().secondaryText
-                    )
+                    colorsScheme().wireAccentColors.get(Accent.fromAccentId(nameBasedAvatar.accentColor))
                 }
             )
             .then(semantics)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24378
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Users who never selected an accent color, for example users who only used Web or iOS, could be shown with the current Android user's accent color in bubble message author styling.

### Causes (Optional)

For users without an explicit accent color, Android receives or stores the accent as `Accent.Unknown` / `accentId = 0`. In bubble message author styling, `Accent.Unknown` fell back to the current theme primary color, which is based on the logged-in user's selected accent.

### Solutions

Use the default Wire Blue accent for `Accent.Unknown` in bubble message author styling, while preserving the existing non-bubble fallback behavior. Also render name-based avatars with the default accent color mapping so unknown accents resolve consistently in light and dark mode.
