### PR TITLE
fix: MLS certificate icon content description [WPB-14746]

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -145,7 +145,7 @@
     <string name="content_description_record_audio_button_start">Audio aufnehmen</string>
     <string name="content_description_record_audio_button_stop">Aufnahme stoppen</string>
     <string name="content_description_record_audio_button_send">Audionachricht senden</string>
-    <string name="content_description_mls_certificate_valid">Alle Geräte aller Teilnehmer haben ein gültiges MLS-Zertifikat</string>
+    <string name="content_description_mls_certificate_valid">Alle Geräte sind überprüft (Ende-zu-Ende-Identität)</string>
     <string name="content_description_jump_to_last_message">Zum Ende der Unterhaltung scrollen</string>
     <string name="content_description_conversation_details_more_btn">Unterhaltungsoptionen öffnen</string>
     <string name="content_description_conversation_details_options_tab_header">Optionen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,7 +183,7 @@
     <string name="content_description_record_audio_button_start">Record Audio</string>
     <string name="content_description_record_audio_button_stop">Stop Recording Audio</string>
     <string name="content_description_record_audio_button_send">Send Audio Message</string>
-    <string name="content_description_mls_certificate_valid">All devices of all participants have a valid MLS certificate</string>
+    <string name="content_description_mls_certificate_valid">All devices are verified (end-to-end identity)</string>
     <string name="content_description_proteus_certificate_valid">All of all participants are verified (Proteus)</string>
     <string name="content_description_jump_to_last_message">Scroll to end of conversation</string>
     <string name="content_description_location_icon">Location item</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-14746
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixes the MLS certificate shield accessibility label in the chat header.

The icon now uses the same wording as the verified conversation system message:
“All devices are verified (end-to-end identity)”, including the existing German wording:
“Alle Geräte sind überprüft (Ende-zu-Ende-Identität)”.