### PR TITLE
fix: do not show toast when trying to log in again [WPB-25221]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -83,6 +83,7 @@ import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.DoesValidNomadAccountExistUseCase
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
@@ -147,6 +148,7 @@ class WireActivityViewModel @Inject constructor(
     private val automatedLoginManager: AutomatedLoginManager,
     private val nomadProfilesFeatureConfig: NomadProfilesFeatureConfig,
     private val loginTypeSelector: LoginTypeSelector,
+    private val doesValidNomadAccountExist: Lazy<DoesValidNomadAccountExistUseCase>,
 ) : ActionsViewModel<WireActivityViewAction>() {
 
     var globalAppState: GlobalAppState by mutableStateOf(GlobalAppState())
@@ -415,9 +417,11 @@ class WireActivityViewModel @Inject constructor(
 
                 initValidSessionsFlowIfNeeded()
                 if (validSessions.value.filterIsInstance<AccountInfo.Valid>().isNotEmpty()) {
-                    appLogger.w("Nomad login blocked: another session already exists")
-                    sendAction(ShowToast(R.string.nomad_login_blocked_message))
-                    return@launch
+					appLogger.w("Nomad login blocked: a non-nomad session already exists")
+                    if (!doesValidNomadAccountExist.get().invoke()) {
+                        sendAction(ShowToast(R.string.nomad_login_blocked_message))
+                    }
+					return@launch
                 }
 
                 onAutomaticLoginParameters(

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -88,6 +88,7 @@ import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
+import com.wire.kalium.logic.feature.session.DoesValidNomadAccountExistUseCase
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.ObserveSessionsUseCase
@@ -1047,6 +1048,7 @@ class WireActivityViewModelTest {
             every { authenticationScope.isNomadProfilesEnabled } returns isNomadProfilesEnabledUseCase
             coEvery { isNomadProfilesEnabledUseCase() } returns IsNomadProfilesEnabledUseCase.Result.Success(true)
             coEvery { loginTypeSelector.canUseNewLogin(any()) } returns true
+            coEvery { doesValidNomadAccountExist() } returns false
         }
 
         @MockK
@@ -1136,6 +1138,9 @@ class WireActivityViewModelTest {
         @MockK
         lateinit var loginTypeSelector: LoginTypeSelector
 
+        @MockK
+        lateinit var doesValidNomadAccountExist: DoesValidNomadAccountExistUseCase
+
         private val viewModel by lazy {
             WireActivityViewModel(
                 coreLogic = { coreLogic },
@@ -1164,6 +1169,7 @@ class WireActivityViewModelTest {
                 automatedLoginManager = automatedLoginManager,
                 nomadProfilesFeatureConfig = nomadProfilesFeatureConfig,
                 loginTypeSelector = loginTypeSelector,
+                doesValidNomadAccountExist = { doesValidNomadAccountExist },
             )
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25221
<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

When starting a nomad profile login flow via intent, if the user was already logged in, the user would see a toast informing them that they can't log in again.

However, the customer using nomad profiles will always start the app via the intent. They should not see an error if they are already logged in with a nomad profile account.