### PR TITLE
fix: mapping for fdroid not found, builds without version code (WPB-8645)

### DIFF
--- a/.github/actions/deploy-to-s3/action.yml
+++ b/.github/actions/deploy-to-s3/action.yml
@@ -69,15 +69,19 @@ runs:
       run: |
         filename=${{ steps.path.outputs.apk_full_path }}
         
-        # Extract version name and version code
         version=$(echo "$filename" | sed -E 's/.*-v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-        version_code=$(echo "$filename" | sed -E 's/.*-([0-9]+)-${{ inputs.build-flavour }}-${{ inputs.build-variant }}\.apk/\1/')
         
-        # Print the extracted version and version code
+        version_code=$(echo "$filename" | sed -n -E 's/.*-([0-9]+)-${{ inputs.build-flavour }}-${{ inputs.build-variant }}\.apk/\1/p')
+        
+        if [[ -z "$version" ]]; then
+          echo "Failed to extract version"
+          echo "filename=$filename"
+          exit 1
+        fi
+        
         echo "Extracted version: v$version"
         echo "Extracted version code: $version_code"
         
-        # set them as environment variables for later use
         echo "VERSION=v$version" >> $GITHUB_ENV
         echo "VERSION_CODE=$version_code" >> $GITHUB_ENV
     - name: Rename mapping file
@@ -85,10 +89,21 @@ runs:
       shell: bash
       id: mapping
       run: |
-        capitalized_variant=$(echo "${{ inputs.build-variant }}" | awk '{print toupper(substr($0,1,1)) tolower(substr($0,2))}')
-        echo "Capitalized Variant: $capitalized_variant"
-        mapping_full_path="app/build/outputs/mapping/${{ inputs.build-flavour }}${capitalized_variant}/mapping.txt"
-        new_mapping_file_name="mapping-${{ env.VERSION }}-${{ env.VERSION_CODE }}-${{ inputs.build-flavour }}-${{ inputs.build-variant }}.txt"
+        mapping_full_path=$(find app/build/outputs/mapping -type f -name mapping.txt | grep "/${{ inputs.build-flavour }}" | head -n1)
+
+        if [[ -z "$mapping_full_path" ]]; then
+          echo "Failed to locate mapping.txt for ${{ inputs.build-flavour }}${{ inputs.build-variant }}"
+          find app/build/outputs/mapping -type f -name mapping.txt
+          exit 1
+        fi
+
+        if [[ -n "${{ env.VERSION_CODE }}" ]]; then
+          new_mapping_file_name="mapping-${{ env.VERSION }}-${{ env.VERSION_CODE }}-${{ inputs.build-flavour }}-${{ inputs.build-variant }}.txt"
+        else
+          # e.g. FDroid does not have version code
+          new_mapping_file_name="mapping-${{ env.VERSION }}-${{ inputs.build-flavour }}-${{ inputs.build-variant }}.txt"
+        fi
+
         mv "$mapping_full_path" "$new_mapping_file_name"
         # Set the new mapping file name as an environment variable
         echo "new_mapping_file_name=$new_mapping_file_name" >> $GITHUB_ENV


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Mapping file for fdroid build is not found

### Causes (Optional)

Fdroid builds does not have version code in their name, so the parsing of the mapping file is not able to get the right path.

### Solutions

Use find instead to find the mapping file, and check if the version code is defined for the build, use it, otherwise ignore it. This keeps retro compat with store builds and fdroid

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
