### PR TITLE
chore: migrate to kotlin Duration usage for polling, timeout units for test framework (WPB-21886)

### DIFF
--- a/.github/actions/deploy-to-s3/action.yml
+++ b/.github/actions/deploy-to-s3/action.yml
@@ -69,15 +69,19 @@ runs:
       run: |
         filename=${{ steps.path.outputs.apk_full_path }}
         
-        # Extract version name and version code
         version=$(echo "$filename" | sed -E 's/.*-v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-        version_code=$(echo "$filename" | sed -E 's/.*-([0-9]+)-${{ inputs.build-flavour }}-${{ inputs.build-variant }}\.apk/\1/')
         
-        # Print the extracted version and version code
+        version_code=$(echo "$filename" | sed -n -E 's/.*-([0-9]+)-${{ inputs.build-flavour }}-${{ inputs.build-variant }}\.apk/\1/p')
+        
+        if [[ -z "$version" ]]; then
+          echo "Failed to extract version"
+          echo "filename=$filename"
+          exit 1
+        fi
+        
         echo "Extracted version: v$version"
         echo "Extracted version code: $version_code"
         
-        # set them as environment variables for later use
         echo "VERSION=v$version" >> $GITHUB_ENV
         echo "VERSION_CODE=$version_code" >> $GITHUB_ENV
     - name: Rename mapping file
@@ -85,10 +89,21 @@ runs:
       shell: bash
       id: mapping
       run: |
-        capitalized_variant=$(echo "${{ inputs.build-variant }}" | awk '{print toupper(substr($0,1,1)) tolower(substr($0,2))}')
-        echo "Capitalized Variant: $capitalized_variant"
-        mapping_full_path="app/build/outputs/mapping/${{ inputs.build-flavour }}${capitalized_variant}/mapping.txt"
-        new_mapping_file_name="mapping-${{ env.VERSION }}-${{ env.VERSION_CODE }}-${{ inputs.build-flavour }}-${{ inputs.build-variant }}.txt"
+        mapping_full_path=$(find app/build/outputs/mapping -type f -name mapping.txt | grep "/${{ inputs.build-flavour }}" | head -n1)
+
+        if [[ -z "$mapping_full_path" ]]; then
+          echo "Failed to locate mapping.txt for ${{ inputs.build-flavour }}${{ inputs.build-variant }}"
+          find app/build/outputs/mapping -type f -name mapping.txt
+          exit 1
+        fi
+
+        if [[ -n "${{ env.VERSION_CODE }}" ]]; then
+          new_mapping_file_name="mapping-${{ env.VERSION }}-${{ env.VERSION_CODE }}-${{ inputs.build-flavour }}-${{ inputs.build-variant }}.txt"
+        else
+          # e.g. FDroid does not have version code
+          new_mapping_file_name="mapping-${{ env.VERSION }}-${{ inputs.build-flavour }}-${{ inputs.build-variant }}.txt"
+        fi
+
         mv "$mapping_full_path" "$new_mapping_file_name"
         # Set the new mapping file name as an environment variable
         echo "new_mapping_file_name=$new_mapping_file_name" >> $GITHUB_ENV

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,7 +75,7 @@ coil = "3.4.0"
 commonmark = "0.28.0"
 
 # Countly
-countly = "24.7.7"
+countly = "26.1.2"
 
 # RSS
 rss-parser = "6.0.7"

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/FileSharingBetweenTeams.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/FileSharingBetweenTeams.kt
@@ -42,6 +42,7 @@ import com.wire.android.tests.support.tags.Category
 import com.wire.android.tests.support.tags.TestCaseId
 import uiautomatorutils.UiWaitUtils
 import uiautomatorutils.UiWaitUtils.waitUntilToastIsDisplayed
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(AndroidJUnit4::class)
 class FileSharingBetweenTeams : BaseUiTest() {
@@ -200,7 +201,7 @@ class FileSharingBetweenTeams : BaseUiTest() {
         step("Play audio message and verify playback time progresses") {
             pages.conversationViewPage.apply {
                 clickPlayButtonOnAudioMessage()
-                UiWaitUtils.waitFor(10)
+                UiWaitUtils.waitFor(10.seconds)
                 clickPauseButtonOnAudioMessage()
                 assertAudioTimeIsNotZeroAnymore()
             }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupMessaging.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupMessaging.kt
@@ -38,6 +38,7 @@ import user.utils.ClientUser
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.tags.Category
 import com.wire.android.tests.support.tags.TestCaseId
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(AndroidJUnit4::class)
 class GroupMessaging : BaseUiTest() {
@@ -196,7 +197,7 @@ class GroupMessaging : BaseUiTest() {
 
         step("Verify self-deleting message expires and expiration note is shown") {
             pages.conversationViewPage.apply {
-                UiWaitUtils.waitFor(14) // Simple wait
+                UiWaitUtils.waitFor(14.seconds) // Simple wait
                 assertMessageNotVisible("This is a Self deleting Message")
                 assertSentMessageIsVisibleInCurrentConversation(
                     "After one participant has seen your message and the timer has expired on their side, this note disappears."

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupVideoCall.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupVideoCall.kt
@@ -47,6 +47,7 @@ import uiautomatorutils.UiWaitUtils.waitUntilToastIsDisplayed
 import user.usermanager.ClientUserManager
 import user.utils.ClientUser
 import kotlin.getValue
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(AndroidJUnit4::class)
 class GroupVideoCall : BaseUiTest() {
@@ -431,14 +432,14 @@ class GroupVideoCall : BaseUiTest() {
 
         step("And I play audio message") {
             pages.conversationViewPage.apply {
-                UiWaitUtils.waitFor(1)
+                UiWaitUtils.waitFor(1.seconds)
                 clickPlayButtonOnAudioMessage()
             }
         }
 
         step("And I pause audio message after 5 seconds") {
             pages.conversationViewPage.apply {
-                UiWaitUtils.waitFor(5)
+                UiWaitUtils.waitFor(5.seconds)
                 clickPauseButtonOnAudioMessage()
             }
         }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/NewMemberMessaging.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/NewMemberMessaging.kt
@@ -40,6 +40,7 @@ import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.tags.Category
 import com.wire.android.tests.support.tags.TestCaseId
 import uiautomatorutils.UiWaitUtils
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(AndroidJUnit4::class)
 class NewMemberMessaging : BaseUiTest() {
@@ -161,7 +162,7 @@ class NewMemberMessaging : BaseUiTest() {
             }
 
             pages.conversationListPage.apply {
-                UiWaitUtils.waitFor(1)
+                UiWaitUtils.waitFor(1.seconds)
                 clickCloseButtonOnNewConversationScreen()
                 assertConversationListVisible()
             }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/PersonalAccountLifeCycle.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/PersonalAccountLifeCycle.kt
@@ -41,6 +41,8 @@ import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.tags.Category
 import com.wire.android.tests.support.tags.TestCaseId
 import uiautomatorutils.KeyboardUtils.closeKeyboardIfOpened
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(AndroidJUnit4::class)
 class PersonalAccountLifeCycle : BaseUiTest() {
@@ -174,7 +176,7 @@ class PersonalAccountLifeCycle : BaseUiTest() {
                 val user = teamHelper.usersManager.findUserByNameOrNameAlias("user1Name")
                 backendClient.acceptAllIncomingConnectionRequests(user)
             }
-            UiWaitUtils.waitFor(1)
+            UiWaitUtils.waitFor(1.seconds)
             pages.conversationListPage.apply {
                 assertPendingStatusIsNoLongerVisible()
                 tapConversationNameInConversationList(teamOwner?.name ?: "")
@@ -184,8 +186,8 @@ class PersonalAccountLifeCycle : BaseUiTest() {
         // The 5s settle window specifically reduces intermittent test-service send flakes right after MLS transition.
         step("Wait until personal 1:1 conversation is upgraded to MLS") {
             pages.conversationViewPage.waitUntilConversationTurnsMls(
-                timeoutMs = 20_000,
-                settleAfterDetectedMs = 5_000
+                timeout = 20_000.milliseconds,
+                settleAfterDetected = 5_000.milliseconds
             )
         }
         step("Send message to team owner in 1:1 conversation") {
@@ -234,7 +236,7 @@ class PersonalAccountLifeCycle : BaseUiTest() {
             }
         }
 
-        UiWaitUtils.waitFor(1)
+        UiWaitUtils.waitFor(1.seconds)
         step("Verify personal account details in settings") {
             pages.settingsPage.apply {
                 tapAccountDetailsButton()

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/SSODeviceBackup.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/SSODeviceBackup.kt
@@ -44,6 +44,7 @@ import service.TestServiceHelper
 import uiautomatorutils.UiWaitUtils
 import user.usermanager.ClientUserManager
 import user.utils.ClientUser
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(AndroidJUnit4::class)
 class SSODeviceBackup : BaseUiTest() {
@@ -127,7 +128,7 @@ class SSODeviceBackup : BaseUiTest() {
                         enterOktaPassword(member1?.password ?: "")
                         tapOktaSignIn()
                         // Wait for Okta → Wire auth handoff to finish; otherwise, setting up wire page will not succeed.
-                        UiWaitUtils.waitFor(5)
+                        UiWaitUtils.waitFor(5.seconds)
                     }
                 }
 
@@ -234,7 +235,7 @@ class SSODeviceBackup : BaseUiTest() {
                         clickLoginButton()
                     }
 
-                    UiWaitUtils.waitFor(5) // Wait for Okta → Wire auth handoff to finish;
+                    UiWaitUtils.waitFor(5.seconds) // Wait for Okta → Wire auth handoff to finish;
                 }
 
                 step("Finish login flow after logout (decline share data)") {

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/CallingPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/CallingPage.kt
@@ -20,6 +20,7 @@ package com.wire.android.tests.core.pages
 import androidx.test.uiautomator.UiDevice
 import uiautomatorutils.UiSelectorParams
 import uiautomatorutils.UiWaitUtils
+import kotlin.time.Duration.Companion.milliseconds
 
 data class CallingPage(private val device: UiDevice) {
     private val hangUpCallButton = UiSelectorParams(description = "Hang up call")
@@ -61,7 +62,7 @@ data class CallingPage(private val device: UiDevice) {
 
     fun iDoNotSeeOngoingGroupCall(): CallingPage {
         try {
-            UiWaitUtils.waitElement(hangUpCallButton, timeoutMillis = 15_000)
+            UiWaitUtils.waitElement(hangUpCallButton, timeout = 15_000.milliseconds)
         } catch (e: AssertionError) {
             return this
         }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConnectedUserProfilePage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConnectedUserProfilePage.kt
@@ -21,6 +21,8 @@ import androidx.test.uiautomator.UiDevice
 import uiautomatorutils.UiSelectorParams
 import uiautomatorutils.UiWaitUtils
 import kotlin.test.DefaultAsserter.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 data class ConnectedUserProfilePage(private val device: UiDevice) {
     private val startConversationButton = UiSelectorParams(text = "Start Conversation")
@@ -55,12 +57,12 @@ data class ConnectedUserProfilePage(private val device: UiDevice) {
 
     fun assertToastMessageIsDisplayed(
         expectedMessage: String,
-        timeoutMillis: Long = 5_000
+        timeout: Duration = 5.seconds
     ): ConnectedUserProfilePage {
         UiWaitUtils.waitUntilVisibleOrThrow(
             params = UiSelectorParams(text = expectedMessage),
-            timeoutMs = timeoutMillis,
-            errorMessage = "Toast message '$expectedMessage' was not displayed within ${timeoutMillis}ms."
+            timeout = timeout,
+            errorMessage = "Toast message '$expectedMessage' was not displayed within ${timeout.inWholeMilliseconds}ms."
         )
 
         return this

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationListPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationListPage.kt
@@ -27,6 +27,9 @@ import uiautomatorutils.UiSelectorParams
 import uiautomatorutils.UiWaitUtils
 import uiautomatorutils.UiWaitUtils.findElementOrNull
 import kotlin.test.DefaultAsserter.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 data class ConversationListPage(private val device: UiDevice) {
 
@@ -69,11 +72,20 @@ data class ConversationListPage(private val device: UiDevice) {
      * The navigation drawer can appear before the Settings entry is fully attached and clickable.
      * Retry for a short window, reopening the drawer at a throttled pace until the Settings row is stable.
      */
-    fun clickSettingsButtonOnMenuEntry(timeoutMs: Long = 10_000): ConversationListPage {
+    fun clickSettingsButtonOnMenuEntry(timeout: Duration = 10.seconds): ConversationListPage {
         var lastMenuClickAt = 0L
 
-        val success = UiWaitUtils.retryUntilTimeout(timeoutMs = timeoutMs, pollingIntervalMs = 120) {
-            if (UiWaitUtils.clickWhenClickable(settingsButton, timeoutMs = 200, pollingIntervalMs = 100)) {
+        val success = UiWaitUtils.retryUntilTimeout(
+            timeout = timeout,
+            pollingInterval = UiWaitUtils.POLLING_DEFAULT
+        ) {
+            if (
+                UiWaitUtils.clickWhenClickable(
+                    settingsButton,
+                    timeout = UiWaitUtils.POLLING_DEFAULT,
+                    pollingInterval = UiWaitUtils.POLLING_FAST
+                )
+            ) {
                 true
             } else {
                 lastMenuClickAt = reopenMenuIfNeeded(lastMenuClickAt)
@@ -82,7 +94,7 @@ data class ConversationListPage(private val device: UiDevice) {
         }
 
         if (!success) {
-            throw AssertionError("Settings menu entry was not found within ${timeoutMs}ms.")
+            throw AssertionError("Settings menu entry was not found within ${timeout.inWholeMilliseconds}ms.")
         }
         return this
     }
@@ -91,7 +103,11 @@ data class ConversationListPage(private val device: UiDevice) {
         val now = SystemClock.uptimeMillis()
         if (
             now - lastMenuClickAt < minIntervalMs ||
-            !UiWaitUtils.clickWhenClickable(mainMenuButton, timeoutMs = 200, pollingIntervalMs = 100)
+            !UiWaitUtils.clickWhenClickable(
+                mainMenuButton,
+                timeout = UiWaitUtils.POLLING_DEFAULT,
+                pollingInterval = UiWaitUtils.POLLING_FAST
+            )
         ) {
             return lastMenuClickAt
         }
@@ -158,7 +174,7 @@ data class ConversationListPage(private val device: UiDevice) {
     fun clickGroupConversation(conversationName: String): ConversationListPage {
         UiWaitUtils.waitUntilVisibleOrThrow(
             params = UiSelectorParams(text = conversationName),
-            timeoutMs = 10_000,
+            timeout = 10.seconds,
             errorMessage = "Group conversation '$conversationName' was not found."
         )
 
@@ -191,20 +207,23 @@ data class ConversationListPage(private val device: UiDevice) {
         return this
     }
 
-    fun clickCloseButtonOnNewConversationScreen(timeoutMs: Long = 5_000): ConversationListPage {
+    fun clickCloseButtonOnNewConversationScreen(timeout: Duration = 5.seconds): ConversationListPage {
         val closeButton = UiSelectorParams(
             className = "android.view.View",
             description = "Close new conversation view"
         )
 
-        val closed = UiWaitUtils.retryUntilTimeout(timeoutMs = timeoutMs, pollingIntervalMs = 150) {
+        val closed = UiWaitUtils.retryUntilTimeout(
+            timeout = timeout,
+            pollingInterval = UiWaitUtils.POLLING_DEFAULT
+        ) {
             runCatching {
-                UiWaitUtils.waitElement(closeButton, timeoutMillis = 200).click()
+                UiWaitUtils.waitElement(closeButton, timeout = UiWaitUtils.POLLING_DEFAULT).click()
             }
             UiWaitUtils.findElementOrNull(conversationListHeading)?.let { !it.visibleBounds.isEmpty } == true
         }
         if (!closed) {
-            throw AssertionError("Conversation list was not visible again within ${timeoutMs}ms")
+            throw AssertionError("Conversation list was not visible again within ${timeout.inWholeMilliseconds}ms")
         }
 
         return this
@@ -221,7 +240,7 @@ data class ConversationListPage(private val device: UiDevice) {
         try {
             UiWaitUtils.waitUntilVisibleOrThrow(
                 params = UiSelectorParams(text = userName),
-                timeoutMs = 10_000,
+                timeout = 10.seconds,
                 errorMessage = "User '$userName' is not visible in the conversation list"
             )
         } catch (e: Throwable) {
@@ -231,7 +250,7 @@ data class ConversationListPage(private val device: UiDevice) {
         try {
             UiWaitUtils.waitUntilVisibleOrThrow(
                 params = pendingApprovalLabel,
-                timeoutMs = 10_000,
+                timeout = 10.seconds,
                 errorMessage = "Pending status is not visible for user '$userName'"
             )
         } catch (e: Throwable) {
@@ -247,8 +266,8 @@ data class ConversationListPage(private val device: UiDevice) {
         UiWaitUtils.waitUntilElementGone(
             device = device,
             selector = userConversationNamePendingLabelSelector,
-            timeoutMillis = 10_000,
-            pollingInterval = 250
+            timeout = 10.seconds,
+            pollingInterval = 250.milliseconds
         )
 
         return this

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationViewPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationViewPage.kt
@@ -29,6 +29,9 @@ import uiautomatorutils.UiWaitUtils
 import uiautomatorutils.UiWaitUtils.findElementOrNull
 import kotlin.test.DefaultAsserter.assertTrue
 import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 data class ConversationViewPage(private val device: UiDevice) {
     private val fileSavedToastPrefix = "The file "
@@ -123,7 +126,7 @@ data class ConversationViewPage(private val device: UiDevice) {
     fun assertAudioTimeIsNotZeroAnymore(): ConversationViewPage {
         UiWaitUtils.waitUntilGoneOrThrow(
             selector = By.text("00:00"),
-            timeoutMs = 5_000,
+            timeout = UiWaitUtils.SHORT_TIMEOUT,
             errorMessage = "Audio time is still at 00:00, expected it to have changed"
         )
         return this
@@ -184,15 +187,15 @@ data class ConversationViewPage(private val device: UiDevice) {
         return this
     }
 
-    fun assertFileActionModalIsVisible(timeoutMs: Long = 8_000): ConversationViewPage {
+    fun assertFileActionModalIsVisible(timeout: Duration = 8.seconds): ConversationViewPage {
         val modalAnchors = listOf(modalTextLocator, saveButton, openButton, cancelButton)
         val visibleAnchor = UiWaitUtils.waitAnyVisible(
             selectors = modalAnchors,
-            timeoutMs = timeoutMs,
-            pollingIntervalMs = 150
+            timeout = timeout,
+            pollingInterval = 150.milliseconds
         )
         if (visibleAnchor == null) {
-            throw AssertionError("The file action modal was not visible within ${timeoutMs}ms.")
+            throw AssertionError("The file action modal was not visible within ${timeout.inWholeMilliseconds}ms.")
         }
         return this
     }
@@ -237,8 +240,8 @@ data class ConversationViewPage(private val device: UiDevice) {
         return this
     }
 
-    fun clickSaveButtonOnDownloadModal(timeoutMs: Long = 8_000): ConversationViewPage {
-        val save = UiWaitUtils.waitElement(saveButton, timeoutMillis = timeoutMs)
+    fun clickSaveButtonOnDownloadModal(timeout: Duration = 8.seconds): ConversationViewPage {
+        val save = UiWaitUtils.waitElement(saveButton, timeout = timeout)
         val bounds = runCatching { save.visibleBounds }.getOrNull()
 
         runCatching { save.click() }
@@ -259,18 +262,18 @@ data class ConversationViewPage(private val device: UiDevice) {
         return this
     }
 
-    fun waitForPreviousFileSavedToastToDisappear(timeoutMillis: Long = 7_000): ConversationViewPage {
+    fun waitForPreviousFileSavedToastToDisappear(timeout: Duration = 7.seconds): ConversationViewPage {
         UiWaitUtils.waitUntilGoneOrThrow(
             selector = By.textContains(fileSavedToastMessage),
-            timeoutMs = timeoutMillis,
-            errorMessage = "File saved toast did not disappear within ${timeoutMillis}ms."
+            timeout = timeout,
+            errorMessage = "File saved toast did not disappear within ${timeout.inWholeMilliseconds}ms."
         )
         return this
     }
 
     fun assertFileSavedToast(
         expectedMessage: String,
-        timeoutMs: Long = 7_000
+        timeout: Duration = 7.seconds
     ): ConversationViewPage {
         val toastPattern = buildSavedFileToastPattern(expectedMessage)
 
@@ -278,8 +281,8 @@ data class ConversationViewPage(private val device: UiDevice) {
             params = UiSelectorParams(
                 textMatches = toastPattern
             ),
-            timeoutMs = timeoutMs,
-            errorMessage = "Toast '$expectedMessage' was not displayed within ${timeoutMs}ms."
+            timeout = timeout,
+            errorMessage = "Toast '$expectedMessage' was not displayed within ${timeout.inWholeMilliseconds}ms."
         )
         return this
     }
@@ -373,8 +376,8 @@ data class ConversationViewPage(private val device: UiDevice) {
 
     fun assertMessageNotVisible(text: String, timeoutSeconds: Int = 5) {
         val notVisible = UiWaitUtils.retryUntilTimeout(
-            timeoutMs = timeoutSeconds * 1_000L,
-            pollingIntervalMs = 250
+            timeout = timeoutSeconds.seconds,
+            pollingInterval = UiWaitUtils.POLLING_SLOW
         ) {
             findElementOrNull(UiSelectorParams(text = text)) == null
         }
@@ -478,7 +481,7 @@ data class ConversationViewPage(private val device: UiDevice) {
 
         UiWaitUtils.waitUntilVisible(
             params = params,
-            timeoutMs = 5_000,
+            timeout = 5.seconds,
             errorMessage = "Group conversation details for user '$userName' not visible"
         )
 
@@ -537,22 +540,22 @@ data class ConversationViewPage(private val device: UiDevice) {
     }
 
     fun waitUntilConversationTurnsMls(
-        timeoutMs: Long = 20_000,
-        settleAfterDetectedMs: Long = 0
+        timeout: Duration = 20.seconds,
+        settleAfterDetected: Duration = Duration.ZERO
     ): ConversationViewPage {
         val mlsMarker = UiWaitUtils.waitAnyVisible(
             selectors = mlsUpgradeMessageSelectors,
-            timeoutMs = timeoutMs,
-            pollingIntervalMs = 200
+            timeout = timeout,
+            pollingInterval = 200.milliseconds
         )
-            if (mlsMarker != null) {
-                // MLS banner can appear slightly before the conversation is fully ready for a first outbound message.
-                if (settleAfterDetectedMs > 0) {
-                    UiWaitUtils.waitForMillis(settleAfterDetectedMs)
-                }
-                return this
+        if (mlsMarker != null) {
+            // MLS banner can appear slightly before the conversation is fully ready for a first outbound message.
+            if (settleAfterDetected > Duration.ZERO) {
+                UiWaitUtils.waitFor(settleAfterDetected)
             }
-        throw AssertionError("MLS upgrade system message was not visible within ${timeoutMs}ms.")
+            return this
+        }
+        throw AssertionError("MLS upgrade system message was not visible within ${timeout.inWholeMilliseconds}ms.")
     }
 
     fun tapPingButton(): ConversationViewPage {

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/DocumentsUIPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/DocumentsUIPage.kt
@@ -21,6 +21,7 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.StaleObjectException
 import uiautomatorutils.UiSelectorParams
 import uiautomatorutils.UiWaitUtils
+import kotlin.time.Duration.Companion.milliseconds
 
 data class DocumentsUIPage(private val device: UiDevice) {
     private val sendButton = UiSelectorParams(text = "Send")
@@ -49,7 +50,7 @@ data class DocumentsUIPage(private val device: UiDevice) {
     private fun clickWithRetry(selector: UiSelectorParams, attempts: Int = 3): Boolean {
         repeat(attempts) {
             try {
-                UiWaitUtils.waitElement(selector, timeoutMillis = 1500).click()
+                UiWaitUtils.waitElement(selector, timeout = 1500.milliseconds).click()
                 return true
             } catch (_: StaleObjectException) {
                 // Retry with a fresh node.

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/NotificationsPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/NotificationsPage.kt
@@ -20,18 +20,23 @@ package com.wire.android.tests.core.pages
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import uiautomatorutils.UiWaitUtils
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 class NotificationsPage(private val device: UiDevice) {
-    fun waitUntilNotificationPopUpGone(timeoutMillis: Long = 10_000L) {
+    fun waitUntilNotificationPopUpGone(timeout: Duration = 10.seconds) {
         val replyButton = By.text("Reply")
-        val appearedWithinProbeWindow = UiWaitUtils.retryUntilTimeout(timeoutMs = 1_000, pollingIntervalMs = 100) {
+        val appearedWithinProbeWindow = UiWaitUtils.retryUntilTimeout(
+            timeout = 1.seconds,
+            pollingInterval = UiWaitUtils.POLLING_FAST
+        ) {
             device.hasObject(replyButton)
         }
         if (appearedWithinProbeWindow) {
             UiWaitUtils.waitUntilGoneOrThrow(
                 selector = replyButton,
-                timeoutMs = timeoutMillis,
-                errorMessage = "Notification pop-up with 'Reply' did not disappear within $timeoutMillis ms"
+                timeout = timeout,
+                errorMessage = "Notification pop-up with 'Reply' did not disappear within ${timeout.inWholeMilliseconds} ms"
             )
         }
     }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/RegistrationPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/RegistrationPage.kt
@@ -28,6 +28,9 @@ import org.junit.Assert.assertTrue
 import uiautomatorutils.UiSelectorParams
 import uiautomatorutils.UiWaitUtils
 import uiautomatorutils.UiWaitUtils.waitUntilElementGone
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class RegistrationPage(private val device: UiDevice) {
 
@@ -71,10 +74,13 @@ class RegistrationPage(private val device: UiDevice) {
     }
 
     fun enterPersonalUserRegistrationEmail(email: String): RegistrationPage {
-        val success = UiWaitUtils.retryUntilTimeout(timeoutMs = 6_000, pollingIntervalMs = 150) {
+        val success = UiWaitUtils.retryUntilTimeout(
+            timeout = 6.seconds,
+            pollingInterval = UiWaitUtils.POLLING_DEFAULT
+        ) {
             runCatching {
-                UiWaitUtils.waitElement(emailInputField, timeoutMillis = 2_000).click()
-                UiWaitUtils.waitElement(emailInputField, timeoutMillis = 2_000).text = email
+                UiWaitUtils.waitElement(emailInputField, timeout = 2.seconds).click()
+                UiWaitUtils.waitElement(emailInputField, timeout = 2.seconds).text = email
             }.isSuccess
         }
 
@@ -85,12 +91,15 @@ class RegistrationPage(private val device: UiDevice) {
     }
 
     @Suppress("NestedBlockDepth")
-    fun clickLoginButton(timeoutMs: Long = 10_000): RegistrationPage {
+    fun clickLoginButton(timeout: Duration = 10.seconds): RegistrationPage {
         var lastError: AssertionError? = null
 
-        val success = UiWaitUtils.retryUntilTimeout(timeoutMs = timeoutMs, pollingIntervalMs = 200) {
+        val success = UiWaitUtils.retryUntilTimeout(
+            timeout = timeout,
+            pollingInterval = UiWaitUtils.POLLING_DEFAULT
+        ) {
             try {
-                UiWaitUtils.waitElement(loginButton, timeoutMillis = 1_500).click()
+                UiWaitUtils.waitElement(loginButton, timeout = 1500.milliseconds).click()
                 true
             } catch (e: AssertionError) {
                 lastError = e
@@ -112,7 +121,7 @@ class RegistrationPage(private val device: UiDevice) {
 
         if (!success) {
             throw AssertionError(
-                "Login button was not clickable within ${timeoutMs}ms.",
+                "Login button was not clickable within ${timeout.inWholeMilliseconds}ms.",
                 lastError
             )
         }
@@ -197,12 +206,12 @@ class RegistrationPage(private val device: UiDevice) {
         val codeInputField = UiWaitUtils.waitElement(UiSelectorParams(className = "android.widget.EditText"))
         codeInputField.click()
         codeInputField.text = code
-        UiWaitUtils.waitElement(userNameInfoText, timeoutMillis = 15_000)
+        UiWaitUtils.waitElement(userNameInfoText, timeout = 15.seconds)
         return this
     }
 
     fun assertEnterYourUserNameInfoText(): RegistrationPage {
-        val info = UiWaitUtils.waitElement(userNameInfoText, timeoutMillis = 15_000)
+        val info = UiWaitUtils.waitElement(userNameInfoText, timeout = 15.seconds)
         assertTrue("Username info not visible", !info.visibleBounds.isEmpty)
         return this
     }
@@ -236,12 +245,15 @@ class RegistrationPage(private val device: UiDevice) {
     }
 
     @Suppress("MagicNumber")
-    fun clickDeclineShareDataAlert(timeoutMs: Long = 10_000): RegistrationPage {
-        val dismissed = UiWaitUtils.retryUntilTimeout(timeoutMs = timeoutMs, pollingIntervalMs = 150) {
+    fun clickDeclineShareDataAlert(timeout: Duration = 10.seconds): RegistrationPage {
+        val dismissed = UiWaitUtils.retryUntilTimeout(
+            timeout = timeout,
+            pollingInterval = UiWaitUtils.POLLING_DEFAULT
+        ) {
             UiWaitUtils.clickWhenClickable(
                 params = declineButton,
-                timeoutMs = 200,
-                pollingIntervalMs = 100
+                timeout = UiWaitUtils.POLLING_DEFAULT,
+                pollingInterval = UiWaitUtils.POLLING_FAST
             )
 
             val dialogVisible = UiWaitUtils.findElementOrNull(consentDialogTitle)?.let { !it.visibleBounds.isEmpty } == true
@@ -249,7 +261,7 @@ class RegistrationPage(private val device: UiDevice) {
             !dialogVisible && !declineVisible
         }
         if (!dismissed) {
-            throw AssertionError("Share data consent alert was not dismissed within ${timeoutMs}ms.")
+            throw AssertionError("Share data consent alert was not dismissed within ${timeout.inWholeMilliseconds}ms.")
         }
         return this
     }
@@ -268,8 +280,8 @@ class RegistrationPage(private val device: UiDevice) {
     fun waitUntilLoginFlowIsCompleted(): RegistrationPage {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         try {
-            waitUntilElementGone(device, loginButtonGoneSelector, timeoutMillis = 15_000)
-            waitUntilElementGone(device, settingUpWireGoneSelector, timeoutMillis = 35_000)
+            waitUntilElementGone(device, loginButtonGoneSelector, timeout = 15.seconds)
+            waitUntilElementGone(device, settingUpWireGoneSelector, timeout = 35.seconds)
         } catch (e: AssertionError) {
             throw AssertionError(
                 "Login flow did not complete: login button or 'Setting up Wire' is still visible",
@@ -281,7 +293,7 @@ class RegistrationPage(private val device: UiDevice) {
 
     fun waitUntilRegistrationFlowIsCompleted(): RegistrationPage {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        waitUntilElementGone(device, UiSelector().text("Confirm"), timeoutMillis = 16_000)
+        waitUntilElementGone(device, UiSelector().text("Confirm"), timeout = 16.seconds)
         return this
     }
 

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SSOPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SSOPage.kt
@@ -20,6 +20,8 @@ package com.wire.android.tests.core.pages
 import androidx.test.uiautomator.UiDevice
 import uiautomatorutils.UiSelectorParams
 import uiautomatorutils.UiWaitUtils
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 data class SSOPage(private val device: UiDevice) {
 
@@ -44,10 +46,10 @@ data class SSOPage(private val device: UiDevice) {
         return this
     }
 
-    fun waitUntilOktaPageLoaded(timeoutMs: Long = 20_000): SSOPage {
+    fun waitUntilOktaPageLoaded(timeout: Duration = 20.seconds): SSOPage {
         UiWaitUtils.waitUntilVisibleOrThrow(
             params = oktaSignInButton,
-            timeoutMs = timeoutMs,
+            timeout = timeout,
             errorMessage = "Okta page did not load: Email and password input field is not visible"
         )
         return this

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SettingsPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SettingsPage.kt
@@ -33,6 +33,8 @@ import uiautomatorutils.UiSelectorParams
 import uiautomatorutils.UiWaitUtils
 import user.usermanager.ClientUserManager
 import kotlin.test.DefaultAsserter.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 data class SettingsPage(private val device: UiDevice) {
     private fun backupFileLocator(uniqueUserName: String) = UiSelectorParams(textContains = "Wire-$uniqueUserName")
@@ -141,21 +143,24 @@ data class SettingsPage(private val device: UiDevice) {
         return this
     }
 
-fun openBackupAndRestoreConversationsMenu(timeoutMs: Long = 10_000): SettingsPage {
-    val opened = UiWaitUtils.retryUntilTimeout(timeoutMs = timeoutMs, pollingIntervalMs = 200) {
-        UiWaitUtils.clickWhenClickable(
-            params = backUpMenuButton,
-            timeoutMs = 200,
-            pollingIntervalMs = 100
-        )
-        isBackupPageOpen()
-    }
+    fun openBackupAndRestoreConversationsMenu(timeout: Duration = UiWaitUtils.MEDIUM_TIMEOUT): SettingsPage {
+        val opened = UiWaitUtils.retryUntilTimeout(
+            timeout = timeout,
+            pollingInterval = UiWaitUtils.POLLING_DEFAULT
+        ) {
+            UiWaitUtils.clickWhenClickable(
+                params = backUpMenuButton,
+                timeout = UiWaitUtils.POLLING_DEFAULT,
+                pollingInterval = UiWaitUtils.POLLING_FAST
+            )
+            isBackupPageOpen()
+        }
 
-    if (!opened) {
-        throw AssertionError("Could not open 'Back up & Restore Conversations' within ${timeoutMs}ms.")
-    }
+        if (!opened) {
+            throw AssertionError("Could not open 'Back up & Restore Conversations' within ${timeout.inWholeMilliseconds}ms.")
+        }
 
-    return this
+        return this
     }
 
     private fun isBackupPageOpen(): Boolean {
@@ -191,7 +196,7 @@ fun openBackupAndRestoreConversationsMenu(timeoutMs: Long = 10_000): SettingsPag
     fun iSeeBackupConfirmation(text: String): SettingsPage {
         UiWaitUtils.waitUntilVisibleOrThrow(
             params = UiSelectorParams(textContains = text),
-            timeoutMs = 5_000,
+            timeout = UiWaitUtils.SHORT_TIMEOUT,
             errorMessage = "Expected message '$text' was not displayed"
         )
         return this
@@ -406,10 +411,10 @@ fun openBackupAndRestoreConversationsMenu(timeoutMs: Long = 10_000): SettingsPag
         context.startActivity(intent)
     }
 
-    fun assertEmailVerifiedMessageVisibleOnChrome(timeoutMillis: Long = 15_000): SettingsPage {
+    fun assertEmailVerifiedMessageVisibleOnChrome(timeout: Duration = 15.seconds): SettingsPage {
         UiWaitUtils.waitUntilVisibleOrThrow(
             params = UiSelectorParams(textContains = "Email verified"),
-            timeoutMs = timeoutMillis,
+            timeout = timeout,
             errorMessage = "Email Verified text not found in Chrome after 15 seconds."
         )
         return this
@@ -430,14 +435,17 @@ fun openBackupAndRestoreConversationsMenu(timeoutMs: Long = 10_000): SettingsPag
     fun assertChromeUrlIsDisplayed(expectedUrl: String): SettingsPage {
         UiWaitUtils.waitUntilVisibleOrThrow(
             params = UiSelectorParams(textContains = expectedUrl),
-            timeoutMs = 5_000,
+            timeout = UiWaitUtils.SHORT_TIMEOUT,
             errorMessage = "Expected URL '$expectedUrl' was not found in Chrome"
         )
         return this
     }
 
-    fun assertDeleteAccountConfirmationModalIsNoLongerVisible(timeoutMs: Long = 10_000): SettingsPage {
-        val isGone = UiWaitUtils.retryUntilTimeout(timeoutMs = timeoutMs, pollingIntervalMs = 150) {
+    fun assertDeleteAccountConfirmationModalIsNoLongerVisible(timeout: Duration = 10.seconds): SettingsPage {
+        val isGone = UiWaitUtils.retryUntilTimeout(
+            timeout = timeout,
+            pollingInterval = UiWaitUtils.POLLING_DEFAULT
+        ) {
             val modal = UiWaitUtils.findElementOrNull(deleteAccountConfirmationModal)
             modal == null || modal.visibleBounds.isEmpty
         }
@@ -467,7 +475,7 @@ fun openBackupAndRestoreConversationsMenu(timeoutMs: Long = 10_000): SettingsPag
     fun waitUntilThisTextIsDisplayedOnBackupAlert(text: String): SettingsPage {
         UiWaitUtils.waitUntilVisibleOrThrow(
             params = UiSelectorParams(text = text),
-            timeoutMs = 5_000,
+            timeout = UiWaitUtils.SHORT_TIMEOUT,
             errorMessage = "Text '$text' was not displayed on the backup alert within timeout"
         )
         return this

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/tests/PersonalUserRegistrationTest.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/tests/PersonalUserRegistrationTest.kt
@@ -35,6 +35,7 @@ import com.wire.android.tests.support.tags.Category
 import com.wire.android.tests.support.tags.TestCaseId
 import uiautomatorutils.KeyboardUtils.closeKeyboardIfOpened
 import uiautomatorutils.UiWaitUtils
+import kotlin.time.Duration.Companion.seconds
 
 /*
 This test works on the following conditions:
@@ -127,7 +128,7 @@ class PersonalUserRegistrationTest : BaseUiTest() {
         step("Enter OTP and complete account creation") {
             pages.registrationPage.apply {
                 enter2FAOnCreatePersonalAccountPage(otp)
-                UiWaitUtils.waitFor(5)
+                UiWaitUtils.waitFor(5.seconds)
 
                 assertEnterYourUserNameInfoText()
                 assertUserNameHelpText()

--- a/tests/testsSupport/src/main/call/CallHelper.kt
+++ b/tests/testsSupport/src/main/call/CallHelper.kt
@@ -33,6 +33,7 @@ import call.pinger.UiAutomatorPinger
 import uiautomatorutils.UiSelectorParams
 import uiautomatorutils.UiWaitUtils
 import user.usermanager.ClientUserManager
+import kotlin.time.Duration.Companion.seconds
 
 class CallHelper {
     lateinit var usersManager: ClientUserManager
@@ -74,7 +75,7 @@ class CallHelper {
         callingManager.verifyAcceptingCallStatus(
             usersManager.splitAliases(callees),
             expectedStatuses,
-            timeoutSeconds
+            timeoutSeconds.seconds
         )
         UiAutomatorPinger.stopPinging()
     }

--- a/tests/testsSupport/src/main/call/CallingManager.kt
+++ b/tests/testsSupport/src/main/call/CallingManager.kt
@@ -56,15 +56,18 @@ import org.json.JSONObject
 import service.getConversationByName
 import user.utils.ClientUser
 import java.util.concurrent.TimeoutException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class CallingManager(private val usersManager: ClientUserManager) {
     companion object {
-        private const val POLL_INTERVAL_MS = 2000L
-        private const val TIMEOUT_INSTANCE_START = 190_000L
-        private const val TIMEOUT_POSITIVE_FLOWCHECK = 30_000L
-        private const val TIMEOUT_NEGATIVE_FLOWCHECK = 20_000L
-        private const val TIMEOUT_PEER_CONNECTIONS = 20_000L
-        private const val FLOWCHECK_POLLING_MS = 2000L
+        private val POLL_INTERVAL = 2.seconds
+        private val TIMEOUT_INSTANCE_START = 190.seconds
+        private val TIMEOUT_POSITIVE_FLOWCHECK = 30.seconds
+        private val TIMEOUT_NEGATIVE_FLOWCHECK = 20.seconds
+        private val TIMEOUT_PEER_CONNECTIONS = 20.seconds
+        private val FLOWCHECK_POLLING = 2.seconds
 
         private const val CHROME_SUPPORT_VERSION = "102.0.5005.115"
         private const val CHROME_CURRENT_VERSION = "128.0.6613.137"
@@ -178,16 +181,16 @@ class CallingManager(private val usersManager: ClientUserManager) {
     suspend fun verifyInstanceStatus(
         userNames: List<String>,
         expected: InstanceStatus,
-        timeoutMs: Long = TIMEOUT_INSTANCE_START
+        timeout: Duration = TIMEOUT_INSTANCE_START
     ) = withContext(Dispatchers.IO) {
         userNames.forEach { name ->
             val user = usersManager.findUserByNameOrNameAlias(name)
             val instance = getInstance(user)
-            withTimeout(timeoutMs) {
+            withTimeout(timeout) {
                 while (true) {
                     val status = client.getInstanceStatus(instance)
                     if (status == expected) return@withTimeout
-                    delay(POLL_INTERVAL_MS)
+                    delay(POLL_INTERVAL)
                 }
             }
         }
@@ -197,18 +200,18 @@ class CallingManager(private val usersManager: ClientUserManager) {
         callerName: String,
         conversationName: String,
         expected: List<CallStatus>,
-        timeoutMs: Long = TIMEOUT_PEER_CONNECTIONS
+        timeout: Duration = TIMEOUT_PEER_CONNECTIONS
     ) = withContext(Dispatchers.IO) {
         val user = usersManager.findUserByNameOrNameAlias(callerName)
         val convId = getConversationId(user, conversationName)
         val instance = getInstance(user)
         val call = getOutgoingCall(user, convId)
 
-        withTimeout(timeoutMs) {
+        withTimeout(timeout) {
             while (true) {
                 val status = client.getCall(instance, call).status
                 if (status in expected) return@withTimeout
-                delay(POLL_INTERVAL_MS)
+                delay(POLL_INTERVAL)
             }
         }
     }
@@ -216,7 +219,7 @@ class CallingManager(private val usersManager: ClientUserManager) {
     suspend fun verifyAcceptingCallStatus(
         calleeNames: List<String>,
         expectedStatuses: String,
-        secondsTimeout: Int
+        timeout: Duration
     ) {
         for (calleeName in calleeNames) {
             val userAs = usersManager.findUserByNameOrNameAlias(calleeName)
@@ -224,7 +227,7 @@ class CallingManager(private val usersManager: ClientUserManager) {
                 getInstance(userAs),
                 getIncomingCall(userAs),
                 callStatusesListToObject(expectedStatuses),
-                secondsTimeout
+                timeout
             )
         }
     }
@@ -253,27 +256,27 @@ class CallingManager(private val usersManager: ClientUserManager) {
         instance: Instance,
         call: Call,
         expectedStatuses: List<CallStatus>,
-        secondsTimeout: Int
+        timeout: Duration
     ) {
-        val millisecondsStarted = System.currentTimeMillis()
+        val startedAt = System.currentTimeMillis()
         var currentStatus: CallStatus? = null
 
-        while (System.currentTimeMillis() - millisecondsStarted <= secondsTimeout * 1000L) {
+        while (System.currentTimeMillis() - startedAt <= timeout.inWholeMilliseconds) {
             currentStatus = client.getCall(instance, call).status
             if (expectedStatuses.contains(currentStatus)) {
                 return
             }
-            delay(2000)
+            delay(2.seconds)
         }
 
         throw TimeoutException(
             "Call status '$currentStatus' for instance '${instance.id}' " +
-                    "has not been changed to '$expectedStatuses' after $secondsTimeout second(s) timeout"
+                    "has not been changed to '$expectedStatuses' after ${timeout.inWholeSeconds} second(s) timeout"
         )
     }
 
     suspend fun <T> withTimeout(
-        timeoutMs: Long,
+        timeout: Duration,
         block: suspend CoroutineScope.() -> T
     ): T = coroutineScope {
         val result = CompletableDeferred<T>()
@@ -294,9 +297,9 @@ class CallingManager(private val usersManager: ClientUserManager) {
                 value // ✅ return the value here
             }
 
-            onTimeout(timeoutMs) {
+            onTimeout(timeout.inWholeMilliseconds) {
                 job.cancel()
-                throw Exception("Timed out after $timeoutMs ms") // ✅ return a T by throwing
+                throw Exception("Timed out after ${timeout.inWholeMilliseconds} ms") // ✅ return a T by throwing
             }
         }
     }
@@ -346,14 +349,14 @@ class CallingManager(private val usersManager: ClientUserManager) {
             val user = usersManager.findUserByNameOrNameAlias(name)
 
             waitUntil(
-                timeoutMs = TIMEOUT_PEER_CONNECTIONS,
-                intervalMs = FLOWCHECK_POLLING_MS
+                timeout = TIMEOUT_PEER_CONNECTIONS,
+                interval = FLOWCHECK_POLLING
             ) {
                 val flows = safeGetFlows(user).filter { !it.isEmptyFlow() }
                 flows.size == expectedFlowCount
             }
 
-            delay(3000)
+            delay(3.seconds)
             val finalFlows = safeGetFlows(user).filter { !it.isEmptyFlow() }
             check(finalFlows.size == expectedFlowCount) {
                 "Unexpected number of flows for $name: got ${finalFlows.size}, expected $expectedFlowCount"
@@ -491,7 +494,7 @@ class CallingManager(private val usersManager: ClientUserManager) {
     ) {
         val flows = mutableListOf<CallFlow>()
 
-        val success = waitUntil(TIMEOUT_POSITIVE_FLOWCHECK, FLOWCHECK_POLLING_MS) {
+        val success = waitUntil(TIMEOUT_POSITIVE_FLOWCHECK, FLOWCHECK_POLLING) {
             val flowSnapshot = getFlowForRemoteUser(user, flowBefore.remoteUserId)
             flows += flowSnapshot
 
@@ -520,7 +523,7 @@ class CallingManager(private val usersManager: ClientUserManager) {
     ) {
         val flows = mutableListOf<CallFlow>()
 
-        val success = waitUntil(TIMEOUT_NEGATIVE_FLOWCHECK, FLOWCHECK_POLLING_MS) {
+        val success = waitUntil(TIMEOUT_NEGATIVE_FLOWCHECK, FLOWCHECK_POLLING) {
             val flowSnapshot = getFlowForRemoteUser(user, flowBefore.remoteUserId)
             flows += flowSnapshot
 
@@ -549,7 +552,7 @@ class CallingManager(private val usersManager: ClientUserManager) {
         withContext(Dispatchers.IO) {
             val flows = client.getFlows(getInstance(user)).filter { !it.isEmptyFlow() }
             flows.ifEmpty {
-                delay(2000)
+                delay(2.seconds)
                 client.getFlows(getInstance(user))
             }
         }
@@ -559,7 +562,7 @@ class CallingManager(private val usersManager: ClientUserManager) {
             val userAs = usersManager.findUserByNameOrNameAlias(user)
             val flows = client.getFlows(getInstance(userAs)).filter { !it.isEmptyFlow() }
             flows.ifEmpty {
-                delay(2000)
+                delay(2.seconds)
                 client.getFlows(getInstance(userAs))
             }
         }
@@ -567,14 +570,14 @@ class CallingManager(private val usersManager: ClientUserManager) {
     private fun CallFlow.isEmptyFlow() = audioPacketsSent == -1L && audioPacketsReceived == -1L
 
     private suspend fun waitUntil(
-        timeoutMs: Long,
-        intervalMs: Long,
+        timeout: Duration,
+        interval: Duration,
         condition: suspend () -> Boolean
     ): Boolean {
         val start = System.currentTimeMillis()
-        while (System.currentTimeMillis() - start < timeoutMs) {
+        while (System.currentTimeMillis() - start < timeout.inWholeMilliseconds) {
             if (condition()) return true
-            delay(intervalMs)
+            delay(interval)
         }
         return false
     }
@@ -618,7 +621,7 @@ class CallingManager(private val usersManager: ClientUserManager) {
             val user = usersManager.findUserByNameOrNameAlias(name)
             val instance = getInstance(user)
             client.getCurrentCall(instance)?.let { client.switchVideoOn(instance, it) }
-            delay(500)
+            delay(500.milliseconds)
         }
     }
 

--- a/tests/testsSupport/src/main/okta/OktaApiClient.kt
+++ b/tests/testsSupport/src/main/okta/OktaApiClient.kt
@@ -30,11 +30,14 @@ import java.net.HttpURLConnection
 import java.net.URL
 import javax.net.ssl.HttpsURLConnection
 import kotlin.math.max
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.minutes
 
 class OktaApiClient {
 
-    private val CONNECT_TIMEOUT_MS = 3_000
-    private val READ_TIMEOUT_MS = 240_000
+    private val CONNECT_TIMEOUT = 3.seconds
+    private val READ_TIMEOUT = 4.minutes
     private val BASE_URI = "https://dev-500508-admin.oktapreview.com"
     private val apiKey: String by lazy { BuildConfig.OKTA_API_KEY_PASSWORD }
 
@@ -73,9 +76,9 @@ class OktaApiClient {
                 }
 
                 if (code == 429 && attempt < retries - 1) {
-                    val waitMs = retryAfterMs ?: (2_000L * (attempt + 1))
+                    val wait = retryAfterMs?.milliseconds ?: (2.seconds * (attempt + 1))
                     try {
-                        Thread.sleep(waitMs)
+                        Thread.sleep(wait.inWholeMilliseconds)
                     } catch (_: InterruptedException) {
                     }
                     return@repeat
@@ -115,8 +118,8 @@ class OktaApiClient {
                 setRequestProperty("Authorization", "SSWS $apiKey")
                 setRequestProperty("Content-Type", "application/json")
                 setRequestProperty("Accept", accept)
-                connectTimeout = CONNECT_TIMEOUT_MS
-                readTimeout = READ_TIMEOUT_MS
+                connectTimeout = CONNECT_TIMEOUT.inWholeMilliseconds.toInt()
+                readTimeout = READ_TIMEOUT.inWholeMilliseconds.toInt()
                 if (method == "POST" || method == "PUT") {
                     doOutput = true
                     body?.let { outputStream.bufferedWriter().use { w -> w.write(it) } }

--- a/tests/testsSupport/src/main/uiautomatorutils/KeyboardUtils.kt
+++ b/tests/testsSupport/src/main/uiautomatorutils/KeyboardUtils.kt
@@ -20,16 +20,17 @@ package uiautomatorutils
 import android.os.SystemClock
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import kotlin.time.Duration.Companion.milliseconds
 
 object KeyboardUtils {
-    private const val keyboardSettleDelayMs = 300L
+    private val keyboardSettleDelay = 300.milliseconds
 
     fun closeKeyboardIfOpened() {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         if (isKeyboardVisible(device)) {
             device.pressBack()
             device.waitForIdle()
-            SystemClock.sleep(keyboardSettleDelayMs)
+            SystemClock.sleep(keyboardSettleDelay.inWholeMilliseconds)
         }
     }
 

--- a/tests/testsSupport/src/main/uiautomatorutils/UiWaitUtils.kt
+++ b/tests/testsSupport/src/main/uiautomatorutils/UiWaitUtils.kt
@@ -31,11 +31,13 @@ import androidx.test.uiautomator.Until
 import junit.framework.TestCase.assertTrue
 import java.io.IOException
 import java.util.regex.Pattern
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
-private const val TIMEOUT_IN_MILLISECONDS = 10000L
-private const val DEFAULT_POLLING_INTERVAL_MS = 200L
-private const val STABILIZE_TIMEOUT_MS = 3_000L
-private const val STABILIZE_POLLING_INTERVAL_MS = 100L
+private val TIMEOUT_DURATION = 10.seconds
+private val STABILIZE_TIMEOUT = 3.seconds
+private val STABILIZE_POLLING_INTERVAL = 100.milliseconds
 
 data class UiSelectorParams(
     val text: String? = null,
@@ -46,7 +48,7 @@ data class UiSelectorParams(
     val description: String? = null,
     val instance: Int? = null,
     val fromParentText: String? = null,
-    val timeout: Long = TIMEOUT_IN_MILLISECONDS
+    val timeout: Duration = TIMEOUT_DURATION
 )
 
 /**
@@ -58,6 +60,14 @@ data class UiSelectorParams(
 
 @Suppress("TooManyFunctions")
 object UiWaitUtils {
+    val POLLING_FAST: Duration = 100.milliseconds
+    val POLLING_DEFAULT: Duration = 200.milliseconds
+    val POLLING_SLOW: Duration = 250.milliseconds
+    val DEFAULT_TIMEOUT: Duration = TIMEOUT_DURATION
+    val SHORT_TIMEOUT: Duration = 5.seconds
+    val MEDIUM_TIMEOUT: Duration = 10.seconds
+    val LONG_TIMEOUT: Duration = 15.seconds
+    val VERY_LONG_TIMEOUT: Duration = 30.seconds
 
     private fun buildSelector(params: UiSelectorParams): BySelector {
         var selector: BySelector? = when {
@@ -106,16 +116,16 @@ object UiWaitUtils {
      * @return `true` if [condition] succeeded before timeout, otherwise `false`.
      */
     fun retryUntilTimeout(
-        timeoutMs: Long,
-        pollingIntervalMs: Long = DEFAULT_POLLING_INTERVAL_MS,
+        timeout: Duration,
+        pollingInterval: Duration = POLLING_DEFAULT,
         condition: () -> Boolean
     ): Boolean {
-        val deadline = SystemClock.uptimeMillis() + timeoutMs
+        val deadline = SystemClock.uptimeMillis() + timeout.inWholeMilliseconds
         while (SystemClock.uptimeMillis() < deadline) {
             if (condition()) {
                 return true
             }
-            SystemClock.sleep(pollingIntervalMs)
+            SystemClock.sleep(pollingInterval.inWholeMilliseconds)
         }
         return condition()
     }
@@ -127,16 +137,16 @@ object UiWaitUtils {
      */
     fun waitUntilVisibleOrThrow(
         params: UiSelectorParams,
-        timeoutMs: Long = TIMEOUT_IN_MILLISECONDS,
+        timeout: Duration = DEFAULT_TIMEOUT,
         errorMessage: String
     ) {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         val isVisible = retryUntilTimeout(
-            timeoutMs = timeoutMs,
-            pollingIntervalMs = DEFAULT_POLLING_INTERVAL_MS
+            timeout = timeout,
+            pollingInterval = POLLING_DEFAULT
         ) {
             runCatching {
-                device.wait(Until.hasObject(params.toBySelector()), DEFAULT_POLLING_INTERVAL_MS)
+                device.wait(Until.hasObject(params.toBySelector()), POLLING_DEFAULT.inWholeMilliseconds)
             }.getOrDefault(false)
         }
 
@@ -152,14 +162,14 @@ object UiWaitUtils {
      */
     fun waitAnyVisible(
         selectors: List<UiSelectorParams>,
-        timeoutMs: Long = TIMEOUT_IN_MILLISECONDS,
-        pollingIntervalMs: Long = DEFAULT_POLLING_INTERVAL_MS
+        timeout: Duration = DEFAULT_TIMEOUT,
+        pollingInterval: Duration = POLLING_DEFAULT
     ): UiObject2? {
         var found: UiObject2? = null
 
         val isFound = retryUntilTimeout(
-            timeoutMs = timeoutMs,
-            pollingIntervalMs = pollingIntervalMs
+            timeout = timeout,
+            pollingInterval = pollingInterval
         ) {
             found = selectors
                 .asSequence()
@@ -180,12 +190,12 @@ object UiWaitUtils {
      */
     fun clickWhenClickable(
         params: UiSelectorParams,
-        timeoutMs: Long = TIMEOUT_IN_MILLISECONDS,
-        pollingIntervalMs: Long = DEFAULT_POLLING_INTERVAL_MS
+        timeout: Duration = DEFAULT_TIMEOUT,
+        pollingInterval: Duration = POLLING_DEFAULT
     ): Boolean {
         return retryUntilTimeout(
-            timeoutMs = timeoutMs,
-            pollingIntervalMs = pollingIntervalMs
+            timeout = timeout,
+            pollingInterval = pollingInterval
         ) {
             val element = findElementOrNull(params) ?: return@retryUntilTimeout false
             try {
@@ -208,11 +218,11 @@ object UiWaitUtils {
      */
     fun waitUntilGoneOrThrow(
         selector: BySelector,
-        timeoutMs: Long = 30_000,
+        timeout: Duration = VERY_LONG_TIMEOUT,
         errorMessage: String
     ) {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        val isGone = device.wait(Until.gone(selector), timeoutMs)
+        val isGone = device.wait(Until.gone(selector), timeout.inWholeMilliseconds)
         if (!isGone) {
             throw AssertionError(errorMessage)
         }
@@ -226,13 +236,13 @@ object UiWaitUtils {
     fun waitUntilGoneOrThrow(
         device: UiDevice,
         selector: UiSelector,
-        timeoutMillis: Long = 30_000,
-        pollingInterval: Long = 500,
+        timeout: Duration = VERY_LONG_TIMEOUT,
+        pollingInterval: Duration = 500.milliseconds,
         errorMessage: String = "Element matching selector [$selector] did not disappear within timeout."
     ) {
         val isGone = retryUntilTimeout(
-            timeoutMs = timeoutMillis,
-            pollingIntervalMs = pollingInterval
+            timeout = timeout,
+            pollingInterval = pollingInterval
         ) {
             !device.findObject(selector).exists()
         }
@@ -250,13 +260,13 @@ object UiWaitUtils {
     @Suppress("MagicNumber", "NestedBlockDepth", "CyclomaticComplexMethod", "ComplexCondition")
     fun waitElement(
         params: UiSelectorParams,
-        timeoutMillis: Long = 10_000
+        timeout: Duration = DEFAULT_TIMEOUT
     ): UiObject2 {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         val sel = buildSelector(params)
 
         // 1) Block until node exists
-        if (!device.wait(Until.hasObject(sel), timeoutMillis)) {
+        if (!device.wait(Until.hasObject(sel), timeout.inWholeMilliseconds)) {
             throw AssertionError("Element not found with selector: ${describe(params)}")
         }
 
@@ -267,8 +277,8 @@ object UiWaitUtils {
         var stableElement: UiObject2? = null
 
         retryUntilTimeout(
-            timeoutMs = STABILIZE_TIMEOUT_MS,
-            pollingIntervalMs = STABILIZE_POLLING_INTERVAL_MS
+            timeout = STABILIZE_TIMEOUT,
+            pollingInterval = STABILIZE_POLLING_INTERVAL
         ) {
             val obj = try {
                 device.findObject(sel)
@@ -320,13 +330,13 @@ object UiWaitUtils {
     fun waitUntilElementGone(
         device: UiDevice,
         selector: UiSelector,
-        timeoutMillis: Long = 30_000,
-        pollingInterval: Long = 500
+        timeout: Duration = VERY_LONG_TIMEOUT,
+        pollingInterval: Duration = 500.milliseconds
     ) {
         waitUntilGoneOrThrow(
             device = device,
             selector = selector,
-            timeoutMillis = timeoutMillis,
+            timeout = timeout,
             pollingInterval = pollingInterval
         )
     }
@@ -338,13 +348,13 @@ object UiWaitUtils {
          *
          * Kept for compatibility in PR-1; call sites migrate in later cleanups.
          */
-        fun waitFor(seconds: Int, startPinging: () -> Unit = {}, stopPinging: () -> Unit = {}) {
-            if (seconds > 20) {
+        fun waitFor(wait: Duration, startPinging: () -> Unit = {}, stopPinging: () -> Unit = {}) {
+            if (wait > 20.seconds) {
                 startPinging()
             }
-            Thread.sleep(seconds * 1000L)
+            Thread.sleep(wait.inWholeMilliseconds)
 
-            if (seconds > 20) {
+            if (wait > 20.seconds) {
                 stopPinging()
             }
         }
@@ -355,15 +365,15 @@ object UiWaitUtils {
      *
      * Internally delegates to [WaitUtils.waitFor] to keep backward compatibility with existing logic.
      */
-    fun waitFor(seconds: Int, startPinging: () -> Unit = {}, stopPinging: () -> Unit = {}) {
-        WaitUtils.waitFor(seconds, startPinging, stopPinging)
+    fun waitFor(wait: Duration, startPinging: () -> Unit = {}, stopPinging: () -> Unit = {}) {
+        WaitUtils.waitFor(wait, startPinging, stopPinging)
     }
 
     /**
      * Fixed millisecond sleep used by callers that already compute millisecond values.
      */
-    fun waitForMillis(milliseconds: Long) {
-        Thread.sleep(milliseconds)
+    fun waitFor(wait: Duration) {
+        Thread.sleep(wait.inWholeMilliseconds)
     }
 
     /**
@@ -371,12 +381,12 @@ object UiWaitUtils {
      */
     fun waitUntilVisible(
         params: UiSelectorParams,
-        timeoutMs: Long = TIMEOUT_IN_MILLISECONDS,
+        timeout: Duration = DEFAULT_TIMEOUT,
         errorMessage: String
     ) {
         waitUntilVisibleOrThrow(
             params = params,
-            timeoutMs = timeoutMs,
+            timeout = timeout,
             errorMessage = errorMessage
         )
     }
@@ -386,12 +396,12 @@ object UiWaitUtils {
      */
     fun waitUntilToastIsDisplayed(
         message: String,
-        timeoutMs: Long = 5_000
+        timeout: Duration = SHORT_TIMEOUT
     ) {
         waitUntilVisible(
             params = UiSelectorParams(textContains = message),
-            timeoutMs = timeoutMs,
-            errorMessage = "Toast message containing '$message' was not displayed within ${timeoutMs}ms."
+            timeout = timeout,
+            errorMessage = "Toast message containing '$message' was not displayed within ${timeout.inWholeMilliseconds}ms."
         )
     }
 
@@ -400,12 +410,12 @@ object UiWaitUtils {
      */
     fun iSeeSystemMessage(
         message: String,
-        timeoutMs: Long = 5_000
+        timeout: Duration = SHORT_TIMEOUT
     ) {
         waitUntilVisible(
             params = UiSelectorParams(textContains = message),
-            timeoutMs = timeoutMs,
-            errorMessage = "System message containing '$message' was not displayed within ${timeoutMs}ms."
+            timeout = timeout,
+            errorMessage = "System message containing '$message' was not displayed within ${timeout.inWholeMilliseconds}ms."
         )
     }
 
@@ -415,7 +425,7 @@ object UiWaitUtils {
      * This uses accessibility events and is useful when UI tree based lookup is not reliable.
      */
     @Suppress("MagicNumber")
-    fun assertToastDisplayed(text: String, trigger: () -> Unit, timeoutMs: Long = 5_000L) {
+    fun assertToastDisplayed(text: String, trigger: () -> Unit, timeout: Duration = SHORT_TIMEOUT) {
         var toastDisplayed = false
         val startTimeMs = System.currentTimeMillis()
 
@@ -436,11 +446,11 @@ object UiWaitUtils {
             // IMPORTANT: trigger AFTER listener is set
             trigger()
 
-            while (!toastDisplayed && System.currentTimeMillis() - startTimeMs < timeoutMs) {
+            while (!toastDisplayed && System.currentTimeMillis() - startTimeMs < timeout.inWholeMilliseconds) {
                 Thread.sleep(50)
             }
 
-            assertTrue("Toast with text '$text' not found within ${timeoutMs}ms", toastDisplayed)
+            assertTrue("Toast with text '$text' not found within ${timeout.inWholeMilliseconds}ms", toastDisplayed)
         } finally {
             uiAutomation.setOnAccessibilityEventListener(null)
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-21886
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Follow up on:
- #4752 

In order to have a better API for devs using the framework and make the testing API stable we are improving the code and refactoring to reflect a less verbose and reduce duplicated code

### Solutions

Deprecate time unit representations in numeric value and use Kotlin Duration.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
