### PR TITLE
fix: call participants list - multiline and opening reactions panel [WPB-1057]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -463,7 +463,11 @@ private fun OngoingCallContent(
                     onHangUpCall = hangUpCall,
                     onToggleVideo = toggleVideo,
                     onCallReactionsClick = {
-                        showInCallReactionsPanel = !showInCallReactionsPanel
+                        scope.launch {
+                            scaffoldState.bottomSheetState.partialExpand()
+                        }.invokeOnCompletion {
+                            showInCallReactionsPanel = !showInCallReactionsPanel
+                        }
                     },
                     onCameraPermissionPermanentlyDenied = onCameraPermissionPermanentlyDenied,
                     modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantslist/ParticipantItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/participantslist/ParticipantItem.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import com.wire.android.R
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
@@ -68,6 +69,8 @@ fun ParticipantItem(
                     text = participant.name.orEmpty(),
                     style = typography().title02,
                     color = colorsScheme().onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
                 MembershipQualifierLabel(membership = participant.membership)
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-1057
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We found two UX-related issues:
- username text on call participant list may extend over multiple lines
- when having participant list open and clicking to open reactions panel, it opens behind it so the user doesn't see it (reactions panel is not a part of the bottom sheet)

### Solutions

- make the username text to be a single line with text overflow
- first close the participant list and then open the reactions panel

### Testing

#### How to Test

Join/start a call, open participants list, click to open the reactions panel.

### Attachments (Optional)

https://github.com/user-attachments/assets/91f4bd2b-4053-4e9b-ad84-90a9b497b157

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
