### PR TITLE
feat: add connecton requests warning WPB-25483

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserConnectionUnverifiedWarning.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserConnectionUnverifiedWarning.kt
@@ -58,6 +58,13 @@ fun OtherUserConnectionUnverifiedWarning(
                     color = MaterialTheme.wireColorScheme.error,
                     style = MaterialTheme.wireTypography.body01
                 )
+                VerticalSpace.x8()
+                Text(
+                    text = stringResource(R.string.connection_label_unverified_support_disclaimer),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.wireColorScheme.error,
+                    style = MaterialTheme.wireTypography.body01
+                )
                 VerticalSpace.x24()
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1194,6 +1194,7 @@
     <string name="connection_label_ignore">Ignore</string>
     <string name="connection_label_send_unverified_warning">Get certainty about the identity of %s\'s before connecting.</string>
     <string name="connection_label_received_unverified_warning">Please verify the person\'s identity before accepting the connection request.</string>
+    <string name="connection_label_unverified_support_disclaimer">Wire\'s Support team will never reach out to you in the app.</string>
     <string name="connection_label_user_not_found_warning_title">Wire can\'t find this person</string>
     <string name="connection_label_user_not_found_warning_description">You may not have permission with this account or the person may not be on Wire.</string>
     <!-- Missing keyPackages dialog -->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25483
<!--jira-description-action-hidden-marker-end-->
Add a warning to connection requests (incoming/outgoing) to remind user that Wire will not reach out to them. If someone pretends to be Wire, it's a scam.