### PR TITLE
fix: update avatar semantics to also keep testTags [WPB-14812]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItemLeading.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/RegularMessageItemLeading.kt
@@ -38,9 +38,7 @@ fun RegularMessageItemLeading(
     val isProfileRedirectEnabled =
         header.userId != null && !(header.isSenderDeleted || header.isSenderUnavailable)
     if (showAuthor) {
-        val openProfileDescription = stringResource(
-            id = R.string.content_description_open_user_profile_label
-        )
+        val openProfileDescription = stringResource(id = R.string.content_description_open_user_profile_label)
         val avatarClickable = remember(isProfileRedirectEnabled, header.userId, openProfileDescription, onOpenProfile) {
             Clickable(
                 enabled = isProfileRedirectEnabled,
@@ -49,14 +47,9 @@ fun RegularMessageItemLeading(
                 onOpenProfile(header.userId!!.toString())
             }
         }
-        val avatarStatusDescription = userAvatarData.getAvailabilityStatusDescriptionId()
-            ?.let { stringResource(id = it) }
-            ?: stringResource(id = commonR.string.user_profile_status_none)
         val avatarContentDescription = listOfNotNull(
             stringResource(id = commonR.string.content_description_user_avatar),
             header.username.asString(),
-            avatarStatusDescription,
-            openProfileDescription.takeIf { isProfileRedirectEnabled }
         ).joinToString(", ")
         // because avatar takes start padding we don't need to add padding to message item
         UserProfileAvatar(

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/avatar/UserProfileAvatar.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/avatar/UserProfileAvatar.kt
@@ -155,7 +155,7 @@ fun UserProfileAvatar(
             .wrapContentSize()
             .clip(CircleShape)
             .clickable(clickable)
-            .semantics(mergeDescendants = true) {
+            .semantics {
                 if (clickable?.enabled == true) {
                     role = Role.Button
                 }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/avatar/UserProfileAvatar.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/avatar/UserProfileAvatar.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -91,7 +92,7 @@ import kotlin.time.Duration.Companion.hours
 
 const val MINUTES_IN_DAY = 60 * 24
 const val STATUS_INDICATOR_TEST_TAG = "status_indicator"
-const val UNREAD_INFO_TEST_TAG = "status_indicator"
+const val UNREAD_INFO_TEST_TAG = "unread_info"
 const val LEGAL_HOLD_INDICATOR_TEST_TAG = "legal_hold_indicator"
 const val TEMP_USER_INDICATOR_TEST_TAG = "temp_user_indicator"
 const val USER_AVATAR_TEST_TAG = "User avatar"
@@ -148,23 +149,17 @@ fun UserProfileAvatar(
         legalHoldIndicatorVisible = false
     ),
 ) {
-    val accessibilityModifier = if (contentDescription != null) {
-        Modifier.clearAndSetSemantics {
-            this.contentDescription = contentDescription
-            if (clickable?.enabled == true) {
-                role = Role.Button
-            }
-        }
-    } else {
-        Modifier
-    }
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .wrapContentSize()
             .clip(CircleShape)
-            .then(accessibilityModifier)
             .clickable(clickable)
+            .semantics(mergeDescendants = true) {
+                if (clickable?.enabled == true) {
+                    role = Role.Button
+                }
+            }
     ) {
         var userStatusIndicatorParams by remember { mutableStateOf(Size.Zero to Offset.Zero) }
         Box(
@@ -247,6 +242,7 @@ fun UserProfileAvatar(
                 )
             }
 
+            val statusContentDescription = avatarData.getAvailabilityStatusDescriptionId()?.let { stringResource(it) }
             UserStatusIndicator(
                 status = avatarData.availabilityStatus,
                 size = statusSize,
@@ -258,7 +254,12 @@ fun UserProfileAvatar(
                     .onGloballyPositioned {
                         userStatusIndicatorParams = it.size.toSize() to it.positionInParent()
                     }
-                    .testTag(STATUS_INDICATOR_TEST_TAG)
+                    .semantics {
+                        this.testTag = STATUS_INDICATOR_TEST_TAG
+                        if (statusContentDescription != null) {
+                            this.contentDescription = statusContentDescription
+                        }
+                    }
             )
         }
     }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-14812
<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After recent changes in semantics, `testTag`s from `UserProfileAvatar` are no longer visible for tests.

### Causes (Optional)

`testTag` is also part of semantics, so using `clearAndSetSemantics` on parent removes tags from children as well.

### Solutions

Instead of `clearAndSetSemantics` use just `semantics` so that it reads all the children, then also let `UserStatusIndicator` to have its own content description so that it's being read as well. 
The result is still similar, like that:

> _Profile picture {user-name}, {user-status}, button, double tap to open profile_

### Testing

#### How to Test

Open conversation with some messages, enable talkback, focus on the avatar of message sender.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
