### PR TITLE
fix: video asset preview and size (WPB-24809)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/AssetLocalPathViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/AssetLocalPathViewModel.kt
@@ -72,13 +72,7 @@ internal class AssetLocalPathViewModelImpl @AssistedInject constructor(
         transferStatus: AssetTransferStatus,
         downloadIfNeeded: Boolean
     ) {
-        val shouldResolve = when {
-            downloadIfNeeded ->
-                transferStatus == AssetTransferStatus.NOT_DOWNLOADED ||
-                transferStatus == AssetTransferStatus.SAVED_INTERNALLY ||
-                transferStatus == AssetTransferStatus.UPLOADED
-            else -> transferStatus == AssetTransferStatus.SAVED_INTERNALLY
-        }
+        val shouldResolve = transferStatus.shouldResolveAsset(downloadIfNeeded)
 
         if (!shouldResolve || localAssetPath != null || resolvingJob?.isActive == true) {
             return

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/ConversationAssetPathsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/ConversationAssetPathsViewModel.kt
@@ -23,6 +23,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
+import com.wire.kalium.logic.data.asset.AssetTransferStatus.DOWNLOAD_IN_PROGRESS
+import com.wire.kalium.logic.data.asset.AssetTransferStatus.NOT_DOWNLOADED
+import com.wire.kalium.logic.data.asset.AssetTransferStatus.SAVED_INTERNALLY
+import com.wire.kalium.logic.data.asset.AssetTransferStatus.UPLOADED
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
@@ -40,13 +44,6 @@ interface ConversationAssetPathsViewModel {
         assetStatus: AssetTransferStatus?,
         downloadIfNeeded: Boolean = false,
     ): String? = null
-
-    fun resolveIfNeeded(
-        conversationId: ConversationId,
-        messageId: String,
-        transferStatus: AssetTransferStatus,
-        downloadIfNeeded: Boolean = false,
-    ) {}
 }
 
 object ConversationAssetPathsViewModelPreview : ConversationAssetPathsViewModel
@@ -72,51 +69,46 @@ class ConversationAssetPathsViewModelImpl @Inject constructor(
             resolveIfNeeded(
                 conversationId = conversationId,
                 messageId = messageId,
-                transferStatus = assetStatus ?: AssetTransferStatus.NOT_DOWNLOADED,
+                transferStatus = assetStatus ?: NOT_DOWNLOADED,
                 downloadIfNeeded = downloadIfNeeded,
             )
         }
     }
 
-    override fun resolveIfNeeded(
+    private fun resolveIfNeeded(
         conversationId: ConversationId,
         messageId: String,
         transferStatus: AssetTransferStatus,
         downloadIfNeeded: Boolean
     ) {
-        val shouldResolve = when {
-            downloadIfNeeded ->
-                transferStatus == AssetTransferStatus.NOT_DOWNLOADED ||
-                    transferStatus == AssetTransferStatus.DOWNLOAD_IN_PROGRESS ||
-                    transferStatus == AssetTransferStatus.SAVED_INTERNALLY ||
-                    transferStatus == AssetTransferStatus.UPLOADED
-
-            else -> transferStatus == AssetTransferStatus.SAVED_INTERNALLY
-        }
-
-        if (!shouldResolve || localAssetPaths[messageId] != null || resolvingJobs[messageId]?.isActive == true) {
-            return
-        }
-
-        resolvingJobs[messageId] = viewModelScope.launch(dispatchers.io()) {
-            try {
-                when (val result = getMessageAsset(conversationId, messageId).await()) {
-                    is MessageAssetResult.Success -> {
-                        val resolvedPath = result.decodedAssetPath.toString()
-                        withContext(dispatchers.main()) {
-                            localAssetPaths[messageId] = resolvedPath
+        if (transferStatus.shouldResolveAsset(downloadIfNeeded)) {
+            resolvingJobs[messageId] = viewModelScope.launch(dispatchers.io()) {
+                try {
+                    when (val result = getMessageAsset(conversationId, messageId).await()) {
+                        is MessageAssetResult.Success -> {
+                            val resolvedPath = result.decodedAssetPath.toString()
+                            withContext(dispatchers.main()) {
+                                localAssetPaths[messageId] = resolvedPath
+                            }
                         }
-                    }
 
-                    is MessageAssetResult.Failure -> Unit
-                }
-            } finally {
-                withContext(dispatchers.main()) {
-                    if (resolvingJobs[messageId] === this@launch) {
-                        resolvingJobs.remove(messageId)
+                        is MessageAssetResult.Failure -> Unit
+                    }
+                } finally {
+                    withContext(dispatchers.main()) {
+                        if (resolvingJobs[messageId] === this@launch) {
+                            resolvingJobs.remove(messageId)
+                        }
                     }
                 }
             }
         }
     }
 }
+
+internal fun AssetTransferStatus.shouldResolveAsset(downloadIfNeeded: Boolean) =
+    if (downloadIfNeeded) {
+        this in setOf(NOT_DOWNLOADED, DOWNLOAD_IN_PROGRESS, SAVED_INTERNALLY, UPLOADED)
+    } else {
+        this in setOf(SAVED_INTERNALLY, UPLOADED)
+    }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/video/VideoMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/video/VideoMessage.kt
@@ -105,6 +105,8 @@ fun VideoMessage(
             size = assetSize,
             messageStyle = messageStyle,
             modifier = Modifier
+                .padding(top = dimensions().spacing4x)
+                .padding(horizontal = dimensions().spacing4x)
                 .fillMaxWidth()
         )
 
@@ -115,7 +117,9 @@ fun VideoMessage(
         }
 
         Text(
-            modifier = Modifier.align(Alignment.Start),
+            modifier = Modifier
+                .padding(horizontal = dimensions().spacing6x)
+                .align(Alignment.Start),
             text = assetName,
             style = typography().body02,
             color = textColor,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.feature.analytics.AnonymousAnalyticsManager
@@ -42,11 +43,11 @@ import com.wire.android.ui.home.conversations.usecase.HandleUriAssetUseCase
 import com.wire.android.ui.home.messagecomposer.model.ComposableMessageBundle
 import com.wire.android.ui.home.messagecomposer.model.MessageBundle
 import com.wire.android.ui.home.messagecomposer.model.Ping
-import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.ui.sharing.SendMessagesSnackbarMessages
 import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.getAudioLengthInMs
+import com.wire.android.util.getVideoMetaData
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.onFailure
@@ -81,7 +82,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -342,48 +342,64 @@ class SendMessageViewModel @Inject constructor(
     }
 
     internal fun sendAttachment(attachmentBundle: AssetBundle?, conversationId: ConversationId) {
-        viewModelScope.launch {
-            withContext(dispatchers.io()) {
-                attachmentBundle?.run {
-                    when (assetType) {
-                        AttachmentType.IMAGE -> {
-                            if (kaliumFileSystem.exists(attachmentBundle.dataPath)) {
-                                val (imgWidth, imgHeight) = imageUtil.extractImageWidthAndHeight(
-                                    kaliumFileSystem,
-                                    attachmentBundle.dataPath
-                                )
-                                sendAssetMessage(attachmentBundle.uploadParams(imgHeight, imgWidth))
-                                    .handleLegalHoldFailureAfterSendingMessage(conversationId)
-                                    .handleAssetContributionEvent(assetType)
-                            } else {
-                                appLogger.e("There was a FileNotFoundException error while sending image asset")
-                                onSnackbarMessage(ConversationSnackbarMessages.ErrorSendingImage)
-                            }
-                        }
 
-                        AttachmentType.VIDEO,
-                        AttachmentType.GENERIC_FILE,
-                        AttachmentType.AUDIO -> {
-                            try {
-                                sendAssetMessage(
-                                    attachmentBundle.uploadParams(
-                                        audioLengthInMs = getAudioLengthInMs(
-                                            dataPath = dataPath,
-                                            mimeType = mimeType
-                                        )
-                                    )
-                                ).handleLegalHoldFailureAfterSendingMessage(conversationId)
-                                    .handleAssetContributionEvent(assetType)
-                            } catch (e: OutOfMemoryError) {
-                                appLogger.e("There was an OutOfMemory error while uploading the asset")
-                                onSnackbarMessage(ConversationSnackbarMessages.ErrorSendingAsset)
-                            }
-                        }
+        val assetType = attachmentBundle?.assetType ?: return
+
+        viewModelScope.launch(dispatchers.io()) {
+            when (assetType) {
+                AttachmentType.IMAGE -> {
+                    if (kaliumFileSystem.exists(attachmentBundle.dataPath)) {
+                        val (imgWidth, imgHeight) = imageUtil.extractImageWidthAndHeight(
+                            kaliumFileSystem,
+                            attachmentBundle.dataPath
+                        )
+                        sendAssetMessage(attachmentBundle.uploadParams(imgHeight, imgWidth))
+                            .handleLegalHoldFailureAfterSendingMessage(conversationId)
+                            .handleAssetContributionEvent(assetType)
+                    } else {
+                        appLogger.e("There was a FileNotFoundException error while sending image asset")
+                        onSnackbarMessage(ConversationSnackbarMessages.ErrorSendingImage)
                     }
                 }
+
+                AttachmentType.VIDEO,
+                AttachmentType.GENERIC_FILE,
+                AttachmentType.AUDIO ->
+                    try {
+                        sendAssetMessage(attachmentBundle.assetUploadParams())
+                            .handleLegalHoldFailureAfterSendingMessage(conversationId)
+                            .handleAssetContributionEvent(assetType)
+                    } catch (e: OutOfMemoryError) {
+                        appLogger.e("There was an OutOfMemory error while uploading the asset")
+                        onSnackbarMessage(ConversationSnackbarMessages.ErrorSendingAsset)
+                    }
             }
         }
     }
+
+    private fun AssetBundle.assetUploadParams(): AssetUploadParams =
+        when (assetType) {
+            AttachmentType.GENERIC_FILE,
+            AttachmentType.AUDIO ->
+                uploadParams(
+                    audioLengthInMs = getAudioLengthInMs(
+                        dataPath = dataPath,
+                        mimeType = mimeType
+                    )
+                )
+
+            AttachmentType.VIDEO -> {
+                getVideoMetaData(dataPath.toString())?.let { metadata ->
+                    uploadParams(
+                        assetWidth = metadata.width,
+                        assetHeight = metadata.height,
+                        audioLengthInMs = metadata.durationMs ?: 0,
+                    )
+                } ?: uploadParams()
+            }
+
+            else -> uploadParams()
+        }
 
     private fun Either<CoreFailure?, Unit>.handleAssetContributionEvent(
         assetType: AttachmentType

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/item/AssetLocalPathViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/item/AssetLocalPathViewModelTest.kt
@@ -104,20 +104,6 @@ class AssetLocalPathViewModelTest {
     }
 
     @Test
-    fun givenUploadedStatusButDownloadIfNeededFalse_whenResolveIfNeeded_thenPathIsNotResolved() = runTest {
-        // given
-        val (arrangement, viewModel) = Arrangement()
-            .arrange()
-
-        // when
-        viewModel.resolveIfNeeded(transferStatus = AssetTransferStatus.UPLOADED, downloadIfNeeded = false)
-
-        // then
-        assertNull(viewModel.localAssetPath)
-        coVerify(exactly = 0) { arrangement.getMessageAsset(any(), any()) }
-    }
-
-    @Test
     fun givenPathAlreadyResolved_whenResolveIfNeededCalledAgain_thenGetAssetIsNotCalledAgain() = runTest {
         // given
         val expectedPath = "/local/path/image.jpg"

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/item/ConversationAssetPathsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/item/ConversationAssetPathsViewModelTest.kt
@@ -141,19 +141,19 @@ class ConversationAssetPathsViewModelTest {
             .withGetMessageAssetSuccess(expectedPath)
             .arrange()
 
-        viewModel.resolveIfNeeded(
+        viewModel.localAssetPath(
             conversationId = arrangement.conversationId,
             messageId = arrangement.messageId,
-            transferStatus = AssetTransferStatus.UPLOADED,
+            assetStatus = AssetTransferStatus.UPLOADED,
             downloadIfNeeded = true
         )
         assertEquals(expectedPath, viewModel.localAssetPath(arrangement.messageId))
 
         // when
-        viewModel.resolveIfNeeded(
+        viewModel.localAssetPath(
             conversationId = arrangement.conversationId,
             messageId = arrangement.messageId,
-            transferStatus = AssetTransferStatus.UPLOADED,
+            assetStatus = AssetTransferStatus.UPLOADED,
             downloadIfNeeded = true
         )
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/item/ConversationAssetPathsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/item/ConversationAssetPathsViewModelTest.kt
@@ -50,10 +50,10 @@ class ConversationAssetPathsViewModelTest {
             .arrange()
 
         // when
-        viewModel.resolveIfNeeded(
+        viewModel.localAssetPath(
             conversationId = arrangement.conversationId,
             messageId = arrangement.messageId,
-            transferStatus = AssetTransferStatus.UPLOADED,
+            assetStatus = AssetTransferStatus.UPLOADED,
             downloadIfNeeded = true
         )
 
@@ -92,10 +92,10 @@ class ConversationAssetPathsViewModelTest {
             .withGetMessageAssetSuccess(expectedPath)
             .arrange()
 
-        viewModel.resolveIfNeeded(
+        viewModel.localAssetPath(
             conversationId = arrangement.conversationId,
             messageId = arrangement.messageId,
-            transferStatus = AssetTransferStatus.UPLOADED,
+            assetStatus = AssetTransferStatus.UPLOADED,
             downloadIfNeeded = true
         )
 
@@ -121,10 +121,10 @@ class ConversationAssetPathsViewModelTest {
             .arrange()
 
         // when
-        viewModel.resolveIfNeeded(
+        viewModel.localAssetPath(
             conversationId = arrangement.conversationId,
             messageId = arrangement.messageId,
-            transferStatus = AssetTransferStatus.DOWNLOAD_IN_PROGRESS,
+            assetStatus = AssetTransferStatus.DOWNLOAD_IN_PROGRESS,
             downloadIfNeeded = true
         )
 
@@ -174,16 +174,16 @@ class ConversationAssetPathsViewModelTest {
             .arrange()
 
         // when
-        viewModel.resolveIfNeeded(
+        viewModel.localAssetPath(
             conversationId = arrangement.conversationId,
             messageId = firstMessageId,
-            transferStatus = AssetTransferStatus.UPLOADED,
+            assetStatus = AssetTransferStatus.UPLOADED,
             downloadIfNeeded = true
         )
-        viewModel.resolveIfNeeded(
+        viewModel.localAssetPath(
             conversationId = arrangement.conversationId,
             messageId = secondMessageId,
-            transferStatus = AssetTransferStatus.UPLOADED,
+            assetStatus = AssetTransferStatus.UPLOADED,
             downloadIfNeeded = true
         )
 
@@ -200,10 +200,10 @@ class ConversationAssetPathsViewModelTest {
             .arrange()
 
         // when
-        viewModel.resolveIfNeeded(
+        viewModel.localAssetPath(
             conversationId = arrangement.conversationId,
             messageId = arrangement.messageId,
-            transferStatus = AssetTransferStatus.UPLOADED,
+            assetStatus = AssetTransferStatus.UPLOADED,
             downloadIfNeeded = true
         )
 
@@ -218,10 +218,10 @@ class ConversationAssetPathsViewModelTest {
             .arrange()
 
         // when
-        viewModel.resolveIfNeeded(
+        viewModel.localAssetPath(
             conversationId = arrangement.conversationId,
             messageId = arrangement.messageId,
-            transferStatus = AssetTransferStatus.UPLOAD_IN_PROGRESS,
+            assetStatus = AssetTransferStatus.UPLOAD_IN_PROGRESS,
             downloadIfNeeded = true
         )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24809
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-24809
----

# What's new in this PR?

### Issues
Issues with showing video preview and duration:
1. Duration is not showing for video previews
2. Preview and message size do not match the video aspect ratio

### Causes (Optional)
1. Missing mapping for the video metadata.
2. Video metadata not read when sending video.
3. Local path for uploaded video file not resolved correctly

### Solutions
Added missing mappings (kalium)
Read video file metadata before sending
Fixed local path resolution for Uploaded video assets

Before:
https://github.com/user-attachments/assets/b9094869-0eb6-4e6d-9aca-3410afa107c4

After:
https://github.com/user-attachments/assets/27b6925a-ed60-4c0e-bd16-1392a611e7f9

