### PR TITLE
fix: Apps shown as disabled in group conversation details (WPB-25306)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -154,7 +154,6 @@ class GroupConversationDetailsViewModel @Inject constructor(
                 }
 
                 val shouldUseNewAppsUi = computeShouldUseNewAppsUi(groupDetails, appsAllowedResult)
-                val isAppsAllowedForConversation = computeAppsEnabledStatus(groupDetails, appsAllowedResult)
                 val isUpdatingAppsAllowedForConversation =
                     computeAppsAllowedStatus(canSelfPerformAdminTasks, isSelfInTeamThatOwnsConversation, groupDetails, appsAllowedResult)
 
@@ -175,7 +174,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
                         isUpdatingNameAllowed = canSelfPerformAdminTasks && !isSelfExternalMember,
                         isUpdatingGuestAllowed = canSelfPerformAdminTasks && isSelfInTeamThatOwnsConversation,
                         isUpdatingChannelAccessAllowed = canSelfPerformAdminTasks && isSelfInTeamThatOwnsConversation,
-                        isAppsAllowed = isAppsAllowedForConversation,
+                        isAppsAllowed = groupDetails.conversation.isServicesAllowed(),
                         shouldUseNewAppsUi = shouldUseNewAppsUi,
                         isUpdatingAppsAllowed = isUpdatingAppsAllowedForConversation,
                         isUpdatingReadReceiptAllowed = canSelfPerformAdminTasks && groupDetails.conversation.isTeamGroup(),
@@ -213,16 +212,6 @@ class GroupConversationDetailsViewModel @Inject constructor(
         appsAllowedResult: AppsAllowedResult
     ) = canSelfPerformAdminTasks &&
         isSelfInTeamThatOwnsConversation &&
-        isServicesSupportedForConversation(groupDetails.conversation.protocol, appsAllowedResult)
-
-    /**
-     * Determine apps visibility based on feature flag and team settings
-     * Or just should be protocol based in case of current logic
-     */
-    private fun computeAppsEnabledStatus(
-        groupDetails: ConversationDetails.Group,
-        appsAllowedResult: AppsAllowedResult
-    ) = groupDetails.conversation.isServicesAllowed() &&
         isServicesSupportedForConversation(groupDetails.conversation.protocol, appsAllowedResult)
 
     private fun isServicesSupportedForConversation(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupDetailsViewModelTest.kt
@@ -256,7 +256,7 @@ class GroupDetailsViewModelTest {
             .withSelfTeamUseCaseReturns(selfTeam)
             .arrange()
 
-        assertEquals(false, viewModel.groupOptionsState.value.isAppsAllowed)
+        assertEquals(true, viewModel.groupOptionsState.value.isAppsAllowed)
         assertEquals(false, viewModel.groupOptionsState.value.shouldUseNewAppsUi)
         assertEquals(false, viewModel.groupOptionsState.value.isUpdatingAppsAllowed)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25306
<!--jira-description-action-hidden-marker-end-->
- Remove extra verification for AppsAllowedResult when only isServicesAllowed is necessary
- adjust existing test

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When:
- web created a group with apps enabled by default (even with apps feature flag disabled)
- web showed enabed
- android showed disabled but should have shown enabled

### Causes (Optional)

The verification was checking for both `conversation.isServicesAllowed` and `AppsAllowedResult` (expecting it to be enabled) but showed disabled

### Solutions

Remove unnecessary check for `AppsAllowedResult` when only `conversation.isServiceAllowed` was enough.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- have a conversation with Apps enabled (MLS conversation + MLS team + Apps feature flag enabled)
- disable Apps feature flag
then: 

v4.25 / v4.26:
- Check conversation details, will show Apps value as OFF / Disabled

this PR:
- Check conversation details, will show Apps value as ON / Enabled (but still not clickable)