### PR TITLE
fix: incorrect missed call for outgoing calls [WPB-24461]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -373,9 +373,16 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                     )
                 }
 
-                is WithUser.MissedCall -> UILastMessageContent.TextMessage(
-                    MessageBody(UIText.PluralResource(R.plurals.unread_event_call, 1, 1))
-                )
+                is WithUser.MissedCall -> if (isSelfMessage) {
+                    UILastMessageContent.SenderWithMessage(
+                        userUIText,
+                        UIText.StringResource(R.string.last_message_call)
+                    )
+                } else {
+                    UILastMessageContent.TextMessage(
+                        MessageBody(UIText.PluralResource(R.plurals.unread_event_call, 1, 1))
+                    )
+                }
 
                 is WithUser.MembersCreationAdded -> UILastMessageContent.None
                 is WithUser.MembersFailedToAdd -> UILastMessageContent.None


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24461
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Outgoing calls are incorrectly labeled as “1 missed call” in the conversation list preview. Inside the conversation view, the correct label “You called” is shown, indicating the issue is limited to the list preview.

### Solutions

Change the format for last outgoing call message on conversation list.

### Testing

#### How to Test

Open the app, open some 1:1 conversation, start a call, end that call, go back to conversation list.

### Attachments (Optional)

<img width="400" src="https://github.com/user-attachments/assets/3e76fdd0-24f9-45e0-98f3-7739a54ea05c" />

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
