### PR TITLE
fix: Nomad profiles should not see app lock - WPB-25543

### DIFF
--- a/app/src/test/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCaseTest.kt
@@ -110,6 +110,42 @@ class ObserveAppLockConfigUseCaseTest {
         }
 
     @Test
+    fun givenValidSessionAndTeamConfigIsNull_whenObservingAppLock_thenSendDisabledStatus() = runTest {
+        val (_, useCase) = Arrangement()
+            .withValidSession()
+            .withTeamAppLockNull()
+            .withAppNonLockedByCurrentUser()
+            .arrange()
+
+        val result = useCase.invoke()
+
+        result.test {
+            val appLockStatus = awaitItem()
+
+            assertEquals(AppLockConfig.Disabled(ObserveAppLockConfigUseCase.DEFAULT_APP_LOCK_TIMEOUT), appLockStatus)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenValidSessionAndTeamConfigIsNullAndLocalPasscodeSet_whenObservingAppLock_thenSendEnabledStatus() = runTest {
+        val (_, useCase) = Arrangement()
+            .withValidSession()
+            .withTeamAppLockNull()
+            .withAppLockedByCurrentUser(true)
+            .arrange()
+
+        val result = useCase.invoke()
+
+        result.test {
+            val appLockStatus = awaitItem()
+
+            assertEquals(AppLockConfig.Enabled(ObserveAppLockConfigUseCase.DEFAULT_APP_LOCK_TIMEOUT), appLockStatus)
+            awaitComplete()
+        }
+    }
+
+    @Test
     fun givenValidSessionAndAppNotLockedByUserNorTeam_whenObservingAppLock_thenSendDisabledStatus() =
         runTest {
             val (_, useCase) = Arrangement()
@@ -187,6 +223,16 @@ class ObserveAppLockConfigUseCaseTest {
             every {
                 appLockTeamFeatureConfigObserver.invoke()
             } returns flowOf(AppLockTeamConfig(false, timeout, false))
+        }
+
+        fun withTeamAppLockNull() = apply {
+            every { coreLogic.getSessionScope(any()) } returns userSessionScope
+            every {
+                userSessionScope.appLockTeamFeatureConfigObserver
+            } returns appLockTeamFeatureConfigObserver
+            every {
+                appLockTeamFeatureConfigObserver.invoke()
+            } returns flowOf(null)
         }
 
         fun withAppLockedByCurrentUser(state: Boolean) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModelTest.kt
@@ -144,6 +144,17 @@ class FeatureFlagNotificationViewModelTest {
     }
 
     @Test
+    fun givenTeamAppLockObserverEmitsNull_whenObservingFeatureFlags_thenTeamAppLockDialogIsNotShown() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withCurrentSessionsFlow(flowOf(CurrentSessionResult.Success(AccountInfo.Valid(UserId("value", "domain")))))
+            .withIsAppLockSetup(false)
+            .arrange()
+        advanceUntilIdle()
+
+        assertEquals(false, viewModel.featureFlagState.shouldShowTeamAppLockDialog)
+    }
+
+    @Test
     fun givenE2EIRequired_thenShowDialog() = runTest {
         val (_, viewModel) = Arrangement()
             .withE2EIRequiredSettings(E2EIRequiredResult.NoGracePeriod.Create)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25543
<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

When an account is configured as a nomad profile, that account should not see any app lock prompt, even if the team administrator enforces app lock for the team.

### Testing
I've manually tested this on Fulu on a team with app lock enabled