### PR TITLE
chore: more generic event for user admin promotion (WPB-25283)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
@@ -52,7 +52,7 @@ class SystemMessageContentMapper @Inject constructor(
     fun mapMessage(
         message: Message.System,
         members: List<User>
-    ): UIMessageContent = when (val content = message.content) {
+    ): UIMessageContent? = when (val content = message.content) {
         is MemberChange -> mapMemberChangeMessage(content, message.senderUserId, members)
         is MessageContent.MissedCall -> mapMissedCallMessage(message.senderUserId, members)
         is MessageContent.ConversationRenamed -> mapConversationRenamedMessage(message.senderUserId, content, members)
@@ -231,7 +231,7 @@ class SystemMessageContentMapper @Inject constructor(
         content: MemberChange,
         senderUserId: UserId,
         userList: List<User>
-    ): UIMessageContent.SystemMessage {
+    ): UIMessageContent.SystemMessage? {
         val sender = userList.findUser(userId = senderUserId)
         val isAuthorSelfAction = content.members.size == 1 && senderUserId == content.members.first()
         val isSelfTriggered = sender is SelfUser
@@ -288,7 +288,12 @@ class SystemMessageContentMapper @Inject constructor(
                 memberNames = memberNameList
             )
 
-            is MemberChange.SelfUserPromotedToAdmin -> UIMessageContent.SystemMessage.SelfUserPromotedToAdmin
+            is MemberChange.UserPromotedToAdmin ->
+                if (content.members.any { userList.findUser(it) is SelfUser }) {
+                    UIMessageContent.SystemMessage.SelfUserPromotedToAdmin
+                } else {
+                    null
+                }
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/mapper/SystemMessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/SystemMessageContentMapperTest.kt
@@ -136,7 +136,7 @@ class SystemMessageContentMapperTest {
                 Locale.getDefault()
             )
 
-        assertIs<SystemMessage.ConversationMessageCreated>(resultConversationCreated)
+        assertIs<SystemMessage.ConversationMessageCreated>(resultConversationCreated!!)
         assertEquals(10584735, (resultConversationCreated.author as UIText.StringResource).resId)
         assertEquals(expectedFormattedDate, resultConversationCreated.date)
     }
@@ -201,6 +201,28 @@ class SystemMessageContentMapperTest {
             assertEquals(it.memberNames[0].asString(arrangement.resources), member2.name)
             assertEquals(it.memberNames[1].asString(arrangement.resources), member3.name)
         }
+    }
+
+    @Test
+    fun givenSelfUserPromotedToAdminContent_whenMapping_thenReturnsSelfUserPromotedSystemMessage() {
+        val (_, mapper) = Arrangement().arrange()
+        val members = listOf(TestUser.SELF_USER, TestUser.OTHER_USER)
+        val content = MessageContent.MemberChange.UserPromotedToAdmin(listOf(TestUser.SELF_USER_ID))
+
+        val result = mapper.mapMemberChangeMessage(content, TestUser.SELF_USER_ID, members)
+
+        assertEquals(SystemMessage.SelfUserPromotedToAdmin, result)
+    }
+
+    @Test
+    fun givenOtherUserPromotedToAdminContent_whenMapping_thenReturnsNull() {
+        val (_, mapper) = Arrangement().arrange()
+        val members = listOf(TestUser.SELF_USER, TestUser.OTHER_USER)
+        val content = MessageContent.MemberChange.UserPromotedToAdmin(listOf(TestUser.OTHER_USER.id))
+
+        val result = mapper.mapMemberChangeMessage(content, TestUser.SELF_USER_ID, members)
+
+        assertEquals(null, result)
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25283
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25283
----

# What's new in this PR?

More generic event handling for user role change. Keep more generic event for future, show system message only when self user is promoted to admin role.