### PR TITLE
chore: use jdk 21 for android and kalium builds [WPB-25756]

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -36,10 +36,10 @@ jobs:
         with:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - uses: WarpBuilds/cache@v1
         with:
@@ -71,10 +71,10 @@ jobs:
         with:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - uses: WarpBuilds/cache@v1
         with:
@@ -133,10 +133,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -23,10 +23,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - uses: WarpBuilds/cache@v1

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -39,10 +39,10 @@ jobs:
           echo "Disk space after cleanup:"
           df -h
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - uses: WarpBuilds/cache@v1

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -25,10 +25,10 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - uses: WarpBuilds/cache@v1
         with:

--- a/.github/workflows/qa-android-critical-flow-tests.yml
+++ b/.github/workflows/qa-android-critical-flow-tests.yml
@@ -213,11 +213,11 @@ jobs:
           clean: true
           submodules: recursive
 
-      - name: Set up Java 17
+      - name: Set up Java 21
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
           cache: gradle
 
       - name: Set up Android SDK (ANDROID_HOME + adb)

--- a/.github/workflows/qa-android-ui-test-manual-deflake.yml
+++ b/.github/workflows/qa-android-ui-test-manual-deflake.yml
@@ -56,11 +56,11 @@ jobs:
           clean: true
           submodules: recursive
 
-      - name: Set up Java 17
+      - name: Set up Java 21
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
           cache: gradle
 
       - name: Set up Android SDK (ANDROID_HOME + adb)

--- a/.github/workflows/qa-runner-health-check.yml
+++ b/.github/workflows/qa-runner-health-check.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Java 17
+      - name: Setup Java 21
         uses: actions/setup-java@v5
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
 
       - name: Ensure ADB is available (no sudo)

--- a/build-logic/plugins/build.gradle.kts
+++ b/build-logic/plugins/build.gradle.kts
@@ -23,14 +23,14 @@ plugins {
     kotlin("plugin.serialization") version embeddedKotlinVersion
 }
 
-// Configure the build-logic plugins to target JDK 17
+// Configure the build-logic plugins to target JDK 21
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 

--- a/build-logic/plugins/src/main/kotlin/KmpLibraryConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/KmpLibraryConventionPlugin.kt
@@ -40,7 +40,7 @@ class KmpLibraryConventionPlugin : Plugin<Project> {
                 compileSdk = AndroidSdk.compile
                 minSdk = AndroidSdk.min
                 compilerOptions {
-                    jvmTarget.set(JvmTarget.JVM_17)
+                    jvmTarget.set(JvmTarget.JVM_21)
                 }
             }
 

--- a/build-logic/plugins/src/main/kotlin/com/wire/android/gradle/KotlinAndroidConfiguration.kt
+++ b/build-logic/plugins/src/main/kotlin/com/wire/android/gradle/KotlinAndroidConfiguration.kt
@@ -38,7 +38,7 @@ internal fun Project.configureKotlinAndroid(
 
     defaultConfig.minSdk = AndroidSdk.min
 
-    compileOptions.targetCompatibility = JavaVersion.VERSION_17
+    compileOptions.targetCompatibility = JavaVersion.VERSION_21
     compileOptions.isCoreLibraryDesugaringEnabled = true
     buildFeatures.resValues = true
 
@@ -57,8 +57,8 @@ internal fun Project.configureKotlinAndroid(
 private fun Project.configureKotlin() {
     tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
-            // Set JVM target to 17
-            jvmTarget.set(JvmTarget.JVM_17)
+            // Set JVM target to 21
+            jvmTarget.set(JvmTarget.JVM_21)
             // Treat all Kotlin warnings as errors (disabled by default)
             // Override by setting warningsAsErrors=true in your ~/.gradle/gradle.properties
             val warningsAsErrors: String? by project


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25756
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Updates Android Gradle build logic to target JDK 21.
- Sets Kotlin JVM targets to `JVM_21` for Android and KMP convention plugins.
- Updates GitHub Actions jobs that run Gradle to set up Java 21.
- Covers lint, detekt, unit tests, UI tests, screenshot tests, build matrix jobs, QA critical flow tests, manual deflake, and QA runner health check.
- Updates the Kalium submodule pointer to the Kalium JDK 21 alignment commit.

This aligns local and CI Android builds with JDK 21 and prevents Gradle/runtime failures caused by Java 17.