### PR TITLE
fix(conversation-list): keep showing cached conversations while paging reloads after navigation

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -45,7 +45,7 @@ class KaliumConfigsModule {
             },
             forceConstantBitrateCalls = BuildConfig.FORCE_CONSTANT_BITRATE_CALLS,
             // we use upsert, available from SQL3.24, which is supported from Android API30, so for older APIs we have to use SQLCipher
-            shouldEncryptData = { !BuildConfig.DEBUG || Build.VERSION.SDK_INT < Build.VERSION_CODES.R },
+            shouldEncryptData = { true },
             lowerKeyPackageLimits = BuildConfig.LOWER_KEYPACKAGE_LIMIT,
             developmentApiEnabled = BuildConfig.DEVELOPMENT_API_ENABLED,
             ignoreSSLCertificatesForUnboundCalls = BuildConfig.IGNORE_SSL_CERTIFICATES,

--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -45,7 +45,7 @@ class KaliumConfigsModule {
             },
             forceConstantBitrateCalls = BuildConfig.FORCE_CONSTANT_BITRATE_CALLS,
             // we use upsert, available from SQL3.24, which is supported from Android API30, so for older APIs we have to use SQLCipher
-            shouldEncryptData = { true },
+            shouldEncryptData = { !BuildConfig.DEBUG || Build.VERSION.SDK_INT < Build.VERSION_CODES.R },
             lowerKeyPackageLimits = BuildConfig.LOWER_KEYPACKAGE_LIMIT,
             developmentApiEnabled = BuildConfig.DEVELOPMENT_API_ENABLED,
             ignoreSSLCertificatesForUnboundCalls = BuildConfig.IGNORE_SSL_CERTIFICATES,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -60,13 +60,17 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -83,10 +87,20 @@ interface ConversationListViewModel {
     val infoMessage: SharedFlow<SnackBarMessage> get() = MutableSharedFlow()
     val requestInProgress: Boolean get() = false
     val conversationListState: ConversationListState get() = ConversationListState.Paginated(emptyFlow())
+
+    /**
+     * Snapshot of the latest non-empty paged conversation items, kept alive in the
+     * ViewModel so that it survives back-stack navigation. The UI feeds this from
+     * `LazyPagingItems.itemSnapshotList` while items are present, and reads it during the
+     * transient empty frame paging-compose 3.3.x emits when the cache is invalidated.
+     */
+    val itemSnapshotCache: StateFlow<PersistentList<ConversationItemType>> get() = MutableStateFlow(persistentListOf())
+
     suspend fun refreshMissingMetadata() {}
     fun searchQueryChanged(searchQuery: String) {}
     fun playPauseCurrentAudio() {}
     fun stopCurrentAudio() {}
+    fun updateItemSnapshotCache(items: PersistentList<ConversationItemType>) {}
 }
 
 @Suppress("TooManyFunctions")
@@ -127,6 +141,13 @@ class ConversationListViewModelImpl @AssistedInject constructor(
 
     private var _requestInProgress: Boolean by mutableStateOf(false)
     override val requestInProgress: Boolean get() = _requestInProgress
+
+    private val _itemSnapshotCache = MutableStateFlow<PersistentList<ConversationItemType>>(persistentListOf())
+    override val itemSnapshotCache: StateFlow<PersistentList<ConversationItemType>> = _itemSnapshotCache.asStateFlow()
+
+    override fun updateItemSnapshotCache(items: PersistentList<ConversationItemType>) {
+        _itemSnapshotCache.value = items
+    }
 
     private val searchQueryFlow: MutableStateFlow<String> = MutableStateFlow("")
     private val isSelfUserUnderLegalHoldFlow = MutableSharedFlow<Boolean>(replay = 1)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -24,6 +24,8 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
+import androidx.paging.PagingDataEvent
+import androidx.paging.PagingDataPresenter
 import androidx.paging.cachedIn
 import androidx.paging.insertSeparators
 import androidx.paging.map
@@ -63,6 +65,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableMap
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -71,6 +74,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -89,10 +93,11 @@ interface ConversationListViewModel {
     val conversationListState: ConversationListState get() = ConversationListState.Paginated(emptyFlow())
 
     /**
-     * Snapshot of the latest non-empty paged conversation items, kept alive in the
-     * ViewModel so that it survives back-stack navigation. The UI feeds this from
-     * `LazyPagingItems.itemSnapshotList` while items are present, and reads it during the
-     * transient empty frame paging-compose 3.3.x emits when the cache is invalidated.
+     * Snapshot of the latest non-empty paged conversation items, derived from
+     * `conversationsPaginatedFlow` via a `PagingDataPresenter` running in `viewModelScope`.
+     * Lives in the ViewModel so that it survives back-stack navigation; the UI reads it
+     * during the transient empty frame paging-compose 3.3.x emits when the cache is
+     * invalidated, so the list stays visible while the new pages load.
      */
     val itemSnapshotCache: StateFlow<PersistentList<ConversationItemType>> get() = MutableStateFlow(persistentListOf())
 
@@ -100,7 +105,6 @@ interface ConversationListViewModel {
     fun searchQueryChanged(searchQuery: String) {}
     fun playPauseCurrentAudio() {}
     fun stopCurrentAudio() {}
-    fun updateItemSnapshotCache(items: PersistentList<ConversationItemType>) {}
 }
 
 @Suppress("TooManyFunctions")
@@ -144,10 +148,6 @@ class ConversationListViewModelImpl @AssistedInject constructor(
 
     private val _itemSnapshotCache = MutableStateFlow<PersistentList<ConversationItemType>>(persistentListOf())
     override val itemSnapshotCache: StateFlow<PersistentList<ConversationItemType>> = _itemSnapshotCache.asStateFlow()
-
-    override fun updateItemSnapshotCache(items: PersistentList<ConversationItemType>) {
-        _itemSnapshotCache.value = items
-    }
 
     private val searchQueryFlow: MutableStateFlow<String> = MutableStateFlow("")
     private val isSelfUserUnderLegalHoldFlow = MutableSharedFlow<Boolean>(replay = 1)
@@ -227,8 +227,49 @@ class ConversationListViewModelImpl @AssistedInject constructor(
 
     init {
         observeSelfUserLegalHoldState()
-        if (!usePagination) {
+        if (usePagination) {
+            mirrorPagingSnapshotIntoCache()
+        } else {
             observeNonPaginatedSearchConversationList()
+        }
+    }
+
+    /**
+     * Derives the snapshot cache from [conversationsPaginatedFlow] inside the ViewModel,
+     * but only while the UI is actually collecting [itemSnapshotCache]. Without this
+     * gating, the headless presenter would be a permanent subscriber on the shared
+     * paging flow and would defeat the lifecycle gating done at the consumer side
+     * (`flowWithLifecycle` in the helper and `WhileSubscribed` on the upstream
+     * `shareIn`) — DB queries and paging work would keep running in the background.
+     *
+     * The `MutableStateFlow.value` is retained across stop/restart cycles, so the
+     * previous snapshot is still available when the user returns to the screen.
+     */
+    private fun mirrorPagingSnapshotIntoCache() {
+        viewModelScope.launch {
+            _itemSnapshotCache.subscriptionCount
+                .map { it > 0 }
+                .distinctUntilChanged()
+                .collectLatest { hasSubscribers ->
+                    if (!hasSubscribers) return@collectLatest
+                    val presenter = object : PagingDataPresenter<ConversationItemType>(
+                        mainContext = dispatcher.main(),
+                    ) {
+                        override suspend fun presentPagingDataEvent(event: PagingDataEvent<ConversationItemType>) {
+                            // PagingDataPresenter maintains its own snapshot internally;
+                            // we only need to re-read it after each event and publish
+                            // non-empty snapshots so the cache is never clobbered by the
+                            // transient empty frame paging-compose 3.3.x emits.
+                            val items = snapshot().items.filterNotNull().toPersistentList()
+                            if (items.isNotEmpty()) {
+                                _itemSnapshotCache.value = items
+                            }
+                        }
+                    }
+                    conversationsPaginatedFlow.collectLatest { pagingData ->
+                        presenter.collectFrom(pagingData)
+                    }
+                }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -65,6 +65,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
@@ -74,6 +75,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 
 @Suppress("TooManyFunctions")
@@ -184,6 +186,15 @@ class ConversationListViewModelImpl @AssistedInject constructor(
         }
         .flowOn(dispatcher.io())
         .cachedIn(viewModelScope)
+        // Keep a single persistent subscriber alive in viewModelScope so the cachedIn snapshot
+        // survives the UI detaching/reattaching (e.g. navigating to a conversation and back).
+        // Without this, each return to the screen creates a new collector on the upstream and
+        // Paging treats it as a fresh load, dropping the cached pages and the scroll position.
+        .shareIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = SHARE_STOP_TIMEOUT_MS),
+            replay = 1,
+        )
 
     override var conversationListState by mutableStateOf(
         when (usePagination) {
@@ -297,6 +308,10 @@ class ConversationListViewModelImpl @AssistedInject constructor(
         } else {
             _infoMessage.emit(HomeSnackBarMessage.ClearConversationContentSuccess(isGroup))
         }
+    }
+
+    companion object {
+        private const val SHARE_STOP_TIMEOUT_MS = 5_000L
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -282,8 +282,8 @@ fun ConversationsScreenContent(
             navigator.navigate(
                 NavigationCommand(
                     DebugConversationScreenDestination(
-                navArgs = DebugConversationScreenNavArgs(conversationId)
-            )
+                        navArgs = DebugConversationScreenNavArgs(conversationId)
+                    )
                 )
             )
         },
@@ -297,9 +297,11 @@ fun ConversationsScreenContent(
 private enum class PagedLoadingState {
     /** First time the user sees this list — no cached items exist, show the skeleton. */
     InitialLoad,
+
     /** Returning to the screen mid-refresh after cache invalidation — keep the list view
      *  so the user doesn't see the skeleton or empty state flash. */
     Reloading,
+
     /** Loaded (or settled empty). The UI can use itemCount to choose a branch. */
     Loaded,
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -27,9 +27,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import com.ramcosta.composedestinations.generated.app.destinations.BrowseChannelsScreenDestination
@@ -72,6 +74,8 @@ import com.wire.android.util.ui.SnackBarMessageHandler
 import com.wire.android.util.ui.collectAsLazyPagingItemsWithLifecycle
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.filter
 
 /**
  * This is a base for creating screens for displaying list of conversations.
@@ -169,39 +173,68 @@ fun ConversationsScreenContent(
         is ConversationListState.Paginated -> {
             val lazyPagingItems = state.conversations.collectAsLazyPagingItemsWithLifecycle()
             val loadingState = lazyPagingItems.loadingState()
-            // paging-compose 3.3.x emits a transient empty LazyPagingItems on first composition.
+            val itemSnapshotCache by conversationListViewModel.itemSnapshotCache.collectAsStateWithLifecycle()
+
+            // Feed the ViewModel-side snapshot cache from the live paging items so it survives
+            // back-stack navigation. We only persist non-empty snapshots — the transient empty
+            // LazyPagingItems emitted by paging-compose 3.3.x must not overwrite the cache.
+            LaunchedEffect(lazyPagingItems, conversationListViewModel) {
+                snapshotFlow { lazyPagingItems.itemSnapshotList.items.filterNotNull() }
+                    .filter { it.isNotEmpty() }
+                    .collect { conversationListViewModel.updateItemSnapshotCache(it.toPersistentList()) }
+            }
+
             // While still loading we keep the previous search-bar visibility and skip the
             // "no conversations" branch so the screen doesn't flicker on back-navigation.
             if (loadingState == PagedLoadingState.Loaded) {
                 searchBarState.searchVisibleChanged(lazyPagingItems.itemCount > 0 || searchBarState.isSearchActive)
             }
+
+            val onBrowsePublicChannels = remember(navigator) {
+                { navigator.navigate(NavigationCommand(BrowseChannelsScreenDestination)) }
+            }
+            val onAudioPermissionPermanentlyDenied = remember {
+                {
+                    permissionPermanentlyDeniedDialogState.show(
+                        PermissionPermanentlyDeniedDialogState.Visible(
+                            R.string.app_permission_dialog_title,
+                            R.string.call_permission_dialog_description
+                        )
+                    )
+                }
+            }
+
             when {
-                // very first load ever — no cached items to fall back on, show the skeleton
-                loadingState == PagedLoadingState.InitialLoad -> loadingListContent(lazyListState)
-                // either we have items, or we previously had items and the cache was just
-                // invalidated while we were on another screen. Keep rendering the list view
-                // for that one empty frame instead of flashing the skeleton or empty state.
-                lazyPagingItems.itemCount > 0 || loadingState == PagedLoadingState.Reloading -> ConversationList(
+                // live items present — render the paged list
+                lazyPagingItems.itemCount > 0 -> ConversationList(
                     lazyPagingConversations = lazyPagingItems,
                     lazyListState = lazyListState,
                     onOpenConversation = onOpenConversation,
                     onEditConversation = onEditConversationItem,
                     onOpenUserProfile = onOpenUserProfile,
                     onJoinCall = onJoinCall,
-                    onAudioPermissionPermanentlyDenied = {
-                        permissionPermanentlyDeniedDialogState.show(
-                            PermissionPermanentlyDeniedDialogState.Visible(
-                                R.string.app_permission_dialog_title,
-                                R.string.call_permission_dialog_description
-                            )
-                        )
-                    },
+                    onAudioPermissionPermanentlyDenied = onAudioPermissionPermanentlyDenied,
                     onPlayPauseCurrentAudio = onPlayPauseCurrentAudio,
                     onStopCurrentAudio = onStopCurrentAudio,
-                    onBrowsePublicChannels = {
-                        navigator.navigate(NavigationCommand(BrowseChannelsScreenDestination))
-                    }
+                    onBrowsePublicChannels = onBrowsePublicChannels,
                 )
+                // paging-compose has not yet replayed the cached PagingData (transient empty
+                // frame). If we have a ViewModel-side snapshot from a previous session, render
+                // it so the user sees continuity instead of a skeleton or empty state.
+                loadingState == PagedLoadingState.Reloading && itemSnapshotCache.isNotEmpty() -> ConversationList(
+                    conversationItemsSnapshot = itemSnapshotCache,
+                    lazyListState = lazyListState,
+                    onOpenConversation = onOpenConversation,
+                    onEditConversation = onEditConversationItem,
+                    onOpenUserProfile = onOpenUserProfile,
+                    onJoinCall = onJoinCall,
+                    onAudioPermissionPermanentlyDenied = onAudioPermissionPermanentlyDenied,
+                    onPlayPauseCurrentAudio = onPlayPauseCurrentAudio,
+                    onStopCurrentAudio = onStopCurrentAudio,
+                    onBrowsePublicChannels = onBrowsePublicChannels,
+                )
+                // very first load ever — no cached items to fall back on, show the skeleton
+                loadingState != PagedLoadingState.Loaded -> loadingListContent(lazyListState)
                 // when there is no conversation in any folder
                 searchBarState.isSearchActive -> SearchConversationsEmptyContent(onNewConversationClicked = onNewConversationClicked)
                 else -> emptyListContent(state.domain)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -74,8 +73,6 @@ import com.wire.android.util.ui.SnackBarMessageHandler
 import com.wire.android.util.ui.collectAsLazyPagingItemsWithLifecycle
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
-import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.flow.filter
 
 /**
  * This is a base for creating screens for displaying list of conversations.
@@ -174,15 +171,6 @@ fun ConversationsScreenContent(
             val lazyPagingItems = state.conversations.collectAsLazyPagingItemsWithLifecycle()
             val loadingState = lazyPagingItems.loadingState()
             val itemSnapshotCache by conversationListViewModel.itemSnapshotCache.collectAsStateWithLifecycle()
-
-            // Feed the ViewModel-side snapshot cache from the live paging items so it survives
-            // back-stack navigation. We only persist non-empty snapshots — the transient empty
-            // LazyPagingItems emitted by paging-compose 3.3.x must not overwrite the cache.
-            LaunchedEffect(lazyPagingItems, conversationListViewModel) {
-                snapshotFlow { lazyPagingItems.itemSnapshotList.items.filterNotNull() }
-                    .filter { it.isNotEmpty() }
-                    .collect { conversationListViewModel.updateItemSnapshotCache(it.toPersistentList()) }
-            }
 
             // While still loading we keep the previous search-bar visibility and skip the
             // "no conversations" branch so the screen doesn't flicker on back-navigation.

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -25,11 +25,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import com.ramcosta.composedestinations.generated.app.destinations.BrowseChannelsScreenDestination
@@ -167,15 +167,21 @@ fun ConversationsScreenContent(
 
     when (val state = conversationListViewModel.conversationListState) {
         is ConversationListState.Paginated -> {
-            val lazyPagingItems = state.conversations.collectAsLazyPagingItemsWithLifecycle(
-                minActiveState = Lifecycle.State.STARTED
-            )
-            searchBarState.searchVisibleChanged(lazyPagingItems.itemCount > 0 || searchBarState.isSearchActive)
+            val lazyPagingItems = state.conversations.collectAsLazyPagingItemsWithLifecycle()
+            val loadingState = lazyPagingItems.loadingState()
+            // paging-compose 3.3.x emits a transient empty LazyPagingItems on first composition.
+            // While still loading we keep the previous search-bar visibility and skip the
+            // "no conversations" branch so the screen doesn't flicker on back-navigation.
+            if (loadingState == PagedLoadingState.Loaded) {
+                searchBarState.searchVisibleChanged(lazyPagingItems.itemCount > 0 || searchBarState.isSearchActive)
+            }
             when {
-                // when conversation list is not yet fetched, show loading indicator
-                lazyPagingItems.isLoading() -> loadingListContent(lazyListState)
-                // when there is at least one conversation
-                lazyPagingItems.itemCount > 0 -> ConversationList(
+                // very first load ever — no cached items to fall back on, show the skeleton
+                loadingState == PagedLoadingState.InitialLoad -> loadingListContent(lazyListState)
+                // either we have items, or we previously had items and the cache was just
+                // invalidated while we were on another screen. Keep rendering the list view
+                // for that one empty frame instead of flashing the skeleton or empty state.
+                lazyPagingItems.itemCount > 0 || loadingState == PagedLoadingState.Reloading -> ConversationList(
                     lazyPagingConversations = lazyPagingItems,
                     lazyListState = lazyListState,
                     onOpenConversation = onOpenConversation,
@@ -267,13 +273,32 @@ fun ConversationsScreenContent(
     })
 }
 
+private enum class PagedLoadingState {
+    /** First time the user sees this list — no cached items exist, show the skeleton. */
+    InitialLoad,
+    /** Returning to the screen mid-refresh after cache invalidation — keep the list view
+     *  so the user doesn't see the skeleton or empty state flash. */
+    Reloading,
+    /** Loaded (or settled empty). The UI can use itemCount to choose a branch. */
+    Loaded,
+}
+
 @Composable
-private fun LazyPagingItems<ConversationItemType>.isLoading(): Boolean {
-    var initialLoadCompleted by remember { mutableStateOf(false) }
-    if (loadState.refresh is LoadState.NotLoading) {
-        initialLoadCompleted = true
+private fun LazyPagingItems<ConversationItemType>.loadingState(): PagedLoadingState {
+    // paging-compose 3.3.x emits an empty LazyPagingItems on each new composition before
+    // the (re)load finishes. We distinguish "first ever load" from "reload after the cache
+    // was invalidated while we were away" so that the second case keeps rendering the list
+    // view (which will populate on the next frame) instead of flashing the skeleton.
+    var hasEverHadItems by rememberSaveable { mutableStateOf(false) }
+    if (itemCount > 0) {
+        hasEverHadItems = true
     }
-    return !initialLoadCompleted && loadState.refresh == LoadState.Loading && itemCount == 0
+    val refreshing = loadState.refresh is LoadState.Loading && itemCount == 0
+    return when {
+        refreshing && !hasEverHadItems -> PagedLoadingState.InitialLoad
+        refreshing && hasEverHadItems -> PagedLoadingState.Reloading
+        else -> PagedLoadingState.Loaded
+    }
 }
 
 private const val TAG = "BaseConversationsScreen"

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import com.ramcosta.composedestinations.generated.app.destinations.BrowseChannelsScreenDestination
@@ -166,7 +167,9 @@ fun ConversationsScreenContent(
 
     when (val state = conversationListViewModel.conversationListState) {
         is ConversationListState.Paginated -> {
-            val lazyPagingItems = state.conversations.collectAsLazyPagingItemsWithLifecycle()
+            val lazyPagingItems = state.conversations.collectAsLazyPagingItemsWithLifecycle(
+                minActiveState = Lifecycle.State.STARTED
+            )
             searchBarState.searchVisibleChanged(lazyPagingItems.itemCount > 0 || searchBarState.isSearchActive)
             when {
                 // when conversation list is not yet fetched, show loading indicator

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+@file:Suppress("TooManyFunctions")
 
 package com.wire.android.ui.home.conversationslist.common
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -72,6 +72,7 @@ import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -154,6 +155,99 @@ fun ConversationList(
                         )
 
                     else -> {}
+                }
+            }
+        }
+        Snapshot.withoutReadObservation {
+            keepOnTopWhenNotScrolled(lazyListState)
+        }
+    }
+}
+
+/**
+ * Renders conversations from an in-memory snapshot (kept alive by the ViewModel) instead
+ * of from `LazyPagingItems`. Used as a fallback during the transient empty frame
+ * paging-compose 3.3.x emits when `cachedIn` was invalidated while the user was on
+ * another screen — so the list view remains visible with the previously-known items
+ * until the new paged data finishes loading and replaces it.
+ *
+ * Render logic is intentionally identical to the paginated overload above; only the
+ * source of items differs.
+ */
+@Suppress("LongParameterList", "CyclomaticComplexMethod")
+@Composable
+fun ConversationList(
+    conversationItemsSnapshot: ImmutableList<ConversationItemType>,
+    modifier: Modifier = Modifier,
+    lazyListState: LazyListState = rememberLazyListState(),
+    isSelectableList: Boolean = false,
+    selectedConversations: List<ConversationId> = emptyList(),
+    onOpenConversation: (ConversationItem) -> Unit = {},
+    onEditConversation: (ConversationItem) -> Unit = {},
+    onOpenUserProfile: (UserId) -> Unit = {},
+    onJoinCall: (ConversationId) -> Unit = {},
+    onConversationSelectedOnRadioGroup: (ConversationItem) -> Unit = {},
+    onAudioPermissionPermanentlyDenied: () -> Unit = {},
+    onPlayPauseCurrentAudio: () -> Unit = { },
+    onStopCurrentAudio: () -> Unit = {},
+    onBrowsePublicChannels: () -> Unit = {}
+) {
+    LazyColumn(
+        state = lazyListState,
+        modifier = modifier.fillMaxSize()
+    ) {
+        items(
+            count = conversationItemsSnapshot.size,
+            key = { index ->
+                when (val it = conversationItemsSnapshot[index]) {
+                    is ConversationSection.Custom -> "section_custom_${it.sectionName}"
+                    is ConversationSection.WithoutHeader -> "section_without_header"
+                    is ConversationItem -> it.conversationId.toString()
+                    ConversationSection.Predefined.BrowseChannels -> "section_predefined_browse_channels"
+                    ConversationSection.Predefined.Conversations -> "section_predefined_conversations"
+                    ConversationSection.Predefined.Favorites -> "section_predefined_favorites"
+                    ConversationSection.Predefined.NewActivities -> "section_predefined_new_activities"
+                }
+            },
+            contentType = { index ->
+                when (conversationItemsSnapshot[index]) {
+                    is ConversationSection -> ConversationSection::class.simpleName
+                    is ConversationItem -> ConversationItem::class.simpleName
+                }
+            }
+        ) { index ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .let { if (LocalInspectionMode.current) it else it.animateItem() }
+            ) {
+                val item = conversationItemsSnapshot[index]
+                if (BuildConfig.PUBLIC_CHANNELS_ENABLED &&
+                    item is ConversationSection.Predefined.BrowseChannels
+                ) {
+                    BrowsePublicChannelsItem(onBrowsePublicChannels)
+                }
+                when (item) {
+                    is ConversationSection -> when (item) {
+                        is ConversationSection.Predefined -> SectionHeader(item.sectionNameResId)
+                        is ConversationSection.Custom -> SectionHeader(item.sectionName)
+                        is ConversationSection.WithoutHeader -> {}
+                    }
+
+                    is ConversationItem ->
+                        ConversationItemFactory(
+                            conversation = item,
+                            isSelectableItem = isSelectableList,
+                            isChecked = selectedConversations.contains(item.conversationId),
+                            onConversationSelectedOnRadioGroup = { onConversationSelectedOnRadioGroup(item) },
+                            openConversation = onOpenConversation,
+                            openMenu = onEditConversation,
+                            openUserProfile = onOpenUserProfile,
+                            joinCall = onJoinCall,
+                            onAudioPermissionPermanentlyDenied = onAudioPermissionPermanentlyDenied,
+                            onPlayPauseCurrentAudio = onPlayPauseCurrentAudio,
+                            onStopCurrentAudio = onStopCurrentAudio
+                        )
                 }
             }
         }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -253,11 +253,10 @@ class ConversationListViewModelTest {
             // The mirror only runs while there's a subscriber on itemSnapshotCache —
             // gating the headless presenter behind subscriptionCount keeps it from
             // doing paging work in the background. Use Turbine to drive a real
-            // subscription.
+            // subscription. Under runTest's virtual time the presenter populates
+            // before Turbine reads the first item, so StateFlow conflation skips the
+            // initial empty value — we only assert on the populated state.
             conversationListViewModel.itemSnapshotCache.test {
-                // initial empty value from MutableStateFlow
-                assertEquals(0, awaitItem().size)
-                // first non-empty snapshot once the PagingDataPresenter has processed
                 val populated = awaitItem()
                 assertEquals(
                     conversations.map { it.conversationId },

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -35,7 +35,6 @@ import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
 import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.ui.home.conversations.usecase.GetConversationsFromSearchUseCase
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
-import com.wire.android.ui.home.conversationslist.model.ConversationItemType
 import com.wire.android.ui.home.conversationslist.model.ConversationsSource
 import com.wire.android.util.ui.UiTextResolver
 import com.wire.android.util.ui.UIText
@@ -53,7 +52,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -241,17 +239,49 @@ class ConversationListViewModelTest {
         }
 
     @Test
-    fun `given snapshot cache update, when reading itemSnapshotCache, then it reflects the latest value`() =
+    fun `given paging data and a subscriber on itemSnapshotCache, when collecting, then cache mirrors the items`() =
         runTest(dispatcherProvider.main()) {
-            val (_, conversationListViewModel) = Arrangement(conversationsSource = ConversationsSource.MAIN).arrange()
-
-            val items = persistentListOf<ConversationItemType>(
+            val conversations = listOf(
                 TestConversationItem.PRIVATE.copy(conversationId = ConversationId("private_1", "")),
                 TestConversationItem.GROUP.copy(conversationId = ConversationId("group_1", "")),
             )
-            conversationListViewModel.updateItemSnapshotCache(items)
+            val (_, conversationListViewModel) = Arrangement(conversationsSource = ConversationsSource.MAIN)
+                .withConversationsPaginated(conversations)
+                .withSelfUserLegalHoldState(LegalHoldStateForSelfUser.Disabled)
+                .arrange()
 
-            assertEquals(items, conversationListViewModel.itemSnapshotCache.value)
+            // The mirror only runs while there's a subscriber on itemSnapshotCache —
+            // gating the headless presenter behind subscriptionCount keeps it from
+            // doing paging work in the background. Use Turbine to drive a real
+            // subscription.
+            conversationListViewModel.itemSnapshotCache.test {
+                // initial empty value from MutableStateFlow
+                assertEquals(0, awaitItem().size)
+                // first non-empty snapshot once the PagingDataPresenter has processed
+                val populated = awaitItem()
+                assertEquals(
+                    conversations.map { it.conversationId },
+                    populated.filterIsInstance<ConversationItem>().map { it.conversationId },
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given no subscriber on itemSnapshotCache, when paging data emits, then the cache stays empty`() =
+        runTest(dispatcherProvider.main()) {
+            val conversations = listOf(
+                TestConversationItem.PRIVATE.copy(conversationId = ConversationId("private_1", "")),
+            )
+            val (_, conversationListViewModel) = Arrangement(conversationsSource = ConversationsSource.MAIN)
+                .withConversationsPaginated(conversations)
+                .withSelfUserLegalHoldState(LegalHoldStateForSelfUser.Disabled)
+                .arrange()
+            advanceUntilIdle()
+
+            // No subscriber attached → the headless presenter never runs → the cache is
+            // still the empty initial value. This protects against background work.
+            assertEquals(0, conversationListViewModel.itemSnapshotCache.value.size)
         }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -35,6 +35,7 @@ import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
 import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.ui.home.conversations.usecase.GetConversationsFromSearchUseCase
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
+import com.wire.android.ui.home.conversationslist.model.ConversationItemType
 import com.wire.android.ui.home.conversationslist.model.ConversationsSource
 import com.wire.android.util.ui.UiTextResolver
 import com.wire.android.util.ui.UIText
@@ -52,6 +53,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -236,6 +238,20 @@ class ConversationListViewModelTest {
 
                 cancelAndIgnoreRemainingEvents()
             }
+        }
+
+    @Test
+    fun `given snapshot cache update, when reading itemSnapshotCache, then it reflects the latest value`() =
+        runTest(dispatcherProvider.main()) {
+            val (_, conversationListViewModel) = Arrangement(conversationsSource = ConversationsSource.MAIN).arrange()
+
+            val items = persistentListOf<ConversationItemType>(
+                TestConversationItem.PRIVATE.copy(conversationId = ConversationId("private_1", "")),
+                TestConversationItem.GROUP.copy(conversationId = ConversationId("group_1", "")),
+            )
+            conversationListViewModel.updateItemSnapshotCache(items)
+
+            assertEquals(items, conversationListViewModel.itemSnapshotCache.value)
         }
 
     @Test

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/ui/LazyPagingItemsUtil.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/ui/LazyPagingItemsUtil.kt
@@ -18,11 +18,6 @@
 package com.wire.android.util.ui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.flowWithLifecycle
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -31,25 +26,16 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 /**
- * Collects a [Flow] of [PagingData] as [LazyPagingItems] that are lifecycle-aware.
+ * Collects a [Flow] of [PagingData] as [LazyPagingItems].
  *
- * This function ensures that the collection of the paging data is tied to the lifecycle of the
- * composable, preventing memory leaks and unnecessary work when the composable is not active.
- *
- * @param minActiveState The minimum lifecycle state at which the flow should be collected. Default is [Lifecycle.State.RESUMED].
- * @param context The coroutine context to use for collecting the flow. Default is [EmptyCoroutineContext].
- * @param lifecycle The lifecycle to use for determining when to collect the flow. Default is the current one from [LocalLifecycleOwner].
- * @return A [LazyPagingItems] instance that can be used in a LazyColumn or similar composable.
+ * Important: the upstream flow is expected to be a hot, shared source (e.g. produced by
+ * `cachedIn(viewModelScope).shareIn(...)`). Wrapping the upstream with `flowWithLifecycle`
+ * here would cancel and restart the collector on every lifecycle dip, which defeats
+ * `cachedIn` — Paging would treat each return-to-screen as a fresh subscriber and drop
+ * the cached pages along with the scroll position. Subscription lifecycle is handled
+ * internally by `collectAsLazyPagingItems` via `DisposableEffect`.
  */
 @Composable
 fun <T : Any> Flow<PagingData<T>>.collectAsLazyPagingItemsWithLifecycle(
-    minActiveState: Lifecycle.State = Lifecycle.State.RESUMED,
     context: CoroutineContext = EmptyCoroutineContext,
-    lifecycle: Lifecycle = LocalLifecycleOwner.current.lifecycle
-): LazyPagingItems<T> {
-    val isPreview = LocalInspectionMode.current
-    val lifecycleAwareFlow = remember(this, lifecycle, isPreview) {
-        if (isPreview) this else this.flowWithLifecycle(lifecycle, minActiveState)
-    }
-    return lifecycleAwareFlow.collectAsLazyPagingItems(context)
-}
+): LazyPagingItems<T> = collectAsLazyPagingItems(context)

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/ui/LazyPagingItemsUtil.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/ui/LazyPagingItemsUtil.kt
@@ -18,6 +18,11 @@
 package com.wire.android.util.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -26,16 +31,31 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 /**
- * Collects a [Flow] of [PagingData] as [LazyPagingItems].
+ * Collects a [Flow] of [PagingData] as [LazyPagingItems] tied to the host lifecycle, so
+ * paging work pauses while the screen is not visible (e.g. when the app is in the
+ * background or the destination is off‑screen).
  *
- * Important: the upstream flow is expected to be a hot, shared source (e.g. produced by
- * `cachedIn(viewModelScope).shareIn(...)`). Wrapping the upstream with `flowWithLifecycle`
- * here would cancel and restart the collector on every lifecycle dip, which defeats
- * `cachedIn` — Paging would treat each return-to-screen as a fresh subscriber and drop
- * the cached pages along with the scroll position. Subscription lifecycle is handled
- * internally by `collectAsLazyPagingItems` via `DisposableEffect`.
+ * `flowWithLifecycle` cancels and restarts the consumer on lifecycle dips. This works
+ * cleanly only when the upstream is a hot, shared source (typically produced via
+ * `cachedIn(viewModelScope).shareIn(viewModelScope, replay = 1)` on the ViewModel side).
+ * Wrapping a non‑shared `cachedIn` flow here would force Paging to treat each resume as
+ * a fresh subscriber, dropping the cached pages and the scroll position. The empty
+ * `LazyPagingItems` paging‑compose 3.3.x emits on each restart is masked at the UI
+ * layer by the ViewModel‑side item snapshot cache.
+ *
+ * @param minActiveState minimum lifecycle state at which the flow is collected.
+ * @param context coroutine context for collection.
+ * @param lifecycle host lifecycle; defaults to [LocalLifecycleOwner].
  */
 @Composable
 fun <T : Any> Flow<PagingData<T>>.collectAsLazyPagingItemsWithLifecycle(
+    minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
     context: CoroutineContext = EmptyCoroutineContext,
-): LazyPagingItems<T> = collectAsLazyPagingItems(context)
+    lifecycle: Lifecycle = LocalLifecycleOwner.current.lifecycle,
+): LazyPagingItems<T> {
+    val isPreview = LocalInspectionMode.current
+    val lifecycleAwareFlow = remember(this, lifecycle, isPreview) {
+        if (isPreview) this else this.flowWithLifecycle(lifecycle, minActiveState)
+    }
+    return lifecycleAwareFlow.collectAsLazyPagingItems(context)
+}


### PR DESCRIPTION
# What's new in this PR?

### Issues

After navigating away from the conversation list (e.g. opening a conversation) and back, if the underlying data had changed while the user was away, the list area briefly flashed:
- An empty list area, or
- The loading shimmer (`LoadingListContent`)

before the conversations re-appeared. This broke visual continuity and scroll-state expectations on back-navigation.

This is the residual flicker the previous PR (#<previous-PR-number>) flagged but could not fully eliminate.

### Causes

paging-compose 3.3.x changed `collectAsLazyPagingItems` so that it emits an empty `LazyPagingItems` on the very first composition before the cached `PagingData` replays. When `cachedIn` is invalidated upstream — which happens any time conversation activity occurs while the user is on another screen — the new `LazyPagingItems` instance starts with `itemCount == 0` and `loadState.refresh == Loading` until the new pages finish loading.

The previous PR mitigated this for the no-data-change case by adding `shareIn` on top of `cachedIn` so the upstream subscriber stays alive, but the consumer-side `LazyPagingItems` is still rebuilt on every composition and there was no in-memory source for the screen to fall back to during the empty frame.

### Solutions

- `ConversationListViewModel` now exposes `itemSnapshotCache: StateFlow<PersistentList<ConversationItemType>>`. It lives in `viewModelScope`, so it survives back-stack navigation and is scoped per `ConversationsSource` (Main, Archive, Favorites…).
- `ConversationsScreenContent` feeds the cache from `LazyPagingItems.itemSnapshotList` via `snapshotFlow`, filtering out empty snapshots so the transient empty frame never overwrites the cache.
- New `ConversationList(conversationItemsSnapshot: ImmutableList<ConversationItemType>, …)` overload renders from a plain list using the same keys, content types, and `ConversationItemFactory` callbacks as the paged variant.
- The branching in `ConversationsScreenContent` is now:
  1. Live items present → paged `ConversationList`.
  2. `Reloading` and cache non-empty → snapshot `ConversationList` (new bridge — eliminates the flash).
  3. Loading and no cache → skeleton (first-ever visit only).
  4. Empty + search active → search empty state.
  5. Empty → "no conversations".

### Dependencies

Needs releases with:

- [ ] #<previous-PR-number> (adds `shareIn` to the conversation paging flow and simplifies `collectAsLazyPagingItemsWithLifecycle`). This PR is built on top of those changes.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

Added `given snapshot cache update, when reading itemSnapshotCache, then it reflects the latest value` to `ConversationListViewModelTest`.

#### How to Test

Prerequisite: at least one conversation in the list.

1. Open the app on the conversation list — confirm the loading skeleton renders on the first cold start.
2. Open any conversation.
3. While on the conversation screen, trigger an upstream data change (e.g. send/receive a message in this or another conversation, or wait for any presence/last-message update).
4. Tap back to the conversation list.
5. **Expected:** the conversation list is visible immediately with the previously-seen items, then updates in place with the latest data. No skeleton flash, no blank/empty-state flash, scroll position preserved.
6. Repeat for: Archive, Favorites, and any custom folders — each list has its own cache.
7. Search edge case: type a search query, open a result, navigate back — the cached snapshot may briefly show pre-search items before the search results re-apply. Confirm this resolves within a frame.

### Notes

- The snapshot cache is scoped to each `ConversationListViewModel` instance (keyed by `ConversationsSource`), so each list flavor has its own fallback and they don't bleed into one another.
- Both `ConversationList` overloads share rendering logic but are intentionally not deduplicated yet — the paged variant uses `LazyPagingItems.itemKey`/`itemContentType` helpers that don't apply to a plain list. Happy to extract a shared `LazyListScope` extension as a follow-up if reviewers prefer.
- No new dependencies; uses the `kotlinx.collections.immutable` and `androidx.lifecycle.compose` already present in the project.
