### PR TITLE
fix: focus order in user profile screen (WPB-14780)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -22,20 +22,16 @@ import com.wire.android.navigation.annotation.app.WireRootDestination
 import android.annotation.SuppressLint
 import android.content.Context
 import android.widget.Toast
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -202,7 +198,6 @@ fun SelfUserProfileScreen(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SelfUserProfileContent(
     state: SelfUserProfileState,
@@ -255,110 +250,93 @@ private fun SelfUserProfileContent(
             val context = LocalContext.current
             Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .scrollable(state = scrollState, orientation = Orientation.Vertical)
+                    .fillMaxSize()
                     .background(MaterialTheme.colorScheme.background)
                     .padding(internalPadding)
             ) {
                 val selectLabel = stringResource(R.string.content_description_select_label)
-                LazyColumn(
+                Column(
                     modifier = Modifier
                         .weight(1F)
                         .fillMaxWidth()
-                        .fillMaxHeight()
-                        .scrollable(state = scrollState, orientation = Orientation.Vertical)
+                        .verticalScroll(scrollState)
                 ) {
                     if (state.isAbleToMigrateToTeamAccount) {
-                        stickyHeader {
-                            Column(
-                                modifier = Modifier
-                                    .padding(
-                                        top = dimensions().spacing16x,
-                                        start = dimensions().spacing16x,
-                                        end = dimensions().spacing16x
-                                    )
-                            ) {
-                                CreateTeamInfoCard(onCreateAccount)
-                            }
+                        Column(
+                            modifier = Modifier
+                                .padding(
+                                    top = dimensions().spacing16x,
+                                    start = dimensions().spacing16x,
+                                    end = dimensions().spacing16x
+                                )
+                        ) {
+                            CreateTeamInfoCard(onCreateAccount)
                         }
                     }
-                    stickyHeader {
-                        UserProfileInfo(
-                            userId = state.userId,
-                            isLoading = state.isAvatarLoading,
-                            avatarAsset = state.avatarAsset,
-                            fullName = fullName,
-                            userName = userName,
-                            teamName = teamName,
-                            onUserProfileClick = onChangeUserProfilePicture,
-                            editableState = EditableState.IsEditable(onEditClick),
-                            onQrCodeClick = onQrCodeClick,
-                            accentId = accentId,
-                            showQrCode = state.showQrCode,
-                        )
-                    }
+                    UserProfileInfo(
+                        userId = state.userId,
+                        isLoading = state.isAvatarLoading,
+                        avatarAsset = state.avatarAsset,
+                        fullName = fullName,
+                        userName = userName,
+                        teamName = teamName,
+                        onUserProfileClick = onChangeUserProfilePicture,
+                        editableState = EditableState.IsEditable(onEditClick),
+                        onQrCodeClick = onQrCodeClick,
+                        accentId = accentId,
+                        showQrCode = state.showQrCode,
+                    )
                     if (state.legalHoldStatus != LegalHoldUIState.None) {
-                        stickyHeader {
-                            Box(
-                                contentAlignment = Alignment.Center,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = dimensions().spacing8x)
-                            ) {
-                                when (state.legalHoldStatus) {
-                                    LegalHoldUIState.Active -> LegalHoldSubjectBanner(onClick = onLegalHoldLearnMoreClick)
-                                    LegalHoldUIState.Pending -> LegalHoldPendingBanner(onClick = onLegalHoldAcceptClick)
-                                    LegalHoldUIState.None -> {
-                                        /* no banner */
-                                    }
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = dimensions().spacing8x)
+                        ) {
+                            when (state.legalHoldStatus) {
+                                LegalHoldUIState.Active -> LegalHoldSubjectBanner(onClick = onLegalHoldLearnMoreClick)
+                                LegalHoldUIState.Pending -> LegalHoldPendingBanner(onClick = onLegalHoldAcceptClick)
+                                LegalHoldUIState.None -> {
+                                    /* no banner */
                                 }
                             }
                         }
                     }
                     if (!state.teamName.isNullOrBlank()) {
-                        stickyHeader {
-                            CurrentSelfUserStatus(
-                                userStatus = status,
-                                onStatusClicked = onStatusClicked,
-                            )
-                        }
+                        CurrentSelfUserStatus(
+                            userStatus = status,
+                            onStatusClicked = onStatusClicked,
+                        )
                     }
-                    stickyHeader {
-                        VerticalSpace.x8()
-                        Box(modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing16x)) {
-                            AccountDetailButton(onAccountDetailsClick = onAccountDetailsClick)
-                        }
+                    VerticalSpace.x8()
+                    Box(modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing16x)) {
+                        AccountDetailButton(onAccountDetailsClick = onAccountDetailsClick)
                     }
                     if (state.otherAccounts.isNotEmpty()) {
-                        stickyHeader {
-                            VerticalSpace.x16()
-                            OtherAccountsHeader()
-                        }
-                        items(
-                            items = otherAccounts,
-                            itemContent = { account ->
-                                OtherAccountItem(
-                                    account = account,
-                                    clickable = remember {
-                                        Clickable(
-                                            enabled = true,
-                                            onClickDescription = selectLabel,
-                                            onClick = {
-                                                if (isUserInCall()) {
-                                                    Toast.makeText(
-                                                        context,
-                                                        R.string.cant_switch_account_in_call,
-                                                        Toast.LENGTH_SHORT
-                                                    ).show()
-                                                } else {
-                                                    onOtherAccountClick(account.id)
-                                                }
+                        VerticalSpace.x16()
+                        OtherAccountsHeader()
+                        otherAccounts.forEach { account ->
+                            OtherAccountItem(
+                                account = account,
+                                clickable = remember(account.id) {
+                                    Clickable(
+                                        enabled = true,
+                                        onClickDescription = selectLabel,
+                                        onClick = {
+                                            if (isUserInCall()) {
+                                                Toast.makeText(
+                                                    context,
+                                                    R.string.cant_switch_account_in_call,
+                                                    Toast.LENGTH_SHORT
+                                                ).show()
+                                            } else {
+                                                onOtherAccountClick(account.id)
                                             }
-                                        )
-                                    }
-                                )
-                            }
-                        )
+                                        }
+                                    )
+                                }
+                            )
+                        }
                     }
                 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-14780
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-14780
----

# What's new in this PR?

### Issues
The order of focus transitions between screen widgets does not follow the widget visual arrangement on the screen.

### Solutions
The screen has a small set of fixed sections. Replacing the LazyColumn with regular Column layout fixed the focus transition without adding complex focus handling.
