### PR TITLE
Mo/feat/in memory active calls

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
@@ -79,6 +79,11 @@ class CallsModule {
 
     @ViewModelScoped
     @Provides
+    fun provideObserveActiveCallConversationIdsUseCase(callsScope: CallsScope) =
+        callsScope.observeActiveCallConversationIds
+
+    @ViewModelScoped
+    @Provides
     fun provideObserveEstablishedCallWithSortedParticipantsUseCase(callsScope: CallsScope) =
         callsScope.observeEstablishedCallWithSortedParticipants
 

--- a/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
@@ -62,7 +62,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
                 mutedStatus = conversationDetails.conversation.mutedStatus,
                 unreadEventCount = unreadEventCount
             ),
-            hasOnGoingCall = conversationDetails.hasOngoingCall && conversationDetails.isSelfUserMember,
+            hasOnGoingCall = false,
             isFromTheSameTeam = conversationDetails.conversation.teamId == selfUserTeamId,
             isSelfUserMember = conversationDetails.isSelfUserMember,
             teamId = conversationDetails.conversation.teamId,
@@ -89,7 +89,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
                 mutedStatus = conversationDetails.conversation.mutedStatus,
                 unreadEventCount = unreadEventCount
             ),
-            hasOnGoingCall = conversationDetails.hasOngoingCall && conversationDetails.isSelfUserMember,
+            hasOnGoingCall = false,
             isFromTheSameTeam = conversationDetails.conversation.teamId == selfUserTeamId,
             isSelfUserMember = conversationDetails.isSelfUserMember,
             teamId = conversationDetails.conversation.teamId,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
@@ -108,7 +108,8 @@ class GetConversationsFromSearchUseCase @Inject constructor(
                         playingAudioMessage = playingAudioMessage
                     )
                 }
-            }.flowOn(dispatchers.io())
+            }
+            .flowOn(dispatchers.io())
     }
 
     private fun staticPagingItems(conversations: List<ConversationDetailsWithEvents>): PagingData<ConversationDetailsWithEvents> {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListState.kt
@@ -20,22 +20,26 @@ package com.wire.android.ui.home.conversationslist
 
 import androidx.compose.runtime.Stable
 import androidx.paging.PagingData
+import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.ui.home.conversationslist.model.ConversationSection
 import com.wire.android.ui.home.conversationslist.model.ConversationItemType
-import com.wire.android.ui.home.conversationslist.model.ConversationItem
+import com.wire.kalium.logic.data.id.ConversationId
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 @Stable
 sealed interface ConversationListState {
     data class Paginated(
         val conversations: Flow<PagingData<ConversationItemType>>,
+        val activeCallConversationIds: Flow<Set<ConversationId>> = flowOf(emptySet()),
         val domain: String = "",
     ) : ConversationListState
     data class NotPaginated(
         val isLoading: Boolean = true,
         val conversations: ImmutableMap<ConversationSection, List<ConversationItem>> = persistentMapOf(),
+        val activeCallConversationIds: Flow<Set<ConversationId>> = flowOf(emptySet()),
         val domain: String = "",
     ) : ConversationListState
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -158,7 +158,11 @@ class ConversationListViewModelImpl @AssistedInject constructor(
         .combine(audioMessagePlayer.playingAudioMessageFlow) { (searchQuery, isSelfUserUnderLegalHold), playingAudioMessage ->
             Triple(searchQuery, isSelfUserUnderLegalHold, playingAudioMessage)
         }
-        .flatMapLatest { (searchQuery, isSelfUserUnderLegalHold, playingAudioMessage) ->
+        .combine(activeCallConversationIdsFlow) { conversationListConfig, activeCallConversationIds ->
+            conversationListConfig to activeCallConversationIds
+        }
+        .flatMapLatest { (conversationListConfig, activeCallConversationIds) ->
+            val (searchQuery, isSelfUserUnderLegalHold, playingAudioMessage) = conversationListConfig
             getConversationsPaginated(
                 searchQuery = searchQuery,
                 fromArchive = conversationsSource == ConversationsSource.ARCHIVE,
@@ -175,15 +179,18 @@ class ConversationListViewModelImpl @AssistedInject constructor(
                             // do not add separators if the list shouldn't show conversations grouped into different folders
                             !containsNewActivitiesSection -> null
 
-                            before == null && after != null && after.hasNewActivitiesToShow ->
+                            before == null && after != null && after.hasNewActivitiesToShow(activeCallConversationIds) ->
                                 // list starts with items with "new activities"
                                 ConversationSection.Predefined.NewActivities
 
-                            before == null && after != null && !after.hasNewActivitiesToShow ->
+                            before == null && after != null && !after.hasNewActivitiesToShow(activeCallConversationIds) ->
                                 // list doesn't contain any items with "new activities"
                                 ConversationSection.Predefined.Conversations
 
-                            before != null && before.hasNewActivitiesToShow && after != null && !after.hasNewActivitiesToShow ->
+                            before != null &&
+                                    before.hasNewActivitiesToShow(activeCallConversationIds) &&
+                                    after != null &&
+                                    !after.hasNewActivitiesToShow(activeCallConversationIds) ->
                                 // end of "new activities" section and beginning of "conversations" section
                                 ConversationSection.Predefined.Conversations
 
@@ -237,8 +244,9 @@ class ConversationListViewModelImpl @AssistedInject constructor(
                             conversationFilter = conversationsSource.toFilter()
                         ),
                         isSelfUserUnderLegalHoldFlow,
-                        audioMessagePlayer.playingAudioMessageFlow
-                    ) { conversations, isSelfUserUnderLegalHold, playingAudioMessage ->
+                        audioMessagePlayer.playingAudioMessageFlow,
+                        activeCallConversationIdsFlow
+                    ) { conversations, isSelfUserUnderLegalHold, playingAudioMessage, activeCallConversationIds ->
                         conversations.map { conversationDetails ->
                             conversationDetails.toConversationItem(
                                 userTypeMapper = userTypeMapper,
@@ -248,17 +256,24 @@ class ConversationListViewModelImpl @AssistedInject constructor(
                                 playingAudioMessage = playingAudioMessage
                             )
                                 .hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold)
-                        } to searchQuery
+                        } to (searchQuery to activeCallConversationIds)
                     }
                 }
-                .map { (conversationItems, searchQuery) ->
+                .map { (conversationItems, searchQueryAndActiveCallConversationIds) ->
+                    val (searchQuery, activeCallConversationIds) = searchQueryAndActiveCallConversationIds
                     if (searchQuery.isEmpty()) {
-                        conversationItems.withSections(source = conversationsSource).toImmutableMap()
+                        conversationItems.withSections(
+                            source = conversationsSource,
+                            activeCallConversationIds = activeCallConversationIds
+                        ).toImmutableMap()
                     } else {
                         searchConversation(
                             conversationDetails = conversationItems,
                             searchQuery = searchQuery
-                        ).withSections(source = conversationsSource).toImmutableMap()
+                        ).withSections(
+                            source = conversationsSource,
+                            activeCallConversationIds = activeCallConversationIds
+                        ).toImmutableMap()
                     }
                 }
                 .flowOn(dispatcher.io())
@@ -346,7 +361,10 @@ private fun ConversationItem.hideIndicatorForSelfUserUnderLegalHold(isSelfUserUn
     }
 
 @Suppress("ComplexMethod")
-private fun List<ConversationItem>.withSections(source: ConversationsSource): Map<ConversationSection, List<ConversationItem>> {
+private fun List<ConversationItem>.withSections(
+    source: ConversationsSource,
+    activeCallConversationIds: Set<ConversationId> = emptySet()
+): Map<ConversationSection, List<ConversationItem>> {
     return when (source) {
         ConversationsSource.ARCHIVE -> {
             buildMap {
@@ -362,7 +380,7 @@ private fun List<ConversationItem>.withSections(source: ConversationsSource): Ma
         ConversationsSource.ONE_ON_ONE,
         is ConversationsSource.FOLDER,
         ConversationsSource.MAIN -> {
-            val (unreadConversations, remainingConversations) = unreadToReadConversationsItems()
+            val (unreadConversations, remainingConversations) = unreadToReadConversationsItems(activeCallConversationIds)
             buildMap {
                 if (unreadConversations.isNotEmpty()) {
                     put(ConversationSection.Predefined.NewActivities, unreadConversations)
@@ -374,7 +392,7 @@ private fun List<ConversationItem>.withSections(source: ConversationsSource): Ma
         }
 
         is ConversationsSource.CHANNELS -> {
-            val (unreadConversations, remainingConversations) = unreadToReadConversationsItems()
+            val (unreadConversations, remainingConversations) = unreadToReadConversationsItems(activeCallConversationIds)
             buildMap {
                 put(ConversationSection.Predefined.BrowseChannels, emptyList())
                 if (unreadConversations.isNotEmpty()) {
@@ -389,7 +407,9 @@ private fun List<ConversationItem>.withSections(source: ConversationsSource): Ma
 }
 
 @Suppress("CyclomaticComplexMethod")
-private fun List<ConversationItem>.unreadToReadConversationsItems(): Pair<List<ConversationItem>, List<ConversationItem>> {
+private fun List<ConversationItem>.unreadToReadConversationsItems(
+    activeCallConversationIds: Set<ConversationId>
+): Pair<List<ConversationItem>, List<ConversationItem>> {
     val unreadConversations = filter {
         when (it.mutedStatus) {
             MutedConversationStatus.AllAllowed -> when (it.badgeEventType) {
@@ -414,15 +434,21 @@ private fun List<ConversationItem>.unreadToReadConversationsItems(): Pair<List<C
                 }
 
             MutedConversationStatus.AllMuted -> false
-        } || (it is ConversationItem.Group && it.hasOnGoingCall)
-    }.sortedByDescending { it.isActiveGroupCall }
+        } || it.isActiveGroupCall(activeCallConversationIds)
+    }.sortedByDescending { it.isActiveGroupCall(activeCallConversationIds) }
 
     val remainingConversations = this - unreadConversations.toSet()
     return unreadConversations to remainingConversations
 }
 
-private val ConversationItem.isActiveGroupCall: Boolean
-    get() = this is ConversationItem.Group && hasOnGoingCall
+private fun ConversationItemType.hasNewActivitiesToShow(activeCallConversationIds: Set<ConversationId>): Boolean =
+    this is ConversationItem && hasNewActivitiesToShow(activeCallConversationIds)
+
+private fun ConversationItem.hasNewActivitiesToShow(activeCallConversationIds: Set<ConversationId>): Boolean =
+    hasNewActivitiesToShow || isActiveGroupCall(activeCallConversationIds)
+
+private fun ConversationItem.isActiveGroupCall(activeCallConversationIds: Set<ConversationId>): Boolean =
+    this is ConversationItem.Group && isSelfUserMember && conversationId in activeCallConversationIds
 
 private fun searchConversation(conversationDetails: List<ConversationItem>, searchQuery: String): List<ConversationItem> =
     conversationDetails.filter { details ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -231,7 +231,8 @@ class ConversationListViewModelImpl @AssistedInject constructor(
                                 searchQuery = searchQuery,
                                 selfUserTeamId = getSelfUser()?.teamId,
                                 playingAudioMessage = playingAudioMessage
-                            ).hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold)
+                            )
+                                .hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold)
                         } to searchQuery
                     }
                 }
@@ -398,11 +399,14 @@ private fun List<ConversationItem>.unreadToReadConversationsItems(): Pair<List<C
 
             MutedConversationStatus.AllMuted -> false
         } || (it is ConversationItem.Group && it.hasOnGoingCall)
-    }
+    }.sortedByDescending { it.isActiveGroupCall }
 
     val remainingConversations = this - unreadConversations.toSet()
     return unreadConversations to remainingConversations
 }
+
+private val ConversationItem.isActiveGroupCall: Boolean
+    get() = this is ConversationItem.Group && hasOnGoingCall
 
 private fun searchConversation(conversationDetails: List<ConversationItem>, searchQuery: String): List<ConversationItem> =
     conversationDetails.filter { details ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -48,7 +48,9 @@ import com.wire.android.util.ui.UiTextResolver
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationFilter
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.call.usecase.ObserveActiveCallConversationIdsUseCase
 import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationListDetailsWithEventsUseCase
 import com.wire.kalium.logic.feature.conversation.RefreshConversationsWithoutMetadataUseCase
@@ -70,7 +72,9 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -104,6 +108,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
     private val observeConversationListDetailsWithEvents: ObserveConversationListDetailsWithEventsUseCase,
     private val refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase,
     private val refreshConversationsWithoutMetadata: RefreshConversationsWithoutMetadataUseCase,
+    private val observeActiveCallConversationIds: ObserveActiveCallConversationIdsUseCase,
     private val observeLegalHoldStateForSelfUser: ObserveLegalHoldStateForSelfUserUseCase,
     private val audioMessagePlayer: ConversationAudioMessagePlayer,
     @CurrentAccount val currentAccount: UserId,
@@ -128,6 +133,11 @@ class ConversationListViewModelImpl @AssistedInject constructor(
 
     private val searchQueryFlow: MutableStateFlow<String> = MutableStateFlow("")
     private val isSelfUserUnderLegalHoldFlow = MutableSharedFlow<Boolean>(replay = 1)
+    private val activeCallConversationIdsFlow: Flow<Set<ConversationId>> = flow {
+        emitAll(observeActiveCallConversationIds())
+    }
+        .onStart { emit(emptySet()) }
+        .flowOn(dispatcher.io())
 
     private val containsNewActivitiesSection = when (conversationsSource) {
         ConversationsSource.MAIN,
@@ -187,8 +197,13 @@ class ConversationListViewModelImpl @AssistedInject constructor(
 
     override var conversationListState by mutableStateOf(
         when (usePagination) {
-            true -> ConversationListState.Paginated(conversations = conversationsPaginatedFlow, domain = currentAccount.domain)
-            false -> ConversationListState.NotPaginated()
+            true -> ConversationListState.Paginated(
+                conversations = conversationsPaginatedFlow,
+                activeCallConversationIds = activeCallConversationIdsFlow,
+                domain = currentAccount.domain
+            )
+
+            false -> ConversationListState.NotPaginated(activeCallConversationIds = activeCallConversationIdsFlow)
         }
     )
         private set
@@ -251,6 +266,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
                     conversationListState = ConversationListState.NotPaginated(
                         isLoading = false,
                         conversations = it,
+                        activeCallConversationIds = activeCallConversationIdsFlow,
                         domain = currentAccount.domain
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import com.ramcosta.composedestinations.generated.app.destinations.BrowseChannelsScreenDestination
@@ -167,6 +168,7 @@ fun ConversationsScreenContent(
     when (val state = conversationListViewModel.conversationListState) {
         is ConversationListState.Paginated -> {
             val lazyPagingItems = state.conversations.collectAsLazyPagingItemsWithLifecycle()
+            val activeCallConversationIds by state.activeCallConversationIds.collectAsStateWithLifecycle(emptySet())
             searchBarState.searchVisibleChanged(lazyPagingItems.itemCount > 0 || searchBarState.isSearchActive)
             when {
                 // when conversation list is not yet fetched, show loading indicator
@@ -179,6 +181,7 @@ fun ConversationsScreenContent(
                     onEditConversation = onEditConversationItem,
                     onOpenUserProfile = onOpenUserProfile,
                     onJoinCall = onJoinCall,
+                    activeCallConversationIds = activeCallConversationIds,
                     onAudioPermissionPermanentlyDenied = {
                         permissionPermanentlyDeniedDialogState.show(
                             PermissionPermanentlyDeniedDialogState.Visible(
@@ -200,6 +203,7 @@ fun ConversationsScreenContent(
         }
 
         is ConversationListState.NotPaginated -> {
+            val activeCallConversationIds by state.activeCallConversationIds.collectAsStateWithLifecycle(emptySet())
             val hasConversations = state.conversations.isNotEmpty() && state.conversations.any { it.value.isNotEmpty() }
             searchBarState.searchVisibleChanged(isSearchVisible = hasConversations || searchBarState.isSearchActive)
             when {
@@ -213,6 +217,7 @@ fun ConversationsScreenContent(
                     onEditConversation = onEditConversationItem,
                     onOpenUserProfile = onOpenUserProfile,
                     onJoinCall = onJoinCall,
+                    activeCallConversationIds = activeCallConversationIds,
                     onAudioPermissionPermanentlyDenied = {
                         permissionPermanentlyDeniedDialogState.show(
                             PermissionPermanentlyDeniedDialogState.Visible(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemActiveCallStatus.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemActiveCallStatus.kt
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.home.conversationslist.common
+
+import com.wire.android.ui.home.conversationslist.model.ConversationItem
+import com.wire.kalium.logic.data.id.ConversationId
+
+internal fun ConversationItem.withActiveCallStatus(activeCallConversationIds: Set<ConversationId>): ConversationItem =
+    when (this) {
+        is ConversationItem.Group.Regular -> {
+            val hasActiveCall = conversationId in activeCallConversationIds && isSelfUserMember
+            copy(
+                hasOnGoingCall = hasActiveCall,
+                hasNewActivitiesToShow = hasNewActivitiesToShow || hasActiveCall
+            )
+        }
+
+        is ConversationItem.Group.Channel -> {
+            val hasActiveCall = conversationId in activeCallConversationIds && isSelfUserMember
+            copy(
+                hasOnGoingCall = hasActiveCall,
+                hasNewActivitiesToShow = hasNewActivitiesToShow || hasActiveCall
+            )
+        }
+
+        is ConversationItem.ConnectionConversation,
+        is ConversationItem.PrivateConversation -> this
+    }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -88,6 +88,7 @@ fun ConversationList(
     onEditConversation: (ConversationItem) -> Unit = {},
     onOpenUserProfile: (UserId) -> Unit = {},
     onJoinCall: (ConversationId) -> Unit = {},
+    activeCallConversationIds: Set<ConversationId> = emptySet(),
     onConversationSelectedOnRadioGroup: (ConversationItem) -> Unit = {},
     onAudioPermissionPermanentlyDenied: () -> Unit = {},
     onPlayPauseCurrentAudio: () -> Unit = { },
@@ -138,12 +139,13 @@ fun ConversationList(
                         is ConversationSection.WithoutHeader -> {}
                     }
 
-                    is ConversationItem ->
+                    is ConversationItem -> {
+                        val conversation = item.withActiveCallStatus(activeCallConversationIds)
                         ConversationItemFactory(
-                            conversation = item,
+                            conversation = conversation,
                             isSelectableItem = isSelectableList,
-                            isChecked = selectedConversations.contains(item.conversationId),
-                            onConversationSelectedOnRadioGroup = { onConversationSelectedOnRadioGroup(item) },
+                            isChecked = selectedConversations.contains(conversation.conversationId),
+                            onConversationSelectedOnRadioGroup = { onConversationSelectedOnRadioGroup(conversation) },
                             openConversation = onOpenConversation,
                             openMenu = onEditConversation,
                             openUserProfile = onOpenUserProfile,
@@ -152,6 +154,7 @@ fun ConversationList(
                             onPlayPauseCurrentAudio = onPlayPauseCurrentAudio,
                             onStopCurrentAudio = onStopCurrentAudio
                         )
+                    }
 
                     else -> {}
                 }
@@ -213,6 +216,7 @@ fun ConversationList(
     onEditConversation: (ConversationItem) -> Unit = {},
     onOpenUserProfile: (UserId) -> Unit = {},
     onJoinCall: (ConversationId) -> Unit = {},
+    activeCallConversationIds: Set<ConversationId> = emptySet(),
     onConversationSelectedOnRadioGroup: (ConversationId) -> Unit = {},
     onAudioPermissionPermanentlyDenied: () -> Unit = {},
     onPlayPauseCurrentAudio: () -> Unit = { },
@@ -233,11 +237,12 @@ fun ConversationList(
                     it.conversationId.toString()
                 }
             ) { generalConversation ->
+                val conversation = generalConversation.withActiveCallStatus(activeCallConversationIds)
                 ConversationItemFactory(
-                    conversation = generalConversation,
+                    conversation = conversation,
                     isSelectableItem = isSelectableList,
-                    isChecked = selectedConversations.contains(generalConversation),
-                    onConversationSelectedOnRadioGroup = { onConversationSelectedOnRadioGroup(generalConversation.conversationId) },
+                    isChecked = selectedConversations.any { it.conversationId == conversation.conversationId },
+                    onConversationSelectedOnRadioGroup = { onConversationSelectedOnRadioGroup(conversation.conversationId) },
                     openConversation = onOpenConversation,
                     openMenu = onEditConversation,
                     openUserProfile = onOpenUserProfile,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModelArrangement.kt
@@ -227,7 +227,6 @@ internal fun mockConversationDetailsGroup(
 ) = ConversationDetails.Group.Regular(
     conversation = TestConversation.GROUP()
         .copy(name = conversationName, id = mockedConversationId),
-    hasOngoingCall = false,
     isSelfUserMember = true,
     selfRole = Conversation.Member.Role.Member,
     wireCell = null,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupDetailsViewModelTest.kt
@@ -699,7 +699,6 @@ class GroupDetailsViewModelTest {
                 proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
                 legalHoldStatus = Conversation.LegalHoldStatus.ENABLED
             ),
-            hasOngoingCall = false,
             isSelfUserMember = true,
             selfRole = Conversation.Member.Role.Member,
             wireCell = null,
@@ -729,7 +728,6 @@ class GroupDetailsViewModelTest {
                 proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
                 legalHoldStatus = Conversation.LegalHoldStatus.ENABLED
             ),
-            hasOngoingCall = false,
             isSelfUserMember = true,
             selfRole = Conversation.Member.Role.Member,
             wireCell = null,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessViewModelTest.kt
@@ -385,7 +385,6 @@ class UpdateAppsAccessViewModelTest {
                 proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
                 legalHoldStatus = Conversation.LegalHoldStatus.ENABLED
             ),
-            hasOngoingCall = false,
             isSelfUserMember = true,
             selfRole = Conversation.Member.Role.Member,
             wireCell = null,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
@@ -66,7 +66,7 @@ class GetConversationsFromSearchUseCaseTest {
                 newActivitiesOnTop = newActivitiesOnTop,
                 onlyInteractionEnabled = onlyInteractionEnabled,
                 useStrictMlsFilter = true
-            )
+            ).asSnapshot()
         }
         // Then
         coVerify {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -41,6 +41,7 @@ import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.ConversationDetailsWithEvents
 import com.wire.kalium.logic.data.conversation.ConversationFilter
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.call.usecase.ObserveActiveCallConversationIdsUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationListDetailsWithEventsUseCase
 import com.wire.kalium.logic.feature.conversation.RefreshConversationsWithoutMetadataUseCase
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
@@ -288,6 +289,9 @@ class ConversationListViewModelTest {
         private lateinit var observeLegalHoldStateForSelfUserUseCase: ObserveLegalHoldStateForSelfUserUseCase
 
         @MockK
+        private lateinit var observeActiveCallConversationIdsUseCase: ObserveActiveCallConversationIdsUseCase
+
+        @MockK
         private lateinit var getSelfUser: GetSelfUserUseCase
 
         @MockK
@@ -312,6 +316,7 @@ class ConversationListViewModelTest {
                 }
             )
             every { audioMessagePlayer.playingAudioMessageFlow } returns flowOf(PlayingAudioMessage.None)
+            coEvery { observeActiveCallConversationIdsUseCase() } returns flowOf(emptySet())
             coEvery { uiTextResolver.resolve(any()) } answers {
                 val text = firstArg<UIText>()
                 when (text) {
@@ -356,6 +361,7 @@ class ConversationListViewModelTest {
             currentAccount = TestUser.SELF_USER_ID,
             observeConversationListDetailsWithEvents = observeConversationListDetailsWithEventsUseCase,
             observeLegalHoldStateForSelfUser = observeLegalHoldStateForSelfUserUseCase,
+            observeActiveCallConversationIds = observeActiveCallConversationIdsUseCase,
             userTypeMapper = UserTypeMapper(),
             getSelfUser = getSelfUser,
             uiTextResolver = uiTextResolver,


### PR DESCRIPTION
rn active calls are stored in DB which means on app init we need to clear them from memory doing not needed work

this data should be in memory only and this is a POC of how this can look like it can be improved but first want to create a POC