### PR TITLE
feat: add GetSelfTeamIdUseCase to retrieve current user's team ID from cache [WPB-25803]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/UserModule.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
 import com.wire.kalium.logic.feature.publicuser.GetKnownUserUseCase
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
 import com.wire.kalium.logic.feature.user.DeleteAccountUseCase
+import com.wire.kalium.logic.feature.user.GetSelfTeamIdUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
@@ -201,6 +202,11 @@ class UserModule {
     @Provides
     fun provideGetSelfUseCase(userScope: UserScope): GetSelfUserUseCase =
         userScope.getSelfUser
+
+    @ViewModelScoped
+    @Provides
+    fun provideGetSelfTeamIdUseCase(userScope: UserScope): GetSelfTeamIdUseCase =
+        userScope.getSelfTeamId
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
@@ -35,7 +35,7 @@ import com.wire.kalium.logic.data.conversation.ConversationQueryConfig
 import com.wire.kalium.logic.feature.conversation.GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCase
 import com.wire.kalium.logic.feature.conversation.folder.GetFavoriteFolderUseCase
 import com.wire.kalium.logic.feature.conversation.folder.ObserveConversationsFromFolderUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.GetSelfTeamIdUseCase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
@@ -48,7 +48,7 @@ class GetConversationsFromSearchUseCase @Inject constructor(
     private val observeConversationsFromFromFolder: ObserveConversationsFromFolderUseCase,
     private val userTypeMapper: UserTypeMapper,
     private val dispatchers: DispatcherProvider,
-    private val getSelfUser: GetSelfUserUseCase,
+    private val getSelfTeamId: GetSelfTeamIdUseCase,
     private val uiTextResolver: UiTextResolver,
 ) {
     @Suppress("LongParameterList")
@@ -61,6 +61,7 @@ class GetConversationsFromSearchUseCase @Inject constructor(
         playingAudioMessage: PlayingAudioMessage = PlayingAudioMessage.None,
         useStrictMlsFilter: Boolean,
     ): Flow<PagingData<ConversationItem>> {
+        val selfUserTeamId = getSelfTeamId()
         val pagingConfig = PagingConfig(
             pageSize = PAGE_SIZE,
             prefetchDistance = PREFETCH_DISTANCE,
@@ -104,7 +105,7 @@ class GetConversationsFromSearchUseCase @Inject constructor(
                         userTypeMapper = userTypeMapper,
                         uiTextResolver = uiTextResolver,
                         searchQuery = searchQuery,
-                        selfUserTeamId = getSelfUser()?.teamId,
+                        selfUserTeamId = selfUserTeamId,
                         playingAudioMessage = playingAudioMessage
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -55,7 +55,7 @@ import com.wire.kalium.logic.feature.conversation.RefreshConversationsWithoutMet
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.GetSelfTeamIdUseCase
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -110,7 +110,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
     private val audioMessagePlayer: ConversationAudioMessagePlayer,
     @CurrentAccount val currentAccount: UserId,
     private val userTypeMapper: UserTypeMapper,
-    private val getSelfUser: GetSelfUserUseCase,
+    private val getSelfTeamId: GetSelfTeamIdUseCase,
     private val uiTextResolver: UiTextResolver,
 ) : ConversationListViewModel, ViewModel() {
 
@@ -214,6 +214,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
 
     private fun observeNonPaginatedSearchConversationList() {
         viewModelScope.launch {
+            val selfTeamId = getSelfTeamId()
             searchQueryFlow
                 .debounce { if (it.isEmpty()) 0L else DEFAULT_SEARCH_QUERY_DEBOUNCE }
                 .onStart { emit("") }
@@ -232,7 +233,7 @@ class ConversationListViewModelImpl @AssistedInject constructor(
                                 userTypeMapper = userTypeMapper,
                                 uiTextResolver = uiTextResolver,
                                 searchQuery = searchQuery,
-                                selfUserTeamId = getSelfUser()?.teamId,
+                                selfUserTeamId = selfTeamId,
                                 playingAudioMessage = playingAudioMessage
                             ).hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold)
                         } to searchQuery

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -56,8 +56,8 @@ import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserU
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
 import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
 import com.wire.kalium.logic.feature.team.SyncSelfTeamInfoUseCase
+import com.wire.kalium.logic.feature.user.GetSelfTeamIdUseCase
 import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
-import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserWithTeamUseCase
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
 import com.wire.kalium.logic.feature.user.UpdateSelfAvailabilityStatusUseCase
@@ -83,7 +83,7 @@ import javax.inject.Inject
 class SelfUserProfileViewModel @Inject constructor(
     @CurrentAccount private val selfUserId: UserId,
     private val dataStore: UserDataStore,
-    private val observeSelf: ObserveSelfUserUseCase,
+    private val getSelfTeamId: GetSelfTeamIdUseCase,
     private val observeSelfUserWithTeam: ObserveSelfUserWithTeamUseCase,
     private val syncSelfTeamInfo: SyncSelfTeamInfoUseCase,
     private val canMigrateFromPersonalToTeam: CanMigrateFromPersonalToTeamUseCase,
@@ -147,7 +147,7 @@ class SelfUserProfileViewModel @Inject constructor(
 
     private fun markCreateTeamNoticeAsRead() {
         viewModelScope.launch {
-            if (observeSelf().first().teamId == null && !dataStore.isCreateTeamNoticeRead().first()) {
+            if (getSelfTeamId() == null && !dataStore.isCreateTeamNoticeRead().first()) {
                 dataStore.setIsCreateTeamNoticeRead(true)
             }
         }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
@@ -36,7 +36,7 @@ import com.wire.kalium.logic.data.conversation.FolderType
 import com.wire.kalium.logic.feature.conversation.GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCase
 import com.wire.kalium.logic.feature.conversation.folder.GetFavoriteFolderUseCase
 import com.wire.kalium.logic.feature.conversation.folder.ObserveConversationsFromFolderUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.GetSelfTeamIdUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -87,7 +87,7 @@ class GetConversationsFromSearchUseCaseTest {
             ConversationDetailsWithEvents(TestConversationDetails.CONVERSATION_ONE_ONE),
             ConversationDetailsWithEvents(TestConversationDetails.GROUP),
         )
-        val (arrangement, useCase) = Arrangement().withPaginatedResult(conversationsList).withSelfUser().arrange()
+        val (arrangement, useCase) = Arrangement().withPaginatedResult(conversationsList).withSelfTeamId().arrange()
         // When
         val result = with(arrangement.queryConfig) {
             useCase(
@@ -117,7 +117,7 @@ class GetConversationsFromSearchUseCaseTest {
         )
 
         val (arrangement, useCase) = Arrangement().withFavoriteFolderResult(folderResult).withFolderConversationsResult(conversationsList)
-            .withSelfUser().arrange()
+            .withSelfTeamId().arrange()
 
         // When
         useCase(
@@ -148,7 +148,7 @@ class GetConversationsFromSearchUseCaseTest {
                     )
                 )
             )
-            val (arrangement, useCase) = Arrangement().withPaginatedResult(conversationsList).withSelfUser().arrange()
+            val (arrangement, useCase) = Arrangement().withPaginatedResult(conversationsList).withSelfTeamId().arrange()
             // When
             val result = with(arrangement.queryConfig) {
                 useCase(
@@ -170,7 +170,7 @@ class GetConversationsFromSearchUseCaseTest {
         runTest(dispatcherProvider.main()) {
             // Given
             val conversationsList = listOf(ConversationDetailsWithEvents(TestConversationDetails.GROUP))
-            val (arrangement, useCase) = Arrangement().withPaginatedResult(conversationsList).withSelfUser().arrange()
+            val (arrangement, useCase) = Arrangement().withPaginatedResult(conversationsList).withSelfTeamId().arrange()
             // When
             val result = with(arrangement.queryConfig) {
                 useCase(
@@ -202,7 +202,7 @@ class GetConversationsFromSearchUseCaseTest {
         lateinit var userTypeMapper: UserTypeMapper
 
         @MockK
-        lateinit var getSelfUser: GetSelfUserUseCase
+        lateinit var getSelfTeamId: GetSelfTeamIdUseCase
 
         @MockK
         lateinit var uiTextResolver: UiTextResolver
@@ -226,6 +226,7 @@ class GetConversationsFromSearchUseCaseTest {
                 }
             }
             coEvery { uiTextResolver.localeTag() } returns "test-locale"
+            withSelfTeamId()
             withPaginatedResult(emptyList())
         }
 
@@ -245,8 +246,8 @@ class GetConversationsFromSearchUseCaseTest {
             } returns flowOf(conversations)
         }
 
-        fun withSelfUser() = apply {
-            coEvery { getSelfUser() } returns TestUser.SELF_USER
+        fun withSelfTeamId() = apply {
+            coEvery { getSelfTeamId() } returns TestUser.SELF_USER.teamId
         }
 
         fun arrange() = this to GetConversationsFromSearchUseCase(
@@ -255,7 +256,7 @@ class GetConversationsFromSearchUseCaseTest {
             observeConversationsFromFolderUseCase,
             userTypeMapper,
             dispatcherProvider,
-            getSelfUser,
+            getSelfTeamId,
             uiTextResolver
         )
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -46,7 +46,7 @@ import com.wire.kalium.logic.feature.conversation.RefreshConversationsWithoutMet
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.GetSelfTeamIdUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -288,7 +288,7 @@ class ConversationListViewModelTest {
         private lateinit var observeLegalHoldStateForSelfUserUseCase: ObserveLegalHoldStateForSelfUserUseCase
 
         @MockK
-        private lateinit var getSelfUser: GetSelfUserUseCase
+        private lateinit var getSelfTeamId: GetSelfTeamIdUseCase
 
         @MockK
         lateinit var audioMessagePlayer: ConversationAudioMessagePlayer
@@ -312,6 +312,7 @@ class ConversationListViewModelTest {
                 }
             )
             every { audioMessagePlayer.playingAudioMessageFlow } returns flowOf(PlayingAudioMessage.None)
+            coEvery { getSelfTeamId() } returns TestUser.SELF_USER.teamId
             coEvery { uiTextResolver.resolve(any()) } answers {
                 val text = firstArg<UIText>()
                 when (text) {
@@ -357,7 +358,7 @@ class ConversationListViewModelTest {
             observeConversationListDetailsWithEvents = observeConversationListDetailsWithEventsUseCase,
             observeLegalHoldStateForSelfUser = observeLegalHoldStateForSelfUserUseCase,
             userTypeMapper = UserTypeMapper(),
-            getSelfUser = getSelfUser,
+            getSelfTeamId = getSelfTeamId,
             uiTextResolver = uiTextResolver,
             usePagination = true,
             audioMessagePlayer = audioMessagePlayer,

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModelArrangement.kt
@@ -38,8 +38,8 @@ import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserU
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
 import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
 import com.wire.kalium.logic.feature.team.SyncSelfTeamInfoUseCase
+import com.wire.kalium.logic.feature.user.GetSelfTeamIdUseCase
 import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
-import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserWithTeamUseCase
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
 import com.wire.kalium.logic.feature.user.UpdateSelfAvailabilityStatusUseCase
@@ -53,7 +53,7 @@ class SelfUserProfileViewModelArrangement {
     lateinit var userDataStore: UserDataStore
 
     @MockK
-    lateinit var getSelf: ObserveSelfUserUseCase
+    lateinit var getSelfTeamId: GetSelfTeamIdUseCase
 
     @MockK
     lateinit var observeSelfUserWithTeam: ObserveSelfUserWithTeamUseCase
@@ -116,7 +116,7 @@ class SelfUserProfileViewModelArrangement {
         SelfUserProfileViewModel(
             selfUserId = TestUser.SELF_USER.id,
             dataStore = userDataStore,
-            observeSelf = getSelf,
+            getSelfTeamId = getSelfTeamId,
             observeSelfUserWithTeam = observeSelfUserWithTeam,
             syncSelfTeamInfo = syncSelfTeamInfo,
             observeValidAccounts = observeValidAccounts,
@@ -143,7 +143,7 @@ class SelfUserProfileViewModelArrangement {
         MockKAnnotations.init(this, relaxUnitFun = true)
         mockUri()
 
-        coEvery { getSelf.invoke() } returns flowOf(TestUser.SELF_USER)
+        coEvery { getSelfTeamId.invoke() } returns TestUser.SELF_USER.teamId
         coEvery { observeSelfUserWithTeam.invoke() } returns flowOf(TestUser.SELF_USER to TestTeam.TEAM)
         coEvery { syncSelfTeamInfo.invoke() } returns TestTeam.TEAM
         coEvery { observeValidAccounts.invoke() } returns flowOf(listOf(TestUser.SELF_USER to TestTeam.TEAM))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25803
<!--jira-description-action-hidden-marker-end-->
Avoid fetching the full self user from DB when only the current team id is needed. The team id is already cached in memory through Kalium, so these paths can use `GetSelfTeamIdUseCase` directly.

## What changed

- Added/provided `GetSelfTeamIdUseCase` through `UserScope` and Hilt.
- Switched conversation list/search and self profile team-id checks to the cached provider.
- Updated affected unit tests.