### PR TITLE
refactor: improve conversation list rendering performance [WPB-26102]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
@@ -17,8 +17,6 @@
  */
 package com.wire.android.mapper
 
-import com.wire.android.media.audiomessage.AudioMediaPlayingState
-import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
@@ -27,7 +25,10 @@ import com.wire.android.ui.home.conversationslist.model.BadgeEventType
 import com.wire.android.ui.home.conversationslist.model.BlockState
 import com.wire.android.ui.home.conversationslist.model.ConversationInfo
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
-import com.wire.android.ui.home.conversationslist.model.PlayingAudioInConversation
+import com.wire.android.ui.home.conversationslist.model.ConversationItem.ConnectionConversation
+import com.wire.android.ui.home.conversationslist.model.ConversationItem.Group.Channel
+import com.wire.android.ui.home.conversationslist.model.ConversationItem.Group.Regular
+import com.wire.android.ui.home.conversationslist.model.ConversationItem.PrivateConversation
 import com.wire.android.ui.home.conversationslist.showLegalHoldIndicator
 import com.wire.android.util.ui.UiTextResolver
 import com.wire.kalium.logic.data.conversation.ConversationDetails
@@ -47,12 +48,10 @@ import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 fun ConversationDetailsWithEvents.toConversationItem(
     userTypeMapper: UserTypeMapper,
     uiTextResolver: UiTextResolver,
-    searchQuery: String,
-    selfUserTeamId: TeamId?,
-    playingAudioMessage: PlayingAudioMessage
+    selfUserTeamId: TeamId?
 ): ConversationItem = when (val conversationDetails = this.conversationDetails) {
     is Group.Regular -> {
-        ConversationItem.Group.Regular(
+        Regular(
             groupName = conversationDetails.conversation.name.orEmpty(),
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
@@ -71,15 +70,13 @@ fun ConversationDetailsWithEvents.toConversationItem(
             mlsVerificationStatus = conversationDetails.conversation.mlsVerificationStatus,
             proteusVerificationStatus = conversationDetails.conversation.proteusVerificationStatus,
             hasNewActivitiesToShow = hasNewActivitiesToShow,
-            searchQuery = searchQuery,
             isFavorite = conversationDetails.isFavorite,
-            folder = conversationDetails.folder,
-            playingAudio = getPlayingAudioInConversation(playingAudioMessage, conversationDetails)
+            folder = conversationDetails.folder
         )
     }
 
     is Group.Channel -> {
-        ConversationItem.Group.Channel(
+        Channel(
             groupName = conversationDetails.conversation.name.orEmpty(),
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
@@ -98,16 +95,14 @@ fun ConversationDetailsWithEvents.toConversationItem(
             mlsVerificationStatus = conversationDetails.conversation.mlsVerificationStatus,
             proteusVerificationStatus = conversationDetails.conversation.proteusVerificationStatus,
             hasNewActivitiesToShow = hasNewActivitiesToShow,
-            searchQuery = searchQuery,
             isFavorite = conversationDetails.isFavorite,
             folder = conversationDetails.folder,
-            playingAudio = getPlayingAudioInConversation(playingAudioMessage, conversationDetails),
             isPrivate = conversationDetails.access == Group.Channel.ChannelAccess.PRIVATE
         )
     }
 
     is OneOne -> {
-        ConversationItem.PrivateConversation(
+        PrivateConversation(
             userAvatarData = UserAvatarData(
                 asset = conversationDetails.otherUser.previewPicture?.let { UserAvatarAsset(it) },
                 availabilityStatus = conversationDetails.otherUser.availabilityStatus,
@@ -139,15 +134,13 @@ fun ConversationDetailsWithEvents.toConversationItem(
             mlsVerificationStatus = conversationDetails.conversation.mlsVerificationStatus,
             proteusVerificationStatus = conversationDetails.conversation.proteusVerificationStatus,
             hasNewActivitiesToShow = hasNewActivitiesToShow,
-            searchQuery = searchQuery,
             isFavorite = conversationDetails.isFavorite,
-            folder = conversationDetails.folder,
-            playingAudio = getPlayingAudioInConversation(playingAudioMessage, conversationDetails)
+            folder = conversationDetails.folder
         )
     }
 
     is Connection -> {
-        ConversationItem.ConnectionConversation(
+        ConnectionConversation(
             userAvatarData = UserAvatarData(
                 asset = previewPictureAsset(conversationDetails),
                 availabilityStatus = conversationDetails.otherUser?.availabilityStatus ?: UserAvailabilityStatus.NONE,
@@ -165,8 +158,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             badgeEventType = parseConnectionEventType(conversationDetails.connection.status),
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
-            hasNewActivitiesToShow = hasNewActivitiesToShow,
-            searchQuery = searchQuery,
+            hasNewActivitiesToShow = hasNewActivitiesToShow
         )
     }
 
@@ -174,29 +166,10 @@ fun ConversationDetailsWithEvents.toConversationItem(
         throw IllegalArgumentException("Self conversations should not be visible to the user.")
     }
 
-    else -> {
-        throw IllegalArgumentException("$this conversations should not be visible to the user.")
+    is ConversationDetails.Team -> {
+        throw IllegalArgumentException("Team conversations should not be visible to the user.")
     }
 }
-
-private fun getPlayingAudioInConversation(
-    playingAudioMessage: PlayingAudioMessage,
-    conversationDetails: ConversationDetails
-): PlayingAudioInConversation? =
-    if (playingAudioMessage is PlayingAudioMessage.Some
-        && playingAudioMessage.conversationId == conversationDetails.conversation.id
-    ) {
-        if (playingAudioMessage.state.isPlaying()) {
-            PlayingAudioInConversation(playingAudioMessage.messageId, false)
-        } else if (playingAudioMessage.state.audioMediaPlayingState is AudioMediaPlayingState.Paused) {
-            PlayingAudioInConversation(playingAudioMessage.messageId, true)
-        } else {
-            // states Fetching, Completed, Stopped, etc. should not be shown in ConversationItem
-            null
-        }
-    } else {
-        null
-    }
 
 private fun parseConnectionEventType(connectionState: ConnectionState) =
     if (connectionState == ConnectionState.SENT) {

--- a/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
@@ -29,7 +29,6 @@ import com.wire.android.ui.home.conversationslist.model.ConversationItem.Connect
 import com.wire.android.ui.home.conversationslist.model.ConversationItem.Group.Channel
 import com.wire.android.ui.home.conversationslist.model.ConversationItem.Group.Regular
 import com.wire.android.ui.home.conversationslist.model.ConversationItem.PrivateConversation
-import com.wire.android.ui.home.conversationslist.showLegalHoldIndicator
 import com.wire.android.util.ui.UiTextResolver
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationDetails.Connection
@@ -55,7 +54,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             groupName = conversationDetails.conversation.name.orEmpty(),
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
-            showLegalHoldIndicator = conversationDetails.conversation.legalHoldStatus.showLegalHoldIndicator(),
+            legalHoldStatus = conversationDetails.conversation.legalHoldStatus,
             lastMessageContent = lastMessage.toUIPreview(unreadEventCount, uiTextResolver),
             badgeEventType = parseConversationEventType(
                 mutedStatus = conversationDetails.conversation.mutedStatus,
@@ -80,7 +79,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             groupName = conversationDetails.conversation.name.orEmpty(),
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
-            showLegalHoldIndicator = conversationDetails.conversation.legalHoldStatus.showLegalHoldIndicator(),
+            legalHoldStatus = conversationDetails.conversation.legalHoldStatus,
             lastMessageContent = lastMessage.toUIPreview(unreadEventCount, uiTextResolver),
             badgeEventType = parseConversationEventType(
                 mutedStatus = conversationDetails.conversation.mutedStatus,
@@ -116,7 +115,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             ),
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
-            showLegalHoldIndicator = conversationDetails.conversation.legalHoldStatus.showLegalHoldIndicator(),
+            legalHoldStatus = conversationDetails.conversation.legalHoldStatus,
             lastMessageContent = lastMessage.toUIPreview(unreadEventCount, uiTextResolver),
             badgeEventType = parsePrivateConversationEventType(
                 conversationDetails.otherUser.connectionStatus,

--- a/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessagePreviewContentMapper.kt
@@ -22,9 +22,6 @@ import com.wire.android.R
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.UILastMessageContent
 import com.wire.android.ui.markdown.MarkdownConstants
-import com.wire.android.ui.markdown.MarkdownPreview
-import com.wire.android.ui.markdown.getFirstInlines
-import com.wire.android.ui.markdown.toMarkdownDocument
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.UiTextResolver
 import com.wire.android.util.ui.toUIText
@@ -55,11 +52,11 @@ fun MessagePreview?.toUIPreview(
         unreadEventCount.size == 1 && unreadEventCount.values.first() == 1 ->
             uiLastMessageContent(uiTextResolver)
         // for the rest take 1 or 2 most prioritized events with count to last message
-        else -> multipleUnreadEventsToLastMessage(unreadEventCount, uiTextResolver)
+        else -> multipleUnreadEventsToLastMessage(unreadEventCount)
     }
 }
 
-private fun multipleUnreadEventsToLastMessage(unreadEventCount: UnreadEventCount, uiTextResolver: UiTextResolver): UILastMessageContent {
+private fun multipleUnreadEventsToLastMessage(unreadEventCount: UnreadEventCount): UILastMessageContent {
     val unreadContentTexts = unreadEventCount
         .toSortedMap()
         .mapNotNull { type ->
@@ -106,11 +103,8 @@ private fun multipleUnreadEventsToLastMessage(unreadEventCount: UnreadEventCount
     } else {
         UILastMessageContent.TextMessage(
             MessageBody(
-                message = first,
-                markdownDocument = (first as? UIText.DynamicString)?.value?.toMarkdownDocument()
+                message = first
             ),
-            markdownPreview = first.toMarkdownPreviewOrNull(uiTextResolver),
-            markdownLocaleTag = uiTextResolver.localeTag()
         )
     }
 }
@@ -121,7 +115,7 @@ private fun String?.userUiText(isSelfMessage: Boolean): UIText = when {
     else -> UIText.StringResource(R.string.username_unavailable_label)
 }
 
-@Suppress("LongMethod", "ComplexMethod", "NestedBlockDepth")
+@Suppress("LongMethod", "ComplexMethod", "NestedBlockDepth", "UNUSED_PARAMETER")
 fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastMessageContent {
     return when (content) {
         is WithUser -> {
@@ -134,8 +128,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                             UILastMessageContent.SenderWithMessage(
                                 userUIText,
                                 message,
-                                markdownPreview = message.toMarkdownPreviewOrNull(uiTextResolver),
-                                markdownLocaleTag = uiTextResolver.localeTag()
                             )
                         }
 
@@ -150,8 +142,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                             UILastMessageContent.SenderWithMessage(
                                 userUIText,
                                 message,
-                                markdownPreview = message.toMarkdownPreviewOrNull(uiTextResolver),
-                                markdownLocaleTag = uiTextResolver.localeTag()
                             )
                         }
 
@@ -166,8 +156,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                             UILastMessageContent.SenderWithMessage(
                                 userUIText,
                                 message,
-                                markdownPreview = message.toMarkdownPreviewOrNull(uiTextResolver),
-                                markdownLocaleTag = uiTextResolver.localeTag()
                             )
                         }
 
@@ -182,8 +170,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                             UILastMessageContent.SenderWithMessage(
                                 userUIText,
                                 message,
-                                markdownPreview = message.toMarkdownPreviewOrNull(uiTextResolver),
-                                markdownLocaleTag = uiTextResolver.localeTag()
                             )
                         }
                 }
@@ -198,8 +184,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                     UILastMessageContent.SenderWithMessage(
                         userUIText,
                         message,
-                        markdownPreview = message.toMarkdownPreviewOrNull(uiTextResolver),
-                        markdownLocaleTag = uiTextResolver.localeTag()
                     )
                 }
 
@@ -213,8 +197,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                     UILastMessageContent.SenderWithMessage(
                         userUIText,
                         message,
-                        markdownPreview = message.toMarkdownPreviewOrNull(uiTextResolver),
-                        markdownLocaleTag = uiTextResolver.localeTag()
                     )
                 }
 
@@ -228,8 +210,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                     UILastMessageContent.SenderWithMessage(
                         userUIText,
                         message,
-                        markdownPreview = message.toMarkdownPreviewOrNull(uiTextResolver),
-                        markdownLocaleTag = uiTextResolver.localeTag()
                     )
                 }
 
@@ -243,8 +223,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                     UILastMessageContent.SenderWithMessage(
                         userUIText,
                         message,
-                        markdownPreview = message.toMarkdownPreviewOrNull(uiTextResolver),
-                        markdownLocaleTag = uiTextResolver.localeTag()
                     )
                 }
 
@@ -252,8 +230,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                     UILastMessageContent.SenderWithMessage(
                         userUIText,
                         message,
-                        markdownPreview = message.toMarkdownPreviewOrNull(uiTextResolver),
-                        markdownLocaleTag = uiTextResolver.localeTag()
                     )
                 }
 
@@ -261,8 +237,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                     UILastMessageContent.SenderWithMessage(
                         userUIText,
                         message,
-                        markdownPreview = message.toMarkdownPreviewOrNull(uiTextResolver),
-                        markdownLocaleTag = uiTextResolver.localeTag()
                     )
                 }
 
@@ -291,11 +265,8 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
 
                     UILastMessageContent.TextMessage(
                         MessageBody(
-                            message = previewMessageContent,
-                            markdownDocument = (previewMessageContent as? UIText.DynamicString)?.value?.toMarkdownDocument()
-                        ),
-                        previewMessageContent.toMarkdownPreviewOrNull(uiTextResolver),
-                        uiTextResolver.localeTag()
+                            message = previewMessageContent
+                        )
                     )
                 }
 
@@ -328,11 +299,8 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
 
                     UILastMessageContent.TextMessage(
                         MessageBody(
-                            message = previewMessageContent,
-                            markdownDocument = (previewMessageContent as? UIText.DynamicString)?.value?.toMarkdownDocument()
-                        ),
-                        previewMessageContent.toMarkdownPreviewOrNull(uiTextResolver),
-                        uiTextResolver.localeTag()
+                            message = previewMessageContent
+                        )
                     )
                 }
 
@@ -343,11 +311,8 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
 
                     UILastMessageContent.TextMessage(
                         MessageBody(
-                            message = previewMessageContent,
-                            markdownDocument = (previewMessageContent as? UIText.DynamicString)?.value?.toMarkdownDocument()
-                        ),
-                        previewMessageContent.toMarkdownPreviewOrNull(uiTextResolver),
-                        uiTextResolver.localeTag()
+                            message = previewMessageContent
+                        )
                     )
                 }
 
@@ -355,10 +320,7 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                 is WithUser.Text -> UILastMessageContent.SenderWithMessage(
                     sender = userUIText,
                     message = (content as WithUser.Text).messageBody.let { UIText.DynamicString(it) },
-                    separator = ":${MarkdownConstants.NON_BREAKING_SPACE}",
-                    markdownPreview = UIText.DynamicString((content as WithUser.Text).messageBody)
-                        .toMarkdownPreviewOrNull(uiTextResolver),
-                    markdownLocaleTag = uiTextResolver.localeTag()
+                    separator = ":${MarkdownConstants.NON_BREAKING_SPACE}"
                 )
 
                 is WithUser.Composite -> {
@@ -368,8 +330,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                         sender = userUIText,
                         message = text,
                         separator = ":${MarkdownConstants.NON_BREAKING_SPACE}",
-                        markdownPreview = text.toMarkdownPreviewOrNull(uiTextResolver),
-                        markdownLocaleTag = uiTextResolver.localeTag()
                     )
                 }
 
@@ -396,8 +356,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                     UILastMessageContent.SenderWithMessage(
                         userUIText,
                         message,
-                        markdownPreview = message.toMarkdownPreviewOrNull(uiTextResolver),
-                        markdownLocaleTag = uiTextResolver.localeTag()
                     )
                 }
 
@@ -406,8 +364,6 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
                         userUIText,
                         message,
                         separator = ":${MarkdownConstants.NON_BREAKING_SPACE}",
-                        markdownPreview = message.toMarkdownPreviewOrNull(uiTextResolver),
-                        markdownLocaleTag = uiTextResolver.localeTag()
                     )
                 }
             }
@@ -438,11 +394,8 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
 
             UILastMessageContent.TextMessage(
                 MessageBody(
-                    message = previewMessageContent,
-                    markdownDocument = (previewMessageContent as? UIText.DynamicString)?.value?.toMarkdownDocument()
-                ),
-                previewMessageContent.toMarkdownPreviewOrNull(uiTextResolver),
-                uiTextResolver.localeTag()
+                    message = previewMessageContent
+                )
             )
         }
 
@@ -475,17 +428,9 @@ fun MessagePreview.uiLastMessageContent(uiTextResolver: UiTextResolver): UILastM
         is MessagePreviewContent.Draft -> UILastMessageContent.SenderWithMessage(
             UIText.StringResource(R.string.label_draft),
             (content as MessagePreviewContent.Draft).message.toUIText(),
-            separator = ":${MarkdownConstants.NON_BREAKING_SPACE}",
-            markdownPreview = (content as MessagePreviewContent.Draft).message.toUIText()
-                .toMarkdownPreviewOrNull(uiTextResolver),
-            markdownLocaleTag = uiTextResolver.localeTag()
+            separator = ":${MarkdownConstants.NON_BREAKING_SPACE}"
         )
 
         Unknown -> UILastMessageContent.None
     }
-}
-
-private fun UIText.toMarkdownPreviewOrNull(uiTextResolver: UiTextResolver): MarkdownPreview? {
-    val resolved = uiTextResolver.resolve(this)
-    return resolved.toMarkdownDocument().getFirstInlines()
 }

--- a/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
@@ -28,8 +28,6 @@ import com.wire.android.ui.home.conversations.model.MessageButton
 import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.home.conversations.model.messagetypes.image.VisualMediaParams
-import com.wire.android.ui.markdown.toMarkdownDocument
-import com.wire.android.ui.markdown.toMarkdownTextWithMentions
 import com.wire.android.ui.theme.Accent
 import com.wire.android.util.time.ISOFormatter
 import com.wire.android.util.ui.UIText
@@ -110,11 +108,7 @@ class RegularMessageMapper @Inject constructor(
 
                 MessageBody(
                     message = UIText.DynamicString(textContent.value, content.textContent?.mentions.orEmpty()),
-                    quotedMessage = quotedMessage,
-                    markdownDocument = UIText.DynamicString(
-                        textContent.value,
-                        content.textContent?.mentions.orEmpty()
-                    ).toMarkdownTextWithMentions().second.toMarkdownDocument()
+                    quotedMessage = quotedMessage
                 )
             }
 
@@ -199,16 +193,9 @@ class RegularMessageMapper @Inject constructor(
                 else -> UIText.StringResource(R.string.sent_a_message_with_unknown_content)
         }
 
-        val markdownDocument = if (uiText is UIText.DynamicString) {
-            uiText.toMarkdownTextWithMentions().second.toMarkdownDocument()
-        } else {
-            null
-        }
-
         return MessageBody(
             message = uiText,
-            quotedMessage = quotedMessage,
-            markdownDocument = markdownDocument
+            quotedMessage = quotedMessage
         ).let { messageBody ->
             UIMessageContent.TextMessage(
                 messageBody = messageBody,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -234,6 +234,8 @@ import com.wire.android.ui.common.R as commonR
  */
 private const val MAXIMUM_SCROLLED_MESSAGES_UNTIL_AUTOSCROLL_STOPS = 5
 
+private const val SCOPED_VIEW_MODEL_PREFETCH_WINDOW = 3
+
 /**
  * The maximum number of participants to start a call without showing a confirmation dialog.
  */
@@ -1396,11 +1398,22 @@ fun MessageList(
         }
     }
 
-    val audioMessageKeysInScope = remember(lazyPagingMessages.itemSnapshotList.items) {
-        lazyPagingMessages.itemSnapshotList.items.mapNotNull { it.audioMessageScopedKeyOrNull() }.distinct()
+    val scopedMessages by remember(lazyListState, lazyPagingMessages) {
+        derivedStateOf {
+            lazyPagingMessages.peekVisibleWindowItems(lazyListState, SCOPED_VIEW_MODEL_PREFETCH_WINDOW)
+        }
     }
-    val assetLocalPathKeysInScope = remember(lazyPagingMessages.itemSnapshotList.items) {
-        lazyPagingMessages.itemSnapshotList.items
+    val playingAudioMessageKey = (playingAudioMessage as? PlayingAudioMessage.Some)?.let {
+        AudioMessageArgs(it.conversationId, it.messageId).key
+    }
+    val audioMessageKeysInScope = remember(scopedMessages, playingAudioMessageKey) {
+        buildList {
+            scopedMessages.mapNotNullTo(this) { it.audioMessageScopedKeyOrNull() }
+            playingAudioMessageKey?.let(::add)
+        }.distinct()
+    }
+    val assetLocalPathKeysInScope = remember(scopedMessages) {
+        scopedMessages
             .flatMap { it.assetLocalPathScopedKeys() }
             .distinct()
     }
@@ -1697,6 +1710,27 @@ private fun BoxScope.ScrollDateOverlay(
 
 private fun LazyPagingItems<UIMessage>.peekOrNull(index: Int): UIMessage? =
     if (index in 0 until itemCount) peek(index) else null
+
+private fun LazyPagingItems<UIMessage>.peekVisibleWindowItems(
+    lazyListState: LazyListState,
+    prefetchWindow: Int
+): List<UIMessage> {
+    val visibleItems = lazyListState.layoutInfo.visibleItemsInfo
+    return if (itemCount == 0 || visibleItems.isEmpty()) {
+        emptyList()
+    } else {
+        val firstVisibleIndex = visibleItems.minOf { it.index }
+        val lastVisibleIndex = visibleItems.maxOf { it.index }
+        val firstIndex = (firstVisibleIndex - prefetchWindow).coerceAtLeast(0)
+        val lastIndex = (lastVisibleIndex + prefetchWindow).coerceAtMost(itemCount - 1)
+
+        if (firstIndex > lastIndex) {
+            emptyList()
+        } else {
+            (firstIndex..lastIndex).mapNotNull { index -> peekOrNull(index) }
+        }
+    }
+}
 
 @Composable
 private fun MessageGroupDateTime(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.DpSize
@@ -105,9 +106,14 @@ internal fun MessageBody(
     clickable: Boolean = true,
     messageStyle: MessageStyle = MessageStyle.NORMAL
 ) {
-    val (displayMentions, text) = messageBody?.message?.let {
-        mapToDisplayMentions(it, LocalContext.current.resources)
-    } ?: Pair(emptyList(), null)
+    val resources = LocalContext.current.resources
+    val configuration = LocalConfiguration.current
+    val message = messageBody?.message
+    val (displayMentions, text) = remember(message, configuration) {
+        message?.let {
+            mapToDisplayMentions(it, resources)
+        } ?: Pair(emptyList(), null)
+    }
 
     val color = when (messageStyle) {
         MessageStyle.BUBBLE_SELF -> colorsScheme().selfBubble.onPrimary

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -652,8 +652,18 @@ enum class MessageSource {
 
 @Serializable
 data class MessageTime(val instant: Instant) {
-    val utcISO: String = instant.toIsoDateTimeString()
-    val formattedDate: String = utcISO.uiMessageDateTime() ?: ""
+    @Transient
+    private val utcISOValue: Lazy<String> = lazy(LazyThreadSafetyMode.PUBLICATION) {
+        instant.toIsoDateTimeString()
+    }
+
+    @Transient
+    private val formattedDateValue: Lazy<String> = lazy(LazyThreadSafetyMode.PUBLICATION) {
+        utcISO.uiMessageDateTime() ?: ""
+    }
+
+    val utcISO: String get() = utcISOValue.value
+    val formattedDate: String get() = formattedDateValue.value
     fun getFormattedDateGroup(now: Long): MessageDateTimeGroup? = utcISO.groupedUIMessageDateTime(now = now)
     fun shouldDisplayDatesDifferenceDivider(previousDate: String): Boolean =
         utcISO.shouldDisplayDatesDifferenceDivider(previousDate = previousDate)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
@@ -18,20 +18,22 @@
 
 package com.wire.android.ui.home.conversations.usecase
 
+import android.os.SystemClock
 import androidx.paging.LoadState
 import androidx.paging.LoadStates
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
+import com.wire.android.appLogger
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.mapper.toConversationItem
-import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.UiTextResolver
 import com.wire.kalium.logic.data.conversation.ConversationDetailsWithEvents
 import com.wire.kalium.logic.data.conversation.ConversationFilter
 import com.wire.kalium.logic.data.conversation.ConversationQueryConfig
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.feature.conversation.GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCase
 import com.wire.kalium.logic.feature.conversation.folder.GetFavoriteFolderUseCase
 import com.wire.kalium.logic.feature.conversation.folder.ObserveConversationsFromFolderUseCase
@@ -58,7 +60,6 @@ class GetConversationsFromSearchUseCase @Inject constructor(
         newActivitiesOnTop: Boolean = false,
         onlyInteractionEnabled: Boolean = false,
         conversationFilter: ConversationFilter = ConversationFilter.All,
-        playingAudioMessage: PlayingAudioMessage = PlayingAudioMessage.None,
         useStrictMlsFilter: Boolean,
     ): Flow<PagingData<ConversationItem>> {
         val selfUserTeamId = getSelfTeamId()
@@ -100,16 +101,32 @@ class GetConversationsFromSearchUseCase @Inject constructor(
             }
         }
             .map { pagingData ->
-                pagingData.map {
-                    it.toConversationItem(
-                        userTypeMapper = userTypeMapper,
-                        uiTextResolver = uiTextResolver,
-                        searchQuery = searchQuery,
-                        selfUserTeamId = selfUserTeamId,
-                        playingAudioMessage = playingAudioMessage
-                    )
-                }
+                pagingData.mapConversationsWithTiming(selfUserTeamId)
             }.flowOn(dispatchers.io())
+    }
+
+    private fun PagingData<ConversationDetailsWithEvents>.mapConversationsWithTiming(
+        selfUserTeamId: TeamId?
+    ): PagingData<ConversationItem> {
+        var pageIndex = 0
+        var itemsInPage = 0
+        var totalMappingNanos = 0L
+        return map {
+            val startNanos = SystemClock.elapsedRealtimeNanos()
+            val item = it.toConversationItem(userTypeMapper, uiTextResolver, selfUserTeamId)
+            totalMappingNanos += SystemClock.elapsedRealtimeNanos() - startNanos
+            itemsInPage++
+
+            val pageSize = if (pageIndex == 0) INITIAL_LOAD_SIZE else PAGE_SIZE
+            if (itemsInPage == pageSize) {
+                appLogger.d("$TAG: page=$pageIndex items=$itemsInPage totalMapperMs=${totalMappingNanos / NANOS_IN_MILLIS}")
+                pageIndex++
+                itemsInPage = 0
+                totalMappingNanos = 0L
+            }
+
+            item
+        }
     }
 
     private fun staticPagingItems(conversations: List<ConversationDetailsWithEvents>): PagingData<ConversationDetailsWithEvents> {
@@ -124,8 +141,10 @@ class GetConversationsFromSearchUseCase @Inject constructor(
     }
 
     private companion object {
+        const val TAG = "ConversationMapperTiming"
         const val PAGE_SIZE = 20
         const val INITIAL_LOAD_SIZE = 40
         const val PREFETCH_DISTANCE = 5
+        const val NANOS_IN_MILLIS = 1_000_000
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -31,7 +31,9 @@ import com.wire.android.BuildConfig
 import com.wire.android.di.CurrentAccount
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.mapper.toConversationItem
+import com.wire.android.media.audiomessage.AudioMediaPlayingState
 import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
+import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.model.SnackBarMessage
 import com.wire.android.ui.common.DEFAULT_SEARCH_QUERY_DEBOUNCE
 import com.wire.android.ui.common.bottomsheet.conversation.ConversationTypeDetail
@@ -43,6 +45,7 @@ import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.ui.home.conversationslist.model.ConversationItemType
 import com.wire.android.ui.home.conversationslist.model.ConversationSection
 import com.wire.android.ui.home.conversationslist.model.ConversationsSource
+import com.wire.android.ui.home.conversationslist.model.PlayingAudioInConversation
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.UiTextResolver
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -78,6 +81,8 @@ import kotlinx.coroutines.launch
 interface ConversationListViewModel {
     val infoMessage: SharedFlow<SnackBarMessage> get() = MutableSharedFlow()
     val requestInProgress: Boolean get() = false
+    val isSelfUserUnderLegalHold: Flow<Boolean> get() = emptyFlow()
+    val playingAudio: Flow<PlayingAudioInConversation?> get() = emptyFlow()
     val conversationListState: ConversationListState get() = ConversationListState.Paginated(emptyFlow())
     suspend fun refreshMissingMetadata() {}
     fun searchQueryChanged(searchQuery: String) {}
@@ -116,7 +121,12 @@ class ConversationListViewModelImpl(
     override val requestInProgress: Boolean get() = _requestInProgress
 
     private val searchQueryFlow: MutableStateFlow<String> = MutableStateFlow("")
-    private val isSelfUserUnderLegalHoldFlow = MutableSharedFlow<Boolean>(replay = 1)
+    private val isSelfUserUnderLegalHoldFlow = MutableStateFlow(false)
+    override val isSelfUserUnderLegalHold: Flow<Boolean> = isSelfUserUnderLegalHoldFlow
+    override val playingAudio: Flow<PlayingAudioInConversation?> = audioMessagePlayer.playingAudioMessageFlow
+        .map { it.toPlayingAudioInConversation() }
+        .distinctUntilChanged()
+        .flowOn(dispatcher.io())
 
     private val containsNewActivitiesSection = when (conversationsSource) {
         ConversationsSource.MAIN,
@@ -132,23 +142,17 @@ class ConversationListViewModelImpl(
     private val conversationsPaginatedFlow: Flow<PagingData<ConversationItemType>> = searchQueryFlow
         .debounce { if (it.isEmpty()) 0L else DEFAULT_SEARCH_QUERY_DEBOUNCE }
         .onStart { emit("") }
-        .combine(isSelfUserUnderLegalHoldFlow.onStart { emit(false) }, ::Pair)
         .distinctUntilChanged()
-        .combine(audioMessagePlayer.playingAudioMessageFlow) { (searchQuery, isSelfUserUnderLegalHold), playingAudioMessage ->
-            Triple(searchQuery, isSelfUserUnderLegalHold, playingAudioMessage)
-        }
-        .flatMapLatest { (searchQuery, isSelfUserUnderLegalHold, playingAudioMessage) ->
+        .flatMapLatest { searchQuery ->
             getConversationsPaginated(
                 searchQuery = searchQuery,
                 fromArchive = conversationsSource == ConversationsSource.ARCHIVE,
                 conversationFilter = conversationsSource.toFilter(),
                 onlyInteractionEnabled = false,
                 newActivitiesOnTop = containsNewActivitiesSection,
-                playingAudioMessage = playingAudioMessage,
                 useStrictMlsFilter = BuildConfig.USE_STRICT_MLS_FILTER,
             ).map { pagingData ->
                 pagingData
-                    .map { it.hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold) }
                     .insertSeparators { before, after ->
                         when {
                             // do not add separators if the list shouldn't show conversations grouped into different folders
@@ -195,7 +199,7 @@ class ConversationListViewModelImpl(
             observeLegalHoldStateForSelfUser()
                 .map { it is LegalHoldStateForSelfUser.Enabled }
                 .flowOn(dispatcher.io())
-                .collect { isSelfUserUnderLegalHoldFlow.emit(it) }
+                .collect { isSelfUserUnderLegalHoldFlow.value = it }
         }
     }
 
@@ -212,16 +216,13 @@ class ConversationListViewModelImpl(
                             fromArchive = conversationsSource == ConversationsSource.ARCHIVE,
                             conversationFilter = conversationsSource.toFilter()
                         ),
-                        isSelfUserUnderLegalHoldFlow,
-                        audioMessagePlayer.playingAudioMessageFlow
-                    ) { conversations, isSelfUserUnderLegalHold, playingAudioMessage ->
+                        isSelfUserUnderLegalHoldFlow
+                    ) { conversations, isSelfUserUnderLegalHold ->
                         conversations.map { conversationDetails ->
                             conversationDetails.toConversationItem(
                                 userTypeMapper = userTypeMapper,
                                 uiTextResolver = uiTextResolver,
-                                searchQuery = searchQuery,
-                                selfUserTeamId = selfTeamId,
-                                playingAudioMessage = playingAudioMessage
+                                selfUserTeamId = selfTeamId
                             ).hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold)
                         } to searchQuery
                     }
@@ -402,4 +403,17 @@ private fun searchConversation(conversationDetails: List<ConversationItem>, sear
             is ConversationItem.Group -> details.groupName.contains(searchQuery, true)
             is ConversationItem.PrivateConversation -> details.conversationInfo.name.contains(searchQuery, true)
         }
+    }
+
+private fun PlayingAudioMessage.toPlayingAudioInConversation(): PlayingAudioInConversation? =
+    if (this is PlayingAudioMessage.Some) {
+        when {
+            state.isPlaying() -> PlayingAudioInConversation(conversationId, messageId, isPaused = false)
+            state.audioMediaPlayingState is AudioMediaPlayingState.Paused ->
+                PlayingAudioInConversation(conversationId, messageId, isPaused = true)
+
+            else -> null
+        }
+    } else {
+        null
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -66,7 +66,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
@@ -211,19 +210,16 @@ class ConversationListViewModelImpl(
                 .onStart { emit("") }
                 .distinctUntilChanged()
                 .flatMapLatest { searchQuery: String ->
-                    combine(
-                        observeConversationListDetailsWithEvents(
-                            fromArchive = conversationsSource == ConversationsSource.ARCHIVE,
-                            conversationFilter = conversationsSource.toFilter()
-                        ),
-                        isSelfUserUnderLegalHoldFlow
-                    ) { conversations, isSelfUserUnderLegalHold ->
+                    observeConversationListDetailsWithEvents(
+                        fromArchive = conversationsSource == ConversationsSource.ARCHIVE,
+                        conversationFilter = conversationsSource.toFilter()
+                    ).map { conversations ->
                         conversations.map { conversationDetails ->
                             conversationDetails.toConversationItem(
                                 userTypeMapper = userTypeMapper,
                                 uiTextResolver = uiTextResolver,
                                 selfUserTeamId = selfTeamId
-                            ).hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold)
+                            )
                         } to searchQuery
                     }
                 }
@@ -303,22 +299,6 @@ private fun ConversationsSource.toFilter(): ConversationFilter = when (this) {
     ConversationsSource.ONE_ON_ONE -> ConversationFilter.OneOnOne
     is ConversationsSource.FOLDER -> ConversationFilter.Folder(folderId = folderId, folderName = folderName)
 }
-
-/**
- * If self user is under legal hold then we shouldn't show legal hold indicator next to every conversation as in that case
- * the legal hold indication is shown in the header of the conversation list for self user in that case and it's enough.
- */
-private fun ConversationItem.hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold: Boolean) =
-    when (isSelfUserUnderLegalHold) {
-        true -> when (this) {
-            is ConversationItem.ConnectionConversation -> this.copy(showLegalHoldIndicator = false)
-            is ConversationItem.Group.Regular -> this.copy(showLegalHoldIndicator = false)
-            is ConversationItem.Group.Channel -> this.copy(showLegalHoldIndicator = false)
-            is ConversationItem.PrivateConversation -> this.copy(showLegalHoldIndicator = false)
-        }
-
-        else -> this
-    }
 
 @Suppress("ComplexMethod")
 private fun List<ConversationItem>.withSections(source: ConversationsSource): Map<ConversationSection, List<ConversationItem>> {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -31,8 +31,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -31,6 +31,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import com.ramcosta.composedestinations.generated.app.destinations.BrowseChannelsScreenDestination
@@ -162,6 +165,9 @@ fun ConversationsScreenContent(
             conversationListViewModel.stopCurrentAudio()
         }
     }
+    val isSelfUserUnderLegalHold by conversationListViewModel.isSelfUserUnderLegalHold.collectAsStateWithLifecycle(false)
+    val playingAudio by conversationListViewModel.playingAudio.collectAsStateWithLifecycle(null)
+    val searchQuery = searchBarState.searchQueryTextState.text.toString()
 
     Box(modifier = modifier) {
         when (val state = conversationListViewModel.conversationListState) {
@@ -175,6 +181,9 @@ fun ConversationsScreenContent(
                     lazyPagingItems.itemCount > 0 -> ConversationList(
                         lazyPagingConversations = lazyPagingItems,
                         lazyListState = lazyListState,
+                        searchQuery = searchQuery,
+                        isSelfUserUnderLegalHold = isSelfUserUnderLegalHold,
+                        playingAudio = playingAudio,
                         firstConversationFocusRequester = firstConversationFocusRequester,
                         onOpenConversation = onOpenConversation,
                         onEditConversation = onEditConversationItem,
@@ -213,6 +222,9 @@ fun ConversationsScreenContent(
                     hasConversations -> ConversationList(
                         lazyListState = lazyListState,
                         conversationListItems = state.conversations,
+                        searchQuery = searchQuery,
+                        isSelfUserUnderLegalHold = isSelfUserUnderLegalHold,
+                        playingAudio = playingAudio,
                         firstConversationFocusRequester = firstConversationFocusRequester,
                         onOpenConversation = onOpenConversation,
                         onEditConversation = onEditConversationItem,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -50,6 +50,7 @@ import com.wire.android.ui.common.rowitem.RowItemTemplate
 import com.wire.android.ui.home.conversations.info.ConversationAvatar
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.UILastMessageContent
+import com.wire.android.ui.home.conversationslist.showLegalHoldIndicator
 import com.wire.android.ui.home.conversationslist.model.BadgeEventType
 import com.wire.android.ui.home.conversationslist.model.BlockingState
 import com.wire.android.ui.home.conversationslist.model.ConversationInfo
@@ -83,18 +84,17 @@ fun ConversationItemFactory(
     onAudioPermissionPermanentlyDenied: () -> Unit = {},
     onPlayPauseCurrentAudio: () -> Unit = { },
     onStopCurrentAudio: () -> Unit = {},
-    searchQuery: String = conversation.searchQuery,
+    searchQuery: String = "",
     isSelfUserUnderLegalHold: Boolean = false,
-    playingAudio: PlayingAudioInConversation? = conversation.playingAudio
+    playingAudio: PlayingAudioInConversation? = null
 ) {
     val openConversationOptionDescription = stringResource(R.string.content_description_conversation_details_more_btn)
     val openUserProfileDescription = stringResource(R.string.content_description_open_user_profile_label)
     val acceptOrIgnoreDescription = stringResource(R.string.content_description_accept_or_ignore_connection_label)
     val openConversationDescription = stringResource(R.string.content_description_open_conversation_label)
-    val showLegalHoldIndicator = conversation.showLegalHoldIndicator && !isSelfUserUnderLegalHold
+    val showLegalHoldIndicator = conversation.legalHoldStatus.showLegalHoldIndicator() && !isSelfUserUnderLegalHold
     val playingAudioInConversation = playingAudio
         ?.takeIf { it.conversationId == conversation.conversationId }
-        ?: conversation.playingAudio
     val onConversationItemClick = remember(conversation) {
         when (val lastEvent = conversation.lastMessageContent) {
             is UILastMessageContent.Connection -> {
@@ -175,12 +175,12 @@ private fun GeneralConversationItem(
     onConversationItemClick: Clickable,
     onJoinCallClick: () -> Unit,
     onAudioPermissionPermanentlyDenied: () -> Unit,
+    showLegalHoldIndicator: Boolean,
     modifier: Modifier = Modifier,
     selectOnRadioGroup: () -> Unit = {},
     subTitle: @Composable () -> Unit = {},
-    searchQuery: String = conversation.searchQuery,
-    showLegalHoldIndicator: Boolean = conversation.showLegalHoldIndicator,
-    playingAudio: PlayingAudioInConversation? = conversation.playingAudio,
+    searchQuery: String = "",
+    playingAudio: PlayingAudioInConversation? = null,
     onPlayPauseCurrentAudio: () -> Unit = { },
     onStopCurrentAudio: () -> Unit = {}
 ) {
@@ -401,8 +401,7 @@ fun PreviewGroupConversationItemWithUnreadCount() = WireTheme {
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
-            folder = null,
-            playingAudio = null
+            folder = null
         ),
         modifier = Modifier,
         isSelectableItem = false,
@@ -431,7 +430,6 @@ fun PreviewChannelGroupConversationItemWithUnreadCount() = WireTheme {
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
             folder = null,
-            playingAudio = null,
             isPrivate = false
         ),
         modifier = Modifier,
@@ -461,7 +459,6 @@ fun PreviewPrivateChannelGroupConversationItemWithUnreadCount() = WireTheme {
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
             folder = null,
-            playingAudio = null,
             isPrivate = true
         ),
         modifier = Modifier,
@@ -490,8 +487,7 @@ fun PreviewGroupConversationItemWithNoBadges() = WireTheme {
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
-            folder = null,
-            playingAudio = null
+            folder = null
         ),
         modifier = Modifier,
         isSelectableItem = false,
@@ -521,8 +517,7 @@ fun PreviewGroupConversationItemWithLastDeletedMessage() = WireTheme {
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
-            folder = null,
-            playingAudio = null
+            folder = null
         ),
         modifier = Modifier,
         isSelectableItem = false,
@@ -550,8 +545,7 @@ fun PreviewGroupConversationItemWithMutedBadgeAndUnreadMentionBadge() = WireThem
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
-            folder = null,
-            playingAudio = null
+            folder = null
         ),
         modifier = Modifier,
         isSelectableItem = false,
@@ -580,8 +574,7 @@ fun PreviewGroupConversationItemWithOngoingCall() = WireTheme {
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
-            folder = null,
-            playingAudio = null
+            folder = null
         ),
         modifier = Modifier,
         isSelectableItem = false,
@@ -666,8 +659,7 @@ fun PreviewPrivateConversationItemWithBlockedBadge() = WireTheme {
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
             isUserDeleted = false,
-            folder = null,
-            playingAudio = null
+            folder = null
         ),
         modifier = Modifier,
         isSelectableItem = false,
@@ -695,12 +687,12 @@ fun PreviewPrivateConversationItemWithPlayingAudio() = WireTheme {
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
-            folder = null,
-            playingAudio = PlayingAudioInConversation(QualifiedID("value", "domain"), "some_id", true)
+            folder = null
         ),
         modifier = Modifier,
         isSelectableItem = false,
         isChecked = false,
-        {}, {}, {}, {}, {}, {}
+        {}, {}, {}, {}, {}, {},
+        playingAudio = PlayingAudioInConversation(QualifiedID("value", "domain"), "some_id", true)
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -82,12 +82,19 @@ fun ConversationItemFactory(
     joinCall: (ConversationId) -> Unit = {},
     onAudioPermissionPermanentlyDenied: () -> Unit = {},
     onPlayPauseCurrentAudio: () -> Unit = { },
-    onStopCurrentAudio: () -> Unit = {}
+    onStopCurrentAudio: () -> Unit = {},
+    searchQuery: String = conversation.searchQuery,
+    isSelfUserUnderLegalHold: Boolean = false,
+    playingAudio: PlayingAudioInConversation? = conversation.playingAudio
 ) {
     val openConversationOptionDescription = stringResource(R.string.content_description_conversation_details_more_btn)
     val openUserProfileDescription = stringResource(R.string.content_description_open_user_profile_label)
     val acceptOrIgnoreDescription = stringResource(R.string.content_description_accept_or_ignore_connection_label)
     val openConversationDescription = stringResource(R.string.content_description_open_conversation_label)
+    val showLegalHoldIndicator = conversation.showLegalHoldIndicator && !isSelfUserUnderLegalHold
+    val playingAudioInConversation = playingAudio
+        ?.takeIf { it.conversationId == conversation.conversationId }
+        ?: conversation.playingAudio
     val onConversationItemClick = remember(conversation) {
         when (val lastEvent = conversation.lastMessageContent) {
             is UILastMessageContent.Connection -> {
@@ -151,6 +158,9 @@ fun ConversationItemFactory(
             joinCall(conversation.conversationId)
         },
         onAudioPermissionPermanentlyDenied = onAudioPermissionPermanentlyDenied,
+        searchQuery = searchQuery,
+        showLegalHoldIndicator = showLegalHoldIndicator,
+        playingAudio = playingAudioInConversation,
         onPlayPauseCurrentAudio = onPlayPauseCurrentAudio,
         onStopCurrentAudio = onStopCurrentAudio
     )
@@ -168,6 +178,9 @@ private fun GeneralConversationItem(
     modifier: Modifier = Modifier,
     selectOnRadioGroup: () -> Unit = {},
     subTitle: @Composable () -> Unit = {},
+    searchQuery: String = conversation.searchQuery,
+    showLegalHoldIndicator: Boolean = conversation.showLegalHoldIndicator,
+    playingAudio: PlayingAudioInConversation? = conversation.playingAudio,
     onPlayPauseCurrentAudio: () -> Unit = { },
     onStopCurrentAudio: () -> Unit = {}
 ) {
@@ -197,7 +210,7 @@ private fun GeneralConversationItem(
                     title = {
                         ConversationTitle(
                             name = groupName.ifEmpty { stringResource(id = R.string.member_name_deleted_label) },
-                            showLegalHoldIndicator = conversation.showLegalHoldIndicator,
+                            showLegalHoldIndicator = showLegalHoldIndicator,
                             searchQuery = searchQuery
                         )
                     },
@@ -210,9 +223,9 @@ private fun GeneralConversationItem(
                                     buttonClick = onJoinCallClick,
                                     onAudioPermissionPermanentlyDenied = onAudioPermissionPermanentlyDenied,
                                 )
-                            } else if (conversation.playingAudio != null) {
+                            } else if (playingAudio != null) {
                                 AudioControlButtons(
-                                    playingAudio = conversation.playingAudio!!,
+                                    playingAudio = playingAudio,
                                     onPlayPauseCurrentAudio = onPlayPauseCurrentAudio,
                                     onStopCurrentAudio = onStopCurrentAudio
                                 )
@@ -251,7 +264,7 @@ private fun GeneralConversationItem(
                     },
                     title = {
                         UserLabel(
-                            userInfoLabel = toUserInfoLabel(),
+                            userInfoLabel = toUserInfoLabel(showLegalHoldIndicator),
                             searchQuery = searchQuery
                         )
                     },
@@ -259,9 +272,9 @@ private fun GeneralConversationItem(
                     clickable = onConversationItemClick,
                     actions = {
                         if (!isSelectable) {
-                            if (conversation.playingAudio != null) {
+                            if (playingAudio != null) {
                                 AudioControlButtons(
-                                    playingAudio = conversation.playingAudio,
+                                    playingAudio = playingAudio,
                                     onPlayPauseCurrentAudio = onPlayPauseCurrentAudio,
                                     onStopCurrentAudio = onStopCurrentAudio
                                 )
@@ -293,7 +306,7 @@ private fun GeneralConversationItem(
                     },
                     title = {
                         UserLabel(
-                            userInfoLabel = toUserInfoLabel(),
+                            userInfoLabel = toUserInfoLabel(showLegalHoldIndicator),
                             searchQuery = searchQuery
                         )
                     },
@@ -683,7 +696,7 @@ fun PreviewPrivateConversationItemWithPlayingAudio() = WireTheme {
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
             folder = null,
-            playingAudio = PlayingAudioInConversation("some_id", true)
+            playingAudio = PlayingAudioInConversation(QualifiedID("value", "domain"), "some_id", true)
         ),
         modifier = Modifier,
         isSelectableItem = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -302,21 +302,20 @@ fun ConversationList(
 }
 
 @Suppress("MagicNumber")
-fun previewConversationList(count: Int, startIndex: Int = 0, unread: Boolean = false, searchQuery: String = "") = buildList {
+fun previewConversationList(count: Int, startIndex: Int = 0, unread: Boolean = false) = buildList {
     repeat(count) { index ->
         val currentIndex = startIndex + index
         when (index % 3) {
-            0 -> add(fakeRegularGroup(currentIndex, unread, searchQuery))
-            1 -> add(fakePrivateConversation(currentIndex, unread, searchQuery))
-            2 -> add(fakeChannel(currentIndex, unread, searchQuery))
+            0 -> add(fakeRegularGroup(currentIndex, unread))
+            1 -> add(fakePrivateConversation(currentIndex, unread))
+            2 -> add(fakeChannel(currentIndex, unread))
         }
     }
 }.toImmutableList()
 
 private fun fakeRegularGroup(
     currentIndex: Int,
-    unread: Boolean,
-    searchQuery: String
+    unread: Boolean
 ) = ConversationItem.Group.Regular(
     groupName = "Conversation $currentIndex",
     conversationId = QualifiedID(currentIndex.toString(), "domain"),
@@ -330,16 +329,13 @@ private fun fakeRegularGroup(
     isFromTheSameTeam = false,
     mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
     proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
-    searchQuery = searchQuery,
     isFavorite = false,
-    folder = null,
-    playingAudio = null
+    folder = null
 )
 
 private fun fakePrivateConversation(
     currentIndex: Int,
-    unread: Boolean,
-    searchQuery: String
+    unread: Boolean
 ) = ConversationItem.PrivateConversation(
     userAvatarData = UserAvatarData(),
     conversationId = QualifiedID(currentIndex.toString(), "domain"),
@@ -353,17 +349,14 @@ private fun fakePrivateConversation(
     isArchived = false,
     mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
     proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
-    searchQuery = searchQuery,
     isFavorite = false,
     isUserDeleted = false,
-    folder = null,
-    playingAudio = null
+    folder = null
 )
 
 private fun fakeChannel(
     currentIndex: Int,
-    unread: Boolean,
-    searchQuery: String
+    unread: Boolean
 ) = ConversationItem.Group.Channel(
     groupName = "Conversation $currentIndex",
     conversationId = QualifiedID(currentIndex.toString(), "domain"),
@@ -377,10 +370,8 @@ private fun fakeChannel(
     isFromTheSameTeam = false,
     mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
     proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
-    searchQuery = searchQuery,
     isFavorite = false,
     folder = null,
-    playingAudio = null,
     isPrivate = currentIndex % 2 == 0
 )
 
@@ -398,6 +389,7 @@ fun previewConversationItemsFlow(
     )
 )
 
+@Suppress("UNUSED_PARAMETER")
 fun previewConversationItems(
     isChannels: Boolean = false,
     withSections: Boolean = true,
@@ -408,9 +400,9 @@ fun previewConversationItems(
     buildList {
         if (isChannels) add(ConversationSection.Predefined.BrowseChannels)
         if (withSections) add(ConversationSection.Predefined.NewActivities)
-        addAll(previewConversationList(unreadCount, 0, true, searchQuery))
+        addAll(previewConversationList(unreadCount, 0, true))
         if (withSections) add(ConversationSection.Predefined.Conversations)
-        addAll(previewConversationList(readCount, unreadCount, false, searchQuery))
+        addAll(previewConversationList(readCount, unreadCount, false))
     }
 
 @PreviewMultipleThemes

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationList.kt
@@ -63,6 +63,7 @@ import com.wire.android.ui.home.conversationslist.model.ConversationInfo
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.ui.home.conversationslist.model.ConversationItemType
 import com.wire.android.ui.home.conversationslist.model.ConversationSection
+import com.wire.android.ui.home.conversationslist.model.PlayingAudioInConversation
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
@@ -86,6 +87,9 @@ fun ConversationList(
     lazyListState: LazyListState = rememberLazyListState(),
     isSelectableList: Boolean = false,
     selectedConversations: List<ConversationId> = emptyList(),
+    searchQuery: String = "",
+    isSelfUserUnderLegalHold: Boolean = false,
+    playingAudio: PlayingAudioInConversation? = null,
     onOpenConversation: (ConversationItem) -> Unit = {},
     onEditConversation: (ConversationItem) -> Unit = {},
     onOpenUserProfile: (UserId) -> Unit = {},
@@ -160,6 +164,9 @@ fun ConversationList(
                             modifier = conversationModifier,
                             isSelectableItem = isSelectableList,
                             isChecked = selectedConversations.contains(item.conversationId),
+                            searchQuery = searchQuery,
+                            isSelfUserUnderLegalHold = isSelfUserUnderLegalHold,
+                            playingAudio = playingAudio,
                             onConversationSelectedOnRadioGroup = { onConversationSelectedOnRadioGroup(item) },
                             openConversation = onOpenConversation,
                             openMenu = onEditConversation,
@@ -227,6 +234,9 @@ fun ConversationList(
     lazyListState: LazyListState = rememberLazyListState(),
     isSelectableList: Boolean = false,
     selectedConversations: List<ConversationItem> = emptyList(),
+    searchQuery: String = "",
+    isSelfUserUnderLegalHold: Boolean = false,
+    playingAudio: PlayingAudioInConversation? = null,
     onOpenConversation: (ConversationItem) -> Unit = {},
     onEditConversation: (ConversationItem) -> Unit = {},
     onOpenUserProfile: (UserId) -> Unit = {},
@@ -270,6 +280,9 @@ fun ConversationList(
                     modifier = conversationModifier,
                     isSelectableItem = isSelectableList,
                     isChecked = selectedConversations.contains(generalConversation),
+                    searchQuery = searchQuery,
+                    isSelfUserUnderLegalHold = isSelfUserUnderLegalHold,
+                    playingAudio = playingAudio,
                     onConversationSelectedOnRadioGroup = { onConversationSelectedOnRadioGroup(generalConversation.conversationId) },
                     openConversation = onOpenConversation,
                     openMenu = onEditConversation,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/LastMessageSubtitle.kt
@@ -21,6 +21,7 @@ package com.wire.android.ui.home.conversationslist.common
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.style.TextOverflow
 import com.wire.android.ui.markdown.MarkdownConstants
@@ -29,6 +30,8 @@ import com.wire.android.ui.markdown.MarkdownPreview
 import com.wire.android.ui.markdown.MarkdownNode
 import com.wire.android.ui.markdown.MessageColors
 import com.wire.android.ui.markdown.NodeData
+import com.wire.android.ui.markdown.previewMarkdownSource
+import com.wire.android.ui.markdown.toLightweightMarkdownPreviewFromSource
 import com.wire.android.ui.theme.Accent
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
@@ -83,8 +86,13 @@ private fun LastMessageMarkdown(
     val locales = LocalConfiguration.current.locales
     val currentLocaleTag = if (locales.isEmpty) "" else locales[0].toLanguageTag()
     val shouldUsePreview = markdownPreview != null && (markdownLocaleTag == null || markdownLocaleTag == currentLocaleTag)
+    val resolvedMarkdownPreview = if (shouldUsePreview) {
+        markdownPreview
+    } else {
+        rememberLightweightMarkdownPreview(text = text)
+    }
 
-    if (shouldUsePreview) {
+    if (resolvedMarkdownPreview != null) {
         val leadingInlines = if (leadingText.isBlank()) {
             persistentListOf()
         } else {
@@ -94,10 +102,7 @@ private fun LastMessageMarkdown(
                 )
             )
         }
-        MarkdownInline(
-            inlines = leadingInlines.plus(markdownPreview.children),
-            nodeData = nodeData
-        )
+        MarkdownInline(inlines = leadingInlines.plus(resolvedMarkdownPreview.children), nodeData = nodeData)
     } else {
         Text(
             text = leadingText.replace(MarkdownConstants.NON_BREAKING_SPACE, " ") +
@@ -108,4 +113,10 @@ private fun LastMessageMarkdown(
             overflow = TextOverflow.Ellipsis
         )
     }
+}
+
+@Composable
+private fun rememberLightweightMarkdownPreview(text: String): MarkdownPreview? {
+    val source = remember(text) { text.previewMarkdownSource() }
+    return remember(source) { source.toLightweightMarkdownPreviewFromSource() }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -36,7 +36,7 @@ import com.wire.kalium.logic.data.conversation.ConversationFolder as CurrentFold
 sealed interface ConversationItem : ConversationItemType {
     val conversationId: ConversationId
     val mutedStatus: MutedConversationStatus
-    val showLegalHoldIndicator: Boolean
+    val legalHoldStatus: Conversation.LegalHoldStatus
     val lastMessageContent: UILastMessageContent?
     val badgeEventType: BadgeEventType
     val teamId: TeamId?
@@ -46,8 +46,6 @@ sealed interface ConversationItem : ConversationItemType {
     val mlsVerificationStatus: Conversation.VerificationStatus
     val proteusVerificationStatus: Conversation.VerificationStatus
     val hasNewActivitiesToShow: Boolean
-    val searchQuery: String
-    val playingAudio: PlayingAudioInConversation?
 
     val isTeamConversation get() = teamId != null
 
@@ -68,7 +66,7 @@ sealed interface ConversationItem : ConversationItemType {
             override val isSelfUserMember: Boolean = true,
             override val conversationId: ConversationId,
             override val mutedStatus: MutedConversationStatus,
-            override val showLegalHoldIndicator: Boolean = false,
+            override val legalHoldStatus: Conversation.LegalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
             override val lastMessageContent: UILastMessageContent?,
             override val badgeEventType: BadgeEventType,
             override val teamId: TeamId?,
@@ -78,8 +76,6 @@ sealed interface ConversationItem : ConversationItemType {
             override val mlsVerificationStatus: Conversation.VerificationStatus,
             override val proteusVerificationStatus: Conversation.VerificationStatus,
             override val hasNewActivitiesToShow: Boolean = false,
-            override val searchQuery: String = "",
-            override val playingAudio: PlayingAudioInConversation? = null
         ) : Group
 
         @Serializable
@@ -91,7 +87,7 @@ sealed interface ConversationItem : ConversationItemType {
             override val isSelfUserMember: Boolean = true,
             override val conversationId: ConversationId,
             override val mutedStatus: MutedConversationStatus,
-            override val showLegalHoldIndicator: Boolean = false,
+            override val legalHoldStatus: Conversation.LegalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
             override val lastMessageContent: UILastMessageContent?,
             override val badgeEventType: BadgeEventType,
             override val teamId: TeamId?,
@@ -101,8 +97,6 @@ sealed interface ConversationItem : ConversationItemType {
             override val mlsVerificationStatus: Conversation.VerificationStatus,
             override val proteusVerificationStatus: Conversation.VerificationStatus,
             override val hasNewActivitiesToShow: Boolean = false,
-            override val searchQuery: String = "",
-            override val playingAudio: PlayingAudioInConversation? = null,
             val isPrivate: Boolean,
         ) : Group
     }
@@ -116,7 +110,7 @@ sealed interface ConversationItem : ConversationItemType {
         val isUserDeleted: Boolean,
         override val conversationId: ConversationId,
         override val mutedStatus: MutedConversationStatus,
-        override val showLegalHoldIndicator: Boolean = false,
+        override val legalHoldStatus: Conversation.LegalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
         override val lastMessageContent: UILastMessageContent?,
         override val badgeEventType: BadgeEventType,
         override val teamId: TeamId?,
@@ -126,8 +120,6 @@ sealed interface ConversationItem : ConversationItemType {
         override val mlsVerificationStatus: Conversation.VerificationStatus,
         override val proteusVerificationStatus: Conversation.VerificationStatus,
         override val hasNewActivitiesToShow: Boolean = false,
-        override val searchQuery: String = "",
-        override val playingAudio: PlayingAudioInConversation? = null
     ) : ConversationItem
 
     @Serializable
@@ -136,19 +128,17 @@ sealed interface ConversationItem : ConversationItemType {
         val conversationInfo: ConversationInfo,
         override val conversationId: ConversationId,
         override val mutedStatus: MutedConversationStatus,
-        override val showLegalHoldIndicator: Boolean = false,
+        override val legalHoldStatus: Conversation.LegalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
         override val lastMessageContent: UILastMessageContent?,
         override val badgeEventType: BadgeEventType,
         override val isArchived: Boolean = false,
         override val isFavorite: Boolean = false,
         override val folder: CurrentFolder? = null,
         override val hasNewActivitiesToShow: Boolean = false,
-        override val searchQuery: String = "",
     ) : ConversationItem {
         override val teamId: TeamId? = null
         override val mlsVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         override val proteusVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
-        override val playingAudio: PlayingAudioInConversation? = null
     }
 }
 
@@ -180,9 +170,7 @@ val OtherUser.BlockState: BlockingState
             else -> BlockingState.NOT_BLOCKED
         }
 
-fun ConversationItem.PrivateConversation.toUserInfoLabel(
-    showLegalHoldIndicator: Boolean = this.showLegalHoldIndicator
-) =
+fun ConversationItem.PrivateConversation.toUserInfoLabel(showLegalHoldIndicator: Boolean) =
     UserInfoLabel(
         labelName = conversationInfo.name,
         showLegalHoldIndicator = showLegalHoldIndicator,
@@ -192,9 +180,7 @@ fun ConversationItem.PrivateConversation.toUserInfoLabel(
         proteusVerificationStatus = proteusVerificationStatus
     )
 
-fun ConversationItem.ConnectionConversation.toUserInfoLabel(
-    showLegalHoldIndicator: Boolean = this.showLegalHoldIndicator
-) =
+fun ConversationItem.ConnectionConversation.toUserInfoLabel(showLegalHoldIndicator: Boolean) =
     UserInfoLabel(
         labelName = conversationInfo.name,
         showLegalHoldIndicator = showLegalHoldIndicator,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.ui.home.conversationslist.model
 
+import androidx.compose.runtime.Immutable
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.conversations.model.UILastMessageContent
 import com.wire.android.ui.home.conversationslist.common.UserInfoLabel
@@ -150,6 +151,7 @@ data class ConversationInfo(
 )
 
 @Serializable
+@Immutable
 data class PlayingAudioInConversation(
     val conversationId: ConversationId,
     val messageId: String,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -79,7 +79,7 @@ sealed interface ConversationItem : ConversationItemType {
             override val proteusVerificationStatus: Conversation.VerificationStatus,
             override val hasNewActivitiesToShow: Boolean = false,
             override val searchQuery: String = "",
-            override val playingAudio: PlayingAudioInConversation?
+            override val playingAudio: PlayingAudioInConversation? = null
         ) : Group
 
         @Serializable
@@ -102,7 +102,7 @@ sealed interface ConversationItem : ConversationItemType {
             override val proteusVerificationStatus: Conversation.VerificationStatus,
             override val hasNewActivitiesToShow: Boolean = false,
             override val searchQuery: String = "",
-            override val playingAudio: PlayingAudioInConversation?,
+            override val playingAudio: PlayingAudioInConversation? = null,
             val isPrivate: Boolean,
         ) : Group
     }
@@ -127,7 +127,7 @@ sealed interface ConversationItem : ConversationItemType {
         override val proteusVerificationStatus: Conversation.VerificationStatus,
         override val hasNewActivitiesToShow: Boolean = false,
         override val searchQuery: String = "",
-        override val playingAudio: PlayingAudioInConversation?
+        override val playingAudio: PlayingAudioInConversation? = null
     ) : ConversationItem
 
     @Serializable
@@ -161,6 +161,7 @@ data class ConversationInfo(
 
 @Serializable
 data class PlayingAudioInConversation(
+    val conversationId: ConversationId,
     val messageId: String,
     val isPaused: Boolean
 )
@@ -179,7 +180,9 @@ val OtherUser.BlockState: BlockingState
             else -> BlockingState.NOT_BLOCKED
         }
 
-fun ConversationItem.PrivateConversation.toUserInfoLabel() =
+fun ConversationItem.PrivateConversation.toUserInfoLabel(
+    showLegalHoldIndicator: Boolean = this.showLegalHoldIndicator
+) =
     UserInfoLabel(
         labelName = conversationInfo.name,
         showLegalHoldIndicator = showLegalHoldIndicator,
@@ -189,7 +192,9 @@ fun ConversationItem.PrivateConversation.toUserInfoLabel() =
         proteusVerificationStatus = proteusVerificationStatus
     )
 
-fun ConversationItem.ConnectionConversation.toUserInfoLabel() =
+fun ConversationItem.ConnectionConversation.toUserInfoLabel(
+    showLegalHoldIndicator: Boolean = this.showLegalHoldIndicator
+) =
     UserInfoLabel(
         labelName = conversationInfo.name,
         showLegalHoldIndicator = showLegalHoldIndicator,

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/LightweightMarkdownPreviewParser.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/LightweightMarkdownPreviewParser.kt
@@ -1,0 +1,76 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.markdown
+
+private const val MAX_PREVIEW_MARKDOWN_CHARS = 200
+private val MARKDOWN_PREVIEW_INLINE_TRIGGERS = charArrayOf('*', '_', '`', '[', '!', '~')
+
+internal fun String.previewMarkdownSource(): String {
+    val newlineIndex = indexOf('\n').takeIf { it >= 0 } ?: length
+    val previewEnd = minOf(newlineIndex, MAX_PREVIEW_MARKDOWN_CHARS)
+    return substring(0, previewEnd).replace(MarkdownConstants.NON_BREAKING_SPACE, " ")
+}
+
+internal fun String.toLightweightMarkdownPreview(): MarkdownPreview? {
+    return previewMarkdownSource().toLightweightMarkdownPreviewFromSource()
+}
+
+internal fun String.toLightweightMarkdownPreviewFromSource(): MarkdownPreview? {
+    if (isBlank() || !hasPreviewMarkdownTrigger()) {
+        return null
+    }
+    return MarkdownParser.parsePreview(this)
+        ?.takeIf { it.children.hasVisiblePreviewText() }
+}
+
+internal fun String.hasPreviewMarkdownTrigger(): Boolean =
+    indexOfAny(MARKDOWN_PREVIEW_INLINE_TRIGGERS) >= 0 || firstNonWhitespaceCharCanStartMarkdown()
+
+private fun String.firstNonWhitespaceCharCanStartMarkdown(): Boolean {
+    val firstContentIndex = indexOfFirst { !it.isWhitespace() }
+    if (firstContentIndex == -1) return false
+    return when (this[firstContentIndex]) {
+        '#', '>', '-', '+', '|' -> true
+        in '0'..'9' -> isOrderedListMarker(firstContentIndex)
+        else -> false
+    }
+}
+
+private fun String.isOrderedListMarker(startIndex: Int): Boolean {
+    var index = startIndex
+    while (index < length && this[index].isDigit()) {
+        index++
+    }
+    return index > startIndex && index + 1 < length && this[index] in ".)" && this[index + 1].isWhitespace()
+}
+
+private fun List<MarkdownNode.Inline>.hasVisiblePreviewText(): Boolean {
+    return any { inline ->
+        when (inline) {
+            is MarkdownNode.Inline.Text -> inline.literal.isNotBlank()
+            is MarkdownNode.Inline.Code -> inline.literal.isNotBlank()
+            is MarkdownNode.Inline.Break -> false
+            is MarkdownNode.Inline.Emphasis -> inline.children.hasVisiblePreviewText()
+            is MarkdownNode.Inline.StrongEmphasis -> inline.children.hasVisiblePreviewText()
+            is MarkdownNode.Inline.Strikethrough -> inline.children.hasVisiblePreviewText()
+            is MarkdownNode.Inline.Link -> inline.children.hasVisiblePreviewText() || inline.destination.isNotBlank()
+            is MarkdownNode.Inline.Image -> inline.children.hasVisiblePreviewText() || inline.destination.isNotBlank()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParser.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/markdown/MarkdownParser.kt
@@ -28,6 +28,10 @@ object MarkdownParser {
         .includeSourceSpans(IncludeSourceSpans.BLOCKS)
         .build()
 
+    private val previewParser = Parser.builder()
+        .extensions(MarkdownConstants.supportedExtensions)
+        .build()
+
     // We preserve blank lines across *all* block types by using source spans:
     // CommonMark collapses empty lines into block boundaries, so we count
     // blank input lines between top-level blocks and insert spacer paragraphs
@@ -56,6 +60,12 @@ object MarkdownParser {
         return MarkdownNode.Document(
             adjustPaddingForSpacers(markdownChildren)
         )
+    }
+
+    fun parsePreview(text: String): MarkdownPreview? {
+        val documentNode = previewParser.parse(text) as Document
+        val firstBlock = documentNode.firstChild ?: return null
+        return (firstBlock.toContent() as? MarkdownNode.Block)?.getFirstInlines()
     }
 
     private fun collectTopLevelBlocks(document: Document): List<org.commonmark.node.Node> {

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -338,6 +338,7 @@ fun ImportMediaRegularContent(
                 ImportMediaContent(
                     state = this,
                     internalPadding = internalPadding,
+                    searchQuery = searchQueryTextState.text.toString(),
                     onConversationClicked = onConversationClicked,
                     lazyListState = lazyListState,
                 )
@@ -544,6 +545,7 @@ fun ImportMediaTopBarContent(
 private fun ImportMediaContent(
     state: ImportMediaAuthenticatedState,
     internalPadding: PaddingValues,
+    searchQuery: String,
     onConversationClicked: (conversationItem: ConversationItem) -> Unit,
     lazyListState: LazyListState = rememberLazyListState(),
 ) {
@@ -559,6 +561,7 @@ private fun ImportMediaContent(
             lazyPagingConversations = lazyPagingConversations,
             selectedConversations = state.selectedConversationItem,
             isSelectableList = true,
+            searchQuery = searchQuery,
             onConversationSelectedOnRadioGroup = onConversationClicked,
             onOpenConversation = onConversationClicked,
             onEditConversation = {},

--- a/app/src/test/kotlin/com/wire/android/framework/TestConversationItem.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestConversationItem.kt
@@ -47,8 +47,7 @@ object TestConversationItem {
         proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
         isFavorite = false,
         isUserDeleted = false,
-        folder = null,
-        playingAudio = null
+        folder = null
     )
 
     val GROUP = ConversationItem.Group.Regular(
@@ -66,8 +65,7 @@ object TestConversationItem {
         mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
         proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
         isFavorite = false,
-        folder = null,
-        playingAudio = null
+        folder = null
     )
 
     val CONNECTION = ConversationItem.ConnectionConversation(

--- a/app/src/test/kotlin/com/wire/android/mapper/MessagePreviewContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessagePreviewContentMapperTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.test.runTest
 import com.wire.android.assertions.shouldBeEqualTo
 import com.wire.android.assertions.shouldBeInstanceOf
 import com.wire.android.util.ui.UiTextResolver
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -147,6 +148,22 @@ class MessagePreviewContentMapperTest {
         val result = senderWithMessage.message.shouldBeInstanceOf<UIText.DynamicString>()
 
         result.value shouldBeEqualTo lastMessage
+    }
+
+    @Test
+    fun givenLastTextMessageContainsMarkdown_whenMappingToUIPreview_thenMarkdownShouldNotBeParsed() = runTest {
+        val lastMessage = "**hello**"
+        val messagePreview = TestMessage.PREVIEW.copy(
+            content = MessagePreviewContent.WithUser.Text("admin", lastMessage),
+        )
+
+        val senderWithMessage = messagePreview.toUIPreview(emptyMap(), uiTextResolver)
+            .shouldBeInstanceOf<UILastMessageContent.SenderWithMessage>()
+        val result = senderWithMessage.message.shouldBeInstanceOf<UIText.DynamicString>()
+
+        result.value shouldBeEqualTo lastMessage
+        assertNull(senderWithMessage.markdownPreview)
+        assertNull(senderWithMessage.markdownLocaleTag)
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/mapper/RegularMessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/RegularMessageContentMapperTest.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.test.runTest
 import okio.Path
 import okio.Path.Companion.toPath
 import okio.buffer
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -81,6 +82,18 @@ class RegularMessageContentMapperTest {
                         (messageBody.message as UIText.StringResource).resId == arrangement.messageResourceProvider.sentAMessageWithContent
             )
         }
+    }
+
+    @Test
+    fun givenTextContent_whenMappingToTextMessageContent_thenMarkdownDocumentShouldBeParsedByUi() = runTest {
+        // Given
+        val (_, mapper) = Arrangement().arrange()
+
+        // When
+        val result = mapper.toText(TestConversation.ID, TestMessage.TEXT_MESSAGE.content, userMembers, DeliveryStatus.CompleteDelivery)
+
+        // Then
+        assertNull(result.messageBody.markdownDocument)
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
@@ -101,7 +101,6 @@ class GetConversationsFromSearchUseCaseTest {
         // Then
         result.forEachIndexed { index, conversationItem ->
             assertEquals(conversationsList[index].conversationDetails.conversation.id, conversationItem.conversationId)
-            assertEquals(arrangement.queryConfig.searchQuery, conversationItem.searchQuery)
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -22,7 +22,6 @@ package com.wire.android.ui.home.conversationslist
 import androidx.paging.LoadState
 import androidx.paging.LoadStates
 import androidx.paging.PagingData
-import androidx.paging.testing.asSnapshot
 import app.cash.turbine.test
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
@@ -31,6 +30,8 @@ import com.wire.android.framework.TestConversationDetails
 import com.wire.android.framework.TestConversationItem
 import com.wire.android.framework.TestUser
 import com.wire.android.mapper.UserTypeMapper
+import com.wire.android.media.audiomessage.AudioMediaPlayingState
+import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
 import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.ui.home.conversations.usecase.GetConversationsFromSearchUseCase
@@ -145,62 +146,39 @@ class ConversationListViewModelTest {
         }
 
     @Test
-    fun `given self user is under legal hold, when collecting conversations, then hide LH indicators`() =
+    fun `given self user is under legal hold, when observing row state, then expose hidden LH indicators state`() =
         runTest(dispatcherProvider.main()) {
             // Given
-            val conversations = listOf(
-                TestConversationItem.CONNECTION.copy(conversationId = ConversationId("conn_1", ""), showLegalHoldIndicator = true),
-                TestConversationItem.CONNECTION.copy(conversationId = ConversationId("conn_2", ""), showLegalHoldIndicator = false),
-                TestConversationItem.PRIVATE.copy(conversationId = ConversationId("private_1", ""), showLegalHoldIndicator = true),
-                TestConversationItem.PRIVATE.copy(conversationId = ConversationId("private_2", ""), showLegalHoldIndicator = false),
-                TestConversationItem.GROUP.copy(conversationId = ConversationId("group_1", ""), showLegalHoldIndicator = true),
-                TestConversationItem.GROUP.copy(conversationId = ConversationId("group_2", ""), showLegalHoldIndicator = false),
-            ).associateBy { it.conversationId }
             val (_, conversationListViewModel) = Arrangement(conversationsSource = ConversationsSource.MAIN)
-                .withConversationsPaginated(conversations.values.toList())
                 .withSelfUserLegalHoldState(LegalHoldStateForSelfUser.Enabled)
                 .arrange()
             advanceUntilIdle()
 
             // When
-            (conversationListViewModel.conversationListState as ConversationListState.Paginated).conversations.asSnapshot()
-                .filterIsInstance<ConversationItem>()
-                .forEach {
-                    // Then
-                    assertEquals(false, it.showLegalHoldIndicator) // self user is under LH so hide LH indicators next to conversations
-                }
+            val isSelfUserUnderLegalHold = conversationListViewModel.isSelfUserUnderLegalHold.first()
+
+            // Then
+            assertEquals(true, isSelfUserUnderLegalHold)
         }
 
     @Test
-    fun `given self user is not under legal hold, when collecting conversations, then show LH indicator when conversation is under LH`() =
+    fun `given self user is not under legal hold, when observing row state, then expose visible LH indicators state`() =
         runTest(dispatcherProvider.main()) {
             // Given
-            val conversations = listOf(
-                TestConversationItem.CONNECTION.copy(conversationId = ConversationId("conn_1", ""), showLegalHoldIndicator = true),
-                TestConversationItem.CONNECTION.copy(conversationId = ConversationId("conn_2", ""), showLegalHoldIndicator = false),
-                TestConversationItem.PRIVATE.copy(conversationId = ConversationId("private_1", ""), showLegalHoldIndicator = true),
-                TestConversationItem.PRIVATE.copy(conversationId = ConversationId("private_2", ""), showLegalHoldIndicator = false),
-                TestConversationItem.GROUP.copy(conversationId = ConversationId("group_1", ""), showLegalHoldIndicator = true),
-                TestConversationItem.GROUP.copy(conversationId = ConversationId("group_2", ""), showLegalHoldIndicator = false),
-            ).associateBy { it.conversationId }
             val (_, conversationListViewModel) = Arrangement(conversationsSource = ConversationsSource.MAIN)
-                .withConversationsPaginated(conversations.values.toList())
                 .withSelfUserLegalHoldState(LegalHoldStateForSelfUser.Disabled)
                 .arrange()
             advanceUntilIdle()
 
             // When
-            (conversationListViewModel.conversationListState as ConversationListState.Paginated).conversations.asSnapshot()
-                .filterIsInstance<ConversationItem>()
-                .forEach {
-                    // Then
-                    val expected = conversations[it.conversationId]!!.showLegalHoldIndicator // show indicator when conversation is under LH
-                    assertEquals(expected, it.showLegalHoldIndicator)
-                }
+            val isSelfUserUnderLegalHold = conversationListViewModel.isSelfUserUnderLegalHold.first()
+
+            // Then
+            assertEquals(false, isSelfUserUnderLegalHold)
         }
 
     @Test
-    fun `given cached PagingData, when self user legal hold changes, then should call paginated use case again`() =
+    fun `given cached PagingData, when self user legal hold changes, then should not call paginated use case again`() =
         runTest(dispatcherProvider.main()) {
             // given
             val conversations = listOf(
@@ -229,8 +207,41 @@ class ConversationListViewModelTest {
                 selfUserLegalHoldStateFlow.emit(LegalHoldStateForSelfUser.Enabled)
                 advanceUntilIdle()
 
-                // then use case should be called again (in total 2 executions) to create new PagingData
-                coVerify(exactly = 2) {
+                // then use case should not be called again because LH is derived per visible row
+                coVerify(exactly = 1) {
+                    arrangement.getConversationsPaginated(any(), any(), any(), any(), useStrictMlsFilter = any())
+                }
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given cached PagingData, when playing audio changes, then should not call paginated use case again`() =
+        runTest(dispatcherProvider.main()) {
+            // given
+            val audioMessageFlow = MutableSharedFlow<PlayingAudioMessage>()
+            val (arrangement, conversationListViewModel) = Arrangement(conversationsSource = ConversationsSource.MAIN)
+                .withPlayingAudioMessageFlow(audioMessageFlow)
+                .arrange()
+            advanceUntilIdle()
+
+            (conversationListViewModel.conversationListState as ConversationListState.Paginated).conversations.test {
+                coVerify(exactly = 1) {
+                    arrangement.getConversationsPaginated(any(), any(), any(), any(), useStrictMlsFilter = any())
+                }
+
+                audioMessageFlow.emit(
+                    PlayingAudioMessage.Some(
+                        conversationId = ConversationId("conn_1", ""),
+                        messageId = "message_id",
+                        authorName = UIText.DynamicString("Author"),
+                        state = AudioState(AudioMediaPlayingState.Playing, 0, AudioState.TotalTimeInMs.NotKnown)
+                    )
+                )
+                advanceUntilIdle()
+
+                coVerify(exactly = 1) {
                     arrangement.getConversationsPaginated(any(), any(), any(), any(), useStrictMlsFilter = any())
                 }
 
@@ -346,6 +357,10 @@ class ConversationListViewModelTest {
 
         fun withSelfUserLegalHoldStateFlow(legalHoldStateForSelfUserFlow: Flow<LegalHoldStateForSelfUser>) = apply {
             coEvery { observeLegalHoldStateForSelfUserUseCase() } returns legalHoldStateForSelfUserFlow
+        }
+
+        fun withPlayingAudioMessageFlow(playingAudioMessageFlow: Flow<PlayingAudioMessage>) = apply {
+            every { audioMessagePlayer.playingAudioMessageFlow } returns playingAudioMessageFlow
         }
 
         fun arrange() = this to ConversationListViewModelImpl(

--- a/app/src/test/kotlin/com/wire/android/ui/markdown/MarkdownHelperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/markdown/MarkdownHelperTest.kt
@@ -136,6 +136,86 @@ class MarkdownHelperTest {
     }
 
     @Test
+    fun `given plain text, when toLightweightMarkdownPreview is called, then it should return null`() {
+        val result = "plain conversation preview".toLightweightMarkdownPreview()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `given markdown text, when toLightweightMarkdownPreview is called, then it should use common markdown nodes`() {
+        val result = "hello **wire**".toLightweightMarkdownPreview()
+
+        assertNotNull(result)
+        assertEquals(2, result!!.children.size)
+        assertTrue(result.children[0] is MarkdownNode.Inline.Text)
+        assertTrue(result.children[1] is MarkdownNode.Inline.StrongEmphasis)
+    }
+
+    @Test
+    fun `given inline code, when toLightweightMarkdownPreview is called, then it should keep code formatting`() {
+        val result = "hello `wire`".toLightweightMarkdownPreview()
+
+        assertNotNull(result)
+        assertEquals(2, result!!.children.size)
+        assertTrue(result.children[0] is MarkdownNode.Inline.Text)
+        assertTrue(result.children[1] is MarkdownNode.Inline.Code)
+        assertEquals("wire", (result.children[1] as MarkdownNode.Inline.Code).literal)
+    }
+
+    @Test
+    fun `given markdown across multiple lines, when toLightweightMarkdownPreview is called, then it should parse only first line`() {
+        val result = "first **line**\nsecond **line**".toLightweightMarkdownPreview()
+
+        assertNotNull(result)
+        assertEquals("first ", (result!!.children[0] as MarkdownNode.Inline.Text).literal)
+        assertEquals("line", ((result.children[1] as MarkdownNode.Inline.StrongEmphasis).children[0] as MarkdownNode.Inline.Text).literal)
+    }
+
+    @Test
+    fun `given fenced code with content after first line, when toLightweightMarkdownPreview is called, then it should return null`() {
+        val result = "```kotlin\nval value = 1\n```".toLightweightMarkdownPreview()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `given tilde fenced code with content after first line, when toLightweightMarkdownPreview is called, then it should return null`() {
+        val result = "~~~kotlin\nval value = 1\n~~~".toLightweightMarkdownPreview()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `given empty list marker on first line, when toLightweightMarkdownPreview is called, then it should return null`() {
+        val result = "-\nlist item text".toLightweightMarkdownPreview()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `given empty ordered list marker on first line, when toLightweightMarkdownPreview is called, then it should return null`() {
+        val result = "1.\nlist item text".toLightweightMarkdownPreview()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `given table markdown, when toLightweightMarkdownPreview is called, then it should keep only first row text`() {
+        val result = "| name | value |\n| --- | --- |\n| Wire | Android |".toLightweightMarkdownPreview()
+
+        assertNotNull(result)
+        assertEquals("| name | value |", (result!!.children[0] as MarkdownNode.Inline.Text).literal)
+    }
+
+    @Test
+    fun `given setext heading marker on second line, when toLightweightMarkdownPreview is called, then it should return null`() {
+        val result = "Heading\n---".toLightweightMarkdownPreview()
+
+        assertNull(result)
+    }
+
+    @Test
     fun `given bullet list node, when toContent is called, then it should return Block BulletList`() {
         val bulletListNode = BulletList()
         bulletListNode.appendChild(ListItem().apply { appendChild(Text("First bullet")) })

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -8064,7 +8064,7 @@ public fun com.wire.android.ui.home.conversationslist.common.AudioControlButtons
   skippable: true
   restartable: true
   params:
-    - playingAudio: STABLE (class with no mutable properties)
+    - playingAudio: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - onPlayPauseCurrentAudio: STABLE (function type)
     - onStopCurrentAudio: STABLE (function type)
@@ -8099,7 +8099,7 @@ public fun com.wire.android.ui.home.conversationslist.common.ConnectionLabel(con
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.wire.android.ui.home.conversationslist.common.ConversationItemFactory(conversation: com.wire.android.ui.home.conversationslist.model.ConversationItem, modifier: androidx.compose.ui.Modifier, isSelectableItem: kotlin.Boolean, isChecked: kotlin.Boolean, onConversationSelectedOnRadioGroup: kotlin.Function0<kotlin.Unit>, openConversation: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, openMenu: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, openUserProfile: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, joinCall: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onAudioPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, onPlayPauseCurrentAudio: kotlin.Function0<kotlin.Unit>, onStopCurrentAudio: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.wire.android.ui.home.conversationslist.common.ConversationItemFactory(conversation: com.wire.android.ui.home.conversationslist.model.ConversationItem, modifier: androidx.compose.ui.Modifier, isSelectableItem: kotlin.Boolean, isChecked: kotlin.Boolean, onConversationSelectedOnRadioGroup: kotlin.Function0<kotlin.Unit>, openConversation: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, openMenu: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, openUserProfile: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, joinCall: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onAudioPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, onPlayPauseCurrentAudio: kotlin.Function0<kotlin.Unit>, onStopCurrentAudio: kotlin.Function0<kotlin.Unit>, searchQuery: kotlin.String, isSelfUserUnderLegalHold: kotlin.Boolean, playingAudio: com.wire.android.ui.home.conversationslist.model.PlayingAudioInConversation?): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -8115,6 +8115,9 @@ public fun com.wire.android.ui.home.conversationslist.common.ConversationItemFac
     - onAudioPermissionPermanentlyDenied: STABLE (function type)
     - onPlayPauseCurrentAudio: STABLE (function type)
     - onStopCurrentAudio: STABLE (function type)
+    - searchQuery: STABLE (String is immutable)
+    - isSelfUserUnderLegalHold: STABLE (primitive type)
+    - playingAudio: STABLE (marked @Stable or @Immutable)
 
 @Composable
 private fun com.wire.android.ui.home.conversationslist.common.ConversationLeadingAvatar(modifier: androidx.compose.ui.Modifier, content: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>): kotlin.Unit
@@ -8125,7 +8128,7 @@ private fun com.wire.android.ui.home.conversationslist.common.ConversationLeadin
     - content: STABLE (composable function type)
 
 @Composable
-public fun com.wire.android.ui.home.conversationslist.common.ConversationList(lazyPagingConversations: androidx.paging.compose.LazyPagingItems<com.wire.android.ui.home.conversationslist.model.ConversationItemType>, modifier: androidx.compose.ui.Modifier, lazyListState: androidx.compose.foundation.lazy.LazyListState, isSelectableList: kotlin.Boolean, selectedConversations: kotlin.collections.List<com.wire.kalium.logic.data.id.QualifiedID>, onOpenConversation: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, onEditConversation: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, onOpenUserProfile: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onJoinCall: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onConversationSelectedOnRadioGroup: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, onAudioPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, onPlayPauseCurrentAudio: kotlin.Function0<kotlin.Unit>, onStopCurrentAudio: kotlin.Function0<kotlin.Unit>, onBrowsePublicChannels: kotlin.Function0<kotlin.Unit>, firstConversationFocusRequester: androidx.compose.ui.focus.FocusRequester?): kotlin.Unit
+public fun com.wire.android.ui.home.conversationslist.common.ConversationList(lazyPagingConversations: androidx.paging.compose.LazyPagingItems<com.wire.android.ui.home.conversationslist.model.ConversationItemType>, modifier: androidx.compose.ui.Modifier, lazyListState: androidx.compose.foundation.lazy.LazyListState, isSelectableList: kotlin.Boolean, selectedConversations: kotlin.collections.List<com.wire.kalium.logic.data.id.QualifiedID>, searchQuery: kotlin.String, isSelfUserUnderLegalHold: kotlin.Boolean, playingAudio: com.wire.android.ui.home.conversationslist.model.PlayingAudioInConversation?, onOpenConversation: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, onEditConversation: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, onOpenUserProfile: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onJoinCall: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onConversationSelectedOnRadioGroup: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, onAudioPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, onPlayPauseCurrentAudio: kotlin.Function0<kotlin.Unit>, onStopCurrentAudio: kotlin.Function0<kotlin.Unit>, onBrowsePublicChannels: kotlin.Function0<kotlin.Unit>, firstConversationFocusRequester: androidx.compose.ui.focus.FocusRequester?): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -8134,6 +8137,9 @@ public fun com.wire.android.ui.home.conversationslist.common.ConversationList(la
     - lazyListState: STABLE (marked @Stable or @Immutable)
     - isSelectableList: STABLE (primitive type)
     - selectedConversations: RUNTIME (requires runtime check)
+    - searchQuery: STABLE (String is immutable)
+    - isSelfUserUnderLegalHold: STABLE (primitive type)
+    - playingAudio: STABLE (marked @Stable or @Immutable)
     - onOpenConversation: STABLE (function type)
     - onEditConversation: STABLE (function type)
     - onOpenUserProfile: STABLE (function type)
@@ -8146,7 +8152,7 @@ public fun com.wire.android.ui.home.conversationslist.common.ConversationList(la
     - firstConversationFocusRequester: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.wire.android.ui.home.conversationslist.common.ConversationList(conversationListItems: kotlinx.collections.immutable.ImmutableMap<com.wire.android.ui.home.conversationslist.model.ConversationSection, kotlin.collections.List<com.wire.android.ui.home.conversationslist.model.ConversationItem>>, modifier: androidx.compose.ui.Modifier, lazyListState: androidx.compose.foundation.lazy.LazyListState, isSelectableList: kotlin.Boolean, selectedConversations: kotlin.collections.List<com.wire.android.ui.home.conversationslist.model.ConversationItem>, onOpenConversation: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, onEditConversation: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, onOpenUserProfile: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onJoinCall: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onConversationSelectedOnRadioGroup: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onAudioPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, onPlayPauseCurrentAudio: kotlin.Function0<kotlin.Unit>, onStopCurrentAudio: kotlin.Function0<kotlin.Unit>, firstConversationFocusRequester: androidx.compose.ui.focus.FocusRequester?): kotlin.Unit
+public fun com.wire.android.ui.home.conversationslist.common.ConversationList(conversationListItems: kotlinx.collections.immutable.ImmutableMap<com.wire.android.ui.home.conversationslist.model.ConversationSection, kotlin.collections.List<com.wire.android.ui.home.conversationslist.model.ConversationItem>>, modifier: androidx.compose.ui.Modifier, lazyListState: androidx.compose.foundation.lazy.LazyListState, isSelectableList: kotlin.Boolean, selectedConversations: kotlin.collections.List<com.wire.android.ui.home.conversationslist.model.ConversationItem>, searchQuery: kotlin.String, isSelfUserUnderLegalHold: kotlin.Boolean, playingAudio: com.wire.android.ui.home.conversationslist.model.PlayingAudioInConversation?, onOpenConversation: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, onEditConversation: kotlin.Function1<com.wire.android.ui.home.conversationslist.model.ConversationItem, kotlin.Unit>, onOpenUserProfile: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onJoinCall: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onConversationSelectedOnRadioGroup: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onAudioPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, onPlayPauseCurrentAudio: kotlin.Function0<kotlin.Unit>, onStopCurrentAudio: kotlin.Function0<kotlin.Unit>, firstConversationFocusRequester: androidx.compose.ui.focus.FocusRequester?): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -8155,6 +8161,9 @@ public fun com.wire.android.ui.home.conversationslist.common.ConversationList(co
     - lazyListState: STABLE (marked @Stable or @Immutable)
     - isSelectableList: STABLE (primitive type)
     - selectedConversations: RUNTIME (requires runtime check)
+    - searchQuery: STABLE (String is immutable)
+    - isSelfUserUnderLegalHold: STABLE (primitive type)
+    - playingAudio: STABLE (marked @Stable or @Immutable)
     - onOpenConversation: STABLE (function type)
     - onEditConversation: STABLE (function type)
     - onOpenUserProfile: STABLE (function type)
@@ -8192,7 +8201,7 @@ public fun com.wire.android.ui.home.conversationslist.common.EventBadgeFactory(e
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-private fun com.wire.android.ui.home.conversationslist.common.GeneralConversationItem(conversation: com.wire.android.ui.home.conversationslist.model.ConversationItem, isChecked: kotlin.Boolean, isSelectable: kotlin.Boolean, onConversationItemClick: com.wire.android.model.Clickable, onJoinCallClick: kotlin.Function0<kotlin.Unit>, onAudioPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, selectOnRadioGroup: kotlin.Function0<kotlin.Unit>, subTitle: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, onPlayPauseCurrentAudio: kotlin.Function0<kotlin.Unit>, onStopCurrentAudio: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+private fun com.wire.android.ui.home.conversationslist.common.GeneralConversationItem(conversation: com.wire.android.ui.home.conversationslist.model.ConversationItem, isChecked: kotlin.Boolean, isSelectable: kotlin.Boolean, onConversationItemClick: com.wire.android.model.Clickable, onJoinCallClick: kotlin.Function0<kotlin.Unit>, onAudioPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, showLegalHoldIndicator: kotlin.Boolean, modifier: androidx.compose.ui.Modifier, selectOnRadioGroup: kotlin.Function0<kotlin.Unit>, subTitle: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, searchQuery: kotlin.String, playingAudio: com.wire.android.ui.home.conversationslist.model.PlayingAudioInConversation?, onPlayPauseCurrentAudio: kotlin.Function0<kotlin.Unit>, onStopCurrentAudio: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -8202,9 +8211,12 @@ private fun com.wire.android.ui.home.conversationslist.common.GeneralConversatio
     - onConversationItemClick: STABLE (class with no mutable properties)
     - onJoinCallClick: STABLE (function type)
     - onAudioPermissionPermanentlyDenied: STABLE (function type)
+    - showLegalHoldIndicator: STABLE (primitive type)
     - modifier: STABLE (marked @Stable or @Immutable)
     - selectOnRadioGroup: STABLE (function type)
     - subTitle: STABLE (composable function type)
+    - searchQuery: STABLE (String is immutable)
+    - playingAudio: STABLE (marked @Stable or @Immutable)
     - onPlayPauseCurrentAudio: STABLE (function type)
     - onStopCurrentAudio: STABLE (function type)
 
@@ -8325,6 +8337,13 @@ public fun com.wire.android.ui.home.conversationslist.common.getConnectionString
   restartable: true
   params:
     - labelId: STABLE (primitive type)
+
+@Composable
+private fun com.wire.android.ui.home.conversationslist.common.rememberLightweightMarkdownPreview(text: kotlin.String): com.wire.android.ui.markdown.MarkdownPreview?
+  skippable: true
+  restartable: true
+  params:
+    - text: STABLE (String is immutable)
 
 @Composable
 public fun com.wire.android.ui.home.conversationslist.filter.ConversationFilterSheetContent(currentFilter: com.wire.kalium.logic.data.conversation.ConversationFilter, folders: kotlin.collections.List<com.wire.kalium.logic.data.conversation.ConversationFolder>, onChangeFilter: kotlin.Function1<com.wire.kalium.logic.data.conversation.ConversationFilter, kotlin.Unit>, isBottomSheetVisible: kotlin.Function0<kotlin.Boolean>): kotlin.Unit
@@ -11305,12 +11324,13 @@ private fun com.wire.android.ui.sharing.ImportMediaBottomBar(state: com.wire.and
     - checkRestrictionsAndSendImportedMedia: STABLE (function type)
 
 @Composable
-private fun com.wire.android.ui.sharing.ImportMediaContent(state: com.wire.android.ui.sharing.ImportMediaAuthenticatedState, internalPadding: androidx.compose.foundation.layout.PaddingValues, onConversationClicked: kotlin.Function1<@[ParameterName(name = \, lazyListState: androidx.compose.foundation.lazy.LazyListState): kotlin.Unit
+private fun com.wire.android.ui.sharing.ImportMediaContent(state: com.wire.android.ui.sharing.ImportMediaAuthenticatedState, internalPadding: androidx.compose.foundation.layout.PaddingValues, searchQuery: kotlin.String, onConversationClicked: kotlin.Function1<@[ParameterName(name = \, lazyListState: androidx.compose.foundation.lazy.LazyListState): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - state: STABLE (marked @Stable or @Immutable)
     - internalPadding: STABLE (marked @Stable or @Immutable)
+    - searchQuery: STABLE (String is immutable)
     - onConversationClicked: STABLE (function type)
     - lazyListState: STABLE (marked @Stable or @Immutable)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26102
<!--jira-description-action-hidden-marker-end-->
Refactors conversation list item rendering to avoid doing UI-only and expensive work during paged item mapping. Search highlighting, legal-hold visibility, and currently playing audio state are now applied closer to rendering, reducing unnecessary remapping when those UI states change.

Also defers last-message markdown preview parsing to the UI layer and adds a lightweight markdown preview parser so conversation subtitles avoid full markdown parsing while preserving formatted previews.