### PR TITLE
refactor: Reduce message list mapping and ViewModel scope overhead [WPB-26100]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
@@ -29,6 +29,7 @@ import com.wire.android.ui.home.conversationslist.model.ConversationItem.Connect
 import com.wire.android.ui.home.conversationslist.model.ConversationItem.Group.Channel
 import com.wire.android.ui.home.conversationslist.model.ConversationItem.Group.Regular
 import com.wire.android.ui.home.conversationslist.model.ConversationItem.PrivateConversation
+import com.wire.android.ui.home.conversationslist.showLegalHoldIndicator
 import com.wire.android.util.ui.UiTextResolver
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationDetails.Connection
@@ -54,7 +55,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             groupName = conversationDetails.conversation.name.orEmpty(),
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
-            legalHoldStatus = conversationDetails.conversation.legalHoldStatus,
+            showLegalHoldIndicator = conversationDetails.conversation.legalHoldStatus.showLegalHoldIndicator(),
             lastMessageContent = lastMessage.toUIPreview(unreadEventCount, uiTextResolver),
             badgeEventType = parseConversationEventType(
                 mutedStatus = conversationDetails.conversation.mutedStatus,
@@ -79,7 +80,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             groupName = conversationDetails.conversation.name.orEmpty(),
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
-            legalHoldStatus = conversationDetails.conversation.legalHoldStatus,
+            showLegalHoldIndicator = conversationDetails.conversation.legalHoldStatus.showLegalHoldIndicator(),
             lastMessageContent = lastMessage.toUIPreview(unreadEventCount, uiTextResolver),
             badgeEventType = parseConversationEventType(
                 mutedStatus = conversationDetails.conversation.mutedStatus,
@@ -115,7 +116,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             ),
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
-            legalHoldStatus = conversationDetails.conversation.legalHoldStatus,
+            showLegalHoldIndicator = conversationDetails.conversation.legalHoldStatus.showLegalHoldIndicator(),
             lastMessageContent = lastMessage.toUIPreview(unreadEventCount, uiTextResolver),
             badgeEventType = parsePrivateConversationEventType(
                 conversationDetails.otherUser.connectionStatus,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -26,7 +26,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.insertSeparators
-import androidx.paging.map
 import com.wire.android.BuildConfig
 import com.wire.android.di.CurrentAccount
 import com.wire.android.mapper.UserTypeMapper
@@ -66,6 +65,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
@@ -210,16 +210,19 @@ class ConversationListViewModelImpl(
                 .onStart { emit("") }
                 .distinctUntilChanged()
                 .flatMapLatest { searchQuery: String ->
-                    observeConversationListDetailsWithEvents(
-                        fromArchive = conversationsSource == ConversationsSource.ARCHIVE,
-                        conversationFilter = conversationsSource.toFilter()
-                    ).map { conversations ->
+                    combine(
+                        observeConversationListDetailsWithEvents(
+                            fromArchive = conversationsSource == ConversationsSource.ARCHIVE,
+                            conversationFilter = conversationsSource.toFilter()
+                        ),
+                        isSelfUserUnderLegalHoldFlow
+                    ) { conversations, isSelfUserUnderLegalHold ->
                         conversations.map { conversationDetails ->
                             conversationDetails.toConversationItem(
                                 userTypeMapper = userTypeMapper,
                                 uiTextResolver = uiTextResolver,
                                 selfUserTeamId = selfTeamId
-                            )
+                            ).hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold)
                         } to searchQuery
                     }
                 }
@@ -299,6 +302,22 @@ private fun ConversationsSource.toFilter(): ConversationFilter = when (this) {
     ConversationsSource.ONE_ON_ONE -> ConversationFilter.OneOnOne
     is ConversationsSource.FOLDER -> ConversationFilter.Folder(folderId = folderId, folderName = folderName)
 }
+
+/**
+ * If self user is under legal hold then we shouldn't show legal hold indicator next to every conversation as in that case
+ * the legal hold indication is shown in the header of the conversation list for self user in that case and it's enough.
+ */
+private fun ConversationItem.hideIndicatorForSelfUserUnderLegalHold(isSelfUserUnderLegalHold: Boolean) =
+    when (isSelfUserUnderLegalHold) {
+        true -> when (this) {
+            is ConversationItem.ConnectionConversation -> this.copy(showLegalHoldIndicator = false)
+            is ConversationItem.Group.Regular -> this.copy(showLegalHoldIndicator = false)
+            is ConversationItem.Group.Channel -> this.copy(showLegalHoldIndicator = false)
+            is ConversationItem.PrivateConversation -> this.copy(showLegalHoldIndicator = false)
+        }
+
+        else -> this
+    }
 
 @Suppress("ComplexMethod")
 private fun List<ConversationItem>.withSections(source: ConversationsSource): Map<ConversationSection, List<ConversationItem>> {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -50,7 +50,6 @@ import com.wire.android.ui.common.rowitem.RowItemTemplate
 import com.wire.android.ui.home.conversations.info.ConversationAvatar
 import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.UILastMessageContent
-import com.wire.android.ui.home.conversationslist.showLegalHoldIndicator
 import com.wire.android.ui.home.conversationslist.model.BadgeEventType
 import com.wire.android.ui.home.conversationslist.model.BlockingState
 import com.wire.android.ui.home.conversationslist.model.ConversationInfo
@@ -84,17 +83,18 @@ fun ConversationItemFactory(
     onAudioPermissionPermanentlyDenied: () -> Unit = {},
     onPlayPauseCurrentAudio: () -> Unit = { },
     onStopCurrentAudio: () -> Unit = {},
-    searchQuery: String = "",
+    searchQuery: String = conversation.searchQuery,
     isSelfUserUnderLegalHold: Boolean = false,
-    playingAudio: PlayingAudioInConversation? = null
+    playingAudio: PlayingAudioInConversation? = conversation.playingAudio
 ) {
     val openConversationOptionDescription = stringResource(R.string.content_description_conversation_details_more_btn)
     val openUserProfileDescription = stringResource(R.string.content_description_open_user_profile_label)
     val acceptOrIgnoreDescription = stringResource(R.string.content_description_accept_or_ignore_connection_label)
     val openConversationDescription = stringResource(R.string.content_description_open_conversation_label)
-    val showLegalHoldIndicator = conversation.legalHoldStatus.showLegalHoldIndicator() && !isSelfUserUnderLegalHold
+    val showLegalHoldIndicator = conversation.showLegalHoldIndicator && !isSelfUserUnderLegalHold
     val playingAudioInConversation = playingAudio
         ?.takeIf { it.conversationId == conversation.conversationId }
+        ?: conversation.playingAudio
     val onConversationItemClick = remember(conversation) {
         when (val lastEvent = conversation.lastMessageContent) {
             is UILastMessageContent.Connection -> {
@@ -179,8 +179,8 @@ private fun GeneralConversationItem(
     modifier: Modifier = Modifier,
     selectOnRadioGroup: () -> Unit = {},
     subTitle: @Composable () -> Unit = {},
-    searchQuery: String = "",
-    playingAudio: PlayingAudioInConversation? = null,
+    searchQuery: String = conversation.searchQuery,
+    playingAudio: PlayingAudioInConversation? = conversation.playingAudio,
     onPlayPauseCurrentAudio: () -> Unit = { },
     onStopCurrentAudio: () -> Unit = {}
 ) {
@@ -687,7 +687,8 @@ fun PreviewPrivateConversationItemWithPlayingAudio() = WireTheme {
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             isFavorite = false,
-            folder = null
+            folder = null,
+            playingAudio = PlayingAudioInConversation(QualifiedID("value", "domain"), "some_id", true)
         ),
         modifier = Modifier,
         isSelectableItem = false,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -37,7 +37,7 @@ import com.wire.kalium.logic.data.conversation.ConversationFolder as CurrentFold
 sealed interface ConversationItem : ConversationItemType {
     val conversationId: ConversationId
     val mutedStatus: MutedConversationStatus
-    val legalHoldStatus: Conversation.LegalHoldStatus
+    val showLegalHoldIndicator: Boolean
     val lastMessageContent: UILastMessageContent?
     val badgeEventType: BadgeEventType
     val teamId: TeamId?
@@ -47,6 +47,8 @@ sealed interface ConversationItem : ConversationItemType {
     val mlsVerificationStatus: Conversation.VerificationStatus
     val proteusVerificationStatus: Conversation.VerificationStatus
     val hasNewActivitiesToShow: Boolean
+    val searchQuery: String
+    val playingAudio: PlayingAudioInConversation?
 
     val isTeamConversation get() = teamId != null
 
@@ -67,7 +69,7 @@ sealed interface ConversationItem : ConversationItemType {
             override val isSelfUserMember: Boolean = true,
             override val conversationId: ConversationId,
             override val mutedStatus: MutedConversationStatus,
-            override val legalHoldStatus: Conversation.LegalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
+            override val showLegalHoldIndicator: Boolean = false,
             override val lastMessageContent: UILastMessageContent?,
             override val badgeEventType: BadgeEventType,
             override val teamId: TeamId?,
@@ -77,6 +79,8 @@ sealed interface ConversationItem : ConversationItemType {
             override val mlsVerificationStatus: Conversation.VerificationStatus,
             override val proteusVerificationStatus: Conversation.VerificationStatus,
             override val hasNewActivitiesToShow: Boolean = false,
+            override val searchQuery: String = "",
+            override val playingAudio: PlayingAudioInConversation? = null
         ) : Group
 
         @Serializable
@@ -88,7 +92,7 @@ sealed interface ConversationItem : ConversationItemType {
             override val isSelfUserMember: Boolean = true,
             override val conversationId: ConversationId,
             override val mutedStatus: MutedConversationStatus,
-            override val legalHoldStatus: Conversation.LegalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
+            override val showLegalHoldIndicator: Boolean = false,
             override val lastMessageContent: UILastMessageContent?,
             override val badgeEventType: BadgeEventType,
             override val teamId: TeamId?,
@@ -98,6 +102,8 @@ sealed interface ConversationItem : ConversationItemType {
             override val mlsVerificationStatus: Conversation.VerificationStatus,
             override val proteusVerificationStatus: Conversation.VerificationStatus,
             override val hasNewActivitiesToShow: Boolean = false,
+            override val searchQuery: String = "",
+            override val playingAudio: PlayingAudioInConversation? = null,
             val isPrivate: Boolean,
         ) : Group
     }
@@ -111,7 +117,7 @@ sealed interface ConversationItem : ConversationItemType {
         val isUserDeleted: Boolean,
         override val conversationId: ConversationId,
         override val mutedStatus: MutedConversationStatus,
-        override val legalHoldStatus: Conversation.LegalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
+        override val showLegalHoldIndicator: Boolean = false,
         override val lastMessageContent: UILastMessageContent?,
         override val badgeEventType: BadgeEventType,
         override val teamId: TeamId?,
@@ -121,6 +127,8 @@ sealed interface ConversationItem : ConversationItemType {
         override val mlsVerificationStatus: Conversation.VerificationStatus,
         override val proteusVerificationStatus: Conversation.VerificationStatus,
         override val hasNewActivitiesToShow: Boolean = false,
+        override val searchQuery: String = "",
+        override val playingAudio: PlayingAudioInConversation? = null
     ) : ConversationItem
 
     @Serializable
@@ -129,17 +137,19 @@ sealed interface ConversationItem : ConversationItemType {
         val conversationInfo: ConversationInfo,
         override val conversationId: ConversationId,
         override val mutedStatus: MutedConversationStatus,
-        override val legalHoldStatus: Conversation.LegalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
+        override val showLegalHoldIndicator: Boolean = false,
         override val lastMessageContent: UILastMessageContent?,
         override val badgeEventType: BadgeEventType,
         override val isArchived: Boolean = false,
         override val isFavorite: Boolean = false,
         override val folder: CurrentFolder? = null,
         override val hasNewActivitiesToShow: Boolean = false,
+        override val searchQuery: String = "",
     ) : ConversationItem {
         override val teamId: TeamId? = null
         override val mlsVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
         override val proteusVerificationStatus: Conversation.VerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED
+        override val playingAudio: PlayingAudioInConversation? = null
     }
 }
 
@@ -172,7 +182,9 @@ val OtherUser.BlockState: BlockingState
             else -> BlockingState.NOT_BLOCKED
         }
 
-fun ConversationItem.PrivateConversation.toUserInfoLabel(showLegalHoldIndicator: Boolean) =
+fun ConversationItem.PrivateConversation.toUserInfoLabel(
+    showLegalHoldIndicator: Boolean = this.showLegalHoldIndicator
+) =
     UserInfoLabel(
         labelName = conversationInfo.name,
         showLegalHoldIndicator = showLegalHoldIndicator,
@@ -182,7 +194,9 @@ fun ConversationItem.PrivateConversation.toUserInfoLabel(showLegalHoldIndicator:
         proteusVerificationStatus = proteusVerificationStatus
     )
 
-fun ConversationItem.ConnectionConversation.toUserInfoLabel(showLegalHoldIndicator: Boolean) =
+fun ConversationItem.ConnectionConversation.toUserInfoLabel(
+    showLegalHoldIndicator: Boolean = this.showLegalHoldIndicator
+) =
     UserInfoLabel(
         labelName = conversationInfo.name,
         showLegalHoldIndicator = showLegalHoldIndicator,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26100
<!--jira-description-action-hidden-marker-end-->
## Summary
- Defer markdown parsing for text messages to the UI layer instead of doing it during message mapping
- Cache mention display mapping across recompositions and lazily compute formatted message timestamps
- Limit scoped audio and asset local path ViewModel keys to the visible message window plus a small prefetch buffer
- Keep the currently playing audio message in scope while playback is active

## Testing
- Added regression coverage for deferring markdown document parsing