### PR TITLE
chore: add Metro build infrastructure [WPB-23495]

### DIFF
--- a/build-logic/plugins/build.gradle.kts
+++ b/build-logic/plugins/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     compileOnly(libs.android.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.kover.gradlePlugin)
+    compileOnly(libs.metro.gradlePlugin)
 
     testImplementation(libs.junit4)
     testImplementation(kotlin("test"))

--- a/build-logic/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -29,6 +29,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project): Unit = with(target) {
         with(pluginManager) {
             apply("com.android.application")
+            apply("dev.zacsweers.metro")
         }
 
         extensions.configure<ApplicationExtension> {

--- a/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -28,6 +28,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project): Unit = with(target) {
         with(pluginManager) {
             apply("com.android.library")
+            apply("dev.zacsweers.metro")
         }
 
         extensions.configure<LibraryExtension> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,7 @@ allprojects {
 plugins {
     id(ScriptPlugins.infrastructure)
     alias(libs.plugins.ksp) apply false // https://github.com/google/dagger/issues/3965
+    alias(libs.plugins.metro) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.cyclonedx)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ desugaring = "2.1.5"
 firebaseBOM = "34.7.0"
 fragment = "1.5.6"
 resaca = "5.0.2"
+metro = "1.1.1"
 bundlizer = "0.8.0"
 squareup-javapoet = "1.13.0"
 visibilityModifiers = "1.1.0"
@@ -133,6 +134,7 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin.android", version.ref = "aboutLibraries" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot"}
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 cyclonedx = { id = "org.cyclonedx.bom", version.ref = "cyclonedx" }
@@ -163,6 +165,7 @@ googleGms-gradlePlugin = { module = "com.google.gms:google-services", version.re
 googleGms-location = { module = "com.google.android.gms:play-services-location", version.ref = "gms-location" }
 aboutLibraries-gradlePlugin = { module = "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin", version.ref = "aboutLibraries" }
 kover-gradlePlugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
+metro-gradlePlugin = { module = "dev.zacsweers.metro:dev.zacsweers.metro.gradle.plugin", version.ref = "metro" }
 ktx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "ktx-serialization" }
 ktx-dateTime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "ktx-dateTime" }
 ktx-immutableCollections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "ktx-immutableCollections" }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23495
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Adds Metro as build infrastructure for Android modules.

This PR only makes the Metro Gradle plugin available through the existing build conventions:
- adds Metro `1.1.1` to the version catalog
- registers the Metro Gradle plugin at the root
- adds the Metro Gradle plugin dependency to build-logic
- applies `dev.zacsweers.metro` from Android application/library convention plugins