### PR TITLE
refactor: hide Hilt behind scoped ViewModel boundary [WPB-23495]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/ViewModelScoped.kt
+++ b/app/src/main/kotlin/com/wire/android/di/ViewModelScoped.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.lifecycle.ViewModel
 import com.sebaslogen.resaca.KeyInScopeResolver
-import com.sebaslogen.resaca.hilt.hiltViewModelScoped
+import com.sebaslogen.resaca.hilt.hiltViewModelScoped as resacaHiltViewModelScoped
 import kotlin.time.Duration
 
 /**
@@ -32,7 +32,7 @@ interface AssistedViewModelFactory<VM : ViewModel, R : ScopedArgs> {
 }
 
 /**
- * Custom implementation of [hiltViewModelScoped] that uses our generated previews for scoped ViewModels
+ * Repo-local scoped ViewModel accessor that uses our generated previews for scoped ViewModels
  * and creates assisted injected scoped [ViewModel] instances using [ScopedArgs].
  *
  * [ViewModel] needs to implement an interface annotated with [ViewModelScopedPreview] and with default
@@ -45,10 +45,10 @@ interface AssistedViewModelFactory<VM : ViewModel, R : ScopedArgs> {
 @Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 @Composable
 inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedViewModelFactory<T, R>>
-        hiltViewModelScoped(arguments: R, clearDelay: Duration? = null): S where T : ViewModel, T : S = when {
+        wireViewModelScoped(arguments: R, clearDelay: Duration? = null): S where T : ViewModel, T : S = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
-    else -> hiltViewModelScoped<T, F>(key = arguments.key?.toString(), clearDelay = clearDelay) { factory ->
+    else -> resacaHiltViewModelScoped<T, F>(key = arguments.key?.toString(), clearDelay = clearDelay) { factory ->
         factory.create(arguments)
     }
 }
@@ -56,7 +56,7 @@ inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedVi
 @Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 @Composable
 inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedViewModelFactory<T, R>>
-        hiltViewModelScoped(
+        wireViewModelScoped(
     arguments: R,
     noinline keyInScopeResolver: KeyInScopeResolver<String>,
     clearDelay: Duration? = null,
@@ -67,7 +67,7 @@ inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedVi
         val scopedKey = requireNotNull(arguments.key?.toString()) {
             "Scoped key must not be null for ${T::class.qualifiedName}"
         }
-        hiltViewModelScoped<T, F, String>(
+        resacaHiltViewModelScoped<T, F, String>(
             key = scopedKey,
             keyInScopeResolver = keyInScopeResolver,
             clearDelay = clearDelay
@@ -78,7 +78,7 @@ inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedVi
 }
 
 /**
- * Custom implementation of [hiltViewModelScoped] that uses our generated previews for scoped ViewModels.
+ * Repo-local scoped ViewModel accessor that uses our generated previews for scoped ViewModels.
  * This is version that does not take and pass any arguments, it does not use any key to generate a new
  * version when it changes, so it basically keeps the same instance.
  *
@@ -87,11 +87,50 @@ inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedVi
  */
 @Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 @Composable
-inline fun <reified T, reified S> hiltViewModelScoped(): S where T : ViewModel, T : S = when {
+inline fun <reified T, reified S> wireViewModelScoped(): S where T : ViewModel, T : S = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
-    else -> hiltViewModelScoped<T>()
+    else -> resacaHiltViewModelScoped<T>()
 }
+
+@Composable
+inline fun <reified T : ViewModel> wireViewModelScoped(): T = when {
+    LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? T }
+    espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? T }
+    else -> resacaHiltViewModelScoped<T>()
+}
+
+@Deprecated("Use wireViewModelScoped so call sites do not depend on the Hilt-backed implementation.")
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
+@Composable
+inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedViewModelFactory<T, R>>
+        hiltViewModelScoped(arguments: R, clearDelay: Duration? = null): S where T : ViewModel, T : S =
+    wireViewModelScoped<T, S, R, F>(arguments = arguments, clearDelay = clearDelay)
+
+@Deprecated("Use wireViewModelScoped so call sites do not depend on the Hilt-backed implementation.")
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
+@Composable
+inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedViewModelFactory<T, R>>
+        hiltViewModelScoped(
+    arguments: R,
+    noinline keyInScopeResolver: KeyInScopeResolver<String>,
+    clearDelay: Duration? = null,
+): S where T : ViewModel, T : S =
+    wireViewModelScoped<T, S, R, F>(
+        arguments = arguments,
+        keyInScopeResolver = keyInScopeResolver,
+        clearDelay = clearDelay
+    )
+
+@Deprecated("Use wireViewModelScoped so call sites do not depend on the Hilt-backed implementation.")
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
+@Composable
+inline fun <reified T, reified S> hiltViewModelScoped(): S where T : ViewModel, T : S =
+    wireViewModelScoped<T, S>()
+
+@Deprecated("Use wireViewModelScoped so call sites do not depend on the Hilt-backed implementation.")
+@Composable
+inline fun <reified T : ViewModel> hiltViewModelScoped(): T = wireViewModelScoped<T>()
 
 val espresso
     get() = try {

--- a/app/src/main/kotlin/com/wire/android/ui/common/AddContactButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/AddContactButton.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.snackbar.collectAndShowSnackbar
@@ -42,7 +42,7 @@ fun AddContactButton(
     userName: String,
     modifier: Modifier = Modifier,
     viewModel: ConnectionActionButtonViewModel =
-        hiltViewModelScoped<
+        wireViewModelScoped<
                 ConnectionActionButtonViewModelImpl,
                 ConnectionActionButtonViewModel,
                 ConnectionActionButtonArgs,

--- a/app/src/main/kotlin/com/wire/android/ui/common/banner/SecurityClassificationBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/banner/SecurityClassificationBanner.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireTheme
@@ -56,7 +56,7 @@ fun SecurityClassificationBannerForConversation(
     conversationId: ConversationId,
     modifier: Modifier = Modifier,
     viewModel: SecurityClassificationViewModel =
-        hiltViewModelScoped<
+        wireViewModelScoped<
                 SecurityClassificationViewModelImpl,
                 SecurityClassificationViewModel,
                 SecurityClassificationArgs,
@@ -74,7 +74,7 @@ fun SecurityClassificationBannerForUser(
     userId: UserId,
     modifier: Modifier = Modifier,
     viewModel: SecurityClassificationViewModel =
-        hiltViewModelScoped<
+        wireViewModelScoped<
                 SecurityClassificationViewModelImpl,
                 SecurityClassificationViewModel,
                 SecurityClassificationArgs,

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/conversation/ConversationOptionsModalSheetLayout.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
 import com.wire.android.ui.common.bottomsheet.WireModalSheetState
@@ -58,7 +58,7 @@ fun ConversationOptionsModalSheetLayout(
     onPromoteAdmin: (ConversationId) -> Unit = {},
     openConversationDebugMenu: (ConversationId) -> Unit = {},
     viewModel: ConversationOptionsMenuViewModel =
-        hiltViewModelScoped<ConversationOptionsMenuViewModelImpl, ConversationOptionsMenuViewModel>()
+        wireViewModelScoped<ConversationOptionsMenuViewModelImpl, ConversationOptionsMenuViewModel>()
 ) {
     val context = LocalContext.current
     val snackbarHostState = LocalSnackbarHostState.current

--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.VisibilityState
@@ -73,7 +73,7 @@ fun ConnectionActionButton(
     onConnectionRequestIgnored: (String) -> Unit = {},
     onOpenConversation: (ConversationId) -> Unit = {},
     viewModel: ConnectionActionButtonViewModel =
-        hiltViewModelScoped<
+        wireViewModelScoped<
                 ConnectionActionButtonViewModelImpl,
                 ConnectionActionButtonViewModel,
                 ConnectionActionButtonArgs,

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.wire.android.BuildConfig
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.feature.analytics.AnonymousAnalyticsManagerImpl
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.WireDialog
@@ -70,7 +70,7 @@ fun DebugDataOptions(
     onShowFeatureFlags: () -> Unit,
     onShowCryptoStats: () -> Unit,
     viewModel: DebugDataOptionsViewModel =
-        hiltViewModelScoped<DebugDataOptionsViewModelImpl, DebugDataOptionsViewModel>()
+        wireViewModelScoped<DebugDataOptionsViewModelImpl, DebugDataOptionsViewModel>()
 ) {
     LocalSnackbarHostState.current.collectAndShowSnackbar(snackbarFlow = viewModel.infoMessage)
     DebugDataOptionsContent(

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.BuildConfig
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.model.Clickable
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
@@ -149,7 +149,7 @@ internal fun UserDebugContent(
 fun DangerOptions(
     modifier: Modifier = Modifier,
     exportObfuscatedCopyViewModel: ExportObfuscatedCopyViewModel =
-        hiltViewModelScoped<ExportObfuscatedCopyViewModelImpl, ExportObfuscatedCopyViewModel>()
+        wireViewModelScoped<ExportObfuscatedCopyViewModelImpl, ExportObfuscatedCopyViewModel>()
 ) {
 
     Column(modifier = modifier) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/UsersTypingIndicator.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/UsersTypingIndicator.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.avatar.UserProfileAvatarsRow
@@ -74,7 +74,7 @@ private const val ANIMATION_SPEED_MILLIS = 1_500
 fun UsersTypingIndicatorForConversation(
     conversationId: ConversationId,
     viewModel: TypingIndicatorViewModel =
-        hiltViewModelScoped<
+        wireViewModelScoped<
                 TypingIndicatorViewModelImpl,
                 TypingIndicatorViewModel,
                 TypingIndicatorArgs,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
 import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
@@ -62,7 +62,7 @@ fun MessageOptionsModalSheetLayout(
     onDownloadAssetClick: (messageId: String) -> Unit,
     onOpenAssetClick: (messageId: String) -> Unit,
     viewModel: MessageOptionsMenuViewModel =
-        hiltViewModelScoped<
+        wireViewModelScoped<
                 MessageOptionsMenuViewModelImpl,
                 MessageOptionsMenuViewModel,
                 MessageOptionsMenuArgs,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -55,7 +55,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import coil3.compose.SubcomposeAsyncImage
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.model.Clickable
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.common.StatusBox
@@ -622,7 +622,7 @@ private fun QuotedImageThumbnail(
     val keyInScopeResolver = LocalAssetLocalPathKeyInScopeResolver.current
     val viewModel: AssetLocalPathViewModel =
         if (keyInScopeResolver != null && keyInScopeResolver(args.key)) {
-            hiltViewModelScoped<
+            wireViewModelScoped<
                     AssetLocalPathViewModelImpl,
                     AssetLocalPathViewModel,
                     AssetLocalPathArgs,
@@ -632,7 +632,7 @@ private fun QuotedImageThumbnail(
                 keyInScopeResolver = keyInScopeResolver,
             )
         } else {
-            hiltViewModelScoped<
+            wireViewModelScoped<
                     AssetLocalPathViewModelImpl,
                     AssetLocalPathViewModel,
                     AssetLocalPathArgs,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.DpSize
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.model.Clickable
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.common.applyIf
@@ -168,7 +168,7 @@ fun MessageButtonsContent(
     messageStyle: MessageStyle,
     modifier: Modifier = Modifier,
     viewModel: CompositeMessageViewModel =
-        hiltViewModelScoped<
+        wireViewModelScoped<
                 CompositeMessageViewModelImpl,
                 CompositeMessageViewModel,
                 CompositeMessageArgs,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -65,7 +65,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.media.audiomessage.AudioMediaPlayingState
 import com.wire.android.media.audiomessage.AudioMessageArgs
 import com.wire.android.media.audiomessage.AudioMessageViewModel
@@ -182,14 +182,14 @@ private fun UploadedAudioMessage(
 ) {
     val keyInScopeResolver = LocalAudioMessageKeyInScopeResolver.current
     val viewModel: AudioMessageViewModel = if (keyInScopeResolver != null) {
-        hiltViewModelScoped<
+        wireViewModelScoped<
                 AudioMessageViewModelImpl,
                 AudioMessageViewModel,
                 AudioMessageArgs,
                 AudioMessageViewModelImpl.Factory
                 >(audioMessageArgs, keyInScopeResolver)
     } else {
-        hiltViewModelScoped<
+        wireViewModelScoped<
                 AudioMessageViewModelImpl,
                 AudioMessageViewModel,
                 AudioMessageArgs,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposeActions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposeActions.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryIconButton
@@ -245,7 +245,7 @@ fun SelfDeletingMessageAction(
     conversationId: ConversationId,
     onButtonClicked: (SelfDeletionTimer) -> Unit,
     viewModel: SelfDeletingMessageActionViewModel =
-        hiltViewModelScoped<
+        wireViewModelScoped<
                 SelfDeletingMessageActionViewModelImpl,
                 SelfDeletingMessageActionViewModel,
                 SelfDeletingMessageActionArgs,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -55,7 +55,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import androidx.constraintlayout.compose.atMost
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.VerticalSpace
@@ -184,7 +184,7 @@ private fun InputContent(
     onPlusClick: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SelfDeletingMessageActionViewModel =
-        hiltViewModelScoped<
+        wireViewModelScoped<
                 SelfDeletingMessageActionViewModelImpl,
                 SelfDeletingMessageActionViewModel,
                 SelfDeletingMessageActionArgs,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachments/AdditionalOptionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachments/AdditionalOptionButton.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.theme.WireTheme
@@ -52,7 +52,7 @@ fun AdditionalOptionButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: IsFileSharingEnabledViewModel =
-        hiltViewModelScoped<IsFileSharingEnabledViewModelImpl, IsFileSharingEnabledViewModel>()
+        wireViewModelScoped<IsFileSharingEnabledViewModelImpl, IsFileSharingEnabledViewModel>()
 ) {
     var enableAgain by remember { mutableStateOf(true) }
     LaunchedEffect(enableAgain, block = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioComponent.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
-import com.sebaslogen.resaca.hilt.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
@@ -52,7 +52,7 @@ fun RecordAudioComponent(
     modifier: Modifier = Modifier,
     lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
 ) {
-    val viewModel: RecordAudioViewModel = hiltViewModelScoped<RecordAudioViewModel>()
+    val viewModel: RecordAudioViewModel = wireViewModelScoped<RecordAudioViewModel>()
     val context = LocalContext.current
     val snackbarHostState = LocalSnackbarHostState.current
 

--- a/app/src/main/kotlin/com/wire/android/ui/joinConversation/JoinConversationViaDeepLinkDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/joinConversation/JoinConversationViaDeepLinkDialog.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import com.sebaslogen.resaca.hilt.hiltViewModelScoped
+import com.wire.android.di.wireViewModelScoped
 import com.wire.android.R
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
@@ -79,7 +79,7 @@ fun JoinConversationViaDeepLinkDialog(
     onFlowCompleted: (conversationId: ConversationId?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val viewModel = hiltViewModelScoped<JoinConversationViaCodeViewModel>()
+    val viewModel = wireViewModelScoped<JoinConversationViaCodeViewModel>()
 
     val isLoading: Boolean by remember {
         derivedStateOf { viewModel.state is JoinViaDeepLinkDialogState.Loading }

--- a/core/ui-common/src/main/kotlin/com/wire/android/model/ImageAssetViewModelFactory.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/model/ImageAssetViewModelFactory.kt
@@ -18,6 +18,7 @@
 package com.wire.android.model
 
 import com.wire.android.util.ui.WireSessionImageLoader
+
 class ImageAssetViewModelFactory(
     private val imageLoader: () -> WireSessionImageLoader,
 ) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23495
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

## Summary

This PR introduces a repo-local `wireViewModelScoped(...)` API for scoped ViewModels and updates existing scoped ViewModel call sites to use it instead of calling `hiltViewModelScoped(...)` directly.

This is an incremental Metro migration step. Runtime behavior remains Hilt/Resaca-backed for now, but screen code no longer depends on the Hilt-specific scoped ViewModel API.

## Changes

- Added `wireViewModelScoped(...)` overloads in `ViewModelScoped.kt`.
- Kept the existing Hilt/Resaca implementation behind the local wrapper.
- Marked old repo-local `hiltViewModelScoped(...)` overloads as deprecated.
- Replaced scoped ViewModel call sites in:
  - conversation options
  - message options
  - message composer actions/input
  - record audio component
  - quoted/audio/message item helpers
  - security classification banner
  - add contact / connection action button
  - debug scoped screens
  - join conversation deep link dialog

## Why

The broader Metro migration needs call sites to depend on our own ViewModel creation boundary instead of Hilt-specific APIs.

This PR keeps the migration safe and reviewable:
- no behavior change intended,
- no graph replacement yet,
- no broad composer/conversation refactor yet,
- future PRs can switch the implementation under `wireViewModelScoped(...)` without touching every screen again.
