### PR TITLE
fix: forgot password accessibility role [WPB-14786]

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/ui/authentication/login/email/ForgotPasswordLabelTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/authentication/login/email/ForgotPasswordLabelTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.authentication.login.email
+
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.wire.android.ui.WireTestTheme
+import org.junit.Rule
+import org.junit.Test
+
+class ForgotPasswordLabelTest {
+
+    @get:Rule
+    val composeTestRule by lazy { createComposeRule() }
+
+    @Test
+    fun givenForgotPasswordLabel_whenRendered_thenSemanticsRoleIsButton() {
+        composeTestRule.setContent {
+            WireTestTheme {
+                ForgotPasswordLabel(forgotPasswordUrl = "https://wire.com")
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag("Forgot password?")
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.input.ImeAction
@@ -284,6 +285,7 @@ fun ForgotPasswordLabel(
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
+                    role = Role.Button,
                     onClick = { openForgotPasswordPage(context, forgotPasswordUrl) },
                     onClickLabel = stringResource(R.string.content_description_open_link_label)
                 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-14786
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Add `Role.Button` semantics to the login “Forgot password?” control.
- Add a focused Compose regression test for the forgot-password label role.