### PR TITLE
fix: profile avatar accessibility role [WPB-14782]

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/ui/common/UserProfileAvatarTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/common/UserProfileAvatarTest.kt
@@ -17,10 +17,16 @@
  */
 package com.wire.android.ui.common
 
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import com.wire.android.model.Clickable
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.WireTestTheme
 import com.wire.android.ui.common.avatar.LEGAL_HOLD_INDICATOR_TEST_TAG
@@ -116,4 +122,27 @@ class UserProfileAvatarTest {
         shouldLegalHoldIndicatorBeVisible = false,
         shouldTemporaryUserIndicatorBeVisible = true,
     )
+
+    @Test
+    fun givenAvatarIsClickable_whenRendered_thenSemanticsRoleIsButton() {
+        val contentDescription = "Profile Picture"
+        composeTestRule.setContent {
+            WireTestTheme {
+                UserProfileAvatar(
+                    avatarData = UserAvatarData(availabilityStatus = UserAvailabilityStatus.AVAILABLE),
+                    clickable = Clickable(
+                        enabled = true,
+                        onClickDescription = "Open",
+                        onClick = {}
+                    ),
+                    contentDescription = contentDescription
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(contentDescription)
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.ContentDescription, listOf(contentDescription)))
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
+    }
 }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/avatar/UserProfileAvatar.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/avatar/UserProfileAvatar.kt
@@ -149,14 +149,16 @@ fun UserProfileAvatar(
         legalHoldIndicatorVisible = false
     ),
 ) {
+    val isClickable = clickable?.enabled == true
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .wrapContentSize()
             .clip(CircleShape)
             .clickable(clickable)
-            .semantics {
-                if (clickable?.enabled == true) {
+            .semantics(mergeDescendants = isClickable) {
+                if (isClickable) {
+                    contentDescription?.let { this.contentDescription = it }
                     role = Role.Button
                 }
             }
@@ -185,7 +187,7 @@ fun UserProfileAvatar(
                 withCrossfadeAnimation = withCrossfadeAnimation,
                 type = type,
                 size = size,
-                contentDescription = contentDescription,
+                contentDescription = if (isClickable) null else contentDescription,
                 modifier = Modifier
                     .padding(padding)
                     .clip(CircleShape)

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/avatar/UserProfileAvatar.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/avatar/UserProfileAvatar.kt
@@ -258,7 +258,7 @@ fun UserProfileAvatar(
                     }
                     .semantics {
                         this.testTag = STATUS_INDICATOR_TEST_TAG
-                        if (statusContentDescription != null) {
+                        if (!isClickable && statusContentDescription != null) {
                             this.contentDescription = statusContentDescription
                         }
                     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-14782
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Merge clickable profile avatar semantics into a single accessible control.
- Expose clickable avatars with `Role.Button` and avoid duplicate content descriptions.
- Add a regression test for the “Profile Picture” avatar role.