### PR TITLE
fix: security classification banner TalkBack label [WPB-23455]

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/ui/common/banner/SecurityClassificationBannerTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/common/banner/SecurityClassificationBannerTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.common.banner
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import com.wire.android.R
+import com.wire.android.ui.WireTestTheme
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.conversation.SecurityClassificationType
+import org.junit.Rule
+import org.junit.Test
+
+class SecurityClassificationBannerTest {
+
+    @get:Rule
+    val composeTestRule by lazy { createComposeRule() }
+
+    @Test
+    fun givenSecurityClassificationBanner_whenRendered_thenSemanticsDescriptionIsPlainText() {
+        val expectedDescription = InstrumentationRegistry
+            .getInstrumentation()
+            .targetContext
+            .getString(R.string.conversation_details_is_classified)
+
+        composeTestRule.setContent {
+            WireTestTheme {
+                SecurityClassificationBannerForConversation(
+                    conversationId = ConversationId("conversation_id", "domain"),
+                    viewModel = FakeSecurityClassificationViewModel(SecurityClassificationType.CLASSIFIED)
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(expectedDescription)
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.ContentDescription, listOf(expectedDescription)))
+        composeTestRule.onNodeWithText(expectedDescription).assertDoesNotExist()
+    }
+
+    private class FakeSecurityClassificationViewModel(
+        private val state: SecurityClassificationType
+    ) : SecurityClassificationViewModel {
+
+        override fun state(): SecurityClassificationType = state
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/common/banner/SecurityClassificationBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/banner/SecurityClassificationBanner.kt
@@ -40,6 +40,9 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import com.wire.android.R
 import com.wire.android.di.wireViewModelScoped
 import com.wire.android.ui.common.colorsScheme
@@ -94,8 +97,12 @@ private fun SecurityClassificationBanner(
     state: SecurityClassificationType,
     modifier: Modifier = Modifier
 ) {
-    val state = if (LocalInspectionMode.current) (LocalPreviewSecurityClassificationBannerState.current ?: state) else state
+    val state = when {
+        LocalInspectionMode.current -> LocalPreviewSecurityClassificationBannerState.current ?: state
+        else -> state
+    }
     if (state != SecurityClassificationType.NONE) {
+        val text = getTextFor(state)
         Column(modifier = modifier) {
             HorizontalDivider(color = getDividerColorFor(state))
             Row(
@@ -105,6 +112,9 @@ private fun SecurityClassificationBanner(
                     .background(getBackgroundColorFor(state))
                     .height(dimensions().spacing24x)
                     .fillMaxWidth()
+                    .semantics {
+                        contentDescription = text
+                    }
             ) {
                 Icon(
                     painter = getIconFor(state),
@@ -113,9 +123,10 @@ private fun SecurityClassificationBanner(
                     modifier = Modifier.padding(end = dimensions().spacing8x)
                 )
                 Text(
-                    text = getTextFor(state),
+                    text = text,
                     color = getColorTextFor(state),
-                    style = MaterialTheme.wireTypography.label03
+                    style = MaterialTheme.wireTypography.label03,
+                    modifier = Modifier.clearAndSetSemantics { }
                 )
             }
             HorizontalDivider(color = getDividerColorFor(state))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23455
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixes TalkBack output for the security classification banner in conversations.