### PR TITLE
refactor: route feature view models through provider boundary [WPB-25946]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.di.metro
+
+import androidx.lifecycle.ViewModel
+import com.wire.android.feature.cells.ui.CellsViewModelFactory
+import com.wire.android.feature.cells.ui.CellsViewModelGraph
+import com.wire.android.model.ImageAssetViewModelFactory
+import com.wire.android.model.ImageAssetViewModelGraph
+import com.wire.android.util.ui.WireSessionImageLoader
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import javax.inject.Provider
+
+/**
+ * Android-only bridge for feature ViewModel factories while feature UI is being decoupled from Hilt call sites.
+ */
+@HiltViewModel
+class WireActivityViewModelGraphBridge @Inject constructor(
+    imageLoader: Provider<WireSessionImageLoader>,
+    private val cellsViewModelFactoryProvider: Provider<CellsViewModelFactory>,
+) : ViewModel(), ImageAssetViewModelGraph, CellsViewModelGraph {
+    override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
+        ImageAssetViewModelFactory(imageLoader = imageLoader::get)
+
+    override val cellsViewModelFactory: CellsViewModelFactory
+        get() = cellsViewModelFactoryProvider.get()
+}

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -74,8 +74,8 @@ import com.wire.android.config.CustomUiConfigurationProvider
 import com.wire.android.config.LocalCustomUiConfigurationProvider
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.di.assistedViewModels
-import com.wire.android.di.metro.ImageAssetViewModelGraphBridgeViewModel
 import com.wire.android.di.metro.LocalMetroViewModelGraph
+import com.wire.android.di.metro.WireActivityViewModelGraphBridge
 import com.wire.android.emm.ManagedConfigurationsManager
 import com.wire.android.feature.NavigationSwitchAccountActions
 import com.wire.android.navigation.BackStackMode
@@ -256,7 +256,7 @@ class WireActivity : BaseActivity() {
     private fun setComposableContent(startDestination: Direction) {
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
-            val imageAssetViewModelGraph = wireViewModel<ImageAssetViewModelGraphBridgeViewModel>()
+            val wireActivityViewModelGraph = wireViewModel<WireActivityViewModelGraphBridge>()
 
             HandleThemeChanges(viewModel.globalAppState.themeOption)
 
@@ -265,7 +265,7 @@ class WireActivity : BaseActivity() {
                 LocalSyncStateObserver provides SyncStateObserver(viewModel.observeSyncFlowState),
                 LocalCustomUiConfigurationProvider provides CustomUiConfigurationProvider,
                 LocalSnackbarHostState provides snackbarHostState,
-                LocalMetroViewModelGraph provides imageAssetViewModelGraph,
+                LocalMetroViewModelGraph provides wireActivityViewModelGraph,
                 LocalActivity provides this
             ) {
                 WireTheme(accent = viewModel.globalAppState.userAccent) {

--- a/core/di/src/main/kotlin/com/wire/android/di/metro/MetroViewModelGraph.kt
+++ b/core/di/src/main/kotlin/com/wire/android/di/metro/MetroViewModelGraph.kt
@@ -20,8 +20,10 @@ package com.wire.android.di.metro
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
@@ -55,6 +57,32 @@ inline fun <reified Graph, reified VM> metroViewModel(
         viewModelFactory {
             initializer {
                 graph.create()
+            }
+        }
+    }
+    return viewModel(
+        modelClass = VM::class,
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = key,
+        factory = factory,
+    )
+}
+
+@Composable
+inline fun <reified Graph, reified VM> metroSavedStateViewModel(
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+    key: String? = null,
+    crossinline create: Graph.(SavedStateHandle) -> VM,
+): VM where Graph : MetroViewModelGraph, VM : ViewModel {
+    val graph = checkNotNull(LocalMetroViewModelGraph.current as? Graph) {
+        "No Metro graph matching ${Graph::class.qualifiedName} was provided"
+    }
+    val factory = remember(graph) {
+        viewModelFactory {
+            initializer {
+                graph.create(createSavedStateHandle())
             }
         }
     }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ramcosta.composedestinations.generated.cells.destinations.AddRemoveTagsScreenDestination
 import com.ramcosta.composedestinations.generated.cells.destinations.PublicLinkScreenDestination
@@ -44,7 +43,7 @@ import com.wire.android.ui.common.topappbar.search.SearchTopBar
 fun AllFilesScreen(
     navigator: WireNavigator,
     modifier: Modifier = Modifier,
-    viewModel: CellViewModel = wireViewModel(),
+    viewModel: CellViewModel = cellViewModel(),
 ) {
 
     val pagingListItems = viewModel.nodesFlow.collectAsLazyPagingItems()

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
@@ -55,7 +55,6 @@ import com.wire.kalium.common.functional.fold
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.logic.data.featureConfig.CollaboraEdition
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -74,11 +73,9 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import okio.Path.Companion.toPath
-import javax.inject.Inject
 
 @Suppress("TooManyFunctions", "LongParameterList")
-@HiltViewModel
-class CellViewModel @Inject constructor(
+class CellViewModel(
     val savedStateHandle: SavedStateHandle,
     private val getCellFilesPaged: GetPaginatedFilesFlowUseCase,
     private val deleteCellAsset: DeleteCellAssetUseCase,

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsViewModelFactory.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsViewModelFactory.kt
@@ -1,0 +1,191 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.cells.ui
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.feature.cells.ui.create.file.CreateFileViewModel
+import com.wire.android.feature.cells.ui.create.folder.CreateFolderViewModel
+import com.wire.android.feature.cells.ui.edit.OnlineEditor
+import com.wire.android.feature.cells.ui.movetofolder.MoveToFolderViewModel
+import com.wire.android.feature.cells.ui.publiclink.PublicLinkViewModel
+import com.wire.android.feature.cells.ui.publiclink.settings.expiration.PublicLinkExpirationScreenViewModel
+import com.wire.android.feature.cells.ui.publiclink.settings.password.PublicLinkPasswordScreenViewModel
+import com.wire.android.feature.cells.ui.rename.RenameNodeViewModel
+import com.wire.android.feature.cells.ui.search.SearchScreenViewModel
+import com.wire.android.feature.cells.ui.tags.AddRemoveTagsViewModel
+import com.wire.android.feature.cells.ui.versioning.VersionHistoryViewModel
+import com.wire.android.feature.cells.util.FileHelper
+import com.wire.android.util.FileSizeFormatter
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.cells.domain.usecase.DeleteCellAssetUseCase
+import com.wire.kalium.cells.domain.usecase.GetAllTagsUseCase
+import com.wire.kalium.cells.domain.usecase.GetEditorUrlUseCase
+import com.wire.kalium.cells.domain.usecase.GetFoldersUseCase
+import com.wire.kalium.cells.domain.usecase.GetOwnersUseCase
+import com.wire.kalium.cells.domain.usecase.GetPaginatedCellConversationsFlowUseCase
+import com.wire.kalium.cells.domain.usecase.GetPaginatedFilesFlowUseCase
+import com.wire.kalium.cells.domain.usecase.GetWireCellConfigurationUseCase
+import com.wire.kalium.cells.domain.usecase.IsAtLeastOneCellAvailableUseCase
+import com.wire.kalium.cells.domain.usecase.MoveNodeUseCase
+import com.wire.kalium.cells.domain.usecase.RemoveNodeTagsUseCase
+import com.wire.kalium.cells.domain.usecase.RenameNodeUseCase
+import com.wire.kalium.cells.domain.usecase.RestoreNodeFromRecycleBinUseCase
+import com.wire.kalium.cells.domain.usecase.UpdateNodeTagsUseCase
+import com.wire.kalium.cells.domain.usecase.create.CreateDocumentFileUseCase
+import com.wire.kalium.cells.domain.usecase.create.CreateFolderUseCase
+import com.wire.kalium.cells.domain.usecase.create.CreatePresentationFileUseCase
+import com.wire.kalium.cells.domain.usecase.create.CreateSpreadsheetFileUseCase
+import com.wire.kalium.cells.domain.usecase.download.DownloadCellVersionUseCase
+import com.wire.kalium.cells.domain.usecase.publiclink.CreatePublicLinkPasswordUseCase
+import com.wire.kalium.cells.domain.usecase.publiclink.CreatePublicLinkUseCase
+import com.wire.kalium.cells.domain.usecase.publiclink.DeletePublicLinkUseCase
+import com.wire.kalium.cells.domain.usecase.publiclink.GetPublicLinkPasswordUseCase
+import com.wire.kalium.cells.domain.usecase.publiclink.GetPublicLinkUseCase
+import com.wire.kalium.cells.domain.usecase.publiclink.SetPublicLinkExpirationUseCase
+import com.wire.kalium.cells.domain.usecase.publiclink.UpdatePublicLinkPasswordUseCase
+import com.wire.kalium.cells.domain.usecase.versioning.GetNodeVersionsUseCase
+import com.wire.kalium.cells.domain.usecase.versioning.RestoreNodeVersionUseCase
+import com.wire.kalium.logic.util.RandomPassword
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+class CellsViewModelFactory @Inject constructor(
+    private val getCellFilesPaged: GetPaginatedFilesFlowUseCase,
+    private val deleteCellAsset: DeleteCellAssetUseCase,
+    private val restoreNodeFromRecycleBinUseCase: RestoreNodeFromRecycleBinUseCase,
+    private val isCellAvailable: IsAtLeastOneCellAvailableUseCase,
+    private val fileHelper: FileHelper,
+    private val getEditorUrl: GetEditorUrlUseCase,
+    private val onlineEditor: OnlineEditor,
+    private val cellFileActionsMenu: CellFileActionsMenu,
+    private val getWireCellsConfig: GetWireCellConfigurationUseCase,
+    private val sharedPathCache: CellFileLocalPathCache,
+    private val openFileDownloadController: OpenFileDownloadController,
+    private val createPresentationFileUseCase: CreatePresentationFileUseCase,
+    private val createDocumentFileUseCase: CreateDocumentFileUseCase,
+    private val createSpreadsheetFileUseCase: CreateSpreadsheetFileUseCase,
+    private val createFolderUseCase: CreateFolderUseCase,
+    private val getFoldersUseCase: GetFoldersUseCase,
+    private val moveNodeUseCase: MoveNodeUseCase,
+    private val renameNodeUseCase: RenameNodeUseCase,
+    private val createPublicLink: CreatePublicLinkUseCase,
+    private val getPublicLinkUseCase: GetPublicLinkUseCase,
+    private val deletePublicLinkUseCase: DeletePublicLinkUseCase,
+    private val setPublicLinkExpiration: SetPublicLinkExpirationUseCase,
+    private val generateRandomPassword: RandomPassword,
+    private val createPublicLinkPassword: CreatePublicLinkPasswordUseCase,
+    private val updatePublicLinkPassword: UpdatePublicLinkPasswordUseCase,
+    private val getPublicLinkPassword: GetPublicLinkPasswordUseCase,
+    private val getAllTagsUseCase: GetAllTagsUseCase,
+    private val updateNodeTagsUseCase: UpdateNodeTagsUseCase,
+    private val removeNodeTagsUseCase: RemoveNodeTagsUseCase,
+    private val getOwners: GetOwnersUseCase,
+    private val getPaginatedConversations: GetPaginatedCellConversationsFlowUseCase,
+    private val getNodeVersionsUseCase: GetNodeVersionsUseCase,
+    private val fileSizeFormatter: FileSizeFormatter,
+    private val restoreNodeVersionUseCase: RestoreNodeVersionUseCase,
+    private val downloadCellVersionUseCase: DownloadCellVersionUseCase,
+    private val dispatchers: DispatcherProvider,
+) {
+    internal fun cellViewModel(savedStateHandle: SavedStateHandle) = CellViewModel(
+        savedStateHandle = savedStateHandle,
+        getCellFilesPaged = getCellFilesPaged,
+        deleteCellAsset = deleteCellAsset,
+        restoreNodeFromRecycleBinUseCase = restoreNodeFromRecycleBinUseCase,
+        isCellAvailable = isCellAvailable,
+        fileHelper = fileHelper,
+        getEditorUrl = getEditorUrl,
+        onlineEditor = onlineEditor,
+        cellFileActionsMenu = cellFileActionsMenu,
+        getWireCellsConfig = getWireCellsConfig,
+        sharedPathCache = sharedPathCache,
+        openFileDownloadController = openFileDownloadController,
+    )
+
+    internal fun createFileViewModel(savedStateHandle: SavedStateHandle) = CreateFileViewModel(
+        savedStateHandle = savedStateHandle,
+        createPresentationFileUseCase = createPresentationFileUseCase,
+        createDocumentFileUseCase = createDocumentFileUseCase,
+        createSpreadsheetFileUseCase = createSpreadsheetFileUseCase,
+    )
+
+    internal fun createFolderViewModel(savedStateHandle: SavedStateHandle) = CreateFolderViewModel(
+        savedStateHandle = savedStateHandle,
+        createFolderUseCase = createFolderUseCase,
+    )
+
+    internal fun moveToFolderViewModel(savedStateHandle: SavedStateHandle) = MoveToFolderViewModel(
+        savedStateHandle = savedStateHandle,
+        getFoldersUseCase = getFoldersUseCase,
+        moveNodeUseCase = moveNodeUseCase,
+    )
+
+    internal fun renameNodeViewModel(savedStateHandle: SavedStateHandle) = RenameNodeViewModel(
+        savedStateHandle = savedStateHandle,
+        renameNodeUseCase = renameNodeUseCase,
+    )
+
+    internal fun publicLinkViewModel(savedStateHandle: SavedStateHandle) = PublicLinkViewModel(
+        savedStateHandle = savedStateHandle,
+        createPublicLink = createPublicLink,
+        getPublicLinkUseCase = getPublicLinkUseCase,
+        deletePublicLinkUseCase = deletePublicLinkUseCase,
+        fileHelper = fileHelper,
+    )
+
+    internal fun publicLinkExpirationScreenViewModel(savedStateHandle: SavedStateHandle) = PublicLinkExpirationScreenViewModel(
+        setExpiration = setPublicLinkExpiration,
+        savedStateHandle = savedStateHandle,
+    )
+
+    internal fun publicLinkPasswordScreenViewModel(savedStateHandle: SavedStateHandle) = PublicLinkPasswordScreenViewModel(
+        generateRandomPassword = generateRandomPassword,
+        createPassword = createPublicLinkPassword,
+        updatePassword = updatePublicLinkPassword,
+        getPublicLinkPassword = getPublicLinkPassword,
+        savedStateHandle = savedStateHandle,
+    )
+
+    internal fun searchScreenViewModel(savedStateHandle: SavedStateHandle) = SearchScreenViewModel(
+        savedStateHandle = savedStateHandle,
+        getAllTagsUseCase = getAllTagsUseCase,
+        getCellFilesPaged = getCellFilesPaged,
+        getOwners = getOwners,
+        getPaginatedConversations = getPaginatedConversations,
+        sharedPathCache = sharedPathCache,
+    )
+
+    internal fun addRemoveTagsViewModel(savedStateHandle: SavedStateHandle) = AddRemoveTagsViewModel(
+        savedStateHandle = savedStateHandle,
+        getAllTagsUseCase = getAllTagsUseCase,
+        updateNodeTagsUseCase = updateNodeTagsUseCase,
+        removeNodeTagsUseCase = removeNodeTagsUseCase,
+    )
+
+    internal fun versionHistoryViewModel(savedStateHandle: SavedStateHandle) = VersionHistoryViewModel(
+        savedStateHandle = savedStateHandle,
+        getNodeVersionsUseCase = getNodeVersionsUseCase,
+        fileSizeFormatter = fileSizeFormatter,
+        restoreNodeVersionUseCase = restoreNodeVersionUseCase,
+        downloadCellVersionUseCase = downloadCellVersionUseCase,
+        fileHelper = fileHelper,
+        onlineEditor = onlineEditor,
+        getEditorUrl = getEditorUrl,
+        dispatchers = dispatchers,
+    )
+}

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsViewModelGraph.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsViewModelGraph.kt
@@ -1,0 +1,90 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.cells.ui
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import com.wire.android.di.metro.MetroViewModelGraph
+import com.wire.android.di.metro.metroSavedStateViewModel
+import com.wire.android.feature.cells.ui.create.file.CreateFileViewModel
+import com.wire.android.feature.cells.ui.create.folder.CreateFolderViewModel
+import com.wire.android.feature.cells.ui.movetofolder.MoveToFolderViewModel
+import com.wire.android.feature.cells.ui.publiclink.PublicLinkViewModel
+import com.wire.android.feature.cells.ui.publiclink.settings.expiration.PublicLinkExpirationScreenViewModel
+import com.wire.android.feature.cells.ui.publiclink.settings.password.PublicLinkPasswordScreenViewModel
+import com.wire.android.feature.cells.ui.rename.RenameNodeViewModel
+import com.wire.android.feature.cells.ui.search.SearchScreenViewModel
+import com.wire.android.feature.cells.ui.tags.AddRemoveTagsViewModel
+import com.wire.android.feature.cells.ui.versioning.VersionHistoryViewModel
+
+interface CellsViewModelGraph : MetroViewModelGraph {
+    val cellsViewModelFactory: CellsViewModelFactory
+}
+
+@Composable
+inline fun <reified VM> cellsViewModel(
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+    key: String? = null,
+    crossinline create: CellsViewModelFactory.(SavedStateHandle) -> VM,
+): VM where VM : ViewModel =
+    metroSavedStateViewModel<CellsViewModelGraph, VM>(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = key,
+    ) { savedStateHandle ->
+        cellsViewModelFactory.create(savedStateHandle)
+    }
+
+@Composable
+fun cellViewModel(): CellViewModel = cellsViewModel { cellViewModel(it) }
+
+@Composable
+fun createFileViewModel(): CreateFileViewModel = cellsViewModel { createFileViewModel(it) }
+
+@Composable
+fun createFolderViewModel(): CreateFolderViewModel = cellsViewModel { createFolderViewModel(it) }
+
+@Composable
+fun moveToFolderViewModel(): MoveToFolderViewModel = cellsViewModel { moveToFolderViewModel(it) }
+
+@Composable
+fun publicLinkViewModel(): PublicLinkViewModel = cellsViewModel { publicLinkViewModel(it) }
+
+@Composable
+internal fun publicLinkExpirationScreenViewModel(): PublicLinkExpirationScreenViewModel =
+    cellsViewModel { publicLinkExpirationScreenViewModel(it) }
+
+@Composable
+internal fun publicLinkPasswordScreenViewModel(): PublicLinkPasswordScreenViewModel =
+    cellsViewModel { publicLinkPasswordScreenViewModel(it) }
+
+@Composable
+fun renameNodeViewModel(): RenameNodeViewModel = cellsViewModel { renameNodeViewModel(it) }
+
+@Composable
+fun searchScreenViewModel(): SearchScreenViewModel = cellsViewModel { searchScreenViewModel(it) }
+
+@Composable
+fun addRemoveTagsViewModel(): AddRemoveTagsViewModel = cellsViewModel { addRemoveTagsViewModel(it) }
+
+@Composable
+fun versionHistoryViewModel(): VersionHistoryViewModel = cellsViewModel { versionHistoryViewModel(it) }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -101,7 +100,7 @@ import kotlinx.coroutines.flow.flowOf
 fun ConversationFilesScreen(
     navigator: WireNavigator,
     animatedVisibilityScope: AnimatedVisibilityScope,
-    viewModel: CellViewModel = wireViewModel(),
+    viewModel: CellViewModel = cellViewModel(),
 ) {
     ConversationFilesScreenContent(
         animatedVisibilityScope = animatedVisibilityScope,

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesWithSlideInTransitionScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesWithSlideInTransitionScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ramcosta.composedestinations.generated.cells.destinations.RecycleBinScreenDestination
 import com.wire.android.feature.cells.R
@@ -41,7 +40,7 @@ fun ConversationFilesWithSlideInTransitionScreen(
     navigator: WireNavigator,
     cellFilesNavArgs: CellFilesNavArgs,
     animatedVisibilityScope: AnimatedVisibilityScope,
-    viewModel: CellViewModel = wireViewModel(),
+    viewModel: CellViewModel = cellViewModel(),
 ) {
     LaunchedEffect(viewModel.navigateToRecycleBinRoot.collectAsState().value) {
         if (viewModel.navigateToRecycleBinRoot.value) {

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/file/CreateFileScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/file/CreateFileScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.window.DialogProperties
-import com.wire.android.di.wireViewModel
+import com.wire.android.feature.cells.ui.createFileViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.feature.cells.R
 import com.wire.android.feature.cells.ui.common.FileNameError
@@ -64,7 +64,7 @@ fun CreateFileScreen(
     navigator: WireNavigator,
     resultNavigator: ResultBackNavigator<Boolean>,
     modifier: Modifier = Modifier,
-    createFileViewModel: CreateFileViewModel = wireViewModel()
+    createFileViewModel: CreateFileViewModel = createFileViewModel()
 ) {
     val showErrorDialog = remember { mutableStateOf(false) }
 

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/file/CreateFileViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/file/CreateFileViewModel.kt
@@ -33,14 +33,11 @@ import com.wire.kalium.cells.domain.usecase.create.CreatePresentationFileUseCase
 import com.wire.kalium.cells.domain.usecase.create.CreateSpreadsheetFileUseCase
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class CreateFileViewModel @Inject constructor(
+class CreateFileViewModel(
     private val savedStateHandle: SavedStateHandle,
     private val createPresentationFileUseCase: CreatePresentationFileUseCase,
     private val createDocumentFileUseCase: CreateDocumentFileUseCase,

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/folder/CreateFolderScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/folder/CreateFolderScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.window.DialogProperties
-import com.wire.android.di.wireViewModel
+import com.wire.android.feature.cells.ui.createFolderViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.feature.cells.R
 import com.wire.android.feature.cells.ui.common.FileNameError
@@ -69,7 +69,7 @@ fun CreateFolderScreen(
     navigator: WireNavigator,
     resultNavigator: ResultBackNavigator<Boolean>,
     modifier: Modifier = Modifier,
-    createFolderViewModel: CreateFolderViewModel = wireViewModel()
+    createFolderViewModel: CreateFolderViewModel = createFolderViewModel()
 ) {
     val showErrorDialog = remember { mutableStateOf(false) }
 

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/folder/CreateFolderViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/folder/CreateFolderViewModel.kt
@@ -31,14 +31,11 @@ import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.kalium.cells.domain.usecase.create.CreateFolderUseCase
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class CreateFolderViewModel @Inject constructor(
+class CreateFolderViewModel(
     val savedStateHandle: SavedStateHandle,
     private val createFolderUseCase: CreateFolderUseCase,
 ) : ActionsViewModel<CreateFolderViewModelAction>() {

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/movetofolder/MoveToFolderScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/movetofolder/MoveToFolderScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import com.wire.android.di.wireViewModel
+import com.wire.android.feature.cells.ui.moveToFolderViewModel
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultRecipient
 import com.wire.android.feature.cells.R
@@ -79,7 +79,7 @@ fun MoveToFolderScreen(
     navigator: WireNavigator,
     createFolderResultRecipient: ResultRecipient<CreateFolderScreenDestination, Boolean>,
     modifier: Modifier = Modifier,
-    moveToFolderViewModel: MoveToFolderViewModel = wireViewModel()
+    moveToFolderViewModel: MoveToFolderViewModel = moveToFolderViewModel()
 ) {
     val context = LocalContext.current
     val viewState by moveToFolderViewModel.state.collectAsState()

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/movetofolder/MoveToFolderViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/movetofolder/MoveToFolderViewModel.kt
@@ -27,15 +27,12 @@ import com.wire.kalium.cells.domain.usecase.GetFoldersUseCase
 import com.wire.kalium.cells.domain.usecase.MoveNodeUseCase
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class MoveToFolderViewModel @Inject constructor(
+class MoveToFolderViewModel(
     val savedStateHandle: SavedStateHandle,
     private val getFoldersUseCase: GetFoldersUseCase,
     private val moveNodeUseCase: MoveNodeUseCase

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/PublicLinkScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/PublicLinkScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
-import com.wire.android.di.wireViewModel
+import com.wire.android.feature.cells.ui.publicLinkViewModel
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultRecipient
 import com.ramcosta.composedestinations.spec.TypedDestinationSpec
@@ -82,7 +82,7 @@ fun PublicLinkScreen(
     onPasswordChange: ResultRecipient<PublicLinkPasswordScreenDestination, Boolean>,
     onExpirationChange: ResultRecipient<PublicLinkExpirationScreenDestination, PublicLinkExpirationResult>,
     modifier: Modifier = Modifier,
-    viewModel: PublicLinkViewModel = wireViewModel(),
+    viewModel: PublicLinkViewModel = publicLinkViewModel(),
 ) {
 
     val context = LocalContext.current

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/PublicLinkViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/PublicLinkViewModel.kt
@@ -30,15 +30,12 @@ import com.wire.kalium.cells.domain.usecase.publiclink.DeletePublicLinkUseCase
 import com.wire.kalium.cells.domain.usecase.publiclink.GetPublicLinkUseCase
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class PublicLinkViewModel @Inject constructor(
+class PublicLinkViewModel(
     val savedStateHandle: SavedStateHandle,
     private val createPublicLink: CreatePublicLinkUseCase,
     private val getPublicLinkUseCase: GetPublicLinkUseCase,

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/expiration/PublicLinkExpirationScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/expiration/PublicLinkExpirationScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.feature.cells.ui.publicLinkExpirationScreenViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.feature.cells.R
 import com.wire.android.feature.cells.ui.common.WireCellErrorDialog
@@ -72,7 +72,7 @@ import kotlinx.parcelize.Parcelize
 internal fun PublicLinkExpirationScreen(
     resultNavigator: ResultBackNavigator<PublicLinkExpirationResult>,
     modifier: Modifier = Modifier,
-    viewModel: PublicLinkExpirationScreenViewModel = wireViewModel(),
+    viewModel: PublicLinkExpirationScreenViewModel = publicLinkExpirationScreenViewModel(),
 ) {
 
     val state by viewModel.state.collectAsState()

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/expiration/PublicLinkExpirationScreenViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/expiration/PublicLinkExpirationScreenViewModel.kt
@@ -29,7 +29,6 @@ import com.wire.android.util.uiLinkExpirationTime
 import com.wire.kalium.cells.domain.usecase.publiclink.SetPublicLinkExpirationUseCase
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -41,10 +40,8 @@ import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
-import javax.inject.Inject
 
-@HiltViewModel
-internal class PublicLinkExpirationScreenViewModel @Inject constructor(
+internal class PublicLinkExpirationScreenViewModel(
     val setExpiration: SetPublicLinkExpirationUseCase,
     val savedStateHandle: SavedStateHandle,
 ) : ActionsViewModel<PublicLinkExpirationScreenAction>() {

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/password/PublicLinkPasswordScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/password/PublicLinkPasswordScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.feature.cells.ui.publicLinkPasswordScreenViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.feature.cells.R
 import com.wire.android.feature.cells.ui.common.WireCellErrorDialog
@@ -69,7 +69,7 @@ import com.wire.android.ui.theme.WireTheme
 internal fun PublicLinkPasswordScreen(
     resultNavigator: ResultBackNavigator<Boolean>,
     modifier: Modifier = Modifier,
-    viewModel: PublicLinkPasswordScreenViewModel = wireViewModel(),
+    viewModel: PublicLinkPasswordScreenViewModel = publicLinkPasswordScreenViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
     val clipboardManager = LocalClipboardManager.current

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/password/PublicLinkPasswordScreenViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/publiclink/settings/password/PublicLinkPasswordScreenViewModel.kt
@@ -32,16 +32,13 @@ import com.wire.kalium.cells.domain.usecase.publiclink.UpdatePublicLinkPasswordU
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.logic.util.RandomPassword
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-internal class PublicLinkPasswordScreenViewModel @Inject constructor(
+internal class PublicLinkPasswordScreenViewModel(
     private val generateRandomPassword: RandomPassword,
     private val createPassword: CreatePublicLinkPasswordUseCase,
     private val updatePassword: UpdatePublicLinkPasswordUseCase,

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/recyclebin/RecycleBinScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/recyclebin/RecycleBinScreen.kt
@@ -27,12 +27,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.wire.android.feature.cells.R
 import com.wire.android.feature.cells.ui.CellFilesNavArgs
 import com.wire.android.feature.cells.ui.CellScreenContent
 import com.wire.android.feature.cells.ui.CellViewModel
+import com.wire.android.feature.cells.ui.cellViewModel
 import com.wire.android.feature.cells.ui.common.Breadcrumbs
 import com.ramcosta.composedestinations.generated.cells.destinations.ConversationFilesWithSlideInTransitionScreenDestination
 import com.ramcosta.composedestinations.generated.cells.destinations.MoveToFolderScreenDestination
@@ -55,7 +55,7 @@ import com.wire.android.ui.theme.wireTypography
 fun RecycleBinScreen(
     navigator: WireNavigator,
     modifier: Modifier = Modifier,
-    cellViewModel: CellViewModel = wireViewModel()
+    cellViewModel: CellViewModel = cellViewModel()
 ) {
 
     Box(modifier = modifier) {

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/rename/RenameNodeScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/rename/RenameNodeScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.feature.cells.ui.renameNodeViewModel
 import com.wire.android.feature.cells.R
 import com.wire.android.feature.cells.ui.common.FILE_NAME_MAX_COUNT
 import com.wire.android.feature.cells.ui.common.FileNameError
@@ -65,7 +65,7 @@ import com.wire.android.ui.theme.wireDimensions
 fun RenameNodeScreen(
     navigator: WireNavigator,
     modifier: Modifier = Modifier,
-    renameNodeViewModel: RenameNodeViewModel = wireViewModel()
+    renameNodeViewModel: RenameNodeViewModel = renameNodeViewModel()
 ) {
     val context = LocalContext.current
 

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/rename/RenameNodeViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/rename/RenameNodeViewModel.kt
@@ -33,17 +33,14 @@ import com.wire.kalium.cells.domain.usecase.RenameNodeUseCase
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.logic.util.splitFileExtension
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
-@HiltViewModel
-class RenameNodeViewModel @Inject constructor(
+class RenameNodeViewModel(
     val savedStateHandle: SavedStateHandle,
     private val renameNodeUseCase: RenameNodeUseCase,
 ) : ActionsViewModel<RenameNodeViewModelAction>() {

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/search/SearchScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/search/SearchScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.feature.cells.ui.searchScreenViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ramcosta.composedestinations.generated.cells.destinations.AddRemoveTagsScreenDestination
@@ -76,7 +76,7 @@ fun SearchScreen(
     animatedVisibilityScope: AnimatedVisibilityScope,
     cellViewModel: CellViewModel,
     modifier: Modifier = Modifier,
-    searchScreenViewModel: SearchScreenViewModel = wireViewModel(),
+    searchScreenViewModel: SearchScreenViewModel = searchScreenViewModel(),
 ) {
     val uiState by searchScreenViewModel.uiState.collectAsStateWithLifecycle()
 

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/search/SearchScreenViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/search/SearchScreenViewModel.kt
@@ -51,7 +51,6 @@ import com.wire.kalium.cells.domain.usecase.GetPaginatedFilesFlowUseCase
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.user.UserAssetId
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -65,13 +64,11 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 private const val SEARCH_DEBOUNCE_MILLIS = 200L
 
 @Suppress("TooManyFunctions")
-@HiltViewModel
-class SearchScreenViewModel @Inject constructor(
+class SearchScreenViewModel(
     val savedStateHandle: SavedStateHandle,
     private val getAllTagsUseCase: GetAllTagsUseCase,
     private val getCellFilesPaged: GetPaginatedFilesFlowUseCase,

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/tags/AddRemoveTagsScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/tags/AddRemoveTagsScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.wire.android.di.wireViewModel
+import com.wire.android.feature.cells.ui.addRemoveTagsViewModel
 import com.wire.android.feature.cells.R
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.navigation.WireNavigator
@@ -78,7 +78,7 @@ import kotlinx.coroutines.launch
 fun AddRemoveTagsScreen(
     navigator: WireNavigator,
     modifier: Modifier = Modifier,
-    addRemoveTagsViewModel: AddRemoveTagsViewModel = wireViewModel(),
+    addRemoveTagsViewModel: AddRemoveTagsViewModel = addRemoveTagsViewModel(),
 ) {
     val context = LocalContext.current
 

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/tags/AddRemoveTagsViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/tags/AddRemoveTagsViewModel.kt
@@ -29,17 +29,14 @@ import com.wire.kalium.cells.domain.usecase.RemoveNodeTagsUseCase
 import com.wire.kalium.cells.domain.usecase.UpdateNodeTagsUseCase
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class AddRemoveTagsViewModel @Inject constructor(
+class AddRemoveTagsViewModel(
     val savedStateHandle: SavedStateHandle,
     private val getAllTagsUseCase: GetAllTagsUseCase,
     private val updateNodeTagsUseCase: UpdateNodeTagsUseCase,

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/versioning/VersionHistoryScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/versioning/VersionHistoryScreen.kt
@@ -38,7 +38,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.feature.cells.ui.versionHistoryViewModel
 import com.wire.android.feature.cells.R
 import com.wire.android.feature.cells.ui.common.ErrorScreen
 import com.wire.android.feature.cells.ui.common.LoadingScreen
@@ -72,7 +72,7 @@ import kotlinx.coroutines.launch
 fun VersionHistoryScreen(
     navigator: WireNavigator,
     modifier: Modifier = Modifier,
-    versionHistoryViewModel: VersionHistoryViewModel = wireViewModel()
+    versionHistoryViewModel: VersionHistoryViewModel = versionHistoryViewModel()
 ) {
     val optionsBottomSheetState = rememberWireModalSheetState<Pair<String, CellVersion>>()
     val snackbarHostState = LocalSnackbarHostState.current

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/versioning/VersionHistoryViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/versioning/VersionHistoryViewModel.kt
@@ -41,7 +41,6 @@ import com.wire.kalium.cells.domain.usecase.versioning.GetNodeVersionsUseCase
 import com.wire.kalium.cells.domain.usecase.versioning.RestoreNodeVersionUseCase
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -50,10 +49,8 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import javax.inject.Inject
 
-@HiltViewModel
-class VersionHistoryViewModel @Inject constructor(
+class VersionHistoryViewModel(
     private val savedStateHandle: SavedStateHandle,
     private val getNodeVersionsUseCase: GetNodeVersionsUseCase,
     private val fileSizeFormatter: FileSizeFormatter,

--- a/features/meetings/build.gradle.kts
+++ b/features/meetings/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id(libs.plugins.wire.android.library.get().pluginId)
     id(libs.plugins.wire.kover.get().pluginId)
-    id(libs.plugins.wire.hilt.get().pluginId)
     id(BuildPlugins.kotlinParcelize)
     id(BuildPlugins.junit5)
     alias(libs.plugins.ksp)
@@ -13,7 +12,6 @@ plugins {
 dependencies {
     implementation("com.wire.kalium:kalium-common")
     implementation("com.wire.kalium:kalium-logic")
-    implementation(project(":core:di"))
     implementation(project(":core:ui-common"))
     implementation(libs.androidx.core)
     implementation(libs.androidx.appcompat)

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingList.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingList.kt
@@ -26,12 +26,14 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
-import com.wire.android.di.wireViewModel
 import com.wire.android.feature.meetings.R
 import com.wire.android.feature.meetings.model.MeetingHeader
 import com.wire.android.feature.meetings.model.MeetingItem
@@ -43,6 +45,7 @@ import com.wire.android.ui.common.rowitem.EmptyListArrowFooter
 import com.wire.android.ui.common.rowitem.EmptyListContent
 import com.wire.android.ui.common.rowitem.LoadingListContent
 import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.dispatchers.DefaultDispatcherProvider
 
 @Composable
 fun MeetingList(
@@ -52,11 +55,16 @@ fun MeetingList(
     openMeetingOptions: (meetingId: String) -> Unit = {},
     meetingListViewModel: MeetingListViewModel = when {
         LocalInspectionMode.current -> MeetingListViewModelPreview(CurrentTimeProvider.Preview, type)
-        else -> wireViewModel<MeetingListViewModelImpl, MeetingListViewModelImpl.Factory>(
+        else -> viewModel<MeetingListViewModelImpl>(
             key = "meeting_list_${type.name}",
-            creationCallback = { factory ->
-                factory.create(type = type)
-            }
+            factory = viewModelFactory {
+                initializer {
+                    MeetingListViewModelImpl(
+                        type = type,
+                        dispatcher = DefaultDispatcherProvider(),
+                    )
+                }
+            },
         )
     },
 ) {

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingListViewModel.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingListViewModel.kt
@@ -31,10 +31,6 @@ import com.wire.android.feature.meetings.ui.MeetingsTabItem
 import com.wire.android.feature.meetings.ui.mock.MeetingMocksProvider
 import com.wire.android.feature.meetings.ui.util.CurrentTimeProvider
 import com.wire.android.util.dispatchers.DispatcherProvider
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -66,16 +62,10 @@ class MeetingListViewModelPreview(
         MutableStateFlow(PagingData.from(meetingMocksProvider.getItems(showingAll, type).insertHeaders(type)))
 }
 
-@HiltViewModel(assistedFactory = MeetingListViewModelImpl.Factory::class)
-class MeetingListViewModelImpl @AssistedInject constructor(
-    @Assisted val type: MeetingsTabItem,
+class MeetingListViewModelImpl(
+    val type: MeetingsTabItem,
     dispatcher: DispatcherProvider,
 ) : ViewModel(), MeetingListViewModel {
-    @AssistedFactory
-    interface Factory {
-        fun create(type: MeetingsTabItem): MeetingListViewModelImpl
-    }
-
     override val isShowingAll = MutableStateFlow(type == MeetingsTabItem.PAST) // for PAST always show all, for NEXT start with false
     private val meetingMocksProvider = MeetingMocksProvider(CurrentTimeProvider.Default) // TODO replace with real data source
     override val meetings: Flow<PagingData<MeetingListItem>> = isShowingAll

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/options/MeetingOptionsMenuViewModel.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/options/MeetingOptionsMenuViewModel.kt
@@ -22,10 +22,8 @@ import com.wire.android.feature.meetings.model.MeetingItem
 import com.wire.android.feature.meetings.ui.mock.MeetingMocksProvider
 import com.wire.android.feature.meetings.ui.mock.scheduledRepeatingGroupMeeting
 import com.wire.android.feature.meetings.ui.util.CurrentTimeProvider
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import javax.inject.Inject
 
 interface MeetingOptionsMenuViewModel {
     fun observeMeetingStateFlow(meetingId: String): StateFlow<MeetingOptionsMenuState> = MutableStateFlow(
@@ -42,8 +40,7 @@ class MeetingOptionsMenuViewModelPreview(currentTimeProvider: CurrentTimeProvide
     )
 }
 
-@HiltViewModel
-class MeetingOptionsMenuViewModelImpl @Inject constructor() : MeetingOptionsMenuViewModel, ViewModel() {
+class MeetingOptionsMenuViewModelImpl : MeetingOptionsMenuViewModel, ViewModel() {
     private val meetingMocksProvider = MeetingMocksProvider(CurrentTimeProvider.Default) // TODO replace with real data source
     override fun observeMeetingStateFlow(meetingId: String): StateFlow<MeetingOptionsMenuState> = MutableStateFlow(
         meetingMocksProvider.getItem(meetingId)?.let {

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/options/MeetingOptionsModalSheetLayout.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/options/MeetingOptionsModalSheetLayout.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.wire.android.di.wireViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.wire.android.feature.meetings.R
 import com.wire.android.feature.meetings.model.MeetingItem
 import com.wire.android.feature.meetings.ui.list.MeetingLeadingIcon
@@ -53,7 +53,7 @@ fun MeetingOptionsModalSheetLayout(
     sheetState: WireModalSheetState<String>,
     viewModel: MeetingOptionsMenuViewModel = when {
         LocalInspectionMode.current -> MeetingOptionsMenuViewModelPreview(CurrentTimeProvider.Preview)
-        else -> wireViewModel<MeetingOptionsMenuViewModelImpl>()
+        else -> viewModel<MeetingOptionsMenuViewModelImpl>()
     }
 ) {
     val deletedMeetingOptionsClosedMessage = stringResource(R.string.deleted_meeting_options_closed)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25946
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Route Cells ViewModel creation through a feature-local provider boundary.
- Add SavedState-aware Metro ViewModel helper support.
- Add `WireActivityViewModelGraphBridge` to expose feature ViewModel factories from the existing Android/Hilt boundary.
- Remove Hilt ViewModel usage from Cells and Meetings screen call sites.

## Why
This continues the incremental Metro migration while keeping Hilt and Metro side by side. The PR moves feature ViewModel creation behind local boundaries without changing screen behavior or removing the existing app/session providers yet.