### PR TITLE
fix: conversation details focus traversal order [WPB-14810]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -60,6 +59,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wire.android.di.wireViewModel
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultBackNavigator
@@ -153,7 +153,7 @@ fun GroupConversationDetailsScreen(
     val resources = LocalContext.current.resources
     val snackbarHostState = LocalSnackbarHostState.current
     val sheetState = rememberWireModalSheetState<ConversationSheetState>()
-    val groupOptions by viewModel.groupOptionsState.collectAsState()
+    val groupOptions by viewModel.groupOptionsState.collectAsStateWithLifecycle()
 
     val onSearchConversationMessagesClick: () -> Unit = {
         navigator.navigate(
@@ -392,7 +392,7 @@ private fun GroupConversationDetailsContent(
     )
     val currentTabState by remember { derivedStateOf { pagerState.calculateCurrentTab() } }
     val legalHoldSubjectDialogState = rememberVisibilityState<Unit>()
-    val isLoading by isScreenLoading.collectAsState()
+    val isLoading by isScreenLoading.collectAsStateWithLifecycle()
 
     CollapsingTopBarScaffold(
         topBarHeader = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -392,6 +392,7 @@ private fun GroupConversationDetailsContent(
     )
     val currentTabState by remember { derivedStateOf { pagerState.calculateCurrentTab() } }
     val legalHoldSubjectDialogState = rememberVisibilityState<Unit>()
+    val isLoading by isScreenLoading.collectAsState()
 
     CollapsingTopBarScaffold(
         topBarHeader = {
@@ -428,7 +429,7 @@ private fun GroupConversationDetailsContent(
             }
 
             AnimatedContent(
-                targetState = isScreenLoading.collectAsState().value,
+                targetState = isLoading,
                 transitionSpec = {
                     val enter = fadeIn(tween(durationMillis = 500, delayMillis = 100))
                     val exit = fadeOut()
@@ -456,8 +457,8 @@ private fun GroupConversationDetailsContent(
             }
         },
         topBarFooter = {
-            Crossfade(isScreenLoading.collectAsState().value) {
-                if (it) {
+            Crossfade(isLoading) { loading ->
+                if (loading) {
                     LoadingWireTabRow()
                 } else {
                     WireTabRow(
@@ -508,7 +509,7 @@ private fun GroupConversationDetailsContent(
         contentLazyListState = lazyListStates[currentTabState],
     ) {
         AnimatedVisibility(
-            visible = isScreenLoading.collectAsState().value,
+            visible = isLoading,
             enter = fadeIn(),
             exit = fadeOut()
         ) {
@@ -520,7 +521,7 @@ private fun GroupConversationDetailsContent(
         val focusManager = LocalFocusManager.current
 
         AnimatedVisibility(
-            visible = !isScreenLoading.collectAsState().value,
+            visible = !isLoading,
             enter = fadeIn(
                 animationSpec = tween(durationMillis = 500, delayMillis = 100)
             ),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsTopBarCollapsing.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsTopBarCollapsing.kt
@@ -19,6 +19,7 @@ package com.wire.android.ui.home.conversations.details
 
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -71,6 +72,7 @@ fun GroupConversationDetailsTopBarCollapsing(
         modifier = modifier
             .fillMaxWidth()
             .wrapContentHeight()
+            .focusGroup()
     ) {
         Box(contentAlignment = Alignment.Center) {
             GroupConversationAvatar(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-14810
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Fixes keyboard focus traversal in conversation details
- Groups the collapsing top bar focus targets so Search and Media are reached before the tab row
- Reuses a single collected loading state in the screen content