### PR TITLE
refactor: migrate debug info view models to metro [WPB-25946]

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/ui/debug/DebugScreenComposeTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/debug/DebugScreenComposeTest.kt
@@ -43,6 +43,8 @@ class DebugScreenComposeTest {
                         onShowFeatureFlags = {},
                         onShowCryptoStats = {},
                         onFlushLogs = { CompletableDeferred(Unit) },
+                        debugDataOptionsViewModel = object : DebugDataOptionsViewModel {},
+                        exportObfuscatedCopyViewModel = object : ExportObfuscatedCopyViewModel {},
                     )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
@@ -22,6 +22,8 @@ import com.wire.android.feature.cells.ui.CellsViewModelFactory
 import com.wire.android.feature.cells.ui.CellsViewModelGraph
 import com.wire.android.model.ImageAssetViewModelFactory
 import com.wire.android.model.ImageAssetViewModelGraph
+import com.wire.android.ui.debug.DebugInfoViewModelFactory
+import com.wire.android.ui.debug.DebugInfoViewModelGraph
 import com.wire.android.util.ui.WireSessionImageLoader
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -34,10 +36,14 @@ import javax.inject.Provider
 class WireActivityViewModelGraphBridge @Inject constructor(
     imageLoader: Provider<WireSessionImageLoader>,
     private val cellsViewModelFactoryProvider: Provider<CellsViewModelFactory>,
-) : ViewModel(), ImageAssetViewModelGraph, CellsViewModelGraph {
+    private val debugInfoViewModelFactoryProvider: Provider<DebugInfoViewModelFactory>,
+) : ViewModel(), ImageAssetViewModelGraph, CellsViewModelGraph, DebugInfoViewModelGraph {
     override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
         ImageAssetViewModelFactory(imageLoader = imageLoader::get)
 
     override val cellsViewModelFactory: CellsViewModelFactory
         get() = cellsViewModelFactoryProvider.get()
+
+    override val debugInfoViewModelFactory: DebugInfoViewModelFactory
+        get() = debugInfoViewModelFactoryProvider.get()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.wire.android.BuildConfig
 import com.wire.android.R
-import com.wire.android.di.wireViewModelScoped
 import com.wire.android.feature.analytics.AnonymousAnalyticsManagerImpl
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.WireDialog
@@ -69,8 +68,7 @@ fun DebugDataOptions(
     onCopyText: (String) -> Unit,
     onShowFeatureFlags: () -> Unit,
     onShowCryptoStats: () -> Unit,
-    viewModel: DebugDataOptionsViewModel =
-        wireViewModelScoped<DebugDataOptionsViewModelImpl, DebugDataOptionsViewModel>()
+    viewModel: DebugDataOptionsViewModel = debugDataOptionsViewModel()
 ) {
     LocalSnackbarHostState.current.collectAndShowSnackbar(snackbarFlow = viewModel.infoMessage)
     DebugDataOptionsContent(

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptionsViewModel.kt
@@ -27,7 +27,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.BuildConfig.DOMAIN_REMOVAL_KEYS_FOR_REPAIR
 import com.wire.android.appLogger
-import com.wire.android.di.CurrentAccount
 import com.wire.android.di.ViewModelScopedPreview
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.getDeviceIdString
@@ -60,8 +59,6 @@ import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
 import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import com.wire.kalium.logic.sync.periodic.UpdateApiVersionsScheduler
 import com.wire.kalium.logic.sync.slow.RestartSlowSyncProcessForRecoveryUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -70,7 +67,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 import kotlin.time.Duration.Companion.days
 
 @Suppress("TooManyFunctions")
@@ -97,11 +93,9 @@ interface DebugDataOptionsViewModel {
 }
 
 @Suppress("LongParameterList", "TooManyFunctions")
-@HiltViewModel
-class DebugDataOptionsViewModelImpl
-@Inject constructor(
-    @ApplicationContext private val context: Context,
-    @CurrentAccount val currentAccount: UserId,
+class DebugDataOptionsViewModelImpl(
+    private val context: Context,
+    val currentAccount: UserId,
     private val updateApiVersions: UpdateApiVersionsScheduler,
     private val mlsKeyPackageCount: MLSKeyPackageCountUseCase,
     private val restartSlowSyncProcessForRecovery: RestartSlowSyncProcessForRecoveryUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugInfoViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugInfoViewModelFactory.kt
@@ -1,0 +1,164 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.debug
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.di.CurrentAccount
+import com.wire.android.ui.debug.conversation.DebugConversationViewModel
+import com.wire.android.ui.debug.cryptostats.ConversationCryptoStatsViewModel
+import com.wire.android.ui.debug.featureflags.DebugFeatureFlagsViewModel
+import com.wire.android.ui.home.settings.about.dependencies.DependenciesViewModel
+import com.wire.android.ui.home.settings.about.licenses.LicensesViewModel
+import com.wire.android.ui.home.whatsnew.WhatsNewViewModel
+import com.wire.android.ui.settings.about.AboutThisAppViewModel
+import com.wire.android.util.FileManager
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.logging.LogFileWriter
+import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
+import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.analytics.GetCurrentAnalyticsTrackingIdentifierUseCase
+import com.wire.kalium.logic.feature.backup.CreateObfuscatedCopyUseCase
+import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.debug.ChangeProfilingUseCase
+import com.wire.kalium.logic.feature.debug.DebugFeedConversationUseCase
+import com.wire.kalium.logic.feature.debug.GetConversationCryptoStatsUseCase
+import com.wire.kalium.logic.feature.debug.GetConversationEpochFromCCUseCase
+import com.wire.kalium.logic.feature.debug.GetDebugE2EICertificateExpirationUseCase
+import com.wire.kalium.logic.feature.debug.GetFeatureConfigUseCase
+import com.wire.kalium.logic.feature.debug.ObserveDatabaseLoggerStateUseCase
+import com.wire.kalium.logic.feature.debug.ObserveDebugCRLExpirationAfterOneMinuteUseCase
+import com.wire.kalium.logic.feature.debug.ObserveIsConsumableNotificationsEnabledUseCase
+import com.wire.kalium.logic.feature.debug.RepairFaultyRemovalKeysUseCase
+import com.wire.kalium.logic.feature.debug.SetDebugCRLExpirationAfterOneMinuteUseCase
+import com.wire.kalium.logic.feature.debug.SetDebugE2EICertificateExpirationUseCase
+import com.wire.kalium.logic.feature.debug.StartUsingAsyncNotificationsUseCase
+import com.wire.kalium.logic.feature.e2ei.CheckCrlRevocationListUseCase
+import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCase
+import com.wire.kalium.logic.feature.notificationToken.SendFCMTokenUseCase
+import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
+import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
+import com.wire.kalium.logic.sync.periodic.UpdateApiVersionsScheduler
+import com.wire.kalium.logic.sync.slow.RestartSlowSyncProcessForRecoveryUseCase
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+class DebugInfoViewModelFactory @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @CurrentAccount private val currentAccount: UserId,
+    private val logFileWriter: LogFileWriter,
+    private val currentClientIdUseCase: ObserveCurrentClientIdUseCase,
+    private val globalDataStore: GlobalDataStore,
+    private val changeProfilingUseCase: ChangeProfilingUseCase,
+    private val observeDatabaseLoggerState: ObserveDatabaseLoggerStateUseCase,
+    private val updateApiVersions: UpdateApiVersionsScheduler,
+    private val mlsKeyPackageCount: MLSKeyPackageCountUseCase,
+    private val restartSlowSyncProcessForRecovery: RestartSlowSyncProcessForRecoveryUseCase,
+    private val checkCrlRevocationList: CheckCrlRevocationListUseCase,
+    private val getCurrentAnalyticsTrackingIdentifier: GetCurrentAnalyticsTrackingIdentifierUseCase,
+    private val sendFCMToken: SendFCMTokenUseCase,
+    private val dispatcherProvider: DispatcherProvider,
+    private val selfServerConfigUseCase: SelfServerConfigUseCase,
+    private val getDefaultProtocolUseCase: GetDefaultProtocolUseCase,
+    private val observeAsyncNotificationsEnabled: ObserveIsConsumableNotificationsEnabledUseCase,
+    private val startUsingAsyncNotifications: StartUsingAsyncNotificationsUseCase,
+    private val repairFaultyRemovalKeys: RepairFaultyRemovalKeysUseCase,
+    private val getDebugE2EICertificateExpiration: GetDebugE2EICertificateExpirationUseCase,
+    private val setDebugE2EICertificateExpiration: SetDebugE2EICertificateExpirationUseCase,
+    private val observeDebugCRLExpirationAfterOneMinute: ObserveDebugCRLExpirationAfterOneMinuteUseCase,
+    private val setDebugCRLExpirationAfterOneMinute: SetDebugCRLExpirationAfterOneMinuteUseCase,
+    private val createUnencryptedCopy: CreateObfuscatedCopyUseCase,
+    private val fileManager: FileManager,
+    private val conversationDetails: ObserveConversationDetailsUseCase,
+    private val resetMLSConversation: ResetMLSConversationUseCase,
+    private val fetchConversation: FetchConversationUseCase,
+    private val feedConversation: DebugFeedConversationUseCase,
+    private val getConversationEpochFromCC: GetConversationEpochFromCCUseCase,
+    private val getConversationCryptoStats: GetConversationCryptoStatsUseCase,
+    private val getFeatureConfig: GetFeatureConfigUseCase,
+) {
+    fun userDebugViewModel() = UserDebugViewModel(
+        currentAccount = currentAccount,
+        logFileWriter = logFileWriter,
+        currentClientIdUseCase = currentClientIdUseCase,
+        globalDataStore = globalDataStore,
+        changeProfilingUseCase = changeProfilingUseCase,
+        observeDatabaseLoggerState = observeDatabaseLoggerState,
+    )
+
+    fun logManagementViewModel() = LogManagementViewModel(
+        logFileWriter = logFileWriter,
+        globalDataStore = globalDataStore,
+    )
+
+    fun debugDataOptionsViewModel() = DebugDataOptionsViewModelImpl(
+        context = context,
+        currentAccount = currentAccount,
+        updateApiVersions = updateApiVersions,
+        mlsKeyPackageCount = mlsKeyPackageCount,
+        restartSlowSyncProcessForRecovery = restartSlowSyncProcessForRecovery,
+        checkCrlRevocationList = checkCrlRevocationList,
+        getCurrentAnalyticsTrackingIdentifier = getCurrentAnalyticsTrackingIdentifier,
+        sendFCMToken = sendFCMToken,
+        dispatcherProvider = dispatcherProvider,
+        selfServerConfigUseCase = selfServerConfigUseCase,
+        getDefaultProtocolUseCase = getDefaultProtocolUseCase,
+        observeAsyncNotificationsEnabled = observeAsyncNotificationsEnabled,
+        startUsingAsyncNotifications = startUsingAsyncNotifications,
+        repairFaultyRemovalKeys = repairFaultyRemovalKeys,
+        getDebugE2EICertificateExpiration = getDebugE2EICertificateExpiration,
+        setDebugE2EICertificateExpiration = setDebugE2EICertificateExpiration,
+        observeDebugCRLExpirationAfterOneMinute = observeDebugCRLExpirationAfterOneMinute,
+        setDebugCRLExpirationAfterOneMinute = setDebugCRLExpirationAfterOneMinute,
+    )
+
+    fun exportObfuscatedCopyViewModel() = ExportObfuscatedCopyViewModelImpl(
+        createUnencryptedCopy = createUnencryptedCopy,
+        dispatcher = dispatcherProvider,
+        fileManager = fileManager,
+    )
+
+    fun debugConversationViewModel(savedStateHandle: SavedStateHandle) = DebugConversationViewModel(
+        conversationDetails = conversationDetails,
+        resetMLSConversation = resetMLSConversation,
+        fetchConversation = fetchConversation,
+        feedConversation = feedConversation,
+        getConversationEpochFromCC = getConversationEpochFromCC,
+        savedStateHandle = savedStateHandle,
+    )
+
+    fun conversationCryptoStatsViewModel() = ConversationCryptoStatsViewModel(
+        getConversationCryptoStats = getConversationCryptoStats,
+    )
+
+    fun debugFeatureFlagsViewModel() = DebugFeatureFlagsViewModel(
+        getFeatureConfig = getFeatureConfig,
+    )
+
+    fun whatsNewViewModel() = WhatsNewViewModel(context = context)
+
+    fun aboutThisAppViewModel() = AboutThisAppViewModel(context = context)
+
+    fun dependenciesViewModel() = DependenciesViewModel(context = context)
+
+    fun licensesViewModel() = LicensesViewModel(context = context)
+}

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugInfoViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugInfoViewModelGraph.kt
@@ -1,0 +1,106 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.debug
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import com.wire.android.di.metro.MetroViewModelGraph
+import com.wire.android.di.metro.metroSavedStateViewModel
+import com.wire.android.di.metro.metroViewModel
+import com.wire.android.ui.debug.conversation.DebugConversationViewModel
+import com.wire.android.ui.debug.cryptostats.ConversationCryptoStatsViewModel
+import com.wire.android.ui.debug.featureflags.DebugFeatureFlagsViewModel
+import com.wire.android.ui.home.settings.about.dependencies.DependenciesViewModel
+import com.wire.android.ui.home.settings.about.licenses.LicensesViewModel
+import com.wire.android.ui.home.whatsnew.WhatsNewViewModel
+import com.wire.android.ui.settings.about.AboutThisAppViewModel
+
+interface DebugInfoViewModelGraph : MetroViewModelGraph {
+    val debugInfoViewModelFactory: DebugInfoViewModelFactory
+}
+
+@Composable
+inline fun <reified VM> debugInfoViewModel(
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+    key: String? = null,
+    crossinline create: DebugInfoViewModelFactory.() -> VM,
+): VM where VM : ViewModel =
+    metroViewModel<DebugInfoViewModelGraph, VM>(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = key,
+    ) {
+        debugInfoViewModelFactory.create()
+    }
+
+@Composable
+inline fun <reified VM> debugInfoSavedStateViewModel(
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+    key: String? = null,
+    crossinline create: DebugInfoViewModelFactory.(SavedStateHandle) -> VM,
+): VM where VM : ViewModel =
+    metroSavedStateViewModel<DebugInfoViewModelGraph, VM>(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = key,
+    ) { savedStateHandle ->
+        debugInfoViewModelFactory.create(savedStateHandle)
+    }
+
+@Composable
+fun userDebugViewModel(): UserDebugViewModel = debugInfoViewModel { userDebugViewModel() }
+
+@Composable
+fun logManagementViewModel(): LogManagementViewModel = debugInfoViewModel { logManagementViewModel() }
+
+@Composable
+fun debugDataOptionsViewModel(): DebugDataOptionsViewModel =
+    debugInfoViewModel<DebugDataOptionsViewModelImpl> { debugDataOptionsViewModel() }
+
+@Composable
+fun exportObfuscatedCopyViewModel(): ExportObfuscatedCopyViewModel =
+    debugInfoViewModel<ExportObfuscatedCopyViewModelImpl> { exportObfuscatedCopyViewModel() }
+
+@Composable
+fun debugConversationViewModel(): DebugConversationViewModel =
+    debugInfoSavedStateViewModel { debugConversationViewModel(it) }
+
+@Composable
+fun conversationCryptoStatsViewModel(): ConversationCryptoStatsViewModel =
+    debugInfoViewModel { conversationCryptoStatsViewModel() }
+
+@Composable
+fun debugFeatureFlagsViewModel(): DebugFeatureFlagsViewModel =
+    debugInfoViewModel { debugFeatureFlagsViewModel() }
+
+@Composable
+fun whatsNewViewModel(): WhatsNewViewModel = debugInfoViewModel { whatsNewViewModel() }
+
+@Composable
+fun aboutThisAppViewModel(): AboutThisAppViewModel = debugInfoViewModel { aboutThisAppViewModel() }
+
+@Composable
+fun dependenciesViewModel(): DependenciesViewModel = debugInfoViewModel { dependenciesViewModel() }
+
+@Composable
+fun licensesViewModel(): LicensesViewModel = debugInfoViewModel { licensesViewModel() }

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
@@ -99,6 +99,8 @@ internal fun UserDebugContent(
     onFlushLogs: () -> Deferred<Unit>,
     onShowFeatureFlags: () -> Unit,
     onShowCryptoStats: () -> Unit,
+    debugDataOptionsViewModel: DebugDataOptionsViewModel = debugDataOptionsViewModel(),
+    exportObfuscatedCopyViewModel: ExportObfuscatedCopyViewModel = exportObfuscatedCopyViewModel(),
 ) {
     val debugContentState: DebugContentState = rememberDebugContentState(state.logPath)
 
@@ -134,9 +136,10 @@ internal fun UserDebugContent(
                     onCopyText = debugContentState::copyToClipboard,
                     onShowFeatureFlags = onShowFeatureFlags,
                     onShowCryptoStats = onShowCryptoStats,
+                    viewModel = debugDataOptionsViewModel,
                 )
                 if (BuildConfig.PRIVATE_BUILD) {
-                    DangerOptions()
+                    DangerOptions(exportObfuscatedCopyViewModel = exportObfuscatedCopyViewModel)
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
@@ -41,10 +41,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.di.wireViewModel
 import com.wire.android.BuildConfig
 import com.wire.android.R
-import com.wire.android.di.wireViewModelScoped
 import com.wire.android.model.Clickable
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
@@ -73,7 +71,7 @@ import java.io.File
 @Composable
 fun DebugScreen(
     navigator: Navigator,
-    userDebugViewModel: UserDebugViewModel = wireViewModel(),
+    userDebugViewModel: UserDebugViewModel = userDebugViewModel(),
 ) {
     UserDebugContent(
         onNavigationPressed = navigator::navigateBack,
@@ -148,8 +146,7 @@ internal fun UserDebugContent(
 @Composable
 fun DangerOptions(
     modifier: Modifier = Modifier,
-    exportObfuscatedCopyViewModel: ExportObfuscatedCopyViewModel =
-        wireViewModelScoped<ExportObfuscatedCopyViewModelImpl, ExportObfuscatedCopyViewModel>()
+    exportObfuscatedCopyViewModel: ExportObfuscatedCopyViewModel = exportObfuscatedCopyViewModel()
 ) {
 
     Column(modifier = modifier) {

--- a/app/src/main/kotlin/com/wire/android/ui/debug/ExportObfuscatedCopyViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/ExportObfuscatedCopyViewModel.kt
@@ -38,10 +38,8 @@ import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.feature.backup.CreateBackupResult
 import com.wire.kalium.logic.feature.backup.CreateObfuscatedCopyUseCase
 import com.wire.kalium.util.DelicateKaliumApi
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
 @ViewModelScopedPreview
 interface ExportObfuscatedCopyViewModel {
@@ -57,8 +55,7 @@ interface ExportObfuscatedCopyViewModel {
     fun cancelBackupCreation() {}
 }
 
-@HiltViewModel
-class ExportObfuscatedCopyViewModelImpl @OptIn(DelicateKaliumApi::class) @Inject constructor(
+class ExportObfuscatedCopyViewModelImpl @OptIn(DelicateKaliumApi::class) constructor(
     private val createUnencryptedCopy: CreateObfuscatedCopyUseCase,
     private val dispatcher: DispatcherProvider = DefaultDispatcherProvider(),
     private val fileManager: FileManager,

--- a/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.dimensions
@@ -38,7 +37,7 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 fun LogManagementScreen(
     navigator: Navigator,
     modifier: Modifier = Modifier,
-    viewModel: LogManagementViewModel = wireViewModel()
+    viewModel: LogManagementViewModel = logManagementViewModel()
 ) {
     val state = viewModel.state
     val contentState = rememberDebugContentState(state.logPath)

--- a/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementViewModel.kt
@@ -26,19 +26,16 @@ import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.util.logging.LogFileWriter
 import com.wire.kalium.common.logger.CoreLogger
 import com.wire.kalium.logger.KaliumLogLevel
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 data class LogManagementState(
     val isLoggingEnabled: Boolean = false,
     val logPath: String
 )
 
-@HiltViewModel
-class LogManagementViewModel @Inject constructor(
+class LogManagementViewModel(
     private val logFileWriter: LogFileWriter,
     private val globalDataStore: GlobalDataStore
 ) : ViewModel() {

--- a/app/src/main/kotlin/com/wire/android/ui/debug/UserDebugViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/UserDebugViewModel.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.GlobalDataStore
-import com.wire.android.di.CurrentAccount
 import com.wire.android.util.EMPTY
 import com.wire.android.util.logging.LogFileWriter
 import com.wire.kalium.common.logger.CoreLogger
@@ -33,11 +32,9 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.debug.ChangeProfilingUseCase
 import com.wire.kalium.logic.feature.debug.ObserveDatabaseLoggerStateUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 data class UserDebugState(
     val isLoggingEnabled: Boolean = false,
@@ -50,10 +47,8 @@ data class UserDebugState(
 )
 
 @Suppress("LongParameterList")
-@HiltViewModel
-class UserDebugViewModel
-@Inject constructor(
-    @CurrentAccount val currentAccount: UserId,
+class UserDebugViewModel(
+    val currentAccount: UserId,
     private val logFileWriter: LogFileWriter,
     private val currentClientIdUseCase: ObserveCurrentClientIdUseCase,
     private val globalDataStore: GlobalDataStore,

--- a/app/src/main/kotlin/com/wire/android/ui/debug/conversation/DebugConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/conversation/DebugConversationScreen.kt
@@ -35,11 +35,11 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
-import com.wire.android.di.wireViewModel
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.navigation.Navigator
+import com.wire.android.ui.debug.debugConversationViewModel
 import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
@@ -66,7 +66,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 fun DebugConversationScreen(
     navigator: Navigator,
     modifier: Modifier = Modifier,
-    viewModel: DebugConversationViewModel = wireViewModel(),
+    viewModel: DebugConversationViewModel = debugConversationViewModel(),
 ) {
 
     val context = LocalContext.current

--- a/app/src/main/kotlin/com/wire/android/ui/debug/conversation/DebugConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/conversation/DebugConversationViewModel.kt
@@ -33,15 +33,12 @@ import com.wire.kalium.logic.feature.debug.DebugFeedConversationUseCase
 import com.wire.kalium.logic.feature.debug.DebugFeedResult
 import com.wire.kalium.logic.feature.debug.GetConversationEpochFromCCResult
 import com.wire.kalium.logic.feature.debug.GetConversationEpochFromCCUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class DebugConversationViewModel @Inject constructor(
+class DebugConversationViewModel(
     private val conversationDetails: ObserveConversationDetailsUseCase,
     private val resetMLSConversation: ResetMLSConversationUseCase,
     private val fetchConversation: FetchConversationUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/debug/cryptostats/ConversationCryptoStatsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/cryptostats/ConversationCryptoStatsScreen.kt
@@ -38,9 +38,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
+import com.wire.android.ui.debug.conversationCryptoStatsViewModel
 import com.wire.android.ui.common.SearchBarInput
 import com.wire.android.ui.common.chip.WireFilterChip
 import com.wire.android.ui.common.dimensions
@@ -58,7 +58,7 @@ import com.wire.android.ui.theme.wireTypography
 fun ConversationCryptoStatsScreen(
     navigator: Navigator,
     modifier: Modifier = Modifier,
-    viewModel: ConversationCryptoStatsViewModel = wireViewModel(),
+    viewModel: ConversationCryptoStatsViewModel = conversationCryptoStatsViewModel(),
 ) {
     val scrollState = rememberScrollState()
     val state by viewModel.state.collectAsState()

--- a/app/src/main/kotlin/com/wire/android/ui/debug/cryptostats/ConversationCryptoStatsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/cryptostats/ConversationCryptoStatsViewModel.kt
@@ -26,12 +26,10 @@ import com.wire.kalium.logic.feature.debug.ConversationCryptoStats
 import com.wire.kalium.logic.feature.debug.DetailGroupState
 import com.wire.kalium.logic.feature.debug.GetConversationCryptoStatsResult
 import com.wire.kalium.logic.feature.debug.GetConversationCryptoStatsUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 enum class ProtocolFilter(val label: String) {
     ALL("All"),
@@ -49,8 +47,7 @@ enum class EstablishmentFilter(val label: String) {
     NOT_APPLICABLE("N/A (Proteus)"),
 }
 
-@HiltViewModel
-class ConversationCryptoStatsViewModel @Inject constructor(
+class ConversationCryptoStatsViewModel(
     private val getConversationCryptoStats: GetConversationCryptoStatsUseCase,
 ) : ViewModel() {
 

--- a/app/src/main/kotlin/com/wire/android/ui/debug/featureflags/DebugFeatureFlagsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/featureflags/DebugFeatureFlagsScreen.kt
@@ -28,9 +28,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
+import com.wire.android.ui.debug.debugFeatureFlagsViewModel
 import com.wire.android.ui.common.rememberTopBarElevationState
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.NavigationIconType
@@ -43,7 +43,7 @@ import com.wire.android.ui.common.typography
 fun DebugFeatureFlagsScreen(
     navigator: Navigator,
     modifier: Modifier = Modifier,
-    viewModel: DebugFeatureFlagsViewModel = wireViewModel(),
+    viewModel: DebugFeatureFlagsViewModel = debugFeatureFlagsViewModel(),
 ) {
     val scrollState = rememberScrollState()
 

--- a/app/src/main/kotlin/com/wire/android/ui/debug/featureflags/DebugFeatureFlagsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/featureflags/DebugFeatureFlagsViewModel.kt
@@ -24,16 +24,13 @@ import com.wire.kalium.logic.data.featureConfig.ChannelFeatureConfiguration
 import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.feature.debug.GetFeatureConfigResult
 import com.wire.kalium.logic.feature.debug.GetFeatureConfigUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
-import javax.inject.Inject
 
-@HiltViewModel
-class DebugFeatureFlagsViewModel @Inject constructor(
+class DebugFeatureFlagsViewModel(
     private val getFeatureConfig: GetFeatureConfigUseCase,
 ) : ViewModel() {
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/about/dependencies/DependenciesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/about/dependencies/DependenciesScreen.kt
@@ -29,9 +29,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
+import com.wire.android.ui.debug.dependenciesViewModel
 import com.wire.android.ui.common.rowitem.RowItemTemplate
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.scaffold.WireScaffold
@@ -46,7 +46,7 @@ import kotlinx.collections.immutable.persistentMapOf
 @WireRootDestination
 fun DependenciesScreen(
     navigator: Navigator,
-    viewModel: DependenciesViewModel = wireViewModel()
+    viewModel: DependenciesViewModel = dependenciesViewModel()
 ) {
     WireScaffold(topBar = {
         WireCenterAlignedTopAppBar(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/about/dependencies/DependenciesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/about/dependencies/DependenciesViewModel.kt
@@ -24,15 +24,11 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.util.getDependenciesVersion
-import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class DependenciesViewModel @Inject constructor(
-    @ApplicationContext val context: Context
+class DependenciesViewModel(
+    val context: Context
 ) : ViewModel() {
 
     var state: DependenciesState by mutableStateOf(DependenciesState())

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/about/licenses/LicensesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/about/licenses/LicensesScreen.kt
@@ -28,11 +28,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.wire.android.di.wireViewModel
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
+import com.wire.android.ui.debug.licensesViewModel
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 
@@ -40,7 +40,7 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 @Composable
 fun LicensesScreen(
     navigator: Navigator,
-    viewModel: LicensesViewModel = wireViewModel()
+    viewModel: LicensesViewModel = licensesViewModel()
 ) {
     WireScaffold(topBar = {
         WireCenterAlignedTopAppBar(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/about/licenses/LicensesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/about/licenses/LicensesViewModel.kt
@@ -25,15 +25,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.util.withContext
-import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class LicensesViewModel @Inject constructor(
-    @ApplicationContext context: Context
+class LicensesViewModel(
+    context: Context
 ) : ViewModel() {
 
     var state: LicensesState by mutableStateOf(LicensesState())

--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewScreen.kt
@@ -30,13 +30,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.di.wireViewModel
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.navigation.HomeDestination
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.handleNavigation
+import com.wire.android.ui.debug.whatsNewViewModel
 import com.wire.android.ui.home.HomeStateHolder
 import com.wire.android.util.ui.sectionWithElements
 import com.wire.android.util.ui.UIText
@@ -45,7 +45,7 @@ import com.wire.android.util.ui.UIText
 @Composable
 fun WhatsNewScreen(
     homeStateHolder: HomeStateHolder,
-    whatsNewViewModel: WhatsNewViewModel = wireViewModel()
+    whatsNewViewModel: WhatsNewViewModel = whatsNewViewModel()
 ) {
     val context = LocalContext.current
     WhatsNewScreenContent(

--- a/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/whatsnew/WhatsNewViewModel.kt
@@ -26,14 +26,11 @@ import androidx.lifecycle.viewModelScope
 import com.prof18.rssparser.RssParser
 import com.wire.android.R
 import com.wire.android.util.toMediumOnlyDateTime
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Locale
-import javax.inject.Inject
 
-@HiltViewModel
-class WhatsNewViewModel @Inject constructor(context: Context) : ViewModel() {
+class WhatsNewViewModel(context: Context) : ViewModel() {
     private val rssParser = RssParser()
     private val publishDateFormat = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss", Locale.ENGLISH)
 

--- a/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.navigation.NavigationCommand
@@ -44,6 +43,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.debug.aboutThisAppViewModel
 import com.wire.android.ui.home.settings.SettingsItem
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
@@ -52,7 +52,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 @Composable
 fun AboutThisAppScreen(
     navigator: Navigator,
-    viewModel: AboutThisAppViewModel = wireViewModel()
+    viewModel: AboutThisAppViewModel = aboutThisAppViewModel()
 ) {
     val context = LocalContext.current
     AboutThisAppContent(

--- a/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/about/AboutThisAppViewModel.kt
@@ -25,14 +25,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.util.AppNameUtil
 import com.wire.android.util.getGitBuildId
-import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class AboutThisAppViewModel @Inject constructor(
-    @ApplicationContext private val context: Context
+class AboutThisAppViewModel(
+    private val context: Context
 ) : ViewModel() {
 
     var state by mutableStateOf(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25946
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Migrates debug, about, dependencies, licenses, and what's-new ViewModel creation to the Metro ViewModel boundary.
- Adds `DebugInfoViewModelFactory` and `DebugInfoViewModelGraph`.
- Wires the new graph through `WireActivityViewModelGraphBridge`.
- Removes Hilt ViewModel annotations and Hilt Compose call sites from this slice.
