### PR TITLE
refactor: settings account metro boundary [WPB-25946]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/metro/ImageAssetViewModelGraphBridgeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/ImageAssetViewModelGraphBridgeViewModel.kt
@@ -20,6 +20,8 @@ package com.wire.android.di.metro
 import androidx.lifecycle.ViewModel
 import com.wire.android.model.ImageAssetViewModelFactory
 import com.wire.android.model.ImageAssetViewModelGraph
+import com.wire.android.ui.home.settings.SettingsViewModelFactory
+import com.wire.android.ui.home.settings.SettingsViewModelGraph
 import com.wire.android.util.ui.WireSessionImageLoader
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -31,7 +33,11 @@ import javax.inject.Provider
 @HiltViewModel
 class ImageAssetViewModelGraphBridgeViewModel @Inject constructor(
     imageLoader: Provider<WireSessionImageLoader>,
-) : ViewModel(), ImageAssetViewModelGraph {
+    private val settingsViewModelFactoryProvider: Provider<SettingsViewModelFactory>,
+) : ViewModel(), ImageAssetViewModelGraph, SettingsViewModelGraph {
     override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
         ImageAssetViewModelFactory(imageLoader = imageLoader::get)
+
+    override val settingsViewModelFactory: SettingsViewModelFactory
+        get() = settingsViewModelFactoryProvider.get()
 }

--- a/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
@@ -24,6 +24,8 @@ import com.wire.android.model.ImageAssetViewModelFactory
 import com.wire.android.model.ImageAssetViewModelGraph
 import com.wire.android.ui.debug.DebugInfoViewModelFactory
 import com.wire.android.ui.debug.DebugInfoViewModelGraph
+import com.wire.android.ui.home.settings.SettingsViewModelFactory
+import com.wire.android.ui.home.settings.SettingsViewModelGraph
 import com.wire.android.util.ui.WireSessionImageLoader
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -37,7 +39,8 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     imageLoader: Provider<WireSessionImageLoader>,
     private val cellsViewModelFactoryProvider: Provider<CellsViewModelFactory>,
     private val debugInfoViewModelFactoryProvider: Provider<DebugInfoViewModelFactory>,
-) : ViewModel(), ImageAssetViewModelGraph, CellsViewModelGraph, DebugInfoViewModelGraph {
+    private val settingsViewModelFactoryProvider: Provider<SettingsViewModelFactory>,
+) : ViewModel(), ImageAssetViewModelGraph, CellsViewModelGraph, DebugInfoViewModelGraph, SettingsViewModelGraph {
     override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
         ImageAssetViewModelFactory(imageLoader = imageLoader::get)
 
@@ -46,4 +49,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
 
     override val debugInfoViewModelFactory: DebugInfoViewModelFactory
         get() = debugInfoViewModelFactoryProvider.get()
+
+    override val settingsViewModelFactory: SettingsViewModelFactory
+        get() = settingsViewModelFactoryProvider.get()
 }

--- a/app/src/main/kotlin/com/wire/android/navigation/MainNavHost.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/MainNavHost.kt
@@ -55,7 +55,7 @@ import com.wire.android.ui.authentication.login.LoginNavArgs
 import com.wire.android.ui.authentication.login.email.LoginEmailViewModel
 import com.wire.android.ui.home.conversations.ConversationScreen
 import com.wire.android.ui.home.newconversation.NewConversationViewModel
-import com.wire.android.ui.userprofile.teammigration.TeamMigrationViewModel
+import com.wire.android.ui.home.settings.teamMigrationViewModel
 
 @OptIn(ExperimentalAnimationApi::class, ExperimentalSharedTransitionApi::class)
 @Composable
@@ -118,7 +118,7 @@ fun MainNavHost(
                         val parentEntry = remember(navBackStackEntry) {
                             navController.getBackStackEntry(PersonalToTeamMigrationGraph.route)
                         }
-                        dependency(wireViewModel<TeamMigrationViewModel>(parentEntry))
+                        dependency(teamMigrationViewModel(parentEntry))
                     }
                 },
                 manualComposableCallsBuilder = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockCodeScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextAlign
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.ui.LocalActivity
 import com.wire.android.ui.WireActivity
@@ -59,6 +58,7 @@ import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.rememberBottomBarElevationState
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.visbility.rememberVisibilityState
+import com.wire.android.ui.home.settings.forgotLockScreenViewModel
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -71,7 +71,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 @WireRootDestination
 @Composable
 fun ForgotLockCodeScreen(
-    viewModel: ForgotLockScreenViewModel = wireViewModel(),
+    viewModel: ForgotLockScreenViewModel = forgotLockScreenViewModel(),
 ) {
     val activity = LocalActivity.current
     val logoutOptionsDialogState = rememberVisibilityState<LogoutOptionsDialogState>()

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/forgot/ForgotLockScreenViewModel.kt
@@ -36,14 +36,12 @@ import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @Suppress("LongParameterList")
-@HiltViewModel
 class ForgotLockScreenViewModel @Inject constructor(
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val globalDataStore: GlobalDataStore,

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.input.ImeAction
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.rememberNavigator
@@ -65,6 +64,7 @@ import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.home.settings.setLockScreenViewModel
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -78,7 +78,7 @@ import java.util.Locale
 @Composable
 fun SetLockCodeScreen(
     navigator: Navigator,
-    viewModel: SetLockScreenViewModel = wireViewModel(),
+    viewModel: SetLockScreenViewModel = setLockScreenViewModel(),
 ) {
     SetLockCodeScreenContent(
         navigator = navigator,

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockScreenViewModel.kt
@@ -31,14 +31,12 @@ import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.feature.applock.MarkTeamAppLockStatusAsNotifiedUseCase
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
 import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-@HiltViewModel
 class SetLockScreenViewModel @Inject constructor(
     private val validatePassword: ValidatePasswordUseCase,
     private val globalDataStore: GlobalDataStore,

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/unlock/AppUnlockWithBiometricsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/unlock/AppUnlockWithBiometricsScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.biometric.showBiometricPrompt
@@ -44,12 +43,13 @@ import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.ramcosta.composedestinations.generated.app.destinations.EnterLockCodeScreenDestination
+import com.wire.android.ui.home.settings.appUnlockWithBiometricsViewModel
 
 @WireRootDestination
 @Composable
 fun AppUnlockWithBiometricsScreen(
     navigator: Navigator,
-    appUnlockWithBiometricsViewModel: AppUnlockWithBiometricsViewModel = wireViewModel()
+    appUnlockWithBiometricsViewModel: AppUnlockWithBiometricsViewModel = appUnlockWithBiometricsViewModel()
 ) {
     AppUnLockBackground()
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/unlock/AppUnlockWithBiometricsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/unlock/AppUnlockWithBiometricsViewModel.kt
@@ -19,10 +19,8 @@ package com.wire.android.ui.home.appLock.unlock
 
 import androidx.lifecycle.ViewModel
 import com.wire.android.ui.home.appLock.LockCodeTimeManager
-import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
-@HiltViewModel
 class AppUnlockWithBiometricsViewModel @Inject constructor(
     private val lockCodeTimeManager: LockCodeTimeManager
 ) : ViewModel() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/unlock/EnterLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/unlock/EnterLockCodeScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.input.ImeAction
-import com.wire.android.di.wireViewModel
 import com.ramcosta.composedestinations.utils.destination
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
@@ -63,6 +62,7 @@ import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.ramcosta.composedestinations.generated.app.destinations.AppUnlockWithBiometricsScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.ForgotLockCodeScreenDestination
+import com.wire.android.ui.home.settings.enterLockScreenViewModel
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -74,7 +74,7 @@ import java.util.Locale
 @Composable
 fun EnterLockCodeScreen(
     navigator: Navigator,
-    viewModel: EnterLockScreenViewModel = wireViewModel(),
+    viewModel: EnterLockScreenViewModel = enterLockScreenViewModel(),
 ) {
     EnterLockCodeScreenContent(
         state = viewModel.state,

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/unlock/EnterLockScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/unlock/EnterLockScreenViewModel.kt
@@ -29,14 +29,12 @@ import com.wire.android.ui.home.appLock.LockCodeTimeManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.sha256
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-@HiltViewModel
 class EnterLockScreenViewModel @Inject constructor(
     private val validatePassword: ValidatePasswordUseCase,
     private val globalDataStore: GlobalDataStore,

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import com.wire.android.di.wireViewModel
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.appLogger
@@ -50,7 +49,7 @@ import com.wire.android.util.ui.UIText
 @Composable
 fun SettingsScreen(
     homeStateHolder: HomeStateHolder,
-    viewModel: SettingsViewModel = wireViewModel()
+    viewModel: SettingsViewModel = settingsScreenViewModel()
 ) {
     val turnAppLockOffDialogState = rememberVisibilityState<Unit>()
     val onAppLockSwitchClicked: (Boolean) -> Unit = remember {

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModel.kt
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.home.settings
-
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -27,15 +25,12 @@ import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-@HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val globalDataStore: GlobalDataStore,
     private val observeIsAppLockEditable: ObserveIsAppLockEditableUseCase,
@@ -44,7 +39,6 @@ class SettingsViewModel @Inject constructor(
 ) : ViewModel() {
     var state by mutableStateOf(SettingsState())
         private set
-
     init {
         viewModelScope.launch {
             combine(
@@ -62,18 +56,15 @@ class SettingsViewModel @Inject constructor(
             fetchSelfUser()
         }
     }
-
     fun disableAppLock() {
         viewModelScope.launch {
             globalDataStore.clearAppLockPasscode()
         }
     }
-
     private suspend fun fetchSelfUser() {
         viewModelScope.launch {
             val self =
                 getSelf().flowOn(dispatchers.io()).shareIn(this, SharingStarted.WhileSubscribed(1))
-
             self.collect { user ->
                 state = state.copy(userName = user.name ?: "")
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModelFactory.kt
@@ -1,0 +1,227 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.settings
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.di.CurrentAccount
+import com.wire.android.feature.analytics.AnonymousAnalyticsManager
+import com.wire.android.mapper.UserTypeMapper
+import com.wire.android.ui.home.appLock.forgot.ForgotLockScreenViewModel
+import com.wire.android.ui.home.appLock.set.SetLockScreenViewModel
+import com.wire.android.ui.home.appLock.unlock.AppUnlockWithBiometricsViewModel
+import com.wire.android.ui.home.appLock.unlock.EnterLockScreenViewModel
+import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveConversationRoleForUserUseCase
+import com.wire.android.ui.home.settings.account.MyAccountViewModel
+import com.wire.android.ui.home.settings.account.color.ChangeUserColorViewModel
+import com.wire.android.ui.home.settings.account.deleteAccount.DeleteAccountViewModel
+import com.wire.android.ui.home.settings.account.displayname.ChangeDisplayNameViewModel
+import com.wire.android.ui.home.settings.account.email.updateEmail.ChangeEmailViewModel
+import com.wire.android.ui.home.settings.account.email.verifyEmail.VerifyEmailViewModel
+import com.wire.android.ui.home.settings.account.handle.ChangeHandleViewModel
+import com.wire.android.ui.home.settings.appearance.CustomizationViewModel
+import com.wire.android.ui.home.settings.appsettings.networkSettings.NetworkSettingsViewModel
+import com.wire.android.ui.home.settings.backup.BackupAndRestoreViewModel
+import com.wire.android.ui.home.settings.privacy.PrivacySettingsViewModel
+import com.wire.android.ui.settings.devices.DeviceDetailsViewModel
+import com.wire.android.ui.settings.devices.SelfDevicesViewModel
+import com.wire.android.ui.settings.devices.e2ei.E2eiCertificateDetailsViewModel
+import com.wire.android.ui.userprofile.avatarpicker.AvatarPickerViewModel
+import com.wire.android.ui.userprofile.other.OtherUserProfileScreenViewModel
+import com.wire.android.ui.userprofile.qr.SelfQRCodeViewModel
+import com.wire.android.ui.userprofile.self.SelfUserProfileViewModel
+import com.wire.android.ui.userprofile.service.ServiceDetailsViewModelImpl
+import com.wire.android.ui.userprofile.teammigration.TeamMigrationViewModel
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.app.GetAppByIdUseCase
+import com.wire.kalium.logic.feature.app.ObserveIsAppMemberUseCase
+import com.wire.kalium.logic.feature.client.ClientFingerprintUseCase
+import com.wire.kalium.logic.feature.client.DeleteClientUseCase
+import com.wire.kalium.logic.feature.client.FetchUsersClientsFromRemoteUseCase
+import com.wire.kalium.logic.feature.client.ObserveClientDetailsUseCase
+import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
+import com.wire.kalium.logic.feature.client.UpdateClientVerificationStatusUseCase
+import com.wire.kalium.logic.feature.conversation.AddMemberToConversationUseCase
+import com.wire.kalium.logic.feature.conversation.AddServiceToConversationUseCase
+import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
+import com.wire.kalium.logic.feature.conversation.IsOneToOneConversationCreatedUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
+import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
+import com.wire.kalium.logic.feature.debug.BreakSessionUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.GetMLSClientIdentityUseCase as GetE2EIMLSClientIdentityUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.IsOtherUserE2EIVerifiedUseCase
+import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppsAllowedForUsageUseCase
+import com.wire.kalium.logic.feature.service.GetServiceByIdUseCase
+import com.wire.kalium.logic.feature.service.ObserveIsServiceMemberUseCase
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
+import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
+import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
+import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
+import com.wire.kalium.logic.feature.user.UpdateEmailUseCase
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Provider
+
+@Suppress("LongParameterList", "TooManyFunctions")
+class SettingsViewModelFactory @Inject constructor(
+    private val settingsViewModel: Provider<SettingsViewModel>,
+    private val myAccountViewModel: Provider<MyAccountViewModel>,
+    private val deleteAccountViewModel: Provider<DeleteAccountViewModel>,
+    private val changeDisplayNameViewModel: Provider<ChangeDisplayNameViewModel>,
+    private val changeUserColorViewModel: Provider<ChangeUserColorViewModel>,
+    private val changeEmailViewModel: Provider<ChangeEmailViewModel>,
+    private val changeHandleViewModel: Provider<ChangeHandleViewModel>,
+    private val customizationViewModel: Provider<CustomizationViewModel>,
+    private val networkSettingsViewModel: Provider<NetworkSettingsViewModel>,
+    private val privacySettingsViewModel: Provider<PrivacySettingsViewModel>,
+    private val backupAndRestoreViewModel: Provider<BackupAndRestoreViewModel>,
+    private val setLockScreenViewModel: Provider<SetLockScreenViewModel>,
+    private val forgotLockScreenViewModel: Provider<ForgotLockScreenViewModel>,
+    private val appUnlockWithBiometricsViewModel: Provider<AppUnlockWithBiometricsViewModel>,
+    private val enterLockScreenViewModel: Provider<EnterLockScreenViewModel>,
+    private val selfDevicesViewModel: Provider<SelfDevicesViewModel>,
+    private val avatarPickerViewModel: Provider<AvatarPickerViewModel>,
+    private val selfUserProfileViewModel: Provider<SelfUserProfileViewModel>,
+    private val teamMigrationViewModel: Provider<TeamMigrationViewModel>,
+    private val updateEmail: Provider<UpdateEmailUseCase>,
+    private val getSelfUser: Provider<GetSelfUserUseCase>,
+    @CurrentAccount private val currentUserId: Provider<UserId>,
+    private val deleteClient: Provider<DeleteClientUseCase>,
+    private val observeClientDetails: Provider<ObserveClientDetailsUseCase>,
+    private val isPasswordRequired: Provider<IsPasswordRequiredUseCase>,
+    private val fingerprintUseCase: Provider<ClientFingerprintUseCase>,
+    private val updateClientVerificationStatus: Provider<UpdateClientVerificationStatusUseCase>,
+    private val observeUserInfo: Provider<ObserveUserInfoUseCase>,
+    private val mlsClientIdentity: Provider<GetE2EIMLSClientIdentityUseCase>,
+    private val breakSession: Provider<BreakSessionUseCase>,
+    private val isE2EIEnabledUseCase: Provider<IsE2EIEnabledUseCase>,
+    @ApplicationContext private val context: Provider<Context>,
+    private val selfServerLinks: Provider<SelfServerConfigUseCase>,
+    private val kaliumFileSystem: Provider<KaliumFileSystem>,
+    private val dispatchers: Provider<DispatcherProvider>,
+    private val analyticsManager: Provider<AnonymousAnalyticsManager>,
+    private val userTypeMapper: Provider<UserTypeMapper>,
+    private val observeConversationRoleForUser: Provider<ObserveConversationRoleForUserUseCase>,
+    private val removeMemberFromConversation: Provider<RemoveMemberFromConversationUseCase>,
+    private val updateMemberRole: Provider<UpdateConversationMemberRoleUseCase>,
+    private val observeClientList: Provider<ObserveClientsByUserIdUseCase>,
+    private val fetchUsersClients: Provider<FetchUsersClientsFromRemoteUseCase>,
+    private val getUserE2eiCertificateStatus: Provider<IsOtherUserE2EIVerifiedUseCase>,
+    private val isOneToOneConversationCreated: Provider<IsOneToOneConversationCreatedUseCase>,
+    private val getServiceById: Provider<GetServiceByIdUseCase>,
+    private val getAppById: Provider<GetAppByIdUseCase>,
+    private val observeConversationDetails: Provider<ObserveConversationDetailsUseCase>,
+    private val observeIsServiceMember: Provider<ObserveIsServiceMemberUseCase>,
+    private val observeIsAppMember: Provider<ObserveIsAppMemberUseCase>,
+    private val observeIsAppsAllowedForUsage: Provider<ObserveIsAppsAllowedForUsageUseCase>,
+    private val addServiceToConversation: Provider<AddServiceToConversationUseCase>,
+    private val addMemberToConversation: Provider<AddMemberToConversationUseCase>,
+    private val getOrCreateOneToOneConversation: Provider<GetOrCreateOneToOneConversationUseCase>,
+) {
+    fun settingsViewModel() = settingsViewModel.get()
+    fun myAccountViewModel() = myAccountViewModel.get()
+    fun deleteAccountViewModel() = deleteAccountViewModel.get()
+    fun changeDisplayNameViewModel() = changeDisplayNameViewModel.get()
+    fun changeUserColorViewModel() = changeUserColorViewModel.get()
+    fun changeEmailViewModel() = changeEmailViewModel.get()
+    fun changeHandleViewModel() = changeHandleViewModel.get()
+    fun customizationViewModel() = customizationViewModel.get()
+    fun networkSettingsViewModel() = networkSettingsViewModel.get()
+    fun privacySettingsViewModel() = privacySettingsViewModel.get()
+    fun backupAndRestoreViewModel() = backupAndRestoreViewModel.get()
+    fun setLockScreenViewModel() = setLockScreenViewModel.get()
+    fun forgotLockScreenViewModel() = forgotLockScreenViewModel.get()
+    fun appUnlockWithBiometricsViewModel() = appUnlockWithBiometricsViewModel.get()
+    fun enterLockScreenViewModel() = enterLockScreenViewModel.get()
+    fun selfDevicesViewModel() = selfDevicesViewModel.get()
+    fun avatarPickerViewModel() = avatarPickerViewModel.get()
+    fun selfUserProfileViewModel() = selfUserProfileViewModel.get()
+    fun teamMigrationViewModel() = teamMigrationViewModel.get()
+
+    fun verifyEmailViewModel(savedStateHandle: SavedStateHandle) = VerifyEmailViewModel(
+        updateEmail = updateEmail.get(),
+        savedStateHandle = savedStateHandle,
+    )
+
+    fun e2eiCertificateDetailsViewModel(savedStateHandle: SavedStateHandle) = E2eiCertificateDetailsViewModel(
+        savedStateHandle = savedStateHandle,
+        getSelfUser = getSelfUser.get(),
+    )
+
+    fun deviceDetailsViewModel(savedStateHandle: SavedStateHandle) = DeviceDetailsViewModel(
+        savedStateHandle = savedStateHandle,
+        currentUserId = currentUserId.get(),
+        deleteClient = deleteClient.get(),
+        observeClientDetails = observeClientDetails.get(),
+        isPasswordRequired = isPasswordRequired.get(),
+        fingerprintUseCase = fingerprintUseCase.get(),
+        updateClientVerificationStatus = updateClientVerificationStatus.get(),
+        observeUserInfo = observeUserInfo.get(),
+        mlsClientIdentity = mlsClientIdentity.get(),
+        breakSession = breakSession.get(),
+        isE2EIEnabledUseCase = isE2EIEnabledUseCase.get(),
+    )
+
+    fun selfQRCodeViewModel(savedStateHandle: SavedStateHandle) = SelfQRCodeViewModel(
+        savedStateHandle = savedStateHandle,
+        context = context.get(),
+        selfUserId = currentUserId.get(),
+        selfServerLinks = selfServerLinks.get(),
+        kaliumFileSystem = kaliumFileSystem.get(),
+        dispatchers = dispatchers.get(),
+        analyticsManager = analyticsManager.get(),
+    )
+
+    fun otherUserProfileScreenViewModel(savedStateHandle: SavedStateHandle) = OtherUserProfileScreenViewModel(
+        dispatchers = dispatchers.get(),
+        observeUserInfo = observeUserInfo.get(),
+        userTypeMapper = userTypeMapper.get(),
+        observeConversationRoleForUser = observeConversationRoleForUser.get(),
+        removeMemberFromConversation = removeMemberFromConversation.get(),
+        updateMemberRole = updateMemberRole.get(),
+        observeClientList = observeClientList.get(),
+        fetchUsersClients = fetchUsersClients.get(),
+        getUserE2eiCertificateStatus = getUserE2eiCertificateStatus.get(),
+        isOneToOneConversationCreated = isOneToOneConversationCreated.get(),
+        mlsClientIdentity = mlsClientIdentity.get(),
+        isE2EIEnabled = isE2EIEnabledUseCase.get(),
+        savedStateHandle = savedStateHandle,
+    )
+
+    fun serviceDetailsViewModel(savedStateHandle: SavedStateHandle) = ServiceDetailsViewModelImpl(
+        dispatchers = dispatchers.get(),
+        selfUserId = currentUserId.get(),
+        getServiceById = getServiceById.get(),
+        getAppById = getAppById.get(),
+        observeConversationDetails = observeConversationDetails.get(),
+        observeIsServiceMember = observeIsServiceMember.get(),
+        observeIsAppMember = observeIsAppMember.get(),
+        observeIsAppsAllowedForUsage = observeIsAppsAllowedForUsage.get(),
+        observeConversationRoleForUser = observeConversationRoleForUser.get(),
+        removeMemberFromConversation = removeMemberFromConversation.get(),
+        addServiceToConversation = addServiceToConversation.get(),
+        addMemberToConversation = addMemberToConversation.get(),
+        isOneToOneConversationCreated = isOneToOneConversationCreated.get(),
+        getOrCreateOneToOneConversation = getOrCreateOneToOneConversation.get(),
+        savedStateHandle = savedStateHandle,
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModelGraph.kt
@@ -1,0 +1,169 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+@file:Suppress("TooManyFunctions")
+
+package com.wire.android.ui.home.settings
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import com.wire.android.di.metro.MetroViewModelGraph
+import com.wire.android.di.metro.metroSavedStateViewModel
+import com.wire.android.di.metro.metroViewModel
+import com.wire.android.ui.home.appLock.forgot.ForgotLockScreenViewModel
+import com.wire.android.ui.home.appLock.set.SetLockScreenViewModel
+import com.wire.android.ui.home.appLock.unlock.AppUnlockWithBiometricsViewModel
+import com.wire.android.ui.home.appLock.unlock.EnterLockScreenViewModel
+import com.wire.android.ui.home.settings.account.MyAccountViewModel
+import com.wire.android.ui.home.settings.account.color.ChangeUserColorViewModel
+import com.wire.android.ui.home.settings.account.deleteAccount.DeleteAccountViewModel
+import com.wire.android.ui.home.settings.account.displayname.ChangeDisplayNameViewModel
+import com.wire.android.ui.home.settings.account.email.updateEmail.ChangeEmailViewModel
+import com.wire.android.ui.home.settings.account.email.verifyEmail.VerifyEmailViewModel
+import com.wire.android.ui.home.settings.account.handle.ChangeHandleViewModel
+import com.wire.android.ui.home.settings.appearance.CustomizationViewModel
+import com.wire.android.ui.home.settings.appsettings.networkSettings.NetworkSettingsViewModel
+import com.wire.android.ui.home.settings.backup.BackupAndRestoreViewModel
+import com.wire.android.ui.home.settings.privacy.PrivacySettingsViewModel
+import com.wire.android.ui.settings.devices.DeviceDetailsViewModel
+import com.wire.android.ui.settings.devices.SelfDevicesViewModel
+import com.wire.android.ui.settings.devices.e2ei.E2eiCertificateDetailsViewModel
+import com.wire.android.ui.userprofile.avatarpicker.AvatarPickerViewModel
+import com.wire.android.ui.userprofile.other.OtherUserProfileScreenViewModel
+import com.wire.android.ui.userprofile.qr.SelfQRCodeViewModel
+import com.wire.android.ui.userprofile.self.SelfUserProfileViewModel
+import com.wire.android.ui.userprofile.service.ServiceDetailsViewModel
+import com.wire.android.ui.userprofile.service.ServiceDetailsViewModelImpl
+import com.wire.android.ui.userprofile.teammigration.TeamMigrationViewModel
+
+interface SettingsViewModelGraph : MetroViewModelGraph {
+    val settingsViewModelFactory: SettingsViewModelFactory
+}
+
+@Composable
+inline fun <reified VM> settingsViewModel(
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+    key: String? = null,
+    crossinline create: SettingsViewModelFactory.() -> VM,
+): VM where VM : ViewModel =
+    metroViewModel<SettingsViewModelGraph, VM>(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = key,
+    ) {
+        settingsViewModelFactory.create()
+    }
+
+@Composable
+inline fun <reified VM> settingsSavedStateViewModel(
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+    key: String? = null,
+    crossinline create: SettingsViewModelFactory.(SavedStateHandle) -> VM,
+): VM where VM : ViewModel =
+    metroSavedStateViewModel<SettingsViewModelGraph, VM>(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = key,
+    ) { savedStateHandle ->
+        settingsViewModelFactory.create(savedStateHandle)
+    }
+
+@Composable
+fun settingsScreenViewModel(): SettingsViewModel = settingsViewModel { settingsViewModel() }
+
+@Composable
+fun myAccountViewModel(): MyAccountViewModel = settingsViewModel { myAccountViewModel() }
+
+@Composable
+fun deleteAccountViewModel(): DeleteAccountViewModel = settingsViewModel { deleteAccountViewModel() }
+
+@Composable
+fun changeDisplayNameViewModel(): ChangeDisplayNameViewModel = settingsViewModel { changeDisplayNameViewModel() }
+
+@Composable
+fun changeUserColorViewModel(): ChangeUserColorViewModel = settingsViewModel { changeUserColorViewModel() }
+
+@Composable
+fun changeEmailViewModel(): ChangeEmailViewModel = settingsViewModel { changeEmailViewModel() }
+
+@Composable
+fun verifyEmailViewModel(): VerifyEmailViewModel = settingsSavedStateViewModel { verifyEmailViewModel(it) }
+
+@Composable
+fun changeHandleViewModel(): ChangeHandleViewModel = settingsViewModel { changeHandleViewModel() }
+
+@Composable
+fun customizationViewModel(): CustomizationViewModel = settingsViewModel { customizationViewModel() }
+
+@Composable
+fun networkSettingsViewModel(): NetworkSettingsViewModel = settingsViewModel { networkSettingsViewModel() }
+
+@Composable
+fun privacySettingsViewModel(): PrivacySettingsViewModel = settingsViewModel { privacySettingsViewModel() }
+
+@Composable
+fun backupAndRestoreViewModel(): BackupAndRestoreViewModel = settingsViewModel { backupAndRestoreViewModel() }
+
+@Composable
+fun setLockScreenViewModel(): SetLockScreenViewModel = settingsViewModel { setLockScreenViewModel() }
+
+@Composable
+fun forgotLockScreenViewModel(): ForgotLockScreenViewModel = settingsViewModel { forgotLockScreenViewModel() }
+
+@Composable
+fun appUnlockWithBiometricsViewModel(): AppUnlockWithBiometricsViewModel =
+    settingsViewModel { appUnlockWithBiometricsViewModel() }
+
+@Composable
+fun enterLockScreenViewModel(): EnterLockScreenViewModel = settingsViewModel { enterLockScreenViewModel() }
+
+@Composable
+fun selfDevicesViewModel(): SelfDevicesViewModel = settingsViewModel { selfDevicesViewModel() }
+
+@Composable
+fun deviceDetailsViewModel(): DeviceDetailsViewModel = settingsSavedStateViewModel { deviceDetailsViewModel(it) }
+
+@Composable
+fun e2eiCertificateDetailsViewModel(): E2eiCertificateDetailsViewModel =
+    settingsSavedStateViewModel { e2eiCertificateDetailsViewModel(it) }
+
+@Composable
+fun avatarPickerViewModel(): AvatarPickerViewModel = settingsViewModel { avatarPickerViewModel() }
+
+@Composable
+fun selfUserProfileViewModel(): SelfUserProfileViewModel = settingsViewModel { selfUserProfileViewModel() }
+
+@Composable
+fun selfQRCodeViewModel(): SelfQRCodeViewModel = settingsSavedStateViewModel { selfQRCodeViewModel(it) }
+
+@Composable
+fun teamMigrationViewModel(
+    viewModelStoreOwner: ViewModelStoreOwner,
+): TeamMigrationViewModel = settingsViewModel(viewModelStoreOwner = viewModelStoreOwner) { teamMigrationViewModel() }
+
+@Composable
+fun otherUserProfileScreenViewModel(): OtherUserProfileScreenViewModel =
+    settingsSavedStateViewModel { otherUserProfileScreenViewModel(it) }
+
+@Composable
+fun serviceDetailsViewModel(): ServiceDetailsViewModel =
+    settingsSavedStateViewModel<ServiceDetailsViewModelImpl> { serviceDetailsViewModel(it) }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountScreen.kt
@@ -42,7 +42,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.deleteAccountViewModel
+import com.wire.android.ui.home.settings.myAccountViewModel
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultRecipient
 import com.ramcosta.composedestinations.spec.DestinationSpec
@@ -94,8 +95,8 @@ fun MyAccountScreen(
     changeDisplayNameResultRecipient: ResultRecipient<ChangeDisplayNameScreenDestination, Boolean>,
     changeHandleResultRecipient: ResultRecipient<ChangeHandleScreenDestination, Boolean>,
     changeUserColorResultRecipient: ResultRecipient<ChangeUserColorScreenDestination, Boolean>,
-    viewModel: MyAccountViewModel = wireViewModel(),
-    deleteAccountViewModel: DeleteAccountViewModel = wireViewModel()
+    viewModel: MyAccountViewModel = myAccountViewModel(),
+    deleteAccountViewModel: DeleteAccountViewModel = deleteAccountViewModel()
 ) {
     val snackbarHostState = LocalSnackbarHostState.current
     val scope = rememberCoroutineScope()

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/MyAccountViewModel.kt
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.home.settings.account
-
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,7 +33,6 @@ import com.wire.kalium.logic.feature.user.IsSelfATeamMemberUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserWithTeamUseCase
 import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
@@ -46,9 +43,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import kotlin.properties.Delegates
-
 @Suppress("LongParameterList")
-@HiltViewModel
 class MyAccountViewModel @Inject constructor(
     private val getSelf: ObserveSelfUserUseCase,
     private val observeSelfUserWithTeam: ObserveSelfUserWithTeamUseCase,
@@ -59,7 +54,6 @@ class MyAccountViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val isE2EIEnabledUseCase: IsE2EIEnabledUseCase
 ) : ViewModel() {
-
     var myAccountState by mutableStateOf(MyAccountState())
         private set
 
@@ -74,7 +68,6 @@ class MyAccountViewModel @Inject constructor(
 
     init {
         initScreenState()
-
         runBlocking {
             hasSAMLCred = when (val result = isPasswordRequired()) {
                 is IsPasswordRequiredUseCase.Result.Failure -> false
@@ -82,7 +75,6 @@ class MyAccountViewModel @Inject constructor(
                     !result.value
                 }
             }
-
             // is the account is read only it means it is not maneged by wire
             managedByWire = !isReadOnlyAccount()
             isE2EIEnabled = isE2EIEnabledUseCase()
@@ -92,14 +84,12 @@ class MyAccountViewModel @Inject constructor(
             isEditNameAllowed = managedByWire && !isE2EIEnabled,
             isEditHandleAllowed = managedByWire && !isE2EIEnabled
         )
-
         viewModelScope.launch {
             if (!hasSAMLCred) {
                 loadChangePasswordUrl()
             }
         }
     }
-
     private fun initScreenState() {
         viewModelScope.launch {
             initCanDeleteAccountValue()
@@ -109,22 +99,18 @@ class MyAccountViewModel @Inject constructor(
         }
         fetchSelfUserTeam()
     }
-
     private suspend fun loadChangePasswordUrl() {
         when (val result = withContext(dispatchers.io()) { serverConfig() }) {
             is SelfServerConfigUseCase.Result.Failure -> appLogger.e(
                 "Error when fetching the accounts url for change password"
             )
-
             is SelfServerConfigUseCase.Result.Success ->
                 myAccountState = myAccountState.copy(changePasswordUrl = result.serverLinks.links.forgotPassword)
         }
     }
-
     private fun fetchSelfUser() {
         viewModelScope.launch {
             val self = getSelf().flowOn(dispatchers.io()).shareIn(this, SharingStarted.WhileSubscribed(1))
-
             self.collect { user ->
                 myAccountState = myAccountState.copy(
                     fullName = user.name.orEmpty(),
@@ -136,14 +122,12 @@ class MyAccountViewModel @Inject constructor(
             }
         }
     }
-
     private suspend fun initCanDeleteAccountValue() {
         val canDeleteAccount = !isSelfATeamMember()
         myAccountState = myAccountState.copy(
             canDeleteAccount = canDeleteAccount,
         )
     }
-
     private fun fetchSelfUserTeam() {
         viewModelScope.launch {
             observeSelfUserWithTeam()
@@ -157,7 +141,6 @@ class MyAccountViewModel @Inject constructor(
                 }
         }
     }
-
     companion object {
         /**
          * This is a build time flag that allows to enable/disable the change email feature.

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/color/ChangeUserColorScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/color/ChangeUserColorScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.changeUserColorViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.BuildConfig.IS_BUBBLE_UI_ENABLED
@@ -83,7 +83,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 fun ChangeUserColorScreen(
     navigator: Navigator,
     resultNavigator: ResultBackNavigator<Boolean>,
-    viewModel: ChangeUserColorViewModel = wireViewModel()
+    viewModel: ChangeUserColorViewModel = changeUserColorViewModel()
 ) {
     with(viewModel) {
         ChangeUserColorContent(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/color/ChangeUserColorViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/color/ChangeUserColorViewModel.kt
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.home.settings.account.color
-
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -27,19 +25,14 @@ import com.wire.android.ui.theme.Accent
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.UpdateAccentColorResult
 import com.wire.kalium.logic.feature.user.UpdateAccentColorUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-@HiltViewModel
 class ChangeUserColorViewModel @Inject constructor(
     private val getSelf: GetSelfUserUseCase,
     private val updateAccentColor: UpdateAccentColorUseCase,
 ) : ActionsViewModel<ChangeUserColorAction>() {
-
     var accentState: AccentActionState by mutableStateOf(AccentActionState(null))
         private set
-
     init {
         viewModelScope.launch {
             getSelf()?.accentId.let { accentId ->
@@ -49,11 +42,9 @@ class ChangeUserColorViewModel @Inject constructor(
             }
         }
     }
-
     fun changeAccentColor(accent: Accent) {
         accentState = accentState.copy(accent = accent)
     }
-
     fun saveAccentColor() {
         viewModelScope.launch {
             accentState.accent?.let { accent ->
@@ -72,12 +63,10 @@ class ChangeUserColorViewModel @Inject constructor(
         }
     }
 }
-
 data class AccentActionState(
     val accent: Accent?,
     val isPerformingAction: Boolean = false,
 )
-
 enum class ChangeUserColorAction {
     Success,
     Failure

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/deleteAccount/DeleteAccountViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/deleteAccount/DeleteAccountViewModel.kt
@@ -16,33 +16,25 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 package com.wire.android.ui.home.settings.account.deleteAccount
-
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.kalium.logic.feature.user.DeleteAccountUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-@HiltViewModel
 class DeleteAccountViewModel @Inject constructor(
     private val deleteAccount: DeleteAccountUseCase,
 ) : ViewModel() {
-
     var state by mutableStateOf(DeleteAccountState())
         private set
-
     fun onDeleteAccountClicked() {
         state = state.copy(startDeleteAccountFlow = true)
     }
-
     fun onDeleteAccountDialogDismissed() {
         state = state.copy(startDeleteAccountFlow = false)
     }
-
     fun onDeleteAccountDialogConfirmed() {
         viewModelScope.launch {
             deleteAccount(null)

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.changeDisplayNameViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.R
@@ -74,7 +74,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 fun ChangeDisplayNameScreen(
     navigator: Navigator,
     resultNavigator: ResultBackNavigator<Boolean>,
-    viewModel: ChangeDisplayNameViewModel = wireViewModel()
+    viewModel: ChangeDisplayNameViewModel = changeDisplayNameViewModel()
 ) {
     with(viewModel) {
         LaunchedEffect(viewModel.displayNameState.completed) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/displayname/ChangeDisplayNameViewModel.kt
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.home.settings.account.displayname
-
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.getValue
@@ -30,21 +28,16 @@ import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.kalium.logic.feature.user.DisplayNameUpdateResult
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.UpdateDisplayNameUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-@HiltViewModel
 class ChangeDisplayNameViewModel @Inject constructor(
     private val getSelf: GetSelfUserUseCase,
     private val updateDisplayName: UpdateDisplayNameUseCase,
 ) : ViewModel() {
-
     val textState: TextFieldState = TextFieldState()
     var displayNameState: DisplayNameState by mutableStateOf(DisplayNameState())
         private set
-
     init {
         viewModelScope.launch {
             getSelf()?.name.orEmpty().let { currentDisplayName ->
@@ -62,7 +55,6 @@ class ChangeDisplayNameViewModel @Inject constructor(
             }
         }
     }
-
     fun saveDisplayName() {
         displayNameState = displayNameState.copy(loading = true)
         viewModelScope.launch {
@@ -78,7 +70,6 @@ class ChangeDisplayNameViewModel @Inject constructor(
                 }
         }
     }
-
     companion object {
         const val NAME_MAX_COUNT = 64
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/email/updateEmail/ChangeEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/email/updateEmail/ChangeEmailScreen.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.changeEmailViewModel
 import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.R
 import com.wire.android.navigation.BackStackMode
@@ -69,7 +69,7 @@ import com.wire.android.ui.common.R as commonR
 @Composable
 fun ChangeEmailScreen(
     navigator: Navigator,
-    viewModel: ChangeEmailViewModel = wireViewModel()
+    viewModel: ChangeEmailViewModel = changeEmailViewModel()
 ) {
     when (val flowState = viewModel.state.flowState) {
         is ChangeEmailState.FlowState.NoChange,

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/email/updateEmail/ChangeEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/email/updateEmail/ChangeEmailViewModel.kt
@@ -16,7 +16,6 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 package com.wire.android.ui.home.settings.account.email.updateEmail
-
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
@@ -29,22 +28,17 @@ import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.util.Patterns
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.UpdateEmailUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-@HiltViewModel
 class ChangeEmailViewModel @Inject constructor(
     private val updateEmail: UpdateEmailUseCase,
     private val getSelf: GetSelfUserUseCase,
 ) : ViewModel() {
-
     val textState: TextFieldState = TextFieldState()
     var state: ChangeEmailState by mutableStateOf(ChangeEmailState())
         @VisibleForTesting
         set
-
     init {
         viewModelScope.launch {
             getSelf()?.email?.let { currentEmail ->
@@ -61,7 +55,6 @@ class ChangeEmailViewModel @Inject constructor(
             }
         }
     }
-
     fun onSaveClicked() {
         state = state.copy(saveEnabled = false, flowState = ChangeEmailState.FlowState.Loading)
         viewModelScope.launch {
@@ -73,21 +66,18 @@ class ChangeEmailViewModel @Inject constructor(
                         saveEnabled = false,
                         flowState = ChangeEmailState.FlowState.Error.TextFieldError.AlreadyInUse,
                     )
-
                 UpdateEmailUseCase.Result.Failure.InvalidEmail ->
                     state =
                     state.copy(
                         saveEnabled = false,
                         flowState = ChangeEmailState.FlowState.Error.TextFieldError.InvalidEmail
                     )
-
                 is UpdateEmailUseCase.Result.Failure.GenericFailure ->
                     state =
                     state.copy(
                         saveEnabled = false,
                         flowState = ChangeEmailState.FlowState.Error.TextFieldError.Generic
                     )
-
                 is UpdateEmailUseCase.Result.Success.VerificationEmailSent ->
                     state = state.copy(flowState = ChangeEmailState.FlowState.Success(email))
                 is UpdateEmailUseCase.Result.Success.NoChange ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/email/verifyEmail/VerifyEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/email/verifyEmail/VerifyEmailScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.verifyEmailViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.button.WireButtonState.Default
@@ -57,7 +57,7 @@ import com.wire.android.util.ui.stringWithStyledArgs
 @Composable
 fun VerifyEmailScreen(
     navigator: Navigator,
-    viewModel: VerifyEmailViewModel = wireViewModel()
+    viewModel: VerifyEmailViewModel = verifyEmailViewModel()
 ) {
     LaunchedEffect(viewModel.state.noChange) {
         if (viewModel.state.noChange) navigator.navigateBack()

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/email/verifyEmail/VerifyEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/email/verifyEmail/VerifyEmailViewModel.kt
@@ -16,7 +16,6 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 package com.wire.android.ui.home.settings.account.email.verifyEmail
-
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -25,22 +24,16 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.kalium.logic.feature.user.UpdateEmailUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-@HiltViewModel
 class VerifyEmailViewModel @Inject constructor(
     private val updateEmail: UpdateEmailUseCase,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
-
     var state: VerifyEmailState by mutableStateOf(VerifyEmailState())
         private set
-
     private val verifyEmailNavArgs: VerifyEmailNavArgs = savedStateHandle.navArgs()
     val newEmail: String = verifyEmailNavArgs.newEmail
-
     fun onResendVerificationEmailClicked() {
         newEmail.let {
             state = state.copy(isResendEmailEnabled = false)
@@ -52,7 +45,6 @@ class VerifyEmailViewModel @Inject constructor(
                     UpdateEmailUseCase.Result.Success.VerificationEmailSent -> {
                         /*no-op*/
                     }
-
                     UpdateEmailUseCase.Result.Success.NoChange -> state = state.copy(noChange = true)
                 }
                 state = state.copy(isResendEmailEnabled = true)

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/handle/ChangeHandleScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/handle/ChangeHandleScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.changeHandleViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.R
@@ -63,7 +63,7 @@ import com.wire.android.ui.common.R as commonR
 fun ChangeHandleScreen(
     navigator: Navigator,
     resultNavigator: ResultBackNavigator<Boolean>,
-    viewModel: ChangeHandleViewModel = wireViewModel()
+    viewModel: ChangeHandleViewModel = changeHandleViewModel()
 ) {
     LaunchedEffect(viewModel.state.isSuccess) {
         if (viewModel.state.isSuccess) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/account/handle/ChangeHandleViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/account/handle/ChangeHandleViewModel.kt
@@ -16,7 +16,6 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 package com.wire.android.ui.home.settings.account.handle
-
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
@@ -32,23 +31,18 @@ import com.wire.kalium.logic.feature.auth.ValidateUserHandleUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.SetUserHandleResult
 import com.wire.kalium.logic.feature.user.SetUserHandleUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-@HiltViewModel
 class ChangeHandleViewModel @Inject constructor(
     private val updateHandle: SetUserHandleUseCase,
     private val validateHandle: ValidateUserHandleUseCase,
     private val getSelf: GetSelfUserUseCase
 ) : ViewModel() {
-
     val textState: TextFieldState = TextFieldState()
     var state: ChangeHandleState by mutableStateOf(ChangeHandleState())
         @VisibleForTesting
         set
-
     init {
         viewModelScope.launch {
             getSelf()?.handle.orEmpty().let { currentHandle ->
@@ -68,21 +62,16 @@ class ChangeHandleViewModel @Inject constructor(
             }
         }
     }
-
     fun onSaveClicked() {
         viewModelScope.launch {
             state = when (val result = updateHandle(textState.text.toString().trim())) {
                 is SetUserHandleResult.Failure.Generic -> state.copy(error = HandleUpdateErrorState.DialogError.GenericError(result.error))
-
                 SetUserHandleResult.Failure.HandleExists -> state.copy(error = HandleUpdateErrorState.TextFieldError.UsernameTakenError)
-
                 SetUserHandleResult.Failure.InvalidHandle -> state.copy(error = HandleUpdateErrorState.TextFieldError.UsernameInvalidError)
-
                 SetUserHandleResult.Success -> state.copy(isSuccess = true)
             }
         }
     }
-
     fun onErrorDismiss() {
         state = state.copy(error = HandleUpdateErrorState.None)
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appearance/CustomizationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appearance/CustomizationScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.customizationViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.dimensions
@@ -64,7 +64,7 @@ import com.wire.android.util.ui.UIText
 @Composable
 fun CustomizationScreen(
     navigator: Navigator,
-    viewModel: CustomizationViewModel = wireViewModel()
+    viewModel: CustomizationViewModel = customizationViewModel()
 ) {
     val lazyListState: LazyListState = rememberLazyListState()
     CustomizationScreenContent(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appearance/CustomizationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appearance/CustomizationViewModel.kt
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.home.settings.appearance
-
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -25,40 +23,32 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.ui.theme.ThemeOption
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-@HiltViewModel
 class CustomizationViewModel @Inject constructor(
     private val globalDataStore: GlobalDataStore,
 ) : ViewModel() {
     var state by mutableStateOf(CustomizationState())
         private set
-
     init {
         observeThemeState()
         observePressEnterToSendState()
     }
-
     private fun observePressEnterToSendState() {
         viewModelScope.launch {
             globalDataStore.enterToSendFlow().collect { state = state.copy(pressEnterToSentState = it) }
         }
     }
-
     private fun observeThemeState() {
         viewModelScope.launch {
             globalDataStore.selectedThemeOptionFlow().collect { option -> state = state.copy(selectedThemeOption = option) }
         }
     }
-
     fun selectPressEnterToSendOption(option: Boolean) {
         viewModelScope.launch {
             globalDataStore.setEnterToSend(option)
         }
     }
-
     fun selectThemeOption(option: ThemeOption) {
         viewModelScope.launch {
             globalDataStore.setThemeOption(option)

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.networkSettingsViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.dimensions
@@ -42,7 +42,7 @@ import com.wire.android.ui.theme.WireTheme
 @Composable
 fun NetworkSettingsScreen(
     navigator: Navigator,
-    networkSettingsViewModel: NetworkSettingsViewModel = wireViewModel()
+    networkSettingsViewModel: NetworkSettingsViewModel = networkSettingsViewModel()
 ) {
     NetworkSettingsScreenContent(
         onBackPressed = navigator::navigateBack,

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/networkSettings/NetworkSettingsViewModel.kt
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.home.settings.appsettings.networkSettings
-
 import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,12 +29,9 @@ import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import com.wire.kalium.logic.feature.user.webSocketStatus.PersistPersistentWebSocketConnectionStatusUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-@HiltViewModel
 class NetworkSettingsViewModel
 @Inject constructor(
     private val persistPersistentWebSocketConnectionStatus: PersistPersistentWebSocketConnectionStatusUseCase,
@@ -46,19 +41,16 @@ class NetworkSettingsViewModel
     @ApplicationContext private val context: Context
 ) : ViewModel() {
     var networkSettingsState by mutableStateOf(NetworkSettingsState())
-
     init {
         checkWebSocketEnforcedByDefault()
         observePersistentWebSocketConnection()
         observeMDMEnforcement()
     }
-
     private fun checkWebSocketEnforcedByDefault() {
         networkSettingsState = networkSettingsState.copy(
             isWebSocketEnforcedByDefault = isWebsocketEnabledByDefault(context)
         )
     }
-
     private fun observeMDMEnforcement() {
         viewModelScope.launch {
             managedConfigurationsManager.persistentWebSocketEnforcedByMDM.collect { isEnforced ->
@@ -73,20 +65,16 @@ class NetworkSettingsViewModel
             }
         }
     }
-
     private fun observePersistentWebSocketConnection() =
         viewModelScope.launch {
-
             when (val currentSession = currentSession()) {
                 is CurrentSessionResult.Success -> {
                     val userId = currentSession.accountInfo.userId
-
                     observePersistentWebSocketConnectionStatus().let {
                         when (it) {
                             is ObservePersistentWebSocketConnectionStatusUseCase.Result.Failure -> {
                                 appLogger.e("Failure while fetching persistent web socket status flow from network settings")
                             }
-
                             is ObservePersistentWebSocketConnectionStatusUseCase.Result.Success -> {
                                 it.persistentWebSocketStatusListFlow.collect {
                                     it.map { persistentWebSocketStatus ->
@@ -103,13 +91,11 @@ class NetworkSettingsViewModel
                         }
                     }
                 }
-
                 else -> {
                     // NO SESSION - Nothing to do
                 }
             }
         }
-
     fun setWebSocketState(isEnabled: Boolean) {
         // Block changes when MDM enforces the setting
         if (networkSettingsState.isEnforcedByMDM) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreScreen.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.backupAndRestoreViewModel
 import com.wire.android.R
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -64,7 +64,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 @Composable
 fun BackupAndRestoreScreen(
     navigator: Navigator,
-    viewModel: BackupAndRestoreViewModel = wireViewModel()
+    viewModel: BackupAndRestoreViewModel = backupAndRestoreViewModel()
 ) {
     BackupAndRestoreContent(
         backUpAndRestoreState = viewModel.state,

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.home.settings.backup
-
 import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.text.input.TextFieldState
@@ -52,7 +50,6 @@ import com.wire.kalium.logic.feature.backup.RestoreMPBackupUseCase
 import com.wire.kalium.logic.feature.backup.VerifyBackupResult
 import com.wire.kalium.logic.feature.backup.VerifyBackupUseCase
 import com.wire.kalium.util.DateTimeUtil
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
@@ -60,9 +57,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okio.Path
 import javax.inject.Inject
-
 @Suppress("LongParameterList", "TooManyFunctions")
-@HiltViewModel
 class BackupAndRestoreViewModel @Inject constructor(
     private val importBackup: RestoreBackupUseCase,
     private val importMpBackup: RestoreMPBackupUseCase,
@@ -76,7 +71,6 @@ class BackupAndRestoreViewModel @Inject constructor(
     private val dispatcher: DispatcherProvider,
     private val mpBackupSettings: MPBackupSettings,
 ) : ViewModel() {
-
     val createBackupPasswordState: TextFieldState = TextFieldState()
     val restoreBackupPasswordState: TextFieldState = TextFieldState()
     var state by mutableStateOf(BackupAndRestoreState.INITIAL_STATE)
@@ -93,7 +87,6 @@ class BackupAndRestoreViewModel @Inject constructor(
         observeLastBackupDate()
         observeCreateBackupPasswordChanges()
     }
-
     private fun observeCreateBackupPasswordChanges() {
         viewModelScope.launch {
             createBackupPasswordState.textAsFlow().collectLatest {
@@ -101,7 +94,6 @@ class BackupAndRestoreViewModel @Inject constructor(
             }
         }
     }
-
     private fun observeLastBackupDate() {
         viewModelScope.launch {
             userDataStore.lastBackupDateSeconds().collect {
@@ -109,14 +101,10 @@ class BackupAndRestoreViewModel @Inject constructor(
             }
         }
     }
-
     fun createBackup() {
-
         createRestoreJob?.cancel()
         createRestoreJob = viewModelScope.launch {
-
             val password = createBackupPasswordState.text.toString()
-
             val result = if (mpBackupSettings is MPBackupSettings.Enabled) {
                 createMpBackupFile(password) { progress ->
                     updateCreationProgress(progress)
@@ -124,7 +112,6 @@ class BackupAndRestoreViewModel @Inject constructor(
             } else {
                 createBackupFile(password)
             }
-
             when (result) {
                 is CreateBackupResult.Success -> {
                     state = state.copy(backupCreationProgress = BackupCreationProgress.Finished(result.backupFileName))
@@ -135,7 +122,6 @@ class BackupAndRestoreViewModel @Inject constructor(
                     )
                     createBackupPasswordState.clearText()
                 }
-
                 is CreateBackupResult.Failure -> {
                     state = state.copy(backupCreationProgress = BackupCreationProgress.Failed)
                     appLogger.e("Failed to create backup: ${result.coreFailure}")
@@ -144,13 +130,11 @@ class BackupAndRestoreViewModel @Inject constructor(
             }
         }
     }
-
     private suspend fun updateLastBackupDate() {
         DateTimeUtil.currentInstant().epochSeconds.also { currentTime ->
             userDataStore.setLastBackupDateSeconds(currentTime)
         }
     }
-
     fun shareBackup() = viewModelScope.launch {
         updateLastBackupDate()
         latestCreatedBackup?.let { backupData ->
@@ -166,7 +150,6 @@ class BackupAndRestoreViewModel @Inject constructor(
             passwordValidation = ValidatePasswordResult.Valid,
         )
     }
-
     fun saveBackup(uri: Uri) = viewModelScope.launch {
         updateLastBackupDate()
         latestCreatedBackup?.let { backupData ->
@@ -180,17 +163,14 @@ class BackupAndRestoreViewModel @Inject constructor(
             passwordValidation = ValidatePasswordResult.Valid,
         )
     }
-
     fun chooseBackupFileToRestore(uri: Uri) = viewModelScope.launch {
         latestImportedBackupTempPath = kaliumFileSystem.tempFilePath(TEMP_IMPORTED_BACKUP_FILE_NAME)
         fileManager.copyToPath(uri, latestImportedBackupTempPath)
         verifyBackupFile(latestImportedBackupTempPath)
     }
-
     private fun showPasswordDialog() {
         state = state.copy(restoreFileValidation = RestoreFileValidation.PasswordRequired)
     }
-
     private suspend fun verifyBackupFile(importedBackupPath: Path) = withContext(dispatcher.main()) {
         when (val result = verifyBackup(importedBackupPath)) {
             is VerifyBackupResult.Success -> {
@@ -204,7 +184,6 @@ class BackupAndRestoreViewModel @Inject constructor(
                     restoreBackup(importedBackupPath, null)
                 }
             }
-
             is VerifyBackupResult.Failure -> {
                 state = state.copy(restoreFileValidation = RestoreFileValidation.IncompatibleBackup)
                 val errorMessage = when (result) {
@@ -220,13 +199,11 @@ class BackupAndRestoreViewModel @Inject constructor(
                         "Invalid user ID"
                     }
                 }
-
                 AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.BackupRestoreFailed)
                 appLogger.e("Failed to extract backup files: $errorMessage")
             }
         }
     }
-
     fun restorePasswordProtectedBackup() = viewModelScope.launch(dispatcher.main()) {
         state = state.copy(
             restorePasswordValidation = PasswordValidation.NotVerified
@@ -235,40 +212,34 @@ class BackupAndRestoreViewModel @Inject constructor(
         val fileValidationState = state.restoreFileValidation
         if (fileValidationState is RestoreFileValidation.PasswordRequired) {
             state = state.copy(restorePasswordValidation = PasswordValidation.Entered)
-
             restoreBackup(latestImportedBackupTempPath, restoreBackupPasswordState.text.toString())
         } else {
             state = state.copy(backupRestoreProgress = BackupRestoreProgress.Failed)
             AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.BackupRestoreFailed)
         }
     }
-
     private fun mapBackupRestoreFailure(failure: RestoreBackupResult.BackupRestoreFailure) = when (failure) {
         InvalidPassword -> state = state.copy(
             backupRestoreProgress = BackupRestoreProgress.Failed,
             restoreFileValidation = RestoreFileValidation.PasswordRequired,
             restorePasswordValidation = PasswordValidation.NotValid,
         )
-
         InvalidUserId -> state = state.copy(
             backupRestoreProgress = BackupRestoreProgress.Failed,
             restoreFileValidation = RestoreFileValidation.WrongBackup,
             restorePasswordValidation = PasswordValidation.Valid
         )
-
         is IncompatibleBackup -> state = state.copy(
             backupRestoreProgress = BackupRestoreProgress.Failed,
             restoreFileValidation = RestoreFileValidation.IncompatibleBackup,
             restorePasswordValidation = PasswordValidation.Valid
         )
-
         is BackupIOFailure, is DecryptionFailure -> state = state.copy(
             backupRestoreProgress = BackupRestoreProgress.Failed,
             restoreFileValidation = RestoreFileValidation.GeneralFailure,
             restorePasswordValidation = PasswordValidation.Valid
         )
     }
-
     fun validateBackupCreationPassword(backupPassword: String) {
         state = state.copy(
             passwordValidation = if (backupPassword.isEmpty()) {
@@ -278,13 +249,11 @@ class BackupAndRestoreViewModel @Inject constructor(
             }
         )
     }
-
     fun cancelBackupCreation() = viewModelScope.launch(dispatcher.main()) {
         createRestoreJob?.cancel()
         createBackupPasswordState.clearText()
         updateCreationProgress(0f)
     }
-
     fun cancelBackupRestore() = viewModelScope.launch {
         createRestoreJob?.cancel()
         restoreBackupPasswordState.clearText()
@@ -302,7 +271,6 @@ class BackupAndRestoreViewModel @Inject constructor(
             }
         }
     }
-
     private fun restoreBackup(backupFilePath: Path, password: String?) {
         createRestoreJob?.cancel()
         createRestoreJob = viewModelScope.launch {
@@ -321,7 +289,6 @@ class BackupAndRestoreViewModel @Inject constructor(
                     restoreBackupPasswordState.clearText()
                     AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.BackupRestoreSucceeded)
                 }
-
                 is RestoreBackupResult.Failure -> {
                     mapBackupRestoreFailure(result.failure)
                     AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.BackupRestoreFailed)
@@ -329,15 +296,12 @@ class BackupAndRestoreViewModel @Inject constructor(
             }
         }
     }
-
     private fun updateCreationProgress(progress: Float) = viewModelScope.launch {
         state = state.copy(backupCreationProgress = BackupCreationProgress.InProgress(progress))
     }
-
     private fun updateRestoreProgress(progress: Float) = viewModelScope.launch {
         state = state.copy(backupRestoreProgress = BackupRestoreProgress.InProgress(progress))
     }
-
     internal companion object {
         const val TEMP_IMPORTED_BACKUP_FILE_NAME = "tempImportedBackup.zip"
         const val SMALL_DELAY = 300L

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.privacySettingsViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.colorsScheme
@@ -43,7 +43,7 @@ import com.wire.android.ui.theme.WireTheme
 @Composable
 fun PrivacySettingsConfigScreen(
     navigator: Navigator,
-    viewModel: PrivacySettingsViewModel = wireViewModel()
+    viewModel: PrivacySettingsViewModel = privacySettingsViewModel()
 ) {
     with(viewModel) {
         PrivacySettingsScreenContent(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/privacy/PrivacySettingsViewModel.kt
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.home.settings.privacy
-
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -39,14 +37,11 @@ import com.wire.kalium.logic.feature.user.screenshotCensoring.PersistScreenshotC
 import com.wire.kalium.logic.feature.user.typingIndicator.ObserveTypingIndicatorEnabledUseCase
 import com.wire.kalium.logic.feature.user.typingIndicator.PersistTypingIndicatorStatusConfigUseCase
 import com.wire.kalium.logic.feature.user.typingIndicator.TypingIndicatorConfigResult
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-
 @Suppress("LongParameterList")
-@HiltViewModel
 class PrivacySettingsViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val persistReadReceiptsStatusConfig: PersistReadReceiptsStatusConfigUseCase,
@@ -59,10 +54,8 @@ class PrivacySettingsViewModel @Inject constructor(
     private val selfServerConfig: SelfServerConfigUseCase,
     private val dataStore: UserDataStore
 ) : ViewModel() {
-
     var state by mutableStateOf(PrivacySettingsState())
         private set
-
     init {
         viewModelScope.launch {
             val shouldShowAnalyticsUsage = shouldShowAnalyticsUsage()
@@ -80,10 +73,8 @@ class PrivacySettingsViewModel @Inject constructor(
                     screenshotCensoringConfig = when (screenshotCensoringConfig) {
                         ObserveScreenshotCensoringConfigResult.Disabled ->
                             ScreenshotCensoringConfig.DISABLED
-
                         ObserveScreenshotCensoringConfigResult.Enabled.ChosenByUser ->
                             ScreenshotCensoringConfig.ENABLED_BY_USER
-
                         ObserveScreenshotCensoringConfigResult.Enabled.EnforcedByTeamSelfDeletingSettings ->
                             ScreenshotCensoringConfig.ENFORCED_BY_TEAM
                     },
@@ -91,7 +82,6 @@ class PrivacySettingsViewModel @Inject constructor(
             }.collect { state = it }
         }
     }
-
     private suspend fun shouldShowAnalyticsUsage(): Boolean {
         // TODO(Analytics): To be changed with UseCase
         val isAnalyticsConfigurationEnabled = analyticsEnabled is AnalyticsConfiguration.Enabled
@@ -101,10 +91,8 @@ class PrivacySettingsViewModel @Inject constructor(
                         || serverConfig.serverLinks.links.api == ServerConfig.STAGING.api
             is SelfServerConfigUseCase.Result.Failure -> false
         }
-
         return isAnalyticsConfigurationEnabled && isValidBackend
     }
-
     fun setReadReceiptsState(isEnabled: Boolean) {
         viewModelScope.launch {
             state =
@@ -113,7 +101,6 @@ class PrivacySettingsViewModel @Inject constructor(
                         appLogger.e("Something went wrong while updating read receipts config")
                         state.copy(areReadReceiptsEnabled = !isEnabled)
                     }
-
                     is ReadReceiptStatusConfigResult.Success -> {
                         appLogger.d("Read receipts config changed")
                         state.copy(areReadReceiptsEnabled = isEnabled)
@@ -121,7 +108,6 @@ class PrivacySettingsViewModel @Inject constructor(
                 }
         }
     }
-
     fun setTypingIndicatorState(isEnabled: Boolean) {
         viewModelScope.launch {
             state =
@@ -130,7 +116,6 @@ class PrivacySettingsViewModel @Inject constructor(
                         appLogger.e("Something went wrong while updating typing indicator config")
                         state.copy(isTypingIndicatorEnabled = !isEnabled)
                     }
-
                     is TypingIndicatorConfigResult.Success -> {
                         appLogger.d("Typing indicator configuration changed successfully")
                         state.copy(isTypingIndicatorEnabled = isEnabled)
@@ -138,21 +123,18 @@ class PrivacySettingsViewModel @Inject constructor(
                 }
         }
     }
-
     fun setScreenshotCensoringConfig(isEnabled: Boolean) {
         viewModelScope.launch {
             when (persistScreenshotCensoringConfig(isEnabled)) {
                 is PersistScreenshotCensoringConfigResult.Failure -> {
                     appLogger.e("Something went wrong while updating screenshot censoring config")
                 }
-
                 is PersistScreenshotCensoringConfigResult.Success -> {
                     appLogger.d("Screenshot censoring config changed")
                 }
             }
         }
     }
-
     fun setAnonymousUsageDataEnabled(enabled: Boolean) {
         viewModelScope.launch {
             dataStore.setIsAnonymousAnalyticsEnabled(enabled)

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.deviceDetailsViewModel
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
@@ -107,7 +107,7 @@ import kotlinx.datetime.Instant
 @Composable
 fun DeviceDetailsScreen(
     navigator: Navigator,
-    viewModel: DeviceDetailsViewModel = wireViewModel()
+    viewModel: DeviceDetailsViewModel = deviceDetailsViewModel()
 ) {
     when {
         viewModel.state.error is RemoveDeviceError.InitError -> navigator.navigateBack()

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsViewModel.kt
@@ -16,7 +16,6 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 package com.wire.android.ui.settings.devices
-
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText
 import androidx.compose.runtime.getValue
@@ -53,14 +52,11 @@ import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
 @Suppress("TooManyFunctions", "LongParameterList")
-@HiltViewModel
 class DeviceDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     @CurrentAccount
@@ -75,11 +71,9 @@ class DeviceDetailsViewModel @Inject constructor(
     private val breakSession: BreakSessionUseCase,
     private val isE2EIEnabledUseCase: IsE2EIEnabledUseCase
 ) : ViewModel() {
-
     private val deviceDetailsNavArgs: DeviceDetailsNavArgs = savedStateHandle.navArgs()
     private val deviceId: ClientId = deviceDetailsNavArgs.clientId
     private val userId: UserId = deviceDetailsNavArgs.userId
-
     val passwordTextState: TextFieldState = TextFieldState()
     var state: DeviceDetailsState by mutableStateOf(
         DeviceDetailsState(
@@ -87,7 +81,6 @@ class DeviceDetailsViewModel @Inject constructor(
         )
     )
         private set
-
     init {
         observeDeviceDetails()
         getClientFingerPrint()
@@ -96,7 +89,6 @@ class DeviceDetailsViewModel @Inject constructor(
         observePasswordTextChanges()
         getIsE2EIEnabled()
     }
-
     private fun getIsE2EIEnabled() {
         viewModelScope.launch {
             isE2EIEnabledUseCase().let {
@@ -104,10 +96,8 @@ class DeviceDetailsViewModel @Inject constructor(
             }
         }
     }
-
     private val isSelfClient: Boolean
         get() = currentUserId == userId
-
     private fun observePasswordTextChanges() {
         viewModelScope.launch {
             passwordTextState.textAsFlow().distinctUntilChanged().collectLatest { newPassword ->
@@ -120,7 +110,6 @@ class DeviceDetailsViewModel @Inject constructor(
             }
         }
     }
-
     private fun observeUserName() {
         if (!isSelfClient) {
             viewModelScope.launch {
@@ -129,7 +118,6 @@ class DeviceDetailsViewModel @Inject constructor(
                         GetUserInfoResult.Failure -> {
                             /* no-op */
                         }
-
                         is GetUserInfoResult.Success ->
                             state =
                             state.copy(userName = result.otherUser.name)
@@ -138,7 +126,6 @@ class DeviceDetailsViewModel @Inject constructor(
             }
         }
     }
-
     private fun getE2eiCertificate() {
         viewModelScope.launch {
             state = when (val result = mlsClientIdentity(deviceId)) {
@@ -163,11 +150,9 @@ class DeviceDetailsViewModel @Inject constructor(
             }
         }
     }
-
     fun enrollE2EICertificate() {
         state = state.copy(isLoadingCertificate = true, startGettingE2EICertificate = true)
     }
-
     fun handleE2EIEnrollmentResult(result: FinalizeEnrollmentResult) {
         state = when (result) {
             is FinalizeEnrollmentResult.Failure -> {
@@ -186,7 +171,6 @@ class DeviceDetailsViewModel @Inject constructor(
             }
         }
     }
-
     private fun getClientFingerPrint() {
         viewModelScope.launch {
             state = when (val result = fingerprintUseCase(userId, deviceId)) {
@@ -195,7 +179,6 @@ class DeviceDetailsViewModel @Inject constructor(
             }
         }
     }
-
     private fun observeDeviceDetails() {
         viewModelScope.launch {
             observeClientDetails(userId, deviceId).collect { result ->
@@ -204,7 +187,6 @@ class DeviceDetailsViewModel @Inject constructor(
                         appLogger.e("Error getting self clients $result")
                         state.copy(error = RemoveDeviceError.InitError)
                     }
-
                     is GetClientDetailsResult.Success -> {
                         state.copy(
                             device = state.device.updateFromClient(result.client),
@@ -220,7 +202,6 @@ class DeviceDetailsViewModel @Inject constructor(
             }
         }
     }
-
     private fun mapCipherSuiteSignatureToShortName(signature: MLSPublicKeyType): String? {
         return when (signature) {
             MLSPublicKeyType.ECDSA_SECP256R1_SHA256 -> "P256"
@@ -231,7 +212,6 @@ class DeviceDetailsViewModel @Inject constructor(
             is MLSPublicKeyType.Unknown -> null
         }
     }
-
     fun removeDevice() {
         viewModelScope.launch {
             val isPasswordRequired: Boolean = when (val passwordRequiredResult = isPasswordRequired()) {
@@ -239,7 +219,6 @@ class DeviceDetailsViewModel @Inject constructor(
                     state = state.copy(error = RemoveDeviceError.GenericError(passwordRequiredResult.cause))
                     return@launch
                 }
-
                 is IsPasswordRequiredUseCase.Result.Success -> passwordRequiredResult.value
             }
             when (isPasswordRequired) {
@@ -248,7 +227,6 @@ class DeviceDetailsViewModel @Inject constructor(
             }
         }
     }
-
     private fun showDeleteClientDialog(device: Device) {
         passwordTextState.clearText()
         state = device.let { RemoveDeviceDialogState.Visible(it) }.let {
@@ -258,22 +236,18 @@ class DeviceDetailsViewModel @Inject constructor(
             )
         }
     }
-
     private suspend fun deleteDevice(password: String?) {
         when (val result = deleteClient(DeleteClientParam(password, deviceId))) {
             is DeleteClientResult.Failure.Generic -> state = state.copy(
                 error = RemoveDeviceError.GenericError(result.genericFailure)
             )
-
             DeleteClientResult.Failure.InvalidCredentials -> state = state.copy(
                 error = RemoveDeviceError.InvalidCredentialsError
             )
-
             DeleteClientResult.Failure.PasswordAuthRequired -> showDeleteClientDialog(state.device)
             DeleteClientResult.Success -> state = state.copy(deviceRemoved = true)
         }
     }
-
     fun onRemoveConfirmed() {
         (state.removeDeviceDialogState as? RemoveDeviceDialogState.Visible)?.let { dialogStateVisible ->
             updateStateIfDialogVisible {
@@ -287,36 +261,29 @@ class DeviceDetailsViewModel @Inject constructor(
             }
         }
     }
-
     private fun updateStateIfDialogVisible(newValue: (RemoveDeviceDialogState.Visible) -> DeviceDetailsState) {
         if (state.removeDeviceDialogState is RemoveDeviceDialogState.Visible) {
             state = newValue(state.removeDeviceDialogState as RemoveDeviceDialogState.Visible)
         }
     }
-
     fun onUpdateVerificationStatus(status: Boolean) {
         viewModelScope.launch {
             updateClientVerificationStatus(userId, deviceId, status)
         }
     }
-
     fun onDialogDismissed() {
         passwordTextState.clearText()
         state = state.copy(removeDeviceDialogState = RemoveDeviceDialogState.Hidden)
     }
-
     fun clearDeleteClientError() {
         state = state.copy(error = RemoveDeviceError.None)
     }
-
     fun hideEnrollE2EICertificateError() {
         state = state.copy(isE2EICertificateEnrollError = false)
     }
-
     fun hideEnrollE2EICertificateSuccess() {
         state = state.copy(isE2EICertificateEnrollSuccess = false)
     }
-
     fun breakSession() {
         viewModelScope.launch { breakSession(userId, deviceId) }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.selfDevicesViewModel
 import androidx.lifecycle.Lifecycle
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
@@ -56,7 +56,7 @@ import com.wire.kalium.logic.data.conversation.ClientId
 @Composable
 fun SelfDevicesScreen(
     navigator: Navigator,
-    viewModel: SelfDevicesViewModel = wireViewModel()
+    viewModel: SelfDevicesViewModel = selfDevicesViewModel()
 ) {
     val lifecycleEvent = rememberLifecycleEvent()
     LaunchedEffect(lifecycleEvent) {

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/SelfDevicesViewModel.kt
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.settings.devices
-
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -32,15 +30,12 @@ import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
 import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserMlsClientIdentitiesUseCase
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-@HiltViewModel
 class SelfDevicesViewModel @Inject constructor(
     @CurrentAccount val currentAccountId: UserId,
     private val fetchSelfClientsFromRemote: FetchSelfClientsFromRemoteUseCase,
@@ -49,21 +44,17 @@ class SelfDevicesViewModel @Inject constructor(
     private val getUserMlsClientIdentities: GetUserMlsClientIdentitiesUseCase,
     private val isE2EIEnabledUseCase: IsE2EIEnabledUseCase
 ) : ViewModel() {
-
     var state: SelfDevicesState by mutableStateOf(
         SelfDevicesState(deviceList = listOf(), isLoadingClientsList = true, currentDevice = null)
     )
         private set
-
     private val refreshE2eiCertificates: MutableSharedFlow<Unit> = MutableSharedFlow<Unit>()
     private val observeMlsClientIdentities = refreshE2eiCertificates.map { getUserMlsClientIdentities(currentAccountId) }
-
     init {
         observeClientList()
         updateSelfClientsListFromRemote()
         getIsE2EIEnabled()
     }
-
     private fun getIsE2EIEnabled() {
         viewModelScope.launch {
             isE2EIEnabledUseCase().let {
@@ -71,13 +62,11 @@ class SelfDevicesViewModel @Inject constructor(
             }
         }
     }
-
     private fun updateSelfClientsListFromRemote() {
         viewModelScope.launch {
             fetchSelfClientsFromRemote()
         }
     }
-
     private fun observeClientList() {
         viewModelScope.launch {
             observeClientList(currentAccountId)
@@ -101,7 +90,6 @@ class SelfDevicesViewModel @Inject constructor(
                 }
         }
     }
-
     fun loadCertificates() {
         viewModelScope.launch {
             refreshE2eiCertificates.emit(Unit)

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.sp
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.e2eiCertificateDetailsViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.style.PopUpNavigationAnimation
@@ -61,7 +61,7 @@ import kotlinx.coroutines.withContext
 @Composable
 fun E2eiCertificateDetailsScreen(
     navigator: Navigator,
-    e2eiCertificateDetailsViewModel: E2eiCertificateDetailsViewModel = wireViewModel()
+    e2eiCertificateDetailsViewModel: E2eiCertificateDetailsViewModel = e2eiCertificateDetailsViewModel()
 ) {
     val snackbarHostState = LocalSnackbarHostState.current
     val scope = rememberCoroutineScope()

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
@@ -16,7 +16,6 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 package com.wire.android.ui.settings.devices.e2ei
-
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -24,48 +23,37 @@ import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.util.fileDateTime
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.util.DateTimeUtil
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-@HiltViewModel
 class E2eiCertificateDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val getSelfUser: GetSelfUserUseCase,
 ) : ViewModel() {
     private val navArgs: E2eiCertificateDetailsScreenNavArgs =
         savedStateHandle.navArgs()
-
     private var selfUserHandle: String? = null
-
     init {
         getSelfUserHandle()
     }
-
     private fun getSelfUserHandle() {
         viewModelScope.launch {
             selfUserHandle = getSelfUser()?.handle
         }
     }
-
     fun getCertificate() =
         when (navArgs.certificateDetails) {
             is E2EICertificateDetails.DuringLoginCertificateDetails ->
                 navArgs.certificateDetails.certificate
-
             is E2EICertificateDetails.AfterLoginCertificateDetails ->
                 navArgs.certificateDetails.mlsClientIdentity.x509Identity?.certificate ?: ""
         }
-
     fun userHandle() =
         when (navArgs.certificateDetails) {
             is E2EICertificateDetails.DuringLoginCertificateDetails ->
                 selfUserHandle
-
             is E2EICertificateDetails.AfterLoginCertificateDetails ->
                 navArgs.certificateDetails.mlsClientIdentity.x509Identity?.handle?.handle ?: ""
         }
-
     fun getCertificateName(): String {
         val date = DateTimeUtil.currentInstant().fileDateTime()
         return "wire-certificate-${userHandle()}-$date.txt"

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.core.net.toUri
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.avatarPickerViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
@@ -72,7 +72,7 @@ import com.wire.android.util.ui.PreviewMultipleThemesForSquare
 fun AvatarPickerScreen(
     navigator: Navigator,
     resultNavigator: ResultBackNavigator<String?>,
-    viewModel: AvatarPickerViewModel = wireViewModel()
+    viewModel: AvatarPickerViewModel = avatarPickerViewModel()
 ) {
     val permissionPermanentlyDeniedDialogState =
         rememberVisibilityState<PermissionPermanentlyDeniedDialogState>()

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.userprofile.avatarpicker
-
 import android.content.Context
 import android.net.Uri
 import androidx.compose.runtime.Stable
@@ -44,7 +42,6 @@ import com.wire.kalium.logic.feature.asset.GetAvatarAssetUseCase
 import com.wire.kalium.logic.feature.asset.PublicAssetResult
 import com.wire.kalium.logic.feature.user.UploadAvatarResult
 import com.wire.kalium.logic.feature.user.UploadUserAvatarUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -53,8 +50,6 @@ import kotlinx.coroutines.launch
 import okio.Path
 import java.io.FileNotFoundException
 import javax.inject.Inject
-
-@HiltViewModel
 @Suppress("LongParameterList")
 class AvatarPickerViewModel @Inject constructor(
     private val dataStore: UserDataStore,
@@ -66,18 +61,13 @@ class AvatarPickerViewModel @Inject constructor(
     private val qualifiedIdMapper: QualifiedIdMapper,
     @ApplicationContext private val appContext: Context
 ) : ViewModel() {
-
     var pictureState by mutableStateOf<PictureState>(PictureState.Empty)
         private set
-
     private var initialPictureLoadingState by mutableStateOf<InitialPictureLoadingState>(InitialPictureLoadingState.None)
-
     private val _infoMessage = MutableSharedFlow<UIText>()
     val infoMessage = _infoMessage.asSharedFlow()
-
     val defaultAvatarPath: Path
         get() = kaliumFileSystem.selfUserAvatarPath()
-
     val temporaryAvatarUri: Uri = avatarImageManager.getShareableTempAvatarUri(defaultAvatarPath)
 
     init {
@@ -105,7 +95,6 @@ class AvatarPickerViewModel @Inject constructor(
             }
         }
     }
-
     fun updatePickedAvatarUri(originalUri: Uri, updatedUri: Uri) = viewModelScope.launch {
         sanitizeAvatarImage(originalUri, defaultAvatarPath)
         pictureState = PictureState.Picked(updatedUri)
@@ -123,23 +112,18 @@ class AvatarPickerViewModel @Inject constructor(
             shouldRemoveMetadata = true
         )
     }
-
     fun uploadNewPickedAvatar() {
         val imgUri = pictureState.avatarUri
-
         viewModelScope.launch {
             pictureState = PictureState.Uploading(imgUri)
-
             val avatarPath = defaultAvatarPath
             try {
                 val imageDataSize = imgUri.toByteArray(appContext, dispatchers).size.toLong()
-
                 when (val result = uploadUserAvatar(avatarPath, imageDataSize)) {
                     is UploadAvatarResult.Success -> {
                         dataStore.updateUserAvatarAssetId(result.userAssetId.toString())
                         pictureState = PictureState.Completed(imgUri, dataStore.avatarAssetId.first())
                     }
-
                     is UploadAvatarResult.Failure -> {
                         when (result.coreFailure) {
                             is NetworkFailure.NoNetworkConnection -> showInfoMessage(InfoMessageType.NoNetworkError)
@@ -159,7 +143,6 @@ class AvatarPickerViewModel @Inject constructor(
             }
         }
     }
-
     private suspend fun showInfoMessage(type: SnackBarMessage) {
         _infoMessage.emit(type.uiText)
     }
@@ -179,7 +162,6 @@ class AvatarPickerViewModel @Inject constructor(
         data class Completed(override val avatarUri: Uri, val assetId: String?) : PictureState(avatarUri)
         data object Empty : PictureState("".toUri())
     }
-
     sealed class InfoMessageType(override val uiText: UIText) : SnackBarMessage {
         data object UploadAvatarError : InfoMessageType(UIText.StringResource(R.string.error_uploading_user_avatar))
         data object NoNetworkError : InfoMessageType(UIText.StringResource(R.string.error_no_network_message))

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.otherUserProfileScreenViewModel
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.ramcosta.composedestinations.result.ResultRecipient
@@ -121,7 +121,7 @@ fun OtherUserProfileScreen(
     resultNavigator: ResultBackNavigator<String>,
     conversationFoldersScreenResultRecipient:
     ResultRecipient<ConversationFoldersScreenDestination, ConversationFoldersNavBackArgs>,
-    viewModel: OtherUserProfileScreenViewModel = wireViewModel()
+    viewModel: OtherUserProfileScreenViewModel = otherUserProfileScreenViewModel()
 ) {
     val snackbarHostState = LocalSnackbarHostState.current
     val context = LocalContext.current

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.userprofile.other
-
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -53,7 +51,6 @@ import com.wire.kalium.logic.feature.e2ei.usecase.IsOtherUserE2EIVerifiedUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.Flow
@@ -64,9 +61,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-
 @Suppress("LongParameterList", "TooManyFunctions")
-@HiltViewModel
 class OtherUserProfileScreenViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val observeUserInfo: ObserveUserInfoUseCase,
@@ -82,11 +77,9 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     private val isE2EIEnabled: IsE2EIEnabledUseCase,
     savedStateHandle: SavedStateHandle
 ) : ActionsViewModel<OtherUserProfileViewAction>(), OtherUserProfileEventsHandler {
-
     private val otherUserProfileNavArgs: OtherUserProfileNavArgs = savedStateHandle.navArgs()
     private val userId: QualifiedID = otherUserProfileNavArgs.userId
     private val groupConversationId: QualifiedID? = otherUserProfileNavArgs.groupConversationId
-
     var state: OtherUserProfileState by mutableStateOf(
         OtherUserProfileState(
             userId = userId,
@@ -96,7 +89,6 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         )
     )
     val removeConversationMemberDialogState: VisibilityState<RemoveConversationMemberState> by mutableStateOf(VisibilityState())
-
     init {
         observeUserInfoAndUpdateViewState()
         persistClients()
@@ -104,26 +96,22 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         getIfConversationExist()
         getE2EIStatus()
     }
-
     private fun getIfConversationExist() {
         viewModelScope.launch {
             val isOneToOneConversationCreated = isOneToOneConversationCreated(userId)
             state = state.copy(isConversationStarted = isOneToOneConversationCreated)
         }
     }
-
     private fun getMLSVerificationStatus() {
         viewModelScope.launch {
             val isMLSVerified = getUserE2eiCertificateStatus(userId)
             state = state.copy(isMLSVerified = isMLSVerified)
         }
     }
-
     private fun getE2EIStatus() = viewModelScope.launch {
         val isE2EIEnabled = isE2EIEnabled()
         state = state.copy(isE2EIEnabled = isE2EIEnabled)
     }
-
     override fun observeClientList() {
         viewModelScope.launch(dispatchers.io()) {
             observeClientList(userId)
@@ -132,7 +120,6 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                         is ObserveClientsByUserIdUseCase.Result.Failure -> {
                             state = state.copy(otherUserDevices = emptyList())
                         }
-
                         is ObserveClientsByUserIdUseCase.Result.Success -> {
                             val devices = result.clients.map { client ->
                                 async {
@@ -146,20 +133,17 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                                     )
                                 }
                             }.awaitAll()
-
                             state = state.copy(otherUserDevices = devices)
                         }
                     }
                 }
         }
     }
-
     private fun persistClients() {
         viewModelScope.launch(dispatchers.io()) {
             fetchUsersClients(listOf(userId))
         }
     }
-
     private fun observeUserInfoAndUpdateViewState() {
         viewModelScope.launch {
             combine(
@@ -174,7 +158,6 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                             appLogger.e("Couldn't not find the user with provided id: ${userId.toLogString()}")
                             updateUserInfoStateForError()
                         }
-
                         is GetUserInfoResult.Success -> {
                             updateUserInfoState(userResult, groupInfo)
                         }
@@ -182,7 +165,6 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                 }
         }
     }
-
     private suspend fun observeGroupInfo(): Flow<OtherUserProfileGroupState?> {
         return groupConversationId?.let {
             observeConversationRoleForUser(it, userId)
@@ -198,7 +180,6 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                 }
         } ?: flowOf(null)
     }
-
     fun onChangeMemberRole(role: Conversation.Member.Role) {
         viewModelScope.launch {
             if (groupConversationId != null) {
@@ -210,7 +191,6 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             }
         }
     }
-
     override fun onRemoveConversationMember(state: RemoveConversationMemberState) {
         viewModelScope.launch {
             removeConversationMemberDialogState.update { it.copy(loading = true) }
@@ -227,7 +207,6 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             removeConversationMemberDialogState.dismiss()
         }
     }
-
     private fun updateUserInfoStateForError() {
         state = state.copy(
             isDataLoading = false,
@@ -235,7 +214,6 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             errorLoadingUser = ErrorLoadingUser.USER_NOT_FOUND
         )
     }
-
     private fun updateUserInfoState(
         userResult: GetUserInfoResult.Success,
         groupInfo: OtherUserProfileGroupState?,
@@ -243,7 +221,6 @@ class OtherUserProfileScreenViewModel @Inject constructor(
         val otherUser = userResult.otherUser
         val userAvatarAsset = otherUser.completePicture
             ?.let { pic -> ImageAsset.UserAvatarAsset(pic) }
-
         state = state.copy(
             isDataLoading = false,
             isAvatarLoading = false,
@@ -266,10 +243,8 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             activeOneOnOneConversationId = otherUser.activeOneOnOneConversationId
         )
     }
-
     private fun onMessage(message: SnackBarMessage) = sendAction(OtherUserProfileViewAction.Message(message))
 }
-
 sealed interface OtherUserProfileViewAction {
     data class Message(val message: SnackBarMessage) : OtherUserProfileViewAction
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeScreen.kt
@@ -55,7 +55,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.selfQRCodeViewModel
 import com.lightspark.composeqr.DotShape
 import com.lightspark.composeqr.QrCodeView
 import com.wire.android.R
@@ -82,7 +82,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun SelfQRCodeScreen(
     navigator: Navigator,
-    viewModel: SelfQRCodeViewModel = wireViewModel()
+    viewModel: SelfQRCodeViewModel = selfQRCodeViewModel()
 ) {
     if (viewModel.selfQRCodeState.hasError) {
         navigator.navigateBack()

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeViewModel.kt
@@ -16,7 +16,6 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 package com.wire.android.ui.userprofile.qr
-
 import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
@@ -36,7 +35,6 @@ import com.wire.android.util.getTempWritableAttachmentUri
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -44,8 +42,6 @@ import okio.Path
 import okio.Path.Companion.toPath
 import java.io.FileOutputStream
 import javax.inject.Inject
-
-@HiltViewModel
 class SelfQRCodeViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val context: Context,
@@ -66,13 +62,11 @@ class SelfQRCodeViewModel @Inject constructor(
         private set
     private val cachePath: Path
         get() = kaliumFileSystem.rootCachePath
-
     init {
         viewModelScope.launch {
             getServerLinks()
         }
     }
-
     suspend fun shareQRAsset(bitmap: Bitmap): Uri {
         val job = viewModelScope.async {
             val qrImageFile = getTempWritableQRUri(cachePath)
@@ -91,16 +85,13 @@ class SelfQRCodeViewModel @Inject constructor(
         }
         return job.await()
     }
-
     fun trackAnalyticsEvent(event: AnalyticsEvent.QrCode.Modal) {
         analyticsManager.sendEvent(event)
     }
-
     private suspend fun getTempWritableQRUri(tempCachePath: Path): Uri = withContext(dispatchers.io()) {
         val tempImagePath = "$tempCachePath/$TEMP_SELF_QR_FILENAME".toPath()
         return@withContext getTempWritableAttachmentUri(context, tempImagePath)
     }
-
     private suspend fun getServerLinks() {
         selfQRCodeState =
             when (val result = selfServerLinks()) {
@@ -108,17 +99,14 @@ class SelfQRCodeViewModel @Inject constructor(
                 is SelfServerConfigUseCase.Result.Success -> generateSelfUserUrls(result.serverLinks.links.accounts)
             }
     }
-
     private fun generateSelfUserUrls(accountsUrl: String): SelfQRCodeState =
         selfQRCodeState.copy(
             userAccountProfileLink = String.format(BASE_USER_PROFILE_URL, accountsUrl, selfUserId),
             userProfileLink = String.format(DIRECT_BASE_USER_PROFILE_URL, selfUserId.domain, selfUserId.value)
         )
-
     companion object {
         const val TEMP_SELF_QR_FILENAME = "temp_self_qr.jpg"
         const val BASE_USER_PROFILE_URL = "%s/user-profile/?id=%s"
-
         const val DIRECT_BASE_USER_PROFILE_URL = "wire://user/%s/%s"
         const val QR_QUALITY_COMPRESSION = 80
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.settings.selfUserProfileViewModel
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultRecipient
 import com.wire.android.R
@@ -113,7 +114,7 @@ fun SelfUserProfileScreen(
     navigator: Navigator,
     loginTypeSelector: LoginTypeSelector,
     avatarPickerResultRecipient: ResultRecipient<AvatarPickerScreenDestination, String?>,
-    viewModelSelf: SelfUserProfileViewModel = wireViewModel(),
+    viewModelSelf: SelfUserProfileViewModel = selfUserProfileViewModel(),
     legalHoldRequestedViewModel: LegalHoldRequestedViewModel = wireViewModel()
 ) {
     val legalHoldSubjectDialogState = rememberVisibilityState<Unit>()

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileViewModel.kt
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.android.ui.userprofile.self
-
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -61,7 +59,6 @@ import com.wire.kalium.logic.feature.user.IsReadOnlyAccountUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserWithTeamUseCase
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
 import com.wire.kalium.logic.feature.user.UpdateSelfAvailabilityStatusUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -75,11 +72,9 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-
 // TODO cover this class with unit test
 // Suppress for now after removing mockMethodForAvatar it should not complain
 @Suppress("TooManyFunctions", "LongParameterList")
-@HiltViewModel
 class SelfUserProfileViewModel @Inject constructor(
     @CurrentAccount private val selfUserId: UserId,
     private val dataStore: UserDataStore,
@@ -104,12 +99,9 @@ class SelfUserProfileViewModel @Inject constructor(
     private val getTeamUrl: GetTeamUrlUseCase,
     private val isProfileQRCodeEnabled: IsProfileQRCodeEnabledUseCase,
 ) : ViewModel() {
-
     var userProfileState by mutableStateOf(SelfUserProfileState(userId = selfUserId, isAvatarLoading = true))
         private set
-
     private lateinit var establishedCallsList: StateFlow<List<Call>>
-
     init {
         viewModelScope.launch {
             fetchSelfUser()
@@ -120,22 +112,18 @@ class SelfUserProfileViewModel @Inject constructor(
             fetchProfileQRCodeState()
         }
     }
-
     fun fetchProfileQRCodeState() = viewModelScope.launch {
         val isEnabled = isProfileQRCodeEnabled()
         userProfileState = userProfileState.copy(showQrCode = isEnabled)
     }
-
     suspend fun checkIfUserAbleToMigrateToTeamAccount() {
         val canMigrate = canMigrateFromPersonalToTeam()
         userProfileState = userProfileState.copy(isAbleToMigrateToTeamAccount = canMigrate)
     }
-
     private suspend fun fetchIsReadOnlyAccount() {
         val isReadOnlyAccount = isReadOnlyAccount()
         userProfileState = userProfileState.copy(isReadOnlyAccount = isReadOnlyAccount)
     }
-
     private fun observeEstablishedCall() {
         viewModelScope.launch {
             establishedCallsList = observeEstablishedCalls()
@@ -144,7 +132,6 @@ class SelfUserProfileViewModel @Inject constructor(
                 .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
         }
     }
-
     private fun markCreateTeamNoticeAsRead() {
         viewModelScope.launch {
             if (getSelfTeamId() == null && !dataStore.isCreateTeamNoticeRead().first()) {
@@ -152,25 +139,20 @@ class SelfUserProfileViewModel @Inject constructor(
             }
         }
     }
-
     fun isUserInCall(): Boolean = establishedCallsList.value.isNotEmpty()
-
     fun reloadNewPickedAvatar(avatarAssetId: String) {
         updateUserAvatar(avatarAssetId = avatarAssetId.toQualifiedID(qualifiedIdMapper))
     }
-
     private fun fetchSelfUser() {
         viewModelScope.launch {
             viewModelScope.launch(dispatchers.io()) {
                 syncSelfTeamInfo()
             }
-
             val selfWithTeam = observeSelfUserWithTeam()
                 .flowOn(dispatchers.io())
                 .shareIn(this, SharingStarted.WhileSubscribed(1))
             val validAccounts =
                 observeValidAccounts().flowOn(dispatchers.io()).shareIn(this, SharingStarted.WhileSubscribed(1))
-
             combine(selfWithTeam, validAccounts) { (selfUser, selfTeam), list ->
                 Triple(
                     selfUser,
@@ -184,9 +166,7 @@ class SelfUserProfileViewModel @Inject constructor(
                     with(selfUser) {
                         // Load user avatar raw image data
                         completePicture?.let { updateUserAvatar(it) }
-
                         val teamUrl = getTeamUrl().takeIf { userType.isTeamAdmin() }
-
                         // Update user data state
                         userProfileState = userProfileState.copy(
                             status = availabilityStatus,
@@ -203,7 +183,6 @@ class SelfUserProfileViewModel @Inject constructor(
                 }
         }
     }
-
     private fun observeLegalHoldStatus() {
         viewModelScope.launch {
             observeLegalHoldStatusForSelfUser()
@@ -217,20 +196,16 @@ class SelfUserProfileViewModel @Inject constructor(
                 .collectLatest { userProfileState = userProfileState.copy(legalHoldStatus = it) }
         }
     }
-
     private fun showErrorMessage() {
         userProfileState = userProfileState.copy(errorMessageCode = ErrorCodes.DownloadUserInfoError)
     }
-
     private fun showLoadingAvatar(show: Boolean) {
         userProfileState = userProfileState.copy(isAvatarLoading = show)
     }
-
     private fun updateUserAvatar(avatarAssetId: UserAssetId) {
         if (avatarAssetId == userProfileState.avatarAsset?.userAssetId) {
             return
         }
-
         // We try to download the user avatar on a separate thread so that we don't block the display of the user's info
         viewModelScope.launch {
             showLoadingAvatar(true)
@@ -246,11 +221,9 @@ class SelfUserProfileViewModel @Inject constructor(
                 // Show error snackbar if avatar download fails
                 showErrorMessage()
             }
-
             showLoadingAvatar(false)
         }
     }
-
     fun logout(wipeData: Boolean, switchAccountActions: SwitchAccountActions) {
         viewModelScope.launch {
             userProfileState = userProfileState.copy(isLoggingOut = true)
@@ -260,14 +233,12 @@ class SelfUserProfileViewModel @Inject constructor(
                     endCall(call.conversationId)
                 }
             }.join()
-
             val logoutReason = if (wipeData) LogoutReason.SELF_HARD_LOGOUT else LogoutReason.SELF_SOFT_LOGOUT
             logout(logoutReason, waitUntilCompletes = true)
             if (wipeData) {
                 // TODO this should be moved to some service that will clear all the data in the app
                 dataStore.clear()
             }
-
             notificationManager.stopObservingOnLogout(selfUserId)
             accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount).also {
                 if (it == SwitchAccountResult.NoOtherAccountToSwitch) {
@@ -276,33 +247,27 @@ class SelfUserProfileViewModel @Inject constructor(
             }.callAction(switchAccountActions)
         }
     }
-
     fun switchAccount(userId: UserId, switchAccountActions: SwitchAccountActions) {
         viewModelScope.launch {
             accountSwitch(SwitchAccountParam.SwitchToAccount(userId))
                 .callAction(switchAccountActions)
         }
     }
-
     fun dismissStatusDialog() {
         userProfileState = userProfileState.copy(statusDialogData = null)
     }
-
     fun changeStatus(status: UserAvailabilityStatus) {
         setNotShowStatusRationaleAgainIfNeeded(status)
         viewModelScope.launch { updateStatus(status) }
         dismissStatusDialog()
     }
-
     fun dialogCheckBoxStateChanged(isChecked: Boolean) {
         userProfileState.run {
             userProfileState = copy(statusDialogData = statusDialogData?.changeCheckBoxState(isChecked))
         }
     }
-
     fun changeStatusClick(status: UserAvailabilityStatus) {
         if (userProfileState.status == status) return
-
         viewModelScope.launch {
             if (shouldShowStatusRationaleDialog(status)) {
                 val statusDialogInfo = when (status) {
@@ -317,7 +282,6 @@ class SelfUserProfileViewModel @Inject constructor(
             }
         }
     }
-
     private fun setNotShowStatusRationaleAgainIfNeeded(status: UserAvailabilityStatus) {
         userProfileState.statusDialogData.let { dialogState ->
             if (dialogState?.isCheckBoxChecked == true) {
@@ -325,14 +289,11 @@ class SelfUserProfileViewModel @Inject constructor(
             }
         }
     }
-
     private suspend fun shouldShowStatusRationaleDialog(status: UserAvailabilityStatus): Boolean =
         dataStore.shouldShowStatusRationaleFlow(status).first()
-
     fun clearErrorMessage() {
         userProfileState = userProfileState.copy(errorMessageCode = null)
     }
-
     fun trackQrCodeClick() {
         anonymousAnalyticsManager.sendEvent(
             AnalyticsEvent.QrCode.Click(
@@ -340,7 +301,6 @@ class SelfUserProfileViewModel @Inject constructor(
             )
         )
     }
-
     sealed class ErrorCodes {
         data object DownloadUserInfoError : ErrorCodes()
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import com.ramcosta.composedestinations.generated.app.destinations.ConversationScreenDestination
 import com.wire.android.R
-import com.wire.android.di.hiltViewModelScoped
+import com.wire.android.ui.home.settings.serviceDetailsViewModel
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
@@ -77,7 +77,7 @@ import kotlinx.coroutines.launch
 fun ServiceDetailsScreen(
     navigator: Navigator,
     viewModel: ServiceDetailsViewModel =
-        hiltViewModelScoped<ServiceDetailsViewModelImpl, ServiceDetailsViewModel>()
+        serviceDetailsViewModel()
 ) {
     val snackbarHostState = LocalSnackbarHostState.current
     val coroutineScope = rememberCoroutineScope()

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsViewModel.kt
@@ -16,7 +16,6 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 package com.wire.android.ui.userprofile.service
-
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -52,7 +51,6 @@ import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppsAllowedForUsageU
 import com.wire.kalium.logic.feature.service.GetServiceByIdUseCase
 import com.wire.kalium.logic.feature.service.ObserveIsServiceMemberResult
 import com.wire.kalium.logic.feature.service.ObserveIsServiceMemberUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterIsInstance
@@ -63,7 +61,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-
 @ViewModelScopedPreview
 interface ServiceDetailsViewModel : ActionsManager<ServiceDetailsViewActions> {
     fun serviceDetailsState(): ServiceDetailsState = ServiceDetailsState()
@@ -73,7 +70,6 @@ interface ServiceDetailsViewModel : ActionsManager<ServiceDetailsViewActions> {
 }
 
 @Suppress("LongParameterList")
-@HiltViewModel
 class ServiceDetailsViewModelImpl @Inject constructor(
     private val dispatchers: DispatcherProvider,
     @CurrentAccount private val selfUserId: UserId,
@@ -91,34 +87,26 @@ class ServiceDetailsViewModelImpl @Inject constructor(
     private val getOrCreateOneToOneConversation: GetOrCreateOneToOneConversationUseCase,
     savedStateHandle: SavedStateHandle
 ) : ServiceDetailsViewModel, ActionsViewModel<ServiceDetailsViewActions>() {
-
     private val serviceDetailsNavArgs: ServiceDetailsNavArgs = savedStateHandle.navArgs()
-
     private val serviceId: ServiceId = serviceDetailsNavArgs.id.serviceId
     private val userId: UserId = serviceDetailsNavArgs.id.userId
     private val conversationId: QualifiedID? = serviceDetailsNavArgs.conversationId
-
     private var state by mutableStateOf(ServiceDetailsState())
     override fun serviceDetailsState(): ServiceDetailsState = state
-
     init {
         viewModelScope.launch {
             getIfConversationExist()
-
             val appsAllowedResult = observeIsAppsAllowedForUsage().firstOrNull()
-
             val conversationProtocolInfo = conversationId?.let {
                 observeConversationDetails(it)
                     .filterIsInstance<ObserveConversationDetailsUseCase.Result.Success>()
                     .map { result -> result.conversationDetails.conversation.protocol }
                     .firstOrNull()
             }
-
             val isAppsEnabled = AppsUtil.isAppsAllowed(
                 appsAllowedResult = appsAllowedResult,
                 conversationProtocol = conversationProtocolInfo
             )
-
             state = state.copy(
                 serviceId = serviceId,
                 conversationId = conversationId,
@@ -126,7 +114,6 @@ class ServiceDetailsViewModelImpl @Inject constructor(
                 isAvatarLoading = true,
                 isAppsEnabled = isAppsEnabled
             )
-
             when (val id = serviceDetailsNavArgs.id) {
                 is ServiceDetailsNavArgs.Id.AppId -> {
                     val details = getAppDetailsAndUpdateViewState(id.appId)
@@ -134,7 +121,6 @@ class ServiceDetailsViewModelImpl @Inject constructor(
                         observeIsAppConversationMember(id.appId)
                     }
                 }
-
                 is ServiceDetailsNavArgs.Id.BotServiceId -> {
                     getServiceDetailsAndUpdateViewState()?.let {
                         observeIsServiceConversationMember()
@@ -143,7 +129,6 @@ class ServiceDetailsViewModelImpl @Inject constructor(
             }
         }
     }
-
     override fun onAddService() {
         viewModelScope.launch {
             state = state.copy(isActionLoading = true)
@@ -153,7 +138,6 @@ class ServiceDetailsViewModelImpl @Inject constructor(
                         conversationId = requireNotNull(conversationId),
                         userIdList = listOf(id.appId)
                     )
-
                     when (response) {
                         is AddMemberToConversationUseCase.Result.Failure -> ServiceDetailsInfoMessageType.ErrorAddService
                         is AddMemberToConversationUseCase.Result.Success -> ServiceDetailsInfoMessageType.SuccessAddService
@@ -166,19 +150,16 @@ class ServiceDetailsViewModelImpl @Inject constructor(
                             serviceId = id.serviceId
                         )
                     }
-
                     when (response) {
                         is AddServiceToConversationUseCase.Result.Failure -> ServiceDetailsInfoMessageType.ErrorAddService
                         is AddServiceToConversationUseCase.Result.Success -> ServiceDetailsInfoMessageType.SuccessAddService
                     }
                 }
             }
-
             sendAction(ServiceDetailsViewActions.Message(responseMessage.uiText.asSnackBarMessage()))
             state = state.copy(isActionLoading = false)
         }
     }
-
     override fun onRemoveService() {
         viewModelScope.launch {
             state.serviceMemberId?.let { serviceMemberId ->
@@ -189,29 +170,24 @@ class ServiceDetailsViewModelImpl @Inject constructor(
                         userIdToRemove = serviceMemberId
                     )
                 }
-
                 val responseMessage = when (response) {
                     is RemoveMemberFromConversationUseCase.Result.Failure -> ServiceDetailsInfoMessageType.ErrorRemoveService
                     is RemoveMemberFromConversationUseCase.Result.Success -> ServiceDetailsInfoMessageType.SuccessRemoveService
                 }
-
                 sendAction(ServiceDetailsViewActions.Message(responseMessage.uiText.asSnackBarMessage()))
                 state = state.copy(isActionLoading = false)
             }
         }
     }
-
     override fun onOpenConversation() {
         viewModelScope.launch {
             state = state.copy(isActionLoading = true)
             val result = withContext(dispatchers.io()) {
                 getOrCreateOneToOneConversation(userId)
             }
-
             when (result) {
                 is CreateConversationResult.Failure -> {
                     appLogger.d("Couldn't retrieve or create the conversation")
-
                     sendAction(
                         ServiceDetailsViewActions.Message(
                             ServiceDetailsInfoMessageType
@@ -227,14 +203,12 @@ class ServiceDetailsViewModelImpl @Inject constructor(
             state = state.copy(isActionLoading = false)
         }
     }
-
     private suspend fun getServiceDetailsAndUpdateViewState(): ServiceDetails? =
         getServiceById(serviceId = serviceId).also { service ->
             if (service != null) {
                 val serviceAvatarAsset = service.completeAssetId?.let { asset ->
                     ImageAsset.UserAvatarAsset(asset)
                 }
-
                 state = state.copy(
                     isDataLoading = false,
                     isAvatarLoading = false,
@@ -245,7 +219,6 @@ class ServiceDetailsViewModelImpl @Inject constructor(
                 serviceNotFound()
             }
         }
-
     private suspend fun getAppDetailsAndUpdateViewState(appId: UserId): ServiceDetails? =
         getAppById(appId = appId).also { app ->
             if (app != null) {
@@ -254,7 +227,6 @@ class ServiceDetailsViewModelImpl @Inject constructor(
                 } ?: app.previewAssetId?.let { asset ->
                     ImageAsset.UserAvatarAsset(asset)
                 }
-
                 state = state.copy(
                     isDataLoading = false,
                     isAvatarLoading = false,
@@ -265,7 +237,6 @@ class ServiceDetailsViewModelImpl @Inject constructor(
                 serviceNotFound()
             }
         }
-
     private suspend fun observeGroupInfo(): Flow<ServiceDetailsGroupState> =
         conversationId?.let {
             observeConversationRoleForUser(conversationId, selfUserId)
@@ -276,7 +247,6 @@ class ServiceDetailsViewModelImpl @Inject constructor(
                     )
                 }
         } ?: flowOf()
-
     private suspend fun observeIsServiceConversationMember() {
         conversationId?.let {
             observeIsServiceMember(
@@ -295,7 +265,6 @@ class ServiceDetailsViewModelImpl @Inject constructor(
                 }
         }
     }
-
     private suspend fun observeIsAppConversationMember(appId: UserId) {
         conversationId?.let {
             observeIsAppMember(
@@ -313,7 +282,6 @@ class ServiceDetailsViewModelImpl @Inject constructor(
                 }
         }
     }
-
     private fun getIfConversationExist() {
         viewModelScope.launch {
             if (conversationId == null) {
@@ -322,14 +290,12 @@ class ServiceDetailsViewModelImpl @Inject constructor(
             }
         }
     }
-
     private fun serviceNotFound() {
         state = state.copy(
             serviceDetails = null,
             buttonState = ServiceDetailsButtonState.HIDDEN
         )
     }
-
     private fun updateViewStateButton(
         serviceMemberId: UserId?,
         groupInfo: ServiceDetailsGroupState
@@ -343,13 +309,11 @@ class ServiceDetailsViewModelImpl @Inject constructor(
         } else {
             ServiceDetailsButtonState.HIDDEN
         }
-
         state = state.copy(
             buttonState = buttonState,
             serviceMemberId = serviceMemberId
         )
     }
-
     private companion object {
         const val TAG = "ServiceDetailsViewModel"
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/TeamMigrationViewModel.kt
@@ -16,7 +16,6 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 package com.wire.android.ui.userprofile.teammigration
-
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -29,11 +28,8 @@ import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.migration.MigrateFromPersonalToTeamResult
 import com.wire.kalium.logic.feature.user.migration.MigrateFromPersonalToTeamUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-@HiltViewModel
 class TeamMigrationViewModel @Inject constructor(
     private val anonymousAnalyticsManager: AnonymousAnalyticsManager,
     private val migrateFromPersonalToTeam: MigrateFromPersonalToTeamUseCase,
@@ -41,20 +37,16 @@ class TeamMigrationViewModel @Inject constructor(
     private val dataStore: UserDataStore,
     private val getTeamUrl: GetTeamUrlUseCase
 ) : ViewModel() {
-
     var teamMigrationState by mutableStateOf(TeamMigrationState())
         private set
-
     init {
         setUsername()
         setTeamUrl()
         observeMigrationDotActive()
     }
-
     fun setCurrentStep(step: Int) {
         sendPersonalTeamCreationFlowStepEvent(step)
     }
-
     fun migrateFromPersonalToTeamAccount() {
         viewModelScope.launch {
             teamMigrationState = teamMigrationState.copy(isMigrating = true)
@@ -64,18 +56,15 @@ class TeamMigrationViewModel @Inject constructor(
                 teamMigrationState = when (result) {
                     is MigrateFromPersonalToTeamResult.Success ->
                         teamMigrationState.copy(isMigrating = false, migrationCompleted = true)
-
                     is MigrateFromPersonalToTeamResult.Error ->
                         teamMigrationState.copy(isMigrating = false, migrationFailure = result.failure)
                 }
             }
         }
     }
-
     fun failureHandled() {
         teamMigrationState = teamMigrationState.copy(migrationFailure = null)
     }
-
     private fun setUsername() {
         viewModelScope.launch {
             observeSelfUser().collect { selfUser ->
@@ -85,14 +74,12 @@ class TeamMigrationViewModel @Inject constructor(
             }
         }
     }
-
     private fun setTeamUrl() {
         viewModelScope.launch {
             val teamUrl = getTeamUrl()
             teamMigrationState = teamMigrationState.copy(teamUrl = teamUrl)
         }
     }
-
     private fun observeMigrationDotActive() {
         viewModelScope.launch {
             dataStore.isCreateTeamNoticeRead().collect { isRead ->
@@ -102,13 +89,11 @@ class TeamMigrationViewModel @Inject constructor(
             }
         }
     }
-
     private fun sendPersonalTeamCreationFlowStepEvent(step: Int) {
         val event = when (step) {
             TEAM_MIGRATION_TEAM_PLAN_STEP -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowTeamPlan(
                 isMigrationDotActive = teamMigrationState.isMigrationDotActive
             )
-
             TEAM_MIGRATION_TEAM_NAME_STEP -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowTeamName
             TEAM_MIGRATION_CONFIRMATION_STEP -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowConfirm
             TEAM_MIGRATION_DONE_STEP -> AnalyticsEvent.PersonalTeamMigration.PersonalTeamCreationFlowCompleted
@@ -116,7 +101,6 @@ class TeamMigrationViewModel @Inject constructor(
         }
         event?.let { anonymousAnalyticsManager.sendEvent(event) }
     }
-
     companion object {
         const val TEAM_MIGRATION_TEAM_PLAN_STEP = 1
         const val TEAM_MIGRATION_TEAM_NAME_STEP = 2

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -3767,8 +3767,8 @@ private fun com.wire.android.ui.debug.UserDataBaseProfileSwitch(isEnabled: kotli
     - onCheckedChange: STABLE (function type)
 
 @Composable
-internal fun com.wire.android.ui.debug.UserDebugContent(state: com.wire.android.ui.debug.UserDebugState, onNavigationPressed: kotlin.Function0<kotlin.Unit>, onLoggingEnabledChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onDatabaseLoggerEnabledChanged: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onDeleteLogs: kotlin.Function0<kotlin.Unit>, onFlushLogs: kotlin.Function0<kotlinx.coroutines.Deferred<kotlin.Unit>>, onShowFeatureFlags: kotlin.Function0<kotlin.Unit>, onShowCryptoStats: kotlin.Function0<kotlin.Unit>): kotlin.Unit
-  skippable: true
+internal fun com.wire.android.ui.debug.UserDebugContent(state: com.wire.android.ui.debug.UserDebugState, onNavigationPressed: kotlin.Function0<kotlin.Unit>, onLoggingEnabledChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onDatabaseLoggerEnabledChanged: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onDeleteLogs: kotlin.Function0<kotlin.Unit>, onFlushLogs: kotlin.Function0<kotlinx.coroutines.Deferred<kotlin.Unit>>, onShowFeatureFlags: kotlin.Function0<kotlin.Unit>, onShowCryptoStats: kotlin.Function0<kotlin.Unit>, debugDataOptionsViewModel: com.wire.android.ui.debug.DebugDataOptionsViewModel, exportObfuscatedCopyViewModel: com.wire.android.ui.debug.ExportObfuscatedCopyViewModel): kotlin.Unit
+  skippable: false
   restartable: true
   params:
     - state: STABLE (class with no mutable properties)
@@ -3779,6 +3779,14 @@ internal fun com.wire.android.ui.debug.UserDebugContent(state: com.wire.android.
     - onFlushLogs: STABLE (function type)
     - onShowFeatureFlags: STABLE (function type)
     - onShowCryptoStats: STABLE (function type)
+    - debugDataOptionsViewModel: RUNTIME (requires runtime check)
+    - exportObfuscatedCopyViewModel: RUNTIME (requires runtime check)
+
+@Composable
+public fun com.wire.android.ui.debug.aboutThisAppViewModel(): com.wire.android.ui.settings.about.AboutThisAppViewModel
+  skippable: true
+  restartable: true
+  params:
 
 @Composable
 private fun com.wire.android.ui.debug.conversation.ConversationActionsView(state: com.wire.android.ui.debug.conversation.DebugConversationViewState, onUpdate: kotlin.Function0<kotlin.Unit>, onReset: kotlin.Function0<kotlin.Unit>): kotlin.Unit
@@ -3828,6 +3836,12 @@ private fun com.wire.android.ui.debug.conversation.MlsDetailsView(state: com.wir
     - onRefreshCcEpoch: STABLE (function type)
 
 @Composable
+public fun com.wire.android.ui.debug.conversationCryptoStatsViewModel(): com.wire.android.ui.debug.cryptostats.ConversationCryptoStatsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 public fun com.wire.android.ui.debug.cryptostats.ConversationCryptoStatsScreen(navigator: com.wire.android.navigation.Navigator, modifier: androidx.compose.ui.Modifier, viewModel: com.wire.android.ui.debug.cryptostats.ConversationCryptoStatsViewModel): kotlin.Unit
   skippable: false
   restartable: true
@@ -3868,6 +3882,54 @@ private fun com.wire.android.ui.debug.cryptostats.StatsSummary(uiModel: com.wire
     - uiModel: RUNTIME (requires runtime check)
 
 @Composable
+public fun com.wire.android.ui.debug.debugConversationViewModel(): com.wire.android.ui.debug.conversation.DebugConversationViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.debug.debugDataOptionsViewModel(): com.wire.android.ui.debug.DebugDataOptionsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.debug.debugFeatureFlagsViewModel(): com.wire.android.ui.debug.featureflags.DebugFeatureFlagsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.debug.debugInfoSavedStateViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function2<com.wire.android.ui.debug.DebugInfoViewModelFactory, androidx.lifecycle.SavedStateHandle, VM of com.wire.android.ui.debug.debugInfoSavedStateViewModel>): VM of com.wire.android.ui.debug.debugInfoSavedStateViewModel
+  skippable: false
+  restartable: true
+  params:
+    - viewModelStoreOwner: RUNTIME (requires runtime check)
+    - key: STABLE (class with no mutable properties)
+    - create: STABLE (function type)
+
+@Composable
+public fun com.wire.android.ui.debug.debugInfoViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function1<com.wire.android.ui.debug.DebugInfoViewModelFactory, VM of com.wire.android.ui.debug.debugInfoViewModel>): VM of com.wire.android.ui.debug.debugInfoViewModel
+  skippable: false
+  restartable: true
+  params:
+    - viewModelStoreOwner: RUNTIME (requires runtime check)
+    - key: STABLE (class with no mutable properties)
+    - create: STABLE (function type)
+
+@Composable
+public fun com.wire.android.ui.debug.dependenciesViewModel(): com.wire.android.ui.home.settings.about.dependencies.DependenciesViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.debug.exportObfuscatedCopyViewModel(): com.wire.android.ui.debug.ExportObfuscatedCopyViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 public fun com.wire.android.ui.debug.featureflags.DebugFeatureFlagsScreen(navigator: com.wire.android.navigation.Navigator, modifier: androidx.compose.ui.Modifier, viewModel: com.wire.android.ui.debug.featureflags.DebugFeatureFlagsViewModel): kotlin.Unit
   skippable: false
   restartable: true
@@ -3885,11 +3947,35 @@ public fun com.wire.android.ui.debug.featureflags.FeatureListItem(feature: com.w
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
+public fun com.wire.android.ui.debug.licensesViewModel(): com.wire.android.ui.home.settings.about.licenses.LicensesViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.debug.logManagementViewModel(): com.wire.android.ui.debug.LogManagementViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 public fun com.wire.android.ui.debug.rememberDebugContentState(logPath: kotlin.String): com.wire.android.ui.debug.DebugContentState
   skippable: true
   restartable: true
   params:
     - logPath: STABLE (String is immutable)
+
+@Composable
+public fun com.wire.android.ui.debug.userDebugViewModel(): com.wire.android.ui.debug.UserDebugViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.debug.whatsNewViewModel(): com.wire.android.ui.home.whatsnew.WhatsNewViewModel
+  skippable: true
+  restartable: true
+  params:
 
 @Composable
 public fun com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentScreen(navigator: com.wire.android.navigation.Navigator, loginTypeSelector: com.wire.android.navigation.LoginTypeSelector, viewModel: com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentViewModel, clearSessionViewModel: com.wire.android.ui.authentication.devices.common.ClearSessionViewModel): kotlin.Unit
@@ -9220,6 +9306,12 @@ public fun com.wire.android.ui.home.settings.account.handle.ChangeHandleScreen(n
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
+public fun com.wire.android.ui.home.settings.appUnlockWithBiometricsViewModel(): com.wire.android.ui.home.appLock.unlock.AppUnlockWithBiometricsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 public fun com.wire.android.ui.home.settings.appearance.CustomizationOptionsContent(enterToSendState: kotlin.Boolean, enterToSendClicked: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
@@ -9283,6 +9375,12 @@ public fun com.wire.android.ui.home.settings.appsettings.networkSettings.Network
     - isWebSocketEnforcedByDefault: STABLE (primitive type)
     - setWebSocketState: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)
+
+@Composable
+public fun com.wire.android.ui.home.settings.avatarPickerViewModel(): com.wire.android.ui.userprofile.avatarpicker.AvatarPickerViewModel
+  skippable: true
+  restartable: true
+  params:
 
 @Composable
 public fun com.wire.android.ui.home.settings.backup.BackupAndRestoreContent(backUpAndRestoreState: com.wire.android.ui.home.settings.backup.BackupAndRestoreState, createBackupPasswordTextState: androidx.compose.foundation.text.input.TextFieldState, restoreBackupPasswordTextState: androidx.compose.foundation.text.input.TextFieldState, onCreateBackup: kotlin.Function0<kotlin.Unit>, onSaveBackup: kotlin.Function1<android.net.Uri, kotlin.Unit>, onShareBackup: kotlin.Function0<kotlin.Unit>, onCancelBackupCreation: kotlin.Function0<kotlin.Unit>, onCancelBackupRestore: kotlin.Function0<kotlin.Unit>, onChooseBackupFile: kotlin.Function1<android.net.Uri, kotlin.Unit>, onRestoreBackup: kotlin.Function0<kotlin.Unit>, onOpenConversations: kotlin.Function0<kotlin.Unit>, onBackPressed: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -9475,6 +9573,90 @@ public fun com.wire.android.ui.home.settings.backup.rememberBackUpAndRestoreStat
   params:
 
 @Composable
+public fun com.wire.android.ui.home.settings.backupAndRestoreViewModel(): com.wire.android.ui.home.settings.backup.BackupAndRestoreViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.changeDisplayNameViewModel(): com.wire.android.ui.home.settings.account.displayname.ChangeDisplayNameViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.changeEmailViewModel(): com.wire.android.ui.home.settings.account.email.updateEmail.ChangeEmailViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.changeHandleViewModel(): com.wire.android.ui.home.settings.account.handle.ChangeHandleViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.changeUserColorViewModel(): com.wire.android.ui.home.settings.account.color.ChangeUserColorViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.customizationViewModel(): com.wire.android.ui.home.settings.appearance.CustomizationViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.deleteAccountViewModel(): com.wire.android.ui.home.settings.account.deleteAccount.DeleteAccountViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.deviceDetailsViewModel(): com.wire.android.ui.settings.devices.DeviceDetailsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.e2eiCertificateDetailsViewModel(): com.wire.android.ui.settings.devices.e2ei.E2eiCertificateDetailsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.enterLockScreenViewModel(): com.wire.android.ui.home.appLock.unlock.EnterLockScreenViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.forgotLockScreenViewModel(): com.wire.android.ui.home.appLock.forgot.ForgotLockScreenViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.myAccountViewModel(): com.wire.android.ui.home.settings.account.MyAccountViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.networkSettingsViewModel(): com.wire.android.ui.home.settings.appsettings.networkSettings.NetworkSettingsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.otherUserProfileScreenViewModel(): com.wire.android.ui.userprofile.other.OtherUserProfileScreenViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 public fun com.wire.android.ui.home.settings.privacy.PrivacySettingsConfigScreen(navigator: com.wire.android.navigation.Navigator, viewModel: com.wire.android.ui.home.settings.privacy.PrivacySettingsViewModel): kotlin.Unit
   skippable: false
   restartable: true
@@ -9498,6 +9680,79 @@ public fun com.wire.android.ui.home.settings.privacy.PrivacySettingsScreenConten
     - setAnonymousUsageDataEnabled: STABLE (function type)
     - onBackPressed: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)
+
+@Composable
+public fun com.wire.android.ui.home.settings.privacySettingsViewModel(): com.wire.android.ui.home.settings.privacy.PrivacySettingsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.selfDevicesViewModel(): com.wire.android.ui.settings.devices.SelfDevicesViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.selfQRCodeViewModel(): com.wire.android.ui.userprofile.qr.SelfQRCodeViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.selfUserProfileViewModel(): com.wire.android.ui.userprofile.self.SelfUserProfileViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.serviceDetailsViewModel(): com.wire.android.ui.userprofile.service.ServiceDetailsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.setLockScreenViewModel(): com.wire.android.ui.home.appLock.set.SetLockScreenViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.settingsSavedStateViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function2<com.wire.android.ui.home.settings.SettingsViewModelFactory, androidx.lifecycle.SavedStateHandle, VM of com.wire.android.ui.home.settings.settingsSavedStateViewModel>): VM of com.wire.android.ui.home.settings.settingsSavedStateViewModel
+  skippable: false
+  restartable: true
+  params:
+    - viewModelStoreOwner: RUNTIME (requires runtime check)
+    - key: STABLE (class with no mutable properties)
+    - create: STABLE (function type)
+
+@Composable
+public fun com.wire.android.ui.home.settings.settingsScreenViewModel(): com.wire.android.ui.home.settings.SettingsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.settings.settingsViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function1<com.wire.android.ui.home.settings.SettingsViewModelFactory, VM of com.wire.android.ui.home.settings.settingsViewModel>): VM of com.wire.android.ui.home.settings.settingsViewModel
+  skippable: false
+  restartable: true
+  params:
+    - viewModelStoreOwner: RUNTIME (requires runtime check)
+    - key: STABLE (class with no mutable properties)
+    - create: STABLE (function type)
+
+@Composable
+public fun com.wire.android.ui.home.settings.teamMigrationViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner): com.wire.android.ui.userprofile.teammigration.TeamMigrationViewModel
+  skippable: false
+  restartable: true
+  params:
+    - viewModelStoreOwner: RUNTIME (requires runtime check)
+
+@Composable
+public fun com.wire.android.ui.home.settings.verifyEmailViewModel(): com.wire.android.ui.home.settings.account.email.verifyEmail.VerifyEmailViewModel
+  skippable: true
+  restartable: true
+  params:
 
 @Composable
 public fun com.wire.android.ui.home.vault.VaultScreen(): kotlin.Unit


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25946
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Migrates settings/account ViewModels from Hilt call-site creation to Metro-backed factories.
- Reuses the existing Metro ViewModel bridge introduced in the settings/debug PR.
- Adds the Compose test fake wiring needed by the migrated account/debug ViewModel graph.
