### PR TITLE
refactor: migrate auth view models to metro [WPB-25946]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
@@ -22,6 +22,8 @@ import com.wire.android.feature.cells.ui.CellsViewModelFactory
 import com.wire.android.feature.cells.ui.CellsViewModelGraph
 import com.wire.android.model.ImageAssetViewModelFactory
 import com.wire.android.model.ImageAssetViewModelGraph
+import com.wire.android.ui.authentication.AuthenticationViewModelFactory
+import com.wire.android.ui.authentication.AuthenticationViewModelGraph
 import com.wire.android.ui.debug.DebugInfoViewModelFactory
 import com.wire.android.ui.debug.DebugInfoViewModelGraph
 import com.wire.android.ui.home.settings.SettingsViewModelFactory
@@ -38,14 +40,23 @@ import javax.inject.Provider
 class WireActivityViewModelGraphBridge @Inject constructor(
     imageLoader: Provider<WireSessionImageLoader>,
     private val cellsViewModelFactoryProvider: Provider<CellsViewModelFactory>,
+    private val authenticationViewModelFactoryProvider: Provider<AuthenticationViewModelFactory>,
     private val debugInfoViewModelFactoryProvider: Provider<DebugInfoViewModelFactory>,
     private val settingsViewModelFactoryProvider: Provider<SettingsViewModelFactory>,
-) : ViewModel(), ImageAssetViewModelGraph, CellsViewModelGraph, DebugInfoViewModelGraph, SettingsViewModelGraph {
+) : ViewModel(),
+    ImageAssetViewModelGraph,
+    CellsViewModelGraph,
+    AuthenticationViewModelGraph,
+    DebugInfoViewModelGraph,
+    SettingsViewModelGraph {
     override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
         ImageAssetViewModelFactory(imageLoader = imageLoader::get)
 
     override val cellsViewModelFactory: CellsViewModelFactory
         get() = cellsViewModelFactoryProvider.get()
+
+    override val authenticationViewModelFactory: AuthenticationViewModelFactory
+        get() = authenticationViewModelFactoryProvider.get()
 
     override val debugInfoViewModelFactory: DebugInfoViewModelFactory
         get() = debugInfoViewModelFactoryProvider.get()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelFactory.kt
@@ -1,0 +1,254 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.authentication
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.analytics.FinalizeRegistrationAnalyticsMetadataUseCase
+import com.wire.android.analytics.RegistrationAnalyticsManagerUseCase
+import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.datastore.UserDataStore
+import com.wire.android.datastore.UserDataStoreProvider
+import com.wire.android.di.ClientScopeProvider
+import com.wire.android.di.DefaultWebSocketEnabledByDefault
+import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.feature.AccountSwitchUseCase
+import com.wire.android.ui.authentication.create.code.CreateAccountCodeViewModel
+import com.wire.android.ui.authentication.create.details.CreateAccountDetailsViewModel
+import com.wire.android.ui.authentication.create.email.CreateAccountEmailViewModel
+import com.wire.android.ui.authentication.create.overview.CreateAccountOverviewViewModel
+import com.wire.android.ui.authentication.create.summary.CreateAccountSummaryViewModel
+import com.wire.android.ui.authentication.create.username.CreateAccountUsernameViewModel
+import com.wire.android.ui.authentication.devices.common.ClearSessionViewModel
+import com.wire.android.ui.authentication.devices.register.RegisterDeviceViewModel
+import com.wire.android.ui.authentication.devices.remove.RemoveDeviceViewModel
+import com.wire.android.ui.authentication.login.LoginNavArgs
+import com.wire.android.ui.authentication.login.LoginSavedInputStore
+import com.wire.android.ui.authentication.login.LoginViewModelExtension
+import com.wire.android.ui.authentication.login.SavedStateLoginSavedInputStore
+import com.wire.android.ui.authentication.login.email.LoginEmailViewModel
+import com.wire.android.ui.authentication.login.sso.LoginSSOViewModel
+import com.wire.android.ui.authentication.login.sso.LoginSSOViewModelExtension
+import com.wire.android.ui.authentication.welcome.WelcomeViewModel
+import com.wire.android.ui.newauthentication.login.NewLoginViewModel
+import com.wire.android.ui.newauthentication.login.ValidateEmailOrSSOCodeUseCase
+import com.wire.android.ui.registration.code.CreateAccountVerificationCodeViewModel
+import com.wire.android.ui.registration.details.CreateAccountDataDetailViewModel
+import com.wire.android.ui.registration.selector.CreateAccountSelectorViewModel
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.ui.CountdownTimer
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
+import com.wire.kalium.logic.feature.auth.LogoutUseCase
+import com.wire.kalium.logic.feature.auth.ValidateEmailUseCase
+import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
+import com.wire.kalium.logic.feature.auth.ValidateUserHandleUseCase
+import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerificationCodeUseCase
+import com.wire.kalium.logic.feature.client.DeleteClientUseCase
+import com.wire.kalium.logic.feature.client.FetchSelfClientsFromRemoteUseCase
+import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
+import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
+import com.wire.kalium.logic.feature.session.DoesValidNomadAccountExistUseCase
+import com.wire.kalium.logic.feature.session.GetSessionsUseCase
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
+import com.wire.kalium.logic.feature.user.SetUserHandleUseCase
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Provider
+
+@Suppress("LongParameterList", "TooManyFunctions")
+class AuthenticationViewModelFactory @Inject constructor(
+    private val globalDataStore: Provider<GlobalDataStore>,
+    private val userDataStore: Provider<UserDataStore>,
+    private val userDataStoreProvider: Provider<UserDataStoreProvider>,
+    @KaliumCoreLogic private val coreLogic: Provider<CoreLogic>,
+    private val defaultServerConfig: Provider<ServerConfig.Links>,
+    @DefaultWebSocketEnabledByDefault private val defaultWebSocketEnabledByDefault: Provider<Boolean>,
+    @Named("ssoCodeConfig") private val defaultSSOCodeConfig: Provider<String>,
+    private val addAuthenticatedUser: Provider<AddAuthenticatedUserUseCase>,
+    private val clientScopeProviderFactory: Provider<ClientScopeProvider.Factory>,
+    private val dispatchers: Provider<DispatcherProvider>,
+    private val validateEmailOrSSOCode: Provider<ValidateEmailOrSSOCodeUseCase>,
+    private val validateEmail: Provider<ValidateEmailUseCase>,
+    private val validatePassword: Provider<ValidatePasswordUseCase>,
+    private val validateUserHandle: Provider<ValidateUserHandleUseCase>,
+    private val setUserHandle: Provider<SetUserHandleUseCase>,
+    private val finalizeRegistrationAnalyticsMetadata: Provider<FinalizeRegistrationAnalyticsMetadataUseCase>,
+    private val registrationAnalyticsManager: Provider<RegistrationAnalyticsManagerUseCase>,
+    private val getSessions: Provider<GetSessionsUseCase>,
+    private val doesValidNomadAccountExist: Provider<DoesValidNomadAccountExistUseCase>,
+    private val currentSession: Provider<CurrentSessionUseCase>,
+    private val deleteSession: Provider<DeleteSessionUseCase>,
+    private val switchAccount: Provider<AccountSwitchUseCase>,
+    private val logout: Provider<LogoutUseCase>,
+    private val getOrRegisterClient: Provider<GetOrRegisterClientUseCase>,
+    private val isPasswordRequired: Provider<IsPasswordRequiredUseCase>,
+    private val getSelfUser: Provider<GetSelfUserUseCase>,
+    private val requestSecondFactorVerificationCode: Provider<RequestSecondFactorVerificationCodeUseCase>,
+    private val countdownTimer: Provider<CountdownTimer>,
+    private val fetchSelfClientsFromRemote: Provider<FetchSelfClientsFromRemoteUseCase>,
+    private val deleteClient: Provider<DeleteClientUseCase>,
+) {
+    fun welcomeViewModel(savedStateHandle: SavedStateHandle) = WelcomeViewModel(
+        savedStateHandle = savedStateHandle,
+        getSessions = getSessions.get(),
+        doesValidNomadAccountExist = doesValidNomadAccountExist.get(),
+        defaultServerConfig = defaultServerConfig.get(),
+    )
+
+    fun newLoginViewModel(savedStateHandle: SavedStateHandle) = NewLoginViewModel(
+        validateEmailOrSSOCode = validateEmailOrSSOCode.get(),
+        coreLogic = coreLogic.get(),
+        savedStateHandle = savedStateHandle,
+        clientScopeProviderFactory = clientScopeProviderFactory.get(),
+        userDataStoreProvider = userDataStoreProvider.get(),
+        loginExtension = LoginViewModelExtension(clientScopeProviderFactory.get(), userDataStoreProvider.get()),
+        ssoExtension = LoginSSOViewModelExtension(
+            addAuthenticatedUser = addAuthenticatedUser.get(),
+            coreLogic = coreLogic.get(),
+            defaultWebSocketEnabledByDefault = defaultWebSocketEnabledByDefault.get(),
+        ),
+        dispatchers = dispatchers.get(),
+        defaultServerConfig = defaultServerConfig.get(),
+        defaultSSOCodeConfig = defaultSSOCodeConfig.get(),
+    )
+
+    fun loginEmailViewModel(loginNavArgs: LoginNavArgs, savedStateHandle: SavedStateHandle) = LoginEmailViewModel(
+        loginNavArgs = loginNavArgs,
+        addAuthenticatedUser = addAuthenticatedUser.get(),
+        clientScopeProviderFactory = clientScopeProviderFactory.get(),
+        savedInputStore = loginSavedInputStore(savedStateHandle),
+        userDataStoreProvider = userDataStoreProvider.get(),
+        coreLogic = coreLogic.get(),
+        resendCodeTimer = countdownTimer.get(),
+        dispatchers = dispatchers.get(),
+        defaultServerConfig = defaultServerConfig.get(),
+        defaultWebSocketEnabledByDefault = defaultWebSocketEnabledByDefault.get(),
+    )
+
+    fun loginSSOViewModel(loginNavArgs: LoginNavArgs, savedStateHandle: SavedStateHandle) = LoginSSOViewModel(
+        loginNavArgs = loginNavArgs,
+        savedInputStore = loginSavedInputStore(savedStateHandle),
+        addAuthenticatedUser = addAuthenticatedUser.get(),
+        validateEmailUseCase = validateEmail.get(),
+        coreLogic = coreLogic.get(),
+        clientScopeProviderFactory = clientScopeProviderFactory.get(),
+        userDataStoreProvider = userDataStoreProvider.get(),
+        serverConfig = defaultServerConfig.get(),
+        ssoExtension = LoginSSOViewModelExtension(
+            addAuthenticatedUser = addAuthenticatedUser.get(),
+            coreLogic = coreLogic.get(),
+            defaultWebSocketEnabledByDefault = defaultWebSocketEnabledByDefault.get(),
+        ),
+        dispatchers = dispatchers.get(),
+    )
+
+    fun registerDeviceViewModel() = RegisterDeviceViewModel(
+        registerClientUseCase = getOrRegisterClient.get(),
+        isPasswordRequired = isPasswordRequired.get(),
+        userDataStore = userDataStore.get(),
+        getSelfUser = getSelfUser.get(),
+        requestSecondFactorVerificationCodeUseCase = requestSecondFactorVerificationCode.get(),
+        resendCodeTimer = countdownTimer.get(),
+    )
+
+    fun removeDeviceViewModel() = RemoveDeviceViewModel(
+        fetchSelfClientsFromRemote = fetchSelfClientsFromRemote.get(),
+        deleteClientUseCase = deleteClient.get(),
+        registerClientUseCase = getOrRegisterClient.get(),
+        isPasswordRequired = isPasswordRequired.get(),
+        userDataStore = userDataStore.get(),
+        getSelfUser = getSelfUser.get(),
+        requestSecondFactorVerificationCodeUseCase = requestSecondFactorVerificationCode.get(),
+    )
+
+    fun clearSessionViewModel() = ClearSessionViewModel(
+        currentSession = currentSession.get(),
+        deleteSession = deleteSession.get(),
+        switchAccount = switchAccount.get(),
+        logout = logout.get(),
+    )
+
+    fun createAccountUsernameViewModel() = CreateAccountUsernameViewModel(
+        validateUserHandleUseCase = validateUserHandle.get(),
+        setUserHandleUseCase = setUserHandle.get(),
+        finalizeRegistrationAnalyticsMetadata = finalizeRegistrationAnalyticsMetadata.get(),
+        registrationAnalyticsManager = registrationAnalyticsManager.get(),
+    )
+
+    fun createAccountOverviewViewModel(savedStateHandle: SavedStateHandle) = CreateAccountOverviewViewModel(
+        savedStateHandle = savedStateHandle,
+        defaultServerConfig = defaultServerConfig.get(),
+    )
+
+    fun createAccountEmailViewModel(savedStateHandle: SavedStateHandle) = CreateAccountEmailViewModel(
+        savedStateHandle = savedStateHandle,
+        validateEmail = validateEmail.get(),
+        coreLogic = coreLogic.get(),
+        defaultServerConfig = defaultServerConfig.get(),
+    )
+
+    fun createAccountDetailsViewModel(savedStateHandle: SavedStateHandle) = CreateAccountDetailsViewModel(
+        savedStateHandle = savedStateHandle,
+        validatePasswordUseCase = validatePassword.get(),
+        defaultServerConfig = defaultServerConfig.get(),
+    )
+
+    fun createAccountCodeViewModel(savedStateHandle: SavedStateHandle) = CreateAccountCodeViewModel(
+        savedStateHandle = savedStateHandle,
+        coreLogic = coreLogic.get(),
+        addAuthenticatedUser = addAuthenticatedUser.get(),
+        clientScopeProviderFactory = clientScopeProviderFactory.get(),
+        defaultServerConfig = defaultServerConfig.get(),
+        defaultWebSocketEnabledByDefault = defaultWebSocketEnabledByDefault.get(),
+    )
+
+    fun createAccountSummaryViewModel(savedStateHandle: SavedStateHandle) =
+        CreateAccountSummaryViewModel(savedStateHandle = savedStateHandle)
+
+    fun createAccountSelectorViewModel(savedStateHandle: SavedStateHandle) = CreateAccountSelectorViewModel(
+        globalDataStore = globalDataStore.get(),
+        savedStateHandle = savedStateHandle,
+        defaultServerConfig = defaultServerConfig.get(),
+    )
+
+    fun createAccountDataDetailViewModel(savedStateHandle: SavedStateHandle) = CreateAccountDataDetailViewModel(
+        savedStateHandle = savedStateHandle,
+        validatePassword = validatePassword.get(),
+        validateEmail = validateEmail.get(),
+        globalDataStore = globalDataStore.get(),
+        registrationAnalyticsManager = registrationAnalyticsManager.get(),
+        coreLogic = coreLogic.get(),
+        defaultServerConfig = defaultServerConfig.get(),
+    )
+
+    fun createAccountVerificationCodeViewModel(savedStateHandle: SavedStateHandle) = CreateAccountVerificationCodeViewModel(
+        savedStateHandle = savedStateHandle,
+        coreLogic = coreLogic.get(),
+        addAuthenticatedUser = addAuthenticatedUser.get(),
+        registrationAnalyticsManager = registrationAnalyticsManager.get(),
+        clientScopeProviderFactory = clientScopeProviderFactory.get(),
+        defaultServerConfig = defaultServerConfig.get(),
+        defaultWebSocketEnabledByDefault = defaultWebSocketEnabledByDefault.get(),
+    )
+
+    private fun loginSavedInputStore(savedStateHandle: SavedStateHandle): LoginSavedInputStore =
+        SavedStateLoginSavedInputStore(savedStateHandle)
+}

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelGraph.kt
@@ -1,0 +1,139 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+@file:Suppress("TooManyFunctions")
+
+package com.wire.android.ui.authentication
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import com.wire.android.di.metro.MetroViewModelGraph
+import com.wire.android.di.metro.metroSavedStateViewModel
+import com.wire.android.di.metro.metroViewModel
+import com.wire.android.ui.authentication.create.code.CreateAccountCodeViewModel
+import com.wire.android.ui.authentication.create.details.CreateAccountDetailsViewModel
+import com.wire.android.ui.authentication.create.email.CreateAccountEmailViewModel
+import com.wire.android.ui.authentication.create.overview.CreateAccountOverviewViewModel
+import com.wire.android.ui.authentication.create.summary.CreateAccountSummaryViewModel
+import com.wire.android.ui.authentication.create.username.CreateAccountUsernameViewModel
+import com.wire.android.ui.authentication.devices.common.ClearSessionViewModel
+import com.wire.android.ui.authentication.devices.register.RegisterDeviceViewModel
+import com.wire.android.ui.authentication.devices.remove.RemoveDeviceViewModel
+import com.wire.android.ui.authentication.login.LoginNavArgs
+import com.wire.android.ui.authentication.login.email.LoginEmailViewModel
+import com.wire.android.ui.authentication.login.sso.LoginSSOViewModel
+import com.wire.android.ui.authentication.welcome.WelcomeViewModel
+import com.wire.android.ui.newauthentication.login.NewLoginViewModel
+import com.wire.android.ui.registration.code.CreateAccountVerificationCodeViewModel
+import com.wire.android.ui.registration.details.CreateAccountDataDetailViewModel
+import com.wire.android.ui.registration.selector.CreateAccountSelectorViewModel
+
+interface AuthenticationViewModelGraph : MetroViewModelGraph {
+    val authenticationViewModelFactory: AuthenticationViewModelFactory
+}
+
+@Composable
+inline fun <reified VM> authenticationViewModel(
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+    key: String? = null,
+    crossinline create: AuthenticationViewModelFactory.() -> VM,
+): VM where VM : ViewModel =
+    metroViewModel<AuthenticationViewModelGraph, VM>(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = key,
+    ) {
+        authenticationViewModelFactory.create()
+    }
+
+@Composable
+inline fun <reified VM> authenticationSavedStateViewModel(
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+    key: String? = null,
+    crossinline create: AuthenticationViewModelFactory.(SavedStateHandle) -> VM,
+): VM where VM : ViewModel =
+    metroSavedStateViewModel<AuthenticationViewModelGraph, VM>(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = key,
+    ) { savedStateHandle ->
+        authenticationViewModelFactory.create(savedStateHandle)
+    }
+
+@Composable
+fun welcomeViewModel(): WelcomeViewModel = authenticationSavedStateViewModel { welcomeViewModel(it) }
+
+@Composable
+fun newLoginViewModel(): NewLoginViewModel = authenticationSavedStateViewModel { newLoginViewModel(it) }
+
+@Composable
+fun loginEmailViewModel(loginNavArgs: LoginNavArgs): LoginEmailViewModel =
+    authenticationSavedStateViewModel { loginEmailViewModel(loginNavArgs, it) }
+
+@Composable
+fun loginSSOViewModel(loginNavArgs: LoginNavArgs): LoginSSOViewModel =
+    authenticationSavedStateViewModel { loginSSOViewModel(loginNavArgs, it) }
+
+@Composable
+fun registerDeviceViewModel(): RegisterDeviceViewModel = authenticationViewModel { registerDeviceViewModel() }
+
+@Composable
+fun removeDeviceViewModel(): RemoveDeviceViewModel = authenticationViewModel { removeDeviceViewModel() }
+
+@Composable
+fun clearSessionViewModel(): ClearSessionViewModel = authenticationViewModel { clearSessionViewModel() }
+
+@Composable
+fun createAccountUsernameViewModel(): CreateAccountUsernameViewModel =
+    authenticationViewModel { createAccountUsernameViewModel() }
+
+@Composable
+fun createAccountOverviewViewModel(): CreateAccountOverviewViewModel =
+    authenticationSavedStateViewModel { createAccountOverviewViewModel(it) }
+
+@Composable
+fun createAccountEmailViewModel(): CreateAccountEmailViewModel =
+    authenticationSavedStateViewModel { createAccountEmailViewModel(it) }
+
+@Composable
+fun createAccountDetailsViewModel(): CreateAccountDetailsViewModel =
+    authenticationSavedStateViewModel { createAccountDetailsViewModel(it) }
+
+@Composable
+fun createAccountCodeViewModel(): CreateAccountCodeViewModel =
+    authenticationSavedStateViewModel { createAccountCodeViewModel(it) }
+
+@Composable
+fun createAccountSummaryViewModel(): CreateAccountSummaryViewModel =
+    authenticationSavedStateViewModel { createAccountSummaryViewModel(it) }
+
+@Composable
+fun createAccountSelectorViewModel(): CreateAccountSelectorViewModel =
+    authenticationSavedStateViewModel { createAccountSelectorViewModel(it) }
+
+@Composable
+fun createAccountDataDetailViewModel(): CreateAccountDataDetailViewModel =
+    authenticationSavedStateViewModel { createAccountDataDetailViewModel(it) }
+
+@Composable
+fun createAccountVerificationCodeViewModel(): CreateAccountVerificationCodeViewModel =
+    authenticationSavedStateViewModel { createAccountVerificationCodeViewModel(it) }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.createAccountCodeViewModel
 import com.wire.android.R
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -75,7 +75,7 @@ import kotlinx.coroutines.job
 @Composable
 fun CreateAccountCodeScreen(
     navigator: Navigator,
-    createAccountCodeViewModel: CreateAccountCodeViewModel = wireViewModel()
+    createAccountCodeViewModel: CreateAccountCodeViewModel = createAccountCodeViewModel()
 ) {
     with(createAccountCodeViewModel) {
         fun navigateToSummaryScreen() = navigator.navigate(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeViewModel.kt
@@ -48,13 +48,11 @@ import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.register.RegisterParam
 import com.wire.kalium.logic.feature.register.RegisterResult
 import com.wire.kalium.logic.feature.register.RequestActivationCodeResult
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 // TODO: Cover this viewModel  with unit test
-@HiltViewModel
 class CreateAccountCodeViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     @KaliumCoreLogic private val coreLogic: CoreLogic,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.createAccountDetailsViewModel
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
@@ -74,7 +74,7 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 @Composable
 fun CreateAccountDetailsScreen(
     navigator: Navigator,
-    createAccountDetailsViewModel: CreateAccountDetailsViewModel = wireViewModel()
+    createAccountDetailsViewModel: CreateAccountDetailsViewModel = createAccountDetailsViewModel()
 ) {
     with(createAccountDetailsViewModel) {
         fun navigateToCodeScreen() = navigator.navigate(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/details/CreateAccountDetailsViewModel.kt
@@ -30,13 +30,11 @@ import com.wire.android.ui.common.textfield.textAsFlow
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 // TODO: Cover this viewModel  with unit test
-@HiltViewModel
 class CreateAccountDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val validatePasswordUseCase: ValidatePasswordUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.createAccountEmailViewModel
 import com.wire.android.R
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -85,7 +85,7 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 @Composable
 fun CreateAccountEmailScreen(
     navigator: Navigator,
-    createAccountEmailViewModel: CreateAccountEmailViewModel = wireViewModel()
+    createAccountEmailViewModel: CreateAccountEmailViewModel = createAccountEmailViewModel()
 ) {
     with(createAccountEmailViewModel) {
         fun navigateToDetailsScreen() = navigator.navigate(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailViewModel.kt
@@ -33,13 +33,11 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.feature.auth.ValidateEmailUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
 import com.wire.kalium.logic.feature.register.RequestActivationCodeResult
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 // TODO: Cover this viewModel  with unit test
-@HiltViewModel
 class CreateAccountEmailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val validateEmail: ValidateEmailUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreateAccountOverviewViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreateAccountOverviewViewModel.kt
@@ -21,10 +21,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.kalium.logic.configuration.server.ServerConfig
-import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
-@HiltViewModel
 class CreateAccountOverviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     defaultServerConfig: ServerConfig.Links

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreatePersonalAccountOverviewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreatePersonalAccountOverviewScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.createAccountOverviewViewModel
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
@@ -64,7 +64,7 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 @Composable
 fun CreatePersonalAccountOverviewScreen(
     navigator: Navigator,
-    viewModel: CreateAccountOverviewViewModel = wireViewModel()
+    viewModel: CreateAccountOverviewViewModel = createAccountOverviewViewModel()
 ) {
     CreateAccountOverviewScreen(navigator, CreateAccountFlowType.CreatePersonalAccount, viewModel)
 }
@@ -73,7 +73,7 @@ fun CreatePersonalAccountOverviewScreen(
 @Composable
 fun CreateTeamAccountOverviewScreen(
     navigator: Navigator,
-    viewModel: CreateAccountOverviewViewModel = wireViewModel()
+    viewModel: CreateAccountOverviewViewModel = createAccountOverviewViewModel()
 ) {
     CreateAccountOverviewScreen(navigator, CreateAccountFlowType.CreateTeam, viewModel)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/summary/CreateAccountSummaryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/summary/CreateAccountSummaryScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.createAccountSummaryViewModel
 import com.wire.android.R
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -52,7 +52,7 @@ import com.wire.android.ui.theme.wireTypography
 @Composable
 fun CreateAccountSummaryScreen(
     navigator: Navigator,
-    viewModel: CreateAccountSummaryViewModel = wireViewModel()
+    viewModel: CreateAccountSummaryViewModel = createAccountSummaryViewModel()
 ) {
     SummaryContent(
         state = viewModel.summaryState,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/summary/CreateAccountSummaryViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/summary/CreateAccountSummaryViewModel.kt
@@ -25,10 +25,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.wire.android.ui.authentication.create.common.CreateAccountFlowType
 import com.ramcosta.composedestinations.generated.app.navArgs
-import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
-@HiltViewModel
 class CreateAccountSummaryViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/username/CreateAccountUsernameScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/username/CreateAccountUsernameScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.createAccountUsernameViewModel
 import com.wire.android.R
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -58,7 +58,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 @Composable
 fun CreateAccountUsernameScreen(
     navigator: Navigator,
-    viewModel: CreateAccountUsernameViewModel = wireViewModel()
+    viewModel: CreateAccountUsernameViewModel = createAccountUsernameViewModel()
 ) {
     UsernameContent(
         textState = viewModel.textState,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/username/CreateAccountUsernameViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/username/CreateAccountUsernameViewModel.kt
@@ -33,13 +33,11 @@ import com.wire.kalium.logic.feature.auth.ValidateUserHandleResult
 import com.wire.kalium.logic.feature.auth.ValidateUserHandleUseCase
 import com.wire.kalium.logic.feature.user.SetUserHandleResult
 import com.wire.kalium.logic.feature.user.SetUserHandleUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
 class CreateAccountUsernameViewModel @Inject constructor(
     private val validateUserHandleUseCase: ValidateUserHandleUseCase,
     private val setUserHandleUseCase: SetUserHandleUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/common/ClearSessionViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/common/ClearSessionViewModel.kt
@@ -32,11 +32,9 @@ import com.wire.kalium.logic.feature.auth.LogoutUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
 class ClearSessionViewModel @Inject constructor(
     private val currentSession: CurrentSessionUseCase,
     private val deleteSession: DeleteSessionUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceScreen.kt
@@ -39,7 +39,8 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.clearSessionViewModel
+import com.wire.android.ui.authentication.registerDeviceViewModel
 import com.wire.android.R
 import com.wire.android.feature.NavigationSwitchAccountActions
 import com.wire.android.navigation.BackStackMode
@@ -80,8 +81,8 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 fun RegisterDeviceScreen(
     navigator: Navigator,
     loginTypeSelector: LoginTypeSelector,
-    viewModel: RegisterDeviceViewModel = wireViewModel(),
-    clearSessionViewModel: ClearSessionViewModel = wireViewModel(),
+    viewModel: RegisterDeviceViewModel = registerDeviceViewModel(),
+    clearSessionViewModel: ClearSessionViewModel = clearSessionViewModel(),
 ) {
     clearAutofillTree()
     when (val flowState = viewModel.state.flowState) {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceVerificationCodeScreen.kt
@@ -20,7 +20,7 @@ package com.wire.android.ui.authentication.devices.register
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.registerDeviceViewModel
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeScreenContent
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeState
 import com.wire.android.ui.theme.WireTheme
@@ -28,7 +28,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
 fun RegisterDeviceVerificationCodeScreen(
-    viewModel: RegisterDeviceViewModel = wireViewModel()
+    viewModel: RegisterDeviceViewModel = registerDeviceViewModel()
 ) = VerificationCodeScreenContent(
     viewModel.secondFactorVerificationCodeTextState,
     viewModel.secondFactorVerificationCodeState,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
@@ -38,7 +38,6 @@ import com.wire.kalium.logic.feature.client.RegisterClientParam
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -46,7 +45,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
-@HiltViewModel
 class RegisterDeviceViewModel @Inject constructor(
     private val registerClientUseCase: GetOrRegisterClientUseCase,
     private val isPasswordRequired: IsPasswordRequiredUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceScreen.kt
@@ -37,7 +37,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.clearSessionViewModel
+import com.wire.android.ui.authentication.removeDeviceViewModel
 import com.wire.android.R
 import com.wire.android.feature.NavigationSwitchAccountActions
 import com.wire.android.navigation.BackStackMode
@@ -78,8 +79,8 @@ import com.wire.kalium.logic.data.conversation.ClientId
 fun RemoveDeviceScreen(
     navigator: Navigator,
     loginTypeSelector: LoginTypeSelector,
-    viewModel: RemoveDeviceViewModel = wireViewModel(),
-    clearSessionViewModel: ClearSessionViewModel = wireViewModel(),
+    viewModel: RemoveDeviceViewModel = removeDeviceViewModel(),
+    clearSessionViewModel: ClearSessionViewModel = clearSessionViewModel(),
 ) {
     fun navigateAfterSuccess(initialSyncCompleted: Boolean, isE2EIRequired: Boolean) = navigator.navigate(
         NavigationCommand(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceVerificationCodeScreen.kt
@@ -18,12 +18,12 @@
 package com.wire.android.ui.authentication.devices.remove
 
 import androidx.compose.runtime.Composable
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.removeDeviceViewModel
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeScreenContent
 
 @Composable
 fun RemoveDeviceVerificationCodeScreen(
-    viewModel: RemoveDeviceViewModel = wireViewModel()
+    viewModel: RemoveDeviceViewModel = removeDeviceViewModel()
 ) = VerificationCodeScreenContent(
     viewModel.secondFactorVerificationCodeTextState,
     viewModel.secondFactorVerificationCodeState,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModel.kt
@@ -43,7 +43,6 @@ import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.client.SelfClientsResult
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -52,7 +51,6 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
-@HiltViewModel
 class RemoveDeviceViewModel @Inject constructor(
     private val fetchSelfClientsFromRemote: FetchSelfClientsFromRemoteUseCase,
     private val deleteClientUseCase: DeleteClientUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -49,7 +49,7 @@ import com.ramcosta.composedestinations.generated.app.destinations.HomeScreenDes
 import com.ramcosta.composedestinations.generated.app.destinations.InitialSyncScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.RemoveDeviceScreenDestination
 import com.wire.android.R
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.loginEmailViewModel
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
@@ -86,9 +86,7 @@ import kotlinx.coroutines.launch
 fun LoginScreen(
     navigator: Navigator,
     loginNavArgs: LoginNavArgs,
-    loginEmailViewModel: LoginEmailViewModel = wireViewModel<LoginEmailViewModel, LoginEmailViewModel.Factory>(
-        creationCallback = { factory -> factory.create(loginNavArgs) }
-    )
+    loginEmailViewModel: LoginEmailViewModel = loginEmailViewModel(loginNavArgs)
 ) {
 
     LoginContent(
@@ -272,9 +270,7 @@ private fun PreviewLoginScreen() = WireTheme {
             onSuccess = { _, _ -> },
             onRemoveDeviceNeeded = {},
             loginNavArgs = LoginNavArgs(),
-            loginEmailViewModel = wireViewModel<LoginEmailViewModel, LoginEmailViewModel.Factory>(
-                creationCallback = { factory -> factory.create(LoginNavArgs()) }
-            ),
+            loginEmailViewModel = loginEmailViewModel(LoginNavArgs()),
             ssoLoginResult = null,
             ssoCodeAutoLogin = null
         )

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/SavedStateLoginSavedInputStore.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/SavedStateLoginSavedInputStore.kt
@@ -19,10 +19,6 @@
 package com.wire.android.ui.authentication.login
 
 import androidx.lifecycle.SavedStateHandle
-import dagger.Module
-import dagger.Provides
-import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ViewModelComponent
 
 private const val USER_IDENTIFIER_SAVED_STATE_KEY = "user_identifier"
 private const val SSO_CODE_SAVED_STATE_KEY = "sso_code"
@@ -41,12 +37,4 @@ class SavedStateLoginSavedInputStore(
         set(value) {
             savedStateHandle[SSO_CODE_SAVED_STATE_KEY] = value
         }
-}
-
-@Module
-@InstallIn(ViewModelComponent::class)
-object LoginSavedInputStoreModule {
-    @Provides
-    fun provideLoginSavedInputStore(savedStateHandle: SavedStateHandle): LoginSavedInputStore =
-        SavedStateLoginSavedInputStore(savedStateHandle)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -61,7 +61,6 @@ import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -73,7 +72,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @Suppress("LongParameterList", "ComplexMethod", "TooManyFunctions")
-@HiltViewModel(assistedFactory = LoginEmailViewModel.Factory::class)
 class LoginEmailViewModel @AssistedInject constructor(
     @Assisted val loginNavArgs: LoginNavArgs,
     private val addAuthenticatedUser: AddAuthenticatedUserUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import com.wire.android.R
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.loginSSOViewModel
 import com.wire.android.ui.authentication.login.LoginErrorDialog
 import com.wire.android.ui.authentication.login.LoginNavArgs
 import com.wire.android.ui.authentication.login.SSOCodeAutoLogin
@@ -68,9 +68,7 @@ fun LoginSSOScreen(
     loginNavArgs: LoginNavArgs,
     ssoLoginResult: DeepLinkResult.SSOLogin?,
     ssoCodeAutoLogin: SSOCodeAutoLogin?,
-    loginSSOViewModel: LoginSSOViewModel = wireViewModel<LoginSSOViewModel, LoginSSOViewModel.Factory>(
-        creationCallback = { factory -> factory.create(loginNavArgs) }
-    ),
+    loginSSOViewModel: LoginSSOViewModel = loginSSOViewModel(loginNavArgs),
     scrollState: ScrollState = rememberScrollState()
 ) {
     val scope = rememberCoroutineScope()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -61,7 +61,6 @@ import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -71,7 +70,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @Suppress("LongParameterList", "TooManyFunctions")
-@HiltViewModel(assistedFactory = LoginSSOViewModel.Factory::class)
 class LoginSSOViewModel : LoginViewModel {
     private val savedInputStore: LoginSavedInputStore
     val addAuthenticatedUser: AddAuthenticatedUserUseCase

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -66,7 +66,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.welcomeViewModel
 import com.wire.android.BuildConfig.ENABLE_NEW_REGISTRATION
 import com.wire.android.R
 import com.wire.android.config.LocalCustomUiConfigurationProvider
@@ -113,7 +113,7 @@ import kotlinx.coroutines.flow.scan
 @Composable
 fun WelcomeScreen(
     navigator: Navigator,
-    viewModel: WelcomeViewModel = wireViewModel()
+    viewModel: WelcomeViewModel = welcomeViewModel()
 ) {
     WelcomeContent(
         viewModel.state.isThereActiveSession,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeViewModel.kt
@@ -31,11 +31,9 @@ import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.feature.session.DoesValidNomadAccountExistUseCase
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
 class WelcomeViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val getSessions: GetSessionsUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.newLoginViewModel
 import com.ramcosta.composedestinations.generated.app.destinations.E2EIEnrollmentScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.HomeScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.InitialSyncScreenDestination
@@ -97,7 +97,7 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 fun NewLoginScreen(
     navigator: Navigator,
     navArgs: LoginNavArgs,
-    viewModel: NewLoginViewModel = wireViewModel()
+    viewModel: NewLoginViewModel = newLoginViewModel()
 ) {
     val context = LocalContext.current
     val currentKeyboardController by rememberUpdatedState(LocalSoftwareKeyboardController.current)

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -62,7 +62,6 @@ import com.wire.kalium.logic.feature.auth.sso.SSOLoginSessionResult
 import com.wire.kalium.logic.feature.backup.RestoreCryptoStateResult
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -76,7 +75,6 @@ import javax.inject.Inject
 import javax.inject.Named
 
 @Suppress("LongParameterList", "TooManyFunctions")
-@HiltViewModel
 class NewLoginViewModel(
     private val validateEmailOrSSOCode: ValidateEmailOrSSOCodeUseCase,
     val coreLogic: CoreLogic,

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/password/NewLoginPasswordScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/password/NewLoginPasswordScreen.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import com.wire.android.BuildConfig
 import com.wire.android.BuildConfig.ENABLE_NEW_REGISTRATION
 import com.wire.android.R
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.loginEmailViewModel
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
@@ -105,9 +105,7 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 fun NewLoginPasswordScreen(
     navigator: Navigator,
     navArgs: LoginNavArgs,
-    loginEmailViewModel: LoginEmailViewModel = wireViewModel<LoginEmailViewModel, LoginEmailViewModel.Factory>(
-        creationCallback = { factory -> factory.create(navArgs) }
-    )
+    loginEmailViewModel: LoginEmailViewModel = loginEmailViewModel(navArgs)
 ) {
     clearAutofillTree()
     LoginStateNavigationAndDialogs(loginEmailViewModel, navigator)

--- a/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.createAccountVerificationCodeViewModel
 import com.wire.android.R
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -80,7 +80,8 @@ import kotlinx.coroutines.job
 @Composable
 fun CreateAccountVerificationCodeScreen(
     navigator: Navigator,
-    createAccountCodeVerificationViewModel: CreateAccountVerificationCodeViewModel = wireViewModel()
+    createAccountCodeVerificationViewModel: CreateAccountVerificationCodeViewModel =
+        createAccountVerificationCodeViewModel()
 ) {
     with(createAccountCodeVerificationViewModel) {
         fun navigateToUsernameScreen() = navigator.navigate(

--- a/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeViewModel.kt
@@ -46,12 +46,10 @@ import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.register.RegisterParam
 import com.wire.kalium.logic.feature.register.RegisterResult
 import com.wire.kalium.logic.feature.register.RequestActivationCodeResult
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
 class CreateAccountVerificationCodeViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     @KaliumCoreLogic private val coreLogic: CoreLogic,

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
@@ -53,7 +53,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.createAccountDataDetailViewModel
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
@@ -95,7 +95,7 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 @Composable
 fun CreateAccountDataDetailScreen(
     navigator: Navigator,
-    createAccountDataDetailViewModel: CreateAccountDataDetailViewModel = wireViewModel()
+    createAccountDataDetailViewModel: CreateAccountDataDetailViewModel = createAccountDataDetailViewModel()
 ) {
     with(createAccountDataDetailViewModel) {
         fun navigateToCodeScreen() = navigator.navigate(

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailViewModel.kt
@@ -37,14 +37,12 @@ import com.wire.kalium.logic.feature.auth.ValidateEmailUseCase
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
 import com.wire.kalium.logic.feature.register.RequestActivationCodeResult
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
-@HiltViewModel
 class CreateAccountDataDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val validatePassword: ValidatePasswordUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.core.net.toUri
-import com.wire.android.di.wireViewModel
+import com.wire.android.ui.authentication.createAccountSelectorViewModel
 import com.wire.android.R
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -82,7 +82,7 @@ import com.wire.android.ui.common.R as commonR
 @Composable
 fun CreateAccountSelectorScreen(
     navigator: Navigator,
-    viewModel: CreateAccountSelectorViewModel = wireViewModel()
+    viewModel: CreateAccountSelectorViewModel = createAccountSelectorViewModel()
 ) {
     val context = LocalContext.current
     fun navigateToEmailScreen() {

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorViewModel.kt
@@ -23,11 +23,9 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.GlobalDataStore
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.kalium.logic.configuration.server.ServerConfig
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
 class CreateAccountSelectorViewModel @Inject constructor(
     private val globalDataStore: GlobalDataStore,
     savedStateHandle: SavedStateHandle,

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -823,6 +823,30 @@ private fun com.wire.android.ui.WireActivity.SetUpNavigation(navigator: com.wire
     - navigator: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
+public fun com.wire.android.ui.authentication.authenticationSavedStateViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function2<com.wire.android.ui.authentication.AuthenticationViewModelFactory, androidx.lifecycle.SavedStateHandle, VM of com.wire.android.ui.authentication.authenticationSavedStateViewModel>): VM of com.wire.android.ui.authentication.authenticationSavedStateViewModel
+  skippable: false
+  restartable: true
+  params:
+    - viewModelStoreOwner: RUNTIME (requires runtime check)
+    - key: STABLE (class with no mutable properties)
+    - create: STABLE (function type)
+
+@Composable
+public fun com.wire.android.ui.authentication.authenticationViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function1<com.wire.android.ui.authentication.AuthenticationViewModelFactory, VM of com.wire.android.ui.authentication.authenticationViewModel>): VM of com.wire.android.ui.authentication.authenticationViewModel
+  skippable: false
+  restartable: true
+  params:
+    - viewModelStoreOwner: RUNTIME (requires runtime check)
+    - key: STABLE (class with no mutable properties)
+    - create: STABLE (function type)
+
+@Composable
+public fun com.wire.android.ui.authentication.clearSessionViewModel(): com.wire.android.ui.authentication.devices.common.ClearSessionViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 private fun com.wire.android.ui.authentication.create.code.CodeContent(state: com.wire.android.ui.authentication.create.code.CreateAccountCodeViewState, textState: androidx.compose.foundation.text.input.TextFieldState, onResendCodePressed: kotlin.Function0<kotlin.Unit>, onBackPressed: kotlin.Function0<kotlin.Unit>, serverConfig: com.wire.kalium.logic.configuration.server.ServerConfig.Links): kotlin.Unit
   skippable: false
   restartable: true
@@ -1029,6 +1053,60 @@ private fun com.wire.android.ui.authentication.create.username.UsernameContent(t
     - state: STABLE (class with no mutable properties)
     - onContinuePressed: STABLE (function type)
     - onErrorDismiss: STABLE (function type)
+
+@Composable
+public fun com.wire.android.ui.authentication.createAccountCodeViewModel(): com.wire.android.ui.authentication.create.code.CreateAccountCodeViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.authentication.createAccountDataDetailViewModel(): com.wire.android.ui.registration.details.CreateAccountDataDetailViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.authentication.createAccountDetailsViewModel(): com.wire.android.ui.authentication.create.details.CreateAccountDetailsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.authentication.createAccountEmailViewModel(): com.wire.android.ui.authentication.create.email.CreateAccountEmailViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.authentication.createAccountOverviewViewModel(): com.wire.android.ui.authentication.create.overview.CreateAccountOverviewViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.authentication.createAccountSelectorViewModel(): com.wire.android.ui.registration.selector.CreateAccountSelectorViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.authentication.createAccountSummaryViewModel(): com.wire.android.ui.authentication.create.summary.CreateAccountSummaryViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.authentication.createAccountUsernameViewModel(): com.wire.android.ui.authentication.create.username.CreateAccountUsernameViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.authentication.createAccountVerificationCodeViewModel(): com.wire.android.ui.registration.code.CreateAccountVerificationCodeViewModel
+  skippable: true
+  restartable: true
+  params:
 
 @Composable
 public fun com.wire.android.ui.authentication.devices.DeviceItem(device: com.wire.android.ui.authentication.devices.model.Device, placeholder: kotlin.Boolean, shouldShowVerifyLabel: kotlin.Boolean, icon: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, isCurrentClient: kotlin.Boolean, shouldShowE2EIInfo: kotlin.Boolean, isWholeItemClickable: kotlin.Boolean, onClickAction: kotlin.Function1<com.wire.android.ui.authentication.devices.model.Device, kotlin.Unit>?): kotlin.Unit
@@ -1415,6 +1493,38 @@ public fun com.wire.android.ui.authentication.login.toLoginDialogErrorData(): co
   params:
 
 @Composable
+public fun com.wire.android.ui.authentication.loginEmailViewModel(loginNavArgs: com.wire.android.ui.authentication.login.LoginNavArgs): com.wire.android.ui.authentication.login.email.LoginEmailViewModel
+  skippable: false
+  restartable: true
+  params:
+    - loginNavArgs: UNSTABLE (has mutable properties or unstable members)
+
+@Composable
+public fun com.wire.android.ui.authentication.loginSSOViewModel(loginNavArgs: com.wire.android.ui.authentication.login.LoginNavArgs): com.wire.android.ui.authentication.login.sso.LoginSSOViewModel
+  skippable: false
+  restartable: true
+  params:
+    - loginNavArgs: UNSTABLE (has mutable properties or unstable members)
+
+@Composable
+public fun com.wire.android.ui.authentication.newLoginViewModel(): com.wire.android.ui.newauthentication.login.NewLoginViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.authentication.registerDeviceViewModel(): com.wire.android.ui.authentication.devices.register.RegisterDeviceViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.authentication.removeDeviceViewModel(): com.wire.android.ui.authentication.devices.remove.RemoveDeviceViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 private fun com.wire.android.ui.authentication.verificationcode.MainContent(codeTextState: androidx.compose.foundation.text.input.TextFieldState, codeState: com.wire.android.ui.authentication.verificationcode.VerificationCodeState, isLoading: kotlin.Boolean, onResendCode: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
@@ -1541,6 +1651,12 @@ private fun com.wire.android.ui.authentication.welcome.typedArrayResource(id: ko
   restartable: true
   params:
     - id: STABLE (primitive type)
+
+@Composable
+public fun com.wire.android.ui.authentication.welcomeViewModel(): com.wire.android.ui.authentication.welcome.WelcomeViewModel
+  skippable: true
+  restartable: true
+  params:
 
 @Composable
 public fun com.wire.android.ui.calling.CallActivity.Content(): kotlin.Unit


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25946
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Migrates auth/registration ViewModels from Hilt call-site creation to Metro-backed factories.
- Extends the Metro ViewModel bridge stack after settings account migration.
- Keeps the auth/registration UI call sites on the same ViewModel contracts while changing only creation wiring.
