### PR TITLE
refactor: migrate calling view models to metro [WPB-25946]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/metro/ImageAssetViewModelGraphBridgeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/ImageAssetViewModelGraphBridgeViewModel.kt
@@ -20,6 +20,8 @@ package com.wire.android.di.metro
 import androidx.lifecycle.ViewModel
 import com.wire.android.model.ImageAssetViewModelFactory
 import com.wire.android.model.ImageAssetViewModelGraph
+import com.wire.android.ui.calling.CallingViewModelFactory
+import com.wire.android.ui.calling.CallingViewModelGraph
 import com.wire.android.ui.home.settings.SettingsViewModelFactory
 import com.wire.android.ui.home.settings.SettingsViewModelGraph
 import com.wire.android.util.ui.WireSessionImageLoader
@@ -33,10 +35,14 @@ import javax.inject.Provider
 @HiltViewModel
 class ImageAssetViewModelGraphBridgeViewModel @Inject constructor(
     imageLoader: Provider<WireSessionImageLoader>,
+    private val callingViewModelFactoryProvider: Provider<CallingViewModelFactory>,
     private val settingsViewModelFactoryProvider: Provider<SettingsViewModelFactory>,
-) : ViewModel(), ImageAssetViewModelGraph, SettingsViewModelGraph {
+) : ViewModel(), ImageAssetViewModelGraph, CallingViewModelGraph, SettingsViewModelGraph {
     override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
         ImageAssetViewModelFactory(imageLoader = imageLoader::get)
+
+    override val callingViewModelFactory: CallingViewModelFactory
+        get() = callingViewModelFactoryProvider.get()
 
     override val settingsViewModelFactory: SettingsViewModelFactory
         get() = settingsViewModelFactoryProvider.get()

--- a/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
@@ -24,6 +24,8 @@ import com.wire.android.model.ImageAssetViewModelFactory
 import com.wire.android.model.ImageAssetViewModelGraph
 import com.wire.android.ui.authentication.AuthenticationViewModelFactory
 import com.wire.android.ui.authentication.AuthenticationViewModelGraph
+import com.wire.android.ui.calling.CallingViewModelFactory
+import com.wire.android.ui.calling.CallingViewModelGraph
 import com.wire.android.ui.debug.DebugInfoViewModelFactory
 import com.wire.android.ui.debug.DebugInfoViewModelGraph
 import com.wire.android.ui.home.conversations.ConversationCoreViewModelFactory
@@ -43,6 +45,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     imageLoader: Provider<WireSessionImageLoader>,
     private val cellsViewModelFactoryProvider: Provider<CellsViewModelFactory>,
     private val authenticationViewModelFactoryProvider: Provider<AuthenticationViewModelFactory>,
+    private val callingViewModelFactoryProvider: Provider<CallingViewModelFactory>,
     private val debugInfoViewModelFactoryProvider: Provider<DebugInfoViewModelFactory>,
     private val settingsViewModelFactoryProvider: Provider<SettingsViewModelFactory>,
     private val conversationCoreViewModelFactoryProvider: Provider<ConversationCoreViewModelFactory>,
@@ -50,6 +53,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     ImageAssetViewModelGraph,
     CellsViewModelGraph,
     AuthenticationViewModelGraph,
+    CallingViewModelGraph,
     DebugInfoViewModelGraph,
     SettingsViewModelGraph,
     ConversationCoreViewModelGraph {
@@ -61,6 +65,9 @@ class WireActivityViewModelGraphBridge @Inject constructor(
 
     override val authenticationViewModelFactory: AuthenticationViewModelFactory
         get() = authenticationViewModelFactoryProvider.get()
+
+    override val callingViewModelFactory: CallingViewModelFactory
+        get() = callingViewModelFactoryProvider.get()
 
     override val debugInfoViewModelFactory: DebugInfoViewModelFactory
         get() = debugInfoViewModelFactoryProvider.get()

--- a/app/src/main/kotlin/com/wire/android/ui/CallFeedbackViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/CallFeedbackViewModel.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.analytics.AnonymousAnalyticsManager
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.ui.analytics.IsAnalyticsAvailableUseCase
@@ -33,7 +32,6 @@ import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.ShouldAskCallFeedbackUseCaseResult
 import dagger.Lazy
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -42,11 +40,9 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class CallFeedbackViewModel @Inject constructor(
-    @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>,
+class CallFeedbackViewModel(
+    private val coreLogic: Lazy<CoreLogic>,
     private val currentSessionFlow: Lazy<CurrentSessionFlowUseCase>,
     private val isAnalyticsAvailable: Lazy<IsAnalyticsAvailableUseCase>,
     private val analyticsManager: Lazy<AnonymousAnalyticsManager>,

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -48,10 +48,11 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import com.wire.android.di.wireViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.ramcosta.composedestinations.generated.app.destinations.E2EIEnrollmentScreenDestination
@@ -160,9 +161,16 @@ class WireActivity : BaseActivity() {
     @Inject
     lateinit var managedConfigurationsManager: ManagedConfigurationsManager
 
+    private val wireActivityViewModelGraph: WireActivityViewModelGraphBridge by viewModels()
     private val viewModel: WireActivityViewModel by viewModels()
     private val featureFlagNotificationViewModel: FeatureFlagNotificationViewModel by viewModels()
-    private val callFeedbackViewModel: CallFeedbackViewModel by viewModels()
+    private val callFeedbackViewModel: CallFeedbackViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                wireActivityViewModelGraph.callingViewModelFactory.callFeedbackViewModel()
+            }
+        }
+    }
 
     private val commonTopAppBarViewModel by assistedViewModels<CommonTopAppBarViewModel, CommonTopAppBarViewModel.Factory> { factory ->
         factory.create(CommonTopAppBarParams(showNoNetwork = true, showSync = true, showActiveCalls = true))
@@ -256,7 +264,6 @@ class WireActivity : BaseActivity() {
     private fun setComposableContent(startDestination: Direction) {
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
-            val wireActivityViewModelGraph = wireViewModel<WireActivityViewModelGraphBridge>()
 
             HandleThemeChanges(viewModel.globalAppState.themeOption)
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
@@ -37,11 +37,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import com.wire.android.appLogger
 import com.wire.android.di.assistedViewModels
 import com.wire.android.di.metro.ImageAssetViewModelGraphBridgeViewModel
 import com.wire.android.di.metro.LocalMetroViewModelGraph
-import com.wire.android.di.wireViewModel
 import com.wire.android.ui.AppLockActivity
 import com.wire.android.ui.BaseActivity
 import com.wire.android.ui.LocalActivity
@@ -79,7 +80,14 @@ abstract class CallActivity : BaseActivity() {
         const val TAG = "CallActivity"
     }
 
-    private val callActivityViewModel: CallActivityViewModel by viewModels()
+    private val imageAssetViewModelGraph: ImageAssetViewModelGraphBridgeViewModel by viewModels()
+    private val callActivityViewModel: CallActivityViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                imageAssetViewModelGraph.callingViewModelFactory.callActivityViewModel()
+            }
+        }
+    }
     protected val qualifiedIdMapper = QualifiedIdMapper(null)
 
     override fun onNewIntent(intent: Intent) {
@@ -103,7 +111,6 @@ abstract class CallActivity : BaseActivity() {
 
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
-            val imageAssetViewModelGraph = wireViewModel<ImageAssetViewModelGraphBridgeViewModel>()
             CompositionLocalProvider(
                 LocalSnackbarHostState provides snackbarHostState,
                 LocalMetroViewModelGraph provides imageAssetViewModelGraph,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivityViewModel.kt
@@ -28,16 +28,13 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class CallActivityViewModel @Inject constructor(
+class CallActivityViewModel(
     private val dispatchers: DispatcherProvider,
     private val currentSession: CurrentSessionUseCase,
     private val observeScreenshotCensoringConfigUseCaseProviderFactory:

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallingViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallingViewModelFactory.kt
@@ -1,0 +1,242 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.calling
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.di.CurrentAccount
+import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.di.ObserveScreenshotCensoringConfigUseCaseProvider
+import com.wire.android.feature.AccountSwitchUseCase
+import com.wire.android.feature.analytics.AnonymousAnalyticsManager
+import com.wire.android.mapper.UICallParticipantMapper
+import com.wire.android.mapper.UserTypeMapper
+import com.wire.android.media.CallRinger
+import com.wire.android.notification.CallNotificationManager
+import com.wire.android.ui.CallFeedbackViewModel
+import com.wire.android.ui.analytics.IsAnalyticsAvailableUseCase
+import com.wire.android.ui.calling.common.SharedCallingViewModel
+import com.wire.android.ui.calling.incoming.IncomingCallViewModel
+import com.wire.android.ui.calling.ongoing.OngoingCallViewModel
+import com.wire.android.ui.calling.outgoing.OutgoingCallViewModel
+import com.wire.android.ui.calling.usecase.HangUpCallUseCase
+import com.wire.android.ui.home.appLock.LockCodeTimeManager
+import com.wire.android.ui.home.conversations.call.ConversationCallViewModel
+import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
+import com.wire.android.ui.home.conversationslist.ConversationListCallViewModelImpl
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.FlipToBackCameraUseCase
+import com.wire.kalium.logic.feature.call.usecase.FlipToFrontCameraUseCase
+import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCase
+import com.wire.kalium.logic.feature.call.usecase.IsEligibleToStartCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.IsLastCallClosedUseCase
+import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveCallModerationActionsUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveCallQualityDataUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveConferenceCallingEnabledUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveLastActiveCallWithSortedParticipantsUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingCallsUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveOutgoingCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveSpeakerUseCase
+import com.wire.kalium.logic.feature.call.usecase.RejectCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.RequestVideoStreamsUseCase
+import com.wire.kalium.logic.feature.call.usecase.SetCallQualityIntervalUseCase
+import com.wire.kalium.logic.feature.call.usecase.SetUIRotationUseCase
+import com.wire.kalium.logic.feature.call.usecase.SetVideoPreviewUseCase
+import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
+import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
+import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.video.SetVideoSendStateUseCase
+import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
+import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveDegradedConversationNotifiedUseCase
+import com.wire.kalium.logic.feature.conversation.SetUserInformedAboutVerificationUseCase
+import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
+import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
+import com.wire.kalium.network.NetworkStateObserver
+import dagger.Lazy
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+class CallingViewModelFactory @Inject constructor(
+    private val dispatchers: DispatcherProvider,
+    private val currentSession: CurrentSessionUseCase,
+    private val observeScreenshotCensoringConfigUseCaseProviderFactory:
+    ObserveScreenshotCensoringConfigUseCaseProvider.Factory,
+    private val accountSwitch: AccountSwitchUseCase,
+    @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>,
+    private val currentSessionFlow: Lazy<CurrentSessionFlowUseCase>,
+    private val isAnalyticsAvailable: Lazy<IsAnalyticsAvailableUseCase>,
+    private val analyticsManager: Lazy<AnonymousAnalyticsManager>,
+    @CurrentAccount private val currentAccount: UserId,
+    private val callNotificationManager: CallNotificationManager,
+    private val incomingCalls: GetIncomingCallsUseCase,
+    private val rejectCall: RejectCallUseCase,
+    private val answerCall: AnswerCallUseCase,
+    private val muteCall: MuteCallUseCase,
+    private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
+    private val endCall: EndCallUseCase,
+    private val lockCodeTimeManager: LockCodeTimeManager,
+    private val observeOutgoingCall: ObserveOutgoingCallUseCase,
+    private val startCall: StartCallUseCase,
+    private val isLastCallClosed: IsLastCallClosedUseCase,
+    private val callRinger: CallRinger,
+    private val globalDataStore: GlobalDataStore,
+    private val networkStateObserver: NetworkStateObserver,
+    private val observeLastActiveCallWithSortedParticipants: ObserveLastActiveCallWithSortedParticipantsUseCase,
+    private val requestVideoStreams: RequestVideoStreamsUseCase,
+    private val setVideoSendState: SetVideoSendStateUseCase,
+    private val observeCallQualityData: ObserveCallQualityDataUseCase,
+    private val setCallQualityInterval: SetCallQualityIntervalUseCase,
+    private val getCurrentClientId: ObserveCurrentClientIdUseCase,
+    private val observeInCallReactionsUseCase: ObserveInCallReactionsUseCase,
+    private val sendInCallReactionUseCase: SendInCallReactionUseCase,
+    private val observeCallModerationActions: ObserveCallModerationActionsUseCase,
+    private val uiCallParticipantMapper: UICallParticipantMapper,
+    private val conversationDetails: ObserveConversationDetailsUseCase,
+    private val hangUpCall: HangUpCallUseCase,
+    private val unMuteCall: UnMuteCallUseCase,
+    private val updateVideoState: UpdateVideoStateUseCase,
+    private val setVideoPreview: SetVideoPreviewUseCase,
+    private val setUIRotationUseCase: SetUIRotationUseCase,
+    private val turnLoudSpeakerOff: TurnLoudSpeakerOffUseCase,
+    private val turnLoudSpeakerOn: TurnLoudSpeakerOnUseCase,
+    private val flipToFrontCamera: FlipToFrontCameraUseCase,
+    private val flipToBackCamera: FlipToBackCameraUseCase,
+    private val observeSpeaker: ObserveSpeakerUseCase,
+    private val userTypeMapper: UserTypeMapper,
+    private val observeOngoingCalls: ObserveOngoingCallsUseCase,
+    private val observeParticipantsForConversation: ObserveParticipantsForConversationUseCase,
+    private val observeSyncState: ObserveSyncStateUseCase,
+    private val isConferenceCallingEnabled: IsEligibleToStartCallUseCase,
+    private val setUserInformedAboutVerification: SetUserInformedAboutVerificationUseCase,
+    private val observeDegradedConversationNotified: ObserveDegradedConversationNotifiedUseCase,
+    private val observeConferenceCallingEnabled: ObserveConferenceCallingEnabledUseCase,
+    private val observeSelf: ObserveSelfUserUseCase,
+) {
+    fun callActivityViewModel() = CallActivityViewModel(
+        dispatchers = dispatchers,
+        currentSession = currentSession,
+        observeScreenshotCensoringConfigUseCaseProviderFactory =
+        observeScreenshotCensoringConfigUseCaseProviderFactory,
+        accountSwitch = accountSwitch,
+    )
+
+    fun callFeedbackViewModel() = CallFeedbackViewModel(
+        coreLogic = coreLogic,
+        currentSessionFlow = currentSessionFlow,
+        isAnalyticsAvailable = isAnalyticsAvailable,
+        analyticsManager = analyticsManager,
+    )
+
+    fun incomingCallViewModel(conversationId: ConversationId) = IncomingCallViewModel(
+        conversationId = conversationId,
+        currentAccount = currentAccount,
+        callNotificationManager = callNotificationManager,
+        incomingCalls = incomingCalls,
+        rejectCall = rejectCall,
+        acceptCall = answerCall,
+        muteCall = muteCall,
+        observeEstablishedCalls = observeEstablishedCalls,
+        endCall = endCall,
+        lockCodeTimeManager = lockCodeTimeManager,
+    )
+
+    fun outgoingCallViewModel(conversationId: ConversationId) = OutgoingCallViewModel(
+        conversationId = conversationId,
+        observeEstablishedCalls = observeEstablishedCalls,
+        observeOutgoingCall = observeOutgoingCall,
+        startCall = startCall,
+        endCall = endCall,
+        isLastCallClosed = isLastCallClosed,
+        callRinger = callRinger,
+    )
+
+    fun ongoingCallViewModel(conversationId: ConversationId) = OngoingCallViewModel(
+        conversationId = conversationId,
+        currentUserId = currentAccount,
+        globalDataStore = globalDataStore,
+        networkStateObserver = networkStateObserver,
+        observeLastActiveCall = observeLastActiveCallWithSortedParticipants,
+        requestVideoStreams = requestVideoStreams,
+        setVideoSendState = setVideoSendState,
+        observeCallQualityData = observeCallQualityData,
+        setCallQualityInterval = setCallQualityInterval,
+        getCurrentClientId = getCurrentClientId,
+        observeInCallReactionsUseCase = observeInCallReactionsUseCase,
+        sendInCallReactionUseCase = sendInCallReactionUseCase,
+        observeCallModerationActions = observeCallModerationActions,
+        uiCallParticipantMapper = uiCallParticipantMapper,
+        dispatchers = dispatchers,
+    )
+
+    fun sharedCallingViewModel(conversationId: ConversationId) = SharedCallingViewModel(
+        conversationId = conversationId,
+        conversationDetails = conversationDetails,
+        observeLastActiveCallWithSortedParticipants = observeLastActiveCallWithSortedParticipants,
+        hangUpCall = hangUpCall,
+        muteCall = muteCall,
+        unMuteCall = unMuteCall,
+        updateVideoState = updateVideoState,
+        setVideoPreview = setVideoPreview,
+        setUIRotationUseCase = setUIRotationUseCase,
+        turnLoudSpeakerOff = turnLoudSpeakerOff,
+        turnLoudSpeakerOn = turnLoudSpeakerOn,
+        flipToFrontCamera = flipToFrontCamera,
+        flipToBackCamera = flipToBackCamera,
+        observeSpeaker = observeSpeaker,
+        userTypeMapper = userTypeMapper,
+        dispatchers = dispatchers,
+    )
+
+    fun conversationCallViewModel(savedStateHandle: SavedStateHandle) = ConversationCallViewModel(
+        savedStateHandle = savedStateHandle,
+        currentAccount = currentAccount,
+        observeOngoingCalls = observeOngoingCalls,
+        observeEstablishedCalls = observeEstablishedCalls,
+        observeParticipantsForConversation = observeParticipantsForConversation,
+        answerCall = answerCall,
+        endCall = endCall,
+        observeSyncState = observeSyncState,
+        isConferenceCallingEnabled = isConferenceCallingEnabled,
+        observeConversationDetails = conversationDetails,
+        setUserInformedAboutVerification = setUserInformedAboutVerification,
+        observeDegradedConversationNotified = observeDegradedConversationNotified,
+        observeConferenceCallingEnabled = observeConferenceCallingEnabled,
+        observeSelf = observeSelf,
+    )
+
+    fun conversationListCallViewModel() = ConversationListCallViewModelImpl(
+        currentAccount = currentAccount,
+        answerCall = answerCall,
+        observeEstablishedCalls = observeEstablishedCalls,
+        endCall = endCall,
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallingViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallingViewModelGraph.kt
@@ -1,0 +1,76 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.calling
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalInspectionMode
+import com.wire.android.di.metro.MetroViewModelGraph
+import com.wire.android.di.metro.metroSavedStateViewModel
+import com.wire.android.di.metro.metroViewModel
+import com.wire.android.ui.calling.common.SharedCallingViewModel
+import com.wire.android.ui.calling.incoming.IncomingCallViewModel
+import com.wire.android.ui.calling.ongoing.OngoingCallViewModel
+import com.wire.android.ui.calling.outgoing.OutgoingCallViewModel
+import com.wire.android.ui.home.conversations.call.ConversationCallViewModel
+import com.wire.android.ui.home.conversationslist.ConversationListCallViewModel
+import com.wire.android.ui.home.conversationslist.ConversationListCallViewModelImpl
+import com.wire.android.ui.home.conversationslist.ConversationListCallViewModelPreview
+import com.wire.android.ui.home.conversationslist.model.ConversationsSource
+import com.wire.kalium.logic.data.id.ConversationId
+
+interface CallingViewModelGraph : MetroViewModelGraph {
+    val callingViewModelFactory: CallingViewModelFactory
+}
+
+@Composable
+fun incomingCallViewModel(conversationId: ConversationId): IncomingCallViewModel =
+    metroViewModel<CallingViewModelGraph, IncomingCallViewModel>(key = "incoming_$conversationId") {
+        callingViewModelFactory.incomingCallViewModel(conversationId)
+    }
+
+@Composable
+fun outgoingCallViewModel(conversationId: ConversationId): OutgoingCallViewModel =
+    metroViewModel<CallingViewModelGraph, OutgoingCallViewModel>(key = "outgoing_$conversationId") {
+        callingViewModelFactory.outgoingCallViewModel(conversationId)
+    }
+
+@Composable
+fun ongoingCallViewModel(conversationId: ConversationId): OngoingCallViewModel =
+    metroViewModel<CallingViewModelGraph, OngoingCallViewModel>(key = "ongoing_$conversationId") {
+        callingViewModelFactory.ongoingCallViewModel(conversationId)
+    }
+
+@Composable
+fun sharedCallingViewModel(conversationId: ConversationId): SharedCallingViewModel =
+    metroViewModel<CallingViewModelGraph, SharedCallingViewModel>(key = "shared_$conversationId") {
+        callingViewModelFactory.sharedCallingViewModel(conversationId)
+    }
+
+@Composable
+fun conversationCallViewModel(): ConversationCallViewModel =
+    metroSavedStateViewModel<CallingViewModelGraph, ConversationCallViewModel> {
+        callingViewModelFactory.conversationCallViewModel(it)
+    }
+
+@Composable
+fun conversationListCallViewModel(conversationsSource: ConversationsSource): ConversationListCallViewModel = when {
+    LocalInspectionMode.current -> ConversationListCallViewModelPreview
+    else -> metroViewModel<CallingViewModelGraph, ConversationListCallViewModelImpl>(key = "call_$conversationsSource") {
+        callingViewModelFactory.conversationListCallViewModel()
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/SharedCallingViewModel.kt
@@ -52,10 +52,6 @@ import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.util.PlatformRotation
 import com.wire.kalium.logic.util.PlatformView
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -68,9 +64,8 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 
 @Suppress("LongParameterList", "TooManyFunctions")
-@HiltViewModel(assistedFactory = SharedCallingViewModel.Factory::class)
-class SharedCallingViewModel @AssistedInject constructor(
-    @Assisted val conversationId: ConversationId,
+class SharedCallingViewModel(
+    val conversationId: ConversationId,
     private val conversationDetails: ObserveConversationDetailsUseCase,
     private val observeLastActiveCallWithSortedParticipants: ObserveLastActiveCallWithSortedParticipantsUseCase,
     private val hangUpCall: HangUpCallUseCase,
@@ -251,11 +246,6 @@ class SharedCallingViewModel @AssistedInject constructor(
         viewModelScope.launch {
             setUIRotationUseCase(PlatformRotation(rotation))
         }
-    }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(conversationId: ConversationId): SharedCallingViewModel
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.di.wireViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -47,6 +46,8 @@ import com.wire.android.ui.calling.common.CallVideoPreview
 import com.wire.android.ui.calling.common.CallerDetails
 import com.wire.android.ui.calling.common.ObserveRotation
 import com.wire.android.ui.calling.common.SharedCallingViewModel
+import com.wire.android.ui.calling.incomingCallViewModel
+import com.wire.android.ui.calling.sharedCallingViewModel
 import com.wire.android.ui.calling.controlbuttons.AcceptButton
 import com.wire.android.ui.calling.controlbuttons.CallOptionsControls
 import com.wire.android.ui.calling.controlbuttons.HangUpButton
@@ -70,15 +71,8 @@ import com.wire.kalium.logic.data.id.ConversationId
 fun IncomingCallScreen(
     conversationId: ConversationId,
     shouldTryToAnswerCallAutomatically: Boolean,
-    incomingCallViewModel: IncomingCallViewModel = wireViewModel<IncomingCallViewModel, IncomingCallViewModel.Factory>(
-        key = "incoming_$conversationId",
-        creationCallback = { factory -> factory.create(conversationId = conversationId) }
-    ),
-    sharedCallingViewModel: SharedCallingViewModel =
-    wireViewModel<SharedCallingViewModel, SharedCallingViewModel.Factory>(
-        key = "shared_$conversationId",
-        creationCallback = { factory -> factory.create(conversationId = conversationId) }
-    ),
+    incomingCallViewModel: IncomingCallViewModel = incomingCallViewModel(conversationId),
+    sharedCallingViewModel: SharedCallingViewModel = sharedCallingViewModel(conversationId),
     onCallAccepted: () -> Unit
 ) {
     val activity = LocalActivity.current

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallViewModel.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
-import com.wire.android.di.CurrentAccount
 import com.wire.android.notification.CallNotificationManager
 import com.wire.android.ui.calling.incoming.IncomingCallState.WaitingUnlockState
 import com.wire.android.ui.common.ActionsViewModel
@@ -35,10 +34,6 @@ import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.RejectCallUseCase
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -49,10 +44,9 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
 @Suppress("LongParameterList")
-@HiltViewModel(assistedFactory = IncomingCallViewModel.Factory::class)
-class IncomingCallViewModel @AssistedInject constructor(
-    @Assisted val conversationId: ConversationId,
-    @CurrentAccount val currentAccount: UserId,
+class IncomingCallViewModel(
+    val conversationId: ConversationId,
+    val currentAccount: UserId,
     private var callNotificationManager: CallNotificationManager,
     private val incomingCalls: GetIncomingCallsUseCase,
     private val rejectCall: RejectCallUseCase,
@@ -202,11 +196,6 @@ class IncomingCallViewModel @AssistedInject constructor(
 
     companion object {
         const val DELAY_END_CALL = 200L
-    }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(conversationId: ConversationId): IncomingCallViewModel
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -73,7 +73,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import androidx.compose.ui.zIndex
-import com.wire.android.di.wireViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
@@ -85,6 +84,8 @@ import com.wire.android.ui.calling.common.ObservePictureInPictureMode
 import com.wire.android.ui.calling.common.ObserveRotation
 import com.wire.android.ui.calling.common.SharedCallingViewActions
 import com.wire.android.ui.calling.common.SharedCallingViewModel
+import com.wire.android.ui.calling.ongoingCallViewModel
+import com.wire.android.ui.calling.sharedCallingViewModel
 import com.wire.android.ui.calling.controlbuttons.CameraButton
 import com.wire.android.ui.calling.controlbuttons.HangUpOngoingButton
 import com.wire.android.ui.calling.controlbuttons.InCallReactionsButton
@@ -154,15 +155,8 @@ import java.util.Locale
 @Composable
 fun OngoingCallScreen(
     conversationId: ConversationId,
-    ongoingCallViewModel: OngoingCallViewModel = wireViewModel<OngoingCallViewModel, OngoingCallViewModel.Factory>(
-        key = "ongoing_$conversationId",
-        creationCallback = { factory -> factory.create(conversationId = conversationId) }
-    ),
-    sharedCallingViewModel: SharedCallingViewModel =
-        wireViewModel<SharedCallingViewModel, SharedCallingViewModel.Factory>(
-            key = "shared_$conversationId",
-            creationCallback = { factory -> factory.create(conversationId = conversationId) }
-        )
+    ongoingCallViewModel: OngoingCallViewModel = ongoingCallViewModel(conversationId),
+    sharedCallingViewModel: SharedCallingViewModel = sharedCallingViewModel(conversationId)
 ) {
     val scope = rememberCoroutineScope()
     val permissionPermanentlyDeniedDialogState = rememberVisibilityState<PermissionPermanentlyDeniedDialogState>()

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallViewModel.kt
@@ -27,7 +27,6 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.BuildConfig
 import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
-import com.wire.android.di.CurrentAccount
 import com.wire.android.mapper.UICallParticipantMapper
 import com.wire.android.ui.calling.model.InCallReaction
 import com.wire.android.ui.calling.model.ReactionSender
@@ -62,10 +61,6 @@ import com.wire.kalium.logic.feature.client.ObserveCurrentClientIdUseCase
 import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
 import com.wire.kalium.network.NetworkState
 import com.wire.kalium.network.NetworkStateObserver
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -87,10 +82,9 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 
 @Suppress("LongParameterList", "TooManyFunctions")
-@HiltViewModel(assistedFactory = OngoingCallViewModel.Factory::class)
-class OngoingCallViewModel @AssistedInject constructor(
-    @Assisted val conversationId: ConversationId,
-    @CurrentAccount val currentUserId: UserId,
+class OngoingCallViewModel(
+    val conversationId: ConversationId,
+    val currentUserId: UserId,
     private val globalDataStore: GlobalDataStore,
     private val networkStateObserver: NetworkStateObserver,
     private val observeLastActiveCall: ObserveLastActiveCallWithSortedParticipantsUseCase,
@@ -374,11 +368,6 @@ class OngoingCallViewModel @AssistedInject constructor(
         const val DOUBLE_TAP_TOAST_DISPLAY_TIME = 7000L // according to the designs
         const val DELAY_TO_SHOW_DOUBLE_TAP_TOAST = 500L
         const val TAG = "OngoingCallViewModel"
-    }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(conversationId: ConversationId): OngoingCallViewModel
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/outgoing/OutgoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/outgoing/OutgoingCallScreen.kt
@@ -34,13 +34,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.ui.LocalActivity
 import com.wire.android.ui.calling.common.CallVideoPreview
 import com.wire.android.ui.calling.common.CallerDetails
 import com.wire.android.ui.calling.common.ObserveRotation
 import com.wire.android.ui.calling.common.SharedCallingViewModel
+import com.wire.android.ui.calling.outgoingCallViewModel
+import com.wire.android.ui.calling.sharedCallingViewModel
 import com.wire.android.ui.calling.controlbuttons.CallOptionsControls
 import com.wire.android.ui.calling.controlbuttons.HangUpButton
 import com.wire.android.ui.calling.model.CallState
@@ -55,15 +56,8 @@ import com.wire.kalium.logic.data.id.ConversationId
 @Composable
 fun OutgoingCallScreen(
     conversationId: ConversationId,
-    sharedCallingViewModel: SharedCallingViewModel =
-    wireViewModel<SharedCallingViewModel, SharedCallingViewModel.Factory>(
-        key = "shared_$conversationId",
-        creationCallback = { factory -> factory.create(conversationId = conversationId) }
-    ),
-    outgoingCallViewModel: OutgoingCallViewModel = wireViewModel<OutgoingCallViewModel, OutgoingCallViewModel.Factory>(
-        key = "outgoing_$conversationId",
-        creationCallback = { factory -> factory.create(conversationId = conversationId) }
-    ),
+    sharedCallingViewModel: SharedCallingViewModel = sharedCallingViewModel(conversationId),
+    outgoingCallViewModel: OutgoingCallViewModel = outgoingCallViewModel(conversationId),
     onCallAccepted: () -> Unit
 ) {
     val permissionPermanentlyDeniedDialogState =

--- a/app/src/main/kotlin/com/wire/android/ui/calling/outgoing/OutgoingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/outgoing/OutgoingCallViewModel.kt
@@ -32,10 +32,6 @@ import com.wire.kalium.logic.feature.call.usecase.IsLastCallClosedUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveOutgoingCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -44,9 +40,8 @@ import org.jetbrains.annotations.VisibleForTesting
 import java.util.Calendar
 
 @Suppress("LongParameterList")
-@HiltViewModel(assistedFactory = OutgoingCallViewModel.Factory::class)
-class OutgoingCallViewModel @AssistedInject constructor(
-    @Assisted val conversationId: ConversationId,
+class OutgoingCallViewModel(
+    val conversationId: ConversationId,
     private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
     private val observeOutgoingCall: ObserveOutgoingCallUseCase,
     private val startCall: StartCallUseCase,
@@ -132,10 +127,5 @@ class OutgoingCallViewModel @AssistedInject constructor(
             stopRingerAndMarkCallAsHungUp()
             state = state.copy(flowState = OutgoingCallState.FlowState.CallClosed)
         }
-    }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(conversationId: ConversationId): OutgoingCallViewModel
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -117,6 +117,7 @@ import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.annotation.app.WireRootDestination
 import com.wire.android.ui.calling.getOutgoingCallIntent
+import com.wire.android.ui.calling.conversationCallViewModel
 import com.wire.android.ui.calling.ongoing.getOngoingCallIntent
 import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.PageLoadingIndicator
@@ -260,7 +261,7 @@ fun ConversationScreen(
     resultNavigator: ResultBackNavigator<GroupConversationDetailsNavBackArgs>,
     conversationInfoViewModel: ConversationInfoViewModel = wireViewModel(),
     conversationBannerViewModel: ConversationBannerViewModel = wireViewModel(),
-    conversationCallViewModel: ConversationCallViewModel = wireViewModel(),
+    conversationCallViewModel: ConversationCallViewModel = conversationCallViewModel(),
     conversationMessagesViewModel: ConversationMessagesViewModel = conversationMessagesViewModel(),
     messageComposerViewModel: MessageComposerViewModel = messageComposerViewModel(),
     sendMessageViewModel: SendMessageViewModel = sendMessageViewModel(),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/ConversationCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/ConversationCallViewModel.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.wire.android.di.CurrentAccount
 import com.wire.android.ui.common.ActionsViewModel
 import com.wire.android.ui.home.conversations.ConversationNavArgs
 import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
@@ -49,7 +48,6 @@ import com.wire.kalium.logic.feature.conversation.ObserveDegradedConversationNot
 import com.wire.kalium.logic.feature.conversation.SetUserInformedAboutVerificationUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -57,13 +55,11 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
 @Suppress("LongParameterList", "TooManyFunctions")
-class ConversationCallViewModel @Inject constructor(
+class ConversationCallViewModel(
     val savedStateHandle: SavedStateHandle,
-    @CurrentAccount val currentAccount: UserId,
+    val currentAccount: UserId,
     private val observeOngoingCalls: ObserveOngoingCallsUseCase,
     private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
     private val observeParticipantsForConversation: ObserveParticipantsForConversationUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListCallViewModel.kt
@@ -19,7 +19,6 @@
 package com.wire.android.ui.home.conversationslist
 
 import androidx.lifecycle.viewModelScope
-import com.wire.android.di.CurrentAccount
 import com.wire.android.ui.common.ActionsManager
 import com.wire.android.ui.common.ActionsViewModel
 import com.wire.android.ui.common.visbility.VisibilityState
@@ -29,12 +28,10 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 interface ConversationListCallViewModel : ActionsManager<ConversationListCallViewActions> {
     val joinCallDialogState: VisibilityState<ConversationId> get() = VisibilityState()
@@ -45,9 +42,8 @@ interface ConversationListCallViewModel : ActionsManager<ConversationListCallVie
 object ConversationListCallViewModelPreview : ConversationListCallViewModel
 
 @Suppress("MagicNumber", "TooManyFunctions", "LongParameterList")
-@HiltViewModel
-class ConversationListCallViewModelImpl @Inject constructor(
-    @CurrentAccount val currentAccount: UserId,
+class ConversationListCallViewModelImpl(
+    val currentAccount: UserId,
     private val answerCall: AnswerCallUseCase,
     private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
     private val endCall: EndCallUseCase

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -49,6 +49,7 @@ import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.rememberNavigator
+import com.wire.android.ui.calling.conversationListCallViewModel
 import com.wire.android.ui.calling.ongoing.getOngoingCallIntent
 import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.VisibilityState
@@ -101,10 +102,7 @@ fun ConversationsScreenContent(
             }
         )
     },
-    conversationListCallViewModel: ConversationListCallViewModel = when {
-        LocalInspectionMode.current -> ConversationListCallViewModelPreview
-        else -> wireViewModel<ConversationListCallViewModelImpl>(key = "call_$conversationsSource")
-    },
+    conversationListCallViewModel: ConversationListCallViewModel = conversationListCallViewModel(conversationsSource),
 ) {
     val sheetState = rememberWireModalSheetState<ConversationSheetState>()
     val permissionPermanentlyDeniedDialogState = rememberVisibilityState<PermissionPermanentlyDeniedDialogState>()

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -1860,6 +1860,19 @@ public fun com.wire.android.ui.calling.controlbuttons.WireCallControlButton(isSe
     - iconSize: STABLE (marked @Stable or @Immutable)
 
 @Composable
+public fun com.wire.android.ui.calling.conversationCallViewModel(): com.wire.android.ui.home.conversations.call.ConversationCallViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.calling.conversationListCallViewModel(conversationsSource: com.wire.android.ui.home.conversationslist.model.ConversationsSource): com.wire.android.ui.home.conversationslist.ConversationListCallViewModel
+  skippable: true
+  restartable: true
+  params:
+    - conversationsSource: STABLE (class with no mutable properties)
+
+@Composable
 public fun com.wire.android.ui.calling.incoming.AudioPermissionCheckFlow(onAcceptCall: kotlin.Function0<kotlin.Unit>, onPermanentPermissionDecline: kotlin.Function0<kotlin.Unit>): com.wire.android.util.permission.RequestLauncher
   skippable: true
   restartable: true
@@ -1892,6 +1905,13 @@ public fun com.wire.android.ui.calling.incoming.IncomingCallScreen(conversationI
     - incomingCallViewModel: UNSTABLE (has mutable properties or unstable members)
     - sharedCallingViewModel: UNSTABLE (has mutable properties or unstable members)
     - onCallAccepted: STABLE (function type)
+
+@Composable
+public fun com.wire.android.ui.calling.incomingCallViewModel(conversationId: com.wire.kalium.logic.data.id.QualifiedID): com.wire.android.ui.calling.incoming.IncomingCallViewModel
+  skippable: false
+  restartable: true
+  params:
+    - conversationId: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
 private fun com.wire.android.ui.calling.ongoing.CallingControls(conversationId: com.wire.kalium.logic.data.id.QualifiedID, isMuted: kotlin.Boolean, isCameraOn: kotlin.Boolean, isSpeakerOn: kotlin.Boolean, isShowingCallReactions: kotlin.Boolean, isConnecting: kotlin.Boolean, inCallReactionsEnabled: kotlin.Boolean, toggleSpeaker: kotlin.Function0<kotlin.Unit>, toggleMute: kotlin.Function0<kotlin.Unit>, onHangUpCall: kotlin.Function0<kotlin.Unit>, onToggleVideo: kotlin.Function0<kotlin.Unit>, onCallReactionsClick: kotlin.Function0<kotlin.Unit>, onCameraPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -2514,6 +2534,13 @@ private fun com.wire.android.ui.calling.ongoing.toast.styledText(stringResId: ko
     - formatArgs: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
+public fun com.wire.android.ui.calling.ongoingCallViewModel(conversationId: com.wire.kalium.logic.data.id.QualifiedID): com.wire.android.ui.calling.ongoing.OngoingCallViewModel
+  skippable: false
+  restartable: true
+  params:
+    - conversationId: UNSTABLE (has mutable properties or unstable members)
+
+@Composable
 private fun com.wire.android.ui.calling.outgoing.OutgoingCallContent(callState: com.wire.android.ui.calling.model.CallState, toggleMute: kotlin.Function0<kotlin.Unit>, toggleSpeaker: kotlin.Function0<kotlin.Unit>, toggleVideo: kotlin.Function0<kotlin.Unit>, onHangUpCall: kotlin.Function0<kotlin.Unit>, onVideoPreviewCreated: kotlin.Function1<@[ParameterName(name = \, onSelfClearVideoPreview: kotlin.Function0<kotlin.Unit>, onCameraPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, onMinimiseScreen: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
@@ -2537,6 +2564,20 @@ public fun com.wire.android.ui.calling.outgoing.OutgoingCallScreen(conversationI
     - sharedCallingViewModel: UNSTABLE (has mutable properties or unstable members)
     - outgoingCallViewModel: UNSTABLE (has mutable properties or unstable members)
     - onCallAccepted: STABLE (function type)
+
+@Composable
+public fun com.wire.android.ui.calling.outgoingCallViewModel(conversationId: com.wire.kalium.logic.data.id.QualifiedID): com.wire.android.ui.calling.outgoing.OutgoingCallViewModel
+  skippable: false
+  restartable: true
+  params:
+    - conversationId: UNSTABLE (has mutable properties or unstable members)
+
+@Composable
+public fun com.wire.android.ui.calling.sharedCallingViewModel(conversationId: com.wire.kalium.logic.data.id.QualifiedID): com.wire.android.ui.calling.common.SharedCallingViewModel
+  skippable: false
+  restartable: true
+  params:
+    - conversationId: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
 public fun com.wire.android.ui.common.AddContactButton(userId: com.wire.kalium.logic.data.id.QualifiedID, userName: kotlin.String, modifier: androidx.compose.ui.Modifier, viewModel: com.wire.android.ui.connection.ConnectionActionButtonViewModel): kotlin.Unit
@@ -6718,7 +6759,7 @@ public fun com.wire.android.ui.home.conversations.messages.item.remainingColor()
   params:
 
 @Composable
-private fun com.wire.android.ui.home.conversations.messages.item.shouldShowBottomLabels(messageStyle: com.wire.android.ui.home.conversations.messages.item.MessageStyle, messageStatus: com.wire.android.ui.home.conversations.model.MessageStatus, useSmallBottomPadding: kotlin.Boolean, selfDeletionTimerState: com.wire.android.ui.home.conversations.SelfDeletionTimerHelper.SelfDeletionTimerState, decryptionFailed: kotlin.Boolean): kotlin.Boolean
+private fun com.wire.android.ui.home.conversations.messages.item.shouldShowBottomLabels(messageStyle: com.wire.android.ui.home.conversations.messages.item.MessageStyle, messageStatus: com.wire.android.ui.home.conversations.model.MessageStatus, useSmallBottomPadding: kotlin.Boolean, selfDeletionTimerState: com.wire.android.ui.home.conversations.SelfDeletionTimerHelper.SelfDeletionTimerState, decryptionFailed: kotlin.Boolean, isPending: kotlin.Boolean): kotlin.Boolean
   skippable: true
   restartable: true
   params:
@@ -6727,6 +6768,7 @@ private fun com.wire.android.ui.home.conversations.messages.item.shouldShowBotto
     - useSmallBottomPadding: STABLE (primitive type)
     - selfDeletionTimerState: STABLE (class with no mutable properties)
     - decryptionFailed: STABLE (primitive type)
+    - isPending: STABLE (primitive type)
 
 @Composable
 public fun com.wire.android.ui.home.conversations.messages.item.surface(): androidx.compose.ui.graphics.Color


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25946
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Migrates calling and call activity ViewModels from Hilt call-site creation to Metro-backed factories.
- Wires calling screens through the app Metro ViewModel graph.
- Keeps existing call UI state/effect contracts unchanged.