### PR TITLE
refactor: migrate home list view models to metro [WPB-25946]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
@@ -30,6 +30,8 @@ import com.wire.android.ui.calling.CallingViewModelFactory
 import com.wire.android.ui.calling.CallingViewModelGraph
 import com.wire.android.ui.debug.DebugInfoViewModelFactory
 import com.wire.android.ui.debug.DebugInfoViewModelGraph
+import com.wire.android.ui.home.HomeViewModelFactory
+import com.wire.android.ui.home.HomeViewModelGraph
 import com.wire.android.ui.home.conversations.ConversationCoreViewModelFactory
 import com.wire.android.ui.home.conversations.ConversationCoreViewModelGraph
 import com.wire.android.ui.home.settings.SettingsViewModelFactory
@@ -49,6 +51,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     private val authenticationViewModelFactoryProvider: Provider<AuthenticationViewModelFactory>,
     private val callingViewModelFactoryProvider: Provider<CallingViewModelFactory>,
     private val debugInfoViewModelFactoryProvider: Provider<DebugInfoViewModelFactory>,
+    private val homeViewModelFactoryProvider: Provider<HomeViewModelFactory>,
     private val settingsViewModelFactoryProvider: Provider<SettingsViewModelFactory>,
     private val conversationCoreViewModelFactoryProvider: Provider<ConversationCoreViewModelFactory>,
     private val meetingsViewModelFactoryProvider: Provider<MeetingsViewModelFactory>,
@@ -58,6 +61,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     AuthenticationViewModelGraph,
     CallingViewModelGraph,
     DebugInfoViewModelGraph,
+    HomeViewModelGraph,
     SettingsViewModelGraph,
     ConversationCoreViewModelGraph,
     MeetingsViewModelGraph {
@@ -75,6 +79,9 @@ class WireActivityViewModelGraphBridge @Inject constructor(
 
     override val debugInfoViewModelFactory: DebugInfoViewModelFactory
         get() = debugInfoViewModelFactoryProvider.get()
+
+    override val homeViewModelFactory: HomeViewModelFactory
+        get() = homeViewModelFactoryProvider.get()
 
     override val settingsViewModelFactory: SettingsViewModelFactory
         get() = settingsViewModelFactoryProvider.get()

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -163,11 +163,17 @@ class WireActivity : BaseActivity() {
 
     private val wireActivityViewModelGraph: WireActivityViewModelGraphBridge by viewModels()
     private val viewModel: WireActivityViewModel by viewModels()
-    private val featureFlagNotificationViewModel: FeatureFlagNotificationViewModel by viewModels()
     private val callFeedbackViewModel: CallFeedbackViewModel by viewModels {
         viewModelFactory {
             initializer {
                 wireActivityViewModelGraph.callingViewModelFactory.callFeedbackViewModel()
+            }
+        }
+    }
+    private val featureFlagNotificationViewModel: FeatureFlagNotificationViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                wireActivityViewModelGraph.homeViewModelFactory.featureFlagNotificationViewModel()
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/AppSyncViewModel.kt
@@ -23,19 +23,16 @@ import com.wire.android.appLogger
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.feature.debug.ObserveDebugCRLExpirationAfterOneMinuteUseCase
 import com.wire.kalium.logic.sync.ForegroundActionsUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
-@HiltViewModel
-class AppSyncViewModel @Inject constructor(
+class AppSyncViewModel(
     private val foregroundActionsUseCase: ForegroundActionsUseCase,
     observeDebugCRLExpirationAfterOneMinute: ObserveDebugCRLExpirationAfterOneMinuteUseCase,
     private val dispatcher: DispatcherProvider,

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -115,9 +115,9 @@ fun HomeScreen(
     otherUserProfileScreenResultRecipient: ResultRecipient<OtherUserProfileScreenDestination, String>,
     conversationFoldersScreenResultRecipient:
     ResultRecipient<ConversationFoldersScreenDestination, ConversationFoldersNavBackArgs>,
-    homeViewModel: HomeViewModel = wireViewModel(),
-    appSyncViewModel: AppSyncViewModel = wireViewModel(),
-    homeDrawerViewModel: HomeDrawerViewModel = wireViewModel(),
+    homeViewModel: HomeViewModel = homeViewModel(),
+    appSyncViewModel: AppSyncViewModel = appSyncViewModel(),
+    homeDrawerViewModel: HomeDrawerViewModel = homeDrawerViewModel(),
     analyticsUsageViewModel: AnalyticsUsageViewModel = wireViewModel(),
 ) {
     val context = LocalContext.current

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -39,17 +39,14 @@ import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import dagger.Lazy
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @Suppress("LongParameterList")
-@HiltViewModel
-class HomeViewModel @Inject constructor(
+class HomeViewModel(
     val savedStateHandle: SavedStateHandle,
     private val dataStore: UserDataStore,
     private val observeSelf: ObserveSelfUserUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModelFactory.kt
@@ -1,0 +1,132 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.BuildConfig
+import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.datastore.UserDataStore
+import com.wire.android.di.CurrentAccount
+import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.mapper.UserTypeMapper
+import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
+import com.wire.android.feature.DisableAppLockUseCase
+import com.wire.android.ui.home.conversations.usecase.GetConversationsFromSearchUseCase
+import com.wire.android.ui.home.conversationslist.ConversationListViewModelImpl
+import com.wire.android.ui.home.conversationslist.model.ConversationsSource
+import com.wire.android.ui.home.drawer.HomeDrawerViewModel
+import com.wire.android.ui.home.sync.FeatureFlagNotificationViewModel
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.ui.UiTextResolver
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.client.IsWireCellsEnabledUseCase
+import com.wire.kalium.logic.feature.client.NeedsToRegisterClientUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveArchivedUnreadConversationsCountUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationListDetailsWithEventsUseCase
+import com.wire.kalium.logic.feature.conversation.RefreshConversationsWithoutMetadataUseCase
+import com.wire.kalium.logic.feature.debug.ObserveDebugCRLExpirationAfterOneMinuteUseCase
+import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
+import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
+import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
+import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
+import com.wire.kalium.logic.feature.user.GetSelfTeamIdUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
+import com.wire.kalium.logic.sync.ForegroundActionsUseCase
+import dagger.Lazy
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+class HomeViewModelFactory @Inject constructor(
+    private val dataStore: UserDataStore,
+    private val observeSelf: ObserveSelfUserUseCase,
+    private val needsToRegisterClient: NeedsToRegisterClientUseCase,
+    private val canMigrateFromPersonalToTeam: CanMigrateFromPersonalToTeamUseCase,
+    private val observeLegalHoldStatusForSelfUser: ObserveLegalHoldStateForSelfUserUseCase,
+    private val currentSessionFlow: Lazy<CurrentSessionFlowUseCase>,
+    private val foregroundActionsUseCase: ForegroundActionsUseCase,
+    private val observeDebugCRLExpirationAfterOneMinute: ObserveDebugCRLExpirationAfterOneMinuteUseCase,
+    private val dispatcher: DispatcherProvider,
+    private val observeArchivedUnreadConversationsCount: Lazy<ObserveArchivedUnreadConversationsCountUseCase>,
+    private val getTeamUrl: GetTeamUrlUseCase,
+    private val isWireCellsEnabled: IsWireCellsEnabledUseCase,
+    @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>,
+    private val globalDataStore: Lazy<GlobalDataStore>,
+    private val disableAppLockUseCase: Lazy<DisableAppLockUseCase>,
+    private val getConversationsPaginated: GetConversationsFromSearchUseCase,
+    private val observeConversationListDetailsWithEvents: ObserveConversationListDetailsWithEventsUseCase,
+    private val refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase,
+    private val refreshConversationsWithoutMetadata: RefreshConversationsWithoutMetadataUseCase,
+    private val observeLegalHoldStateForSelfUser: ObserveLegalHoldStateForSelfUserUseCase,
+    private val audioMessagePlayer: ConversationAudioMessagePlayer,
+    @CurrentAccount private val currentAccount: UserId,
+    private val userTypeMapper: UserTypeMapper,
+    private val getSelfTeamId: GetSelfTeamIdUseCase,
+    private val uiTextResolver: UiTextResolver,
+) {
+    fun homeViewModel(savedStateHandle: SavedStateHandle) = HomeViewModel(
+        savedStateHandle = savedStateHandle,
+        dataStore = dataStore,
+        observeSelf = observeSelf,
+        needsToRegisterClient = needsToRegisterClient,
+        canMigrateFromPersonalToTeam = canMigrateFromPersonalToTeam,
+        observeLegalHoldStatusForSelfUser = observeLegalHoldStatusForSelfUser,
+        currentSessionFlow = currentSessionFlow,
+    )
+
+    fun appSyncViewModel() = AppSyncViewModel(
+        foregroundActionsUseCase = foregroundActionsUseCase,
+        observeDebugCRLExpirationAfterOneMinute = observeDebugCRLExpirationAfterOneMinute,
+        dispatcher = dispatcher,
+    )
+
+    fun homeDrawerViewModel(savedStateHandle: SavedStateHandle) = HomeDrawerViewModel(
+        savedStateHandle = savedStateHandle,
+        observeArchivedUnreadConversationsCount = observeArchivedUnreadConversationsCount,
+        observeSelfUser = observeSelf,
+        getTeamUrl = getTeamUrl,
+        isWireCellsEnabled = isWireCellsEnabled,
+    )
+
+    fun featureFlagNotificationViewModel() = FeatureFlagNotificationViewModel(
+        coreLogic = coreLogic,
+        currentSessionFlow = currentSessionFlow,
+        globalDataStore = globalDataStore,
+        disableAppLockUseCase = disableAppLockUseCase,
+    )
+
+    fun conversationListViewModel(
+        conversationsSource: ConversationsSource,
+        usePagination: Boolean = BuildConfig.PAGINATED_CONVERSATION_LIST_ENABLED,
+    ) = ConversationListViewModelImpl(
+        conversationsSource = conversationsSource,
+        usePagination = usePagination,
+        dispatcher = dispatcher,
+        getConversationsPaginated = getConversationsPaginated,
+        observeConversationListDetailsWithEvents = observeConversationListDetailsWithEvents,
+        refreshUsersWithoutMetadata = refreshUsersWithoutMetadata,
+        refreshConversationsWithoutMetadata = refreshConversationsWithoutMetadata,
+        observeLegalHoldStateForSelfUser = observeLegalHoldStateForSelfUser,
+        audioMessagePlayer = audioMessagePlayer,
+        currentAccount = currentAccount,
+        userTypeMapper = userTypeMapper,
+        getSelfTeamId = getSelfTeamId,
+        uiTextResolver = uiTextResolver,
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModelGraph.kt
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalInspectionMode
+import com.wire.android.di.metro.MetroViewModelGraph
+import com.wire.android.di.metro.metroSavedStateViewModel
+import com.wire.android.di.metro.metroViewModel
+import com.wire.android.ui.home.conversationslist.ConversationListViewModel
+import com.wire.android.ui.home.conversationslist.ConversationListViewModelImpl
+import com.wire.android.ui.home.conversationslist.ConversationListViewModelPreview
+import com.wire.android.ui.home.conversationslist.model.ConversationsSource
+import com.wire.android.ui.home.drawer.HomeDrawerViewModel
+
+interface HomeViewModelGraph : MetroViewModelGraph {
+    val homeViewModelFactory: HomeViewModelFactory
+}
+
+@Composable
+fun homeViewModel(): HomeViewModel =
+    metroSavedStateViewModel<HomeViewModelGraph, HomeViewModel> { homeViewModelFactory.homeViewModel(it) }
+
+@Composable
+fun appSyncViewModel(): AppSyncViewModel =
+    metroViewModel<HomeViewModelGraph, AppSyncViewModel> { homeViewModelFactory.appSyncViewModel() }
+
+@Composable
+fun homeDrawerViewModel(): HomeDrawerViewModel =
+    metroSavedStateViewModel<HomeViewModelGraph, HomeDrawerViewModel> { homeViewModelFactory.homeDrawerViewModel(it) }
+
+@Composable
+fun conversationListViewModel(conversationsSource: ConversationsSource): ConversationListViewModel = when {
+    LocalInspectionMode.current -> ConversationListViewModelPreview()
+    else -> metroViewModel<HomeViewModelGraph, ConversationListViewModelImpl>(key = "list_$conversationsSource") {
+        homeViewModelFactory.conversationListViewModel(conversationsSource)
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -56,10 +56,6 @@ import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
 import com.wire.kalium.logic.feature.user.GetSelfTeamIdUseCase
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -97,10 +93,9 @@ class ConversationListViewModelPreview(
 }
 
 @Suppress("MagicNumber", "TooManyFunctions", "LongParameterList")
-@HiltViewModel(assistedFactory = ConversationListViewModelImpl.Factory::class)
-class ConversationListViewModelImpl @AssistedInject constructor(
-    @Assisted val conversationsSource: ConversationsSource,
-    @Assisted private val usePagination: Boolean = BuildConfig.PAGINATED_CONVERSATION_LIST_ENABLED,
+class ConversationListViewModelImpl(
+    val conversationsSource: ConversationsSource,
+    private val usePagination: Boolean = BuildConfig.PAGINATED_CONVERSATION_LIST_ENABLED,
     private val dispatcher: DispatcherProvider,
     private val getConversationsPaginated: GetConversationsFromSearchUseCase,
     private val observeConversationListDetailsWithEvents: ObserveConversationListDetailsWithEventsUseCase,
@@ -113,14 +108,6 @@ class ConversationListViewModelImpl @AssistedInject constructor(
     private val getSelfTeamId: GetSelfTeamIdUseCase,
     private val uiTextResolver: UiTextResolver,
 ) : ConversationListViewModel, ViewModel() {
-
-    @AssistedFactory
-    interface Factory {
-        fun create(
-            conversationsSource: ConversationsSource,
-            usePagination: Boolean = BuildConfig.PAGINATED_CONVERSATION_LIST_ENABLED,
-        ): ConversationListViewModelImpl
-    }
 
     private val _infoMessage = MutableSharedFlow<SnackBarMessage>()
     override val infoMessage = _infoMessage.asSharedFlow()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -31,8 +31,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalInspectionMode
-import com.wire.android.di.wireViewModel
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import com.ramcosta.composedestinations.generated.app.destinations.BrowseChannelsScreenDestination
@@ -65,6 +63,7 @@ import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.debug.conversation.DebugConversationScreenNavArgs
 import com.wire.android.ui.home.conversations.PermissionPermanentlyDeniedDialogState
 import com.wire.android.ui.home.conversations.promoteadmin.PromoteAdminNavArgs
+import com.wire.android.ui.home.conversationListViewModel
 import com.wire.android.ui.home.conversationslist.common.ConversationList
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.ui.home.conversationslist.model.ConversationItemType
@@ -93,16 +92,8 @@ fun ConversationsScreenContent(
     conversationsSource: ConversationsSource = ConversationsSource.MAIN,
     emptySearchResultFocusRequester: FocusRequester? = null,
     firstConversationFocusRequester: FocusRequester? = null,
-    conversationListViewModel: ConversationListViewModel = when {
-        LocalInspectionMode.current -> ConversationListViewModelPreview()
-        else -> wireViewModel<ConversationListViewModelImpl, ConversationListViewModelImpl.Factory>(
-            key = "list_$conversationsSource",
-            creationCallback = { factory ->
-                factory.create(conversationsSource = conversationsSource)
-            }
-        )
-    },
     conversationListCallViewModel: ConversationListCallViewModel = conversationListCallViewModel(conversationsSource),
+    conversationListViewModel: ConversationListViewModel = conversationListViewModel(conversationsSource),
 ) {
     val sheetState = rememberWireModalSheetState<ConversationSheetState>()
     val permissionPermanentlyDeniedDialogState = rememberVisibilityState<PermissionPermanentlyDeniedDialogState>()

--- a/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/drawer/HomeDrawerViewModel.kt
@@ -33,17 +33,14 @@ import com.wire.kalium.logic.feature.conversation.ObserveArchivedUnreadConversat
 import com.wire.kalium.logic.feature.server.GetTeamUrlUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import dagger.Lazy
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @Suppress("LongParameterList")
-@HiltViewModel
-class HomeDrawerViewModel @Inject constructor(
+class HomeDrawerViewModel(
     val savedStateHandle: SavedStateHandle,
     private val observeArchivedUnreadConversationsCount: Lazy<ObserveArchivedUnreadConversationsCountUseCase>,
     private val observeSelfUser: ObserveSelfUserUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/FeatureFlagNotificationViewModel.kt
@@ -25,7 +25,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
-import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.AppLockSource
 import com.wire.android.feature.DisableAppLockUseCase
 import com.wire.android.ui.home.FeatureFlagState
@@ -41,19 +40,16 @@ import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.E2EIRequiredResult
 import dagger.Lazy
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
-@HiltViewModel
-class FeatureFlagNotificationViewModel @Inject constructor(
-    @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>,
+class FeatureFlagNotificationViewModel(
+    private val coreLogic: Lazy<CoreLogic>,
     private val currentSessionFlow: Lazy<CurrentSessionFlowUseCase>,
     private val globalDataStore: Lazy<GlobalDataStore>,
     private val disableAppLockUseCase: Lazy<DisableAppLockUseCase>,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25946
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Migrates home shell and conversation list ViewModels from Hilt call-site creation to Metro-backed factories.
- Adds the required Metro graph wiring for home/list screen entry points.
- Keeps existing UI-facing ViewModel APIs unchanged.