### PR TITLE
refactor: migrate conversation core view models to metro [WPB-25946]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
@@ -26,6 +26,8 @@ import com.wire.android.ui.authentication.AuthenticationViewModelFactory
 import com.wire.android.ui.authentication.AuthenticationViewModelGraph
 import com.wire.android.ui.debug.DebugInfoViewModelFactory
 import com.wire.android.ui.debug.DebugInfoViewModelGraph
+import com.wire.android.ui.home.conversations.ConversationCoreViewModelFactory
+import com.wire.android.ui.home.conversations.ConversationCoreViewModelGraph
 import com.wire.android.ui.home.settings.SettingsViewModelFactory
 import com.wire.android.ui.home.settings.SettingsViewModelGraph
 import com.wire.android.util.ui.WireSessionImageLoader
@@ -43,12 +45,14 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     private val authenticationViewModelFactoryProvider: Provider<AuthenticationViewModelFactory>,
     private val debugInfoViewModelFactoryProvider: Provider<DebugInfoViewModelFactory>,
     private val settingsViewModelFactoryProvider: Provider<SettingsViewModelFactory>,
+    private val conversationCoreViewModelFactoryProvider: Provider<ConversationCoreViewModelFactory>,
 ) : ViewModel(),
     ImageAssetViewModelGraph,
     CellsViewModelGraph,
     AuthenticationViewModelGraph,
     DebugInfoViewModelGraph,
-    SettingsViewModelGraph {
+    SettingsViewModelGraph,
+    ConversationCoreViewModelGraph {
     override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
         ImageAssetViewModelFactory(imageLoader = imageLoader::get)
 
@@ -63,4 +67,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
 
     override val settingsViewModelFactory: SettingsViewModelFactory
         get() = settingsViewModelFactoryProvider.get()
+
+    override val conversationCoreViewModelFactory: ConversationCoreViewModelFactory
+        get() = conversationCoreViewModelFactoryProvider.get()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelFactory.kt
@@ -18,10 +18,6 @@
 package com.wire.android.ui.home.conversations
 
 import androidx.lifecycle.SavedStateHandle
-import com.wire.android.feature.analytics.AnonymousAnalyticsManager
-import com.wire.android.mapper.ContactMapper
-import com.wire.android.media.PingRinger
-import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
 import com.wire.android.ui.home.conversations.attachment.MessageAttachmentsViewModel
 import com.wire.android.ui.home.conversations.composer.MessageComposerViewModel
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
@@ -29,212 +25,37 @@ import com.wire.android.ui.home.conversations.messages.draft.MessageDraftViewMod
 import com.wire.android.ui.home.conversations.messages.item.ConversationAssetPathsViewModelImpl
 import com.wire.android.ui.home.conversations.migration.ConversationMigrationViewModel
 import com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
-import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversationUseCase
-import com.wire.android.ui.home.conversations.usecase.GetQuoteMessageForConversationUseCase
-import com.wire.android.ui.home.conversations.usecase.HandleUriAssetUseCase
-import com.wire.android.util.FileManager
-import com.wire.android.util.GetMediaMetadataUseCase
-import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
-import com.wire.android.datastore.GlobalDataStore
-import com.wire.kalium.cells.domain.CellUploadManager
-import com.wire.kalium.cells.domain.usecase.AddAttachmentDraftUseCase
-import com.wire.kalium.cells.domain.usecase.ObserveAttachmentDraftsUseCase
-import com.wire.kalium.cells.domain.usecase.RemoveAttachmentDraftUseCase
-import com.wire.kalium.cells.domain.usecase.RetryAttachmentUploadUseCase
-import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
-import com.wire.kalium.logic.feature.asset.ObserveAssetStatusesUseCase
-import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCase
-import com.wire.kalium.logic.feature.asset.upload.ScheduleNewAssetMessageUseCase
-import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
-import com.wire.kalium.logic.feature.client.IsWireCellsEnabledForConversationUseCase
-import com.wire.kalium.logic.feature.client.IsWireCellsEnabledUseCase
-import com.wire.kalium.logic.feature.conversation.ClearUsersTypingEventsUseCase
-import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
-import com.wire.kalium.logic.feature.conversation.MembersToMentionUseCase
-import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
-import com.wire.kalium.logic.feature.conversation.ObserveConversationInteractionAvailabilityUseCase
-import com.wire.kalium.logic.feature.conversation.MarkConversationAsReadLocallyUseCase
-import com.wire.kalium.logic.feature.conversation.ObserveConversationUnderLegalHoldNotifiedUseCase
-import com.wire.kalium.logic.feature.conversation.ObserveDegradedConversationNotifiedUseCase
-import com.wire.kalium.logic.feature.conversation.SendTypingEventUseCase
-import com.wire.kalium.logic.feature.conversation.SetNotifiedAboutConversationUnderLegalHoldUseCase
-import com.wire.kalium.logic.feature.conversation.SetUserInformedAboutVerificationUseCase
-import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
-import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
-import com.wire.kalium.logic.feature.message.FetchOlderNomadMessagesByConversationUseCase
-import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
-import com.wire.kalium.logic.feature.message.GetSearchedConversationMessagePositionUseCase
-import com.wire.kalium.logic.feature.message.RetryFailedMessageUseCase
-import com.wire.kalium.logic.feature.message.SendEditMultipartMessageUseCase
-import com.wire.kalium.logic.feature.message.SendEditTextMessageUseCase
-import com.wire.kalium.logic.feature.message.SendKnockUseCase
-import com.wire.kalium.logic.feature.message.SendLocationUseCase
-import com.wire.kalium.logic.feature.message.SendMultipartMessageUseCase
-import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
-import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
-import com.wire.kalium.logic.feature.message.draft.GetMessageDraftUseCase
-import com.wire.kalium.logic.feature.message.draft.RemoveMessageDraftUseCase
-import com.wire.kalium.logic.feature.message.draft.SaveMessageDraftUseCase
-import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
-import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
-import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
-import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
-import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import javax.inject.Inject
 
-@Suppress("LongParameterList")
 class ConversationCoreViewModelFactory @Inject constructor(
-    private val observeConversationDetails: ObserveConversationDetailsUseCase,
+    private val conversationMessagesViewModelFactory: ConversationMessagesViewModel.Factory,
+    private val messageComposerViewModelFactory: MessageComposerViewModel.Factory,
+    private val sendMessageViewModelFactory: SendMessageViewModel.Factory,
+    private val messageDraftViewModelFactory: MessageDraftViewModel.Factory,
+    private val messageAttachmentsViewModelFactory: MessageAttachmentsViewModel.Factory,
+    private val conversationMigrationViewModelFactory: ConversationMigrationViewModel.Factory,
     private val getMessageAsset: GetMessageAssetUseCase,
-    private val getMessageByIdUseCase: GetMessageByIdUseCase,
-    private val updateAssetMessageDownloadStatus: UpdateAssetMessageTransferStatusUseCase,
-    private val observeAssetStatusesUseCase: ObserveAssetStatusesUseCase,
-    private val fileManager: FileManager,
     private val dispatchers: DispatcherProvider,
-    private val getMessageForConversation: GetMessagesForConversationUseCase,
-    private val fetchOlderNomadMessages: FetchOlderNomadMessagesByConversationUseCase,
-    private val toggleReaction: ToggleReactionUseCase,
-    private val resetSession: ResetSessionUseCase,
-    private val audioMessagePlayer: ConversationAudioMessagePlayer,
-    private val getConversationUnreadEventsCount: GetConversationUnreadEventsCountUseCase,
-    private val clearUsersTypingEvents: ClearUsersTypingEventsUseCase,
-    private val getSearchedConversationMessagePosition: GetSearchedConversationMessagePositionUseCase,
-    private val deleteMessage: DeleteMessageUseCase,
-    private val isWireCellFeatureEnabled: IsWireCellsEnabledUseCase,
-    private val isFileSharingEnabled: IsFileSharingEnabledUseCase,
-    private val observeConversationInteractionAvailability: ObserveConversationInteractionAvailabilityUseCase,
-    private val updateConversationReadDate: UpdateConversationReadDateUseCase,
-    private val markConversationAsReadLocally: MarkConversationAsReadLocallyUseCase,
-    private val contactMapper: ContactMapper,
-    private val membersToMention: MembersToMentionUseCase,
-    private val enqueueMessageSelfDeletion: EnqueueMessageSelfDeletionUseCase,
-    private val persistNewSelfDeletingStatus: PersistNewSelfDeletionTimerUseCase,
-    private val sendTypingEvent: SendTypingEventUseCase,
-    private val kaliumFileSystem: KaliumFileSystem,
-    private val currentSessionFlowUseCase: CurrentSessionFlowUseCase,
-    private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
-    private val globalDataStore: GlobalDataStore,
-    private val sendAssetMessage: ScheduleNewAssetMessageUseCase,
-    private val sendTextMessage: SendTextMessageUseCase,
-    private val sendMultipartMessage: SendMultipartMessageUseCase,
-    private val sendEditTextMessage: SendEditTextMessageUseCase,
-    private val sendEditMultipartMessage: SendEditMultipartMessageUseCase,
-    private val retryFailedMessage: RetryFailedMessageUseCase,
-    private val handleUriAsset: HandleUriAssetUseCase,
-    private val sendKnock: SendKnockUseCase,
-    private val pingRinger: PingRinger,
-    private val imageUtil: ImageUtil,
-    private val setUserInformedAboutVerification: SetUserInformedAboutVerificationUseCase,
-    private val observeDegradedConversationNotified: ObserveDegradedConversationNotifiedUseCase,
-    private val setNotifiedAboutConversationUnderLegalHold: SetNotifiedAboutConversationUnderLegalHoldUseCase,
-    private val observeConversationUnderLegalHoldNotified: ObserveConversationUnderLegalHoldNotifiedUseCase,
-    private val sendLocation: SendLocationUseCase,
-    private val removeMessageDraft: RemoveMessageDraftUseCase,
-    private val analyticsManager: AnonymousAnalyticsManager,
-    private val isWireCellsEnabledForConversation: IsWireCellsEnabledForConversationUseCase,
-    private val sharedState: MessageSharedState,
-    private val getMessageDraft: GetMessageDraftUseCase,
-    private val getQuotedMessage: GetQuoteMessageForConversationUseCase,
-    private val saveMessageDraft: SaveMessageDraftUseCase,
-    private val observeAttachments: ObserveAttachmentDraftsUseCase,
-    private val addAttachment: AddAttachmentDraftUseCase,
-    private val removeAttachment: RemoveAttachmentDraftUseCase,
-    private val retryUpload: RetryAttachmentUploadUseCase,
-    private val uploadManager: CellUploadManager,
-    private val getMediaMetadata: GetMediaMetadataUseCase,
 ) {
-    fun conversationMessagesViewModel(savedStateHandle: SavedStateHandle) = ConversationMessagesViewModel(
-        savedStateHandle = savedStateHandle,
-        observeConversationDetails = observeConversationDetails,
-        getMessageAsset = getMessageAsset,
-        getMessageByIdUseCase = getMessageByIdUseCase,
-        updateAssetMessageDownloadStatus = updateAssetMessageDownloadStatus,
-        observeAssetStatusesUseCase = observeAssetStatusesUseCase,
-        fileManager = fileManager,
-        dispatchers = dispatchers,
-        getMessageForConversation = getMessageForConversation,
-        fetchOlderNomadMessages = fetchOlderNomadMessages,
-        toggleReaction = toggleReaction,
-        resetSession = resetSession,
-        audioMessagePlayer = audioMessagePlayer,
-        getConversationUnreadEventsCount = getConversationUnreadEventsCount,
-        clearUsersTypingEvents = clearUsersTypingEvents,
-        getSearchedConversationMessagePosition = getSearchedConversationMessagePosition,
-        deleteMessage = deleteMessage,
-        isWireCellFeatureEnabled = isWireCellFeatureEnabled,
-    )
+    fun conversationMessagesViewModel(savedStateHandle: SavedStateHandle) =
+        conversationMessagesViewModelFactory.create(savedStateHandle)
 
-    fun messageComposerViewModel(savedStateHandle: SavedStateHandle) = MessageComposerViewModel(
-        savedStateHandle = savedStateHandle,
-        dispatchers = dispatchers,
-        isFileSharingEnabled = isFileSharingEnabled,
-        observeConversationInteractionAvailability = observeConversationInteractionAvailability,
-        updateConversationReadDate = updateConversationReadDate,
-        markConversationAsReadLocally = markConversationAsReadLocally,
-        contactMapper = contactMapper,
-        membersToMention = membersToMention,
-        enqueueMessageSelfDeletion = enqueueMessageSelfDeletion,
-        persistNewSelfDeletingStatus = persistNewSelfDeletingStatus,
-        sendTypingEvent = sendTypingEvent,
-        fileManager = fileManager,
-        kaliumFileSystem = kaliumFileSystem,
-        currentSessionFlowUseCase = currentSessionFlowUseCase,
-        observeEstablishedCalls = observeEstablishedCalls,
-        globalDataStore = globalDataStore,
-    )
+    fun messageComposerViewModel(savedStateHandle: SavedStateHandle) =
+        messageComposerViewModelFactory.create(savedStateHandle)
 
-    fun sendMessageViewModel(savedStateHandle: SavedStateHandle) = SendMessageViewModel(
-        savedStateHandle = savedStateHandle,
-        sendAssetMessage = sendAssetMessage,
-        sendTextMessage = sendTextMessage,
-        sendMultipartMessage = sendMultipartMessage,
-        sendEditTextMessage = sendEditTextMessage,
-        sendEditMultipartMessage = sendEditMultipartMessage,
-        retryFailedMessage = retryFailedMessage,
-        dispatchers = dispatchers,
-        kaliumFileSystem = kaliumFileSystem,
-        handleUriAsset = handleUriAsset,
-        sendKnock = sendKnock,
-        sendTypingEvent = sendTypingEvent,
-        pingRinger = pingRinger,
-        imageUtil = imageUtil,
-        setUserInformedAboutVerification = setUserInformedAboutVerification,
-        observeDegradedConversationNotified = observeDegradedConversationNotified,
-        setNotifiedAboutConversationUnderLegalHold = setNotifiedAboutConversationUnderLegalHold,
-        observeConversationUnderLegalHoldNotified = observeConversationUnderLegalHoldNotified,
-        sendLocation = sendLocation,
-        removeMessageDraft = removeMessageDraft,
-        analyticsManager = analyticsManager,
-        isWireCellsEnabledForConversation = isWireCellsEnabledForConversation,
-        sharedState = sharedState,
-    )
+    fun sendMessageViewModel(savedStateHandle: SavedStateHandle) =
+        sendMessageViewModelFactory.create(savedStateHandle)
 
-    fun messageDraftViewModel(savedStateHandle: SavedStateHandle) = MessageDraftViewModel(
-        savedStateHandle = savedStateHandle,
-        getMessageDraft = getMessageDraft,
-        getQuotedMessage = getQuotedMessage,
-        saveMessageDraft = saveMessageDraft,
-    )
+    fun messageDraftViewModel(savedStateHandle: SavedStateHandle) =
+        messageDraftViewModelFactory.create(savedStateHandle)
 
-    fun messageAttachmentsViewModel(savedStateHandle: SavedStateHandle) = MessageAttachmentsViewModel(
-        savedStateHandle = savedStateHandle,
-        handleUriAsset = handleUriAsset,
-        observeAttachments = observeAttachments,
-        addAttachment = addAttachment,
-        removeAttachment = removeAttachment,
-        retryUpload = retryUpload,
-        uploadManager = uploadManager,
-        fileManager = fileManager,
-        sharedState = sharedState,
-        getMediaMetadata = getMediaMetadata,
-    )
+    fun messageAttachmentsViewModel(savedStateHandle: SavedStateHandle) =
+        messageAttachmentsViewModelFactory.create(savedStateHandle)
 
-    fun conversationMigrationViewModel(savedStateHandle: SavedStateHandle) = ConversationMigrationViewModel(
-        savedStateHandle = savedStateHandle,
-        observeConversationDetails = observeConversationDetails,
-    )
+    fun conversationMigrationViewModel(savedStateHandle: SavedStateHandle) =
+        conversationMigrationViewModelFactory.create(savedStateHandle)
 
     fun conversationAssetPathsViewModel() = ConversationAssetPathsViewModelImpl(
         getMessageAsset = getMessageAsset,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelFactory.kt
@@ -1,0 +1,243 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.feature.analytics.AnonymousAnalyticsManager
+import com.wire.android.mapper.ContactMapper
+import com.wire.android.media.PingRinger
+import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
+import com.wire.android.ui.home.conversations.attachment.MessageAttachmentsViewModel
+import com.wire.android.ui.home.conversations.composer.MessageComposerViewModel
+import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
+import com.wire.android.ui.home.conversations.messages.draft.MessageDraftViewModel
+import com.wire.android.ui.home.conversations.messages.item.ConversationAssetPathsViewModelImpl
+import com.wire.android.ui.home.conversations.migration.ConversationMigrationViewModel
+import com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
+import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversationUseCase
+import com.wire.android.ui.home.conversations.usecase.GetQuoteMessageForConversationUseCase
+import com.wire.android.ui.home.conversations.usecase.HandleUriAssetUseCase
+import com.wire.android.util.FileManager
+import com.wire.android.util.GetMediaMetadataUseCase
+import com.wire.android.util.ImageUtil
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.datastore.GlobalDataStore
+import com.wire.kalium.cells.domain.CellUploadManager
+import com.wire.kalium.cells.domain.usecase.AddAttachmentDraftUseCase
+import com.wire.kalium.cells.domain.usecase.ObserveAttachmentDraftsUseCase
+import com.wire.kalium.cells.domain.usecase.RemoveAttachmentDraftUseCase
+import com.wire.kalium.cells.domain.usecase.RetryAttachmentUploadUseCase
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
+import com.wire.kalium.logic.feature.asset.ObserveAssetStatusesUseCase
+import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCase
+import com.wire.kalium.logic.feature.asset.upload.ScheduleNewAssetMessageUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
+import com.wire.kalium.logic.feature.client.IsWireCellsEnabledForConversationUseCase
+import com.wire.kalium.logic.feature.client.IsWireCellsEnabledUseCase
+import com.wire.kalium.logic.feature.conversation.ClearUsersTypingEventsUseCase
+import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
+import com.wire.kalium.logic.feature.conversation.MembersToMentionUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationInteractionAvailabilityUseCase
+import com.wire.kalium.logic.feature.conversation.MarkConversationAsReadLocallyUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationUnderLegalHoldNotifiedUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveDegradedConversationNotifiedUseCase
+import com.wire.kalium.logic.feature.conversation.SendTypingEventUseCase
+import com.wire.kalium.logic.feature.conversation.SetNotifiedAboutConversationUnderLegalHoldUseCase
+import com.wire.kalium.logic.feature.conversation.SetUserInformedAboutVerificationUseCase
+import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
+import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
+import com.wire.kalium.logic.feature.message.FetchOlderNomadMessagesByConversationUseCase
+import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
+import com.wire.kalium.logic.feature.message.GetSearchedConversationMessagePositionUseCase
+import com.wire.kalium.logic.feature.message.RetryFailedMessageUseCase
+import com.wire.kalium.logic.feature.message.SendEditMultipartMessageUseCase
+import com.wire.kalium.logic.feature.message.SendEditTextMessageUseCase
+import com.wire.kalium.logic.feature.message.SendKnockUseCase
+import com.wire.kalium.logic.feature.message.SendLocationUseCase
+import com.wire.kalium.logic.feature.message.SendMultipartMessageUseCase
+import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
+import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
+import com.wire.kalium.logic.feature.message.draft.GetMessageDraftUseCase
+import com.wire.kalium.logic.feature.message.draft.RemoveMessageDraftUseCase
+import com.wire.kalium.logic.feature.message.draft.SaveMessageDraftUseCase
+import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
+import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
+import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
+import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+class ConversationCoreViewModelFactory @Inject constructor(
+    private val observeConversationDetails: ObserveConversationDetailsUseCase,
+    private val getMessageAsset: GetMessageAssetUseCase,
+    private val getMessageByIdUseCase: GetMessageByIdUseCase,
+    private val updateAssetMessageDownloadStatus: UpdateAssetMessageTransferStatusUseCase,
+    private val observeAssetStatusesUseCase: ObserveAssetStatusesUseCase,
+    private val fileManager: FileManager,
+    private val dispatchers: DispatcherProvider,
+    private val getMessageForConversation: GetMessagesForConversationUseCase,
+    private val fetchOlderNomadMessages: FetchOlderNomadMessagesByConversationUseCase,
+    private val toggleReaction: ToggleReactionUseCase,
+    private val resetSession: ResetSessionUseCase,
+    private val audioMessagePlayer: ConversationAudioMessagePlayer,
+    private val getConversationUnreadEventsCount: GetConversationUnreadEventsCountUseCase,
+    private val clearUsersTypingEvents: ClearUsersTypingEventsUseCase,
+    private val getSearchedConversationMessagePosition: GetSearchedConversationMessagePositionUseCase,
+    private val deleteMessage: DeleteMessageUseCase,
+    private val isWireCellFeatureEnabled: IsWireCellsEnabledUseCase,
+    private val isFileSharingEnabled: IsFileSharingEnabledUseCase,
+    private val observeConversationInteractionAvailability: ObserveConversationInteractionAvailabilityUseCase,
+    private val updateConversationReadDate: UpdateConversationReadDateUseCase,
+    private val markConversationAsReadLocally: MarkConversationAsReadLocallyUseCase,
+    private val contactMapper: ContactMapper,
+    private val membersToMention: MembersToMentionUseCase,
+    private val enqueueMessageSelfDeletion: EnqueueMessageSelfDeletionUseCase,
+    private val persistNewSelfDeletingStatus: PersistNewSelfDeletionTimerUseCase,
+    private val sendTypingEvent: SendTypingEventUseCase,
+    private val kaliumFileSystem: KaliumFileSystem,
+    private val currentSessionFlowUseCase: CurrentSessionFlowUseCase,
+    private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
+    private val globalDataStore: GlobalDataStore,
+    private val sendAssetMessage: ScheduleNewAssetMessageUseCase,
+    private val sendTextMessage: SendTextMessageUseCase,
+    private val sendMultipartMessage: SendMultipartMessageUseCase,
+    private val sendEditTextMessage: SendEditTextMessageUseCase,
+    private val sendEditMultipartMessage: SendEditMultipartMessageUseCase,
+    private val retryFailedMessage: RetryFailedMessageUseCase,
+    private val handleUriAsset: HandleUriAssetUseCase,
+    private val sendKnock: SendKnockUseCase,
+    private val pingRinger: PingRinger,
+    private val imageUtil: ImageUtil,
+    private val setUserInformedAboutVerification: SetUserInformedAboutVerificationUseCase,
+    private val observeDegradedConversationNotified: ObserveDegradedConversationNotifiedUseCase,
+    private val setNotifiedAboutConversationUnderLegalHold: SetNotifiedAboutConversationUnderLegalHoldUseCase,
+    private val observeConversationUnderLegalHoldNotified: ObserveConversationUnderLegalHoldNotifiedUseCase,
+    private val sendLocation: SendLocationUseCase,
+    private val removeMessageDraft: RemoveMessageDraftUseCase,
+    private val analyticsManager: AnonymousAnalyticsManager,
+    private val isWireCellsEnabledForConversation: IsWireCellsEnabledForConversationUseCase,
+    private val sharedState: MessageSharedState,
+    private val getMessageDraft: GetMessageDraftUseCase,
+    private val getQuotedMessage: GetQuoteMessageForConversationUseCase,
+    private val saveMessageDraft: SaveMessageDraftUseCase,
+    private val observeAttachments: ObserveAttachmentDraftsUseCase,
+    private val addAttachment: AddAttachmentDraftUseCase,
+    private val removeAttachment: RemoveAttachmentDraftUseCase,
+    private val retryUpload: RetryAttachmentUploadUseCase,
+    private val uploadManager: CellUploadManager,
+    private val getMediaMetadata: GetMediaMetadataUseCase,
+) {
+    fun conversationMessagesViewModel(savedStateHandle: SavedStateHandle) = ConversationMessagesViewModel(
+        savedStateHandle = savedStateHandle,
+        observeConversationDetails = observeConversationDetails,
+        getMessageAsset = getMessageAsset,
+        getMessageByIdUseCase = getMessageByIdUseCase,
+        updateAssetMessageDownloadStatus = updateAssetMessageDownloadStatus,
+        observeAssetStatusesUseCase = observeAssetStatusesUseCase,
+        fileManager = fileManager,
+        dispatchers = dispatchers,
+        getMessageForConversation = getMessageForConversation,
+        fetchOlderNomadMessages = fetchOlderNomadMessages,
+        toggleReaction = toggleReaction,
+        resetSession = resetSession,
+        audioMessagePlayer = audioMessagePlayer,
+        getConversationUnreadEventsCount = getConversationUnreadEventsCount,
+        clearUsersTypingEvents = clearUsersTypingEvents,
+        getSearchedConversationMessagePosition = getSearchedConversationMessagePosition,
+        deleteMessage = deleteMessage,
+        isWireCellFeatureEnabled = isWireCellFeatureEnabled,
+    )
+
+    fun messageComposerViewModel(savedStateHandle: SavedStateHandle) = MessageComposerViewModel(
+        savedStateHandle = savedStateHandle,
+        dispatchers = dispatchers,
+        isFileSharingEnabled = isFileSharingEnabled,
+        observeConversationInteractionAvailability = observeConversationInteractionAvailability,
+        updateConversationReadDate = updateConversationReadDate,
+        markConversationAsReadLocally = markConversationAsReadLocally,
+        contactMapper = contactMapper,
+        membersToMention = membersToMention,
+        enqueueMessageSelfDeletion = enqueueMessageSelfDeletion,
+        persistNewSelfDeletingStatus = persistNewSelfDeletingStatus,
+        sendTypingEvent = sendTypingEvent,
+        fileManager = fileManager,
+        kaliumFileSystem = kaliumFileSystem,
+        currentSessionFlowUseCase = currentSessionFlowUseCase,
+        observeEstablishedCalls = observeEstablishedCalls,
+        globalDataStore = globalDataStore,
+    )
+
+    fun sendMessageViewModel(savedStateHandle: SavedStateHandle) = SendMessageViewModel(
+        savedStateHandle = savedStateHandle,
+        sendAssetMessage = sendAssetMessage,
+        sendTextMessage = sendTextMessage,
+        sendMultipartMessage = sendMultipartMessage,
+        sendEditTextMessage = sendEditTextMessage,
+        sendEditMultipartMessage = sendEditMultipartMessage,
+        retryFailedMessage = retryFailedMessage,
+        dispatchers = dispatchers,
+        kaliumFileSystem = kaliumFileSystem,
+        handleUriAsset = handleUriAsset,
+        sendKnock = sendKnock,
+        sendTypingEvent = sendTypingEvent,
+        pingRinger = pingRinger,
+        imageUtil = imageUtil,
+        setUserInformedAboutVerification = setUserInformedAboutVerification,
+        observeDegradedConversationNotified = observeDegradedConversationNotified,
+        setNotifiedAboutConversationUnderLegalHold = setNotifiedAboutConversationUnderLegalHold,
+        observeConversationUnderLegalHoldNotified = observeConversationUnderLegalHoldNotified,
+        sendLocation = sendLocation,
+        removeMessageDraft = removeMessageDraft,
+        analyticsManager = analyticsManager,
+        isWireCellsEnabledForConversation = isWireCellsEnabledForConversation,
+        sharedState = sharedState,
+    )
+
+    fun messageDraftViewModel(savedStateHandle: SavedStateHandle) = MessageDraftViewModel(
+        savedStateHandle = savedStateHandle,
+        getMessageDraft = getMessageDraft,
+        getQuotedMessage = getQuotedMessage,
+        saveMessageDraft = saveMessageDraft,
+    )
+
+    fun messageAttachmentsViewModel(savedStateHandle: SavedStateHandle) = MessageAttachmentsViewModel(
+        savedStateHandle = savedStateHandle,
+        handleUriAsset = handleUriAsset,
+        observeAttachments = observeAttachments,
+        addAttachment = addAttachment,
+        removeAttachment = removeAttachment,
+        retryUpload = retryUpload,
+        uploadManager = uploadManager,
+        fileManager = fileManager,
+        sharedState = sharedState,
+        getMediaMetadata = getMediaMetadata,
+    )
+
+    fun conversationMigrationViewModel(savedStateHandle: SavedStateHandle) = ConversationMigrationViewModel(
+        savedStateHandle = savedStateHandle,
+        observeConversationDetails = observeConversationDetails,
+    )
+
+    fun conversationAssetPathsViewModel() = ConversationAssetPathsViewModelImpl(
+        getMessageAsset = getMessageAsset,
+        dispatchers = dispatchers,
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelFactory.kt
@@ -18,6 +18,11 @@
 package com.wire.android.ui.home.conversations
 
 import androidx.lifecycle.SavedStateHandle
+import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.feature.analytics.AnonymousAnalyticsManager
+import com.wire.android.mapper.ContactMapper
+import com.wire.android.media.PingRinger
+import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
 import com.wire.android.ui.home.conversations.attachment.MessageAttachmentsViewModel
 import com.wire.android.ui.home.conversations.composer.MessageComposerViewModel
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
@@ -25,37 +30,211 @@ import com.wire.android.ui.home.conversations.messages.draft.MessageDraftViewMod
 import com.wire.android.ui.home.conversations.messages.item.ConversationAssetPathsViewModelImpl
 import com.wire.android.ui.home.conversations.migration.ConversationMigrationViewModel
 import com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
+import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversationUseCase
+import com.wire.android.ui.home.conversations.usecase.GetQuoteMessageForConversationUseCase
+import com.wire.android.ui.home.conversations.usecase.HandleUriAssetUseCase
+import com.wire.android.util.FileManager
+import com.wire.android.util.GetMediaMetadataUseCase
+import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.cells.domain.CellUploadManager
+import com.wire.kalium.cells.domain.usecase.AddAttachmentDraftUseCase
+import com.wire.kalium.cells.domain.usecase.ObserveAttachmentDraftsUseCase
+import com.wire.kalium.cells.domain.usecase.RemoveAttachmentDraftUseCase
+import com.wire.kalium.cells.domain.usecase.RetryAttachmentUploadUseCase
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
+import com.wire.kalium.logic.feature.asset.ObserveAssetStatusesUseCase
+import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCase
+import com.wire.kalium.logic.feature.asset.upload.ScheduleNewAssetMessageUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
+import com.wire.kalium.logic.feature.client.IsWireCellsEnabledForConversationUseCase
+import com.wire.kalium.logic.feature.client.IsWireCellsEnabledUseCase
+import com.wire.kalium.logic.feature.conversation.ClearUsersTypingEventsUseCase
+import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
+import com.wire.kalium.logic.feature.conversation.MarkConversationAsReadLocallyUseCase
+import com.wire.kalium.logic.feature.conversation.MembersToMentionUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationInteractionAvailabilityUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationUnderLegalHoldNotifiedUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveDegradedConversationNotifiedUseCase
+import com.wire.kalium.logic.feature.conversation.SendTypingEventUseCase
+import com.wire.kalium.logic.feature.conversation.SetNotifiedAboutConversationUnderLegalHoldUseCase
+import com.wire.kalium.logic.feature.conversation.SetUserInformedAboutVerificationUseCase
+import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
+import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
+import com.wire.kalium.logic.feature.message.FetchOlderNomadMessagesByConversationUseCase
+import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
+import com.wire.kalium.logic.feature.message.GetSearchedConversationMessagePositionUseCase
+import com.wire.kalium.logic.feature.message.RetryFailedMessageUseCase
+import com.wire.kalium.logic.feature.message.SendEditMultipartMessageUseCase
+import com.wire.kalium.logic.feature.message.SendEditTextMessageUseCase
+import com.wire.kalium.logic.feature.message.SendKnockUseCase
+import com.wire.kalium.logic.feature.message.SendLocationUseCase
+import com.wire.kalium.logic.feature.message.SendMultipartMessageUseCase
+import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
+import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
+import com.wire.kalium.logic.feature.message.draft.GetMessageDraftUseCase
+import com.wire.kalium.logic.feature.message.draft.RemoveMessageDraftUseCase
+import com.wire.kalium.logic.feature.message.draft.SaveMessageDraftUseCase
+import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
+import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
+import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
+import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import javax.inject.Inject
 
+@Suppress("LongParameterList")
 class ConversationCoreViewModelFactory @Inject constructor(
-    private val conversationMessagesViewModelFactory: ConversationMessagesViewModel.Factory,
-    private val messageComposerViewModelFactory: MessageComposerViewModel.Factory,
-    private val sendMessageViewModelFactory: SendMessageViewModel.Factory,
-    private val messageDraftViewModelFactory: MessageDraftViewModel.Factory,
-    private val messageAttachmentsViewModelFactory: MessageAttachmentsViewModel.Factory,
-    private val conversationMigrationViewModelFactory: ConversationMigrationViewModel.Factory,
+    private val observeConversationDetails: ObserveConversationDetailsUseCase,
     private val getMessageAsset: GetMessageAssetUseCase,
+    private val getMessageById: GetMessageByIdUseCase,
+    private val updateAssetMessageDownloadStatus: UpdateAssetMessageTransferStatusUseCase,
+    private val observeAssetStatuses: ObserveAssetStatusesUseCase,
+    private val fileManager: FileManager,
     private val dispatchers: DispatcherProvider,
+    private val getMessagesForConversation: GetMessagesForConversationUseCase,
+    private val fetchOlderNomadMessages: FetchOlderNomadMessagesByConversationUseCase,
+    private val toggleReaction: ToggleReactionUseCase,
+    private val resetSession: ResetSessionUseCase,
+    private val audioMessagePlayer: ConversationAudioMessagePlayer,
+    private val getConversationUnreadEventsCount: GetConversationUnreadEventsCountUseCase,
+    private val clearUsersTypingEvents: ClearUsersTypingEventsUseCase,
+    private val getSearchedConversationMessagePosition: GetSearchedConversationMessagePositionUseCase,
+    private val deleteMessage: DeleteMessageUseCase,
+    private val isWireCellsEnabled: IsWireCellsEnabledUseCase,
+    private val isFileSharingEnabled: IsFileSharingEnabledUseCase,
+    private val observeConversationInteractionAvailability: ObserveConversationInteractionAvailabilityUseCase,
+    private val updateConversationReadDate: UpdateConversationReadDateUseCase,
+    private val markConversationAsReadLocally: MarkConversationAsReadLocallyUseCase,
+    private val contactMapper: ContactMapper,
+    private val membersToMention: MembersToMentionUseCase,
+    private val enqueueMessageSelfDeletion: EnqueueMessageSelfDeletionUseCase,
+    private val persistNewSelfDeletingStatus: PersistNewSelfDeletionTimerUseCase,
+    private val sendTypingEvent: SendTypingEventUseCase,
+    private val kaliumFileSystem: KaliumFileSystem,
+    private val currentSessionFlowUseCase: CurrentSessionFlowUseCase,
+    private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
+    private val globalDataStore: GlobalDataStore,
+    private val sendAssetMessage: ScheduleNewAssetMessageUseCase,
+    private val sendTextMessage: SendTextMessageUseCase,
+    private val sendMultipartMessage: SendMultipartMessageUseCase,
+    private val sendEditTextMessage: SendEditTextMessageUseCase,
+    private val sendEditMultipartMessage: SendEditMultipartMessageUseCase,
+    private val retryFailedMessage: RetryFailedMessageUseCase,
+    private val handleUriAsset: HandleUriAssetUseCase,
+    private val sendKnock: SendKnockUseCase,
+    private val pingRinger: PingRinger,
+    private val imageUtil: ImageUtil,
+    private val setUserInformedAboutVerification: SetUserInformedAboutVerificationUseCase,
+    private val observeDegradedConversationNotified: ObserveDegradedConversationNotifiedUseCase,
+    private val setNotifiedAboutConversationUnderLegalHold: SetNotifiedAboutConversationUnderLegalHoldUseCase,
+    private val observeConversationUnderLegalHoldNotified: ObserveConversationUnderLegalHoldNotifiedUseCase,
+    private val sendLocation: SendLocationUseCase,
+    private val removeMessageDraft: RemoveMessageDraftUseCase,
+    private val analyticsManager: AnonymousAnalyticsManager,
+    private val isWireCellsEnabledForConversation: IsWireCellsEnabledForConversationUseCase,
+    private val messageSharedState: MessageSharedState,
+    private val getMessageDraft: GetMessageDraftUseCase,
+    private val getQuotedMessage: GetQuoteMessageForConversationUseCase,
+    private val saveMessageDraft: SaveMessageDraftUseCase,
+    private val observeAttachments: ObserveAttachmentDraftsUseCase,
+    private val addAttachment: AddAttachmentDraftUseCase,
+    private val removeAttachment: RemoveAttachmentDraftUseCase,
+    private val retryAttachmentUpload: RetryAttachmentUploadUseCase,
+    private val cellUploadManager: CellUploadManager,
+    private val getMediaMetadata: GetMediaMetadataUseCase,
 ) {
-    fun conversationMessagesViewModel(savedStateHandle: SavedStateHandle) =
-        conversationMessagesViewModelFactory.create(savedStateHandle)
+    fun conversationMessagesViewModel(savedStateHandle: SavedStateHandle) = ConversationMessagesViewModel(
+        savedStateHandle = savedStateHandle,
+        observeConversationDetails = observeConversationDetails,
+        getMessageAsset = getMessageAsset,
+        getMessageByIdUseCase = getMessageById,
+        updateAssetMessageDownloadStatus = updateAssetMessageDownloadStatus,
+        observeAssetStatusesUseCase = observeAssetStatuses,
+        fileManager = fileManager,
+        dispatchers = dispatchers,
+        getMessageForConversation = getMessagesForConversation,
+        fetchOlderNomadMessages = fetchOlderNomadMessages,
+        toggleReaction = toggleReaction,
+        resetSession = resetSession,
+        audioMessagePlayer = audioMessagePlayer,
+        getConversationUnreadEventsCount = getConversationUnreadEventsCount,
+        clearUsersTypingEvents = clearUsersTypingEvents,
+        getSearchedConversationMessagePosition = getSearchedConversationMessagePosition,
+        deleteMessage = deleteMessage,
+        isWireCellFeatureEnabled = isWireCellsEnabled,
+    )
 
-    fun messageComposerViewModel(savedStateHandle: SavedStateHandle) =
-        messageComposerViewModelFactory.create(savedStateHandle)
+    fun messageComposerViewModel(savedStateHandle: SavedStateHandle) = MessageComposerViewModel(
+        savedStateHandle = savedStateHandle,
+        dispatchers = dispatchers,
+        isFileSharingEnabled = isFileSharingEnabled,
+        observeConversationInteractionAvailability = observeConversationInteractionAvailability,
+        updateConversationReadDate = updateConversationReadDate,
+        markConversationAsReadLocally = markConversationAsReadLocally,
+        contactMapper = contactMapper,
+        membersToMention = membersToMention,
+        enqueueMessageSelfDeletion = enqueueMessageSelfDeletion,
+        persistNewSelfDeletingStatus = persistNewSelfDeletingStatus,
+        sendTypingEvent = sendTypingEvent,
+        fileManager = fileManager,
+        kaliumFileSystem = kaliumFileSystem,
+        currentSessionFlowUseCase = currentSessionFlowUseCase,
+        observeEstablishedCalls = observeEstablishedCalls,
+        globalDataStore = globalDataStore,
+    )
 
-    fun sendMessageViewModel(savedStateHandle: SavedStateHandle) =
-        sendMessageViewModelFactory.create(savedStateHandle)
+    fun sendMessageViewModel(savedStateHandle: SavedStateHandle) = SendMessageViewModel(
+        savedStateHandle = savedStateHandle,
+        sendAssetMessage = sendAssetMessage,
+        sendTextMessage = sendTextMessage,
+        sendMultipartMessage = sendMultipartMessage,
+        sendEditTextMessage = sendEditTextMessage,
+        sendEditMultipartMessage = sendEditMultipartMessage,
+        retryFailedMessage = retryFailedMessage,
+        dispatchers = dispatchers,
+        kaliumFileSystem = kaliumFileSystem,
+        handleUriAsset = handleUriAsset,
+        sendKnock = sendKnock,
+        sendTypingEvent = sendTypingEvent,
+        pingRinger = pingRinger,
+        imageUtil = imageUtil,
+        setUserInformedAboutVerification = setUserInformedAboutVerification,
+        observeDegradedConversationNotified = observeDegradedConversationNotified,
+        setNotifiedAboutConversationUnderLegalHold = setNotifiedAboutConversationUnderLegalHold,
+        observeConversationUnderLegalHoldNotified = observeConversationUnderLegalHoldNotified,
+        sendLocation = sendLocation,
+        removeMessageDraft = removeMessageDraft,
+        analyticsManager = analyticsManager,
+        isWireCellsEnabledForConversation = isWireCellsEnabledForConversation,
+        sharedState = messageSharedState,
+    )
 
-    fun messageDraftViewModel(savedStateHandle: SavedStateHandle) =
-        messageDraftViewModelFactory.create(savedStateHandle)
+    fun messageDraftViewModel(savedStateHandle: SavedStateHandle) = MessageDraftViewModel(
+        savedStateHandle = savedStateHandle,
+        getMessageDraft = getMessageDraft,
+        getQuotedMessage = getQuotedMessage,
+        saveMessageDraft = saveMessageDraft,
+    )
 
-    fun messageAttachmentsViewModel(savedStateHandle: SavedStateHandle) =
-        messageAttachmentsViewModelFactory.create(savedStateHandle)
+    fun messageAttachmentsViewModel(savedStateHandle: SavedStateHandle) = MessageAttachmentsViewModel(
+        savedStateHandle = savedStateHandle,
+        handleUriAsset = handleUriAsset,
+        observeAttachments = observeAttachments,
+        addAttachment = addAttachment,
+        removeAttachment = removeAttachment,
+        retryUpload = retryAttachmentUpload,
+        uploadManager = cellUploadManager,
+        fileManager = fileManager,
+        sharedState = messageSharedState,
+        getMediaMetadata = getMediaMetadata,
+    )
 
-    fun conversationMigrationViewModel(savedStateHandle: SavedStateHandle) =
-        conversationMigrationViewModelFactory.create(savedStateHandle)
+    fun conversationMigrationViewModel(savedStateHandle: SavedStateHandle) = ConversationMigrationViewModel(
+        savedStateHandle = savedStateHandle,
+        observeConversationDetails = observeConversationDetails,
+    )
 
     fun conversationAssetPathsViewModel() = ConversationAssetPathsViewModelImpl(
         getMessageAsset = getMessageAsset,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelGraph.kt
@@ -1,0 +1,81 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalInspectionMode
+import com.wire.android.di.metro.MetroViewModelGraph
+import com.wire.android.di.metro.metroSavedStateViewModel
+import com.wire.android.di.metro.metroViewModel
+import com.wire.android.ui.home.conversations.attachment.MessageAttachmentsViewModel
+import com.wire.android.ui.home.conversations.composer.MessageComposerViewModel
+import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
+import com.wire.android.ui.home.conversations.messages.draft.MessageDraftViewModel
+import com.wire.android.ui.home.conversations.messages.item.ConversationAssetPathsViewModel
+import com.wire.android.ui.home.conversations.messages.item.ConversationAssetPathsViewModelImpl
+import com.wire.android.ui.home.conversations.messages.item.ConversationAssetPathsViewModelPreview
+import com.wire.android.ui.home.conversations.migration.ConversationMigrationViewModel
+import com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
+
+interface ConversationCoreViewModelGraph : MetroViewModelGraph {
+    val conversationCoreViewModelFactory: ConversationCoreViewModelFactory
+}
+
+@Composable
+fun conversationMessagesViewModel(): ConversationMessagesViewModel =
+    metroSavedStateViewModel<ConversationCoreViewModelGraph, ConversationMessagesViewModel> {
+        conversationCoreViewModelFactory.conversationMessagesViewModel(it)
+    }
+
+@Composable
+fun messageComposerViewModel(): MessageComposerViewModel =
+    metroSavedStateViewModel<ConversationCoreViewModelGraph, MessageComposerViewModel> {
+        conversationCoreViewModelFactory.messageComposerViewModel(it)
+    }
+
+@Composable
+fun sendMessageViewModel(): SendMessageViewModel =
+    metroSavedStateViewModel<ConversationCoreViewModelGraph, SendMessageViewModel> {
+        conversationCoreViewModelFactory.sendMessageViewModel(it)
+    }
+
+@Composable
+fun messageDraftViewModel(): MessageDraftViewModel =
+    metroSavedStateViewModel<ConversationCoreViewModelGraph, MessageDraftViewModel> {
+        conversationCoreViewModelFactory.messageDraftViewModel(it)
+    }
+
+@Composable
+fun messageAttachmentsViewModel(): MessageAttachmentsViewModel =
+    metroSavedStateViewModel<ConversationCoreViewModelGraph, MessageAttachmentsViewModel> {
+        conversationCoreViewModelFactory.messageAttachmentsViewModel(it)
+    }
+
+@Composable
+fun conversationMigrationViewModel(): ConversationMigrationViewModel =
+    metroSavedStateViewModel<ConversationCoreViewModelGraph, ConversationMigrationViewModel> {
+        conversationCoreViewModelFactory.conversationMigrationViewModel(it)
+    }
+
+@Composable
+fun conversationAssetPathsViewModel(conversationKey: String): ConversationAssetPathsViewModel = when {
+    LocalInspectionMode.current -> ConversationAssetPathsViewModelPreview
+    else -> metroViewModel<ConversationCoreViewModelGraph, ConversationAssetPathsViewModelImpl>(key = conversationKey) {
+        conversationCoreViewModelFactory.conversationAssetPathsViewModel()
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -261,12 +261,12 @@ fun ConversationScreen(
     conversationInfoViewModel: ConversationInfoViewModel = wireViewModel(),
     conversationBannerViewModel: ConversationBannerViewModel = wireViewModel(),
     conversationCallViewModel: ConversationCallViewModel = wireViewModel(),
-    conversationMessagesViewModel: ConversationMessagesViewModel = wireViewModel(),
-    messageComposerViewModel: MessageComposerViewModel = wireViewModel(),
-    sendMessageViewModel: SendMessageViewModel = wireViewModel(),
-    conversationMigrationViewModel: ConversationMigrationViewModel = wireViewModel(),
-    messageDraftViewModel: MessageDraftViewModel = wireViewModel(),
-    messageAttachmentsViewModel: MessageAttachmentsViewModel = wireViewModel(),
+    conversationMessagesViewModel: ConversationMessagesViewModel = conversationMessagesViewModel(),
+    messageComposerViewModel: MessageComposerViewModel = messageComposerViewModel(),
+    sendMessageViewModel: SendMessageViewModel = sendMessageViewModel(),
+    conversationMigrationViewModel: ConversationMigrationViewModel = conversationMigrationViewModel(),
+    messageDraftViewModel: MessageDraftViewModel = messageDraftViewModel(),
+    messageAttachmentsViewModel: MessageAttachmentsViewModel = messageAttachmentsViewModel(),
 ) {
     val coroutineScope = rememberCoroutineScope()
     val uriHandler = LocalUriHandler.current

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/attachment/MessageAttachmentsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/attachment/MessageAttachmentsViewModel.kt
@@ -61,10 +61,13 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import okio.Path.Companion.toPath
 import java.io.File
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 
 @Suppress("TooManyFunctions", "LongParameterList")
-class MessageAttachmentsViewModel(
-    val savedStateHandle: SavedStateHandle,
+class MessageAttachmentsViewModel @AssistedInject constructor(
+    @Assisted val savedStateHandle: SavedStateHandle,
     private val handleUriAsset: HandleUriAssetUseCase,
     private val observeAttachments: ObserveAttachmentDraftsUseCase,
     private val addAttachment: AddAttachmentDraftUseCase,
@@ -108,6 +111,11 @@ class MessageAttachmentsViewModel(
                 }
             }
         }
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(savedStateHandle: SavedStateHandle): MessageAttachmentsViewModel
     }
 
     fun onAudioRecorded(uri: Uri, wavesMask: List<Int>?) = viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/attachment/MessageAttachmentsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/attachment/MessageAttachmentsViewModel.kt
@@ -52,7 +52,6 @@ import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.AssetContent
 import com.wire.kalium.logic.util.fileExtension
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -62,11 +61,9 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import okio.Path.Companion.toPath
 import java.io.File
-import javax.inject.Inject
 
 @Suppress("TooManyFunctions", "LongParameterList")
-@HiltViewModel
-class MessageAttachmentsViewModel @Inject constructor(
+class MessageAttachmentsViewModel(
     val savedStateHandle: SavedStateHandle,
     private val handleUriAsset: HandleUriAssetUseCase,
     private val observeAttachments: ObserveAttachmentDraftsUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/attachment/MessageAttachmentsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/attachment/MessageAttachmentsViewModel.kt
@@ -61,13 +61,10 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import okio.Path.Companion.toPath
 import java.io.File
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 
 @Suppress("TooManyFunctions", "LongParameterList")
-class MessageAttachmentsViewModel @AssistedInject constructor(
-    @Assisted val savedStateHandle: SavedStateHandle,
+class MessageAttachmentsViewModel(
+    val savedStateHandle: SavedStateHandle,
     private val handleUriAsset: HandleUriAssetUseCase,
     private val observeAttachments: ObserveAttachmentDraftsUseCase,
     private val addAttachment: AddAttachmentDraftUseCase,
@@ -111,11 +108,6 @@ class MessageAttachmentsViewModel @AssistedInject constructor(
                 }
             }
         }
-    }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(savedStateHandle: SavedStateHandle): MessageAttachmentsViewModel
     }
 
     fun onAudioRecorded(uri: Uri, wavesMask: List<Int>?) = viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModel.kt
@@ -55,7 +55,6 @@ import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletion
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -66,11 +65,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
-import javax.inject.Inject
 
 @Suppress("LongParameterList", "TooManyFunctions")
-@HiltViewModel
-class MessageComposerViewModel @Inject constructor(
+class MessageComposerViewModel(
     val savedStateHandle: SavedStateHandle,
     private val dispatchers: DispatcherProvider,
     private val isFileSharingEnabled: IsFileSharingEnabledUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModel.kt
@@ -65,10 +65,13 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 
 @Suppress("LongParameterList", "TooManyFunctions")
-class MessageComposerViewModel(
-    val savedStateHandle: SavedStateHandle,
+class MessageComposerViewModel @AssistedInject constructor(
+    @Assisted val savedStateHandle: SavedStateHandle,
     private val dispatchers: DispatcherProvider,
     private val isFileSharingEnabled: IsFileSharingEnabledUseCase,
     private val observeConversationInteractionAvailability: ObserveConversationInteractionAvailabilityUseCase,
@@ -115,6 +118,11 @@ class MessageComposerViewModel(
         setFileSharingStatus()
         getEnterToSendState()
         observeCallState()
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(savedStateHandle: SavedStateHandle): MessageComposerViewModel
     }
 
     private fun getEnterToSendState() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/composer/MessageComposerViewModel.kt
@@ -65,13 +65,10 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 
 @Suppress("LongParameterList", "TooManyFunctions")
-class MessageComposerViewModel @AssistedInject constructor(
-    @Assisted val savedStateHandle: SavedStateHandle,
+class MessageComposerViewModel(
+    val savedStateHandle: SavedStateHandle,
     private val dispatchers: DispatcherProvider,
     private val isFileSharingEnabled: IsFileSharingEnabledUseCase,
     private val observeConversationInteractionAvailability: ObserveConversationInteractionAvailabilityUseCase,
@@ -118,11 +115,6 @@ class MessageComposerViewModel @AssistedInject constructor(
         setFileSharingStatus()
         getEnterToSendState()
         observeCallState()
-    }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(savedStateHandle: SavedStateHandle): MessageComposerViewModel
     }
 
     private fun getEnterToSendState() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
@@ -66,6 +66,7 @@ import com.ramcosta.composedestinations.generated.app.destinations.MediaGalleryS
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
 import com.wire.android.ui.home.conversations.DownloadedAssetDialog
 import com.wire.android.ui.home.conversations.PermissionPermanentlyDeniedDialogState
+import com.wire.android.ui.home.conversations.conversationMessagesViewModel
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogState
 import com.wire.android.ui.home.conversations.edit.assetOptionsMenuItems
@@ -88,7 +89,7 @@ import kotlinx.serialization.Serializable
 fun ConversationMediaScreen(
     navigator: Navigator,
     conversationAssetMessagesViewModel: ConversationAssetMessagesViewModel = wireViewModel(),
-    conversationMessagesViewModel: ConversationMessagesViewModel = wireViewModel()
+    conversationMessagesViewModel: ConversationMessagesViewModel = conversationMessagesViewModel()
 ) {
     val permissionPermanentlyDeniedDialogState = rememberVisibilityState<PermissionPermanentlyDeniedDialogState>()
     val context = LocalContext.current

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -83,12 +83,15 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okio.Path
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlin.math.max
 import kotlin.time.Duration.Companion.seconds
 
 @Suppress("LongParameterList", "TooManyFunctions")
-class ConversationMessagesViewModel(
-    val savedStateHandle: SavedStateHandle,
+class ConversationMessagesViewModel @AssistedInject constructor(
+    @Assisted val savedStateHandle: SavedStateHandle,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
     private val getMessageAsset: GetMessageAssetUseCase,
     private val getMessageByIdUseCase: GetMessageByIdUseCase,
@@ -133,6 +136,11 @@ class ConversationMessagesViewModel(
         loadLastMessageInstant()
         observeAudioPlayerState()
         observeAssetStatuses()
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(savedStateHandle: SavedStateHandle): ConversationMessagesViewModel
     }
 
     val currentTimeInMillisFlow: Flow<Long> = flow {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -68,7 +68,6 @@ import com.wire.kalium.logic.feature.message.GetSearchedConversationMessagePosit
 import com.wire.kalium.logic.feature.message.ToggleReactionUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionResult
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -84,13 +83,11 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okio.Path
-import javax.inject.Inject
 import kotlin.math.max
 import kotlin.time.Duration.Companion.seconds
 
-@HiltViewModel
 @Suppress("LongParameterList", "TooManyFunctions")
-class ConversationMessagesViewModel @Inject constructor(
+class ConversationMessagesViewModel(
     val savedStateHandle: SavedStateHandle,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
     private val getMessageAsset: GetMessageAssetUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -83,15 +83,12 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okio.Path
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 import kotlin.math.max
 import kotlin.time.Duration.Companion.seconds
 
 @Suppress("LongParameterList", "TooManyFunctions")
-class ConversationMessagesViewModel @AssistedInject constructor(
-    @Assisted val savedStateHandle: SavedStateHandle,
+class ConversationMessagesViewModel(
+    val savedStateHandle: SavedStateHandle,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
     private val getMessageAsset: GetMessageAssetUseCase,
     private val getMessageByIdUseCase: GetMessageByIdUseCase,
@@ -136,11 +133,6 @@ class ConversationMessagesViewModel @AssistedInject constructor(
         loadLastMessageInstant()
         observeAudioPlayerState()
         observeAssetStatuses()
-    }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(savedStateHandle: SavedStateHandle): ConversationMessagesViewModel
     }
 
     val currentTimeInMillisFlow: Flow<Long> = flow {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
@@ -34,12 +34,9 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.draft.MessageDraft
 import com.wire.kalium.logic.feature.message.draft.GetMessageDraftUseCase
 import com.wire.kalium.logic.feature.message.draft.SaveMessageDraftUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class MessageDraftViewModel @Inject constructor(
+class MessageDraftViewModel(
     val savedStateHandle: SavedStateHandle,
     private val getMessageDraft: GetMessageDraftUseCase,
     private val getQuotedMessage: GetQuoteMessageForConversationUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
@@ -35,12 +35,9 @@ import com.wire.kalium.logic.data.message.draft.MessageDraft
 import com.wire.kalium.logic.feature.message.draft.GetMessageDraftUseCase
 import com.wire.kalium.logic.feature.message.draft.SaveMessageDraftUseCase
 import kotlinx.coroutines.launch
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 
-class MessageDraftViewModel @AssistedInject constructor(
-    @Assisted val savedStateHandle: SavedStateHandle,
+class MessageDraftViewModel(
+    val savedStateHandle: SavedStateHandle,
     private val getMessageDraft: GetMessageDraftUseCase,
     private val getQuotedMessage: GetQuoteMessageForConversationUseCase,
     private val saveMessageDraft: SaveMessageDraftUseCase,
@@ -54,11 +51,6 @@ class MessageDraftViewModel @AssistedInject constructor(
 
     init {
         loadMessageDraft()
-    }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(savedStateHandle: SavedStateHandle): MessageDraftViewModel
     }
 
     fun clearDraft() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
@@ -35,9 +35,12 @@ import com.wire.kalium.logic.data.message.draft.MessageDraft
 import com.wire.kalium.logic.feature.message.draft.GetMessageDraftUseCase
 import com.wire.kalium.logic.feature.message.draft.SaveMessageDraftUseCase
 import kotlinx.coroutines.launch
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 
-class MessageDraftViewModel(
-    val savedStateHandle: SavedStateHandle,
+class MessageDraftViewModel @AssistedInject constructor(
+    @Assisted val savedStateHandle: SavedStateHandle,
     private val getMessageDraft: GetMessageDraftUseCase,
     private val getQuotedMessage: GetQuoteMessageForConversationUseCase,
     private val saveMessageDraft: SaveMessageDraftUseCase,
@@ -51,6 +54,11 @@ class MessageDraftViewModel(
 
     init {
         loadMessageDraft()
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(savedStateHandle: SavedStateHandle): MessageDraftViewModel
     }
 
     fun clearDraft() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/ConversationAssetPathsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/ConversationAssetPathsViewModel.kt
@@ -31,11 +31,9 @@ import com.wire.kalium.logic.data.asset.AssetTransferStatus.UPLOADED
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
 interface ConversationAssetPathsViewModel {
     fun localAssetPath(messageId: String): String? = null
@@ -49,8 +47,7 @@ interface ConversationAssetPathsViewModel {
 
 object ConversationAssetPathsViewModelPreview : ConversationAssetPathsViewModel
 
-@HiltViewModel
-class ConversationAssetPathsViewModelImpl @Inject constructor(
+class ConversationAssetPathsViewModelImpl(
     private val getMessageAsset: GetMessageAssetUseCase,
     private val dispatchers: DispatcherProvider,
 ) : ViewModel(), ConversationAssetPathsViewModel {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
@@ -25,8 +25,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalInspectionMode
-import com.wire.android.di.wireViewModel
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -38,6 +36,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.home.conversations.info.ConversationDetailsData
+import com.wire.android.ui.home.conversations.conversationAssetPathsViewModel
 import com.wire.android.ui.home.conversations.messages.QuotedMessage
 import com.wire.android.ui.home.conversations.messages.QuotedMessageStyle
 import com.wire.android.ui.home.conversations.messages.QuotedStyle
@@ -78,10 +77,7 @@ internal fun UIMessage.Regular.MessageContentAndStatus(
     conversationDetailsData: ConversationDetailsData,
     accent: Accent = Accent.Unknown,
 ) {
-    val conversationAssetPathsViewModel: ConversationAssetPathsViewModel = when {
-        LocalInspectionMode.current -> ConversationAssetPathsViewModelPreview
-        else -> wireViewModel<ConversationAssetPathsViewModelImpl>(key = message.conversationId.toString())
-    }
+    val conversationAssetPathsViewModel = conversationAssetPathsViewModel(message.conversationId.toString())
 
     val onAssetClickable = remember(message) {
         Clickable(enabled = isAvailable, onClick = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/migration/ConversationMigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/migration/ConversationMigrationViewModel.kt
@@ -29,15 +29,12 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class ConversationMigrationViewModel @Inject constructor(
+class ConversationMigrationViewModel(
     val savedStateHandle: SavedStateHandle,
     private val observeConversationDetails: ObserveConversationDetailsUseCase
 ) : ViewModel() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/migration/ConversationMigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/migration/ConversationMigrationViewModel.kt
@@ -33,12 +33,9 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 
-class ConversationMigrationViewModel @AssistedInject constructor(
-    @Assisted val savedStateHandle: SavedStateHandle,
+class ConversationMigrationViewModel(
+    val savedStateHandle: SavedStateHandle,
     private val observeConversationDetails: ObserveConversationDetailsUseCase
 ) : ViewModel() {
 
@@ -53,11 +50,6 @@ class ConversationMigrationViewModel @AssistedInject constructor(
 
     private val conversationNavArgs = savedStateHandle.navArgs<ConversationNavArgs>()
     private val conversationId: QualifiedID = conversationNavArgs.conversationId
-
-    @AssistedFactory
-    interface Factory {
-        fun create(savedStateHandle: SavedStateHandle): ConversationMigrationViewModel
-    }
 
     init {
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/migration/ConversationMigrationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/migration/ConversationMigrationViewModel.kt
@@ -33,9 +33,12 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 
-class ConversationMigrationViewModel(
-    val savedStateHandle: SavedStateHandle,
+class ConversationMigrationViewModel @AssistedInject constructor(
+    @Assisted val savedStateHandle: SavedStateHandle,
     private val observeConversationDetails: ObserveConversationDetailsUseCase
 ) : ViewModel() {
 
@@ -50,6 +53,11 @@ class ConversationMigrationViewModel(
 
     private val conversationNavArgs = savedStateHandle.navArgs<ConversationNavArgs>()
     private val conversationId: QualifiedID = conversationNavArgs.conversationId
+
+    @AssistedFactory
+    interface Factory {
+        fun create(savedStateHandle: SavedStateHandle): ConversationMigrationViewModel
+    }
 
     init {
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -75,18 +75,15 @@ import com.wire.kalium.logic.feature.message.SendLocationUseCase
 import com.wire.kalium.logic.feature.message.SendMultipartMessageUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.message.draft.RemoveMessageDraftUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @Suppress("LongParameterList", "TooManyFunctions")
-@HiltViewModel
-class SendMessageViewModel @Inject constructor(
+class SendMessageViewModel(
     val savedStateHandle: SavedStateHandle,
     private val sendAssetMessage: ScheduleNewAssetMessageUseCase,
     private val sendTextMessage: SendTextMessageUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -81,10 +81,13 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 
 @Suppress("LongParameterList", "TooManyFunctions")
-class SendMessageViewModel(
-    val savedStateHandle: SavedStateHandle,
+class SendMessageViewModel @AssistedInject constructor(
+    @Assisted val savedStateHandle: SavedStateHandle,
     private val sendAssetMessage: ScheduleNewAssetMessageUseCase,
     private val sendTextMessage: SendTextMessageUseCase,
     private val sendMultipartMessage: SendMultipartMessageUseCase,
@@ -130,6 +133,11 @@ class SendMessageViewModel(
         conversationNavArgs.pendingBundles?.let {
             handlePendingBundles(it)
         }
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(savedStateHandle: SavedStateHandle): SendMessageViewModel
     }
 
     // for cells conversations we need to add the items to attachments list

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -81,13 +81,10 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 
 @Suppress("LongParameterList", "TooManyFunctions")
-class SendMessageViewModel @AssistedInject constructor(
-    @Assisted val savedStateHandle: SavedStateHandle,
+class SendMessageViewModel(
+    val savedStateHandle: SavedStateHandle,
     private val sendAssetMessage: ScheduleNewAssetMessageUseCase,
     private val sendTextMessage: SendTextMessageUseCase,
     private val sendMultipartMessage: SendMultipartMessageUseCase,
@@ -133,11 +130,6 @@ class SendMessageViewModel @AssistedInject constructor(
         conversationNavArgs.pendingBundles?.let {
             handlePendingBundles(it)
         }
-    }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(savedStateHandle: SavedStateHandle): SendMessageViewModel
     }
 
     // for cells conversations we need to add the items to attachments list

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -4940,6 +4940,25 @@ private fun com.wire.android.ui.home.conversations.channels.Content(searchQueryT
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
+public fun com.wire.android.ui.home.conversations.conversationAssetPathsViewModel(conversationKey: kotlin.String): com.wire.android.ui.home.conversations.messages.item.ConversationAssetPathsViewModel
+  skippable: true
+  restartable: true
+  params:
+    - conversationKey: STABLE (String is immutable)
+
+@Composable
+public fun com.wire.android.ui.home.conversations.conversationMessagesViewModel(): com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.conversations.conversationMigrationViewModel(): com.wire.android.ui.home.conversations.migration.ConversationMigrationViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 internal fun com.wire.android.ui.home.conversations.delete.DeleteMessageDialog(dialogState: com.wire.android.ui.common.visbility.VisibilityState<com.wire.android.ui.home.conversations.delete.DeleteMessageDialogState>, deleteMessage: kotlin.Function2<@[ParameterName(name = \): kotlin.Unit
   skippable: false
   restartable: true
@@ -5904,6 +5923,24 @@ public fun com.wire.android.ui.home.conversations.mention.MemberItemToMention(av
     - searchQuery: STABLE (String is immutable)
     - clickable: STABLE (class with no mutable properties)
     - modifier: STABLE (marked @Stable or @Immutable)
+
+@Composable
+public fun com.wire.android.ui.home.conversations.messageAttachmentsViewModel(): com.wire.android.ui.home.conversations.attachment.MessageAttachmentsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.conversations.messageComposerViewModel(): com.wire.android.ui.home.conversations.composer.MessageComposerViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.conversations.messageDraftViewModel(): com.wire.android.ui.home.conversations.messages.draft.MessageDraftViewModel
+  skippable: true
+  restartable: true
+  params:
 
 @Composable
 public fun com.wire.android.ui.home.conversations.messagedetails.MessageDetailsEmptyScreenText(onClick: kotlin.Function0<kotlin.Unit>, text: kotlin.String, learnMoreText: kotlin.String, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -7599,6 +7636,12 @@ public fun com.wire.android.ui.home.conversations.selfdeletion.selfDeletionMenuI
   params:
     - currentlySelected: STABLE (class with no mutable properties)
     - onSelfDeletionDurationChanged: STABLE (function type)
+
+@Composable
+public fun com.wire.android.ui.home.conversations.sendMessageViewModel(): com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
+  skippable: true
+  restartable: true
+  params:
 
 @Composable
 private fun com.wire.android.ui.home.conversations.stringResourceProvider(): com.wire.android.ui.home.conversations.StringResourceProvider


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25946
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Migrates core conversation screen ViewModels from Hilt call-site creation to Metro-backed factories.
- Covers messages, composer, drafts, send flow, attachments, and asset-related conversation core wiring.
- Keeps existing state/effect contracts and screen call sites behaviorally unchanged.
