### PR TITLE
refactor: migrate conversation details view models to metro [WPB-25946]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
@@ -34,6 +34,8 @@ import com.wire.android.ui.home.HomeViewModelFactory
 import com.wire.android.ui.home.HomeViewModelGraph
 import com.wire.android.ui.home.conversations.ConversationCoreViewModelFactory
 import com.wire.android.ui.home.conversations.ConversationCoreViewModelGraph
+import com.wire.android.ui.home.conversations.ConversationDetailsViewModelFactory
+import com.wire.android.ui.home.conversations.ConversationDetailsViewModelGraph
 import com.wire.android.ui.home.conversations.ScopedMessageViewModelFactory
 import com.wire.android.ui.home.conversations.ScopedMessageViewModelGraph
 import com.wire.android.ui.home.settings.SettingsViewModelFactory
@@ -57,6 +59,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     private val homeViewModelFactoryProvider: Provider<HomeViewModelFactory>,
     private val settingsViewModelFactoryProvider: Provider<SettingsViewModelFactory>,
     private val conversationCoreViewModelFactoryProvider: Provider<ConversationCoreViewModelFactory>,
+    private val conversationDetailsViewModelFactoryProvider: Provider<ConversationDetailsViewModelFactory>,
     private val meetingsViewModelFactoryProvider: Provider<MeetingsViewModelFactory>,
     private val scopedMessageViewModelFactoryProvider: Provider<ScopedMessageViewModelFactory>,
 ) : ViewModel(),
@@ -68,6 +71,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     HomeViewModelGraph,
     SettingsViewModelGraph,
     ConversationCoreViewModelGraph,
+    ConversationDetailsViewModelGraph,
     MeetingsViewModelGraph,
     ScopedMessageViewModelGraph {
     override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
@@ -93,6 +97,9 @@ class WireActivityViewModelGraphBridge @Inject constructor(
 
     override val conversationCoreViewModelFactory: ConversationCoreViewModelFactory
         get() = conversationCoreViewModelFactoryProvider.get()
+
+    override val conversationDetailsViewModelFactory: ConversationDetailsViewModelFactory
+        get() = conversationDetailsViewModelFactoryProvider.get()
 
     override val meetingsViewModelFactory: MeetingsViewModelFactory
         get() = meetingsViewModelFactoryProvider.get()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationDetailsViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationDetailsViewModelFactory.kt
@@ -1,0 +1,164 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel
+import com.wire.android.ui.home.conversations.details.editguestaccess.EditGuestAccessViewModel
+import com.wire.android.ui.home.conversations.details.editguestaccess.createPasswordProtectedGuestLink.CreatePasswordGuestLinkViewModel
+import com.wire.android.ui.home.conversations.details.editselfdeletingmessages.EditSelfDeletingMessagesViewModel
+import com.wire.android.ui.home.conversations.details.metadata.EditConversationMetadataViewModel
+import com.wire.android.ui.home.conversations.details.participants.GroupConversationParticipantsViewModel
+import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
+import com.wire.android.ui.home.conversations.details.updateappsaccess.UpdateAppsAccessViewModel
+import com.wire.android.ui.home.conversations.details.updatechannelaccess.UpdateChannelAccessViewModel
+import com.wire.android.ui.home.conversations.media.CheckAssetRestrictionsViewModel
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
+import com.wire.kalium.logic.feature.client.IsWireCellsEnabledUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.conversation.RenameConversationUseCase
+import com.wire.kalium.logic.feature.conversation.SyncConversationCodeUseCase
+import com.wire.kalium.logic.feature.conversation.UpdateConversationAccessRoleUseCase
+import com.wire.kalium.logic.feature.conversation.UpdateConversationReceiptModeUseCase
+import com.wire.kalium.logic.feature.conversation.apps.ChangeAccessForAppsInConversationUseCase
+import com.wire.kalium.logic.feature.conversation.channel.UpdateChannelAddPermissionUseCase
+import com.wire.kalium.logic.feature.conversation.guestroomlink.CanCreatePasswordProtectedLinksUseCase
+import com.wire.kalium.logic.feature.conversation.guestroomlink.GenerateGuestRoomLinkUseCase
+import com.wire.kalium.logic.feature.conversation.guestroomlink.ObserveGuestRoomLinkUseCase
+import com.wire.kalium.logic.feature.conversation.guestroomlink.RevokeGuestRoomLinkUseCase
+import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTimerUseCase
+import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppsAllowedForUsageUseCase
+import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
+import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
+import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserWithTeamUseCase
+import com.wire.kalium.logic.feature.user.guestroomlink.ObserveGuestRoomLinkFeatureFlagUseCase
+import com.wire.kalium.logic.util.RandomPassword
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+class ConversationDetailsViewModelFactory @Inject constructor(
+    private val dispatcher: DispatcherProvider,
+    private val observeConversationDetails: ObserveConversationDetailsUseCase,
+    private val observeParticipantsForConversation: ObserveParticipantsForConversationUseCase,
+    private val observeSelfUserWithTeam: ObserveSelfUserWithTeamUseCase,
+    private val updateConversationReceiptMode: UpdateConversationReceiptModeUseCase,
+    private val observeSelfDeletionTimerSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase,
+    private val observeIsAppsAllowedForUsage: ObserveIsAppsAllowedForUsageUseCase,
+    private val isMLSEnabled: IsMLSEnabledUseCase,
+    private val refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase,
+    private val isWireCellsEnabled: IsWireCellsEnabledUseCase,
+    private val renameConversation: RenameConversationUseCase,
+    private val updateMessageTimer: UpdateMessageTimerUseCase,
+    private val observeSelfUser: ObserveSelfUserUseCase,
+    private val updateChannelAddPermission: UpdateChannelAddPermissionUseCase,
+    private val qualifiedIdMapper: QualifiedIdMapper,
+    private val changeAccessForAppsInConversation: ChangeAccessForAppsInConversationUseCase,
+    private val updateConversationAccessRole: UpdateConversationAccessRoleUseCase,
+    private val generateGuestRoomLink: GenerateGuestRoomLinkUseCase,
+    private val revokeGuestRoomLink: RevokeGuestRoomLinkUseCase,
+    private val observeGuestRoomLink: ObserveGuestRoomLinkUseCase,
+    private val observeGuestRoomLinkFeatureFlag: ObserveGuestRoomLinkFeatureFlagUseCase,
+    private val canCreatePasswordProtectedLinks: CanCreatePasswordProtectedLinksUseCase,
+    private val syncConversationCode: SyncConversationCodeUseCase,
+    private val getDefaultProtocol: GetDefaultProtocolUseCase,
+    private val validatePassword: ValidatePasswordUseCase,
+    private val generatePassword: RandomPassword,
+) {
+    fun groupConversationDetailsViewModel(savedStateHandle: SavedStateHandle) = GroupConversationDetailsViewModel(
+        dispatcher = dispatcher,
+        observeConversationDetails = observeConversationDetails,
+        observeConversationMembers = observeParticipantsForConversation,
+        observeSelfUserWithTeam = observeSelfUserWithTeam,
+        updateConversationReceiptMode = updateConversationReceiptMode,
+        observeSelfDeletionTimerSettingsForConversation = observeSelfDeletionTimerSettingsForConversation,
+        observeIsAppsAllowedForUsage = observeIsAppsAllowedForUsage,
+        savedStateHandle = savedStateHandle,
+        isMLSEnabled = isMLSEnabled,
+        refreshUsersWithoutMetadata = refreshUsersWithoutMetadata,
+        isWireCellsEnabled = isWireCellsEnabled,
+    )
+
+    fun groupConversationParticipantsViewModel(savedStateHandle: SavedStateHandle) = GroupConversationParticipantsViewModel(
+        savedStateHandle = savedStateHandle,
+        observeConversationMembers = observeParticipantsForConversation,
+        refreshUsersWithoutMetadata = refreshUsersWithoutMetadata,
+    )
+
+    fun editConversationMetadataViewModel(savedStateHandle: SavedStateHandle) = EditConversationMetadataViewModel(
+        dispatcher = dispatcher,
+        observeConversationDetails = observeConversationDetails,
+        renameConversation = renameConversation,
+        savedStateHandle = savedStateHandle,
+    )
+
+    fun editSelfDeletingMessagesViewModel(savedStateHandle: SavedStateHandle) = EditSelfDeletingMessagesViewModel(
+        dispatcher = dispatcher,
+        observeConversationMembers = observeParticipantsForConversation,
+        observeSelfDeletionTimerSettingsForConversation = observeSelfDeletionTimerSettingsForConversation,
+        updateMessageTimer = updateMessageTimer,
+        selfUser = observeSelfUser,
+        conversationDetails = observeConversationDetails,
+        savedStateHandle = savedStateHandle,
+    )
+
+    fun updateChannelAccessViewModel(savedStateHandle: SavedStateHandle) = UpdateChannelAccessViewModel(
+        savedStateHandle = savedStateHandle,
+        updateChannelAddPermission = updateChannelAddPermission,
+        qualifiedIdMapper = qualifiedIdMapper,
+    )
+
+    fun updateAppsAccessViewModel(savedStateHandle: SavedStateHandle) = UpdateAppsAccessViewModel(
+        dispatcher = dispatcher,
+        observeConversationDetails = observeConversationDetails,
+        observeConversationMembers = observeParticipantsForConversation,
+        observeIsAppsAllowedForUsage = observeIsAppsAllowedForUsage,
+        selfUser = observeSelfUser,
+        changeAccessForAppsInConversation = changeAccessForAppsInConversation,
+        savedStateHandle = savedStateHandle,
+    )
+
+    fun editGuestAccessViewModel(savedStateHandle: SavedStateHandle) = EditGuestAccessViewModel(
+        dispatcher = dispatcher,
+        updateConversationAccessRole = updateConversationAccessRole,
+        observeConversationDetails = observeConversationDetails,
+        observeConversationMembers = observeParticipantsForConversation,
+        generateGuestRoomLink = generateGuestRoomLink,
+        revokeGuestRoomLink = revokeGuestRoomLink,
+        observeGuestRoomLink = observeGuestRoomLink,
+        observeGuestRoomLinkFeatureFlag = observeGuestRoomLinkFeatureFlag,
+        canCreatePasswordProtectedLinks = canCreatePasswordProtectedLinks,
+        syncConversationCode = syncConversationCode,
+        getDefaultProtocol = getDefaultProtocol,
+        selfUser = observeSelfUser,
+        savedStateHandle = savedStateHandle,
+    )
+
+    fun createPasswordGuestLinkViewModel(savedStateHandle: SavedStateHandle) = CreatePasswordGuestLinkViewModel(
+        generateGuestRoomLink = generateGuestRoomLink,
+        validatePassword = validatePassword,
+        generatePassword = generatePassword,
+        savedStateHandle = savedStateHandle,
+    )
+
+    fun checkAssetRestrictionsViewModel() = CheckAssetRestrictionsViewModel()
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationDetailsViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationDetailsViewModelGraph.kt
@@ -1,0 +1,90 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations
+
+import androidx.compose.runtime.Composable
+import com.wire.android.di.metro.MetroViewModelGraph
+import com.wire.android.di.metro.metroSavedStateViewModel
+import com.wire.android.di.metro.metroViewModel
+import com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel
+import com.wire.android.ui.home.conversations.details.editguestaccess.EditGuestAccessViewModel
+import com.wire.android.ui.home.conversations.details.editguestaccess.createPasswordProtectedGuestLink.CreatePasswordGuestLinkViewModel
+import com.wire.android.ui.home.conversations.details.editselfdeletingmessages.EditSelfDeletingMessagesViewModel
+import com.wire.android.ui.home.conversations.details.metadata.EditConversationMetadataViewModel
+import com.wire.android.ui.home.conversations.details.participants.GroupConversationParticipantsViewModel
+import com.wire.android.ui.home.conversations.details.updateappsaccess.UpdateAppsAccessViewModel
+import com.wire.android.ui.home.conversations.details.updatechannelaccess.UpdateChannelAccessViewModel
+import com.wire.android.ui.home.conversations.media.CheckAssetRestrictionsViewModel
+
+interface ConversationDetailsViewModelGraph : MetroViewModelGraph {
+    val conversationDetailsViewModelFactory: ConversationDetailsViewModelFactory
+}
+
+@Composable
+fun groupConversationDetailsViewModel(): GroupConversationDetailsViewModel =
+    metroSavedStateViewModel<ConversationDetailsViewModelGraph, GroupConversationDetailsViewModel> {
+        conversationDetailsViewModelFactory.groupConversationDetailsViewModel(it)
+    }
+
+@Composable
+fun groupConversationParticipantsViewModel(): GroupConversationParticipantsViewModel =
+    metroSavedStateViewModel<ConversationDetailsViewModelGraph, GroupConversationParticipantsViewModel> {
+        conversationDetailsViewModelFactory.groupConversationParticipantsViewModel(it)
+    }
+
+@Composable
+fun editConversationMetadataViewModel(): EditConversationMetadataViewModel =
+    metroSavedStateViewModel<ConversationDetailsViewModelGraph, EditConversationMetadataViewModel> {
+        conversationDetailsViewModelFactory.editConversationMetadataViewModel(it)
+    }
+
+@Composable
+fun editSelfDeletingMessagesViewModel(): EditSelfDeletingMessagesViewModel =
+    metroSavedStateViewModel<ConversationDetailsViewModelGraph, EditSelfDeletingMessagesViewModel> {
+        conversationDetailsViewModelFactory.editSelfDeletingMessagesViewModel(it)
+    }
+
+@Composable
+fun updateChannelAccessViewModel(): UpdateChannelAccessViewModel =
+    metroSavedStateViewModel<ConversationDetailsViewModelGraph, UpdateChannelAccessViewModel> {
+        conversationDetailsViewModelFactory.updateChannelAccessViewModel(it)
+    }
+
+@Composable
+fun updateAppsAccessViewModel(): UpdateAppsAccessViewModel =
+    metroSavedStateViewModel<ConversationDetailsViewModelGraph, UpdateAppsAccessViewModel> {
+        conversationDetailsViewModelFactory.updateAppsAccessViewModel(it)
+    }
+
+@Composable
+fun editGuestAccessViewModel(): EditGuestAccessViewModel =
+    metroSavedStateViewModel<ConversationDetailsViewModelGraph, EditGuestAccessViewModel> {
+        conversationDetailsViewModelFactory.editGuestAccessViewModel(it)
+    }
+
+@Composable
+fun createPasswordGuestLinkViewModel(): CreatePasswordGuestLinkViewModel =
+    metroSavedStateViewModel<ConversationDetailsViewModelGraph, CreatePasswordGuestLinkViewModel> {
+        conversationDetailsViewModelFactory.createPasswordGuestLinkViewModel(it)
+    }
+
+@Composable
+fun checkAssetRestrictionsViewModel(): CheckAssetRestrictionsViewModel =
+    metroViewModel<ConversationDetailsViewModelGraph, CheckAssetRestrictionsViewModel> {
+        conversationDetailsViewModelFactory.checkAssetRestrictionsViewModel()
+    }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -18,7 +18,6 @@
 
 package com.wire.android.ui.home.conversations.details
 
-import com.wire.android.navigation.annotation.app.WireRootDestination
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
@@ -60,16 +59,16 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.wire.android.di.wireViewModel
-import com.ramcosta.composedestinations.result.NavResult
-import com.ramcosta.composedestinations.result.ResultBackNavigator
-import com.ramcosta.composedestinations.result.ResultRecipient
-import com.wire.android.navigation.style.PopUpNavigationAnimation
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.ramcosta.composedestinations.generated.cells.destinations.ConversationFilesScreenDestination
+import com.ramcosta.composedestinations.result.NavResult
+import com.ramcosta.composedestinations.result.ResultBackNavigator
+import com.ramcosta.composedestinations.result.ResultRecipient
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
+import com.wire.android.navigation.annotation.app.WireRootDestination
+import com.wire.android.navigation.style.PopUpNavigationAnimation
 import com.wire.android.ui.common.CollapsingTopBarScaffold
 import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.LoadingWireTabRow
@@ -117,6 +116,7 @@ import com.wire.android.ui.home.conversations.details.updateappsaccess.UpdateApp
 import com.wire.android.ui.home.conversations.details.updatechannelaccess.UpdateChannelAccessArgs
 import com.wire.android.ui.home.conversations.folder.ConversationFoldersNavArgs
 import com.wire.android.ui.home.conversations.folder.ConversationFoldersNavBackArgs
+import com.wire.android.ui.home.conversations.groupConversationDetailsViewModel
 import com.wire.android.ui.home.conversations.info.ConversationAvatar
 import com.wire.android.ui.home.conversationslist.showLegalHoldIndicator
 import com.wire.android.ui.home.newconversation.channelaccess.ChannelAccessType
@@ -147,7 +147,7 @@ fun GroupConversationDetailsScreen(
     editChannelAccessResultRecipient: ResultRecipient<ChannelAccessOnUpdateScreenDestination, UpdateChannelAccessArgs>,
     conversationFoldersScreenResultRecipient:
     ResultRecipient<ConversationFoldersScreenDestination, ConversationFoldersNavBackArgs>,
-    viewModel: GroupConversationDetailsViewModel = wireViewModel(),
+    viewModel: GroupConversationDetailsViewModel = groupConversationDetailsViewModel(),
 ) {
     val scope = rememberCoroutineScope()
     val resources = LocalContext.current.resources

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -50,7 +50,6 @@ import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCa
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserWithTeamUseCase
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -63,11 +62,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
 @Suppress("TooManyFunctions", "LongParameterList")
-@HiltViewModel
-class GroupConversationDetailsViewModel @Inject constructor(
+class GroupConversationDetailsViewModel(
     private val dispatcher: DispatcherProvider,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
     observeConversationMembers: ObserveParticipantsForConversationUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
@@ -18,6 +18,8 @@
 
 package com.wire.android.ui.home.conversations.details.editguestaccess
 
+import com.wire.android.ui.home.conversations.editGuestAccessViewModel
+
 import com.wire.android.navigation.annotation.app.WireRootDestination
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -38,7 +40,6 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.di.wireViewModel
 import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
@@ -70,7 +71,7 @@ import com.wire.android.util.shareViaIntent
 fun EditGuestAccessScreen(
     navigator: Navigator,
     modifier: Modifier = Modifier,
-    editGuestAccessViewModel: EditGuestAccessViewModel = wireViewModel()
+    editGuestAccessViewModel: EditGuestAccessViewModel = editGuestAccessViewModel()
 ) {
     val scrollState = rememberScrollState()
     val snackbarHostState = LocalSnackbarHostState.current

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessViewModel.kt
@@ -47,7 +47,6 @@ import com.wire.kalium.logic.feature.conversation.guestroomlink.RevokeGuestRoomL
 import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.feature.user.guestroomlink.ObserveGuestRoomLinkFeatureFlagUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -59,11 +58,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
-@HiltViewModel
 @Suppress("LongParameterList", "TooManyFunctions")
-class EditGuestAccessViewModel @Inject constructor(
+class EditGuestAccessViewModel(
     private val dispatcher: DispatcherProvider,
     private val updateConversationAccessRole: UpdateConversationAccessRoleUseCase,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordGuestLinkViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordGuestLinkViewModel.kt
@@ -32,15 +32,12 @@ import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
 import com.wire.kalium.logic.feature.conversation.guestroomlink.GenerateGuestRoomLinkResult
 import com.wire.kalium.logic.feature.conversation.guestroomlink.GenerateGuestRoomLinkUseCase
 import com.wire.kalium.logic.util.RandomPassword
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class CreatePasswordGuestLinkViewModel @Inject constructor(
+class CreatePasswordGuestLinkViewModel(
     private val generateGuestRoomLink: GenerateGuestRoomLinkUseCase,
     private val validatePassword: ValidatePasswordUseCase,
     private val generatePassword: RandomPassword,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordProtectedGuestLinkScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/createPasswordProtectedGuestLink/CreatePasswordProtectedGuestLinkScreen.kt
@@ -17,6 +17,8 @@
  */
 package com.wire.android.ui.home.conversations.details.editguestaccess.createPasswordProtectedGuestLink
 
+import com.wire.android.ui.home.conversations.createPasswordGuestLinkViewModel
+
 import com.wire.android.navigation.annotation.app.WireRootDestination
 import android.widget.Toast
 import androidx.compose.foundation.background
@@ -46,7 +48,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.button.GeneratePasswordButton
@@ -73,7 +74,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun CreatePasswordProtectedGuestLinkScreen(
     navigator: Navigator,
-    viewModel: CreatePasswordGuestLinkViewModel = wireViewModel(),
+    viewModel: CreatePasswordGuestLinkViewModel = createPasswordGuestLinkViewModel(),
 ) {
     CreatePasswordProtectedGuestLinkScreenContent(
         state = viewModel.state,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
@@ -18,6 +18,8 @@
 
 package com.wire.android.ui.home.conversations.details.editselfdeletingmessages
 
+import com.wire.android.ui.home.conversations.editSelfDeletingMessagesViewModel
+
 import com.wire.android.navigation.annotation.app.WireRootDestination
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.Orientation
@@ -40,7 +42,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.di.wireViewModel
 import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
@@ -67,7 +68,7 @@ import com.wire.android.util.ui.sectionWithElements
 @Composable
 fun EditSelfDeletingMessagesScreen(
     navigator: Navigator,
-    editSelfDeletingMessagesViewModel: EditSelfDeletingMessagesViewModel = wireViewModel(),
+    editSelfDeletingMessagesViewModel: EditSelfDeletingMessagesViewModel = editSelfDeletingMessagesViewModel(),
 ) {
     val scrollState = rememberScrollState()
     val context = LocalContext.current

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesViewModel.kt
@@ -37,17 +37,14 @@ import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseC
 import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTimerUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
 @Suppress("LongParameterList", "TooManyFunctions")
-class EditSelfDeletingMessagesViewModel @Inject constructor(
+class EditSelfDeletingMessagesViewModel(
     private val dispatcher: DispatcherProvider,
     private val observeConversationMembers: ObserveParticipantsForConversationUseCase,
     private val observeSelfDeletionTimerSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationMetadataViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationMetadataViewModel.kt
@@ -37,7 +37,6 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.RenameConversationUseCase
 import com.wire.kalium.logic.feature.conversation.RenamingResult
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.filterIsInstance
@@ -45,10 +44,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
-@HiltViewModel
-class EditConversationMetadataViewModel @Inject constructor(
+class EditConversationMetadataViewModel(
     private val dispatcher: DispatcherProvider,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
     private val renameConversation: RenameConversationUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationNameScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/metadata/EditConversationNameScreen.kt
@@ -18,11 +18,12 @@
 
 package com.wire.android.ui.home.conversations.details.metadata
 
+import com.wire.android.ui.home.conversations.editConversationMetadataViewModel
+
 import com.wire.android.navigation.annotation.app.WireRootDestination
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import com.wire.android.di.wireViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.navigation.Navigator
@@ -40,7 +41,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 fun EditConversationNameScreen(
     navigator: Navigator,
     resultNavigator: ResultBackNavigator<Boolean>,
-    viewModel: EditConversationMetadataViewModel = wireViewModel(),
+    viewModel: EditConversationMetadataViewModel = editConversationMetadataViewModel(),
 ) {
     with(viewModel) {
         LaunchedEffect(editConversationState.completed) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -20,6 +20,8 @@
 
 package com.wire.android.ui.home.conversations.details.options
 
+import com.wire.android.ui.home.conversations.groupConversationDetailsViewModel
+
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
@@ -37,7 +39,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.times
-import com.wire.android.di.wireViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wire.android.BuildConfig
 import com.wire.android.R
@@ -71,7 +72,7 @@ fun GroupConversationOptions(
     onAppsAccessItemClicked: () -> Unit,
     onChannelAccessItemClicked: () -> Unit,
     onEditSelfDeletingMessages: () -> Unit,
-    viewModel: GroupConversationDetailsViewModel = wireViewModel(),
+    viewModel: GroupConversationDetailsViewModel = groupConversationDetailsViewModel(),
     onEditGroupName: () -> Unit
 ) {
     val state by viewModel.groupOptionsState.collectAsStateWithLifecycle()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationAllParticipantsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationAllParticipantsScreen.kt
@@ -18,6 +18,8 @@
 
 package com.wire.android.ui.home.conversations.details.participants
 
+import com.wire.android.ui.home.conversations.groupConversationParticipantsViewModel
+
 import com.wire.android.navigation.annotation.app.WireRootDestination
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalOverscrollConfiguration
@@ -34,7 +36,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
@@ -57,7 +58,7 @@ import com.wire.android.ui.userprofile.service.ServiceDetailsNavArgs
 fun GroupConversationAllParticipantsScreen(
     navigator: Navigator,
     navArgs: GroupConversationAllParticipantsNavArgs,
-    viewModel: GroupConversationParticipantsViewModel = wireViewModel()
+    viewModel: GroupConversationParticipantsViewModel = groupConversationParticipantsViewModel()
 ) {
     GroupConversationAllParticipantsContent(
         onBackPressed = navigator::navigateBack,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantsViewModel.kt
@@ -28,12 +28,9 @@ import com.wire.android.ui.home.conversations.details.participants.usecase.Obser
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-open class GroupConversationParticipantsViewModel @Inject constructor(
+open class GroupConversationParticipantsViewModel(
     savedStateHandle: SavedStateHandle,
     private val observeConversationMembers: ObserveParticipantsForConversationUseCase,
     private val refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessScreen.kt
@@ -17,6 +17,8 @@
  */
 package com.wire.android.ui.home.conversations.details.updateappsaccess
 
+import com.wire.android.ui.home.conversations.updateAppsAccessViewModel
+
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -29,7 +31,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.annotation.app.WireRootDestination
@@ -54,7 +55,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun UpdateAppsAccessScreen(
     navigator: Navigator,
-    updateAppsAccessViewModel: UpdateAppsAccessViewModel = wireViewModel()
+    updateAppsAccessViewModel: UpdateAppsAccessViewModel = updateAppsAccessViewModel()
 ) {
     UpdateAppsAccessContent(
         onNavigateBack = navigator::navigateBack,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updateappsaccess/UpdateAppsAccessViewModel.kt
@@ -39,7 +39,6 @@ import com.wire.kalium.logic.feature.conversation.apps.ChangeAccessForAppsInConv
 import com.wire.kalium.logic.feature.featureConfig.AppsAllowedResult
 import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppsAllowedForUsageUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -49,10 +48,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
-@HiltViewModel
-class UpdateAppsAccessViewModel @Inject constructor(
+class UpdateAppsAccessViewModel(
     private val dispatcher: DispatcherProvider,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
     private val observeConversationMembers: ObserveParticipantsForConversationUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updatechannelaccess/ChannelAccessOnUpdateScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updatechannelaccess/ChannelAccessOnUpdateScreen.kt
@@ -17,11 +17,12 @@
  */
 package com.wire.android.ui.home.conversations.details.updatechannelaccess
 
+import com.wire.android.ui.home.conversations.updateChannelAccessViewModel
+
 import com.wire.android.navigation.annotation.app.WireRootDestination
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.R
@@ -38,7 +39,7 @@ import com.wire.android.ui.home.newconversation.channelaccess.ChannelAccessScree
 @Composable
 fun ChannelAccessOnUpdateScreen(
     resultNavigator: ResultBackNavigator<UpdateChannelAccessArgs>,
-    updateChannelAccessViewModel: UpdateChannelAccessViewModel = wireViewModel()
+    updateChannelAccessViewModel: UpdateChannelAccessViewModel = updateChannelAccessViewModel()
 ) {
 
     fun navigateBack() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updatechannelaccess/UpdateChannelAccessViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/updatechannelaccess/UpdateChannelAccessViewModel.kt
@@ -31,12 +31,9 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.feature.conversation.channel.UpdateChannelAddPermissionUseCase
 import com.wire.kalium.logic.feature.conversation.channel.UpdateChannelAddPermissionUseCase.UpdateChannelAddPermissionUseCaseResult
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class UpdateChannelAccessViewModel @Inject constructor(
+class UpdateChannelAccessViewModel(
     savedStateHandle: SavedStateHandle,
     val updateChannelAddPermission: UpdateChannelAddPermissionUseCase,
     private val qualifiedIdMapper: QualifiedIdMapper,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/CheckAssetRestrictionsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/CheckAssetRestrictionsViewModel.kt
@@ -24,11 +24,8 @@ import androidx.lifecycle.ViewModel
 import com.wire.android.ui.home.conversations.AssetTooLargeDialogState
 import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.sharing.ImportedMediaAsset
-import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 
-@HiltViewModel
-class CheckAssetRestrictionsViewModel @Inject constructor() : ViewModel() {
+class CheckAssetRestrictionsViewModel : ViewModel() {
 
     var state: RestrictionCheckState by mutableStateOf(RestrictionCheckState.None)
         private set

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/ImagesPreviewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/ImagesPreviewScreen.kt
@@ -17,6 +17,9 @@
  */
 package com.wire.android.ui.home.conversations.media.preview
 
+import com.wire.android.di.wireViewModel
+import com.wire.android.ui.home.conversations.checkAssetRestrictionsViewModel
+
 import com.wire.android.navigation.annotation.app.WireRootDestination
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
@@ -49,7 +52,6 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.wire.android.di.wireViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
@@ -90,7 +92,7 @@ fun ImagesPreviewScreen(
     navigator: Navigator,
     resultNavigator: ResultBackNavigator<ImagesPreviewNavBackArgs>,
     imagesPreviewViewModel: ImagesPreviewViewModel = wireViewModel(),
-    checkAssetRestrictionsViewModel: CheckAssetRestrictionsViewModel = wireViewModel()
+    checkAssetRestrictionsViewModel: CheckAssetRestrictionsViewModel = checkAssetRestrictionsViewModel()
 ) {
     LaunchedEffect(checkAssetRestrictionsViewModel.state) {
         with(checkAssetRestrictionsViewModel.state) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25946
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Migrates conversation details ViewModels from Hilt call-site creation to Metro-backed factories.
- Covers conversation info/details, participants, guest access, metadata, and related details screens.
- Keeps existing screen contracts and navigation behavior unchanged.