### PR TITLE
refactor: migrate conversation search folder view models to metro [WPB-25946]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
@@ -36,6 +36,8 @@ import com.wire.android.ui.home.conversations.ConversationCoreViewModelFactory
 import com.wire.android.ui.home.conversations.ConversationCoreViewModelGraph
 import com.wire.android.ui.home.conversations.ConversationDetailsViewModelFactory
 import com.wire.android.ui.home.conversations.ConversationDetailsViewModelGraph
+import com.wire.android.ui.home.conversations.ConversationSearchFolderViewModelFactory
+import com.wire.android.ui.home.conversations.ConversationSearchFolderViewModelGraph
 import com.wire.android.ui.home.conversations.ScopedMessageViewModelFactory
 import com.wire.android.ui.home.conversations.ScopedMessageViewModelGraph
 import com.wire.android.ui.home.settings.SettingsViewModelFactory
@@ -60,6 +62,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     private val settingsViewModelFactoryProvider: Provider<SettingsViewModelFactory>,
     private val conversationCoreViewModelFactoryProvider: Provider<ConversationCoreViewModelFactory>,
     private val conversationDetailsViewModelFactoryProvider: Provider<ConversationDetailsViewModelFactory>,
+    private val conversationSearchFolderViewModelFactoryProvider: Provider<ConversationSearchFolderViewModelFactory>,
     private val meetingsViewModelFactoryProvider: Provider<MeetingsViewModelFactory>,
     private val scopedMessageViewModelFactoryProvider: Provider<ScopedMessageViewModelFactory>,
 ) : ViewModel(),
@@ -72,6 +75,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     SettingsViewModelGraph,
     ConversationCoreViewModelGraph,
     ConversationDetailsViewModelGraph,
+    ConversationSearchFolderViewModelGraph,
     MeetingsViewModelGraph,
     ScopedMessageViewModelGraph {
     override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
@@ -100,6 +104,9 @@ class WireActivityViewModelGraphBridge @Inject constructor(
 
     override val conversationDetailsViewModelFactory: ConversationDetailsViewModelFactory
         get() = conversationDetailsViewModelFactoryProvider.get()
+
+    override val conversationSearchFolderViewModelFactory: ConversationSearchFolderViewModelFactory
+        get() = conversationSearchFolderViewModelFactoryProvider.get()
 
     override val meetingsViewModelFactory: MeetingsViewModelFactory
         get() = meetingsViewModelFactoryProvider.get()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationSearchFolderViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationSearchFolderViewModelFactory.kt
@@ -1,0 +1,135 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.mapper.ContactMapper
+import com.wire.android.ui.home.conversations.folder.ConversationFoldersStateArgs
+import com.wire.android.ui.home.conversations.folder.ConversationFoldersVMImpl
+import com.wire.android.ui.home.conversations.folder.MoveConversationToFolderArgs
+import com.wire.android.ui.home.conversations.folder.MoveConversationToFolderVMImpl
+import com.wire.android.ui.home.conversations.folder.NewFolderViewModel
+import com.wire.android.ui.home.conversations.promoteadmin.PromoteAdminViewModel
+import com.wire.android.ui.home.conversations.search.SearchUserViewModel
+import com.wire.android.ui.home.conversations.search.adddembertoconversation.AddMembersToConversationViewModel
+import com.wire.android.ui.home.conversations.search.apps.SearchAppsViewModel
+import com.wire.android.ui.home.conversations.search.messages.SearchConversationMessagesViewModel
+import com.wire.android.ui.home.conversations.usecase.GetConversationMessagesFromSearchUseCase
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.feature.app.ObserveAllAppsUseCase
+import com.wire.kalium.logic.feature.app.SearchAppsByNameUseCase
+import com.wire.kalium.logic.feature.auth.ValidateUserHandleUseCase
+import com.wire.kalium.logic.feature.conversation.AddMemberToConversationUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveEligibleMembersForConversationAdminRoleUseCase
+import com.wire.kalium.logic.feature.conversation.PromoteAdminAndLeaveConversationUseCase
+import com.wire.kalium.logic.feature.conversation.folder.CreateConversationFolderUseCase
+import com.wire.kalium.logic.feature.conversation.folder.MoveConversationToFolderUseCase
+import com.wire.kalium.logic.feature.conversation.folder.ObserveUserFoldersUseCase
+import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppsAllowedForUsageUseCase
+import com.wire.kalium.logic.feature.search.FederatedSearchParser
+import com.wire.kalium.logic.feature.search.IsFederationSearchAllowedUseCase
+import com.wire.kalium.logic.feature.search.SearchByHandleUseCase
+import com.wire.kalium.logic.feature.search.SearchUsersUseCase
+import com.wire.kalium.logic.feature.service.ObserveAllServicesUseCase
+import com.wire.kalium.logic.feature.service.SearchServicesByNameUseCase
+import com.wire.kalium.logic.feature.service.SyncServicesUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+class ConversationSearchFolderViewModelFactory @Inject constructor(
+    private val dispatchers: DispatcherProvider,
+    private val observeUserFolders: ObserveUserFoldersUseCase,
+    private val createConversationFolder: CreateConversationFolderUseCase,
+    private val moveConversationToFolder: MoveConversationToFolderUseCase,
+    private val searchUsers: SearchUsersUseCase,
+    private val searchByHandle: SearchByHandleUseCase,
+    private val contactMapper: ContactMapper,
+    private val federatedSearchParser: FederatedSearchParser,
+    private val validateUserHandle: ValidateUserHandleUseCase,
+    private val isFederationSearchAllowed: IsFederationSearchAllowedUseCase,
+    private val addMemberToConversation: AddMemberToConversationUseCase,
+    private val getConversationMessagesFromSearch: GetConversationMessagesFromSearchUseCase,
+    private val observeAllServices: ObserveAllServicesUseCase,
+    private val syncServices: SyncServicesUseCase,
+    private val observeAllApps: ObserveAllAppsUseCase,
+    private val searchServicesByName: SearchServicesByNameUseCase,
+    private val searchAppsByName: SearchAppsByNameUseCase,
+    private val observeIsAppsAllowedForUsage: ObserveIsAppsAllowedForUsageUseCase,
+    private val observeSelfUser: ObserveSelfUserUseCase,
+    private val promoteAdminAndLeave: PromoteAdminAndLeaveConversationUseCase,
+    private val observeEligibleMembers: ObserveEligibleMembersForConversationAdminRoleUseCase,
+) {
+    fun conversationFoldersViewModel(args: ConversationFoldersStateArgs) = ConversationFoldersVMImpl(
+        args = args,
+        observeUserFoldersUseCase = observeUserFolders,
+    )
+
+    fun moveConversationToFolderViewModel(args: MoveConversationToFolderArgs) = MoveConversationToFolderVMImpl(
+        dispatchers = dispatchers,
+        args = args,
+        moveConversationToFolder = moveConversationToFolder,
+    )
+
+    fun newFolderViewModel() = NewFolderViewModel(
+        observeUserFolders = observeUserFolders,
+        createConversationFolder = createConversationFolder,
+    )
+
+    fun searchUserViewModel(savedStateHandle: SavedStateHandle) = SearchUserViewModel(
+        searchUserUseCase = searchUsers,
+        searchByHandleUseCase = searchByHandle,
+        contactMapper = contactMapper,
+        federatedSearchParser = federatedSearchParser,
+        validateUserHandle = validateUserHandle,
+        isFederationSearchAllowed = isFederationSearchAllowed,
+        savedStateHandle = savedStateHandle,
+    )
+
+    fun addMembersToConversationViewModel(savedStateHandle: SavedStateHandle) = AddMembersToConversationViewModel(
+        addMemberToConversation = addMemberToConversation,
+        dispatchers = dispatchers,
+        savedStateHandle = savedStateHandle,
+    )
+
+    fun searchConversationMessagesViewModel(savedStateHandle: SavedStateHandle) = SearchConversationMessagesViewModel(
+        getSearchMessagesForConversation = getConversationMessagesFromSearch,
+        dispatchers = dispatchers,
+        savedStateHandle = savedStateHandle,
+    )
+
+    fun searchAppsViewModel(protocolInfo: Conversation.ProtocolInfo?) = SearchAppsViewModel(
+        protocolInfo = protocolInfo,
+        getAllServices = observeAllServices,
+        syncServices = syncServices,
+        getAllApps = observeAllApps,
+        contactMapper = contactMapper,
+        searchServicesByName = searchServicesByName,
+        searchAppsByName = searchAppsByName,
+        isAppsAllowedForUsage = observeIsAppsAllowedForUsage,
+        observeSelfUser = observeSelfUser,
+    )
+
+    fun promoteAdminViewModel(savedStateHandle: SavedStateHandle) = PromoteAdminViewModel(
+        promoteAdminAndLeave = promoteAdminAndLeave,
+        observeEligibleMembers = observeEligibleMembers,
+        dispatchers = dispatchers,
+        savedStateHandle = savedStateHandle,
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationSearchFolderViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationSearchFolderViewModelGraph.kt
@@ -1,0 +1,94 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations
+
+import androidx.compose.runtime.Composable
+import com.wire.android.di.metro.MetroViewModelGraph
+import com.wire.android.di.metro.metroSavedStateViewModel
+import com.wire.android.di.metro.metroViewModel
+import com.wire.android.ui.home.conversations.folder.ConversationFoldersStateArgs
+import com.wire.android.ui.home.conversations.folder.ConversationFoldersVM
+import com.wire.android.ui.home.conversations.folder.ConversationFoldersVMImpl
+import com.wire.android.ui.home.conversations.folder.MoveConversationToFolderArgs
+import com.wire.android.ui.home.conversations.folder.MoveConversationToFolderVM
+import com.wire.android.ui.home.conversations.folder.MoveConversationToFolderVMImpl
+import com.wire.android.ui.home.conversations.folder.NewFolderViewModel
+import com.wire.android.ui.home.conversations.promoteadmin.PromoteAdminViewModel
+import com.wire.android.ui.home.conversations.search.SearchUserViewModel
+import com.wire.android.ui.home.conversations.search.adddembertoconversation.AddMembersToConversationViewModel
+import com.wire.android.ui.home.conversations.search.apps.SearchAppsViewModel
+import com.wire.android.ui.home.conversations.search.messages.SearchConversationMessagesViewModel
+import com.wire.kalium.logic.data.conversation.Conversation
+
+interface ConversationSearchFolderViewModelGraph : MetroViewModelGraph {
+    val conversationSearchFolderViewModelFactory: ConversationSearchFolderViewModelFactory
+}
+
+@Composable
+fun conversationFoldersViewModel(args: ConversationFoldersStateArgs): ConversationFoldersVM =
+    metroViewModel<ConversationSearchFolderViewModelGraph, ConversationFoldersVMImpl>(
+        key = "conversation_folders_${args.selectedFolderId}"
+    ) {
+        conversationSearchFolderViewModelFactory.conversationFoldersViewModel(args)
+    }
+
+@Composable
+fun moveConversationToFolderViewModel(args: MoveConversationToFolderArgs): MoveConversationToFolderVM =
+    metroViewModel<ConversationSearchFolderViewModelGraph, MoveConversationToFolderVMImpl>(
+        key = "move_conversation_to_folder_${args.conversationId}_${args.currentFolderId}"
+    ) {
+        conversationSearchFolderViewModelFactory.moveConversationToFolderViewModel(args)
+    }
+
+@Composable
+fun newFolderViewModel(): NewFolderViewModel =
+    metroViewModel<ConversationSearchFolderViewModelGraph, NewFolderViewModel> {
+        conversationSearchFolderViewModelFactory.newFolderViewModel()
+    }
+
+@Composable
+fun searchUserViewModel(): SearchUserViewModel =
+    metroSavedStateViewModel<ConversationSearchFolderViewModelGraph, SearchUserViewModel> {
+        conversationSearchFolderViewModelFactory.searchUserViewModel(it)
+    }
+
+@Composable
+fun addMembersToConversationViewModel(): AddMembersToConversationViewModel =
+    metroSavedStateViewModel<ConversationSearchFolderViewModelGraph, AddMembersToConversationViewModel> {
+        conversationSearchFolderViewModelFactory.addMembersToConversationViewModel(it)
+    }
+
+@Composable
+fun searchConversationMessagesViewModel(): SearchConversationMessagesViewModel =
+    metroSavedStateViewModel<ConversationSearchFolderViewModelGraph, SearchConversationMessagesViewModel> {
+        conversationSearchFolderViewModelFactory.searchConversationMessagesViewModel(it)
+    }
+
+@Composable
+fun searchAppsViewModel(protocolInfo: Conversation.ProtocolInfo?): SearchAppsViewModel =
+    metroViewModel<ConversationSearchFolderViewModelGraph, SearchAppsViewModel>(
+        key = "search_apps_protocol_info_${protocolInfo?.name()}"
+    ) {
+        conversationSearchFolderViewModelFactory.searchAppsViewModel(protocolInfo)
+    }
+
+@Composable
+fun promoteAdminViewModel(): PromoteAdminViewModel =
+    metroSavedStateViewModel<ConversationSearchFolderViewModelGraph, PromoteAdminViewModel> {
+        conversationSearchFolderViewModelFactory.promoteAdminViewModel(it)
+    }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/ConversationFoldersScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/ConversationFoldersScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.ramcosta.composedestinations.result.ResultRecipient
@@ -56,6 +55,8 @@ import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.typography
+import com.wire.android.ui.home.conversations.conversationFoldersViewModel
+import com.wire.android.ui.home.conversations.moveConversationToFolderViewModel
 import com.ramcosta.composedestinations.generated.app.destinations.NewConversationFolderScreenDestination
 import com.wire.kalium.logic.data.conversation.ConversationFolder
 import com.wire.kalium.logic.data.conversation.FolderType
@@ -71,14 +72,10 @@ fun ConversationFoldersScreen(
     resultNavigator: ResultBackNavigator<ConversationFoldersNavBackArgs>,
     resultRecipient: ResultRecipient<NewConversationFolderScreenDestination, NewConversationFolderNavBackArgs>,
     foldersViewModel: ConversationFoldersVM =
-        wireViewModel<ConversationFoldersVMImpl, ConversationFoldersVMImpl.Factory>(
-            creationCallback = { it.create(ConversationFoldersStateArgs(args.currentFolderId)) }
-        ),
+        conversationFoldersViewModel(ConversationFoldersStateArgs(args.currentFolderId)),
     moveToFolderVM: MoveConversationToFolderVM =
-        wireViewModel<MoveConversationToFolderVMImpl, MoveConversationToFolderVMImpl.Factory>(
-            creationCallback = {
-                it.create(MoveConversationToFolderArgs(args.conversationId, args.conversationName, args.currentFolderId))
-            }
+        moveConversationToFolderViewModel(
+            MoveConversationToFolderArgs(args.conversationId, args.conversationName, args.currentFolderId)
         )
 ) {
     val resources = LocalContext.current.resources

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/ConversationFoldersVM.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/ConversationFoldersVM.kt
@@ -25,10 +25,6 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.di.ViewModelScopedPreview
 import com.wire.kalium.logic.data.conversation.ConversationFolder
 import com.wire.kalium.logic.feature.conversation.folder.ObserveUserFoldersUseCase
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
@@ -41,16 +37,10 @@ interface ConversationFoldersVM {
     fun onFolderSelected(folderId: String) {}
 }
 
-@HiltViewModel(assistedFactory = ConversationFoldersVMImpl.Factory::class)
-class ConversationFoldersVMImpl @AssistedInject constructor(
-    @Assisted val args: ConversationFoldersStateArgs,
+class ConversationFoldersVMImpl(
+    private val args: ConversationFoldersStateArgs,
     private val observeUserFoldersUseCase: ObserveUserFoldersUseCase,
 ) : ConversationFoldersVM, ViewModel() {
-
-    @AssistedFactory
-    interface Factory {
-        fun create(args: ConversationFoldersStateArgs): ConversationFoldersVMImpl
-    }
 
     private var state by mutableStateOf(ConversationFoldersState(persistentListOf(), args.selectedFolderId))
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/MoveConversationToFolderVM.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/MoveConversationToFolderVM.kt
@@ -29,10 +29,6 @@ import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.ConversationFolder
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.conversation.folder.MoveConversationToFolderUseCase
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -49,19 +45,13 @@ interface MoveConversationToFolderVM {
     fun moveConversationToFolder(folder: ConversationFolder) {}
 }
 
-@HiltViewModel(assistedFactory = MoveConversationToFolderVMImpl.Factory::class)
-class MoveConversationToFolderVMImpl @AssistedInject constructor(
+class MoveConversationToFolderVMImpl(
     private val dispatchers: DispatcherProvider,
-    @Assisted val args: MoveConversationToFolderArgs,
+    private val args: MoveConversationToFolderArgs,
     private val moveConversationToFolder: MoveConversationToFolderUseCase,
 ) : MoveConversationToFolderVM, ViewModel() {
 
     private var state: MoveConversationToFolderState by mutableStateOf(MoveConversationToFolderState())
-
-    @AssistedFactory
-    interface Factory {
-        fun create(args: MoveConversationToFolderArgs): MoveConversationToFolderVMImpl
-    }
 
     private val _infoMessage = MutableSharedFlow<UIText>()
     override val infoMessage = _infoMessage.asSharedFlow()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/NewConversationFolderScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/NewConversationFolderScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
@@ -54,6 +53,7 @@ import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.textfield.maxLengthWithCallback
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.home.conversations.newFolderViewModel
 import com.wire.android.ui.home.settings.account.displayname.ChangeDisplayNameViewModel.Companion.NAME_MAX_COUNT
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
@@ -68,7 +68,7 @@ import com.wire.android.util.ui.SnackBarMessageHandler
 fun NewConversationFolderScreen(
     navigator: Navigator,
     resultNavigator: ResultBackNavigator<NewConversationFolderNavBackArgs>,
-    viewModel: NewFolderViewModel = wireViewModel()
+    viewModel: NewFolderViewModel = newFolderViewModel()
 ) {
 
     LaunchedEffect(viewModel.folderNameState.folderId) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/NewFolderViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/folder/NewFolderViewModel.kt
@@ -30,16 +30,13 @@ import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.feature.conversation.folder.CreateConversationFolderUseCase
 import com.wire.kalium.logic.feature.conversation.folder.ObserveUserFoldersUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class NewFolderViewModel @Inject constructor(
+class NewFolderViewModel(
     private val observeUserFolders: ObserveUserFoldersUseCase,
     private val createConversationFolder: CreateConversationFolderUseCase
 ) : ViewModel() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/promoteadmin/PromoteAdminScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/promoteadmin/PromoteAdminScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wire.android.R
 import com.wire.android.model.Clickable
@@ -56,6 +55,7 @@ import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.home.conversations.promoteAdminViewModel
 import com.wire.android.ui.home.conversations.search.InternalContactSearchResultItem
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.theme.WireTheme
@@ -74,7 +74,7 @@ import com.wire.android.ui.common.R as commonR
 @Composable
 fun PromoteAdminScreen(
     navigator: Navigator,
-    viewModel: PromoteAdminViewModel = wireViewModel(),
+    viewModel: PromoteAdminViewModel = promoteAdminViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = LocalSnackbarHostState.current

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/promoteadmin/PromoteAdminViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/promoteadmin/PromoteAdminViewModel.kt
@@ -29,7 +29,6 @@ import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.ObserveEligibleMembersForConversationAdminRoleUseCase
 import com.wire.kalium.logic.feature.conversation.PromoteAdminAndLeaveConversationUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -37,10 +36,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
-@HiltViewModel
-class PromoteAdminViewModel @Inject constructor(
+class PromoteAdminViewModel(
     private val promoteAdminAndLeave: PromoteAdminAndLeaveConversationUseCase,
     private val observeEligibleMembers: ObserveEligibleMembersForConversationAdminRoleUseCase,
     private val dispatchers: DispatcherProvider,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchUserViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchUserViewModel.kt
@@ -35,7 +35,6 @@ import com.wire.kalium.logic.feature.search.IsFederationSearchAllowedUseCase
 import com.wire.kalium.logic.feature.search.SearchByHandleUseCase
 import com.wire.kalium.logic.feature.search.SearchUserResult
 import com.wire.kalium.logic.feature.search.SearchUsersUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
@@ -48,10 +47,8 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class SearchUserViewModel @Inject constructor(
+class SearchUserViewModel(
     private val searchUserUseCase: SearchUsersUseCase,
     private val searchByHandleUseCase: SearchByHandleUseCase,
     private val contactMapper: ContactMapper,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchUsersAndAppsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/SearchUsersAndAppsScreen.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.model.ItemActionType
 import com.wire.android.ui.common.CollapsingTopBarScaffold
@@ -68,6 +67,7 @@ import com.wire.android.ui.common.search.rememberSearchbarState
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.topappbar.search.SearchTopBar
+import com.wire.android.ui.home.conversations.searchUserViewModel
 import com.wire.android.ui.home.conversations.search.apps.SearchAppsScreen
 import com.wire.android.ui.home.newconversation.common.ContinueButton
 import com.wire.android.ui.home.newconversation.common.CreateRegularGroupOrChannelButtons
@@ -320,7 +320,7 @@ private fun SearchAllPeopleOrContactsScreen(
     actionType: ItemActionType,
     onOpenUserProfile: (Contact) -> Unit,
     onContactChecked: (Boolean, Contact) -> Unit,
-    searchUserViewModel: SearchUserViewModel = wireViewModel(),
+    searchUserViewModel: SearchUserViewModel = searchUserViewModel(),
     lazyListState: LazyListState = rememberLazyListState(),
     firstContactFocusRequester: FocusRequester? = null,
     nextFocusRequester: FocusRequester? = null,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/adddembertoconversation/AddMembersSearchScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/adddembertoconversation/AddMembersSearchScreen.kt
@@ -20,12 +20,12 @@ package com.wire.android.ui.home.conversations.search.adddembertoconversation
 import com.wire.android.navigation.annotation.app.WireRootDestination
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.ramcosta.composedestinations.generated.app.destinations.OtherUserProfileScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.ServiceDetailsScreenDestination
+import com.wire.android.ui.home.conversations.addMembersToConversationViewModel
 import com.wire.android.ui.home.conversations.search.AddMembersSearchNavArgs
 import com.wire.android.ui.home.conversations.search.SearchPeopleScreenType
 import com.wire.android.ui.home.conversations.search.SearchUsersAndAppsScreen
@@ -42,7 +42,7 @@ import com.wire.kalium.logic.data.user.UserId
 fun AddMembersSearchScreen(
     navigator: Navigator,
     navArgs: AddMembersSearchNavArgs,
-    addMembersToConversationViewModel: AddMembersToConversationViewModel = wireViewModel(),
+    addMembersToConversationViewModel: AddMembersToConversationViewModel = addMembersToConversationViewModel(),
 ) {
     if (addMembersToConversationViewModel.newGroupState.isCompleted) {
         navigator.navigateBack()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/adddembertoconversation/AddMembersToConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/adddembertoconversation/AddMembersToConversationViewModel.kt
@@ -30,16 +30,13 @@ import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.AddMemberToConversationUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
-@HiltViewModel
-class AddMembersToConversationViewModel @Inject constructor(
+class AddMembersToConversationViewModel(
     private val addMemberToConversation: AddMemberToConversationUseCase,
     private val dispatchers: DispatcherProvider,
     savedStateHandle: SavedStateHandle

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.ArrowRightIcon
@@ -46,6 +45,7 @@ import com.wire.android.ui.common.progress.CenteredCircularProgressBarIndicator
 import com.wire.android.ui.common.rowitem.RowItemTemplate
 import com.wire.android.ui.common.upgradetoapps.UpgradeToGetAppsBanner
 import com.wire.android.ui.home.conversations.search.HighlightName
+import com.wire.android.ui.home.conversations.searchAppsViewModel
 import com.wire.android.ui.home.conversations.search.widget.SearchFailureBox
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.newconversation.model.Contact
@@ -66,10 +66,7 @@ fun SearchAppsScreen(
     searchQuery: String,
     onServiceClicked: (Contact) -> Unit,
     isConversationAppsEnabled: Boolean,
-    searchAppsViewModel: SearchAppsViewModel = wireViewModel<SearchAppsViewModel, SearchAppsViewModel.Factory>(
-        key = "search_apps_protocol_info_${protocolInfo?.name()}",
-        creationCallback = { factory -> factory.create(protocolInfo = protocolInfo) }
-    ),
+    searchAppsViewModel: SearchAppsViewModel = searchAppsViewModel(protocolInfo),
     lazyListState: LazyListState = rememberLazyListState()
 ) {
     LaunchedEffect(key1 = searchQuery) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/apps/SearchAppsViewModel.kt
@@ -37,10 +37,6 @@ import com.wire.kalium.logic.feature.service.ObserveAllServicesUseCase
 import com.wire.kalium.logic.feature.service.SearchServicesByNameUseCase
 import com.wire.kalium.logic.feature.service.SyncServicesUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -52,9 +48,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 
-@HiltViewModel(assistedFactory = SearchAppsViewModel.Factory::class)
-class SearchAppsViewModel @AssistedInject constructor(
-    @Assisted val protocolInfo: Conversation.ProtocolInfo?,
+class SearchAppsViewModel(
+    private val protocolInfo: Conversation.ProtocolInfo?,
     private val getAllServices: ObserveAllServicesUseCase,
     private val syncServices: SyncServicesUseCase,
     private val getAllApps: ObserveAllAppsUseCase,
@@ -129,11 +124,6 @@ class SearchAppsViewModel @AssistedInject constructor(
                 result = result.first().map(contactMapper::fromService).toImmutableList()
             )
         }
-    }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(protocolInfo: Conversation.ProtocolInfo?): SearchAppsViewModel
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import com.wire.android.di.wireViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ramcosta.composedestinations.generated.app.destinations.ConversationScreenDestination
 import com.ramcosta.composedestinations.generated.cells.destinations.SearchScreenDestination
@@ -45,6 +44,7 @@ import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topBarElevation
 import com.wire.android.ui.common.topappbar.search.SearchTopBar
 import com.wire.android.ui.home.conversations.ConversationNavArgs
+import com.wire.android.ui.home.conversations.searchConversationMessagesViewModel
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -59,7 +59,7 @@ import com.wire.android.ui.common.R as commonR
 @Composable
 fun SearchConversationMessagesScreen(
     navigator: Navigator,
-    searchConversationMessagesViewModel: SearchConversationMessagesViewModel = wireViewModel()
+    searchConversationMessagesViewModel: SearchConversationMessagesViewModel = searchConversationMessagesViewModel()
 ) {
     SearchConversationMessagesResultContent(
         isCellsConversation = searchConversationMessagesViewModel.isCellsConversation,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesViewModel.kt
@@ -29,16 +29,13 @@ import com.wire.android.ui.home.conversations.usecase.GetConversationMessagesFro
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.id.QualifiedID
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.onEach
-import javax.inject.Inject
 
-@HiltViewModel
-class SearchConversationMessagesViewModel @Inject constructor(
+class SearchConversationMessagesViewModel(
     private val getSearchMessagesForConversation: GetConversationMessagesFromSearchUseCase,
     private val dispatchers: DispatcherProvider,
     savedStateHandle: SavedStateHandle

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/AllConversationsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/AllConversationsScreen.kt
@@ -22,15 +22,14 @@ import com.wire.android.navigation.annotation.app.WireHomeDestination
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
-import com.wire.android.di.wireViewModel
 import com.wire.android.navigation.HomeDestination
 import com.wire.android.navigation.rememberNavigator
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
 import com.wire.android.ui.common.search.rememberSearchbarState
 import com.wire.android.ui.home.HomeStateHolder
+import com.wire.android.ui.home.conversations.conversationFoldersViewModel
 import com.wire.android.ui.home.conversations.folder.ConversationFoldersStateArgs
 import com.wire.android.ui.home.conversations.folder.ConversationFoldersVM
-import com.wire.android.ui.home.conversations.folder.ConversationFoldersVMImpl
 import com.wire.android.ui.home.conversationslist.ConversationListViewModelPreview
 import com.wire.android.ui.home.conversationslist.ConversationsScreenContent
 import com.wire.android.ui.home.conversationslist.common.previewConversationItemsFlow
@@ -45,9 +44,7 @@ import com.wire.kalium.logic.data.conversation.ConversationFilter
 fun AllConversationsScreen(
     homeStateHolder: HomeStateHolder,
     foldersViewModel: ConversationFoldersVM =
-        wireViewModel<ConversationFoldersVMImpl, ConversationFoldersVMImpl.Factory>(
-            creationCallback = { it.create(ConversationFoldersStateArgs(null)) }
-        ),
+        conversationFoldersViewModel(ConversationFoldersStateArgs(null)),
 ) {
     with(homeStateHolder) {
         Crossfade(

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -4995,6 +4995,12 @@ public fun com.wire.android.ui.home.conversations.UsersTypingIndicatorForConvers
     - viewModel: RUNTIME (requires runtime check)
 
 @Composable
+public fun com.wire.android.ui.home.conversations.addMembersToConversationViewModel(): com.wire.android.ui.home.conversations.search.adddembertoconversation.AddMembersToConversationViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 public fun com.wire.android.ui.home.conversations.assetLocalPathViewModel(args: com.wire.android.ui.home.conversations.messages.item.AssetLocalPathArgs, keyInScopeResolver: kotlin.Function1<@[ParameterName(name = \): com.wire.android.ui.home.conversations.messages.item.AssetLocalPathViewModel
   skippable: false
   restartable: true
@@ -5051,6 +5057,12 @@ private fun com.wire.android.ui.home.conversations.channels.Content(searchQueryT
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
+public fun com.wire.android.ui.home.conversations.checkAssetRestrictionsViewModel(): com.wire.android.ui.home.conversations.media.CheckAssetRestrictionsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 public fun com.wire.android.ui.home.conversations.compositeMessageViewModel(args: com.wire.android.ui.home.conversations.model.CompositeMessageArgs): com.wire.android.ui.home.conversations.CompositeMessageViewModel
   skippable: true
   restartable: true
@@ -5065,6 +5077,13 @@ public fun com.wire.android.ui.home.conversations.conversationAssetPathsViewMode
     - conversationKey: STABLE (String is immutable)
 
 @Composable
+public fun com.wire.android.ui.home.conversations.conversationFoldersViewModel(args: com.wire.android.ui.home.conversations.folder.ConversationFoldersStateArgs): com.wire.android.ui.home.conversations.folder.ConversationFoldersVM
+  skippable: true
+  restartable: true
+  params:
+    - args: STABLE (class with no mutable properties)
+
+@Composable
 public fun com.wire.android.ui.home.conversations.conversationMessagesViewModel(): com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
   skippable: true
   restartable: true
@@ -5072,6 +5091,12 @@ public fun com.wire.android.ui.home.conversations.conversationMessagesViewModel(
 
 @Composable
 public fun com.wire.android.ui.home.conversations.conversationMigrationViewModel(): com.wire.android.ui.home.conversations.migration.ConversationMigrationViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.conversations.createPasswordGuestLinkViewModel(): com.wire.android.ui.home.conversations.details.editguestaccess.createPasswordProtectedGuestLink.CreatePasswordGuestLinkViewModel
   skippable: true
   restartable: true
   params:
@@ -5803,6 +5828,24 @@ public fun com.wire.android.ui.home.conversations.edit.textMessageEditMenuItems(
     - onEditClick: STABLE (function type)
 
 @Composable
+public fun com.wire.android.ui.home.conversations.editConversationMetadataViewModel(): com.wire.android.ui.home.conversations.details.metadata.EditConversationMetadataViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.conversations.editGuestAccessViewModel(): com.wire.android.ui.home.conversations.details.editguestaccess.EditGuestAccessViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.conversations.editSelfDeletingMessagesViewModel(): com.wire.android.ui.home.conversations.details.editselfdeletingmessages.EditSelfDeletingMessagesViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 private fun com.wire.android.ui.home.conversations.folder.Content(args: com.wire.android.ui.home.conversations.folder.ConversationFoldersNavArgs, foldersState: com.wire.android.ui.home.conversations.folder.ConversationFoldersState, onNavigationPressed: kotlin.Function0<kotlin.Unit>, moveConversationToFolder: kotlin.Function1<@[ParameterName(name = \, onFolderSelected: kotlin.Function1<@[ParameterName(name = \, onCreateFolderPressed: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: false
   restartable: true
@@ -5866,6 +5909,18 @@ private fun com.wire.android.ui.home.conversations.getTitle(dialogState: com.wir
   restartable: true
   params:
     - dialogState: STABLE (class with no mutable properties)
+
+@Composable
+public fun com.wire.android.ui.home.conversations.groupConversationDetailsViewModel(): com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.conversations.groupConversationParticipantsViewModel(): com.wire.android.ui.home.conversations.details.participants.GroupConversationParticipantsViewModel
+  skippable: true
+  restartable: true
+  params:
 
 @Composable
 public fun com.wire.android.ui.home.conversations.isFileSharingEnabledViewModel(): com.wire.android.ui.home.messagecomposer.attachments.IsFileSharingEnabledViewModel
@@ -7398,6 +7453,25 @@ private fun com.wire.android.ui.home.conversations.model.messagetypes.video.Vide
     - durationModifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
+public fun com.wire.android.ui.home.conversations.moveConversationToFolderViewModel(args: com.wire.android.ui.home.conversations.folder.MoveConversationToFolderArgs): com.wire.android.ui.home.conversations.folder.MoveConversationToFolderVM
+  skippable: true
+  restartable: true
+  params:
+    - args: STABLE (matched by stability configuration)
+
+@Composable
+public fun com.wire.android.ui.home.conversations.newFolderViewModel(): com.wire.android.ui.home.conversations.folder.NewFolderViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.conversations.promoteAdminViewModel(): com.wire.android.ui.home.conversations.promoteadmin.PromoteAdminViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 private fun com.wire.android.ui.home.conversations.promoteadmin.PromoteAdminContent(state: com.wire.android.ui.home.conversations.promoteadmin.PromoteAdminState, onSearchQueryChanged: kotlin.Function1<kotlin.String, kotlin.Unit>, onUserSelected: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, onPromoteAdminAndLeave: kotlin.Function0<kotlin.Unit>, onClose: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: false
   restartable: true
@@ -7777,6 +7851,25 @@ public fun com.wire.android.ui.home.conversations.search.widget.SearchFailureBox
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
+public fun com.wire.android.ui.home.conversations.searchAppsViewModel(protocolInfo: com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo?): com.wire.android.ui.home.conversations.search.apps.SearchAppsViewModel
+  skippable: false
+  restartable: true
+  params:
+    - protocolInfo: UNSTABLE (has mutable properties or unstable members)
+
+@Composable
+public fun com.wire.android.ui.home.conversations.searchConversationMessagesViewModel(): com.wire.android.ui.home.conversations.search.messages.SearchConversationMessagesViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.conversations.searchUserViewModel(): com.wire.android.ui.home.conversations.search.SearchUserViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 public fun com.wire.android.ui.home.conversations.selfDeletingMessageActionViewModel(args: com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionArgs): com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModel
   skippable: false
   restartable: true
@@ -7827,6 +7920,18 @@ public fun com.wire.android.ui.home.conversations.typingIndicatorViewModel(args:
   restartable: true
   params:
     - args: UNSTABLE (has mutable properties or unstable members)
+
+@Composable
+public fun com.wire.android.ui.home.conversations.updateAppsAccessViewModel(): com.wire.android.ui.home.conversations.details.updateappsaccess.UpdateAppsAccessViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.conversations.updateChannelAccessViewModel(): com.wire.android.ui.home.conversations.details.updatechannelaccess.UpdateChannelAccessViewModel
+  skippable: true
+  restartable: true
+  params:
 
 @Composable
 public fun com.wire.android.ui.home.conversationslist.ConversationsScreenContent(navigator: com.wire.android.navigation.Navigator, searchBarState: com.wire.android.ui.common.search.SearchBarState, modifier: androidx.compose.ui.Modifier, emptyListContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction1<@[ParameterName(name = \, lazyListState: androidx.compose.foundation.lazy.LazyListState, loadingListContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, conversationsSource: com.wire.android.ui.home.conversationslist.model.ConversationsSource, emptySearchResultFocusRequester: androidx.compose.ui.focus.FocusRequester?, firstConversationFocusRequester: androidx.compose.ui.focus.FocusRequester?, conversationListCallViewModel: com.wire.android.ui.home.conversationslist.ConversationListCallViewModel, conversationListViewModel: com.wire.android.ui.home.conversationslist.ConversationListViewModel): kotlin.Unit

--- a/config/compose-stability.conf
+++ b/config/compose-stability.conf
@@ -1,4 +1,7 @@
 kotlinx.datetime.Instant
+com.wire.android.ui.home.conversations.folder.MoveConversationToFolderArgs
+com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
+com.wire.kalium.logic.data.id.ConversationId
 com.wire.kalium.logic.data.id.GroupID
 com.wire.kalium.logic.data.id.PlainID
 com.wire.kalium.logic.data.id.QualifiedID


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25946
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Migrates conversation search and folder ViewModels from Hilt call-site creation to Metro-backed factories.
- Covers message/user/app search, folder management, and move-to-folder wiring.
- Keeps existing screen contracts and assisted arguments behavior unchanged.