### PR TITLE
refactor: migrate scoped message view models to metro [WPB-25946]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/ViewModelScoped.kt
+++ b/app/src/main/kotlin/com/wire/android/di/ViewModelScoped.kt
@@ -19,9 +19,13 @@ package com.wire.android.di
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import com.wire.android.di.metro.LocalMetroViewModelGraph
+import com.wire.android.di.metro.MetroViewModelGraph
 import com.sebaslogen.resaca.KeyInScopeResolver
 import com.sebaslogen.resaca.hilt.hiltViewModelScoped as resacaHiltViewModelScoped
+import com.sebaslogen.resaca.viewModelScoped as resacaViewModelScoped
 import kotlin.time.Duration
 
 /**
@@ -42,25 +46,23 @@ interface AssistedViewModelFactory<VM : ViewModel, R : ScopedArgs> {
  *
  * @param arguments The arguments that will be provided to the [ViewModel].
  */
-@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 @Composable
 inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedViewModelFactory<T, R>>
-        wireViewModelScoped(arguments: R, clearDelay: Duration? = null): S where T : ViewModel, T : S = when {
+        wireViewModelScoped(arguments: R, clearDelay: Duration? = null): S where T : ViewModel = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     else -> resacaHiltViewModelScoped<T, F>(key = arguments.key?.toString(), clearDelay = clearDelay) { factory ->
         factory.create(arguments)
-    }
+    } as S
 }
 
-@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 @Composable
 inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedViewModelFactory<T, R>>
         wireViewModelScoped(
     arguments: R,
     noinline keyInScopeResolver: KeyInScopeResolver<String>,
     clearDelay: Duration? = null,
-): S where T : ViewModel, T : S = when {
+): S where T : ViewModel = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     else -> {
@@ -73,7 +75,7 @@ inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedVi
             clearDelay = clearDelay
         ) { factory ->
             factory.create(arguments)
-        }
+        } as S
     }
 }
 
@@ -85,12 +87,11 @@ inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedVi
  * [ViewModel] needs to implement an interface annotated with [ViewModelScopedPreview] and with default
  * implementations.
  */
-@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 @Composable
-inline fun <reified T, reified S> wireViewModelScoped(): S where T : ViewModel, T : S = when {
+inline fun <reified T, reified S> wireViewModelScoped(): S where T : ViewModel = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
-    else -> resacaHiltViewModelScoped<T>()
+    else -> resacaHiltViewModelScoped<T>() as S
 }
 
 @Composable
@@ -100,22 +101,99 @@ inline fun <reified T : ViewModel> wireViewModelScoped(): T = when {
     else -> resacaHiltViewModelScoped<T>()
 }
 
+@Composable
+inline fun <reified Graph, reified T, reified S, reified R : ScopedArgs> wireMetroViewModelScoped(
+    arguments: R,
+    clearDelay: Duration? = null,
+    noinline create: Graph.(SavedStateHandle, R) -> T,
+): S where Graph : MetroViewModelGraph, T : ViewModel = when {
+    LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
+    espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
+    else -> {
+        val graph = currentMetroViewModelGraph<Graph>()
+        resacaViewModelScoped<T>(
+            key = arguments.key?.toString(),
+            clearDelay = clearDelay,
+        ) { savedStateHandle ->
+            graph.create(savedStateHandle, arguments)
+        } as S
+    }
+}
+
+@Composable
+inline fun <reified Graph, reified T, reified S, reified R : ScopedArgs> wireMetroViewModelScoped(
+    arguments: R,
+    noinline keyInScopeResolver: KeyInScopeResolver<String>,
+    clearDelay: Duration? = null,
+    noinline create: Graph.(SavedStateHandle, R) -> T,
+): S where Graph : MetroViewModelGraph, T : ViewModel = when {
+    LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
+    espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
+    else -> {
+        val graph = currentMetroViewModelGraph<Graph>()
+        val scopedKey = requireNotNull(arguments.key?.toString()) {
+            "Scoped key must not be null for ${T::class.qualifiedName}"
+        }
+        resacaViewModelScoped<T, String>(
+            key = scopedKey,
+            keyInScopeResolver = keyInScopeResolver,
+            clearDelay = clearDelay,
+        ) { savedStateHandle ->
+            graph.create(savedStateHandle, arguments)
+        } as S
+    }
+}
+
+@Composable
+inline fun <reified Graph, reified T, reified S> wireMetroViewModelScoped(
+    clearDelay: Duration? = null,
+    noinline create: Graph.(SavedStateHandle) -> T,
+): S where Graph : MetroViewModelGraph, T : ViewModel = when {
+    LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
+    espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
+    else -> {
+        val graph = currentMetroViewModelGraph<Graph>()
+        resacaViewModelScoped<T>(clearDelay = clearDelay) { savedStateHandle ->
+            graph.create(savedStateHandle)
+        } as S
+    }
+}
+
+@Composable
+inline fun <reified Graph, reified T> wireMetroViewModelScoped(
+    clearDelay: Duration? = null,
+    noinline create: Graph.(SavedStateHandle) -> T,
+): T where Graph : MetroViewModelGraph, T : ViewModel = when {
+    LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? T }
+    espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? T }
+    else -> {
+        val graph = currentMetroViewModelGraph<Graph>()
+        resacaViewModelScoped<T>(clearDelay = clearDelay) { savedStateHandle ->
+            graph.create(savedStateHandle)
+        }
+    }
+}
+
+@Composable
+inline fun <reified Graph : MetroViewModelGraph> currentMetroViewModelGraph(): Graph =
+    checkNotNull(LocalMetroViewModelGraph.current as? Graph) {
+        "No Metro graph matching ${Graph::class.qualifiedName} was provided"
+    }
+
 @Deprecated("Use wireViewModelScoped so call sites do not depend on the Hilt-backed implementation.")
-@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 @Composable
 inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedViewModelFactory<T, R>>
-        hiltViewModelScoped(arguments: R, clearDelay: Duration? = null): S where T : ViewModel, T : S =
+        hiltViewModelScoped(arguments: R, clearDelay: Duration? = null): S where T : ViewModel =
     wireViewModelScoped<T, S, R, F>(arguments = arguments, clearDelay = clearDelay)
 
 @Deprecated("Use wireViewModelScoped so call sites do not depend on the Hilt-backed implementation.")
-@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 @Composable
 inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedViewModelFactory<T, R>>
         hiltViewModelScoped(
     arguments: R,
     noinline keyInScopeResolver: KeyInScopeResolver<String>,
     clearDelay: Duration? = null,
-): S where T : ViewModel, T : S =
+): S where T : ViewModel =
     wireViewModelScoped<T, S, R, F>(
         arguments = arguments,
         keyInScopeResolver = keyInScopeResolver,
@@ -123,9 +201,8 @@ inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedVi
     )
 
 @Deprecated("Use wireViewModelScoped so call sites do not depend on the Hilt-backed implementation.")
-@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 @Composable
-inline fun <reified T, reified S> hiltViewModelScoped(): S where T : ViewModel, T : S =
+inline fun <reified T, reified S> hiltViewModelScoped(): S where T : ViewModel =
     wireViewModelScoped<T, S>()
 
 @Deprecated("Use wireViewModelScoped so call sites do not depend on the Hilt-backed implementation.")

--- a/app/src/main/kotlin/com/wire/android/di/ViewModelScoped.kt
+++ b/app/src/main/kotlin/com/wire/android/di/ViewModelScoped.kt
@@ -47,8 +47,9 @@ interface AssistedViewModelFactory<VM : ViewModel, R : ScopedArgs> {
  * @param arguments The arguments that will be provided to the [ViewModel].
  */
 @Composable
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedViewModelFactory<T, R>>
-        wireViewModelScoped(arguments: R, clearDelay: Duration? = null): S where T : ViewModel = when {
+        wireViewModelScoped(arguments: R, clearDelay: Duration? = null): S where T : ViewModel, T : S = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     else -> resacaHiltViewModelScoped<T, F>(key = arguments.key?.toString(), clearDelay = clearDelay) { factory ->
@@ -57,12 +58,13 @@ inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedVi
 }
 
 @Composable
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedViewModelFactory<T, R>>
         wireViewModelScoped(
     arguments: R,
     noinline keyInScopeResolver: KeyInScopeResolver<String>,
     clearDelay: Duration? = null,
-): S where T : ViewModel = when {
+): S where T : ViewModel, T : S = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     else -> {
@@ -88,7 +90,8 @@ inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedVi
  * implementations.
  */
 @Composable
-inline fun <reified T, reified S> wireViewModelScoped(): S where T : ViewModel = when {
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
+inline fun <reified T, reified S> wireViewModelScoped(): S where T : ViewModel, T : S = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     else -> resacaHiltViewModelScoped<T>() as S
@@ -102,11 +105,12 @@ inline fun <reified T : ViewModel> wireViewModelScoped(): T = when {
 }
 
 @Composable
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 inline fun <reified Graph, reified T, reified S, reified R : ScopedArgs> wireMetroViewModelScoped(
     arguments: R,
     clearDelay: Duration? = null,
     noinline create: Graph.(SavedStateHandle, R) -> T,
-): S where Graph : MetroViewModelGraph, T : ViewModel = when {
+): S where Graph : MetroViewModelGraph, T : ViewModel, T : S = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     else -> {
@@ -121,12 +125,13 @@ inline fun <reified Graph, reified T, reified S, reified R : ScopedArgs> wireMet
 }
 
 @Composable
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 inline fun <reified Graph, reified T, reified S, reified R : ScopedArgs> wireMetroViewModelScoped(
     arguments: R,
     noinline keyInScopeResolver: KeyInScopeResolver<String>,
     clearDelay: Duration? = null,
     noinline create: Graph.(SavedStateHandle, R) -> T,
-): S where Graph : MetroViewModelGraph, T : ViewModel = when {
+): S where Graph : MetroViewModelGraph, T : ViewModel, T : S = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     else -> {
@@ -145,10 +150,11 @@ inline fun <reified Graph, reified T, reified S, reified R : ScopedArgs> wireMet
 }
 
 @Composable
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 inline fun <reified Graph, reified T, reified S> wireMetroViewModelScoped(
     clearDelay: Duration? = null,
     noinline create: Graph.(SavedStateHandle) -> T,
-): S where Graph : MetroViewModelGraph, T : ViewModel = when {
+): S where Graph : MetroViewModelGraph, T : ViewModel, T : S = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     else -> {
@@ -182,18 +188,20 @@ inline fun <reified Graph : MetroViewModelGraph> currentMetroViewModelGraph(): G
 
 @Deprecated("Use wireViewModelScoped so call sites do not depend on the Hilt-backed implementation.")
 @Composable
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedViewModelFactory<T, R>>
-        hiltViewModelScoped(arguments: R, clearDelay: Duration? = null): S where T : ViewModel =
+        hiltViewModelScoped(arguments: R, clearDelay: Duration? = null): S where T : ViewModel, T : S =
     wireViewModelScoped<T, S, R, F>(arguments = arguments, clearDelay = clearDelay)
 
 @Deprecated("Use wireViewModelScoped so call sites do not depend on the Hilt-backed implementation.")
 @Composable
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedViewModelFactory<T, R>>
         hiltViewModelScoped(
     arguments: R,
     noinline keyInScopeResolver: KeyInScopeResolver<String>,
     clearDelay: Duration? = null,
-): S where T : ViewModel =
+): S where T : ViewModel, T : S =
     wireViewModelScoped<T, S, R, F>(
         arguments = arguments,
         keyInScopeResolver = keyInScopeResolver,
@@ -202,7 +210,8 @@ inline fun <reified T, reified S, reified R : ScopedArgs, reified F : AssistedVi
 
 @Deprecated("Use wireViewModelScoped so call sites do not depend on the Hilt-backed implementation.")
 @Composable
-inline fun <reified T, reified S> hiltViewModelScoped(): S where T : ViewModel =
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
+inline fun <reified T, reified S> hiltViewModelScoped(): S where T : ViewModel, T : S =
     wireViewModelScoped<T, S>()
 
 @Deprecated("Use wireViewModelScoped so call sites do not depend on the Hilt-backed implementation.")

--- a/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
@@ -46,6 +46,7 @@ import javax.inject.Provider
 /**
  * Android-only bridge for feature ViewModel factories while feature UI is being decoupled from Hilt call sites.
  */
+@Suppress("LongParameterList")
 @HiltViewModel
 class WireActivityViewModelGraphBridge @Inject constructor(
     imageLoader: Provider<WireSessionImageLoader>,

--- a/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
@@ -34,6 +34,8 @@ import com.wire.android.ui.home.HomeViewModelFactory
 import com.wire.android.ui.home.HomeViewModelGraph
 import com.wire.android.ui.home.conversations.ConversationCoreViewModelFactory
 import com.wire.android.ui.home.conversations.ConversationCoreViewModelGraph
+import com.wire.android.ui.home.conversations.ScopedMessageViewModelFactory
+import com.wire.android.ui.home.conversations.ScopedMessageViewModelGraph
 import com.wire.android.ui.home.settings.SettingsViewModelFactory
 import com.wire.android.ui.home.settings.SettingsViewModelGraph
 import com.wire.android.util.ui.WireSessionImageLoader
@@ -55,6 +57,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     private val settingsViewModelFactoryProvider: Provider<SettingsViewModelFactory>,
     private val conversationCoreViewModelFactoryProvider: Provider<ConversationCoreViewModelFactory>,
     private val meetingsViewModelFactoryProvider: Provider<MeetingsViewModelFactory>,
+    private val scopedMessageViewModelFactoryProvider: Provider<ScopedMessageViewModelFactory>,
 ) : ViewModel(),
     ImageAssetViewModelGraph,
     CellsViewModelGraph,
@@ -64,7 +67,8 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     HomeViewModelGraph,
     SettingsViewModelGraph,
     ConversationCoreViewModelGraph,
-    MeetingsViewModelGraph {
+    MeetingsViewModelGraph,
+    ScopedMessageViewModelGraph {
     override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
         ImageAssetViewModelFactory(imageLoader = imageLoader::get)
 
@@ -91,4 +95,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
 
     override val meetingsViewModelFactory: MeetingsViewModelFactory
         get() = meetingsViewModelFactoryProvider.get()
+
+    override val scopedMessageViewModelFactory: ScopedMessageViewModelFactory
+        get() = scopedMessageViewModelFactoryProvider.get()
 }

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioMessageViewModel.kt
@@ -23,17 +23,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.di.AssistedViewModelFactory
 import com.wire.android.di.ScopedArgs
 import com.wire.android.di.ViewModelScopedPreview
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.AssetContent.AssetMetadata
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.feature.message.ObserveMessageByIdUseCase
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -51,11 +46,10 @@ interface AudioMessageViewModel {
     fun changeAudioSpeed(audioSpeed: AudioSpeed) {}
 }
 
-@HiltViewModel(assistedFactory = AudioMessageViewModelImpl.Factory::class)
-class AudioMessageViewModelImpl @AssistedInject constructor(
+class AudioMessageViewModelImpl(
     private val audioMessagePlayer: ConversationAudioMessagePlayer,
     private val observeMessageById: ObserveMessageByIdUseCase,
-    @Assisted private val args: AudioMessageArgs,
+    private val args: AudioMessageArgs,
 ) : ViewModel(), AudioMessageViewModel {
 
     override var state: AudioMessageState by mutableStateOf(AudioMessageState())
@@ -138,11 +132,6 @@ class AudioMessageViewModelImpl @AssistedInject constructor(
         viewModelScope.launch {
             audioMessagePlayer.setSpeed(audioSpeed)
         }
-    }
-
-    @AssistedFactory
-    interface Factory : AssistedViewModelFactory<AudioMessageViewModelImpl, AudioMessageArgs> {
-        override fun create(args: AudioMessageArgs): AudioMessageViewModelImpl
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/CompositeMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/CompositeMessageViewModel.kt
@@ -25,16 +25,11 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ramcosta.composedestinations.generated.app.navArgs
-import com.wire.android.di.AssistedViewModelFactory
 import com.wire.android.di.ViewModelScopedPreview
 import com.wire.android.ui.home.conversations.model.CompositeMessageArgs
 import com.wire.kalium.logic.data.id.MessageButtonId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.feature.message.composite.SendButtonActionMessageUseCase
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 
 @ViewModelScopedPreview
@@ -44,11 +39,10 @@ interface CompositeMessageViewModel {
     fun sendButtonActionMessage(buttonId: String) {}
 }
 
-@HiltViewModel(assistedFactory = CompositeMessageViewModelImpl.Factory::class)
-class CompositeMessageViewModelImpl @AssistedInject constructor(
+class CompositeMessageViewModelImpl(
     private val sendButtonActionMessageUseCase: SendButtonActionMessageUseCase,
     savedStateHandle: SavedStateHandle,
-    @Assisted private val scopedArgs: CompositeMessageArgs,
+    scopedArgs: CompositeMessageArgs,
 ) : CompositeMessageViewModel, ViewModel() {
 
     private val conversationNavArgs: ConversationNavArgs = savedStateHandle.navArgs()
@@ -68,10 +62,5 @@ class CompositeMessageViewModelImpl @AssistedInject constructor(
         }.invokeOnCompletion {
             pendingButtonId = null
         }
-    }
-
-    @AssistedFactory
-    interface Factory : AssistedViewModelFactory<CompositeMessageViewModelImpl, CompositeMessageArgs> {
-        override fun create(args: CompositeMessageArgs): CompositeMessageViewModelImpl
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ScopedMessageViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ScopedMessageViewModelFactory.kt
@@ -1,0 +1,138 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.media.audiomessage.AudioFocusHelper
+import com.wire.android.media.audiomessage.AudioMessageArgs
+import com.wire.android.media.audiomessage.AudioMessageViewModelImpl
+import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
+import com.wire.android.media.audiomessage.RecordAudioMessagePlayer
+import com.wire.android.ui.home.conversations.edit.MessageOptionsMenuArgs
+import com.wire.android.ui.home.conversations.edit.MessageOptionsMenuViewModelImpl
+import com.wire.android.ui.home.conversations.messages.item.AssetLocalPathArgs
+import com.wire.android.ui.home.conversations.messages.item.AssetLocalPathViewModelImpl
+import com.wire.android.ui.home.conversations.model.CompositeMessageArgs
+import com.wire.android.ui.home.conversations.typing.TypingIndicatorArgs
+import com.wire.android.ui.home.conversations.typing.TypingIndicatorViewModelImpl
+import com.wire.android.ui.home.conversations.usecase.ObserveMessageForConversationUseCase
+import com.wire.android.ui.home.conversations.usecase.ObserveUsersTypingInConversationUseCase
+import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionArgs
+import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModelImpl
+import com.wire.android.ui.home.messagecomposer.attachments.IsFileSharingEnabledViewModelImpl
+import com.wire.android.ui.home.messagecomposer.recordaudio.AudioMediaRecorder
+import com.wire.android.ui.home.messagecomposer.recordaudio.GenerateAudioFileWithEffectsUseCase
+import com.wire.android.ui.home.messagecomposer.recordaudio.RecordAudioViewModel
+import com.wire.android.util.CurrentScreenManager
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilder
+import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
+import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
+import com.wire.kalium.logic.feature.message.ObserveMessageByIdUseCase
+import com.wire.kalium.logic.feature.message.composite.SendButtonActionMessageUseCase
+import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+class ScopedMessageViewModelFactory @Inject constructor(
+    private val sendButtonActionMessage: SendButtonActionMessageUseCase,
+    private val observeMessageForConversation: ObserveMessageForConversationUseCase,
+    private val observeUsersTypingInConversation: ObserveUsersTypingInConversationUseCase,
+    private val getMessageAsset: GetMessageAssetUseCase,
+    private val dispatchers: DispatcherProvider,
+    private val observeSelfDeletingMessages: ObserveSelfDeletionTimerSettingsForConversationUseCase,
+    private val isFileSharingEnabled: IsFileSharingEnabledUseCase,
+    @ApplicationContext private val context: Context,
+    private val recordAudioMessagePlayer: RecordAudioMessagePlayer,
+    private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
+    private val getAssetSizeLimit: GetAssetSizeLimitUseCase,
+    private val generateAudioFileWithEffects: GenerateAudioFileWithEffectsUseCase,
+    private val currentScreenManager: CurrentScreenManager,
+    private val audioMediaRecorder: AudioMediaRecorder,
+    private val globalDataStore: GlobalDataStore,
+    private val audioNormalizedLoudnessBuilder: AudioNormalizedLoudnessBuilder,
+    private val audioFocusHelper: AudioFocusHelper,
+    private val kaliumFileSystem: KaliumFileSystem,
+    private val audioMessagePlayer: ConversationAudioMessagePlayer,
+    private val observeMessageById: ObserveMessageByIdUseCase,
+) {
+    fun compositeMessageViewModel(savedStateHandle: SavedStateHandle, args: CompositeMessageArgs) =
+        CompositeMessageViewModelImpl(
+            sendButtonActionMessageUseCase = sendButtonActionMessage,
+            savedStateHandle = savedStateHandle,
+            scopedArgs = args,
+        )
+
+    fun messageOptionsMenuViewModel(args: MessageOptionsMenuArgs) =
+        MessageOptionsMenuViewModelImpl(
+            observeMessageForConversation = observeMessageForConversation,
+            args = args,
+        )
+
+    fun typingIndicatorViewModel(args: TypingIndicatorArgs) =
+        TypingIndicatorViewModelImpl(
+            observeUsersTypingInConversation = observeUsersTypingInConversation,
+            args = args,
+        )
+
+    internal fun assetLocalPathViewModel(args: AssetLocalPathArgs) =
+        AssetLocalPathViewModelImpl(
+            getMessageAsset = getMessageAsset,
+            dispatchers = dispatchers,
+            args = args,
+        )
+
+    fun selfDeletingMessageActionViewModel(args: SelfDeletingMessageActionArgs) =
+        SelfDeletingMessageActionViewModelImpl(
+            dispatchers = dispatchers,
+            observeSelfDeletingMessages = observeSelfDeletingMessages,
+            args = args,
+        )
+
+    fun isFileSharingEnabledViewModel() =
+        IsFileSharingEnabledViewModelImpl(isFileSharingEnabledUseCase = isFileSharingEnabled)
+
+    fun recordAudioViewModel() =
+        RecordAudioViewModel(
+            context = context,
+            recordAudioMessagePlayer = recordAudioMessagePlayer,
+            observeEstablishedCalls = observeEstablishedCalls,
+            getAssetSizeLimit = getAssetSizeLimit,
+            generateAudioFileWithEffects = generateAudioFileWithEffects,
+            currentScreenManager = currentScreenManager,
+            audioMediaRecorder = audioMediaRecorder,
+            globalDataStore = globalDataStore,
+            audioNormalizedLoudnessBuilder = audioNormalizedLoudnessBuilder,
+            audioFocusHelper = audioFocusHelper,
+            dispatchers = dispatchers,
+            kaliumFileSystem = kaliumFileSystem,
+        )
+
+    fun audioMessageViewModel(args: AudioMessageArgs) =
+        AudioMessageViewModelImpl(
+            audioMessagePlayer = audioMessagePlayer,
+            observeMessageById = observeMessageById,
+            args = args,
+        )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ScopedMessageViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ScopedMessageViewModelGraph.kt
@@ -1,0 +1,167 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.sebaslogen.resaca.KeyInScopeResolver
+import com.wire.android.di.ScopedArgs
+import com.wire.android.di.metro.MetroViewModelGraph
+import com.wire.android.di.wireMetroViewModelScoped
+import com.wire.android.media.audiomessage.AudioMessageArgs
+import com.wire.android.media.audiomessage.AudioMessageViewModel
+import com.wire.android.media.audiomessage.AudioMessageViewModelImpl
+import com.wire.android.ui.home.conversations.edit.MessageOptionsMenuArgs
+import com.wire.android.ui.home.conversations.edit.MessageOptionsMenuViewModel
+import com.wire.android.ui.home.conversations.edit.MessageOptionsMenuViewModelImpl
+import com.wire.android.ui.home.conversations.messages.item.AssetLocalPathArgs
+import com.wire.android.ui.home.conversations.messages.item.AssetLocalPathViewModel
+import com.wire.android.ui.home.conversations.messages.item.AssetLocalPathViewModelImpl
+import com.wire.android.ui.home.conversations.model.CompositeMessageArgs
+import com.wire.android.ui.home.conversations.typing.TypingIndicatorArgs
+import com.wire.android.ui.home.conversations.typing.TypingIndicatorViewModel
+import com.wire.android.ui.home.conversations.typing.TypingIndicatorViewModelImpl
+import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionArgs
+import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModel
+import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModelImpl
+import com.wire.android.ui.home.messagecomposer.attachments.IsFileSharingEnabledViewModel
+import com.wire.android.ui.home.messagecomposer.attachments.IsFileSharingEnabledViewModelImpl
+import com.wire.android.ui.home.messagecomposer.recordaudio.RecordAudioViewModel
+import kotlin.time.Duration
+
+interface ScopedMessageViewModelGraph : MetroViewModelGraph {
+    val scopedMessageViewModelFactory: ScopedMessageViewModelFactory
+}
+
+@Composable
+private inline fun <reified VM, reified S, reified R : ScopedArgs> scopedMessageViewModel(
+    arguments: R,
+    clearDelay: Duration? = null,
+    noinline create: ScopedMessageViewModelFactory.(SavedStateHandle, R) -> VM,
+): S where VM : ViewModel =
+    wireMetroViewModelScoped<ScopedMessageViewModelGraph, VM, S, R>(
+        arguments = arguments,
+        clearDelay = clearDelay,
+    ) { savedStateHandle, scopedArgs ->
+        scopedMessageViewModelFactory.create(savedStateHandle, scopedArgs)
+    }
+
+@Composable
+private inline fun <reified VM, reified S, reified R : ScopedArgs> scopedMessageViewModel(
+    arguments: R,
+    noinline keyInScopeResolver: KeyInScopeResolver<String>,
+    clearDelay: Duration? = null,
+    noinline create: ScopedMessageViewModelFactory.(SavedStateHandle, R) -> VM,
+): S where VM : ViewModel =
+    wireMetroViewModelScoped<ScopedMessageViewModelGraph, VM, S, R>(
+        arguments = arguments,
+        keyInScopeResolver = keyInScopeResolver,
+        clearDelay = clearDelay,
+    ) { savedStateHandle, scopedArgs ->
+        scopedMessageViewModelFactory.create(savedStateHandle, scopedArgs)
+    }
+
+@Composable
+private inline fun <reified VM, reified S> scopedMessageViewModel(
+    clearDelay: Duration? = null,
+    noinline create: ScopedMessageViewModelFactory.(SavedStateHandle) -> VM,
+): S where VM : ViewModel =
+    wireMetroViewModelScoped<ScopedMessageViewModelGraph, VM, S>(
+        clearDelay = clearDelay,
+    ) { savedStateHandle ->
+        scopedMessageViewModelFactory.create(savedStateHandle)
+    }
+
+@Composable
+fun compositeMessageViewModel(args: CompositeMessageArgs): CompositeMessageViewModel =
+    scopedMessageViewModel<CompositeMessageViewModelImpl, CompositeMessageViewModel, CompositeMessageArgs>(
+        arguments = args,
+    ) { savedStateHandle, scopedArgs ->
+        compositeMessageViewModel(savedStateHandle, scopedArgs)
+    }
+
+@Composable
+fun messageOptionsMenuViewModel(args: MessageOptionsMenuArgs): MessageOptionsMenuViewModel =
+    scopedMessageViewModel<MessageOptionsMenuViewModelImpl, MessageOptionsMenuViewModel, MessageOptionsMenuArgs>(args) { _, scopedArgs ->
+        messageOptionsMenuViewModel(scopedArgs)
+    }
+
+@Composable
+fun typingIndicatorViewModel(args: TypingIndicatorArgs): TypingIndicatorViewModel =
+    scopedMessageViewModel<TypingIndicatorViewModelImpl, TypingIndicatorViewModel, TypingIndicatorArgs>(args) { _, scopedArgs ->
+        typingIndicatorViewModel(scopedArgs)
+    }
+
+@Composable
+fun assetLocalPathViewModel(
+    args: AssetLocalPathArgs,
+    keyInScopeResolver: KeyInScopeResolver<String>? = null,
+): AssetLocalPathViewModel =
+    if (keyInScopeResolver != null) {
+        scopedMessageViewModel<AssetLocalPathViewModelImpl, AssetLocalPathViewModel, AssetLocalPathArgs>(
+            arguments = args,
+            keyInScopeResolver = keyInScopeResolver,
+        ) { _, scopedArgs ->
+            assetLocalPathViewModel(scopedArgs)
+        }
+    } else {
+        scopedMessageViewModel<AssetLocalPathViewModelImpl, AssetLocalPathViewModel, AssetLocalPathArgs>(args) { _, scopedArgs ->
+            assetLocalPathViewModel(scopedArgs)
+        }
+    }
+
+@Composable
+fun selfDeletingMessageActionViewModel(args: SelfDeletingMessageActionArgs): SelfDeletingMessageActionViewModel =
+    scopedMessageViewModel<
+            SelfDeletingMessageActionViewModelImpl,
+            SelfDeletingMessageActionViewModel,
+            SelfDeletingMessageActionArgs,
+            >(args) { _, scopedArgs ->
+        selfDeletingMessageActionViewModel(scopedArgs)
+    }
+
+@Composable
+fun isFileSharingEnabledViewModel(): IsFileSharingEnabledViewModel =
+    scopedMessageViewModel<IsFileSharingEnabledViewModelImpl, IsFileSharingEnabledViewModel> { _ ->
+        isFileSharingEnabledViewModel()
+    }
+
+@Composable
+fun recordAudioViewModel(): RecordAudioViewModel =
+    wireMetroViewModelScoped<ScopedMessageViewModelGraph, RecordAudioViewModel> {
+        scopedMessageViewModelFactory.recordAudioViewModel()
+    }
+
+@Composable
+fun audioMessageViewModel(
+    args: AudioMessageArgs,
+    keyInScopeResolver: KeyInScopeResolver<String>? = null,
+): AudioMessageViewModel =
+    if (keyInScopeResolver != null) {
+        scopedMessageViewModel<AudioMessageViewModelImpl, AudioMessageViewModel, AudioMessageArgs>(
+            arguments = args,
+            keyInScopeResolver = keyInScopeResolver,
+        ) { _, scopedArgs ->
+            audioMessageViewModel(scopedArgs)
+        }
+    } else {
+        scopedMessageViewModel<AudioMessageViewModelImpl, AudioMessageViewModel, AudioMessageArgs>(args) { _, scopedArgs ->
+            audioMessageViewModel(scopedArgs)
+        }
+    }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ScopedMessageViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ScopedMessageViewModelGraph.kt
@@ -50,11 +50,12 @@ interface ScopedMessageViewModelGraph : MetroViewModelGraph {
 }
 
 @Composable
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 private inline fun <reified VM, reified S, reified R : ScopedArgs> scopedMessageViewModel(
     arguments: R,
     clearDelay: Duration? = null,
     noinline create: ScopedMessageViewModelFactory.(SavedStateHandle, R) -> VM,
-): S where VM : ViewModel =
+): S where VM : ViewModel, VM : S =
     wireMetroViewModelScoped<ScopedMessageViewModelGraph, VM, S, R>(
         arguments = arguments,
         clearDelay = clearDelay,
@@ -63,12 +64,13 @@ private inline fun <reified VM, reified S, reified R : ScopedArgs> scopedMessage
     }
 
 @Composable
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 private inline fun <reified VM, reified S, reified R : ScopedArgs> scopedMessageViewModel(
     arguments: R,
     noinline keyInScopeResolver: KeyInScopeResolver<String>,
     clearDelay: Duration? = null,
     noinline create: ScopedMessageViewModelFactory.(SavedStateHandle, R) -> VM,
-): S where VM : ViewModel =
+): S where VM : ViewModel, VM : S =
     wireMetroViewModelScoped<ScopedMessageViewModelGraph, VM, S, R>(
         arguments = arguments,
         keyInScopeResolver = keyInScopeResolver,
@@ -78,10 +80,11 @@ private inline fun <reified VM, reified S, reified R : ScopedArgs> scopedMessage
     }
 
 @Composable
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 private inline fun <reified VM, reified S> scopedMessageViewModel(
     clearDelay: Duration? = null,
     noinline create: ScopedMessageViewModelFactory.(SavedStateHandle) -> VM,
-): S where VM : ViewModel =
+): S where VM : ViewModel, VM : S =
     wireMetroViewModelScoped<ScopedMessageViewModelGraph, VM, S>(
         clearDelay = clearDelay,
     ) { savedStateHandle ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/UsersTypingIndicator.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/UsersTypingIndicator.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
-import com.wire.android.di.wireViewModelScoped
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.avatar.UserProfileAvatarsRow
@@ -58,7 +57,6 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.details.participants.model.UIParticipant
 import com.wire.android.ui.home.conversations.typing.TypingIndicatorArgs
 import com.wire.android.ui.home.conversations.typing.TypingIndicatorViewModel
-import com.wire.android.ui.home.conversations.typing.TypingIndicatorViewModelImpl
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
@@ -74,14 +72,7 @@ private const val ANIMATION_SPEED_MILLIS = 1_500
 fun UsersTypingIndicatorForConversation(
     conversationId: ConversationId,
     viewModel: TypingIndicatorViewModel =
-        wireViewModelScoped<
-                TypingIndicatorViewModelImpl,
-                TypingIndicatorViewModel,
-                TypingIndicatorArgs,
-                TypingIndicatorViewModelImpl.Factory
-                >(
-        TypingIndicatorArgs(conversationId)
-                )
+        typingIndicatorViewModel(TypingIndicatorArgs(conversationId))
 ) {
     UsersTypingIndicator(usersTyping = viewModel.state().usersTyping)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsMenuViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsMenuViewModel.kt
@@ -19,17 +19,12 @@ package com.wire.android.ui.home.conversations.edit
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.di.AssistedViewModelFactory
 import com.wire.android.di.ScopedArgs
 import com.wire.android.di.ViewModelScopedPreview
 import com.wire.android.ui.home.conversations.mock.mockMessageWithText
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.usecase.ObserveMessageForConversationUseCase
 import com.wire.kalium.logic.data.id.QualifiedID
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -48,10 +43,9 @@ interface MessageOptionsMenuViewModel {
         MutableStateFlow(MessageOptionsMenuState.Message(mockMessageWithText))
 }
 
-@HiltViewModel(assistedFactory = MessageOptionsMenuViewModelImpl.Factory::class)
-class MessageOptionsMenuViewModelImpl @AssistedInject constructor(
+class MessageOptionsMenuViewModelImpl(
     private val observeMessageForConversation: ObserveMessageForConversationUseCase,
-    @Assisted private val args: MessageOptionsMenuArgs,
+    private val args: MessageOptionsMenuArgs,
 ) : MessageOptionsMenuViewModel, ViewModel() {
 
     private val messageStateFlow: ConcurrentHashMap<String, StateFlow<MessageOptionsMenuState>> = ConcurrentHashMap()
@@ -74,11 +68,6 @@ class MessageOptionsMenuViewModelImpl @AssistedInject constructor(
                 started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 500L),
                 initialValue = MessageOptionsMenuState.Loading,
             )
-    }
-
-    @AssistedFactory
-    interface Factory : AssistedViewModelFactory<MessageOptionsMenuViewModelImpl, MessageOptionsMenuArgs> {
-        override fun create(args: MessageOptionsMenuArgs): MessageOptionsMenuViewModelImpl
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wire.android.R
-import com.wire.android.di.wireViewModelScoped
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
 import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
@@ -36,6 +35,7 @@ import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
+import com.wire.android.ui.home.conversations.messageOptionsMenuViewModel
 import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent
@@ -62,12 +62,7 @@ fun MessageOptionsModalSheetLayout(
     onDownloadAssetClick: (messageId: String) -> Unit,
     onOpenAssetClick: (messageId: String) -> Unit,
     viewModel: MessageOptionsMenuViewModel =
-        wireViewModelScoped<
-                MessageOptionsMenuViewModelImpl,
-                MessageOptionsMenuViewModel,
-                MessageOptionsMenuArgs,
-                MessageOptionsMenuViewModelImpl.Factory
-                >(MessageOptionsMenuArgs(conversationId))
+        messageOptionsMenuViewModel(MessageOptionsMenuArgs(conversationId))
 ) {
     val context = LocalContext.current
     val snackbarHostState = LocalSnackbarHostState.current

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -55,7 +55,6 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import coil3.compose.SubcomposeAsyncImage
 import com.wire.android.R
-import com.wire.android.di.wireViewModelScoped
 import com.wire.android.model.Clickable
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.common.StatusBox
@@ -65,10 +64,10 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.typography
 import com.wire.android.ui.home.conversations.LocalAssetLocalPathKeyInScopeResolver
+import com.wire.android.ui.home.conversations.assetLocalPathViewModel
 import com.wire.android.ui.home.conversations.messages.item.MessageStyle
 import com.wire.android.ui.home.conversations.messages.item.AssetLocalPathArgs
 import com.wire.android.ui.home.conversations.messages.item.AssetLocalPathViewModel
-import com.wire.android.ui.home.conversations.messages.item.AssetLocalPathViewModelImpl
 import com.wire.android.ui.home.conversations.messages.item.highlighted
 import com.wire.android.ui.home.conversations.messages.item.isBubble
 import com.wire.android.ui.home.conversations.messages.item.textColor
@@ -622,24 +621,9 @@ private fun QuotedImageThumbnail(
     val keyInScopeResolver = LocalAssetLocalPathKeyInScopeResolver.current
     val viewModel: AssetLocalPathViewModel =
         if (keyInScopeResolver != null && keyInScopeResolver(args.key)) {
-            wireViewModelScoped<
-                    AssetLocalPathViewModelImpl,
-                    AssetLocalPathViewModel,
-                    AssetLocalPathArgs,
-                    AssetLocalPathViewModelImpl.Factory,
-                    >(
-                arguments = args,
-                keyInScopeResolver = keyInScopeResolver,
-            )
+            assetLocalPathViewModel(args, keyInScopeResolver)
         } else {
-            wireViewModelScoped<
-                    AssetLocalPathViewModelImpl,
-                    AssetLocalPathViewModel,
-                    AssetLocalPathArgs,
-                    AssetLocalPathViewModelImpl.Factory,
-                    >(
-                args
-            )
+            assetLocalPathViewModel(args)
         }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/AssetLocalPathViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/AssetLocalPathViewModel.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.di.AssistedViewModelFactory
 import com.wire.android.di.ScopedArgs
 import com.wire.android.di.ViewModelScopedPreview
 import com.wire.android.util.dispatchers.DispatcherProvider
@@ -31,10 +30,6 @@ import com.wire.kalium.logic.data.asset.AssetTransferStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -57,11 +52,10 @@ interface AssetLocalPathViewModel {
     ) {}
 }
 
-@HiltViewModel(assistedFactory = AssetLocalPathViewModelImpl.Factory::class)
-internal class AssetLocalPathViewModelImpl @AssistedInject constructor(
+internal class AssetLocalPathViewModelImpl(
     private val getMessageAsset: GetMessageAssetUseCase,
     private val dispatchers: DispatcherProvider,
-    @Assisted private val args: AssetLocalPathArgs,
+    private val args: AssetLocalPathArgs,
 ) : ViewModel(), AssetLocalPathViewModel {
     override var localAssetPath: String? by mutableStateOf(null)
         private set
@@ -98,10 +92,5 @@ internal class AssetLocalPathViewModelImpl @AssistedInject constructor(
                 }
             }
         }
-    }
-
-    @AssistedFactory
-    interface Factory : AssistedViewModelFactory<AssetLocalPathViewModelImpl, AssetLocalPathArgs> {
-        override fun create(args: AssetLocalPathArgs): AssetLocalPathViewModelImpl
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.DpSize
-import com.wire.android.di.wireViewModelScoped
 import com.wire.android.model.Clickable
 import com.wire.android.model.ImageAsset
 import com.wire.android.ui.common.applyIf
@@ -56,7 +55,7 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.home.conversations.CompositeMessageViewModel
-import com.wire.android.ui.home.conversations.CompositeMessageViewModelImpl
+import com.wire.android.ui.home.conversations.compositeMessageViewModel
 import com.wire.android.ui.home.conversations.messages.item.MessageStyle
 import com.wire.android.ui.home.conversations.messages.item.error
 import com.wire.android.ui.home.conversations.messages.item.highlighted
@@ -168,14 +167,7 @@ fun MessageButtonsContent(
     messageStyle: MessageStyle,
     modifier: Modifier = Modifier,
     viewModel: CompositeMessageViewModel =
-        wireViewModelScoped<
-                CompositeMessageViewModelImpl,
-                CompositeMessageViewModel,
-                CompositeMessageArgs,
-                CompositeMessageViewModelImpl.Factory
-                >(
-            CompositeMessageArgs(messageId)
-        )
+        compositeMessageViewModel(CompositeMessageArgs(messageId))
 ) {
     Column(
         modifier = modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -65,11 +65,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
-import com.wire.android.di.wireViewModelScoped
 import com.wire.android.media.audiomessage.AudioMediaPlayingState
 import com.wire.android.media.audiomessage.AudioMessageArgs
 import com.wire.android.media.audiomessage.AudioMessageViewModel
-import com.wire.android.media.audiomessage.AudioMessageViewModelImpl
 import com.wire.android.media.audiomessage.AudioSpeed
 import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.media.audiomessage.equalizedWavesMask
@@ -90,6 +88,7 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.home.conversations.LocalAudioMessageKeyInScopeResolver
+import com.wire.android.ui.home.conversations.audioMessageViewModel
 import com.wire.android.ui.home.conversations.messages.item.MessageStyle
 import com.wire.android.ui.home.conversations.messages.item.isBubble
 import com.wire.android.ui.home.conversations.messages.item.playedColor
@@ -181,21 +180,7 @@ private fun UploadedAudioMessage(
     modifier: Modifier = Modifier,
 ) {
     val keyInScopeResolver = LocalAudioMessageKeyInScopeResolver.current
-    val viewModel: AudioMessageViewModel = if (keyInScopeResolver != null) {
-        wireViewModelScoped<
-                AudioMessageViewModelImpl,
-                AudioMessageViewModel,
-                AudioMessageArgs,
-                AudioMessageViewModelImpl.Factory
-                >(audioMessageArgs, keyInScopeResolver)
-    } else {
-        wireViewModelScoped<
-                AudioMessageViewModelImpl,
-                AudioMessageViewModel,
-                AudioMessageArgs,
-                AudioMessageViewModelImpl.Factory
-                >(audioMessageArgs)
-    }
+    val viewModel: AudioMessageViewModel = audioMessageViewModel(audioMessageArgs, keyInScopeResolver)
 
     val sanitizedAudioState by remember(viewModel.state.audioState, audioMessageDurationInMs) {
         derivedStateOf {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/typing/TypingIndicatorViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/typing/TypingIndicatorViewModel.kt
@@ -22,15 +22,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.di.AssistedViewModelFactory
 import com.wire.android.di.ScopedArgs
 import com.wire.android.di.ViewModelScopedPreview
 import com.wire.android.ui.home.conversations.usecase.ObserveUsersTypingInConversationUseCase
 import com.wire.kalium.logic.data.id.QualifiedID
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
@@ -39,10 +34,9 @@ interface TypingIndicatorViewModel {
     fun state(): UsersTypingViewState = UsersTypingViewState()
 }
 
-@HiltViewModel(assistedFactory = TypingIndicatorViewModelImpl.Factory::class)
-class TypingIndicatorViewModelImpl @AssistedInject constructor(
+class TypingIndicatorViewModelImpl(
     private val observeUsersTypingInConversation: ObserveUsersTypingInConversationUseCase,
-    @Assisted private val args: TypingIndicatorArgs,
+    args: TypingIndicatorArgs,
 ) : TypingIndicatorViewModel, ViewModel() {
 
     val conversationId: QualifiedID = args.conversationId
@@ -59,11 +53,6 @@ class TypingIndicatorViewModelImpl @AssistedInject constructor(
                 usersTypingViewState = usersTypingViewState.copy(usersTyping = it)
             }
         }
-    }
-
-    @AssistedFactory
-    interface Factory : AssistedViewModelFactory<TypingIndicatorViewModelImpl, TypingIndicatorArgs> {
-        override fun create(args: TypingIndicatorArgs): TypingIndicatorViewModelImpl
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposeActions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposeActions.kt
@@ -31,14 +31,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
-import com.wire.android.di.wireViewModelScoped
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryIconButton
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.home.conversations.selfDeletingMessageActionViewModel
 import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionArgs
 import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModel
-import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModelImpl
 import com.wire.android.ui.home.messagecomposer.attachments.AdditionalOptionButton
 import com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSelectItem
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
@@ -245,14 +244,7 @@ fun SelfDeletingMessageAction(
     conversationId: ConversationId,
     onButtonClicked: (SelfDeletionTimer) -> Unit,
     viewModel: SelfDeletingMessageActionViewModel =
-        wireViewModelScoped<
-                SelfDeletingMessageActionViewModelImpl,
-                SelfDeletingMessageActionViewModel,
-                SelfDeletingMessageActionArgs,
-                SelfDeletingMessageActionViewModelImpl.Factory
-                >(
-            SelfDeletingMessageActionArgs(conversationId = conversationId)
-        ),
+        selfDeletingMessageActionViewModel(SelfDeletingMessageActionArgs(conversationId = conversationId)),
 ) {
     when (val state = viewModel.state()) {
         SelfDeletionTimer.Disabled -> {}

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -55,7 +55,6 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import androidx.constraintlayout.compose.atMost
 import com.wire.android.R
-import com.wire.android.di.wireViewModelScoped
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.spacers.VerticalSpace
@@ -65,9 +64,9 @@ import com.wire.android.ui.common.textfield.WireTextFieldColors
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.home.conversations.UsersTypingIndicatorForConversation
 import com.wire.android.ui.home.conversations.messages.QuotedMessagePreview
+import com.wire.android.ui.home.conversations.selfDeletingMessageActionViewModel
 import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionArgs
 import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModel
-import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModelImpl
 import com.wire.android.ui.home.messagecomposer.attachments.AdditionalOptionButton
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
 import com.wire.android.ui.home.messagecomposer.state.InputType
@@ -184,14 +183,7 @@ private fun InputContent(
     onPlusClick: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SelfDeletingMessageActionViewModel =
-        wireViewModelScoped<
-                SelfDeletingMessageActionViewModelImpl,
-                SelfDeletingMessageActionViewModel,
-                SelfDeletingMessageActionArgs,
-                SelfDeletingMessageActionViewModelImpl.Factory
-                >(
-            SelfDeletingMessageActionArgs(conversationId = conversationId)
-        ),
+        selfDeletingMessageActionViewModel(SelfDeletingMessageActionArgs(conversationId = conversationId)),
 ) {
     ConstraintLayout(modifier = modifier) {
         val (additionalOptionButton, input, actions) = createRefs()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/actions/SelfDeletingMessageActionViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/actions/SelfDeletingMessageActionViewModel.kt
@@ -22,16 +22,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.di.AssistedViewModelFactory
 import com.wire.android.di.ViewModelScopedPreview
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
@@ -43,11 +38,10 @@ interface SelfDeletingMessageActionViewModel {
 }
 
 @Suppress("LongParameterList", "TooManyFunctions")
-@HiltViewModel(assistedFactory = SelfDeletingMessageActionViewModelImpl.Factory::class)
-class SelfDeletingMessageActionViewModelImpl @AssistedInject constructor(
+class SelfDeletingMessageActionViewModelImpl(
     private val dispatchers: DispatcherProvider,
     private val observeSelfDeletingMessages: ObserveSelfDeletionTimerSettingsForConversationUseCase,
-    @Assisted private val args: SelfDeletingMessageActionArgs,
+    args: SelfDeletingMessageActionArgs,
 ) : SelfDeletingMessageActionViewModel, ViewModel() {
 
     private val conversationId: QualifiedID = args.conversationId
@@ -70,10 +64,5 @@ class SelfDeletingMessageActionViewModelImpl @AssistedInject constructor(
                     }
                 }
         }
-    }
-
-    @AssistedFactory
-    interface Factory : AssistedViewModelFactory<SelfDeletingMessageActionViewModelImpl, SelfDeletingMessageActionArgs> {
-        override fun create(args: SelfDeletingMessageActionArgs): SelfDeletingMessageActionViewModelImpl
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachments/AdditionalOptionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachments/AdditionalOptionButton.kt
@@ -26,9 +26,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.wire.android.R
-import com.wire.android.di.wireViewModelScoped
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryIconButton
+import com.wire.android.ui.home.conversations.isFileSharingEnabledViewModel
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 import kotlinx.coroutines.delay
@@ -52,7 +52,7 @@ fun AdditionalOptionButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: IsFileSharingEnabledViewModel =
-        wireViewModelScoped<IsFileSharingEnabledViewModelImpl, IsFileSharingEnabledViewModel>()
+        isFileSharingEnabledViewModel()
 ) {
     var enableAgain by remember { mutableStateOf(true) }
     LaunchedEffect(enableAgain, block = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachments/IsFileSharingEnabledViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachments/IsFileSharingEnabledViewModel.kt
@@ -26,17 +26,14 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.di.ViewModelScopedPreview
 import com.wire.kalium.logic.configuration.FileSharingStatus
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @ViewModelScopedPreview
 interface IsFileSharingEnabledViewModel {
     fun isFileSharingEnabled(): Boolean = true
 }
 
-@HiltViewModel
-class IsFileSharingEnabledViewModelImpl @Inject constructor(
+class IsFileSharingEnabledViewModelImpl(
     private val isFileSharingEnabledUseCase: IsFileSharingEnabledUseCase,
 ) : IsFileSharingEnabledViewModel, ViewModel() {
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioComponent.kt
@@ -34,12 +34,12 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
-import com.wire.android.di.wireViewModelScoped
 import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.divider.WireDivider
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
+import com.wire.android.ui.home.conversations.recordAudioViewModel
 import com.wire.android.ui.home.conversations.model.UriAsset
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.extension.openAppInfoScreen
@@ -52,7 +52,7 @@ fun RecordAudioComponent(
     modifier: Modifier = Modifier,
     lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
 ) {
-    val viewModel: RecordAudioViewModel = wireViewModelScoped<RecordAudioViewModel>()
+    val viewModel: RecordAudioViewModel = recordAudioViewModel()
     val context = LocalContext.current
     val snackbarHostState = LocalSnackbarHostState.current
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -44,8 +44,6 @@ import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilder
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.util.DateTimeUtil
-import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -53,13 +51,11 @@ import kotlinx.coroutines.launch
 import okio.Path.Companion.toPath
 import java.io.File
 import java.io.IOException
-import javax.inject.Inject
 import kotlin.io.path.deleteIfExists
 
 @Suppress("TooManyFunctions", "LongParameterList")
-@HiltViewModel
-class RecordAudioViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+class RecordAudioViewModel(
+    private val context: Context,
     private val recordAudioMessagePlayer: RecordAudioMessagePlayer,
     private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
     private val getAssetSizeLimit: GetAssetSizeLimitUseCase,

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -560,6 +560,12 @@ public fun com.ramcosta.composedestinations.generated.app.destinations.WhatsNewS
   params:
 
 @Composable
+public fun com.wire.android.di.currentMetroViewModelGraph(): Graph of com.wire.android.di.currentMetroViewModelGraph
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 public fun com.wire.android.di.hiltViewModelScoped(arguments: R of com.wire.android.di.hiltViewModelScoped, clearDelay: kotlin.time.Duration?): S of com.wire.android.di.hiltViewModelScoped
   skippable: false
   restartable: true
@@ -587,6 +593,41 @@ public fun com.wire.android.di.hiltViewModelScoped(): T of com.wire.android.di.h
   skippable: true
   restartable: true
   params:
+
+@Composable
+public fun com.wire.android.di.wireMetroViewModelScoped(arguments: R of com.wire.android.di.wireMetroViewModelScoped, clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function3<Graph of com.wire.android.di.wireMetroViewModelScoped, androidx.lifecycle.SavedStateHandle, R of com.wire.android.di.wireMetroViewModelScoped, T of com.wire.android.di.wireMetroViewModelScoped>): S of com.wire.android.di.wireMetroViewModelScoped
+  skippable: false
+  restartable: true
+  params:
+    - arguments: RUNTIME (requires runtime check)
+    - clearDelay: STABLE (known stable type)
+    - create: STABLE (function type)
+
+@Composable
+public fun com.wire.android.di.wireMetroViewModelScoped(arguments: R of com.wire.android.di.wireMetroViewModelScoped, keyInScopeResolver: kotlin.Function1<@[ParameterName(name = \, clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function3<Graph of com.wire.android.di.wireMetroViewModelScoped, androidx.lifecycle.SavedStateHandle, R of com.wire.android.di.wireMetroViewModelScoped, T of com.wire.android.di.wireMetroViewModelScoped>): S of com.wire.android.di.wireMetroViewModelScoped
+  skippable: false
+  restartable: true
+  params:
+    - arguments: RUNTIME (requires runtime check)
+    - keyInScopeResolver: STABLE (function type)
+    - clearDelay: STABLE (known stable type)
+    - create: STABLE (function type)
+
+@Composable
+public fun com.wire.android.di.wireMetroViewModelScoped(clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function2<Graph of com.wire.android.di.wireMetroViewModelScoped, androidx.lifecycle.SavedStateHandle, T of com.wire.android.di.wireMetroViewModelScoped>): S of com.wire.android.di.wireMetroViewModelScoped
+  skippable: true
+  restartable: true
+  params:
+    - clearDelay: STABLE (known stable type)
+    - create: STABLE (function type)
+
+@Composable
+public fun com.wire.android.di.wireMetroViewModelScoped(clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function2<Graph of com.wire.android.di.wireMetroViewModelScoped, androidx.lifecycle.SavedStateHandle, T of com.wire.android.di.wireMetroViewModelScoped>): T of com.wire.android.di.wireMetroViewModelScoped
+  skippable: true
+  restartable: true
+  params:
+    - clearDelay: STABLE (known stable type)
+    - create: STABLE (function type)
 
 @Composable
 public fun com.wire.android.di.wireViewModelScoped(arguments: R of com.wire.android.di.wireViewModelScoped, clearDelay: kotlin.time.Duration?): S of com.wire.android.di.wireViewModelScoped
@@ -1908,10 +1949,10 @@ public fun com.wire.android.ui.calling.incoming.IncomingCallScreen(conversationI
 
 @Composable
 public fun com.wire.android.ui.calling.incomingCallViewModel(conversationId: com.wire.kalium.logic.data.id.QualifiedID): com.wire.android.ui.calling.incoming.IncomingCallViewModel
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
 
 @Composable
 private fun com.wire.android.ui.calling.ongoing.CallingControls(conversationId: com.wire.kalium.logic.data.id.QualifiedID, isMuted: kotlin.Boolean, isCameraOn: kotlin.Boolean, isSpeakerOn: kotlin.Boolean, isShowingCallReactions: kotlin.Boolean, isConnecting: kotlin.Boolean, inCallReactionsEnabled: kotlin.Boolean, toggleSpeaker: kotlin.Function0<kotlin.Unit>, toggleMute: kotlin.Function0<kotlin.Unit>, onHangUpCall: kotlin.Function0<kotlin.Unit>, onToggleVideo: kotlin.Function0<kotlin.Unit>, onCallReactionsClick: kotlin.Function0<kotlin.Unit>, onCameraPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -2535,10 +2576,10 @@ private fun com.wire.android.ui.calling.ongoing.toast.styledText(stringResId: ko
 
 @Composable
 public fun com.wire.android.ui.calling.ongoingCallViewModel(conversationId: com.wire.kalium.logic.data.id.QualifiedID): com.wire.android.ui.calling.ongoing.OngoingCallViewModel
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
 
 @Composable
 private fun com.wire.android.ui.calling.outgoing.OutgoingCallContent(callState: com.wire.android.ui.calling.model.CallState, toggleMute: kotlin.Function0<kotlin.Unit>, toggleSpeaker: kotlin.Function0<kotlin.Unit>, toggleVideo: kotlin.Function0<kotlin.Unit>, onHangUpCall: kotlin.Function0<kotlin.Unit>, onVideoPreviewCreated: kotlin.Function1<@[ParameterName(name = \, onSelfClearVideoPreview: kotlin.Function0<kotlin.Unit>, onCameraPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, onMinimiseScreen: kotlin.Function0<kotlin.Unit>): kotlin.Unit
@@ -2567,17 +2608,17 @@ public fun com.wire.android.ui.calling.outgoing.OutgoingCallScreen(conversationI
 
 @Composable
 public fun com.wire.android.ui.calling.outgoingCallViewModel(conversationId: com.wire.kalium.logic.data.id.QualifiedID): com.wire.android.ui.calling.outgoing.OutgoingCallViewModel
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
 
 @Composable
 public fun com.wire.android.ui.calling.sharedCallingViewModel(conversationId: com.wire.kalium.logic.data.id.QualifiedID): com.wire.android.ui.calling.common.SharedCallingViewModel
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
 
 @Composable
 public fun com.wire.android.ui.common.AddContactButton(userId: com.wire.kalium.logic.data.id.QualifiedID, userName: kotlin.String, modifier: androidx.compose.ui.Modifier, viewModel: com.wire.android.ui.connection.ConnectionActionButtonViewModel): kotlin.Unit
@@ -4568,6 +4609,12 @@ public fun com.wire.android.ui.home.appLock.unlock.EnterLockCodeScreenContent(st
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
+public fun com.wire.android.ui.home.appSyncViewModel(): com.wire.android.ui.home.AppSyncViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 public fun com.wire.android.ui.home.archive.ArchiveEmptyContent(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
@@ -4588,6 +4635,13 @@ public fun com.wire.android.ui.home.cell.GlobalCellsScreen(homeStateHolder: com.
   params:
     - homeStateHolder: UNSTABLE (has mutable properties or unstable members)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
+
+@Composable
+public fun com.wire.android.ui.home.conversationListViewModel(conversationsSource: com.wire.android.ui.home.conversationslist.model.ConversationsSource): com.wire.android.ui.home.conversationslist.ConversationListViewModel
+  skippable: true
+  restartable: true
+  params:
+    - conversationsSource: STABLE (class with no mutable properties)
 
 @Composable
 public fun com.wire.android.ui.home.conversations.AssetTooLargeDialog(dialogState: com.wire.android.ui.home.conversations.AssetTooLargeDialogState, hideDialog: kotlin.Function0<kotlin.Unit>): kotlin.Unit
@@ -4941,6 +4995,22 @@ public fun com.wire.android.ui.home.conversations.UsersTypingIndicatorForConvers
     - viewModel: RUNTIME (requires runtime check)
 
 @Composable
+public fun com.wire.android.ui.home.conversations.assetLocalPathViewModel(args: com.wire.android.ui.home.conversations.messages.item.AssetLocalPathArgs, keyInScopeResolver: kotlin.Function1<@[ParameterName(name = \): com.wire.android.ui.home.conversations.messages.item.AssetLocalPathViewModel
+  skippable: false
+  restartable: true
+  params:
+    - args: UNSTABLE (has mutable properties or unstable members)
+    - keyInScopeResolver: STABLE (function type)
+
+@Composable
+public fun com.wire.android.ui.home.conversations.audioMessageViewModel(args: com.wire.android.media.audiomessage.AudioMessageArgs, keyInScopeResolver: kotlin.Function1<@[ParameterName(name = \): com.wire.android.media.audiomessage.AudioMessageViewModel
+  skippable: false
+  restartable: true
+  params:
+    - args: UNSTABLE (has mutable properties or unstable members)
+    - keyInScopeResolver: STABLE (function type)
+
+@Composable
 public fun com.wire.android.ui.home.conversations.banner.ConversationBanner(bannerMessage: com.wire.android.util.ui.UIText?, modifier: androidx.compose.ui.Modifier, spannedTexts: kotlin.collections.List<kotlin.String>): kotlin.Unit
   skippable: false
   restartable: true
@@ -4979,6 +5049,13 @@ private fun com.wire.android.ui.home.conversations.channels.Content(searchQueryT
     - searchQueryTextState: STABLE (marked @Stable or @Immutable)
     - onCloseSearchClicked: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)
+
+@Composable
+public fun com.wire.android.ui.home.conversations.compositeMessageViewModel(args: com.wire.android.ui.home.conversations.model.CompositeMessageArgs): com.wire.android.ui.home.conversations.CompositeMessageViewModel
+  skippable: true
+  restartable: true
+  params:
+    - args: STABLE (class with no mutable properties)
 
 @Composable
 public fun com.wire.android.ui.home.conversations.conversationAssetPathsViewModel(conversationKey: kotlin.String): com.wire.android.ui.home.conversations.messages.item.ConversationAssetPathsViewModel
@@ -5791,6 +5868,12 @@ private fun com.wire.android.ui.home.conversations.getTitle(dialogState: com.wir
     - dialogState: STABLE (class with no mutable properties)
 
 @Composable
+public fun com.wire.android.ui.home.conversations.isFileSharingEnabledViewModel(): com.wire.android.ui.home.messagecomposer.attachments.IsFileSharingEnabledViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 private fun com.wire.android.ui.home.conversations.media.AssetMessagesListContent(groupedAssetMessageList: androidx.paging.compose.LazyPagingItems<com.wire.android.ui.home.conversations.usecase.UIPagingItem>, assetStatuses: kotlinx.collections.immutable.PersistentMap<kotlin.String, com.wire.kalium.logic.data.message.MessageAssetStatus>, onAssetItemClicked: kotlin.Function1<@[ParameterName(name = \, onItemLongClicked: kotlin.Function2<@[ParameterName(name = \): kotlin.Unit
   skippable: false
   restartable: true
@@ -5982,6 +6065,13 @@ public fun com.wire.android.ui.home.conversations.messageDraftViewModel(): com.w
   skippable: true
   restartable: true
   params:
+
+@Composable
+public fun com.wire.android.ui.home.conversations.messageOptionsMenuViewModel(args: com.wire.android.ui.home.conversations.edit.MessageOptionsMenuArgs): com.wire.android.ui.home.conversations.edit.MessageOptionsMenuViewModel
+  skippable: false
+  restartable: true
+  params:
+    - args: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
 public fun com.wire.android.ui.home.conversations.messagedetails.MessageDetailsEmptyScreenText(onClick: kotlin.Function0<kotlin.Unit>, text: kotlin.String, learnMoreText: kotlin.String, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -7327,6 +7417,12 @@ public fun com.wire.android.ui.home.conversations.promoteadmin.PromoteAdminScree
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
+public fun com.wire.android.ui.home.conversations.recordAudioViewModel(): com.wire.android.ui.home.messagecomposer.recordaudio.RecordAudioViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 public fun com.wire.android.ui.home.conversations.rememberConversationScreenState(editSheetState: com.wire.android.ui.common.bottomsheet.WireModalSheetState<kotlin.String>, selfDeletingSheetState: com.wire.android.ui.common.bottomsheet.WireModalSheetState<com.wire.kalium.logic.data.message.SelfDeletionTimer>, locationSheetState: com.wire.android.ui.common.bottomsheet.WireModalSheetState<kotlin.Unit>, coroutineScope: kotlinx.coroutines.CoroutineScope): com.wire.android.ui.home.conversations.ConversationScreenState
   skippable: false
   restartable: true
@@ -7342,6 +7438,33 @@ public fun com.wire.android.ui.home.conversations.rememberSelfDeletionTimer(expi
   restartable: true
   params:
     - expirationStatus: STABLE (class with no mutable properties)
+
+@Composable
+private fun com.wire.android.ui.home.conversations.scopedMessageViewModel(arguments: R of com.wire.android.ui.home.conversations.scopedMessageViewModel, clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function3<com.wire.android.ui.home.conversations.ScopedMessageViewModelFactory, androidx.lifecycle.SavedStateHandle, R of com.wire.android.ui.home.conversations.scopedMessageViewModel, VM of com.wire.android.ui.home.conversations.scopedMessageViewModel>): S of com.wire.android.ui.home.conversations.scopedMessageViewModel
+  skippable: false
+  restartable: true
+  params:
+    - arguments: RUNTIME (requires runtime check)
+    - clearDelay: STABLE (known stable type)
+    - create: STABLE (function type)
+
+@Composable
+private fun com.wire.android.ui.home.conversations.scopedMessageViewModel(arguments: R of com.wire.android.ui.home.conversations.scopedMessageViewModel, keyInScopeResolver: kotlin.Function1<@[ParameterName(name = \, clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function3<com.wire.android.ui.home.conversations.ScopedMessageViewModelFactory, androidx.lifecycle.SavedStateHandle, R of com.wire.android.ui.home.conversations.scopedMessageViewModel, VM of com.wire.android.ui.home.conversations.scopedMessageViewModel>): S of com.wire.android.ui.home.conversations.scopedMessageViewModel
+  skippable: false
+  restartable: true
+  params:
+    - arguments: RUNTIME (requires runtime check)
+    - keyInScopeResolver: STABLE (function type)
+    - clearDelay: STABLE (known stable type)
+    - create: STABLE (function type)
+
+@Composable
+private fun com.wire.android.ui.home.conversations.scopedMessageViewModel(clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function2<com.wire.android.ui.home.conversations.ScopedMessageViewModelFactory, androidx.lifecycle.SavedStateHandle, VM of com.wire.android.ui.home.conversations.scopedMessageViewModel>): S of com.wire.android.ui.home.conversations.scopedMessageViewModel
+  skippable: true
+  restartable: true
+  params:
+    - clearDelay: STABLE (known stable type)
+    - create: STABLE (function type)
 
 @Composable
 public fun com.wire.android.ui.home.conversations.search.EmptySearchQueryScreen(modifier: androidx.compose.ui.Modifier, text: kotlin.String, learnMoreTextToLink: kotlin.Pair<kotlin.String, kotlin.String>): kotlin.Unit
@@ -7654,6 +7777,13 @@ public fun com.wire.android.ui.home.conversations.search.widget.SearchFailureBox
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
+public fun com.wire.android.ui.home.conversations.selfDeletingMessageActionViewModel(args: com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionArgs): com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModel
+  skippable: false
+  restartable: true
+  params:
+    - args: UNSTABLE (has mutable properties or unstable members)
+
+@Composable
 private fun com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionDurationMenuItem(duration: com.wire.android.ui.home.messagecomposer.SelfDeletionDuration, isSelected: kotlin.Boolean, onSelfDeletionDurationSelected: kotlin.Function1<com.wire.android.ui.home.messagecomposer.SelfDeletionDuration, kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
@@ -7692,7 +7822,14 @@ private fun com.wire.android.ui.home.conversations.stringResourceProvider(): com
   params:
 
 @Composable
-public fun com.wire.android.ui.home.conversationslist.ConversationsScreenContent(navigator: com.wire.android.navigation.Navigator, searchBarState: com.wire.android.ui.common.search.SearchBarState, modifier: androidx.compose.ui.Modifier, emptyListContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction1<@[ParameterName(name = \, lazyListState: androidx.compose.foundation.lazy.LazyListState, loadingListContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, conversationsSource: com.wire.android.ui.home.conversationslist.model.ConversationsSource, emptySearchResultFocusRequester: androidx.compose.ui.focus.FocusRequester?, firstConversationFocusRequester: androidx.compose.ui.focus.FocusRequester?, conversationListViewModel: com.wire.android.ui.home.conversationslist.ConversationListViewModel, conversationListCallViewModel: com.wire.android.ui.home.conversationslist.ConversationListCallViewModel): kotlin.Unit
+public fun com.wire.android.ui.home.conversations.typingIndicatorViewModel(args: com.wire.android.ui.home.conversations.typing.TypingIndicatorArgs): com.wire.android.ui.home.conversations.typing.TypingIndicatorViewModel
+  skippable: false
+  restartable: true
+  params:
+    - args: UNSTABLE (has mutable properties or unstable members)
+
+@Composable
+public fun com.wire.android.ui.home.conversationslist.ConversationsScreenContent(navigator: com.wire.android.navigation.Navigator, searchBarState: com.wire.android.ui.common.search.SearchBarState, modifier: androidx.compose.ui.Modifier, emptyListContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction1<@[ParameterName(name = \, lazyListState: androidx.compose.foundation.lazy.LazyListState, loadingListContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, conversationsSource: com.wire.android.ui.home.conversationslist.model.ConversationsSource, emptySearchResultFocusRequester: androidx.compose.ui.focus.FocusRequester?, firstConversationFocusRequester: androidx.compose.ui.focus.FocusRequester?, conversationListCallViewModel: com.wire.android.ui.home.conversationslist.ConversationListCallViewModel, conversationListViewModel: com.wire.android.ui.home.conversationslist.ConversationListViewModel): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -7705,8 +7842,8 @@ public fun com.wire.android.ui.home.conversationslist.ConversationsScreenContent
     - conversationsSource: STABLE (class with no mutable properties)
     - emptySearchResultFocusRequester: STABLE (marked @Stable or @Immutable)
     - firstConversationFocusRequester: STABLE (marked @Stable or @Immutable)
-    - conversationListViewModel: RUNTIME (requires runtime check)
     - conversationListCallViewModel: RUNTIME (requires runtime check)
+    - conversationListViewModel: RUNTIME (requires runtime check)
 
 @Composable
 public fun com.wire.android.ui.home.conversationslist.all.AllConversationsScreen(homeStateHolder: com.wire.android.ui.home.HomeStateHolder, foldersViewModel: com.wire.android.ui.home.conversations.folder.ConversationFoldersVM): kotlin.Unit
@@ -8141,6 +8278,18 @@ public fun com.wire.android.ui.home.gallery.ZoomableImage(image: com.wire.androi
     - image: STABLE (class with no mutable properties)
     - contentDescription: STABLE (String is immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
+
+@Composable
+public fun com.wire.android.ui.home.homeDrawerViewModel(): com.wire.android.ui.home.drawer.HomeDrawerViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.home.homeViewModel(): com.wire.android.ui.home.HomeViewModel
+  skippable: true
+  restartable: true
+  params:
 
 @Composable
 public fun com.wire.android.ui.home.meetings.MeetingsScreen(homeStateHolder: com.wire.android.ui.home.HomeStateHolder): kotlin.Unit


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25946
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Migrates scoped message and composer ViewModels from Hilt assisted factories to Metro-backed Resaca creation.
- Adds `ScopedMessageViewModelFactory` and graph accessors while preserving scoped lifecycle behavior.
- Keeps preview/Espresso fallback behavior in the shared scoped ViewModel helper.