### PR TITLE
refactor: migrate misc view models to metro [WPB-25946]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireActivityViewModelGraphBridge.kt
@@ -24,6 +24,8 @@ import com.wire.android.feature.meetings.ui.MeetingsViewModelFactory
 import com.wire.android.feature.meetings.ui.MeetingsViewModelGraph
 import com.wire.android.model.ImageAssetViewModelFactory
 import com.wire.android.model.ImageAssetViewModelGraph
+import com.wire.android.ui.MiscViewModelFactory
+import com.wire.android.ui.MiscViewModelGraph
 import com.wire.android.ui.authentication.AuthenticationViewModelFactory
 import com.wire.android.ui.authentication.AuthenticationViewModelGraph
 import com.wire.android.ui.calling.CallingViewModelFactory
@@ -65,6 +67,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     private val conversationSearchFolderViewModelFactoryProvider: Provider<ConversationSearchFolderViewModelFactory>,
     private val meetingsViewModelFactoryProvider: Provider<MeetingsViewModelFactory>,
     private val scopedMessageViewModelFactoryProvider: Provider<ScopedMessageViewModelFactory>,
+    private val miscViewModelFactoryProvider: Provider<MiscViewModelFactory>,
 ) : ViewModel(),
     ImageAssetViewModelGraph,
     CellsViewModelGraph,
@@ -77,7 +80,8 @@ class WireActivityViewModelGraphBridge @Inject constructor(
     ConversationDetailsViewModelGraph,
     ConversationSearchFolderViewModelGraph,
     MeetingsViewModelGraph,
-    ScopedMessageViewModelGraph {
+    ScopedMessageViewModelGraph,
+    MiscViewModelGraph {
     override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
         ImageAssetViewModelFactory(imageLoader = imageLoader::get)
 
@@ -113,4 +117,7 @@ class WireActivityViewModelGraphBridge @Inject constructor(
 
     override val scopedMessageViewModelFactory: ScopedMessageViewModelFactory
         get() = scopedMessageViewModelFactoryProvider.get()
+
+    override val miscViewModelFactory: MiscViewModelFactory
+        get() = miscViewModelFactoryProvider.get()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/MiscViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/MiscViewModelFactory.kt
@@ -1,0 +1,127 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.datastore.UserDataStore
+import com.wire.android.datastore.UserDataStoreProvider
+import com.wire.android.di.CurrentAccount
+import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.ui.analytics.AnalyticsConfiguration
+import com.wire.android.ui.analytics.AnalyticsUsageViewModel
+import com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentViewModel
+import com.wire.android.ui.e2eiEnrollment.GetE2EICertificateViewModel
+import com.wire.android.ui.initialsync.InitialSyncViewModel
+import com.wire.android.ui.joinConversation.JoinConversationViaCodeViewModel
+import com.wire.android.ui.legalhold.dialog.deactivated.LegalHoldDeactivatedViewModel
+import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedViewModel
+import com.wire.android.ui.settings.devices.e2ei.E2eiCertificateDetailsViewModel
+import com.wire.android.ui.sharing.ImportMediaAuthenticatedViewModel
+import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.lifecycle.AutomatedLoginManager
+import com.wire.android.ui.home.conversations.usecase.GetConversationsFromSearchUseCase
+import com.wire.android.ui.home.conversations.usecase.HandleUriAssetUseCase
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
+import com.wire.kalium.logic.feature.client.FinalizeMLSClientAfterE2EIEnrollmentUseCase
+import com.wire.kalium.logic.feature.conversation.JoinConversationViaCodeUseCase
+import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
+import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
+import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
+import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
+import dagger.Lazy
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+class MiscViewModelFactory @Inject constructor(
+    private val analyticsEnabled: AnalyticsConfiguration,
+    private val dataStore: Lazy<UserDataStore>,
+    private val selfServerConfig: Lazy<SelfServerConfigUseCase>,
+    private val observeSyncState: ObserveSyncStateUseCase,
+    private val userDataStoreProvider: UserDataStoreProvider,
+    @CurrentAccount private val userId: UserId,
+    private val dispatchers: DispatcherProvider,
+    private val automatedLoginManager: AutomatedLoginManager,
+    private val validatePassword: ValidatePasswordUseCase,
+    @KaliumCoreLogic private val coreLogicLazy: Lazy<CoreLogic>,
+    @KaliumCoreLogic private val coreLogic: CoreLogic,
+    private val finalizeMLSClientAfterE2EIEnrollment: FinalizeMLSClientAfterE2EIEnrollmentUseCase,
+    private val currentSession: CurrentSessionUseCase,
+    private val getSelfUser: GetSelfUserUseCase,
+    private val getSelf: ObserveSelfUserUseCase,
+    private val getConversationsPaginated: GetConversationsFromSearchUseCase,
+    private val handleUriAsset: HandleUriAssetUseCase,
+    private val persistNewSelfDeletionTimer: PersistNewSelfDeletionTimerUseCase,
+    private val observeSelfDeletionSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase,
+    private val joinConversationViaCode: JoinConversationViaCodeUseCase,
+) {
+    fun analyticsUsageViewModel() = AnalyticsUsageViewModel(
+        analyticsEnabled = analyticsEnabled,
+        dataStore = dataStore,
+        selfServerConfig = selfServerConfig,
+    )
+
+    fun initialSyncViewModel() = InitialSyncViewModel(
+        observeSyncState = observeSyncState,
+        userDataStoreProvider = userDataStoreProvider,
+        userId = userId,
+        dispatchers = dispatchers,
+        automatedLoginManager = automatedLoginManager,
+    )
+
+    fun legalHoldRequestedViewModel() = LegalHoldRequestedViewModel(
+        validatePassword = validatePassword,
+        coreLogic = coreLogicLazy,
+    )
+
+    fun legalHoldDeactivatedViewModel() = LegalHoldDeactivatedViewModel(
+        coreLogic = coreLogicLazy,
+    )
+
+    fun e2EIEnrollmentViewModel() = E2EIEnrollmentViewModel(
+        finalizeMLSClientAfterE2EIEnrollment = finalizeMLSClientAfterE2EIEnrollment,
+    )
+
+    fun getE2EICertificateViewModel() = GetE2EICertificateViewModel(
+        coreLogic = coreLogic,
+        currentSession = currentSession,
+        dispatcherProvider = dispatchers,
+    )
+
+    fun e2eiCertificateDetailsViewModel(savedStateHandle: SavedStateHandle) = E2eiCertificateDetailsViewModel(
+        savedStateHandle = savedStateHandle,
+        getSelfUser = getSelfUser,
+    )
+
+    fun importMediaAuthenticatedViewModel() = ImportMediaAuthenticatedViewModel(
+        getSelf = getSelf,
+        getConversationsPaginated = getConversationsPaginated,
+        handleUriAsset = handleUriAsset,
+        persistNewSelfDeletionTimerUseCase = persistNewSelfDeletionTimer,
+        observeSelfDeletionSettingsForConversation = observeSelfDeletionSettingsForConversation,
+        dispatchers = dispatchers,
+    )
+
+    fun joinConversationViaCodeViewModel() = JoinConversationViaCodeViewModel(
+        joinViaCode = joinConversationViaCode,
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/MiscViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/MiscViewModelGraph.kt
@@ -1,0 +1,83 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui
+
+import androidx.compose.runtime.Composable
+import com.wire.android.di.metro.MetroViewModelGraph
+import com.wire.android.di.metro.metroSavedStateViewModel
+import com.wire.android.di.metro.metroViewModel
+import com.wire.android.ui.analytics.AnalyticsUsageViewModel
+import com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentViewModel
+import com.wire.android.ui.e2eiEnrollment.GetE2EICertificateViewModel
+import com.wire.android.ui.initialsync.InitialSyncViewModel
+import com.wire.android.ui.joinConversation.JoinConversationViaCodeViewModel
+import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedViewModel
+import com.wire.android.ui.settings.devices.e2ei.E2eiCertificateDetailsViewModel
+import com.wire.android.ui.sharing.ImportMediaAuthenticatedViewModel
+
+interface MiscViewModelGraph : MetroViewModelGraph {
+    val miscViewModelFactory: MiscViewModelFactory
+}
+
+@Composable
+fun analyticsUsageViewModel(): AnalyticsUsageViewModel =
+    metroViewModel<MiscViewModelGraph, AnalyticsUsageViewModel> {
+        miscViewModelFactory.analyticsUsageViewModel()
+    }
+
+@Composable
+fun initialSyncViewModel(): InitialSyncViewModel =
+    metroViewModel<MiscViewModelGraph, InitialSyncViewModel> {
+        miscViewModelFactory.initialSyncViewModel()
+    }
+
+@Composable
+fun legalHoldRequestedViewModel(): LegalHoldRequestedViewModel =
+    metroViewModel<MiscViewModelGraph, LegalHoldRequestedViewModel> {
+        miscViewModelFactory.legalHoldRequestedViewModel()
+    }
+
+@Composable
+fun e2EIEnrollmentViewModel(): E2EIEnrollmentViewModel =
+    metroViewModel<MiscViewModelGraph, E2EIEnrollmentViewModel> {
+        miscViewModelFactory.e2EIEnrollmentViewModel()
+    }
+
+@Composable
+fun getE2EICertificateViewModel(): GetE2EICertificateViewModel =
+    metroViewModel<MiscViewModelGraph, GetE2EICertificateViewModel> {
+        miscViewModelFactory.getE2EICertificateViewModel()
+    }
+
+@Composable
+fun e2eiCertificateDetailsViewModel(): E2eiCertificateDetailsViewModel =
+    metroSavedStateViewModel<MiscViewModelGraph, E2eiCertificateDetailsViewModel> {
+        miscViewModelFactory.e2eiCertificateDetailsViewModel(it)
+    }
+
+@Composable
+fun importMediaAuthenticatedViewModel(): ImportMediaAuthenticatedViewModel =
+    metroViewModel<MiscViewModelGraph, ImportMediaAuthenticatedViewModel> {
+        miscViewModelFactory.importMediaAuthenticatedViewModel()
+    }
+
+@Composable
+fun joinConversationViaCodeViewModel(): JoinConversationViaCodeViewModel =
+    metroViewModel<MiscViewModelGraph, JoinConversationViaCodeViewModel> {
+        miscViewModelFactory.joinConversationViaCodeViewModel()
+    }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -181,8 +181,20 @@ class WireActivity : BaseActivity() {
     private val commonTopAppBarViewModel by assistedViewModels<CommonTopAppBarViewModel, CommonTopAppBarViewModel.Factory> { factory ->
         factory.create(CommonTopAppBarParams(showNoNetwork = true, showSync = true, showActiveCalls = true))
     }
-    private val legalHoldRequestedViewModel: LegalHoldRequestedViewModel by viewModels()
-    private val legalHoldDeactivatedViewModel: LegalHoldDeactivatedViewModel by viewModels()
+    private val legalHoldRequestedViewModel: LegalHoldRequestedViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                wireActivityViewModelGraph.miscViewModelFactory.legalHoldRequestedViewModel()
+            }
+        }
+    }
+    private val legalHoldDeactivatedViewModel: LegalHoldDeactivatedViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                wireActivityViewModelGraph.miscViewModelFactory.legalHoldDeactivatedViewModel()
+            }
+        }
+    }
 
     private val newIntents = Channel<Pair<Intent, Bundle?>>(Channel.UNLIMITED) // keep new intents until subscribed but do not replay them
     private lateinit var shakeDetector: ShakeDetector

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -161,19 +161,19 @@ class WireActivity : BaseActivity() {
     @Inject
     lateinit var managedConfigurationsManager: ManagedConfigurationsManager
 
-    private val wireActivityViewModelGraph: WireActivityViewModelGraphBridge by viewModels()
+    private val wireActivityViewModelGraphBridge: WireActivityViewModelGraphBridge by viewModels()
     private val viewModel: WireActivityViewModel by viewModels()
     private val callFeedbackViewModel: CallFeedbackViewModel by viewModels {
         viewModelFactory {
             initializer {
-                wireActivityViewModelGraph.callingViewModelFactory.callFeedbackViewModel()
+                wireActivityViewModelGraphBridge.callingViewModelFactory.callFeedbackViewModel()
             }
         }
     }
     private val featureFlagNotificationViewModel: FeatureFlagNotificationViewModel by viewModels {
         viewModelFactory {
             initializer {
-                wireActivityViewModelGraph.homeViewModelFactory.featureFlagNotificationViewModel()
+                wireActivityViewModelGraphBridge.homeViewModelFactory.featureFlagNotificationViewModel()
             }
         }
     }
@@ -184,14 +184,14 @@ class WireActivity : BaseActivity() {
     private val legalHoldRequestedViewModel: LegalHoldRequestedViewModel by viewModels {
         viewModelFactory {
             initializer {
-                wireActivityViewModelGraph.miscViewModelFactory.legalHoldRequestedViewModel()
+                wireActivityViewModelGraphBridge.miscViewModelFactory.legalHoldRequestedViewModel()
             }
         }
     }
     private val legalHoldDeactivatedViewModel: LegalHoldDeactivatedViewModel by viewModels {
         viewModelFactory {
             initializer {
-                wireActivityViewModelGraph.miscViewModelFactory.legalHoldDeactivatedViewModel()
+                wireActivityViewModelGraphBridge.miscViewModelFactory.legalHoldDeactivatedViewModel()
             }
         }
     }
@@ -290,7 +290,7 @@ class WireActivity : BaseActivity() {
                 LocalSyncStateObserver provides SyncStateObserver(viewModel.observeSyncFlowState),
                 LocalCustomUiConfigurationProvider provides CustomUiConfigurationProvider,
                 LocalSnackbarHostState provides snackbarHostState,
-                LocalMetroViewModelGraph provides wireActivityViewModelGraph,
+                LocalMetroViewModelGraph provides wireActivityViewModelGraphBridge,
                 LocalActivity provides this
             ) {
                 WireTheme(accent = viewModel.globalAppState.userAccent) {

--- a/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/analytics/AnalyticsUsageViewModel.kt
@@ -26,13 +26,10 @@ import com.wire.android.datastore.UserDataStore
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import dagger.Lazy
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class AnalyticsUsageViewModel @Inject constructor(
+class AnalyticsUsageViewModel(
     private val analyticsEnabled: AnalyticsConfiguration,
     private val dataStore: Lazy<UserDataStore>,
     private val selfServerConfig: Lazy<SelfServerConfigUseCase>,

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
-import com.wire.android.di.wireViewModel
 import com.wire.android.R
 import com.wire.android.feature.NavigationSwitchAccountActions
 import com.wire.android.navigation.BackStackMode
@@ -53,6 +52,7 @@ import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.visbility.rememberVisibilityState
+import com.wire.android.ui.e2EIEnrollmentViewModel
 import com.ramcosta.composedestinations.generated.app.destinations.E2EiCertificateDetailsScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.InitialSyncScreenDestination
 import com.wire.android.ui.home.E2EIEnrollmentErrorWithDismissDialog
@@ -71,7 +71,7 @@ import com.wire.kalium.logic.feature.e2ei.usecase.FinalizeEnrollmentResult
 fun E2EIEnrollmentScreen(
     navigator: Navigator,
     loginTypeSelector: LoginTypeSelector,
-    viewModel: E2EIEnrollmentViewModel = wireViewModel(),
+    viewModel: E2EIEnrollmentViewModel = e2EIEnrollmentViewModel(),
     clearSessionViewModel: ClearSessionViewModel = clearSessionViewModel(),
 ) {
     val state = viewModel.state

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentViewModel.kt
@@ -24,9 +24,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.kalium.logic.feature.client.FinalizeMLSClientAfterE2EIEnrollmentUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.FinalizeEnrollmentResult
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 data class E2EIEnrollmentState(
     val certificate: String = "null",
@@ -38,8 +36,7 @@ data class E2EIEnrollmentState(
     val startGettingE2EICertificate: Boolean = false
 )
 
-@HiltViewModel
-class E2EIEnrollmentViewModel @Inject constructor(
+class E2EIEnrollmentViewModel(
     private val finalizeMLSClientAfterE2EIEnrollment: FinalizeMLSClientAfterE2EIEnrollmentUseCase,
 ) : ViewModel() {
     var state by mutableStateOf(E2EIEnrollmentState())

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/GetE2EICertificateUI.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/GetE2EICertificateUI.kt
@@ -21,8 +21,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
-import com.wire.android.di.wireViewModel
 import com.wire.android.feature.e2ei.OAuthUseCase
+import com.wire.android.ui.getE2EICertificateViewModel
 import com.wire.android.util.extension.getActivity
 import com.wire.kalium.logic.feature.e2ei.usecase.FinalizeEnrollmentResult
 import kotlinx.coroutines.flow.launchIn
@@ -32,7 +32,7 @@ import kotlinx.coroutines.flow.onEach
 fun GetE2EICertificateUI(
     enrollmentResultHandler: (FinalizeEnrollmentResult) -> Unit,
     isNewClient: Boolean,
-    viewModel: GetE2EICertificateViewModel = wireViewModel()
+    viewModel: GetE2EICertificateViewModel = getE2EICertificateViewModel()
 ) {
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/GetE2EICertificateViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/GetE2EICertificateViewModel.kt
@@ -18,7 +18,6 @@
 package com.wire.android.ui.e2eiEnrollment
 
 import androidx.lifecycle.ViewModel
-import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.e2ei.OAuthUseCase
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
@@ -27,16 +26,13 @@ import com.wire.kalium.logic.feature.e2ei.usecase.FinalizeEnrollmentResult
 import com.wire.kalium.logic.feature.e2ei.usecase.InitialEnrollmentResult
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class GetE2EICertificateViewModel @Inject constructor(
-    @KaliumCoreLogic private val coreLogic: CoreLogic,
+class GetE2EICertificateViewModel(
+    private val coreLogic: CoreLogic,
     private val currentSession: CurrentSessionUseCase,
     val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -60,7 +60,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
-import com.wire.android.di.wireViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -103,6 +102,7 @@ import com.wire.android.ui.home.conversations.folder.ConversationFoldersNavBackA
 import com.wire.android.ui.home.drawer.HomeDrawer
 import com.wire.android.ui.home.drawer.HomeDrawerState
 import com.wire.android.ui.home.drawer.HomeDrawerViewModel
+import com.wire.android.ui.analyticsUsageViewModel
 import com.wire.android.util.permission.rememberShowNotificationsPermissionFlow
 import kotlinx.coroutines.launch
 
@@ -118,7 +118,7 @@ fun HomeScreen(
     homeViewModel: HomeViewModel = homeViewModel(),
     appSyncViewModel: AppSyncViewModel = appSyncViewModel(),
     homeDrawerViewModel: HomeDrawerViewModel = homeDrawerViewModel(),
-    analyticsUsageViewModel: AnalyticsUsageViewModel = wireViewModel(),
+    analyticsUsageViewModel: AnalyticsUsageViewModel = analyticsUsageViewModel(),
 ) {
     val context = LocalContext.current
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
+import com.wire.android.di.wireViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner

--- a/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncScreen.kt
@@ -20,7 +20,6 @@ package com.wire.android.ui.initialsync
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import com.wire.android.di.wireViewModel
 import androidx.lifecycle.lifecycleScope
 import com.ramcosta.composedestinations.generated.app.destinations.HomeScreenDestination
 import com.wire.android.navigation.BackStackMode
@@ -30,6 +29,7 @@ import com.wire.android.navigation.annotation.app.WireRootDestination
 import com.wire.android.navigation.getBaseRoute
 import com.wire.android.ui.LocalActivity
 import com.wire.android.ui.common.SettingUpWireScreenContent
+import com.wire.android.ui.initialSyncViewModel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -38,7 +38,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun InitialSyncScreen(
     navigator: Navigator,
-    viewModel: InitialSyncViewModel = wireViewModel()
+    viewModel: InitialSyncViewModel = initialSyncViewModel()
 ) {
     val activity = LocalActivity.current
     val syncCompletionState = viewModel.syncCompletionState

--- a/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/initialsync/InitialSyncViewModel.kt
@@ -32,15 +32,12 @@ import com.wire.android.util.lifecycle.AutomatedLoginManager
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
-@HiltViewModel
-class InitialSyncViewModel @Inject constructor(
+class InitialSyncViewModel(
     private val observeSyncState: ObserveSyncStateUseCase,
     private val userDataStoreProvider: UserDataStoreProvider,
     @CurrentAccount private val userId: UserId,

--- a/app/src/main/kotlin/com/wire/android/ui/joinConversation/JoinConversationViaCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/joinConversation/JoinConversationViaCodeViewModel.kt
@@ -26,14 +26,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.kalium.logic.feature.conversation.JoinConversationViaCodeUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class JoinConversationViaCodeViewModel @Inject constructor(
+class JoinConversationViaCodeViewModel(
     private val joinViaCode: JoinConversationViaCodeUseCase
 ) : ViewModel() {
 

--- a/app/src/main/kotlin/com/wire/android/ui/joinConversation/JoinConversationViaDeepLinkDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/joinConversation/JoinConversationViaDeepLinkDialog.kt
@@ -36,8 +36,8 @@ import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import com.wire.android.di.wireViewModelScoped
 import com.wire.android.R
+import com.wire.android.ui.joinConversationViaCodeViewModel
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
@@ -79,7 +79,7 @@ fun JoinConversationViaDeepLinkDialog(
     onFlowCompleted: (conversationId: ConversationId?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val viewModel = wireViewModelScoped<JoinConversationViaCodeViewModel>()
+    val viewModel = joinConversationViaCodeViewModel()
 
     val isLoading: Boolean by remember {
         derivedStateOf { viewModel.state is JoinViaDeepLinkDialogState.Loading }

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/deactivated/LegalHoldDeactivatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/deactivated/LegalHoldDeactivatedViewModel.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
-import com.wire.android.di.KaliumCoreLogic
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.UserSessionScope
@@ -32,18 +31,15 @@ import com.wire.kalium.logic.feature.legalhold.MarkLegalHoldChangeAsNotifiedForS
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldChangeNotifiedForSelfUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import dagger.Lazy
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class LegalHoldDeactivatedViewModel @Inject constructor(
-    @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>
+class LegalHoldDeactivatedViewModel(
+    private val coreLogic: Lazy<CoreLogic>
 ) : ViewModel() {
 
     var state: LegalHoldDeactivatedState by mutableStateOf(LegalHoldDeactivatedState.Hidden)

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModel.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
-import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.user.UserId
@@ -36,7 +35,6 @@ import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldRequestUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import dagger.Lazy
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
@@ -46,12 +44,10 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class LegalHoldRequestedViewModel @Inject constructor(
+class LegalHoldRequestedViewModel(
     private val validatePassword: ValidatePasswordUseCase,
-    @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>
+    private val coreLogic: Lazy<CoreLogic>
 ) : ViewModel() {
 
     val passwordTextState: TextFieldState = TextFieldState()

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.sp
-import com.wire.android.ui.home.settings.e2eiCertificateDetailsViewModel
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.style.PopUpNavigationAnimation
@@ -48,6 +47,7 @@ import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.e2eiCertificateDetailsViewModel
 import com.wire.android.util.copyLinkToClipboard
 import com.wire.android.util.createPemFile
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/e2ei/E2eiCertificateDetailsViewModel.kt
@@ -24,8 +24,8 @@ import com.wire.android.util.fileDateTime
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.launch
-import javax.inject.Inject
-class E2eiCertificateDetailsViewModel @Inject constructor(
+
+class E2eiCertificateDetailsViewModel(
     savedStateHandle: SavedStateHandle,
     private val getSelfUser: GetSelfUserUseCase,
 ) : ViewModel() {

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -50,7 +50,6 @@ import com.wire.kalium.logic.data.message.SelfDeletionTimer.Companion.SELF_DELET
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.PersistNewSelfDeletionTimerUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.FlowPreview
@@ -66,12 +65,10 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
-@HiltViewModel
 @OptIn(FlowPreview::class)
 @Suppress("LongParameterList", "TooManyFunctions")
-class ImportMediaAuthenticatedViewModel @Inject constructor(
+class ImportMediaAuthenticatedViewModel(
     private val getSelf: ObserveSelfUserUseCase,
     private val getConversationsPaginated: GetConversationsFromSearchUseCase,
     private val handleUriAsset: HandleUriAssetUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wire.android.di.wireViewModel
+import com.wire.android.ui.importMediaAuthenticatedViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ramcosta.composedestinations.generated.app.destinations.ConversationScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.NewLoginScreenDestination
@@ -193,7 +194,7 @@ private fun ImportMediaAuthenticatedContent(
     navigator: Navigator,
     isRestrictedInTeam: Boolean,
     checkAssetRestrictionsViewModel: CheckAssetRestrictionsViewModel = wireViewModel(),
-    importMediaViewModel: ImportMediaAuthenticatedViewModel = wireViewModel(),
+    importMediaViewModel: ImportMediaAuthenticatedViewModel = importMediaAuthenticatedViewModel(),
 ) {
     if (isRestrictedInTeam) {
         ImportMediaRestrictedContent(

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.wire.android.di.wireViewModel
 import com.wire.android.ui.home.settings.selfUserProfileViewModel
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultRecipient
@@ -90,6 +89,7 @@ import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedDialog
 import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedState
 import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedViewModel
 import com.wire.android.ui.legalhold.dialog.subject.LegalHoldSubjectProfileSelfDialog
+import com.wire.android.ui.legalHoldRequestedViewModel
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -115,7 +115,7 @@ fun SelfUserProfileScreen(
     loginTypeSelector: LoginTypeSelector,
     avatarPickerResultRecipient: ResultRecipient<AvatarPickerScreenDestination, String?>,
     viewModelSelf: SelfUserProfileViewModel = selfUserProfileViewModel(),
-    legalHoldRequestedViewModel: LegalHoldRequestedViewModel = wireViewModel()
+    legalHoldRequestedViewModel: LegalHoldRequestedViewModel = legalHoldRequestedViewModel()
 ) {
     val legalHoldSubjectDialogState = rememberVisibilityState<Unit>()
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25946
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Migrates remaining smaller ViewModels from Hilt call-site creation to Metro-backed factories.
- Covers analytics, legal hold, E2EI, sharing import, join conversation, initial sync, and related small screens.
- Keeps existing UI-facing ViewModel APIs unchanged.