### PR TITLE
feat: show message content for pending messages (WPB-25291)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/ConversationAssetPathsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/ConversationAssetPathsViewModel.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
 import com.wire.kalium.logic.data.asset.AssetTransferStatus.DOWNLOAD_IN_PROGRESS
+import com.wire.kalium.logic.data.asset.AssetTransferStatus.FAILED_UPLOAD
 import com.wire.kalium.logic.data.asset.AssetTransferStatus.NOT_DOWNLOADED
 import com.wire.kalium.logic.data.asset.AssetTransferStatus.SAVED_INTERNALLY
 import com.wire.kalium.logic.data.asset.AssetTransferStatus.UPLOADED
@@ -108,7 +109,7 @@ class ConversationAssetPathsViewModelImpl @Inject constructor(
 
 internal fun AssetTransferStatus.shouldResolveAsset(downloadIfNeeded: Boolean) =
     if (downloadIfNeeded) {
-        this in setOf(NOT_DOWNLOADED, DOWNLOAD_IN_PROGRESS, SAVED_INTERNALLY, UPLOADED)
+        this in setOf(NOT_DOWNLOADED, DOWNLOAD_IN_PROGRESS, SAVED_INTERNALLY, UPLOADED, FAILED_UPLOAD)
     } else {
-        this in setOf(SAVED_INTERNALLY, UPLOADED)
+        this in setOf(SAVED_INTERNALLY, UPLOADED, FAILED_UPLOAD)
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -347,13 +347,16 @@ private fun MessageImageOverlay(
             )
         }
 
-        FAILED_UPLOAD, FAILED_DOWNLOAD -> {
+        FAILED_DOWNLOAD -> {
             ImageMessageFailed(
                 size = size,
-                isDownloadFailure = transferStatus == FAILED_DOWNLOAD,
+                isDownloadFailure = true,
                 errorColor = messageStyle.error()
             )
         }
+
+        // Keep showing the image preview from local image
+        FAILED_UPLOAD -> Unit
 
         else -> Unit
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25291
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25291
----

# What's new in this PR?

Companion PR: https://github.com/wireapp/kalium/pull/4180

### Issues

After an asset upload failed, the image message bubble showed only a generic "failed" overlay; the user lost the local preview and any sense that the original image was still available.

### Solutions

- `ConversationAssetPathsViewModel.shouldResolveAsset` now treats `FAILED_UPLOAD` as resolvable (in both the `downloadIfNeeded` and the local-only branch), so the local file is surfaced to the UI while the retry is pending.
- `MessageTypes.MessageImageOverlay` splits `FAILED_UPLOAD` out of the shared failure overlay and renders nothing for that state, letting the underlying local image preview show through. `FAILED_DOWNLOAD` still renders the failure overlay. The message-bubble level retry/failure affordance continues to indicate failure status.