### PR TITLE
feat: show pending message status for each message (WPB-25296)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentItem.kt
@@ -145,7 +145,8 @@ fun MessageContentItem(
                     messageStatus = header.messageStatus,
                     useSmallBottomPadding = useSmallBottomPadding,
                     selfDeletionTimerState = selfDeletionTimerState,
-                    decryptionFailed = decryptionFailed
+                    decryptionFailed = decryptionFailed,
+                    isPending = isPending,
                 )
             ) {
                 VerticalSpace.x4()
@@ -206,9 +207,11 @@ private fun shouldShowBottomLabels(
     messageStatus: MessageStatus,
     useSmallBottomPadding: Boolean,
     selfDeletionTimerState: SelfDeletionTimerHelper.SelfDeletionTimerState,
-    decryptionFailed: Boolean
+    decryptionFailed: Boolean,
+    isPending: Boolean,
 ): Boolean = messageStyle.isBubble() && !decryptionFailed && (
         !useSmallBottomPadding
                 || messageStatus.editStatus is MessageEditStatus.Edited
                 || selfDeletionTimerState is SelfDeletionTimerHelper.SelfDeletionTimerState.Expirable
+                || isPending
         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25296
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25296
----

# What's new in this PR?

### Issues

When the user sends multiple messages the bubble UI aggregates them via useSmallBottomPadding = true and hides the trailing footer (timestamp + status indicator) on all but the last message in the sequence. If those messages stay PENDING the status indicator is therefore visible only next to the last message. A user can easily misread this as "only the last message failed to send" when in fact every aggregated message is still pending.

### Solution

Show PENDING status for each message.

<img width="300" alt="Screenshot_20260602_112646" src="https://github.com/user-attachments/assets/af4bc9af-ba0c-4051-936c-72cd35dacca0" />
