### PR TITLE
chore: update runner images to warp-ubuntu in CI workflows [WPB-8645]

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   # Inline simple quality check jobs for better check names
   lint:
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-2404-x64-8x
     # Override JVM args from gradle.properties which sets 10GB heap
     steps:
       - name: Checkout
@@ -37,13 +37,20 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+      - uses: WarpBuilds/cache@v1
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v5
+        uses: gradle/actions/wrapper-validation@v6
       - name: Run Linter
         env:
           GRADLE_OPTS: "-Xmx6G -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g"
@@ -57,7 +64,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   style:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-2x
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -65,13 +72,20 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+      - uses: WarpBuilds/cache@v1
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v5
+        uses: gradle/actions/wrapper-validation@v6
       - name: Run Detekt
         run: |
           ./gradlew detektAll
@@ -99,20 +113,20 @@ jobs:
   # Build matrix job - only runs if all quality checks pass
   build:
     name: "Build ${{ matrix.flavor }}-${{ matrix.variant }}"
-    needs: [lint, style, ui-tests, unit-tests]
+    needs: [ lint, style, ui-tests, unit-tests ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # Continue building other flavors even if one fails
       matrix:
         include: ${{ fromJson(inputs.build-config) }}
-    
+
     steps:
       - name: Quality gates passed - starting build
         run: |
           echo "## Build Starting" >> $GITHUB_STEP_SUMMARY
           echo "✅ Quality gates passed successfully" >> $GITHUB_STEP_SUMMARY
           echo "🚀 Building ${{ matrix.flavor }}${{ matrix.variant }}..." >> $GITHUB_STEP_SUMMARY
-          
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -120,7 +134,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -146,18 +160,18 @@ jobs:
       - name: Set build environment variables
         run: |
           echo "Building ${{ matrix.flavor }}${{ matrix.variant }}"
-          
+
           # Load only the required secrets for this keystore type
           case "${{ matrix.keystore-type }}" in
             debug)
               SIGNING_KEY_ALIAS="${{ secrets.SIGNING_KEY_ALIAS_DEBUG }}"
               SIGNING_KEY_PASSWORD="${{ secrets.SIGNING_KEY_PASSWORD_DEBUG }}"
               SIGNING_STORE_PASSWORD="${{ secrets.SIGNING_STORE_PASSWORD_DEBUG }}"
-              
+
               # Mask sensitive values immediately
               echo "::add-mask::${SIGNING_KEY_PASSWORD}"
               echo "::add-mask::${SIGNING_STORE_PASSWORD}"
-              
+
               # Set environment variables for this keystore type only
               echo "KEYSTORE_KEY_NAME_DEBUG=${SIGNING_KEY_ALIAS}" >> $GITHUB_ENV
               echo "KEYPWD_DEBUG=${SIGNING_KEY_PASSWORD}" >> $GITHUB_ENV
@@ -167,11 +181,11 @@ jobs:
               SIGNING_KEY_ALIAS="${{ secrets.SIGNING_KEY_ALIAS_PRE_RELEASE }}"
               SIGNING_KEY_PASSWORD="${{ secrets.SIGNING_KEY_PASSWORD_PRE_RELEASE }}"
               SIGNING_STORE_PASSWORD="${{ secrets.SIGNING_STORE_PASSWORD_PRE_RELEASE }}"
-              
+
               # Mask sensitive values immediately
               echo "::add-mask::${SIGNING_KEY_PASSWORD}"
               echo "::add-mask::${SIGNING_STORE_PASSWORD}"
-              
+
               # Set environment variables for this keystore type only
               echo "KEYSTORE_KEY_NAME_RELEASE=${SIGNING_KEY_ALIAS}" >> $GITHUB_ENV
               echo "KEYPWD_RELEASE=${SIGNING_KEY_PASSWORD}" >> $GITHUB_ENV
@@ -181,11 +195,11 @@ jobs:
               SIGNING_KEY_ALIAS="${{ secrets.SIGNING_KEY_ALIAS_INTERNAL_RELEASE }}"
               SIGNING_KEY_PASSWORD="${{ secrets.SIGNING_KEY_PASSWORD_INTERNAL_RELEASE }}"
               SIGNING_STORE_PASSWORD="${{ secrets.SIGNING_STORE_PASSWORD_INTERNAL_RELEASE }}"
-              
+
               # Mask sensitive values immediately
               echo "::add-mask::${SIGNING_KEY_PASSWORD}"
               echo "::add-mask::${SIGNING_STORE_PASSWORD}"
-              
+
               # Set environment variables for this keystore type only
               echo "KEYSTORE_KEY_NAME_COMPAT=${SIGNING_KEY_ALIAS}" >> $GITHUB_ENV
               echo "KEYPWD_COMPAT=${SIGNING_KEY_PASSWORD}" >> $GITHUB_ENV
@@ -198,11 +212,11 @@ jobs:
               SIGNING_KEY_ALIAS="${{ secrets.SIGNING_KEY_ALIAS_PUBLIC_RELEASE }}"
               SIGNING_KEY_PASSWORD="${{ secrets.SIGNING_KEY_PASSWORD_PUBLIC_RELEASE }}"
               SIGNING_STORE_PASSWORD="${{ secrets.SIGNING_STORE_PASSWORD_PUBLIC_RELEASE }}"
-              
+
               # Mask sensitive values immediately
               echo "::add-mask::${SIGNING_KEY_PASSWORD}"
               echo "::add-mask::${SIGNING_STORE_PASSWORD}"
-              
+
               # Set environment variables for this keystore type only
               echo "KEYSTORE_KEY_NAME_COMPAT_RELEASE=${SIGNING_KEY_ALIAS}" >> $GITHUB_ENV
               echo "KEYPWD_COMPAT_RELEASE=${SIGNING_KEY_PASSWORD}" >> $GITHUB_ENV
@@ -266,7 +280,7 @@ jobs:
           echo "**Variant**: ${{ matrix.variant }}" >> $GITHUB_STEP_SUMMARY
           echo "**Keystore**: ${{ matrix.keystore-type }}" >> $GITHUB_STEP_SUMMARY
           echo "**Build Type**: ${{ matrix.build-type }}" >> $GITHUB_STEP_SUMMARY
-          
+
           # List generated artifacts
           echo "**Generated Artifacts**:" >> $GITHUB_STEP_SUMMARY
           find app/build/outputs/ -name "*.apk" -o -name "*.aab" | head -10 | while read file; do

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   generate-screenshots:
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-2404-x64-8x
 
     if: github.ref == 'refs/heads/develop'
 
@@ -24,14 +24,22 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+
+      - uses: WarpBuilds/cache@v1
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v5
+        uses: gradle/actions/wrapper-validation@v6
 
       - name: Install Git LFS
         run: |
@@ -71,7 +79,7 @@ jobs:
       - name: Clear changes before generating new screenshots
         run: |
           git reset --hard HEAD
-          git clean -fd        
+          git clean -fd
 
       - name: Update Screenshot Reference Images
         run: ./gradlew updateInternalDebugScreenshotTest

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   ui-tests:
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg
+    runs-on: warp-ubuntu-latest-x64-8x
     strategy:
       matrix:
         api-level: [ 29 ]
@@ -40,23 +40,39 @@ jobs:
           df -h
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+
+      - uses: WarpBuilds/cache@v1
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v5
+        uses: gradle/actions/wrapper-validation@v6
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: AVD cache
-        uses: actions/cache@v4
+        uses: WarpBuilds/cache@v1
         id: avd-cache
         with:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+          key: ${{ runner.os }}-avd-${{ matrix.api-level }}
+          restore-keys: |
+            ${{ runner.os }}-avd-
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
   coverage:
     env:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=2g -Xmx4G"'
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-2404-x64-8x
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -26,13 +26,20 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+      - uses: WarpBuilds/cache@v1
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v5
+        uses: gradle/actions/wrapper-validation@v6
 
       - name: Test Build Logic
         run: |


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
Backports the final runner/cache setup from #4739 to the 4.22 release branch so the 4.22.1 cherry-pick PRs can build on GitHub Actions.

Changes included:
- move affected jobs to Warp runners
- use WarpBuilds/cache@v1 for Gradle/AVD caching where applicable
- update actions/setup-java to v5
- update Gradle wrapper validation to v6

Base: release/cycle-4.22
Cherry-picked from: 953e8467e