### PR TITLE
test: add external user channel creation restriction coverage (WPB-26060)

### DIFF
--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/ChannelTest.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/ChannelTest.kt
@@ -1030,4 +1030,93 @@ class ChannelTest : BaseUiTest() {
             waitUntilToastIsDisplayed("You left the conversation.")
         }
     }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    @TestCaseId("TC-26060")
+    @Category("channels", "regression", "RC")
+    @Test
+    fun givenExternalUserInTeam_whenAttemptingToCreateChannelConversation_thenChannelConversationCannotBeCreated() {
+        step("There is TeamOwner with team CreateChannel on Staging backend") {
+            teamHelper.usersManager.createTeamOwnerByAlias(
+                "user1Name",
+                "CreateChannel",
+                "en_US",
+                true,
+                backendClient,
+                context
+            )
+        }
+
+        step("User TeamOwner configures MLS for team CreateChannel") {
+            teamHelper.userConfiguresMLSForTeam("user1Name", "CreateChannel", backendClient)
+        }
+
+        step("TeamOwner enables channel feature for team CreateChannel via backdoor") {
+            teamHelper.userEnablesChannelFeatureForTeam("user1Name", "CreateChannel", backendClient)
+        }
+
+        step("User TeamOwner adds user Member1 to team CreateChannel with role External") {
+            teamHelper.userXAddsUsersToTeam(
+                "user1Name",
+                "user2Name",
+                "CreateChannel",
+                TeamRoles.External,
+                backendClient,
+                context,
+                true
+            )
+        }
+
+        step("Member1 adds a new device Device1 via backend") {
+            testServiceHelper.apply {
+                addDevice("user2Name", null, "Device1")
+            }
+        }
+
+        step("User Member1 is available for login") {
+            member1 = teamHelper.usersManager.findUserByNameOrNameAlias("user2Name")
+        }
+
+        step("And I see welcome screen before login") {
+            pages.registrationPage.apply {
+                assertEmailWelcomePage()
+            }
+        }
+
+        step("And I open staging deep link login flow") {
+            pages.loginPage.apply {
+                clickStagingDeepLink()
+                clickProceedButtonOnDeeplinkOverlay()
+            }
+        }
+
+        step("And I login as Member1") {
+            pages.loginPage.apply {
+                enterTeamOwnerLoggingEmail(member1.email ?: "")
+                clickLoginButton()
+                enterTeamOwnerLoggingPassword(member1.password ?: "")
+                clickLoginButton()
+            }
+        }
+
+        step("And I complete post-login permission and privacy prompts") {
+            pages.registrationPage.apply {
+                waitUntilLoginFlowIsCompleted()
+                clickAllowNotificationButton()
+                clickDeclineShareDataAlert()
+            }
+        }
+
+        step("And I tap Start new conversation flow from conversation list") {
+            pages.conversationListPage.apply {
+                tapStartNewConversationButton()
+            }
+        }
+
+        step("Then I do not see create new channel button") {
+            pages.conversationListPage.apply {
+                assertCreateNewChannelButtonNotVisible()
+            }
+        }
+    }
 }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationListPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationListPage.kt
@@ -61,6 +61,7 @@ data class ConversationListPage(private val device: UiDevice) {
     private val leaveConversationDescriptionOnModal =
         UiSelectorParams(textContains = "You will then no longer be able to send or read messages")
     private val startNewConversation = UiSelectorParams(description = "New. Start a new conversation")
+    private val createNewChannelButton = UiSelectorParams(text = "New Channel")
 
     private val userConversationNamePendingLabelSelector =
         UiSelector().description("pending approval of connection request")
@@ -315,6 +316,15 @@ data class ConversationListPage(private val device: UiDevice) {
 
     fun tapStartNewConversationButton(): ConversationListPage {
         UiWaitUtils.waitElement(startNewConversation).click()
+        return this
+    }
+
+    fun assertCreateNewChannelButtonNotVisible(): ConversationListPage {
+        val createNewChannel = findElementOrNull(createNewChannelButton)
+        Assert.assertTrue(
+            "Create new channel button is visible.",
+            createNewChannel == null || createNewChannel.visibleBounds.isEmpty
+        )
         return this
     }
 

--- a/tests/testsSupport/src/main/backendUtils/team/TeamsExtension.kt
+++ b/tests/testsSupport/src/main/backendUtils/team/TeamsExtension.kt
@@ -539,12 +539,12 @@ val defaultheaders = mapOf(
 )
 
 enum class TeamRoles(val role: String, val permissionBitMask: Int) {
-    Owner("Owner", 8191),
-    Admin("Admin", 5951),
+    Owner("owner", 8191),
+    Admin("admin", 5951),
     Member("member", 1587),
-    Partner("Partner", 1025),
-    External("External", 0),
-    INVALID("Invalid", 1234);
+    Partner("partner", 1025),
+    External("partner", 0),
+    INVALID("invalid", 1234);
 
     companion object {
         fun getByPermissionBitMask(permissionBitMask: Int): TeamRoles =


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26060
<!--jira-description-action-hidden-marker-end-->

…060)

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Adds end-to-end coverage for the external-user restriction on channel creation in ChannelTest.

- Logs in as the external and verifies that the New Channel action is not visible for the external user, confirming they cannot create a channel conversation.

- Updates the test-support team role values to match the backend invite API expectations by lowercasing role strings, allowing the external-user setup in this scenario to work.

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
