### PR TITLE
fix: crash in E2EI screen (WPB-26074)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
@@ -39,6 +39,7 @@ import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.style.PopUpNavigationAnimation
+import com.wire.android.ui.authentication.clearSessionViewModel
 import com.wire.android.ui.authentication.devices.common.ClearSessionState
 import com.wire.android.ui.authentication.devices.common.ClearSessionViewModel
 import com.wire.android.ui.common.TextWithLearnMore
@@ -71,7 +72,7 @@ fun E2EIEnrollmentScreen(
     navigator: Navigator,
     loginTypeSelector: LoginTypeSelector,
     viewModel: E2EIEnrollmentViewModel = wireViewModel(),
-    clearSessionViewModel: ClearSessionViewModel = wireViewModel(),
+    clearSessionViewModel: ClearSessionViewModel = clearSessionViewModel(),
 ) {
     val state = viewModel.state
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26074
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-26074
----

# What's new in this PR?

### Issues

Application crash in E2EI screen.

### Causes (Optional)

E2EI screen not updated during Metro DI migration.
