### PR TITLE
feat: add compose stability config file to stability analyzer [WPB-8645]

### DIFF
--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -1685,7 +1685,7 @@ public fun com.wire.android.ui.calling.common.CallerDetails(conversationId: com.
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - conversationName: STABLE (class with no mutable properties)
     - accentId: STABLE (primitive type)
     - isCameraOn: STABLE (primitive type)
@@ -1887,7 +1887,7 @@ public fun com.wire.android.ui.calling.incoming.IncomingCallScreen(conversationI
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - shouldTryToAnswerCallAutomatically: STABLE (primitive type)
     - incomingCallViewModel: UNSTABLE (has mutable properties or unstable members)
     - sharedCallingViewModel: UNSTABLE (has mutable properties or unstable members)
@@ -1895,10 +1895,10 @@ public fun com.wire.android.ui.calling.incoming.IncomingCallScreen(conversationI
 
 @Composable
 private fun com.wire.android.ui.calling.ongoing.CallingControls(conversationId: com.wire.kalium.logic.data.id.QualifiedID, isMuted: kotlin.Boolean, isCameraOn: kotlin.Boolean, isSpeakerOn: kotlin.Boolean, isShowingCallReactions: kotlin.Boolean, isConnecting: kotlin.Boolean, inCallReactionsEnabled: kotlin.Boolean, toggleSpeaker: kotlin.Function0<kotlin.Unit>, toggleMute: kotlin.Function0<kotlin.Unit>, onHangUpCall: kotlin.Function0<kotlin.Unit>, onToggleVideo: kotlin.Function0<kotlin.Unit>, onCallReactionsClick: kotlin.Function0<kotlin.Unit>, onCameraPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - isMuted: STABLE (primitive type)
     - isCameraOn: STABLE (primitive type)
     - isSpeakerOn: STABLE (primitive type)
@@ -1975,7 +1975,7 @@ public fun com.wire.android.ui.calling.ongoing.OngoingCallScreen(conversationId:
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - ongoingCallViewModel: UNSTABLE (has mutable properties or unstable members)
     - sharedCallingViewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -2533,7 +2533,7 @@ public fun com.wire.android.ui.calling.outgoing.OutgoingCallScreen(conversationI
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - sharedCallingViewModel: UNSTABLE (has mutable properties or unstable members)
     - outgoingCallViewModel: UNSTABLE (has mutable properties or unstable members)
     - onCallAccepted: STABLE (function type)
@@ -2543,7 +2543,7 @@ public fun com.wire.android.ui.common.AddContactButton(userId: com.wire.kalium.l
   skippable: false
   restartable: true
   params:
-    - userId: UNSTABLE (has mutable properties or unstable members)
+    - userId: STABLE (matched by stability configuration)
     - userName: STABLE (String is immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - viewModel: RUNTIME (requires runtime check)
@@ -2976,7 +2976,7 @@ public fun com.wire.android.ui.common.banner.SecurityClassificationBannerForConv
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - modifier: STABLE (marked @Stable or @Immutable)
     - viewModel: RUNTIME (requires runtime check)
 
@@ -2985,7 +2985,7 @@ public fun com.wire.android.ui.common.banner.SecurityClassificationBannerForUser
   skippable: false
   restartable: true
   params:
-    - userId: UNSTABLE (has mutable properties or unstable members)
+    - userId: STABLE (matched by stability configuration)
     - modifier: STABLE (marked @Stable or @Immutable)
     - viewModel: RUNTIME (requires runtime check)
 
@@ -3639,7 +3639,7 @@ public fun com.wire.android.ui.connection.ConnectionActionButton(userId: com.wir
   skippable: false
   restartable: true
   params:
-    - userId: UNSTABLE (has mutable properties or unstable members)
+    - userId: STABLE (matched by stability configuration)
     - userName: STABLE (String is immutable)
     - fullName: STABLE (String is immutable)
     - connectionStatus: STABLE (class with no mutable properties)
@@ -4673,7 +4673,7 @@ private fun com.wire.android.ui.home.conversations.ConversationScreenContent(con
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - bottomSheetVisible: STABLE (primitive type)
     - lastUnreadMessageInstant: UNSTABLE (has mutable properties or unstable members)
     - unreadEventCount: STABLE (primitive type)
@@ -4896,7 +4896,7 @@ public fun com.wire.android.ui.home.conversations.UsersTypingIndicatorForConvers
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - viewModel: RUNTIME (requires runtime check)
 
 @Composable
@@ -5600,7 +5600,7 @@ public fun com.wire.android.ui.home.conversations.edit.MessageOptionsModalSheetL
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - sheetState: UNSTABLE (has mutable properties or unstable members)
     - onCopyClick: STABLE (function type)
     - onDeleteClick: STABLE (function type)
@@ -6127,7 +6127,7 @@ internal fun com.wire.android.ui.home.conversations.messages.QuotedMessage(conve
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - messageData: UNSTABLE (has mutable properties or unstable members)
     - clickable: STABLE (class with no mutable properties)
     - style: STABLE (class with no mutable properties)
@@ -6161,7 +6161,7 @@ public fun com.wire.android.ui.home.conversations.messages.QuotedMessagePreview(
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - quotedMessageData: UNSTABLE (has mutable properties or unstable members)
     - onCancelReply: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)
@@ -6180,7 +6180,7 @@ public fun com.wire.android.ui.home.conversations.messages.QuotedMultipartMessag
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - quotedMessageId: STABLE (String is immutable)
     - senderName: STABLE (class with no mutable properties)
     - originalDateTimeText: STABLE (class with no mutable properties)
@@ -6718,7 +6718,7 @@ public fun com.wire.android.ui.home.conversations.messages.item.remainingColor()
   params:
 
 @Composable
-private fun com.wire.android.ui.home.conversations.messages.item.shouldShowBottomLabels(messageStyle: com.wire.android.ui.home.conversations.messages.item.MessageStyle, messageStatus: com.wire.android.ui.home.conversations.model.MessageStatus, useSmallBottomPadding: kotlin.Boolean, selfDeletionTimerState: com.wire.android.ui.home.conversations.SelfDeletionTimerHelper.SelfDeletionTimerState, decryptionFailed: kotlin.Boolean): kotlin.Boolean
+private fun com.wire.android.ui.home.conversations.messages.item.shouldShowBottomLabels(messageStyle: com.wire.android.ui.home.conversations.messages.item.MessageStyle, messageStatus: com.wire.android.ui.home.conversations.model.MessageStatus, useSmallBottomPadding: kotlin.Boolean, selfDeletionTimerState: com.wire.android.ui.home.conversations.SelfDeletionTimerHelper.SelfDeletionTimerState, decryptionFailed: kotlin.Boolean, isPending: kotlin.Boolean): kotlin.Boolean
   skippable: true
   restartable: true
   params:
@@ -6727,6 +6727,7 @@ private fun com.wire.android.ui.home.conversations.messages.item.shouldShowBotto
     - useSmallBottomPadding: STABLE (primitive type)
     - selfDeletionTimerState: STABLE (class with no mutable properties)
     - decryptionFailed: STABLE (primitive type)
+    - isPending: STABLE (primitive type)
 
 @Composable
 public fun com.wire.android.ui.home.conversations.messages.item.surface(): androidx.compose.ui.graphics.Color
@@ -7101,7 +7102,7 @@ public fun com.wire.android.ui.home.conversations.model.messagetypes.multipart.M
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - attachments: RUNTIME (requires runtime check)
     - messageStyle: STABLE (class with no mutable properties)
     - onImageAttachmentClick: STABLE (function type)
@@ -7312,11 +7313,11 @@ public fun com.wire.android.ui.home.conversations.search.EmptySearchQueryScreen(
 
 @Composable
 public fun com.wire.android.ui.home.conversations.search.ExternalContactSearchResultItem(avatarData: com.wire.android.model.UserAvatarData, userId: com.wire.kalium.logic.data.id.QualifiedID, name: kotlin.String, label: kotlin.String, membership: com.wire.android.ui.home.conversationslist.model.Membership, searchQuery: kotlin.String, connectionState: com.wire.kalium.logic.data.user.ConnectionState, clickable: com.wire.android.model.Clickable, modifier: androidx.compose.ui.Modifier): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
     - avatarData: STABLE (marked @Stable or @Immutable)
-    - userId: UNSTABLE (has mutable properties or unstable members)
+    - userId: STABLE (matched by stability configuration)
     - name: STABLE (String is immutable)
     - label: STABLE (String is immutable)
     - membership: STABLE (class with no mutable properties)
@@ -8112,7 +8113,7 @@ public fun com.wire.android.ui.home.messagecomposer.ActiveMessageComposerInput(c
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - messageComposition: UNSTABLE (has mutable properties or unstable members)
     - messageTextState: STABLE (marked @Stable or @Immutable)
     - isTextExpanded: STABLE (primitive type)
@@ -8178,10 +8179,10 @@ public fun com.wire.android.ui.home.messagecomposer.AdditionalOptionSubMenu(isFi
 
 @Composable
 public fun com.wire.android.ui.home.messagecomposer.AdditionalOptionsMenu(conversationId: com.wire.kalium.logic.data.id.QualifiedID, additionalOptionsState: com.wire.android.ui.home.messagecomposer.state.AdditionalOptionMenuState, selectedOption: com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSelectItem, attachmentsVisible: kotlin.Boolean, isEditing: kotlin.Boolean, isMentionActive: kotlin.Boolean, isFileSharingEnabled: kotlin.Boolean, onAdditionalOptionsMenuClicked: kotlin.Function0<kotlin.Unit>, onMentionButtonClicked: kotlin.Function0<kotlin.Unit>, onPingOptionClicked: kotlin.Function0<kotlin.Unit>, onRichEditingButtonClicked: kotlin.Function0<kotlin.Unit>, onCloseRichEditingButtonClicked: kotlin.Function0<kotlin.Unit>, onRichOptionButtonClicked: kotlin.Function1<com.wire.android.ui.home.messagecomposer.state.RichTextMarkdown, kotlin.Unit>, onDrawingModeClicked: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, onOnSelfDeletingOptionClicked: kotlin.Function1<com.wire.kalium.logic.data.message.SelfDeletionTimer, kotlin.Unit>?, onGifOptionClicked: kotlin.Function0<kotlin.Unit>?): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - additionalOptionsState: STABLE (class with no mutable properties)
     - selectedOption: STABLE (class with no mutable properties)
     - attachmentsVisible: STABLE (primitive type)
@@ -8201,10 +8202,10 @@ public fun com.wire.android.ui.home.messagecomposer.AdditionalOptionsMenu(conver
 
 @Composable
 public fun com.wire.android.ui.home.messagecomposer.AttachmentAndAdditionalOptionsMenuItems(conversationId: com.wire.kalium.logic.data.id.QualifiedID, isEditing: kotlin.Boolean, selectedOption: com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSelectItem, attachmentsVisible: kotlin.Boolean, isMentionActive: kotlin.Boolean, isFileSharingEnabled: kotlin.Boolean, onMentionButtonClicked: kotlin.Function0<kotlin.Unit>, onSelfDeletionOptionButtonClicked: kotlin.Function1<com.wire.kalium.logic.data.message.SelfDeletionTimer, kotlin.Unit>, modifier: androidx.compose.ui.Modifier, onAdditionalOptionsMenuClicked: kotlin.Function0<kotlin.Unit>, onPingClicked: kotlin.Function0<kotlin.Unit>, onGifButtonClicked: kotlin.Function0<kotlin.Unit>, onRichEditingButtonClicked: kotlin.Function0<kotlin.Unit>, onDrawingModeClicked: kotlin.Function0<kotlin.Unit>): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - isEditing: STABLE (primitive type)
     - selectedOption: STABLE (class with no mutable properties)
     - attachmentsVisible: STABLE (primitive type)
@@ -8268,10 +8269,10 @@ public fun com.wire.android.ui.home.messagecomposer.CollapseButton(isCollapsed: 
 
 @Composable
 private fun com.wire.android.ui.home.messagecomposer.ComposingActions(conversationId: com.wire.kalium.logic.data.id.QualifiedID, selectedOption: com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSelectItem, isFileSharingEnabled: kotlin.Boolean, attachmentsVisible: kotlin.Boolean, isMentionActive: kotlin.Boolean, onAdditionalOptionButtonClicked: kotlin.Function0<kotlin.Unit>, onRichEditingButtonClicked: kotlin.Function0<kotlin.Unit>, onGifButtonClicked: kotlin.Function0<kotlin.Unit>, onSelfDeletionOptionButtonClicked: kotlin.Function1<com.wire.kalium.logic.data.message.SelfDeletionTimer, kotlin.Unit>, onPingButtonClicked: kotlin.Function0<kotlin.Unit>, onMentionButtonClicked: kotlin.Function0<kotlin.Unit>, onDrawingModeClicked: kotlin.Function0<kotlin.Unit>): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - selectedOption: STABLE (class with no mutable properties)
     - isFileSharingEnabled: STABLE (primitive type)
     - attachmentsVisible: STABLE (primitive type)
@@ -8286,10 +8287,10 @@ private fun com.wire.android.ui.home.messagecomposer.ComposingActions(conversati
 
 @Composable
 private fun com.wire.android.ui.home.messagecomposer.DisabledInteractionMessageComposer(conversationId: com.wire.kalium.logic.data.id.QualifiedID, warningText: androidx.compose.ui.text.AnnotatedString?, learnMoreLink: kotlin.String?, messageListContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - warningText: STABLE (marked @Stable or @Immutable)
     - learnMoreLink: STABLE (class with no mutable properties)
     - messageListContent: STABLE (composable function type)
@@ -8329,7 +8330,7 @@ public fun com.wire.android.ui.home.messagecomposer.EnabledMessageComposer(conve
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - bottomSheetVisible: STABLE (primitive type)
     - messageComposerStateHolder: UNSTABLE (has mutable properties or unstable members)
     - attachments: RUNTIME (requires runtime check)
@@ -8363,7 +8364,7 @@ private fun com.wire.android.ui.home.messagecomposer.InputContent(conversationId
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - messageTextState: STABLE (marked @Stable or @Immutable)
     - isTextExpanded: STABLE (primitive type)
     - inputType: STABLE (class with no mutable properties)
@@ -8412,10 +8413,10 @@ public fun com.wire.android.ui.home.messagecomposer.MessageAttachments(attachmen
 
 @Composable
 public fun com.wire.android.ui.home.messagecomposer.MessageComposeActions(conversationId: com.wire.kalium.logic.data.id.QualifiedID, isEditing: kotlin.Boolean, attachmentsVisible: kotlin.Boolean, selectedOption: com.wire.android.ui.home.messagecomposer.state.AdditionalOptionSelectItem, onMentionButtonClicked: kotlin.Function0<kotlin.Unit>, onAdditionalOptionButtonClicked: kotlin.Function0<kotlin.Unit>, onPingButtonClicked: kotlin.Function0<kotlin.Unit>, onSelfDeletionOptionButtonClicked: kotlin.Function1<com.wire.kalium.logic.data.message.SelfDeletionTimer, kotlin.Unit>, onGifButtonClicked: kotlin.Function0<kotlin.Unit>, onRichEditingButtonClicked: kotlin.Function0<kotlin.Unit>, isFileSharingEnabled: kotlin.Boolean, isMentionActive: kotlin.Boolean, onDrawingModeClicked: kotlin.Function0<kotlin.Unit>): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - isEditing: STABLE (primitive type)
     - attachmentsVisible: STABLE (primitive type)
     - selectedOption: STABLE (class with no mutable properties)
@@ -8434,7 +8435,7 @@ public fun com.wire.android.ui.home.messagecomposer.MessageComposer(conversation
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - bottomSheetVisible: STABLE (primitive type)
     - messageComposerStateHolder: UNSTABLE (has mutable properties or unstable members)
     - attachments: RUNTIME (requires runtime check)
@@ -8530,7 +8531,7 @@ public fun com.wire.android.ui.home.messagecomposer.SelfDeletingMessageAction(co
   skippable: false
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - onButtonClicked: STABLE (function type)
     - viewModel: RUNTIME (requires runtime check)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,9 @@ subprojects {
         extensions.configure<com.skydoves.compose.stability.gradle.StabilityAnalyzerExtension>("composeStabilityAnalyzer") {
             stabilityValidation {
                 ignoreNonRegressiveChanges.set(true)
+                stabilityConfigurationFiles.add(
+                    rootProject.layout.projectDirectory.file("config/compose-stability.conf")
+                )
             }
         }
     }

--- a/core/ui-common/stability/ui-common-debug.stability
+++ b/core/ui-common/stability/ui-common-debug.stability
@@ -1031,10 +1031,10 @@ public fun com.wire.android.ui.common.card.WireOutlinedCard(title: kotlin.String
 
 @Composable
 public fun com.wire.android.ui.common.channelConversationColor(id: com.wire.kalium.logic.data.id.QualifiedID): com.wire.android.ui.theme.ChannelAvatarColors
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - id: UNSTABLE (has mutable properties or unstable members)
+    - id: STABLE (matched by stability configuration)
 
 @Composable
 public fun com.wire.android.ui.common.chip.CountBadge(count: kotlin.Int, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -1165,10 +1165,10 @@ private fun com.wire.android.ui.common.getButton(modifier: androidx.compose.ui.M
 
 @Composable
 public fun com.wire.android.ui.common.groupConversationColor(id: com.wire.kalium.logic.data.id.QualifiedID): com.wire.android.ui.theme.GroupAvatarColors
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - id: UNSTABLE (has mutable properties or unstable members)
+    - id: STABLE (matched by stability configuration)
 
 @Composable
 public fun com.wire.android.ui.common.image.WireImage(model: kotlin.Any?, contentDescription: kotlin.String, modifier: androidx.compose.ui.Modifier, contentScale: androidx.compose.ui.layout.ContentScale, placeholder: androidx.compose.ui.graphics.painter.Painter?): kotlin.Unit
@@ -2059,10 +2059,10 @@ public fun com.wire.android.ui.common.wireDialogPropertiesBuilder(dismissOnBackP
 
 @Composable
 public fun com.wire.android.ui.home.conversationslist.common.ChannelConversationAvatar(conversationId: com.wire.kalium.logic.data.id.QualifiedID, isPrivateChannel: kotlin.Boolean, modifier: androidx.compose.ui.Modifier, size: androidx.compose.ui.unit.Dp, cornerRadius: androidx.compose.ui.unit.Dp, padding: androidx.compose.ui.unit.Dp, borderWidth: androidx.compose.ui.unit.Dp): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - isPrivateChannel: STABLE (primitive type)
     - modifier: STABLE (marked @Stable or @Immutable)
     - size: STABLE (marked @Stable or @Immutable)
@@ -2091,10 +2091,10 @@ public fun com.wire.android.ui.home.conversationslist.common.CustomGroupAvatarDr
 
 @Composable
 public fun com.wire.android.ui.home.conversationslist.common.RegularGroupConversationAvatar(conversationId: com.wire.kalium.logic.data.id.QualifiedID, modifier: androidx.compose.ui.Modifier, size: androidx.compose.ui.unit.Dp, cornerRadius: androidx.compose.ui.unit.Dp, padding: androidx.compose.ui.unit.Dp, borderWidth: androidx.compose.ui.unit.Dp, borderColor: androidx.compose.ui.graphics.Color): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - modifier: STABLE (marked @Stable or @Immutable)
     - size: STABLE (marked @Stable or @Immutable)
     - cornerRadius: STABLE (marked @Stable or @Immutable)

--- a/features/meetings/stability/meetings-debug.stability
+++ b/features/meetings/stability/meetings-debug.stability
@@ -42,10 +42,10 @@ private fun com.wire.android.feature.meetings.ui.list.MeetingAttendingPrimaryBod
 
 @Composable
 private fun com.wire.android.feature.meetings.ui.list.MeetingBelongingInfoRow(conversationId: com.wire.kalium.logic.data.id.QualifiedID, type: com.wire.android.feature.meetings.model.MeetingItem.BelongingType): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - conversationId: UNSTABLE (has mutable properties or unstable members)
+    - conversationId: STABLE (matched by stability configuration)
     - type: STABLE (class with no mutable properties)
 
 @Composable
@@ -124,10 +124,10 @@ private fun com.wire.android.feature.meetings.ui.list.MeetingOngoingAttendingRow
 
 @Composable
 private fun com.wire.android.feature.meetings.ui.list.MeetingOngoingDurationTimeSublineText(startedTime: kotlinx.datetime.Instant): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - startedTime: UNSTABLE (has mutable properties or unstable members)
+    - startedTime: STABLE (matched by stability configuration)
 
 @Composable
 public fun com.wire.android.feature.meetings.ui.list.MeetingShowAllFooter(onShowAll: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -139,10 +139,10 @@ public fun com.wire.android.feature.meetings.ui.list.MeetingShowAllFooter(onShow
 
 @Composable
 private fun com.wire.android.feature.meetings.ui.list.MeetingStartingInPrimaryBodyText(startTime: kotlinx.datetime.Instant): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - startTime: UNSTABLE (has mutable properties or unstable members)
+    - startTime: STABLE (matched by stability configuration)
 
 @Composable
 private fun com.wire.android.feature.meetings.ui.list.MeetingTimeInfoRow(status: com.wire.android.feature.meetings.model.MeetingItem.Status): kotlin.Unit
@@ -182,10 +182,10 @@ internal fun com.wire.android.feature.meetings.ui.list.VideoCallIcon(tint: andro
 
 @Composable
 private fun com.wire.android.feature.meetings.ui.list.getDateHeaderString(time: kotlinx.datetime.Instant): kotlin.String
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - time: UNSTABLE (has mutable properties or unstable members)
+    - time: STABLE (matched by stability configuration)
 
 @Composable
 private fun com.wire.android.feature.meetings.ui.options.MeetingOptionsModalContent(meeting: com.wire.android.feature.meetings.model.MeetingItem, onStartMeeting: kotlin.Function0<kotlin.Unit>, onCreateConversation: kotlin.Function0<kotlin.Unit>, onCopyLink: kotlin.Function0<kotlin.Unit>, onEditMeeting: kotlin.Function0<kotlin.Unit>, onDeleteMeetingForMe: kotlin.Function0<kotlin.Unit>, onDeleteMeetingForEveryone: kotlin.Function0<kotlin.Unit>): kotlin.Unit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ compose-activity = "1.13.0"
 compose-constraint = "1.1.1"
 compose-navigation = "2.9.5" # aligned with compose-destinations 2.3.0
 compose-destinations = "2.3.0"
-compose-stability-analyzer = "0.7.5"
+compose-stability-analyzer = "0.8.0"
 screenshot = "0.0.1-alpha14"
 jetbrains-compose = "1.10.3"
 # TODO(KMP): switch Compose MPP material3 to stable when available for this stack.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Turns out there's an option to add compose stability config file to the stability analyzer as well.
This PR adds this file so that the analyzer treats all these configured files as stable as well.
Also, baseline got updated to include info about these parameters now being stable (matched by stability configuration).

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
