### PR TITLE
test: add non-creator channel delete restriction coverage (WPB-26086)

### DIFF
--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/ChannelTest.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/ChannelTest.kt
@@ -66,7 +66,7 @@ class ChannelTest : BaseUiTest() {
 
     @After
     fun tearDown() {
-          cleanupCreatedUsers(backendClient, teamHelper.usersManager)
+        cleanupCreatedUsers(backendClient, teamHelper.usersManager)
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
@@ -1116,6 +1116,222 @@ class ChannelTest : BaseUiTest() {
         step("Then I do not see create new channel button") {
             pages.conversationListPage.apply {
                 assertCreateNewChannelButtonNotVisible()
+            }
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    @TestCaseId("TC-26086")
+    @Category("channels", "regression", "RC")
+    @Test
+    fun givenUserIsNotCreatorOfChannelConversation_whenViewingChannelConversationOptions_thenDeleteConversationButtonIsNotVisible() {
+        step("There is TeamOwner with team DeleteChannel on Staging backend") {
+            teamHelper.usersManager.createTeamOwnerByAlias(
+                "user1Name",
+                "DeleteChannel",
+                "en_US",
+                true,
+                backendClient,
+                context
+            )
+        }
+
+        step("User TeamOwner configures MLS for team DeleteChannel") {
+            teamHelper.userConfiguresMLSForTeam("user1Name", "DeleteChannel", backendClient)
+        }
+
+        step("TeamOwner enables channel feature for team DeleteChannel via backdoor") {
+            teamHelper.userEnablesChannelFeatureForTeam("user1Name", "DeleteChannel", backendClient)
+        }
+
+        step("User TeamOwner adds users Member1 to team DeleteChannel with role Member") {
+            teamHelper.userXAddsUsersToTeam(
+                "user1Name",
+                "user2Name",
+                "DeleteChannel",
+                TeamRoles.Member,
+                backendClient,
+                context,
+                true
+            )
+        }
+
+        step("Member1 adds a new device Device1 via backend") {
+            testServiceHelper.apply {
+                addDevice("user2Name", null, "Device1")
+            }
+        }
+
+        step("TeamOwner has channel conversation UnableToDelete in team DeleteChannel") {
+            testServiceHelper.userHasChannelConversationInTeam(
+                "user1Name",
+                "UnableToDelete",
+                "DeleteChannel"
+            )
+        }
+
+        step("User TeamOwner is me") {
+            teamOwner = teamHelper.usersManager.findUserByNameOrNameAlias("user1Name")
+        }
+
+        step("User Member1 is available for channel participant selection and login") {
+            member1 = teamHelper.usersManager.findUserByNameOrNameAlias("user2Name")
+        }
+
+        step("And I see welcome screen before login") {
+            pages.registrationPage.apply {
+                assertEmailWelcomePage()
+            }
+        }
+
+        step("And I open staging deep link login flow") {
+            pages.loginPage.apply {
+                clickStagingDeepLink()
+                clickProceedButtonOnDeeplinkOverlay()
+            }
+        }
+
+        step("And I login as TeamOwner") {
+            pages.loginPage.apply {
+                enterTeamOwnerLoggingEmail(teamOwner.email ?: "")
+                clickLoginButton()
+                enterTeamOwnerLoggingPassword(teamOwner.password ?: "")
+                clickLoginButton()
+            }
+        }
+
+        step("And I complete post-login permission and privacy prompts") {
+            pages.registrationPage.apply {
+                waitUntilLoginFlowIsCompleted()
+                clickAllowNotificationButton()
+                clickDeclineShareDataAlert()
+            }
+        }
+
+        step("And I see conversation UnableToDelete in conversation list") {
+            pages.conversationListPage.apply {
+                assertChannelConversationVisible("UnableToDelete")
+            }
+        }
+
+        step("When I tap on conversation name UnableToDelete in conversation list") {
+            pages.conversationListPage.apply {
+                clickChannelConversation("UnableToDelete")
+            }
+        }
+
+        step("And I tap on channel conversation title UnableToDelete to open group details") {
+            pages.conversationViewPage.apply {
+                UiWaitUtils.waitFor(1.seconds)
+                clickOnChannelConversationDetails("UnableToDelete")
+            }
+        }
+
+        step("And I open participants tab and start add participant flow") {
+            pages.groupConversationDetailsPage.apply {
+                tapOnParticipantsTab()
+                tapAddParticipantsButton()
+            }
+        }
+
+        step("And I select Member1 from participant suggestions") {
+            pages.groupConversationDetailsPage.apply {
+                assertUsernameInSuggestionsListIs(member1.name ?: "")
+                selectUserInSuggestionList(member1.name ?: "")
+                tapContinueButton()
+            }
+        }
+
+        step("And I verify Member1 is added to participants list and click close button") {
+            pages.groupConversationDetailsPage.apply {
+                assertUsernameIsAddedToParticipantsList(member1.name ?: "")
+                tapCloseButtonOnChannelConversationDetailsPage()
+            }
+        }
+
+        step("And I verify system message confirms Member1 was added") {
+            iSeeSystemMessageContainingAll(
+                "You added",
+                member1.name ?: "",
+                "to the conversation"
+            )
+        }
+
+        step("Then I see channel conversation UnableToDelete is in foreground") {
+            pages.conversationViewPage.apply {
+                assertChannelConversationInForeground("UnableToDelete")
+            }
+        }
+
+        step("And I tap back button on conversationViewPage back to conversation list page") {
+            pages.conversationViewPage.apply {
+                tapBackButtonToCloseConversationViewPage()
+            }
+        }
+
+        step("And I tap User Profile Button") {
+            pages.conversationListPage.apply {
+                clickUserProfileButton()
+            }
+        }
+
+        step("And I see User Profile Page") {
+            pages.selfUserProfilePage.apply {
+                iSeeUserProfilePage()
+            }
+        }
+
+        step("When I tap New Team or Account button") {
+            pages.selfUserProfilePage.apply {
+                tapNewTeamOrAddAccountButton()
+            }
+        }
+
+        step("And I see welcome screen before login") {
+            pages.registrationPage.apply {
+                assertEmailWelcomePage()
+            }
+        }
+
+        step("And I open staging deep link login flow") {
+            pages.loginPage.apply {
+                clickStagingDeepLink()
+                clickProceedButtonOnDeeplinkOverlay()
+            }
+        }
+
+        step("And I login as Member1") {
+            pages.loginPage.apply {
+                enterTeamOwnerLoggingEmail(member1.email ?: "")
+                clickLoginButton()
+                enterTeamOwnerLoggingPassword(member1.password ?: "")
+                clickLoginButton()
+            }
+        }
+
+        step("And I complete post-login permission and privacy prompts") {
+            pages.registrationPage.apply {
+                waitUntilLoginFlowIsCompleted()
+                clickAllowNotificationButton()
+                clickDeclineShareDataAlert()
+            }
+        }
+
+        step("And I see conversation UnableToDelete in conversation list") {
+            pages.conversationListPage.apply {
+                assertChannelConversationVisible("UnableToDelete")
+            }
+        }
+
+        step("And I long press on conversation name UnableToDelete in conversation list") {
+            pages.conversationListPage.apply {
+                longPressConversation("UnableToDelete")
+            }
+        }
+
+        step("Then I do not see Delete Conversation button") {
+            pages.conversationListPage.apply {
+                assertDeleteConversationButtonNotVisibleInConversationActions()
             }
         }
     }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationListPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationListPage.kt
@@ -224,6 +224,15 @@ data class ConversationListPage(private val device: UiDevice) {
         return this
     }
 
+    fun assertDeleteConversationButtonNotVisibleInConversationActions(): ConversationListPage {
+        val deleteConversation = findElementOrNull(deleteConversationButton)
+        Assert.assertTrue(
+            "Delete Conversation button is visible in conversation actions.",
+            deleteConversation == null || deleteConversation.visibleBounds.isEmpty
+        )
+        return this
+    }
+
     fun assertLeaveConversationButtonVisibleInConversationActions(): ConversationListPage {
         try {
             UiWaitUtils.waitElement(leaveConversationButton)

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SelfUserProfilePage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/SelfUserProfilePage.kt
@@ -26,6 +26,7 @@ data class SelfUserProfilePage(private val device: UiDevice) {
     private val userProfilePageTitle = UiSelectorParams(text = "User Profile")
     private val logoutButton = UiSelectorParams(text = "Log out")
     private val clearDataAlert = UiSelectorParams(text = "Clear Data?")
+    private val newTeamOrAddAccountButton = UiSelectorParams(text = "New Team or Add Account")
 
     private val infoTextCheckbox = UiSelectorParams(className = "android.widget.CheckBox")
 
@@ -64,6 +65,11 @@ data class SelfUserProfilePage(private val device: UiDevice) {
 
     fun tapInfoTextCheckbox(): SelfUserProfilePage {
         UiWaitUtils.waitElement(infoTextCheckbox).click()
+        return this
+    }
+
+    fun tapNewTeamOrAddAccountButton(): SelfUserProfilePage {
+        UiWaitUtils.waitElement(newTeamOrAddAccountButton).click()
         return this
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26086
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Adds end-to-end coverage for the channel restriction where a participant who is not the channel creator cannot delete the channel conversation.

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
