### PR TITLE
fix: collapsing top bar crash [WPB-8645]

### DIFF
--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/CollapsingTopBarScaffold.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/CollapsingTopBarScaffold.kt
@@ -115,7 +115,7 @@ fun CollapsingTopBarScaffold(
         derivedStateOf {
             with(density) {
                 val collapsingHeight = anchoredDraggableState.calculateCollapsingHeight()
-                val offset = -anchoredDraggableState.offset
+                val offset = -anchoredDraggableState.offset.orExpandedTopBarOffset()
                 val scaledOffset = if (collapsingHeight > 0f && collapsingHeight < maxBarElevationPx) {
                     // if collapsingHeight is less than maxBarElevationPx then the offset needs to be scaled
                     (offset / collapsingHeight) * maxBarElevationPx
@@ -250,7 +250,7 @@ fun CollapsingTopBarScaffold(
                         newTarget = contentLazyListState.targetTopBarState(collapsingEnabled, collapsingPlaceable.height)
                     )
                     layout(constraints.maxWidth, constraints.maxHeight) {
-                        val swipeOffset = anchoredDraggableState.offset.roundToInt()
+                        val swipeOffset = anchoredDraggableState.offset.orExpandedTopBarOffset().roundToInt()
                         contentPlaceable.placeRelative(0, collapsingPlaceable.height + footerPlaceable.height + swipeOffset)
                         containerPlaceable.placeRelative(0, swipeOffset)
                         footerPlaceable.placeRelative(0, collapsingPlaceable.height + swipeOffset)
@@ -273,6 +273,8 @@ private fun LazyListState?.targetTopBarState(collapsingEnabled: Boolean, collaps
     firstVisibleItemIndex > 0 || firstVisibleItemScrollOffset > 0 -> State.COLLAPSED
     else -> State.EXPANDED
 }
+
+internal fun Float.orExpandedTopBarOffset() = if (isNaN()) 0f else this
 
 @OptIn(ExperimentalFoundationApi::class)
 private fun AnchoredDraggableState<State>.calculateCollapsingHeight() = anchors.positionOf(State.COLLAPSED).let {

--- a/core/ui-common/src/test/kotlin/com/wire/android/ui/common/CollapsingTopBarScaffoldTest.kt
+++ b/core/ui-common/src/test/kotlin/com/wire/android/ui/common/CollapsingTopBarScaffoldTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.common
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CollapsingTopBarScaffoldTest {
+
+    @Test
+    fun givenUninitializedOffset_whenResolvingTopBarOffset_thenExpandedOffsetIsUsed() {
+        assertEquals(0f, Float.NaN.orExpandedTopBarOffset())
+    }
+
+    @Test
+    fun givenInitializedOffset_whenResolvingTopBarOffset_thenOriginalOffsetIsUsed() {
+        assertEquals(-42f, (-42f).orExpandedTopBarOffset())
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
## What changed
- Handle the top bar drag offset when Compose has not set it yet.
- Add a small test for that case.

## Why
In 4.26.0, a restored scrolled list can ask the bar to start collapsed before the collapsed anchor exists. Compose can return NaN for the offset, and rounding that value crashes.