### PR TITLE
fix: duplicate offline indicator in conversation (WPB-25293)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -36,6 +36,7 @@ import com.wire.android.ui.home.conversations.ConversationNavArgs
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.OnResetSession
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogState
+import com.wire.android.ui.home.conversations.messages.item.withOfflineIndicator
 import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/OfflineMessageIndicator.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/OfflineMessageIndicator.kt
@@ -16,7 +16,7 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.android.ui.home.conversations.messages
+package com.wire.android.ui.home.conversations.messages.item
 
 import androidx.paging.PagingData
 import androidx.paging.insertSeparators
@@ -39,18 +39,23 @@ internal fun PagingData<UIMessage>.withOfflineIndicator(
 ): PagingData<UIMessage> {
     if (!isOffline) return this
 
-    val offlineMessage = offlineMessage(conversationId)
     return insertSeparators { before, after ->
-        when {
-            before == null && after == null -> offlineMessage
-            before == null && after?.isPending == false -> offlineMessage
-            before?.isPending == true && after?.isPending != true -> offlineMessage
+        val keySuffix = when {
+            before == null && after == null -> "empty"
+            before == null && after?.isPending == false -> "before:${after.header.messageId}"
+            before?.isPending == true && after?.isPending != true -> "after:${before.header.messageId}"
             else -> null
+        }
+
+        if (keySuffix != null) {
+            offlineMessage(conversationId, keySuffix)
+        } else {
+            null
         }
     }
 }
 
-internal fun offlineMessage(conversationId: ConversationId): UIMessage.System =
+internal fun offlineMessage(conversationId: ConversationId, keySuffix: String): UIMessage.System =
     UIMessage.System(
         conversationId = conversationId,
         source = MessageSource.Self,
@@ -64,7 +69,7 @@ internal fun offlineMessage(conversationId: ConversationId): UIMessage.System =
                 flowStatus = MessageFlowStatus.Sent,
                 expirationStatus = ExpirationStatus.NotExpirable,
             ),
-            messageId = "offline-message:$conversationId",
+            messageId = "offline-message:$conversationId:$keySuffix",
             userId = null,
             connectionState = null,
             isSenderDeleted = false,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -60,6 +60,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
 import com.wire.android.assertions.shouldBeEqualTo
+import com.wire.android.ui.home.conversations.messages.item.withOfflineIndicator
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -255,7 +256,7 @@ class ConversationMessagesViewModelTest {
         ).asSnapshot()
 
         assertEquals(
-            listOf("offline-message:$TEST_CONVERSATION_ID", "sent"),
+            listOf("offline-message:$TEST_CONVERSATION_ID:before:sent", "sent"),
             snapshot.map { it.header.messageId }
         )
     }
@@ -273,7 +274,7 @@ class ConversationMessagesViewModelTest {
             ).asSnapshot()
 
             assertEquals(
-                listOf("pending-1", "pending-2", "offline-message:$TEST_CONVERSATION_ID", "sent"),
+                listOf("pending-1", "pending-2", "offline-message:$TEST_CONVERSATION_ID:after:pending-2", "sent"),
                 snapshot.map { it.header.messageId }
             )
         }
@@ -295,11 +296,11 @@ class ConversationMessagesViewModelTest {
             PagingData.from(emptyList<UIMessage>()).withOfflineIndicator(TEST_CONVERSATION_ID, isOffline = true)
         ).asSnapshot()
 
-        assertEquals(listOf("offline-message:$TEST_CONVERSATION_ID"), snapshot.map { it.header.messageId })
+        assertEquals(listOf("offline-message:$TEST_CONVERSATION_ID:empty"), snapshot.map { it.header.messageId })
     }
 
     @Test
-    fun `given network becomes disconnected, when observing messages, then offline message is shown`() = runTest {
+    fun `given network becomes disconnected with no pending messages, when observing messages, then offline message is shown`() = runTest {
         val message = regularMessage(id = "sent")
         val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
             .withSuccessfulViewModelInit()
@@ -314,13 +315,13 @@ class ConversationMessagesViewModelTest {
             advanceUntilIdle()
 
             awaitMessageIds(
-                expectedMessageIds = listOf("offline-message:${arrangement.conversationId}", "sent")
+                expectedMessageIds = listOf("offline-message:${arrangement.conversationId}:before:sent", "sent")
             )
         }
     }
 
     @Test
-    fun `given network is connected without internet, when observing messages, then offline message is shown`() = runTest {
+    fun `given network is connected without internet with no pending messages, when observing messages, then offline message is shown`() = runTest {
         val message = regularMessage(id = "sent")
         val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
             .withSuccessfulViewModelInit()
@@ -332,7 +333,7 @@ class ConversationMessagesViewModelTest {
             arrangement.withPaginatedMessagesReturning(PagingData.from(listOf(message)))
 
             assertEquals(
-                listOf("offline-message:${arrangement.conversationId}", "sent"),
+                listOf("offline-message:${arrangement.conversationId}:before:sent", "sent"),
                 flowOf(awaitItem()).asSnapshot().map { it.header.messageId }
             )
         }
@@ -350,7 +351,7 @@ class ConversationMessagesViewModelTest {
         viewModel.conversationViewState.messages.test {
             arrangement.withPaginatedMessagesReturning(PagingData.from(listOf(message)))
             assertEquals(
-                listOf("offline-message:${arrangement.conversationId}", "sent"),
+                listOf("offline-message:${arrangement.conversationId}:before:sent", "sent"),
                 flowOf(awaitItem()).asSnapshot().map { it.header.messageId }
             )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25293
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25293
----

# What's new in this PR?

Fixing issue with duplicate offline indicator appearing in messages list.
