### PR TITLE
fix: new conversation close crash [WPB-26127] [WPB-26131]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SharedNewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SharedNewConversationViewModel.kt
@@ -18,18 +18,16 @@
 package com.wire.android.ui.home.newconversation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.navigation.compose.currentBackStackEntryAsState
 import com.ramcosta.composedestinations.generated.app.navgraphs.NewConversationGraph
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.home.newConversationViewModel
 
 @Composable
 fun sharedNewConversationViewModel(navigator: Navigator): NewConversationViewModel {
-    val currentEntry by navigator.navController.currentBackStackEntryAsState()
-    val parentEntry = remember(currentEntry) {
-        navigator.navController.getBackStackEntry(NewConversationGraph.route)
+    val navController = navigator.navController
+    val parentEntry = remember(navController) {
+        navController.getBackStackEntry(NewConversationGraph.route)
     }
     return newConversationViewModel(parentEntry)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SharedNewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SharedNewConversationViewModel.kt
@@ -26,7 +26,10 @@ import com.wire.android.ui.home.newConversationViewModel
 @Composable
 fun sharedNewConversationViewModel(navigator: Navigator): NewConversationViewModel {
     val navController = navigator.navController
-    val parentEntry = remember(navController) {
+    val currentEntry = remember(navController) {
+        checkNotNull(navController.currentBackStackEntry)
+    }
+    val parentEntry = remember(currentEntry) {
         navController.getBackStackEntry(NewConversationGraph.route)
     }
     return newConversationViewModel(parentEntry)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ compose-qr = "1.0.1"
 enterprise-feedback = "1.1.0"
 
 # Compose
-composeBom = "2026.05.00"
+composeBom = "2026.01.01"
 compose-activity = "1.13.0"
 compose-constraint = "1.1.1"
 compose-navigation = "2.9.5" # aligned with compose-destinations 2.3.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ compose-qr = "1.0.1"
 enterprise-feedback = "1.1.0"
 
 # Compose
-composeBom = "2026.01.01"
+composeBom = "2026.05.00"
 compose-activity = "1.13.0"
 compose-constraint = "1.1.1"
 compose-navigation = "2.9.5" # aligned with compose-destinations 2.3.0


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26127
<!--jira-description-action-hidden-marker-end-->
## Summary

Fixes a crash when closing the New Conversation screen.

## What was happening

When tapping the X button, the app navigates back to the conversation list.

During the screen exit animation, the New Conversation screen can still be composed for a short moment. At that point, the New Conversation graph was already removed from the navigation back stack, but the screen tried to look it up again.

That caused this crash:

```text
No destination with route app/new_conversation is on the NavController's back stack
```

## Fix

Keep the New Conversation parent back stack entry remembered for the lifetime of the screen composition, instead of looking it up again after navigation starts.

## Testing

Manually 