### PR TITLE
fix: OngoingCallActivity metro injection [WPB-8645]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/metro/WireApplicationGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireApplicationGraph.kt
@@ -59,6 +59,7 @@ import com.wire.android.ui.WireActivity
 import com.wire.android.ui.WireActivityViewModel
 import com.wire.android.ui.debug.StartServiceReceiver
 import com.wire.android.ui.calling.CallActivity
+import com.wire.android.ui.calling.ongoing.OngoingCallActivity
 import com.wire.android.util.NetworkUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.workmanager.WireWorkerFactory
@@ -115,6 +116,7 @@ interface WireApplicationGraph {
     fun inject(activity: WireActivity)
     fun inject(activity: AppLockActivity)
     fun inject(activity: CallActivity)
+    fun inject(activity: OngoingCallActivity)
     fun inject(service: PersistentWebSocketService)
     fun inject(service: CallService)
     fun inject(service: PlayingAudioMessageService)

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import com.wire.android.R
 import com.wire.android.appLogger
+import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.navigation.style.TransitionAnimationType
 import com.wire.android.notification.CallNotificationManager
 import com.wire.android.notification.endOngoingCallPendingIntent
@@ -81,6 +82,7 @@ class OngoingCallActivity : CallActivity() {
 
     @SuppressLint("UnusedContentLambdaTargetStateParameter")
     override fun onCreate(savedInstanceState: Bundle?) {
+        wireApplicationGraph.inject(this)
         super.onCreate(savedInstanceState)
 
         if (shouldAnswerCall && userId != null && conversationId != null) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Answering a call from notification crashes.

### Causes (Optional)

Things are not being properly injected into OngoingCallActivity.

### Solutions

Add OngoingCallActivity to WireApplicationGraph and call `inject`.

#### How to Test

Open the app, receive incoming call, answer from notification.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
