### PR TITLE
feat: add reply in private feature

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/RegularMessageContentMapper.kt
@@ -99,7 +99,12 @@ class RegularMessageMapper @Inject constructor(
 
         is MessageContent.Composite -> {
             val text = content.textContent?.let { textContent ->
-                val quotedMessage = textContent.quotedMessageDetails?.let { mapQuoteData(message.conversationId, it) }
+                val quotedMessage = textContent.quotedMessageDetails?.let {
+                    mapQuoteData(
+                        conversationId = textContent.quotedMessageReference?.quotedMessageConversationId ?: message.conversationId,
+                        details = it
+                    )
+                }
                     ?: if (textContent.quotedMessageReference?.quotedMessageId != null) {
                         UIQuotedMessage.UnavailableData
                     } else {
@@ -169,7 +174,12 @@ class RegularMessageMapper @Inject constructor(
     ): UIMessageContent.TextMessage {
         val messageTextContent = (content as? MessageContent.Text)
 
-        val quotedMessage = messageTextContent?.quotedMessageDetails?.let { mapQuoteData(conversationId, it) }
+        val quotedMessage = messageTextContent?.quotedMessageDetails?.let {
+            mapQuoteData(
+                conversationId = messageTextContent.quotedMessageReference?.quotedMessageConversationId ?: conversationId,
+                details = it
+            )
+        }
             ?: if (messageTextContent?.quotedMessageReference?.quotedMessageId != null) {
                 UIQuotedMessage.UnavailableData
             } else {
@@ -207,6 +217,7 @@ class RegularMessageMapper @Inject constructor(
     private fun mapQuoteData(conversationId: ConversationId, details: MessageContent.QuotedMessageDetails) =
         UIQuotedMessage.UIQuotedData(
             messageId = details.messageId,
+            conversationId = conversationId,
             senderId = details.senderId,
             senderName = details.senderName.orUnknownName(),
             senderAccent = Accent.fromAccentId(details.accentId),
@@ -330,7 +341,12 @@ class RegularMessageMapper @Inject constructor(
         deliveryStatus: DeliveryStatus
     ): UIMessageContent.Multipart {
 
-        val quotedMessage = content.quotedMessageDetails?.let { mapQuoteData(conversationId = conversationId, details = it) }
+        val quotedMessage = content.quotedMessageDetails?.let {
+            mapQuoteData(
+                conversationId = content.quotedMessageReference?.quotedMessageConversationId ?: conversationId,
+                details = it
+            )
+        }
             ?: if (content.quotedMessageReference?.quotedMessageId != null) {
                 UIQuotedMessage.UnavailableData
             } else {

--- a/app/src/main/kotlin/com/wire/android/ui/edit/ReplyMessageOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/ReplyMessageOption.kt
@@ -36,3 +36,17 @@ fun ReplyMessageOption(onReplyItemClick: () -> Unit) {
         onItemClick = onReplyItemClick
     )
 }
+
+@Composable
+fun ReplyInPrivateMessageOption(onReplyItemClick: () -> Unit) {
+    MenuBottomSheetItem(
+        leading = {
+            MenuItemIcon(
+                id = R.drawable.ic_reply,
+                contentDescription = stringResource(R.string.content_description_reply_in_private_to_message),
+            )
+        },
+        title = stringResource(R.string.message_option_reply_in_private),
+        onItemClick = onReplyItemClick
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelFactory.kt
@@ -42,6 +42,7 @@ import com.wire.android.ui.home.conversations.messagedetails.usecase.ObserveRece
 import com.wire.android.ui.home.conversations.migration.ConversationMigrationViewModel
 import com.wire.android.ui.home.conversations.model.messagetypes.multipart.CellAssetRefreshHelper
 import com.wire.android.ui.home.conversations.model.messagetypes.multipart.MultipartAttachmentsViewModelImpl
+import com.wire.android.ui.home.conversations.privateReply.ReplyInPrivateViewModel
 import com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
 import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversationUseCase
 import com.wire.android.ui.home.conversations.usecase.GetQuoteMessageForConversationUseCase
@@ -80,6 +81,7 @@ import com.wire.kalium.logic.feature.client.IsWireCellsEnabledForConversationUse
 import com.wire.kalium.logic.feature.client.IsWireCellsEnabledUseCase
 import com.wire.kalium.logic.feature.conversation.ClearUsersTypingEventsUseCase
 import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
+import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.conversation.MarkConversationAsReadLocallyUseCase
 import com.wire.kalium.logic.feature.conversation.MembersToMentionUseCase
 import com.wire.kalium.logic.feature.conversation.NotifyConversationIsOpenUseCase
@@ -184,6 +186,7 @@ class ConversationCoreViewModelFactory @Inject constructor(
     private val getAssetMessages: GetAssetMessagesFromConversationUseCase,
     private val observeConversationMembersByTypes: ObserveConversationMembersByTypesUseCase,
     private val notifyConversationIsOpen: NotifyConversationIsOpenUseCase,
+    private val getOrCreateOneToOneConversation: GetOrCreateOneToOneConversationUseCase,
     private val qualifiedIdMapper: QualifiedIdMapper,
     private val fetchConversationMLSVerificationStatus: FetchConversationMLSVerificationStatusUseCase,
     private val observeReactionsForMessage: ObserveReactionsForMessageUseCase,
@@ -269,6 +272,11 @@ class ConversationCoreViewModelFactory @Inject constructor(
         savedStateHandle = savedStateHandle,
         getMessageDraft = getMessageDraft,
         getQuotedMessage = getQuotedMessage,
+        saveMessageDraft = saveMessageDraft,
+    )
+
+    fun replyInPrivateViewModel() = ReplyInPrivateViewModel(
+        getOrCreateOneToOneConversation = getOrCreateOneToOneConversation,
         saveMessageDraft = saveMessageDraft,
     )
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelGraph.kt
@@ -43,6 +43,7 @@ import com.wire.android.ui.home.conversations.messages.item.ConversationAssetPat
 import com.wire.android.ui.home.conversations.migration.ConversationMigrationViewModel
 import com.wire.android.ui.home.conversations.model.messagetypes.multipart.MultipartAttachmentsViewModel
 import com.wire.android.ui.home.conversations.model.messagetypes.multipart.MultipartAttachmentsViewModelImpl
+import com.wire.android.ui.home.conversations.privateReply.ReplyInPrivateViewModel
 import com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
 import com.wire.android.ui.home.gallery.MediaGalleryViewModel
 import com.wire.android.ui.home.messagecomposer.location.LocationPickerViewModel
@@ -66,6 +67,10 @@ fun sendMessageViewModel(): SendMessageViewModel =
 @Composable
 fun messageDraftViewModel(): MessageDraftViewModel =
     conversationSavedStateViewModel { this.messageDraftViewModel(it) }
+
+@Composable
+fun replyInPrivateViewModel(): ReplyInPrivateViewModel =
+    conversationViewModel { this.replyInPrivateViewModel() }
 
 @Composable
 fun messageAttachmentsViewModel(): MessageAttachmentsViewModel =

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -177,6 +177,8 @@ import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UIMessageContent
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.home.conversations.model.UriAsset
+import com.wire.android.ui.home.conversations.privateReply.ReplyInPrivateAction
+import com.wire.android.ui.home.conversations.privateReply.ReplyInPrivateViewModel
 import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionOptionsModalSheetLayout
 import com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
 import com.wire.android.ui.home.gallery.MediaGalleryActionType
@@ -269,10 +271,12 @@ fun ConversationScreen(
     conversationMigrationViewModel: ConversationMigrationViewModel = conversationMigrationViewModel(),
     messageDraftViewModel: MessageDraftViewModel = messageDraftViewModel(),
     messageAttachmentsViewModel: MessageAttachmentsViewModel = messageAttachmentsViewModel(),
+    replyInPrivateViewModel: ReplyInPrivateViewModel = replyInPrivateViewModel(),
 ) {
     val coroutineScope = rememberCoroutineScope()
     val uriHandler = LocalUriHandler.current
     val resources = LocalContext.current.resources
+    val snackbarHostState = LocalSnackbarHostState.current
     val showDialog = remember { mutableStateOf(ConversationScreenDialogType.NONE) }
     val messageComposerViewState = messageComposerViewModel.messageComposerViewState
     val messageComposerStateHolder = rememberMessageComposerStateHolder(
@@ -348,7 +352,10 @@ fun ConversationScreen(
     LaunchedEffect(messageDraftViewModel.state.value.quotedMessageId) {
         val compositionState = messageDraftViewModel.state.value
         if (compositionState.quotedMessage != null) {
-            messageComposerStateHolder.messageCompositionHolder.value.updateQuote(compositionState.quotedMessage)
+            messageComposerStateHolder.messageCompositionHolder.value.updateQuote(
+                quotedMessage = compositionState.quotedMessage,
+                quotedMessageConversationId = compositionState.quotedMessageConversationId
+            )
         }
     }
 
@@ -369,6 +376,21 @@ fun ConversationScreen(
                 context.startActivity(getOngoingCallIntent(context, action.conversationId.toString(), action.userId.toString()))
                 AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallJoined)
             }
+        }
+    }
+
+    HandleActions(replyInPrivateViewModel.actions) { action ->
+        when (action) {
+            ReplyInPrivateAction.Failure -> coroutineScope.launch {
+                snackbarHostState.showSnackbar(resources.getString(R.string.error_conversation_generic))
+            }
+
+            is ReplyInPrivateAction.Navigate -> navigator.navigate(
+                NavigationCommand(
+                    ConversationScreenDestination(action.conversationId),
+                    BackStackMode.UPDATE_EXISTED
+                )
+            )
         }
     }
 
@@ -625,6 +647,7 @@ fun ConversationScreen(
         onReactionClick = { messageId, emoji ->
             conversationMessagesViewModel.toggleReaction(messageId, emoji)
         },
+        onReplyInPrivateClick = replyInPrivateViewModel::replyInPrivate,
         onResetSessionClick = conversationMessagesViewModel::onResetSession,
         onUpdateConversationReadDate = messageComposerViewModel::updateConversationReadDate,
         onDropDownClick = {
@@ -671,7 +694,22 @@ fun ConversationScreen(
         shareAsset = conversationMessagesViewModel::shareAsset,
         onDownloadAssetClick = conversationMessagesViewModel::openOrFetchAsset,
         onOpenAssetClick = conversationMessagesViewModel::downloadAndOpenAsset,
-        onNavigateToReplyOriginalMessage = conversationMessagesViewModel::navigateToReplyOriginalMessage,
+        onNavigateToReplyOriginalMessage = { message ->
+            message.quotedMessageData()?.let { quotedData ->
+                navigator.navigate(
+                    NavigationCommand(
+                        ConversationScreenDestination(
+                            navArgs = ConversationNavArgs(
+                                conversationId = quotedData.conversationId,
+                                searchedMessageId = quotedData.messageId
+                            )
+                        ),
+                        BackStackMode.REMOVE_CURRENT_AND_REPLACE,
+                        launchSingleTop = false
+                    )
+                )
+            }
+        },
         onSelfDeletingMessageRead = messageComposerViewModel::startSelfDeletion,
         onNewSelfDeletingMessagesStatus = messageComposerViewModel::updateSelfDeletingMessages,
         tempWritableImageUri = messageComposerViewModel.tempWritableImageUri,
@@ -977,6 +1015,7 @@ private fun ConversationScreen(
     onStartCall: () -> Unit,
     onJoinCall: () -> Unit,
     onReactionClick: (messageId: String, reactionEmoji: String) -> Unit,
+    onReplyInPrivateClick: (UIMessage.Regular) -> Unit,
     onResetSessionClick: (senderUserId: UserId, clientId: String?) -> Unit,
     onUpdateConversationReadDate: (String) -> Unit,
     onDropDownClick: () -> Unit,
@@ -1123,6 +1162,8 @@ private fun ConversationScreen(
             onReactionClick = onReactionClick,
             onDetailsClick = onMessageDetailsClick,
             onReplyClick = messageComposerStateHolder::toReply,
+            onReplyInPrivateClick = onReplyInPrivateClick,
+            isGroupConversation = conversationInfoViewState.conversationType is Conversation.Type.Group,
             onEditClick = messageComposerStateHolder::toEdit,
             onShareAssetClick = { shareAsset(context, it) },
             onDownloadAssetClick = onDownloadAssetClick,
@@ -1943,6 +1984,14 @@ private fun CoroutineScope.withSmoothScreenLoad(block: () -> Unit) = launch {
     block()
 }
 
+private fun UIMessage.quotedMessageData(): UIQuotedMessage.UIQuotedData? =
+    when (val content = messageContent) {
+        is UIMessageContent.TextMessage -> content.messageBody.quotedMessage as? UIQuotedMessage.UIQuotedData
+        is UIMessageContent.Composite -> content.messageBody?.quotedMessage as? UIQuotedMessage.UIQuotedData
+        is UIMessageContent.Multipart -> content.messageBody?.quotedMessage as? UIQuotedMessage.UIQuotedData
+        else -> null
+    }
+
 enum class ConversationActionPermissionType {
     CaptureVideo, TakePicture, ChooseImage, ChooseFile, CallAudio
 }
@@ -1985,6 +2034,7 @@ fun PreviewConversationScreen() = WireTheme {
         onStartCall = { },
         onJoinCall = { },
         onReactionClick = { _, _ -> },
+        onReplyInPrivateClick = { },
         onResetSessionClick = { _, _ -> },
         onUpdateConversationReadDate = { },
         onDropDownClick = { },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/AssetOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/AssetOptionsMenuItems.kt
@@ -23,6 +23,7 @@ import com.wire.android.ui.edit.DownloadAssetExternallyOption
 import com.wire.android.ui.edit.MessageDetailsMenuOption
 import com.wire.android.ui.edit.OpenAssetExternallyOption
 import com.wire.android.ui.edit.ReactionOption
+import com.wire.android.ui.edit.ReplyInPrivateMessageOption
 import com.wire.android.ui.edit.ReplyMessageOption
 import com.wire.android.ui.edit.ShareAssetMenuOption
 
@@ -36,6 +37,8 @@ fun assetMessageOptionsMenuItems(
     onShareAsset: () -> Unit,
     onDownloadAsset: () -> Unit,
     onReplyClick: () -> Unit,
+    onReplyInPrivateClick: () -> Unit,
+    isReplyInPrivateAllowed: Boolean,
     onReactionClick: (emoji: String) -> Unit,
     isOpenable: Boolean = false,
     onOpenAsset: () -> Unit = {},
@@ -58,6 +61,7 @@ fun assetMessageOptionsMenuItems(
                 add { ReactionOption(ownReactions, onReactionClick) }
                 add { MessageDetailsMenuOption(onDetailsClick) }
                 add { ReplyMessageOption(onReplyClick) }
+                if (isReplyInPrivateAllowed) add { ReplyInPrivateMessageOption(onReplyInPrivateClick) }
                 add { DownloadAssetExternallyOption(onDownloadAsset) }
                 add { ShareAssetMenuOption(onShareAsset) }
                 if (isOpenable) add { OpenAssetExternallyOption(onOpenAsset) }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsMenuItems.kt
@@ -35,6 +35,8 @@ fun messageOptionsMenuItems(
     onReactionClick: (reactionEmoji: String) -> Unit,
     onDetailsClick: () -> Unit,
     onReplyClick: () -> Unit,
+    onReplyInPrivateClick: () -> Unit,
+    isReplyInPrivateAllowed: Boolean,
     onEditClick: () -> Unit,
     onShareAssetClick: () -> Unit,
     onDownloadAssetClick: () -> Unit,
@@ -51,6 +53,8 @@ fun messageOptionsMenuItems(
             onShareAsset = onShareAssetClick,
             onDownloadAsset = onDownloadAssetClick,
             onReplyClick = onReplyClick,
+            onReplyInPrivateClick = onReplyInPrivateClick,
+            isReplyInPrivateAllowed = isReplyInPrivateAllowed,
             onReactionClick = onReactionClick,
             onOpenAsset = onOpenAssetClick,
         )
@@ -67,7 +71,9 @@ fun messageOptionsMenuItems(
             onReactionClick = onReactionClick,
             onEditClick = onEditClick,
             onCopyClick = onCopyClick,
-            onReplyClick = onReplyClick
+            onReplyClick = onReplyClick,
+            onReplyInPrivateClick = onReplyInPrivateClick,
+            isReplyInPrivateAllowed = isReplyInPrivateAllowed,
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
@@ -57,6 +57,8 @@ fun MessageOptionsModalSheetLayout(
     onReactionClick: (messageId: String, reactionEmoji: String) -> Unit,
     onDetailsClick: (messageId: String, isSelfMessage: Boolean) -> Unit,
     onReplyClick: (UIMessage.Regular) -> Unit,
+    onReplyInPrivateClick: (UIMessage.Regular) -> Unit,
+    isGroupConversation: Boolean,
     onEditClick: (messageId: String, messageBody: String, mentions: List<MessageMention>, isMultipart: Boolean) -> Unit,
     onShareAssetClick: (messageId: String) -> Unit,
     onDownloadAssetClick: (messageId: String) -> Unit,
@@ -78,6 +80,8 @@ fun MessageOptionsModalSheetLayout(
                     onReactionClick = onReactionClick,
                     onDetailsClick = onDetailsClick,
                     onReplyClick = onReplyClick,
+                    onReplyInPrivateClick = onReplyInPrivateClick,
+                    isGroupConversation = isGroupConversation,
                     onEditClick = onEditClick,
                     onShareAssetClick = onShareAssetClick,
                     onDownloadAssetClick = onDownloadAssetClick,
@@ -111,6 +115,8 @@ private fun MessageOptionsModalContent(
     onReactionClick: (messageId: String, reactionEmoji: String) -> Unit,
     onDetailsClick: (messageId: String, isSelfMessage: Boolean) -> Unit,
     onReplyClick: (UIMessage.Regular) -> Unit,
+    onReplyInPrivateClick: (UIMessage.Regular) -> Unit,
+    isGroupConversation: Boolean,
     onEditClick: (messageId: String, messageBody: String, mentions: List<MessageMention>, isMultipart: Boolean) -> Unit,
     onShareAssetClick: (messageId: String) -> Unit,
     onDownloadAssetClick: (messageId: String) -> Unit,
@@ -121,6 +127,7 @@ private fun MessageOptionsModalContent(
     val isDeleted = message.isDeleted
     val isMyMessage = message.isMyMessage
     val isEphemeral = message.header.messageStatus.expirationStatus is ExpirationStatus.Expirable
+    val isReplyInPrivateAllowed = isGroupConversation && message.isReplyable && !isMyMessage && message.header.userId != null
     WireMenuModalSheetContent(
         header = MenuModalSheetHeader.Gone,
         menuItems = messageOptionsMenuItems(
@@ -172,6 +179,14 @@ private fun MessageOptionsModalContent(
                     }
                 }
             },
+            onReplyInPrivateClick = remember(message.header.messageId) {
+                {
+                    sheetState.hide {
+                        onReplyInPrivateClick(message)
+                    }
+                }
+            },
+            isReplyInPrivateAllowed = isReplyInPrivateAllowed,
             onEditClick = remember(message.header.messageId, message.messageContent) {
                 {
                     when (message.messageContent) {
@@ -255,6 +270,8 @@ fun PreviewMessageOptionsModalSheetLayout() = WireTheme {
         onReactionClick = { _, _ -> },
         onDetailsClick = { _, _ -> },
         onReplyClick = { },
+        onReplyInPrivateClick = { },
+        isGroupConversation = true,
         onEditClick = { _, _, _, _ -> },
         onShareAssetClick = { },
         onDownloadAssetClick = { },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/TextMessageOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/TextMessageOptionsMenuItems.kt
@@ -23,6 +23,7 @@ import com.wire.android.ui.edit.DeleteItemMenuOption
 import com.wire.android.ui.edit.EditMessageMenuOption
 import com.wire.android.ui.edit.MessageDetailsMenuOption
 import com.wire.android.ui.edit.ReactionOption
+import com.wire.android.ui.edit.ReplyInPrivateMessageOption
 import com.wire.android.ui.edit.ReplyMessageOption
 
 @Composable
@@ -36,6 +37,8 @@ fun textMessageEditMenuItems(
     onDeleteClick: () -> Unit,
     onDetailsClick: () -> Unit,
     onReplyClick: () -> Unit,
+    onReplyInPrivateClick: () -> Unit,
+    isReplyInPrivateAllowed: Boolean,
     onCopyClick: () -> Unit,
     onReactionClick: (emoji: String) -> Unit,
     onEditClick: (() -> Unit),
@@ -46,6 +49,7 @@ fun textMessageEditMenuItems(
             add { MessageDetailsMenuOption(onDetailsClick) }
             if (isCopyable) { add { CopyItemMenuOption(onCopyClick) } }
             if (!isEphemeral && !isComposite) add { ReplyMessageOption(onReplyClick) }
+            if (isReplyInPrivateAllowed) add { ReplyInPrivateMessageOption(onReplyInPrivateClick) }
             if (isEditable) add { EditMessageMenuOption(onEditClick) }
         }
         add { DeleteItemMenuOption(onDeleteClick) }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -169,6 +169,9 @@ class ConversationMessagesViewModel(
             is UIMessageContent.TextMessage ->
                 (content.messageBody.quotedMessage as UIQuotedMessage.UIQuotedData).messageId
 
+            is UIMessageContent.Composite ->
+                (content.messageBody?.quotedMessage as? UIQuotedMessage.UIQuotedData)?.messageId
+
             is UIMessageContent.Multipart ->
                 (content.messageBody?.quotedMessage as? UIQuotedMessage.UIQuotedData)?.messageId
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -186,7 +186,7 @@ internal fun QuotedMessage(
         )
 
         is UIQuotedMessage.UIQuotedData.Multipart -> QuotedMultipartMessage(
-            conversationId = conversationId,
+            conversationId = messageData.conversationId,
             quotedMessageId = messageData.messageId,
             senderName = messageData.senderName,
             originalDateTimeText = messageData.originalMessageDateDescription,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModel.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.ui.home.conversations.ConversationNavArgs
 import com.wire.android.ui.home.conversations.model.UIQuotedMessage
 import com.wire.android.ui.home.conversations.model.toUiMention
@@ -28,7 +29,6 @@ import com.wire.android.ui.home.conversations.usecase.GetQuoteMessageForConversa
 import com.wire.android.ui.home.messagecomposer.model.MessageComposition
 import com.wire.android.ui.home.messagecomposer.model.toDraft
 import com.wire.android.ui.home.messagecomposer.model.update
-import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.draft.MessageDraft
@@ -60,6 +60,7 @@ class MessageDraftViewModel(
                     messageComposition.copy(
                         quotedMessageId = null,
                         quotedMessage = null,
+                        quotedMessageConversationId = null,
                         draftText = String.EMPTY,
                     )
                 }
@@ -70,9 +71,11 @@ class MessageDraftViewModel(
 
     private fun loadMessageDraft() = viewModelScope.launch {
         getMessageDraft(conversationId)?.let { draft ->
-
             val quotedMessage = draft.quotedMessageId?.let { quotedMessageId ->
-                getQuotedMessage(conversationId, quotedMessageId)
+                getQuotedMessage(
+                    conversationId = draft.quotedMessageConversationId ?: conversationId,
+                    quotedMessageId = quotedMessageId
+                )
             }
 
             state.update { messageComposition ->
@@ -83,6 +86,7 @@ class MessageDraftViewModel(
                     isMultipart = draft.isMultipartEdit,
                     quotedMessage = quotedMessage as? UIQuotedMessage.UIQuotedData,
                     quotedMessageId = (quotedMessage as? UIQuotedMessage.UIQuotedData)?.messageId,
+                    quotedMessageConversationId = draft.quotedMessageConversationId ?: conversationId,
                 )
             }
         } ?: run {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewMessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewMessageTypes.kt
@@ -111,6 +111,7 @@ fun PreviewMessageWithReply() {
                         message = UIText.DynamicString("Sure, go ahead!"),
                         quotedMessage = UIQuotedMessage.UIQuotedData(
                             messageId = "asdoij",
+                            conversationId = mockMessageWithText.conversationId,
                             senderId = previewUserId,
                             senderName = UIText.DynamicString("John Doe"),
                             originalMessageDateDescription = UIText.StringResource(R.string.label_quote_original_message_date, "10:30"),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIQuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIQuotedMessage.kt
@@ -22,6 +22,7 @@ import com.wire.android.model.ImageAsset
 import com.wire.android.ui.theme.Accent
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.CellAssetContent
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.serialization.Serializable
@@ -35,6 +36,7 @@ sealed class UIQuotedMessage {
     @Serializable
     data class UIQuotedData(
         val messageId: String,
+        val conversationId: ConversationId,
         val senderId: UserId,
         val senderName: UIText,
         val senderAccent: Accent,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/privateReply/ReplyInPrivateAction.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/privateReply/ReplyInPrivateAction.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.privateReply
+
+import com.wire.kalium.logic.data.id.ConversationId
+
+sealed interface ReplyInPrivateAction {
+    data class Navigate(val conversationId: ConversationId) : ReplyInPrivateAction
+    data object Failure : ReplyInPrivateAction
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/privateReply/ReplyInPrivateViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/privateReply/ReplyInPrivateViewModel.kt
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.home.conversations.privateReply
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.ui.home.conversations.model.UIMessage
+import com.wire.kalium.logic.data.message.draft.MessageDraft
+import com.wire.kalium.logic.feature.conversation.CreateConversationResult
+import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
+import com.wire.kalium.logic.feature.message.draft.SaveMessageDraftUseCase
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+
+class ReplyInPrivateViewModel(
+    private val getOrCreateOneToOneConversation: GetOrCreateOneToOneConversationUseCase,
+    private val saveMessageDraft: SaveMessageDraftUseCase,
+) : ViewModel() {
+
+    private val _actions = MutableSharedFlow<ReplyInPrivateAction>()
+    val actions = _actions.asSharedFlow()
+
+    fun replyInPrivate(message: UIMessage.Regular) {
+        val senderId = message.header.userId ?: return emitFailure()
+
+        viewModelScope.launch {
+            when (val result = getOrCreateOneToOneConversation(senderId)) {
+                is CreateConversationResult.Success -> {
+                    val oneToOneConversationId = result.conversation.id
+                    saveMessageDraft(
+                        MessageDraft(
+                            conversationId = oneToOneConversationId,
+                            text = "",
+                            editMessageId = null,
+                            quotedMessageId = message.header.messageId,
+                            selectedMentionList = emptyList(),
+                            quotedMessageConversationId = message.conversationId,
+                        )
+                    )
+                    _actions.emit(ReplyInPrivateAction.Navigate(oneToOneConversationId))
+                }
+
+                is CreateConversationResult.Failure -> {
+                    _actions.emit(ReplyInPrivateAction.Failure)
+                }
+            }
+        }
+    }
+
+    private fun emitFailure() {
+        viewModelScope.launch {
+            _actions.emit(ReplyInPrivateAction.Failure)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -57,6 +57,7 @@ import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.conversation.Conversation.TypingIndicatorMode
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.failure.LegalHoldEnabledForConversationFailure
 import com.wire.kalium.logic.feature.asset.upload.AssetUploadParams
 import com.wire.kalium.logic.feature.asset.upload.ScheduleNewAssetMessageResult
@@ -267,7 +268,7 @@ class SendMessageViewModel(
                         conversationId = conversationId,
                         text = message,
                         mentions = mentions.map { it.intoMessageMention() },
-                        quotedMessageId = quotedMessageId
+                        quotedMessageReference = quotedMessageReference()
                     ).toEither()
                         .handleLegalHoldFailureAfterSendingMessage(conversationId)
                         .handleNonAssetContributionEvent(messageBundle)
@@ -282,7 +283,7 @@ class SendMessageViewModel(
                         conversationId = conversationId,
                         text = message,
                         mentions = mentions.map { it.intoMessageMention() },
-                        quotedMessageId = quotedMessageId
+                        quotedMessageReference = quotedMessageReference()
                     ).toEither()
                         .handleLegalHoldFailureAfterSendingMessage(conversationId)
                         .handleNonAssetContributionEvent(messageBundle)
@@ -307,6 +308,26 @@ class SendMessageViewModel(
             }
         }
     }
+
+    private fun ComposableMessageBundle.SendTextMessageBundle.quotedMessageReference(): MessageContent.QuoteReference? =
+        quotedMessageId?.let {
+            MessageContent.QuoteReference(
+                quotedMessageId = it,
+                quotedMessageConversationId = quotedMessageConversationId,
+                quotedMessageSha256 = null,
+                isVerified = true
+            )
+        }
+
+    private fun ComposableMessageBundle.SendMultipartMessageBundle.quotedMessageReference(): MessageContent.QuoteReference? =
+        quotedMessageId?.let {
+            MessageContent.QuoteReference(
+                quotedMessageId = it,
+                quotedMessageConversationId = quotedMessageConversationId,
+                quotedMessageSha256 = null,
+                isVerified = true
+            )
+        }
 
     private suspend fun handleAssetMessageBundle(
         conversationId: ConversationId,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetQuoteMessageForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetQuoteMessageForConversationUseCase.kt
@@ -49,6 +49,7 @@ class GetQuoteMessageForConversationUseCase @Inject constructor(
                                 uiMessage.header.userId?.let { senderId ->
                                     UIQuotedMessage.UIQuotedData(
                                         messageId = uiMessage.header.messageId,
+                                        conversationId = conversationId,
                                         senderId = senderId,
                                         senderName = uiMessage.header.username,
                                         originalMessageDateDescription = "".toUIText(),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/ObserveQuoteMessageForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/ObserveQuoteMessageForConversationUseCase.kt
@@ -52,6 +52,7 @@ class ObserveQuoteMessageForConversationUseCase @Inject constructor(
                                         uiMessage.header.userId?.let { senderId ->
                                             UIQuotedMessage.UIQuotedData(
                                                 messageId = uiMessage.header.messageId,
+                                                conversationId = conversationId,
                                                 senderId = senderId,
                                                 senderName = uiMessage.header.username,
                                                 originalMessageDateDescription = "".toUIText(),

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/model/MessageBundle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/model/MessageBundle.kt
@@ -44,14 +44,16 @@ sealed class ComposableMessageBundle(override val conversationId: ConversationId
         override val conversationId: ConversationId,
         val message: String,
         val mentions: List<UIMention>,
-        val quotedMessageId: String? = null
+        val quotedMessageId: String? = null,
+        val quotedMessageConversationId: ConversationId? = null
     ) : ComposableMessageBundle(conversationId)
 
     data class SendMultipartMessageBundle(
         override val conversationId: ConversationId,
         val message: String,
         val mentions: List<UIMention>,
-        val quotedMessageId: String? = null
+        val quotedMessageId: String? = null,
+        val quotedMessageConversationId: ConversationId? = null
     ) : ComposableMessageBundle(conversationId)
 
     data class AttachmentPickedBundle(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/model/MessageComposition.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/model/MessageComposition.kt
@@ -31,6 +31,7 @@ data class MessageComposition(
     val editMessageId: String? = null,
     val quotedMessage: UIQuotedMessage.UIQuotedData? = null,
     val quotedMessageId: String? = null,
+    val quotedMessageConversationId: ConversationId? = null,
     val selectedMentions: List<UIMention> = emptyList(),
     val isMultipart: Boolean = false,
 ) {
@@ -86,14 +87,16 @@ data class MessageComposition(
                     conversationId = conversationId,
                     message = messageText,
                     mentions = selectedMentions,
-                    quotedMessageId = quotedMessageId
+                    quotedMessageId = quotedMessageId,
+                    quotedMessageConversationId = quotedMessageConversationId
                 )
             } else {
                 ComposableMessageBundle.SendMultipartMessageBundle(
                     conversationId = conversationId,
                     message = messageText,
                     mentions = selectedMentions,
-                    quotedMessageId = quotedMessageId
+                    quotedMessageId = quotedMessageId,
+                    quotedMessageConversationId = quotedMessageConversationId
                 )
             }
         }
@@ -111,6 +114,7 @@ fun MessageComposition.toDraft(messageText: String): MessageDraft {
         text = messageText,
         editMessageId = editMessageId,
         quotedMessageId = quotedMessageId,
-        selectedMentionList = selectedMentions.map { it.intoMessageMention() }
+        selectedMentionList = selectedMentions.map { it.intoMessageMention() },
+        quotedMessageConversationId = quotedMessageConversationId
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageComposerStateHolder.kt
@@ -51,7 +51,7 @@ fun rememberMessageComposerStateHolder(
 ): MessageComposerStateHolder {
     val density = LocalDensity.current
 
-    val messageComposition = remember(draftMessageComposition) {
+    val messageComposition = remember {
         mutableStateOf(draftMessageComposition)
     }
 
@@ -72,7 +72,9 @@ fun rememberMessageComposerStateHolder(
         )
     }
 
-    LaunchedEffect(draftMessageComposition.draftText) {
+    LaunchedEffect(draftMessageComposition) {
+        messageComposition.value = draftMessageComposition
+
         if (draftMessageComposition.draftText.isNotBlank()) {
             messageTextState.setTextAndPlaceCursorAtEnd(draftMessageComposition.draftText)
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/state/MessageCompositionHolder.kt
@@ -67,11 +67,17 @@ class MessageCompositionHolder(
         const val RICH_TEXT_MARKDOWN_MULTIPLIER = 2
     }
 
-    fun updateQuote(quotedMessage: UIQuotedMessage.UIQuotedData) {
+    private var hasObservedTextUpdate = false
+
+    fun updateQuote(
+        quotedMessage: UIQuotedMessage.UIQuotedData,
+        quotedMessageConversationId: ConversationId? = messageComposition.value.conversationId
+    ) {
         messageComposition.update {
             it.copy(
                 quotedMessage = quotedMessage,
                 quotedMessageId = quotedMessage.messageId,
+                quotedMessageConversationId = quotedMessageConversationId,
                 editMessageId = null
             )
         }
@@ -84,6 +90,7 @@ class MessageCompositionHolder(
         message.mapToQuotedContent()?.let { quotedContent ->
             val quotedMessage = UIQuotedMessage.UIQuotedData(
                 messageId = message.header.messageId,
+                conversationId = message.conversationId,
                 senderId = senderId,
                 senderName = message.header.username,
                 originalMessageDateDescription = "".toUIText(),
@@ -96,6 +103,7 @@ class MessageCompositionHolder(
                 it.copy(
                     quotedMessage = quotedMessage,
                     quotedMessageId = message.header.messageId,
+                    quotedMessageConversationId = message.conversationId,
                     editMessageId = null
                 )
             }
@@ -107,7 +115,8 @@ class MessageCompositionHolder(
         messageComposition.update {
             it.copy(
                 quotedMessage = null,
-                quotedMessageId = null
+                quotedMessageId = null,
+                quotedMessageConversationId = null
             )
         }
         onSaveDraft(messageComposition.value.toDraft(String.EMPTY))
@@ -120,9 +129,20 @@ class MessageCompositionHolder(
                 updateTypingEvent(messageText.toString())
                 updateMentionsIfNeeded(messageText.toString())
                 requestMentionSuggestionIfNeeded(messageText.toString(), selection)
-                onMessageTextUpdate(messageComposition.value.toDraft(messageText = messageText.toString()))
+                val draft = messageComposition.value.toDraft(messageText = messageText.toString())
+                if (!draft.isEmpty() || hasObservedTextUpdate) {
+                    onMessageTextUpdate(draft)
+                }
+                hasObservedTextUpdate = true
             }
     }
+
+    private fun MessageDraft.isEmpty(): Boolean =
+        text.isEmpty() &&
+                editMessageId == null &&
+                quotedMessageId == null &&
+                quotedMessageConversationId == null &&
+                selectedMentionList.isEmpty()
 
     private fun updateMentionsIfNeeded(messageText: String) {
         messageComposition.update { it.copy(selectedMentions = it.getSelectedMentions(messageText)) }
@@ -316,6 +336,7 @@ class MessageCompositionHolder(
             it.copy(
                 quotedMessageId = null,
                 quotedMessage = null,
+                quotedMessageConversationId = null,
                 editMessageId = null,
                 selectedMentions = emptyList()
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,6 +178,7 @@
     <string name="content_description_call_network_quality_view_details">View details</string>
     <string name="content_description_call_network_quality_close_details">Close details</string>
     <string name="content_description_reply_to_messge">Reply to the message</string>
+    <string name="content_description_reply_in_private_to_message">Reply to the message in private</string>
     <string name="content_description_reply_cancel">Cancel message reply</string>
     <string name="content_description_ping_message">Ping message</string>
     <string name="content_description_copy">Copy</string>
@@ -1114,6 +1115,7 @@
     <string name="notification_connection_request">Wants to connect</string>
     <string name="notification_conversation_deleted">Deleted the conversation</string>
     <string name="notification_action_reply">Reply</string>
+    <string name="message_option_reply_in_private">Reply in private</string>
     <string name="notification_receiver_name">You</string>
     <string name="label_type_a_message">Type a message</string>
     <string name="notification_action_open_call">Open Call</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessageViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessageViewModelTest.kt
@@ -132,6 +132,7 @@ class QuotedMultipartMessageViewModelTest {
             } returns flowOf(
                 UIQuotedMessage.UIQuotedData(
                     messageId = "message_id",
+                    conversationId = QualifiedID("conversation", "domain"),
                     senderId = UserId("user", "domain"),
                     senderName = UIText.DynamicString("Sender Name"),
                     senderAccent = Accent.Unknown,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/draft/MessageDraftViewModelTest.kt
@@ -103,6 +103,7 @@ class MessageDraftViewModelTest {
         )
         val quotedData = UIQuotedMessage.UIQuotedData(
             messageId = "quoted_message_id",
+            conversationId = TestConversation.ID,
             senderId = UserId("user_id", "domain"),
             senderName = UIText.DynamicString("John"),
             originalMessageDateDescription = UIText.StringResource(R.string.label_quote_original_message_date, "10:30"),

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetQuoteMessageForConversationUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetQuoteMessageForConversationUseCaseTest.kt
@@ -81,6 +81,7 @@ class GetQuoteMessageForConversationUseCaseTest {
         assertEquals(
             UIQuotedMessage.UIQuotedData(
                 messageId = "message_id",
+                conversationId = CONVERSATION_ID,
                 senderId = USER_ID,
                 senderName = "User".toUIText(),
                 senderAccent = Accent.Unknown,


### PR DESCRIPTION
## Summary

Adds support for **Reply in private** across Kalium and Wire Android.

This lets a user reply privately to a message from a group conversation. The private reply keeps a reference to the original group message, so the receiving side can show the quote when the source message is available.

- Adds a **Reply in private** action to the message options menu.
- Shows the action only for supported group messages.
- Resolves or creates the sender’s 1:1 conversation.
- Opens the private conversation with the quote already prepared.
- Preserves quote metadata through composer and draft state.
- Supports rendering private-reply quotes, with graceful fallback when quote data is unavailable.

## Notes

The new quote field is optional. Old quotes continue to work as before, and clients without the new behavior can still receive the message text.
