### PR TITLE
feat: support message editing in offline (WPB-25295)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -1118,6 +1118,7 @@ private fun ConversationScreen(
         MessageOptionsModalSheetLayout(
             conversationId = conversationInfoViewState.conversationId,
             sheetState = conversationScreenState.editSheetState,
+            isNetworkAvailable = conversationMessagesViewState.isNetworkAvailable,
             onCopyClick = conversationScreenState::copyMessage,
             onDeleteClick = onDeleteMessage,
             onReactionClick = onReactionClick,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
@@ -52,6 +52,7 @@ import com.wire.kalium.logic.data.message.mention.MessageMention
 fun MessageOptionsModalSheetLayout(
     conversationId: ConversationId,
     sheetState: WireModalSheetState<String>,
+    isNetworkAvailable: Boolean,
     onCopyClick: (text: String) -> Unit,
     onDeleteClick: (messageId: String, isMyMessage: Boolean) -> Unit,
     onReactionClick: (messageId: String, reactionEmoji: String) -> Unit,
@@ -75,6 +76,7 @@ fun MessageOptionsModalSheetLayout(
                 is MessageOptionsMenuState.Message -> MessageOptionsModalContent( // message state - show the sheet with proper content
                     message = state.message,
                     sheetState = sheetState,
+                    isNetworkAvailable = isNetworkAvailable,
                     onCopyClick = onCopyClick,
                     onDeleteClick = onDeleteClick,
                     onReactionClick = onReactionClick,
@@ -108,6 +110,7 @@ fun MessageOptionsModalSheetLayout(
 private fun MessageOptionsModalContent(
     message: UIMessage.Regular,
     sheetState: WireModalSheetState<String>,
+    isNetworkAvailable: Boolean,
     onCopyClick: (text: String) -> Unit,
     onDeleteClick: (messageId: String, isMyMessage: Boolean) -> Unit,
     onReactionClick: (messageId: String, reactionEmoji: String) -> Unit,
@@ -119,7 +122,7 @@ private fun MessageOptionsModalContent(
     onOpenAssetClick: (messageId: String) -> Unit,
 ) {
     val context = LocalContext.current
-    val isUploading = message.isPending
+    val isPending = message.isPending
     val isDeleted = message.isDeleted
     val isMyMessage = message.isMyMessage
     val isEphemeral = message.header.messageStatus.expirationStatus is ExpirationStatus.Expirable
@@ -131,7 +134,10 @@ private fun MessageOptionsModalContent(
             isUploading = message.isPending,
             isComposite = message.messageContent is UIMessageContent.Composite,
             isEphemeral = isEphemeral,
-            isEditable = !isUploading && !isDeleted && (message.messageContent?.isEditable() ?: false) && isMyMessage,
+            isEditable = !isDeleted &&
+                    (message.messageContent?.isEditable() ?: false) &&
+                    isMyMessage &&
+                    (!isPending || !isNetworkAvailable),
             isCopyable = message.isCopyable(),
             isOpenable = true,
             onCopyClick = remember(message.messageContent) {
@@ -252,6 +258,7 @@ fun PreviewMessageOptionsModalSheetLayout() = WireTheme {
     MessageOptionsModalSheetLayout(
         conversationId = ConversationId("cid", "domain"),
         sheetState = rememberWireModalSheetState(initialValue = WireSheetValue.Expanded("id")),
+        isNetworkAvailable = true,
         onCopyClick = {},
         onDeleteClick = { _, _ -> },
         onReactionClick = { _, _ -> },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/TextMessageOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/TextMessageOptionsMenuItems.kt
@@ -46,8 +46,8 @@ fun textMessageEditMenuItems(
             add { MessageDetailsMenuOption(onDetailsClick) }
             if (isCopyable) { add { CopyItemMenuOption(onCopyClick) } }
             if (!isEphemeral && !isComposite) add { ReplyMessageOption(onReplyClick) }
-            if (isEditable) add { EditMessageMenuOption(onEditClick) }
         }
+        if (isEditable) add { EditMessageMenuOption(onEditClick) }
         add { DeleteItemMenuOption(onDeleteClick) }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -140,6 +140,17 @@ class ConversationMessagesViewModel(
         loadLastMessageInstant()
         observeAudioPlayerState()
         observeAssetStatuses()
+        observeNetworkAvailability()
+    }
+
+    private fun observeNetworkAvailability() {
+        viewModelScope.launch {
+            networkStateObserver.observeNetworkState().collect { networkState ->
+                conversationViewState = conversationViewState.copy(
+                    isNetworkAvailable = networkState is NetworkState.ConnectedWithInternet
+                )
+            }
+        }
     }
 
     val currentTimeInMillisFlow: Flow<Long> = flow {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewState.kt
@@ -39,6 +39,7 @@ data class ConversationMessagesViewState(
     val searchedMessageId: String? = null,
     val isFetchingOlderMessages: Boolean = false,
     val hasMoreRemoteMessages: Boolean = true,
+    val isNetworkAvailable: Boolean = false,
 )
 
 sealed class DownloadedAssetDialogVisibilityState {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -280,6 +280,62 @@ class ConversationMessagesViewModelTest {
         }
 
     @Test
+    fun `given offline state and multiple pending blocks, when adding offline indicator, then indicators have unique ids`() =
+        runTest {
+            val firstPending = regularMessage(id = "pending-1", flowStatus = MessageFlowStatus.Sending)
+            val firstSent = regularMessage(id = "sent-1")
+            val secondPending = regularMessage(id = "pending-2", flowStatus = MessageFlowStatus.Sending)
+            val secondSent = regularMessage(id = "sent-2")
+
+            val snapshot = flowOf(
+                PagingData.from(listOf<UIMessage>(firstPending, firstSent, secondPending, secondSent))
+                    .withOfflineIndicator(TEST_CONVERSATION_ID, isOffline = true)
+            ).asSnapshot()
+
+            val offlineIndicatorIds = snapshot
+                .map { it.header.messageId }
+                .filter { it.startsWith("offline-message:") }
+
+            assertEquals(offlineIndicatorIds.distinct(), offlineIndicatorIds)
+        }
+
+    @Test
+    fun `given network connected, when observing state, then isNetworkAvailable is true`() = runTest {
+        val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
+            .withSuccessfulViewModelInit()
+            .arrange()
+
+        arrangement.networkState.value = NetworkState.ConnectedWithInternet
+        advanceUntilIdle()
+
+        assertEquals(true, viewModel.conversationViewState.isNetworkAvailable)
+    }
+
+    @Test
+    fun `given network disconnected, when observing state, then isNetworkAvailable is false`() = runTest {
+        val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
+            .withSuccessfulViewModelInit()
+            .arrange()
+
+        arrangement.networkState.value = NetworkState.NotConnected
+        advanceUntilIdle()
+
+        assertEquals(false, viewModel.conversationViewState.isNetworkAvailable)
+    }
+
+    @Test
+    fun `given network without internet, when observing state, then isNetworkAvailable is false`() = runTest {
+        val (arrangement, viewModel) = ConversationMessagesViewModelArrangement()
+            .withSuccessfulViewModelInit()
+            .arrange()
+
+        arrangement.networkState.value = NetworkState.ConnectedWithoutInternet
+        advanceUntilIdle()
+
+        assertEquals(false, viewModel.conversationViewState.isNetworkAvailable)
+    }
+
+    @Test
     fun `given online state, when adding offline indicator, then indicator is not inserted`() = runTest {
         val message = regularMessage(id = "sent")
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25295
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25295
----

# What's new in this PR?

Allow editing messages when no Internet connection is available.
The following scenarios are covered:
1. Online, message status = sent: no changes, current edit feature.
2. Online, message status = pending: edit not allowed to avoid race conditions, message is supposed to be sent shortly.
3. Offline, message status = sent: editing already sent message. Edit will be sent once connected.
4. Offline, message status = pending: editing pending message, only update the message content, message will be sent as regular message once connected.


Key changes in app code:
Enable "Edit" menu for pending messages

Key changes in kalium code:
SendEditTextMessageUseCase - support Pending and Regular message edit flows.
EditMessageBuilder - reuse TextEdited message builder between use case and worker.
MessageDAO \ Repository - new updateTextMessage() function to update only the contents without edit status for pending message editing.
