### PR TITLE
refactor: migrate viewmodel creation to metro [WPB-25946]

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -85,7 +85,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - name: Run Linter
         env:
           GRADLE_OPTS: "-Xmx6G -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g"
@@ -123,7 +123,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - name: Run Detekt
         run: |
           ./gradlew detektAll
@@ -159,7 +159,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - name: Run Compose stability check
         env:
           GRADLE_OPTS: "-Xmx6G -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -285,6 +285,8 @@ dependencies {
 
     // smaller view models
     implementation(libs.resaca.core)
+    implementation(libs.resaca.metro)
+    implementation(libs.metrox.viewModelCompose)
     implementation(libs.bundlizer.core)
 
     allFlavors.forEach { flavor ->

--- a/app/src/androidTest/kotlin/com/wire/android/ui/debug/DebugScreenComposeTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/debug/DebugScreenComposeTest.kt
@@ -33,19 +33,17 @@ class DebugScreenComposeTest {
     @Test
     fun givenAUserIsInDebugScreen_TitleShouldBeDisplayed() = runTest {
         composeTestRule.setContent {
-                WireTestTheme {
-                    UserDebugContent(
-                        onNavigationPressed = { },
-                        state = UserDebugState(logPath = "logPath"),
-                        onLoggingEnabledChange = {},
-                        onDeleteLogs = {},
-                        onDatabaseLoggerEnabledChanged = {},
-                        onShowFeatureFlags = {},
-                        onShowCryptoStats = {},
-                        onFlushLogs = { CompletableDeferred(Unit) },
-                        debugDataOptionsViewModel = object : DebugDataOptionsViewModel {},
-                        exportObfuscatedCopyViewModel = object : ExportObfuscatedCopyViewModel {},
-                    )
+            WireTestTheme {
+                UserDebugContent(
+                    onNavigationPressed = { },
+                    state = UserDebugState(logPath = "logPath"),
+                    onLoggingEnabledChange = {},
+                    onDeleteLogs = {},
+                    onDatabaseLoggerEnabledChanged = {},
+                    onFlushLogs = { CompletableDeferred(Unit) },
+                    debugDataOptionsContent = {},
+                    dangerOptionsContent = {},
+                )
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/di/ViewModelScoped.kt
+++ b/app/src/main/kotlin/com/wire/android/di/ViewModelScoped.kt
@@ -19,94 +19,129 @@ package com.wire.android.di
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.lifecycle.HasDefaultViewModelProviderFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import com.wire.android.di.metro.LocalMetroViewModelGraph
-import com.wire.android.di.metro.MetroViewModelGraph
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import com.wire.android.di.metro.LocalWireViewModelScopeKey
 import com.sebaslogen.resaca.KeyInScopeResolver
-import com.sebaslogen.resaca.viewModelScoped as resacaViewModelScoped
+import com.sebaslogen.resaca.metro.metroViewModelScoped as resacaMetroViewModelScoped
+import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
+import kotlin.reflect.KClass
+import kotlin.reflect.cast
 import kotlin.time.Duration
 
 @Composable
 @Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
-inline fun <reified Graph, reified T, reified S, reified R : ScopedArgs> wireMetroViewModelScoped(
+inline fun <reified T, reified S, reified R : ScopedArgs, reified FactoryType> wireManualMetroViewModelScoped(
     arguments: R,
     clearDelay: Duration? = null,
-    noinline create: Graph.(SavedStateHandle, R) -> T,
-): S where Graph : MetroViewModelGraph, T : ViewModel, T : S = when {
+    noinline create: FactoryType.(SavedStateHandle, R) -> T,
+): S where T : ViewModel, T : S, FactoryType : ManualViewModelAssistedFactory = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     else -> {
-        val graph = currentMetroViewModelGraph<Graph>()
-        resacaViewModelScoped<T>(
-            key = arguments.key?.toString(),
+        resacaMetroViewModelScoped<T>(
+            key = scopedResacaKey(LocalWireViewModelScopeKey.current, arguments.key?.toString()),
             clearDelay = clearDelay,
-        ) { savedStateHandle ->
-            graph.create(savedStateHandle, arguments)
-        } as S
+            factory = manualScopedViewModelFactory<T, FactoryType> { extras ->
+                create(extras.createSavedStateHandle(), arguments)
+            },
+            creationExtras = defaultViewModelCreationExtras(),
+        ) as S
     }
 }
 
 @Composable
 @Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
-inline fun <reified Graph, reified T, reified S, reified R : ScopedArgs> wireMetroViewModelScoped(
+inline fun <reified T, reified S, reified R : ScopedArgs, reified FactoryType> wireManualMetroViewModelScoped(
     arguments: R,
     noinline keyInScopeResolver: KeyInScopeResolver<String>,
     clearDelay: Duration? = null,
-    noinline create: Graph.(SavedStateHandle, R) -> T,
-): S where Graph : MetroViewModelGraph, T : ViewModel, T : S = when {
+    noinline create: FactoryType.(SavedStateHandle, R) -> T,
+): S where T : ViewModel, T : S, FactoryType : ManualViewModelAssistedFactory = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     else -> {
-        val graph = currentMetroViewModelGraph<Graph>()
-        val scopedKey = requireNotNull(arguments.key?.toString()) {
+        val argumentsKey = requireNotNull(arguments.key?.toString()) {
             "Scoped key must not be null for ${T::class.qualifiedName}"
         }
-        resacaViewModelScoped<T, String>(
-            key = scopedKey,
-            keyInScopeResolver = keyInScopeResolver,
+        resacaMetroViewModelScoped<T, String>(
+            key = requireNotNull(scopedResacaKey(LocalWireViewModelScopeKey.current, argumentsKey)),
+            keyInScopeResolver = { keyInScopeResolver(argumentsKey) },
             clearDelay = clearDelay,
-        ) { savedStateHandle ->
-            graph.create(savedStateHandle, arguments)
-        } as S
+            factory = manualScopedViewModelFactory<T, FactoryType> { extras ->
+                create(extras.createSavedStateHandle(), arguments)
+            },
+            creationExtras = defaultViewModelCreationExtras(),
+        ) as S
     }
 }
 
 @Composable
 @Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
-inline fun <reified Graph, reified T, reified S> wireMetroViewModelScoped(
+inline fun <reified T, reified S, reified FactoryType> wireManualMetroViewModelScoped(
     clearDelay: Duration? = null,
-    noinline create: Graph.(SavedStateHandle) -> T,
-): S where Graph : MetroViewModelGraph, T : ViewModel, T : S = when {
+    noinline create: FactoryType.(SavedStateHandle) -> T,
+): S where T : ViewModel, T : S, FactoryType : ManualViewModelAssistedFactory = when {
     LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
     espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? S }
-    else -> {
-        val graph = currentMetroViewModelGraph<Graph>()
-        resacaViewModelScoped<T>(clearDelay = clearDelay) { savedStateHandle ->
-            graph.create(savedStateHandle)
-        } as S
-    }
+    else -> resacaMetroViewModelScoped<T>(
+        key = scopedResacaKey(LocalWireViewModelScopeKey.current),
+        clearDelay = clearDelay,
+        factory = manualScopedViewModelFactory<T, FactoryType> { extras ->
+            create(extras.createSavedStateHandle())
+        },
+        creationExtras = defaultViewModelCreationExtras(),
+    ) as S
 }
 
 @Composable
-inline fun <reified Graph, reified T> wireMetroViewModelScoped(
+inline fun <reified T, reified FactoryType> wireManualMetroViewModelScoped(
     clearDelay: Duration? = null,
-    noinline create: Graph.(SavedStateHandle) -> T,
-): T where Graph : MetroViewModelGraph, T : ViewModel = when {
-    LocalInspectionMode.current -> ViewModelScopedPreviews.firstNotNullOf { it as? T }
-    espresso -> ViewModelScopedPreviews.firstNotNullOf { it as? T }
-    else -> {
-        val graph = currentMetroViewModelGraph<Graph>()
-        resacaViewModelScoped<T>(clearDelay = clearDelay) { savedStateHandle ->
-            graph.create(savedStateHandle)
+    noinline create: FactoryType.(SavedStateHandle) -> T,
+): T where T : ViewModel, FactoryType : ManualViewModelAssistedFactory =
+    wireManualMetroViewModelScoped<T, T, FactoryType>(
+        clearDelay = clearDelay,
+        create = create,
+    )
+
+@Composable
+@PublishedApi
+internal inline fun <reified T, reified FactoryType> manualScopedViewModelFactory(
+    crossinline create: FactoryType.(CreationExtras) -> T,
+): ViewModelProvider.Factory where T : ViewModel, FactoryType : ManualViewModelAssistedFactory {
+    val metroViewModelFactory = LocalMetroViewModelFactory.current
+    return object : ViewModelProvider.Factory {
+        override fun <VM : ViewModel> create(modelClass: KClass<VM>, extras: CreationExtras): VM {
+            val factory = metroViewModelFactory.createManuallyAssistedFactory(FactoryType::class)()
+            return modelClass.cast(factory.create(extras))
         }
     }
 }
 
 @Composable
-inline fun <reified Graph : MetroViewModelGraph> currentMetroViewModelGraph(): Graph =
-    checkNotNull(LocalMetroViewModelGraph.current as? Graph) {
-        "No Metro graph matching ${Graph::class.qualifiedName} was provided"
+@PublishedApi
+internal fun defaultViewModelCreationExtras(): CreationExtras {
+    val viewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    }
+    return if (viewModelStoreOwner is HasDefaultViewModelProviderFactory) {
+        viewModelStoreOwner.defaultViewModelCreationExtras
+    } else {
+        CreationExtras.Empty
+    }
+}
+
+@PublishedApi
+internal fun scopedResacaKey(scopeKey: String?, key: String? = null): String? =
+    when (scopeKey) {
+        null -> key
+        else -> listOfNotNull(key, scopeKey).joinToString(":")
     }
 
 val espresso

--- a/app/src/main/kotlin/com/wire/android/di/ViewModelScoped.kt
+++ b/app/src/main/kotlin/com/wire/android/di/ViewModelScoped.kt
@@ -144,6 +144,10 @@ internal fun scopedResacaKey(scopeKey: String?, key: String? = null): String? =
         else -> listOfNotNull(key, scopeKey).joinToString(":")
     }
 
+@PublishedApi
+internal inline fun <reified S> viewModelScopedPreviewOrNull(): S? =
+    ViewModelScopedPreviews.firstNotNullOfOrNull { it as? S }
+
 val espresso
     get() = try {
         Class.forName("androidx.test.espresso.Espresso")

--- a/app/src/main/kotlin/com/wire/android/di/metro/AppAuthenticationViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/AppAuthenticationViewModelGraph.kt
@@ -17,15 +17,9 @@
  */
 package com.wire.android.di.metro
 
-import com.wire.android.ui.authentication.AuthenticationViewModelFactory
 import com.wire.android.ui.authentication.AuthenticationViewModelGraph
 import dev.zacsweers.metro.Inject
 
-class AppAuthenticationViewModelGraph @Inject constructor(
-    private val authenticationViewModelFactoryProvider: () -> AuthenticationViewModelFactory,
-) : AuthenticationViewModelGraph {
+class AppAuthenticationViewModelGraph @Inject constructor() : AuthenticationViewModelGraph {
     override val viewModelScopeKey: String = "authentication"
-
-    override val authenticationViewModelFactory: AuthenticationViewModelFactory
-        get() = authenticationViewModelFactoryProvider()
 }

--- a/app/src/main/kotlin/com/wire/android/di/metro/AppImageAssetViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/AppImageAssetViewModelGraph.kt
@@ -17,31 +17,18 @@
  */
 package com.wire.android.di.metro
 
-import com.wire.android.model.ImageAssetViewModelFactory
-import com.wire.android.model.ImageAssetViewModelGraph
 import com.wire.android.ui.calling.CallingViewModelFactory
 import com.wire.android.ui.calling.CallingViewModelGraph
 import com.wire.android.ui.common.CommonViewModelFactory
 import com.wire.android.ui.common.CommonViewModelGraph
-import com.wire.android.ui.home.settings.SettingsViewModelFactory
-import com.wire.android.ui.home.settings.SettingsViewModelGraph
-import com.wire.android.util.ui.WireSessionImageLoader
 import dev.zacsweers.metro.Inject
 
 class AppImageAssetViewModelGraph @Inject constructor(
-    imageLoader: () -> WireSessionImageLoader,
     private val callingViewModelFactoryProvider: () -> CallingViewModelFactory,
-    private val settingsViewModelFactoryProvider: () -> SettingsViewModelFactory,
     private val commonViewModelFactoryProvider: () -> CommonViewModelFactory,
-) : ImageAssetViewModelGraph, CallingViewModelGraph, SettingsViewModelGraph, CommonViewModelGraph {
-    override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
-        ImageAssetViewModelFactory(imageLoader = imageLoader)
-
+) : CallingViewModelGraph, CommonViewModelGraph {
     override val callingViewModelFactory: CallingViewModelFactory
         get() = callingViewModelFactoryProvider()
-
-    override val settingsViewModelFactory: SettingsViewModelFactory
-        get() = settingsViewModelFactoryProvider()
 
     override val commonViewModelFactory: CommonViewModelFactory
         get() = commonViewModelFactoryProvider()

--- a/app/src/main/kotlin/com/wire/android/di/metro/AppSessionViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/AppSessionViewModelGraph.kt
@@ -43,7 +43,8 @@ import kotlinx.coroutines.runBlocking
 annotation class MetroSessionScope
 
 @GraphExtension(MetroSessionScope::class, bindingContainers = [WireMetroViewModelBindings::class])
-interface AppSessionViewModelGraph : ViewModelGraph,
+interface AppSessionViewModelGraph :
+    ViewModelGraph,
     MiscViewModelGraph,
     AuthenticationViewModelGraph,
     CallingViewModelGraph,

--- a/app/src/main/kotlin/com/wire/android/di/metro/AppSessionViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/AppSessionViewModelGraph.kt
@@ -18,15 +18,8 @@
 package com.wire.android.di.metro
 
 import com.wire.android.di.CurrentAccount
-import com.wire.android.feature.cells.ui.CellsViewModelFactory
-import com.wire.android.feature.cells.ui.CellsViewModelGraph
-import com.wire.android.feature.meetings.ui.MeetingsViewModelFactory
-import com.wire.android.feature.meetings.ui.MeetingsViewModelGraph
-import com.wire.android.model.ImageAssetViewModelFactory
-import com.wire.android.model.ImageAssetViewModelGraph
 import com.wire.android.ui.MiscViewModelFactory
 import com.wire.android.ui.MiscViewModelGraph
-import com.wire.android.ui.authentication.AuthenticationViewModelFactory
 import com.wire.android.ui.authentication.AuthenticationViewModelGraph
 import com.wire.android.ui.calling.CallingViewModelFactory
 import com.wire.android.ui.calling.CallingViewModelGraph
@@ -34,94 +27,58 @@ import com.wire.android.ui.common.CommonViewModelFactory
 import com.wire.android.ui.common.CommonViewModelGraph
 import com.wire.android.ui.debug.DebugInfoViewModelFactory
 import com.wire.android.ui.debug.DebugInfoViewModelGraph
-import com.wire.android.ui.home.HomeViewModelFactory
-import com.wire.android.ui.home.HomeViewModelGraph
-import com.wire.android.ui.home.conversations.ConversationCoreViewModelFactory
-import com.wire.android.ui.home.conversations.ConversationCoreViewModelGraph
-import com.wire.android.ui.home.conversations.ConversationDetailsViewModelFactory
-import com.wire.android.ui.home.conversations.ConversationDetailsViewModelGraph
-import com.wire.android.ui.home.conversations.ConversationSearchFolderViewModelFactory
-import com.wire.android.ui.home.conversations.ConversationSearchFolderViewModelGraph
-import com.wire.android.ui.home.conversations.ScopedMessageViewModelFactory
-import com.wire.android.ui.home.conversations.ScopedMessageViewModelGraph
-import com.wire.android.ui.home.settings.SettingsViewModelFactory
-import com.wire.android.ui.home.settings.SettingsViewModelGraph
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.user.UserId
-import dev.zacsweers.metro.Inject
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.GraphExtension
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.Scope
+import dev.zacsweers.metro.asContribution
+import dev.zacsweers.metrox.viewmodel.ViewModelGraph
+import kotlinx.coroutines.runBlocking
 
-@Suppress("LongParameterList")
-class AppSessionViewModelGraph @Inject constructor(
-    @CurrentAccount currentAccount: UserId,
-    imageLoader: () -> WireSessionImageLoader,
-    private val cellsViewModelFactoryProvider: () -> CellsViewModelFactory,
-    private val miscViewModelFactoryProvider: () -> MiscViewModelFactory,
-    private val authenticationViewModelFactoryProvider: () -> AuthenticationViewModelFactory,
-    private val callingViewModelFactoryProvider: () -> CallingViewModelFactory,
-    private val debugInfoViewModelFactoryProvider: () -> DebugInfoViewModelFactory,
-    private val homeViewModelFactoryProvider: () -> HomeViewModelFactory,
-    private val settingsViewModelFactoryProvider: () -> SettingsViewModelFactory,
-    private val conversationCoreViewModelFactoryProvider: () -> ConversationCoreViewModelFactory,
-    private val conversationDetailsViewModelFactoryProvider: () -> ConversationDetailsViewModelFactory,
-    private val conversationSearchFolderViewModelFactoryProvider: () -> ConversationSearchFolderViewModelFactory,
-    private val meetingsViewModelFactoryProvider: () -> MeetingsViewModelFactory,
-    private val scopedMessageViewModelFactoryProvider: () -> ScopedMessageViewModelFactory,
-    private val commonViewModelFactoryProvider: () -> CommonViewModelFactory,
-) : ImageAssetViewModelGraph,
-    CellsViewModelGraph,
+@Scope
+annotation class MetroSessionScope
+
+@GraphExtension(MetroSessionScope::class, bindingContainers = [WireMetroViewModelBindings::class])
+interface AppSessionViewModelGraph : ViewModelGraph,
     MiscViewModelGraph,
     AuthenticationViewModelGraph,
     CallingViewModelGraph,
     DebugInfoViewModelGraph,
-    HomeViewModelGraph,
-    SettingsViewModelGraph,
-    ConversationCoreViewModelGraph,
-    ConversationDetailsViewModelGraph,
-    ConversationSearchFolderViewModelGraph,
-    MeetingsViewModelGraph,
-    ScopedMessageViewModelGraph,
     CommonViewModelGraph {
-    override val viewModelScopeKey: String = currentAccount.toString()
+    @get:CurrentAccount
+    val currentAccount: UserId
 
-    override val imageAssetViewModelFactory: ImageAssetViewModelFactory =
-        ImageAssetViewModelFactory(imageLoader = imageLoader)
+    override val viewModelScopeKey: String
+        get() = currentAccount.toString()
 
-    override val cellsViewModelFactory: CellsViewModelFactory
-        get() = cellsViewModelFactoryProvider()
+    val wireSessionImageLoader: WireSessionImageLoader
 
     override val miscViewModelFactory: MiscViewModelFactory
-        get() = miscViewModelFactoryProvider()
-
-    override val authenticationViewModelFactory: AuthenticationViewModelFactory
-        get() = authenticationViewModelFactoryProvider()
-
     override val callingViewModelFactory: CallingViewModelFactory
-        get() = callingViewModelFactoryProvider()
-
     override val debugInfoViewModelFactory: DebugInfoViewModelFactory
-        get() = debugInfoViewModelFactoryProvider()
-
-    override val homeViewModelFactory: HomeViewModelFactory
-        get() = homeViewModelFactoryProvider()
-
-    override val settingsViewModelFactory: SettingsViewModelFactory
-        get() = settingsViewModelFactoryProvider()
-
-    override val conversationCoreViewModelFactory: ConversationCoreViewModelFactory
-        get() = conversationCoreViewModelFactoryProvider()
-
-    override val conversationDetailsViewModelFactory: ConversationDetailsViewModelFactory
-        get() = conversationDetailsViewModelFactoryProvider()
-
-    override val conversationSearchFolderViewModelFactory: ConversationSearchFolderViewModelFactory
-        get() = conversationSearchFolderViewModelFactoryProvider()
-
-    override val meetingsViewModelFactory: MeetingsViewModelFactory
-        get() = meetingsViewModelFactoryProvider()
-
-    override val scopedMessageViewModelFactory: ScopedMessageViewModelFactory
-        get() = scopedMessageViewModelFactoryProvider()
-
     override val commonViewModelFactory: CommonViewModelFactory
-        get() = commonViewModelFactoryProvider()
+
+    @ContributesTo(AppScope::class)
+    @GraphExtension.Factory
+    interface Factory {
+        fun createAppSessionViewModelGraph(@Provides @CurrentAccount currentAccount: UserId): AppSessionViewModelGraph
+    }
+}
+
+fun WireApplicationGraph.createSessionViewModelGraph(currentAccount: UserId): AppSessionViewModelGraph {
+    return asContribution<AppSessionViewModelGraph.Factory>().createAppSessionViewModelGraph(currentAccount)
+}
+
+fun WireApplicationGraph.createCurrentSessionViewModelGraph(): AppSessionViewModelGraph {
+    val currentAccount = runBlocking {
+        when (val result = coreLogic.getGlobalScope().session.currentSession()) {
+            is CurrentSessionResult.Success -> result.accountInfo.userId
+            else -> throw IllegalStateException("no current session was found")
+        }
+    }
+    return createSessionViewModelGraph(currentAccount)
 }

--- a/app/src/main/kotlin/com/wire/android/di/metro/WireApplicationGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireApplicationGraph.kt
@@ -45,6 +45,8 @@ import com.wire.android.di.accountScoped.SearchModule
 import com.wire.android.di.accountScoped.ServicesModule
 import com.wire.android.di.accountScoped.TeamModule
 import com.wire.android.di.accountScoped.UserModule
+import com.wire.android.feature.cells.ui.CellsMetroViewModelBindings
+import com.wire.android.feature.meetings.ui.MeetingsMetroViewModelBindings
 import com.wire.android.notification.broadcastreceivers.EndOngoingCallReceiver
 import com.wire.android.notification.broadcastreceivers.IncomingCallActionReceiver
 import com.wire.android.notification.broadcastreceivers.NomadLogoutReceiver
@@ -68,6 +70,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.createGraphFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelGraph
 
 @DependencyGraph(
     scope = AppScope::class,
@@ -97,15 +100,17 @@ import dev.zacsweers.metro.createGraphFactory
         ServicesModule::class,
         TeamModule::class,
         UserModule::class,
+        WireMetroViewModelBindings::class,
+        CellsMetroViewModelBindings::class,
+        MeetingsMetroViewModelBindings::class,
     ]
 )
 @Suppress("TooManyFunctions")
-interface WireApplicationGraph {
+interface WireApplicationGraph : ViewModelGraph {
     val wireWorkerFactory: WireWorkerFactory
     val wireActivityViewModel: WireActivityViewModel
     val authenticationViewModelGraph: AppAuthenticationViewModelGraph
     val imageAssetViewModelGraph: AppImageAssetViewModelGraph
-    val sessionViewModelGraph: AppSessionViewModelGraph
 
     @get:KaliumCoreLogic
     val coreLogic: CoreLogic

--- a/app/src/main/kotlin/com/wire/android/di/metro/WireMetroViewModelBindings.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireMetroViewModelBindings.kt
@@ -1,0 +1,995 @@
+@file:Suppress("TooManyFunctions")
+
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.di.metro
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.wire.android.ui.CallFeedbackViewModel
+import com.wire.android.ui.debug.DebugDataOptionsViewModelImpl
+import com.wire.android.ui.debug.DebugInfoViewModelFactory
+import com.wire.android.ui.debug.ExportObfuscatedCopyViewModelImpl
+import com.wire.android.ui.debug.LogManagementViewModel
+import com.wire.android.ui.debug.UserDebugViewModel
+import com.wire.android.ui.debug.conversation.DebugConversationViewModel
+import com.wire.android.ui.debug.cryptostats.ConversationCryptoStatsViewModel
+import com.wire.android.ui.debug.featureflags.DebugFeatureFlagsViewModel
+import com.wire.android.ui.MiscViewModelFactory
+import com.wire.android.ui.analytics.AnalyticsUsageViewModel
+import com.wire.android.ui.authentication.AuthenticationManualViewModelFactory
+import com.wire.android.ui.authentication.AuthenticationViewModelFactory
+import com.wire.android.ui.authentication.create.code.CreateAccountCodeViewModel
+import com.wire.android.ui.authentication.create.details.CreateAccountDetailsViewModel
+import com.wire.android.ui.authentication.create.email.CreateAccountEmailViewModel
+import com.wire.android.ui.authentication.create.overview.CreateAccountOverviewViewModel
+import com.wire.android.ui.authentication.create.summary.CreateAccountSummaryViewModel
+import com.wire.android.ui.authentication.create.username.CreateAccountUsernameViewModel
+import com.wire.android.ui.authentication.devices.common.ClearSessionViewModel
+import com.wire.android.ui.authentication.devices.register.RegisterDeviceViewModel
+import com.wire.android.ui.authentication.devices.remove.RemoveDeviceViewModel
+import com.wire.android.ui.authentication.login.LoginNavArgs
+import com.wire.android.ui.authentication.login.email.LoginEmailViewModel
+import com.wire.android.ui.authentication.login.sso.LoginSSOViewModel
+import com.wire.android.ui.authentication.welcome.WelcomeViewModel
+import com.wire.android.ui.calling.CallingManualViewModelFactory
+import com.wire.android.ui.calling.CallingViewModelFactory
+import com.wire.android.ui.calling.common.SharedCallingViewModel
+import com.wire.android.ui.calling.incoming.IncomingCallViewModel
+import com.wire.android.ui.calling.ongoing.OngoingCallViewModel
+import com.wire.android.ui.calling.outgoing.OutgoingCallViewModel
+import com.wire.android.ui.common.CommonManualViewModelFactory
+import com.wire.android.ui.common.CommonViewModelFactory
+import com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentViewModel
+import com.wire.android.ui.e2eiEnrollment.GetE2EICertificateViewModel
+import com.wire.android.ui.home.AppSyncViewModel
+import com.wire.android.ui.home.HomeManualViewModelFactory
+import com.wire.android.ui.home.HomeViewModel
+import com.wire.android.ui.home.HomeViewModelFactory
+import com.wire.android.ui.home.appLock.forgot.ForgotLockScreenViewModel
+import com.wire.android.ui.home.appLock.set.SetLockScreenViewModel
+import com.wire.android.ui.home.appLock.unlock.AppUnlockWithBiometricsViewModel
+import com.wire.android.ui.home.appLock.unlock.EnterLockScreenViewModel
+import com.wire.android.ui.home.conversations.ConversationCoreManualViewModelFactory
+import com.wire.android.ui.home.conversations.ConversationCoreViewModelFactory
+import com.wire.android.ui.home.conversations.ConversationDetailsViewModelFactory
+import com.wire.android.ui.home.conversations.ConversationSearchFolderManualViewModelFactory
+import com.wire.android.ui.home.conversations.ConversationSearchFolderViewModelFactory
+import com.wire.android.ui.home.conversations.attachment.MessageAttachmentsViewModel
+import com.wire.android.ui.home.conversations.banner.ConversationBannerViewModel
+import com.wire.android.ui.home.conversations.call.ConversationCallViewModel
+import com.wire.android.ui.home.conversations.composer.MessageComposerViewModel
+import com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel
+import com.wire.android.ui.home.conversations.details.editguestaccess.EditGuestAccessViewModel
+import com.wire.android.ui.home.conversations.details.editguestaccess.createPasswordProtectedGuestLink.CreatePasswordGuestLinkViewModel
+import com.wire.android.ui.home.conversations.details.editselfdeletingmessages.EditSelfDeletingMessagesViewModel
+import com.wire.android.ui.home.conversations.details.metadata.EditConversationMetadataViewModel
+import com.wire.android.ui.home.conversations.details.participants.GroupConversationParticipantsViewModel
+import com.wire.android.ui.home.conversations.details.updateappsaccess.UpdateAppsAccessViewModel
+import com.wire.android.ui.home.conversations.details.updatechannelaccess.UpdateChannelAccessViewModel
+import com.wire.android.ui.home.conversations.folder.ConversationFoldersStateArgs
+import com.wire.android.ui.home.conversations.folder.ConversationFoldersVMImpl
+import com.wire.android.ui.home.conversations.folder.MoveConversationToFolderArgs
+import com.wire.android.ui.home.conversations.folder.MoveConversationToFolderVMImpl
+import com.wire.android.ui.home.conversations.folder.NewFolderViewModel
+import com.wire.android.ui.home.conversations.info.ConversationInfoViewModel
+import com.wire.android.ui.home.conversations.media.CheckAssetRestrictionsViewModel
+import com.wire.android.ui.home.conversations.media.ConversationAssetMessagesViewModel
+import com.wire.android.ui.home.conversations.media.preview.ImagesPreviewViewModel
+import com.wire.android.ui.home.conversations.messagedetails.MessageDetailsViewModel
+import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
+import com.wire.android.ui.home.conversations.messages.QuotedMultipartMessageViewModel
+import com.wire.android.ui.home.conversations.messages.draft.MessageDraftViewModel
+import com.wire.android.ui.home.conversations.messages.item.ConversationAssetPathsViewModelImpl
+import com.wire.android.ui.home.conversations.migration.ConversationMigrationViewModel
+import com.wire.android.ui.home.conversations.model.messagetypes.multipart.MultipartAttachmentsViewModelImpl
+import com.wire.android.ui.home.conversations.promoteadmin.PromoteAdminViewModel
+import com.wire.android.ui.home.conversations.search.SearchUserViewModel
+import com.wire.android.ui.home.conversations.search.adddembertoconversation.AddMembersToConversationViewModel
+import com.wire.android.ui.home.conversations.search.apps.SearchAppsViewModel
+import com.wire.android.ui.home.conversations.search.messages.SearchConversationMessagesViewModel
+import com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
+import com.wire.android.ui.home.conversations.ScopedMessageManualViewModelFactory
+import com.wire.android.ui.home.conversations.ScopedMessageViewModelFactory
+import com.wire.android.ui.home.conversationslist.ConversationListCallViewModelImpl
+import com.wire.android.ui.home.conversationslist.ConversationListViewModelImpl
+import com.wire.android.ui.home.conversationslist.model.ConversationsSource
+import com.wire.android.ui.home.drawer.HomeDrawerViewModel
+import com.wire.android.ui.home.gallery.MediaGalleryViewModel
+import com.wire.android.ui.home.messagecomposer.location.LocationPickerViewModel
+import com.wire.android.ui.home.newconversation.NewConversationViewModel
+import com.wire.android.ui.home.settings.SettingsViewModel
+import com.wire.android.ui.home.settings.SettingsViewModelFactory
+import com.wire.android.ui.home.settings.account.MyAccountViewModel
+import com.wire.android.ui.home.settings.account.color.ChangeUserColorViewModel
+import com.wire.android.ui.home.settings.account.deleteAccount.DeleteAccountViewModel
+import com.wire.android.ui.home.settings.account.displayname.ChangeDisplayNameViewModel
+import com.wire.android.ui.home.settings.account.email.updateEmail.ChangeEmailViewModel
+import com.wire.android.ui.home.settings.account.email.verifyEmail.VerifyEmailViewModel
+import com.wire.android.ui.home.settings.account.handle.ChangeHandleViewModel
+import com.wire.android.ui.home.settings.appearance.CustomizationViewModel
+import com.wire.android.ui.home.settings.appsettings.networkSettings.NetworkSettingsViewModel
+import com.wire.android.ui.home.settings.backup.BackupAndRestoreViewModel
+import com.wire.android.ui.home.settings.about.dependencies.DependenciesViewModel
+import com.wire.android.ui.home.settings.about.licenses.LicensesViewModel
+import com.wire.android.ui.home.settings.privacy.PrivacySettingsViewModel
+import com.wire.android.ui.home.sync.FeatureFlagNotificationViewModel
+import com.wire.android.ui.home.whatsnew.WhatsNewViewModel
+import com.wire.android.ui.initialsync.InitialSyncViewModel
+import com.wire.android.ui.joinConversation.JoinConversationViaCodeViewModel
+import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedViewModel
+import com.wire.android.ui.newauthentication.login.NewLoginViewModel
+import com.wire.android.ui.registration.code.CreateAccountVerificationCodeViewModel
+import com.wire.android.ui.registration.details.CreateAccountDataDetailViewModel
+import com.wire.android.ui.registration.selector.CreateAccountSelectorViewModel
+import com.wire.android.ui.settings.about.AboutThisAppViewModel
+import com.wire.android.ui.settings.devices.DeviceDetailsViewModel
+import com.wire.android.ui.settings.devices.SelfDevicesViewModel
+import com.wire.android.ui.settings.devices.e2ei.E2eiCertificateDetailsViewModel
+import com.wire.android.ui.sharing.ImportMediaAuthenticatedViewModel
+import com.wire.android.ui.common.banner.SecurityClassificationArgs
+import com.wire.android.ui.common.banner.SecurityClassificationViewModelImpl
+import com.wire.android.ui.common.bottomsheet.conversation.ConversationOptionsMenuViewModelImpl
+import com.wire.android.ui.connection.ConnectionActionButtonArgs
+import com.wire.android.ui.connection.ConnectionActionButtonViewModelImpl
+import com.wire.android.media.audiomessage.AudioMessageArgs
+import com.wire.android.media.audiomessage.AudioMessageViewModelImpl
+import com.wire.android.ui.home.conversations.CompositeMessageViewModelImpl
+import com.wire.android.ui.home.conversations.edit.MessageOptionsMenuArgs
+import com.wire.android.ui.home.conversations.edit.MessageOptionsMenuViewModelImpl
+import com.wire.android.ui.home.conversations.messages.item.AssetLocalPathArgs
+import com.wire.android.ui.home.conversations.messages.item.AssetLocalPathViewModelImpl
+import com.wire.android.ui.home.conversations.model.CompositeMessageArgs
+import com.wire.android.ui.home.conversations.typing.TypingIndicatorArgs
+import com.wire.android.ui.home.conversations.typing.TypingIndicatorViewModelImpl
+import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionArgs
+import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModelImpl
+import com.wire.android.ui.home.messagecomposer.attachments.IsFileSharingEnabledViewModelImpl
+import com.wire.android.ui.home.messagecomposer.recordaudio.RecordAudioViewModel
+import com.wire.android.ui.userprofile.avatarpicker.AvatarPickerViewModel
+import com.wire.android.ui.userprofile.other.OtherUserProfileScreenViewModel
+import com.wire.android.ui.userprofile.qr.SelfQRCodeViewModel
+import com.wire.android.ui.userprofile.self.SelfUserProfileViewModel
+import com.wire.android.ui.userprofile.service.ServiceDetailsViewModelImpl
+import com.wire.android.ui.userprofile.teammigration.TeamMigrationViewModel
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.user.UserId
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.IntoMap
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactoryKey
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
+import dev.zacsweers.metrox.viewmodel.ViewModelKey
+
+@BindingContainer
+object WireMetroViewModelBindings {
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(AppSyncViewModel::class)
+    fun appSyncViewModel(factory: HomeViewModelFactory): ViewModel =
+        factory.appSyncViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(FeatureFlagNotificationViewModel::class)
+    fun featureFlagNotificationViewModel(factory: HomeViewModelFactory): ViewModel =
+        factory.featureFlagNotificationViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(HomeViewModel::class)
+    fun homeViewModel(factory: HomeViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.homeViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(HomeDrawerViewModel::class)
+    fun homeDrawerViewModel(factory: HomeViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.homeDrawerViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(NewConversationViewModel::class)
+    fun newConversationViewModel(factory: HomeViewModelFactory): ViewModel =
+        factory.newConversationViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(CallFeedbackViewModel::class)
+    fun callFeedbackViewModel(factory: CallingViewModelFactory): ViewModel =
+        factory.callFeedbackViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(ConversationCallViewModel::class)
+    fun conversationCallViewModel(factory: CallingViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.conversationCallViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(ConversationListCallViewModelImpl::class)
+    fun conversationListCallViewModel(factory: CallingViewModelFactory): ViewModel =
+        factory.conversationListCallViewModel()
+
+    @Provides
+    @IntoMap
+    @ManualViewModelAssistedFactoryKey(CallingManualViewModelFactory::class)
+    fun callingManualViewModelFactory(factory: CallingViewModelFactory): ManualViewModelAssistedFactory =
+        object : CallingManualViewModelFactory {
+            override fun incomingCallViewModel(conversationId: ConversationId): IncomingCallViewModel =
+                factory.incomingCallViewModel(conversationId)
+
+            override fun outgoingCallViewModel(conversationId: ConversationId): OutgoingCallViewModel =
+                factory.outgoingCallViewModel(conversationId)
+
+            override fun ongoingCallViewModel(conversationId: ConversationId): OngoingCallViewModel =
+                factory.ongoingCallViewModel(conversationId)
+
+            override fun sharedCallingViewModel(conversationId: ConversationId): SharedCallingViewModel =
+                factory.sharedCallingViewModel(conversationId)
+        }
+
+    @Provides
+    @IntoMap
+    @ManualViewModelAssistedFactoryKey(HomeManualViewModelFactory::class)
+    fun homeManualViewModelFactory(factory: HomeViewModelFactory): ManualViewModelAssistedFactory =
+        object : HomeManualViewModelFactory {
+            override fun conversationListViewModel(conversationsSource: ConversationsSource): ConversationListViewModelImpl =
+                factory.conversationListViewModel(conversationsSource)
+        }
+
+    @Provides
+    @IntoMap
+    @ManualViewModelAssistedFactoryKey(CommonManualViewModelFactory::class)
+    fun commonManualViewModelFactory(factory: CommonViewModelFactory): ManualViewModelAssistedFactory =
+        object : CommonManualViewModelFactory {
+            override fun securityClassificationViewModel(args: SecurityClassificationArgs): SecurityClassificationViewModelImpl =
+                factory.securityClassificationViewModel(args)
+
+            override fun connectionActionButtonViewModel(args: ConnectionActionButtonArgs): ConnectionActionButtonViewModelImpl =
+                factory.connectionActionButtonViewModel(args)
+
+            override fun conversationOptionsMenuViewModel(): ConversationOptionsMenuViewModelImpl =
+                factory.conversationOptionsMenuViewModel()
+        }
+
+    @Provides
+    @IntoMap
+    @ManualViewModelAssistedFactoryKey(ScopedMessageManualViewModelFactory::class)
+    fun scopedMessageManualViewModelFactory(factory: ScopedMessageViewModelFactory): ManualViewModelAssistedFactory =
+        object : ScopedMessageManualViewModelFactory {
+            override fun compositeMessageViewModel(
+                savedStateHandle: androidx.lifecycle.SavedStateHandle,
+                args: CompositeMessageArgs
+            ): CompositeMessageViewModelImpl =
+                factory.compositeMessageViewModel(savedStateHandle, args)
+
+            override fun messageOptionsMenuViewModel(args: MessageOptionsMenuArgs): MessageOptionsMenuViewModelImpl =
+                factory.messageOptionsMenuViewModel(args)
+
+            override fun typingIndicatorViewModel(args: TypingIndicatorArgs): TypingIndicatorViewModelImpl =
+                factory.typingIndicatorViewModel(args)
+
+            override fun assetLocalPathViewModel(args: AssetLocalPathArgs): AssetLocalPathViewModelImpl =
+                factory.assetLocalPathViewModel(args)
+
+            override fun selfDeletingMessageActionViewModel(
+                args: SelfDeletingMessageActionArgs
+            ): SelfDeletingMessageActionViewModelImpl =
+                factory.selfDeletingMessageActionViewModel(args)
+
+            override fun isFileSharingEnabledViewModel(): IsFileSharingEnabledViewModelImpl =
+                factory.isFileSharingEnabledViewModel()
+
+            override fun recordAudioViewModel(): RecordAudioViewModel =
+                factory.recordAudioViewModel()
+
+            override fun audioMessageViewModel(args: AudioMessageArgs): AudioMessageViewModelImpl =
+                factory.audioMessageViewModel(args)
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(UserDebugViewModel::class)
+    fun userDebugViewModel(factory: DebugInfoViewModelFactory): ViewModel =
+        factory.userDebugViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(LogManagementViewModel::class)
+    fun logManagementViewModel(factory: DebugInfoViewModelFactory): ViewModel =
+        factory.logManagementViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(DebugDataOptionsViewModelImpl::class)
+    fun debugDataOptionsViewModel(factory: DebugInfoViewModelFactory): ViewModel =
+        factory.debugDataOptionsViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(ExportObfuscatedCopyViewModelImpl::class)
+    fun exportObfuscatedCopyViewModel(factory: DebugInfoViewModelFactory): ViewModel =
+        factory.exportObfuscatedCopyViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(DebugConversationViewModel::class)
+    fun debugConversationViewModel(factory: DebugInfoViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.debugConversationViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(ConversationCryptoStatsViewModel::class)
+    fun conversationCryptoStatsViewModel(factory: DebugInfoViewModelFactory): ViewModel =
+        factory.conversationCryptoStatsViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(DebugFeatureFlagsViewModel::class)
+    fun debugFeatureFlagsViewModel(factory: DebugInfoViewModelFactory): ViewModel =
+        factory.debugFeatureFlagsViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(WhatsNewViewModel::class)
+    fun whatsNewViewModel(factory: DebugInfoViewModelFactory): ViewModel =
+        factory.whatsNewViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(AboutThisAppViewModel::class)
+    fun aboutThisAppViewModel(factory: DebugInfoViewModelFactory): ViewModel =
+        factory.aboutThisAppViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(DependenciesViewModel::class)
+    fun dependenciesViewModel(factory: DebugInfoViewModelFactory): ViewModel =
+        factory.dependenciesViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(LicensesViewModel::class)
+    fun licensesViewModel(factory: DebugInfoViewModelFactory): ViewModel =
+        factory.licensesViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(AnalyticsUsageViewModel::class)
+    fun analyticsUsageViewModel(factory: MiscViewModelFactory): ViewModel =
+        factory.analyticsUsageViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(InitialSyncViewModel::class)
+    fun initialSyncViewModel(factory: MiscViewModelFactory): ViewModel =
+        factory.initialSyncViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(LegalHoldRequestedViewModel::class)
+    fun legalHoldRequestedViewModel(factory: MiscViewModelFactory): ViewModel =
+        factory.legalHoldRequestedViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(E2EIEnrollmentViewModel::class)
+    fun e2EIEnrollmentViewModel(factory: MiscViewModelFactory): ViewModel =
+        factory.e2EIEnrollmentViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(GetE2EICertificateViewModel::class)
+    fun getE2EICertificateViewModel(factory: MiscViewModelFactory): ViewModel =
+        factory.getE2EICertificateViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(E2eiCertificateDetailsViewModel::class)
+    fun e2eiCertificateDetailsViewModel(factory: MiscViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.e2eiCertificateDetailsViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(ImportMediaAuthenticatedViewModel::class)
+    fun importMediaAuthenticatedViewModel(factory: MiscViewModelFactory): ViewModel =
+        factory.importMediaAuthenticatedViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(JoinConversationViaCodeViewModel::class)
+    fun joinConversationViaCodeViewModel(factory: MiscViewModelFactory): ViewModel =
+        factory.joinConversationViaCodeViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(WelcomeViewModel::class)
+    fun welcomeViewModel(factory: AuthenticationViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.welcomeViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(NewLoginViewModel::class)
+    fun newLoginViewModel(factory: AuthenticationViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.newLoginViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(RegisterDeviceViewModel::class)
+    fun registerDeviceViewModel(factory: AuthenticationViewModelFactory): ViewModel =
+        factory.registerDeviceViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(RemoveDeviceViewModel::class)
+    fun removeDeviceViewModel(factory: AuthenticationViewModelFactory): ViewModel =
+        factory.removeDeviceViewModel()
+
+    @Provides
+    @IntoMap
+    @ManualViewModelAssistedFactoryKey(AuthenticationManualViewModelFactory::class)
+    fun authenticationManualViewModelFactory(factory: AuthenticationViewModelFactory): ManualViewModelAssistedFactory =
+        object : AuthenticationManualViewModelFactory {
+            override fun loginEmailViewModel(loginNavArgs: LoginNavArgs, extras: CreationExtras): LoginEmailViewModel =
+                factory.loginEmailViewModel(loginNavArgs, extras.createSavedStateHandle())
+
+            override fun loginSSOViewModel(loginNavArgs: LoginNavArgs, extras: CreationExtras): LoginSSOViewModel =
+                factory.loginSSOViewModel(loginNavArgs, extras.createSavedStateHandle())
+
+            override fun clearSessionViewModel(cancelUserId: UserId?): ClearSessionViewModel =
+                factory.clearSessionViewModel(cancelUserId)
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(CreateAccountUsernameViewModel::class)
+    fun createAccountUsernameViewModel(factory: AuthenticationViewModelFactory): ViewModel =
+        factory.createAccountUsernameViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(CreateAccountOverviewViewModel::class)
+    fun createAccountOverviewViewModel(factory: AuthenticationViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.createAccountOverviewViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(CreateAccountEmailViewModel::class)
+    fun createAccountEmailViewModel(factory: AuthenticationViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.createAccountEmailViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(CreateAccountDetailsViewModel::class)
+    fun createAccountDetailsViewModel(factory: AuthenticationViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.createAccountDetailsViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(CreateAccountCodeViewModel::class)
+    fun createAccountCodeViewModel(factory: AuthenticationViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.createAccountCodeViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(CreateAccountSummaryViewModel::class)
+    fun createAccountSummaryViewModel(factory: AuthenticationViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.createAccountSummaryViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(CreateAccountSelectorViewModel::class)
+    fun createAccountSelectorViewModel(factory: AuthenticationViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.createAccountSelectorViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(CreateAccountDataDetailViewModel::class)
+    fun createAccountDataDetailViewModel(factory: AuthenticationViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.createAccountDataDetailViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(CreateAccountVerificationCodeViewModel::class)
+    fun createAccountVerificationCodeViewModel(factory: AuthenticationViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.createAccountVerificationCodeViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(ConversationMessagesViewModel::class)
+    fun conversationMessagesViewModel(factory: ConversationCoreViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.conversationMessagesViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(MessageComposerViewModel::class)
+    fun messageComposerViewModel(factory: ConversationCoreViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.messageComposerViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(SendMessageViewModel::class)
+    fun sendMessageViewModel(factory: ConversationCoreViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.sendMessageViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(MessageDraftViewModel::class)
+    fun messageDraftViewModel(factory: ConversationCoreViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.messageDraftViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(MessageAttachmentsViewModel::class)
+    fun messageAttachmentsViewModel(factory: ConversationCoreViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.messageAttachmentsViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(ConversationMigrationViewModel::class)
+    fun conversationMigrationViewModel(factory: ConversationCoreViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.conversationMigrationViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(ConversationAssetPathsViewModelImpl::class)
+    fun conversationAssetPathsViewModel(factory: ConversationCoreViewModelFactory): ViewModel =
+        factory.conversationAssetPathsViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(MediaGalleryViewModel::class)
+    fun mediaGalleryViewModel(factory: ConversationCoreViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.mediaGalleryViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(LocationPickerViewModel::class)
+    fun locationPickerViewModel(factory: ConversationCoreViewModelFactory): ViewModel =
+        factory.locationPickerViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(ConversationAssetMessagesViewModel::class)
+    fun conversationAssetMessagesViewModel(factory: ConversationCoreViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.conversationAssetMessagesViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(ImagesPreviewViewModel::class)
+    fun imagesPreviewViewModel(factory: ConversationCoreViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.imagesPreviewViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(MessageDetailsViewModel::class)
+    fun messageDetailsViewModel(factory: ConversationCoreViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.messageDetailsViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(QuotedMultipartMessageViewModel::class)
+    fun quotedMultipartMessageViewModel(factory: ConversationCoreViewModelFactory): ViewModel =
+        factory.quotedMultipartMessageViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(ConversationBannerViewModel::class)
+    fun conversationBannerViewModel(factory: ConversationCoreViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.conversationBannerViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(ConversationInfoViewModel::class)
+    fun conversationInfoViewModel(factory: ConversationCoreViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.conversationInfoViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ManualViewModelAssistedFactoryKey(ConversationCoreManualViewModelFactory::class)
+    fun conversationCoreManualViewModelFactory(
+        factory: ConversationCoreViewModelFactory
+    ): ManualViewModelAssistedFactory =
+        object : ConversationCoreManualViewModelFactory {
+            override fun multipartAttachmentsViewModel(conversationId: ConversationId): MultipartAttachmentsViewModelImpl =
+                factory.multipartAttachmentsViewModel(conversationId)
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(GroupConversationDetailsViewModel::class)
+    fun groupConversationDetailsViewModel(factory: ConversationDetailsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.groupConversationDetailsViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(GroupConversationParticipantsViewModel::class)
+    fun groupConversationParticipantsViewModel(factory: ConversationDetailsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.groupConversationParticipantsViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(EditConversationMetadataViewModel::class)
+    fun editConversationMetadataViewModel(factory: ConversationDetailsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.editConversationMetadataViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(EditSelfDeletingMessagesViewModel::class)
+    fun editSelfDeletingMessagesViewModel(factory: ConversationDetailsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.editSelfDeletingMessagesViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(UpdateChannelAccessViewModel::class)
+    fun updateChannelAccessViewModel(factory: ConversationDetailsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.updateChannelAccessViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(UpdateAppsAccessViewModel::class)
+    fun updateAppsAccessViewModel(factory: ConversationDetailsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.updateAppsAccessViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(EditGuestAccessViewModel::class)
+    fun editGuestAccessViewModel(factory: ConversationDetailsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.editGuestAccessViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(CreatePasswordGuestLinkViewModel::class)
+    fun createPasswordGuestLinkViewModel(factory: ConversationDetailsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.createPasswordGuestLinkViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(CheckAssetRestrictionsViewModel::class)
+    fun checkAssetRestrictionsViewModel(factory: ConversationDetailsViewModelFactory): ViewModel =
+        factory.checkAssetRestrictionsViewModel()
+
+    @Provides
+    @IntoMap
+    @ManualViewModelAssistedFactoryKey(ConversationSearchFolderManualViewModelFactory::class)
+    fun conversationSearchFolderManualViewModelFactory(
+        factory: ConversationSearchFolderViewModelFactory
+    ): ManualViewModelAssistedFactory =
+        object : ConversationSearchFolderManualViewModelFactory {
+            override fun conversationFoldersViewModel(args: ConversationFoldersStateArgs): ConversationFoldersVMImpl =
+                factory.conversationFoldersViewModel(args)
+
+            override fun moveConversationToFolderViewModel(args: MoveConversationToFolderArgs): MoveConversationToFolderVMImpl =
+                factory.moveConversationToFolderViewModel(args)
+
+            override fun searchAppsViewModel(protocolInfo: Conversation.ProtocolInfo?): SearchAppsViewModel =
+                factory.searchAppsViewModel(protocolInfo)
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(NewFolderViewModel::class)
+    fun newFolderViewModel(factory: ConversationSearchFolderViewModelFactory): ViewModel =
+        factory.newFolderViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(SearchUserViewModel::class)
+    fun searchUserViewModel(factory: ConversationSearchFolderViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.searchUserViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(AddMembersToConversationViewModel::class)
+    fun addMembersToConversationViewModel(factory: ConversationSearchFolderViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.addMembersToConversationViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(SearchConversationMessagesViewModel::class)
+    fun searchConversationMessagesViewModel(factory: ConversationSearchFolderViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.searchConversationMessagesViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(PromoteAdminViewModel::class)
+    fun promoteAdminViewModel(factory: ConversationSearchFolderViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.promoteAdminViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(SettingsViewModel::class)
+    fun settingsViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.settingsViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(MyAccountViewModel::class)
+    fun myAccountViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.myAccountViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(DeleteAccountViewModel::class)
+    fun deleteAccountViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.deleteAccountViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(ChangeDisplayNameViewModel::class)
+    fun changeDisplayNameViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.changeDisplayNameViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(ChangeUserColorViewModel::class)
+    fun changeUserColorViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.changeUserColorViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(ChangeEmailViewModel::class)
+    fun changeEmailViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.changeEmailViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(ChangeHandleViewModel::class)
+    fun changeHandleViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.changeHandleViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(CustomizationViewModel::class)
+    fun customizationViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.customizationViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(NetworkSettingsViewModel::class)
+    fun networkSettingsViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.networkSettingsViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(PrivacySettingsViewModel::class)
+    fun privacySettingsViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.privacySettingsViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(BackupAndRestoreViewModel::class)
+    fun backupAndRestoreViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.backupAndRestoreViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(SetLockScreenViewModel::class)
+    fun setLockScreenViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.setLockScreenViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(ForgotLockScreenViewModel::class)
+    fun forgotLockScreenViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.forgotLockScreenViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(AppUnlockWithBiometricsViewModel::class)
+    fun appUnlockWithBiometricsViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.appUnlockWithBiometricsViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(EnterLockScreenViewModel::class)
+    fun enterLockScreenViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.enterLockScreenViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(SelfDevicesViewModel::class)
+    fun selfDevicesViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.selfDevicesViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(AvatarPickerViewModel::class)
+    fun avatarPickerViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.avatarPickerViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(SelfUserProfileViewModel::class)
+    fun selfUserProfileViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.selfUserProfileViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(TeamMigrationViewModel::class)
+    fun teamMigrationViewModel(factory: SettingsViewModelFactory): ViewModel =
+        factory.teamMigrationViewModel()
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(VerifyEmailViewModel::class)
+    fun verifyEmailViewModel(factory: SettingsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.verifyEmailViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(DeviceDetailsViewModel::class)
+    fun deviceDetailsViewModel(factory: SettingsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.deviceDetailsViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(SelfQRCodeViewModel::class)
+    fun selfQRCodeViewModel(factory: SettingsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.selfQRCodeViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(OtherUserProfileScreenViewModel::class)
+    fun otherUserProfileScreenViewModel(factory: SettingsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.otherUserProfileScreenViewModel(extras.createSavedStateHandle())
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(ServiceDetailsViewModelImpl::class)
+    fun serviceDetailsViewModel(factory: SettingsViewModelFactory): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel =
+                factory.serviceDetailsViewModel(extras.createSavedStateHandle())
+        }
+}

--- a/app/src/main/kotlin/com/wire/android/di/metro/WireMetroViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireMetroViewModelFactory.kt
@@ -34,5 +34,6 @@ import kotlin.reflect.KClass
 class WireMetroViewModelFactory(
     override val viewModelProviders: Map<KClass<out ViewModel>, () -> ViewModel>,
     override val assistedFactoryProviders: Map<KClass<out ViewModel>, () -> ViewModelAssistedFactory>,
-    override val manualAssistedFactoryProviders: Map<KClass<out ManualViewModelAssistedFactory>, () -> ManualViewModelAssistedFactory>,
+    override val manualAssistedFactoryProviders:
+    Map<KClass<out ManualViewModelAssistedFactory>, () -> ManualViewModelAssistedFactory>,
 ) : MetroViewModelFactory()

--- a/app/src/main/kotlin/com/wire/android/di/metro/WireMetroViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireMetroViewModelFactory.kt
@@ -1,0 +1,38 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.di.metro
+
+import androidx.lifecycle.ViewModel
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import kotlin.reflect.KClass
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<MetroViewModelFactory>())
+class WireMetroViewModelFactory(
+    override val viewModelProviders: Map<KClass<out ViewModel>, () -> ViewModel>,
+    override val assistedFactoryProviders: Map<KClass<out ViewModel>, () -> ViewModelAssistedFactory>,
+    override val manualAssistedFactoryProviders: Map<KClass<out ManualViewModelAssistedFactory>, () -> ManualViewModelAssistedFactory>,
+) : MetroViewModelFactory()

--- a/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
@@ -28,8 +28,10 @@ import com.ramcosta.composedestinations.generated.app.destinations.AppUnlockWith
 import com.ramcosta.composedestinations.generated.app.destinations.EnterLockCodeScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.SetLockCodeScreenDestination
 import com.wire.android.appLogger
-import com.wire.android.di.metro.LocalMetroViewModelGraph
+import com.wire.android.di.metro.LocalWireViewModelScopeKey
+import com.wire.android.di.metro.createCurrentSessionViewModelGraph
 import com.wire.android.di.metro.wireApplicationGraph
+import com.wire.android.model.LocalWireSessionImageLoader
 import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.MainNavHost
 import com.wire.android.navigation.rememberNavigator
@@ -37,6 +39,7 @@ import com.wire.android.ui.common.setupOrientationForDevice
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.theme.WireTheme
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 
 class AppLockActivity : BaseActivity() {
 
@@ -50,10 +53,12 @@ class AppLockActivity : BaseActivity() {
         enableEdgeToEdge()
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
-            val imageAssetViewModelGraph = remember { wireApplicationGraph.imageAssetViewModelGraph }
+            val sessionViewModelGraph = remember { wireApplicationGraph.createCurrentSessionViewModelGraph() }
             CompositionLocalProvider(
                 LocalSnackbarHostState provides snackbarHostState,
-                LocalMetroViewModelGraph provides imageAssetViewModelGraph,
+                LocalMetroViewModelFactory provides wireApplicationGraph.metroViewModelFactory,
+                LocalWireViewModelScopeKey provides sessionViewModelGraph.viewModelScopeKey,
+                LocalWireSessionImageLoader provides sessionViewModelGraph.wireSessionImageLoader,
                 LocalActivity provides this
             ) {
                 WireTheme {
@@ -79,7 +84,7 @@ class AppLockActivity : BaseActivity() {
                     MainNavHost(
                         navigator = navigator,
                         loginTypeSelector = loginTypeSelector,
-                        startDestination = startDestination
+                        startDestination = startDestination,
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/MiscViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/MiscViewModelGraph.kt
@@ -20,7 +20,7 @@ package com.wire.android.ui
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
 import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.scopedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedMetroViewModel
 import com.wire.android.ui.analytics.AnalyticsUsageViewModel
 import com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentViewModel
 import com.wire.android.ui.e2eiEnrollment.GetE2EICertificateViewModel
@@ -36,7 +36,7 @@ interface MiscViewModelGraph : MetroViewModelGraph {
 
 @Composable
 inline fun <reified VM> miscViewModel(): VM where VM : ViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun analyticsUsageViewModel(): AnalyticsUsageViewModel =

--- a/app/src/main/kotlin/com/wire/android/ui/MiscViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/MiscViewModelGraph.kt
@@ -18,9 +18,9 @@
 package com.wire.android.ui
 
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.ViewModel
 import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.metroSavedStateViewModel
-import com.wire.android.di.metro.metroViewModel
+import com.wire.android.di.metro.scopedMetroViewModel
 import com.wire.android.ui.analytics.AnalyticsUsageViewModel
 import com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentViewModel
 import com.wire.android.ui.e2eiEnrollment.GetE2EICertificateViewModel
@@ -35,49 +35,37 @@ interface MiscViewModelGraph : MetroViewModelGraph {
 }
 
 @Composable
+inline fun <reified VM> miscViewModel(): VM where VM : ViewModel =
+    scopedMetroViewModel()
+
+@Composable
 fun analyticsUsageViewModel(): AnalyticsUsageViewModel =
-    metroViewModel<MiscViewModelGraph, AnalyticsUsageViewModel> {
-        miscViewModelFactory.analyticsUsageViewModel()
-    }
+    miscViewModel()
 
 @Composable
 fun initialSyncViewModel(): InitialSyncViewModel =
-    metroViewModel<MiscViewModelGraph, InitialSyncViewModel> {
-        miscViewModelFactory.initialSyncViewModel()
-    }
+    miscViewModel()
 
 @Composable
 fun legalHoldRequestedViewModel(): LegalHoldRequestedViewModel =
-    metroViewModel<MiscViewModelGraph, LegalHoldRequestedViewModel> {
-        miscViewModelFactory.legalHoldRequestedViewModel()
-    }
+    miscViewModel()
 
 @Composable
 fun e2EIEnrollmentViewModel(): E2EIEnrollmentViewModel =
-    metroViewModel<MiscViewModelGraph, E2EIEnrollmentViewModel> {
-        miscViewModelFactory.e2EIEnrollmentViewModel()
-    }
+    miscViewModel()
 
 @Composable
 fun getE2EICertificateViewModel(): GetE2EICertificateViewModel =
-    metroViewModel<MiscViewModelGraph, GetE2EICertificateViewModel> {
-        miscViewModelFactory.getE2EICertificateViewModel()
-    }
+    miscViewModel()
 
 @Composable
 fun e2eiCertificateDetailsViewModel(): E2eiCertificateDetailsViewModel =
-    metroSavedStateViewModel<MiscViewModelGraph, E2eiCertificateDetailsViewModel> {
-        miscViewModelFactory.e2eiCertificateDetailsViewModel(it)
-    }
+    miscViewModel()
 
 @Composable
 fun importMediaAuthenticatedViewModel(): ImportMediaAuthenticatedViewModel =
-    metroViewModel<MiscViewModelGraph, ImportMediaAuthenticatedViewModel> {
-        miscViewModelFactory.importMediaAuthenticatedViewModel()
-    }
+    miscViewModel()
 
 @Composable
 fun joinConversationViaCodeViewModel(): JoinConversationViaCodeViewModel =
-    metroViewModel<MiscViewModelGraph, JoinConversationViaCodeViewModel> {
-        miscViewModelFactory.joinConversationViaCodeViewModel()
-    }
+    miscViewModel()

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -38,10 +38,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -68,6 +66,8 @@ import com.ramcosta.composedestinations.generated.app.destinations.NewLoginPassw
 import com.ramcosta.composedestinations.generated.app.destinations.NewLoginScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.NewLoginVerificationCodeScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.NewWelcomeEmptyStartScreenDestination
+import com.ramcosta.composedestinations.generated.app.destinations.RegisterDeviceScreenDestination
+import com.ramcosta.composedestinations.generated.app.destinations.RemoveDeviceScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.SelfDevicesScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.SelfUserProfileScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.WelcomeScreenDestination
@@ -81,11 +81,16 @@ import com.wire.android.config.LocalCustomUiConfigurationProvider
 import com.wire.android.datastore.UserDataStore
 import com.wire.android.di.metro.AppAuthenticationViewModelGraph
 import com.wire.android.di.metro.AppSessionViewModelGraph
-import com.wire.android.di.metro.LocalMetroViewModelGraph
+import com.wire.android.di.metro.LocalWireViewModelScopeKey
 import com.wire.android.di.metro.MetroViewModelGraph
+import com.wire.android.di.metro.WireApplicationGraph
+import com.wire.android.di.metro.createCurrentSessionViewModelGraph
+import com.wire.android.di.metro.createSessionViewModelGraph
+import com.wire.android.di.metro.scopedMetroViewModelKey
 import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.emm.ManagedConfigurationsManager
 import com.wire.android.feature.NavigationSwitchAccountActions
+import com.wire.android.model.LocalWireSessionImageLoader
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.MainNavHost
@@ -99,6 +104,7 @@ import com.wire.android.navigation.style.BackgroundStyle
 import com.wire.android.navigation.style.BackgroundType
 import com.wire.android.notification.broadcastreceivers.DynamicReceiversManager
 import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
+import com.wire.android.ui.authentication.LocalAuthenticationCancelUserId
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.setupOrientationForDevice
@@ -115,6 +121,7 @@ import com.wire.android.ui.home.E2EIResultDialog
 import com.wire.android.ui.home.E2EISnoozeDialog
 import com.wire.android.ui.home.FeatureFlagState
 import com.wire.android.ui.home.appLock.LockCodeTimeManager
+import com.wire.android.ui.home.featureFlagNotificationViewModel
 import com.wire.android.ui.home.sync.FeatureFlagNotificationViewModel
 import com.wire.android.ui.legalhold.dialog.deactivated.LegalHoldDeactivatedDialog
 import com.wire.android.ui.legalhold.dialog.deactivated.LegalHoldDeactivatedState
@@ -135,6 +142,7 @@ import com.wire.android.util.SyncStateObserver
 import com.wire.android.util.debug.FeatureVisibilityFlags
 import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.launchUpdateTheApp
+import com.wire.kalium.logic.data.user.UserId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
@@ -143,6 +151,10 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
+import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelGraph
+import dev.zacsweers.metrox.viewmodel.metroViewModel as metroxViewModel
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Suppress("TooManyFunctions", "LargeClass")
@@ -258,31 +270,22 @@ class WireActivity : BaseActivity() {
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
             val currentUserId = viewModel.globalAppState.currentUserId
-            val appGraph = LocalContext.current.wireApplicationGraph
-            val sessionViewModelGraph = remember(appGraph, currentUserId) {
-                currentUserId?.let { appGraph.sessionViewModelGraph }
-            }
+            val context = LocalContext.current
+            val appGraph = context.wireApplicationGraph
             val authenticationViewModelGraph = remember(appGraph) {
                 appGraph.authenticationViewModelGraph
             }
-            val activityViewModels = sessionViewModelGraph?.let {
-                wireActivityScopedViewModels(it)
-            }
-
-            HandleThemeChanges(viewModel.globalAppState.themeOption)
-
             CompositionLocalProvider(
+                LocalMetroViewModelFactory provides appGraph.metroViewModelFactory,
+                LocalWireViewModelScopeKey provides null,
                 LocalFeatureVisibilityFlags provides FeatureVisibilityFlags,
                 LocalSyncStateObserver provides SyncStateObserver(viewModel.observeSyncFlowState),
                 LocalCustomUiConfigurationProvider provides CustomUiConfigurationProvider,
                 LocalSnackbarHostState provides snackbarHostState,
                 LocalActivity provides this
             ) {
-                activityViewModels?.let {
-                    LaunchedEffect(it.legalHoldRequestedViewModel) {
-                        it.legalHoldRequestedViewModel.observeLegalHoldRequest()
-                    }
-                }
+                HandleThemeChanges(viewModel.globalAppState.themeOption)
+
                 WireTheme(accent = viewModel.globalAppState.userAccent) {
                     val navigator = rememberNavigator(
                         finish = this@WireActivity::finish,
@@ -305,12 +308,20 @@ class WireActivity : BaseActivity() {
                         ?.destination
                         ?.route
                         ?.getBaseRoute()
-                    val metroViewModelGraph = rememberMetroViewModelGraph(
+                    val isUserUiBlocked = viewModel.globalAppState.blockUserUI != null
+                    val graphContext = rememberWireActivityGraphContext(
+                        appGraph = appGraph,
+                        authenticationViewModelGraph = authenticationViewModelGraph,
+                        currentUserId = currentUserId,
                         currentBaseRoute = currentBaseRoute,
                         startDestinationBaseRoute = startDestination.baseRoute,
-                        sessionViewModelGraph = sessionViewModelGraph,
-                        authenticationViewModelGraph = authenticationViewModelGraph
+                        isUserUiBlocked = isUserUiBlocked,
                     )
+                    graphContext?.activityViewModels?.let {
+                        LaunchedEffect(it.legalHoldRequestedViewModel) {
+                            it.legalHoldRequestedViewModel.observeLegalHoldRequest()
+                        }
+                    }
                     val backgroundType by remember {
                         derivedStateOf {
                             currentBackStackEntryState.value?.destination()?.style.let {
@@ -321,14 +332,14 @@ class WireActivity : BaseActivity() {
                     if (backgroundType == BackgroundType.Auth) {
                         WireAuthBackgroundLayout()
                     }
-                    metroViewModelGraph?.let {
-                        CompositionLocalProvider(LocalMetroViewModelGraph provides it) {
+                    if (graphContext != null) {
+                        graphContext.ProvideViewModelGraph {
                             Column(
                                 modifier = Modifier
                                     .semantics { testTagsAsResourceId = true }
                             ) {
                                 WireTopAppBar(
-                                    commonTopAppBarState = activityViewModels
+                                    commonTopAppBarState = graphContext.activityViewModels
                                         ?.commonTopAppBarViewModel
                                         ?.state ?: CommonTopAppBarState(),
                                     backgroundType = backgroundType,
@@ -344,10 +355,12 @@ class WireActivity : BaseActivity() {
                                 // can crash before the graph is fully built.
                                 SetUpNavigation(navigator)
                                 HandleScreenshotCensoring()
-                                HandleDialogs(navigator, activityViewModels)
+                                HandleDialogs(navigator, graphContext.activityViewModels)
                                 HandleViewActions(viewModel.actions, navigator, loginTypeSelector)
                             }
                         }
+                    } else {
+                        HandleDialogs(navigator, null)
                     }
                 }
             }
@@ -355,65 +368,74 @@ class WireActivity : BaseActivity() {
     }
 
     @Composable
-    private fun rememberMetroViewModelGraph(
+    private fun rememberWireActivityGraphContext(
+        appGraph: WireApplicationGraph,
+        authenticationViewModelGraph: AppAuthenticationViewModelGraph,
+        currentUserId: UserId?,
         currentBaseRoute: String?,
         startDestinationBaseRoute: String,
-        sessionViewModelGraph: AppSessionViewModelGraph?,
-        authenticationViewModelGraph: AppAuthenticationViewModelGraph,
-    ): MetroViewModelGraph? {
+        isUserUiBlocked: Boolean,
+    ): WireActivityGraphContext? {
+        if (isUserUiBlocked) return null
+
         val effectiveBaseRoute = currentBaseRoute ?: startDestinationBaseRoute
-        val usesAuthenticationGraph = effectiveBaseRoute in authenticationGraphRoutes
-        var useStandaloneAuthenticationGraph by remember {
-            mutableStateOf(false)
+        val sessionGraph = remember(
+            appGraph,
+            currentUserId,
+            currentBaseRoute,
+        ) {
+            when {
+                currentUserId != null -> appGraph.createSessionViewModelGraph(currentUserId)
+                currentBaseRoute in sessionBackedAuthenticationGraphRoutes -> appGraph.createCurrentSessionViewModelGraphOrNull()
+                else -> null
+            }
         }
-        if (usesAuthenticationGraph && sessionViewModelGraph == null) {
-            useStandaloneAuthenticationGraph = true
+        val graph = when {
+            sessionGraph != null -> sessionGraph
+            effectiveBaseRoute in authenticationGraphRoutes -> authenticationViewModelGraph
+            currentBaseRoute == null -> authenticationViewModelGraph
+            else -> return null
         }
-        if (!usesAuthenticationGraph && sessionViewModelGraph != null) {
-            useStandaloneAuthenticationGraph = false
+        val activityViewModels = sessionGraph?.let {
+            wireActivityScopedViewModels(it)
         }
-        return selectMetroViewModelGraph(
-            currentBaseRoute = effectiveBaseRoute,
-            usesAuthenticationGraph = usesAuthenticationGraph,
-            useStandaloneAuthenticationGraph = useStandaloneAuthenticationGraph,
-            sessionViewModelGraph = sessionViewModelGraph,
-            authenticationViewModelGraph = authenticationViewModelGraph
+        return WireActivityGraphContext(
+            graph = graph,
+            viewModelFactory = (graph as? ViewModelGraph)?.metroViewModelFactory ?: appGraph.metroViewModelFactory,
+            sessionGraph = sessionGraph,
+            activityViewModels = activityViewModels,
         )
     }
 
-    private fun selectMetroViewModelGraph(
-        currentBaseRoute: String?,
-        usesAuthenticationGraph: Boolean,
-        useStandaloneAuthenticationGraph: Boolean,
-        sessionViewModelGraph: AppSessionViewModelGraph?,
-        authenticationViewModelGraph: AppAuthenticationViewModelGraph,
-    ): MetroViewModelGraph? = when {
-        useStandaloneAuthenticationGraph && usesAuthenticationGraph -> authenticationViewModelGraph
-        sessionViewModelGraph != null -> sessionViewModelGraph
-        currentBaseRoute == null -> authenticationViewModelGraph
-        else -> null
+    @Composable
+    private fun WireActivityGraphContext.ProvideViewModelGraph(content: @Composable () -> Unit) {
+        CompositionLocalProvider(
+            LocalMetroViewModelFactory provides viewModelFactory,
+            LocalWireViewModelScopeKey provides graph.viewModelScopeKey,
+            LocalAuthenticationCancelUserId provides sessionGraph?.currentAccount,
+            LocalWireSessionImageLoader provides sessionGraph?.wireSessionImageLoader,
+        ) {
+            content()
+        }
     }
+
+    private fun WireApplicationGraph.createCurrentSessionViewModelGraphOrNull(): AppSessionViewModelGraph? =
+        runCatching {
+            createCurrentSessionViewModelGraph()
+        }.getOrNull()
 
     @Composable
     private fun wireActivityScopedViewModels(graph: AppSessionViewModelGraph): WireActivityScopedViewModels {
         val scopeKey = graph.viewModelScopeKey
         return WireActivityScopedViewModels(
-            callFeedbackViewModel = viewModel(
-                key = "CallFeedbackViewModel:$scopeKey",
-                factory = viewModelFactory {
-                    initializer {
-                        graph.callingViewModelFactory.callFeedbackViewModel()
-                    }
-                }
+            callFeedbackViewModel = metroxViewModel(
+                key = scopedMetroViewModelKey(
+                    defaultKey = CallFeedbackViewModel::class.qualifiedName,
+                    key = null,
+                    scopeKey = scopeKey,
+                ),
             ),
-            featureFlagNotificationViewModel = viewModel(
-                key = "FeatureFlagNotificationViewModel:$scopeKey",
-                factory = viewModelFactory {
-                    initializer {
-                        graph.homeViewModelFactory.featureFlagNotificationViewModel()
-                    }
-                }
-            ),
+            featureFlagNotificationViewModel = featureFlagNotificationViewModel(),
             commonTopAppBarViewModel = viewModel(
                 key = "CommonTopAppBarViewModel:$scopeKey",
                 factory = viewModelFactory {
@@ -530,7 +552,10 @@ class WireActivity : BaseActivity() {
 
     @Suppress("ComplexMethod")
     @Composable
-    private fun HandleDialogs(navigator: Navigator, activityViewModels: WireActivityScopedViewModels?) {
+    private fun HandleDialogs(
+        navigator: Navigator,
+        activityViewModels: WireActivityScopedViewModels?,
+    ) {
         val navigate: (NavigationCommand) -> Unit = { navigator.navigate(it) }
         val context = LocalContext.current
         if (activityViewModels == null) {
@@ -891,6 +916,24 @@ private data class WireActivityScopedViewModels(
     val legalHoldDeactivatedViewModel: LegalHoldDeactivatedViewModel,
 )
 
+private data class WireActivityGraphContext(
+    val graph: MetroViewModelGraph,
+    val viewModelFactory: MetroViewModelFactory,
+    val sessionGraph: AppSessionViewModelGraph?,
+    val activityViewModels: WireActivityScopedViewModels?,
+)
+
+private val noSessionAuthenticationGraphRoutes = setOf(
+    NewLoginPasswordScreenDestination.baseRoute,
+    NewLoginVerificationCodeScreenDestination.baseRoute,
+)
+
+private val sessionBackedAuthenticationGraphRoutes = setOf(
+    RegisterDeviceScreenDestination.baseRoute,
+    RemoveDeviceScreenDestination.baseRoute,
+    E2EIEnrollmentScreenDestination.baseRoute,
+)
+
 private val authenticationGraphRoutes = setOf(
     WelcomeScreenDestination.baseRoute,
     NewWelcomeEmptyStartScreenDestination.baseRoute,
@@ -898,6 +941,8 @@ private val authenticationGraphRoutes = setOf(
     NewLoginScreenDestination.baseRoute,
     NewLoginPasswordScreenDestination.baseRoute,
     NewLoginVerificationCodeScreenDestination.baseRoute,
+    RegisterDeviceScreenDestination.baseRoute,
+    RemoveDeviceScreenDestination.baseRoute,
 )
 
 internal fun Navigator.shouldReplaceWelcomeLoginStartDestination(): Boolean {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -86,7 +86,7 @@ import com.wire.android.di.metro.MetroViewModelGraph
 import com.wire.android.di.metro.WireApplicationGraph
 import com.wire.android.di.metro.createCurrentSessionViewModelGraph
 import com.wire.android.di.metro.createSessionViewModelGraph
-import com.wire.android.di.metro.scopedMetroViewModelKey
+import com.wire.android.di.metro.sessionKeyedMetroViewModelKey
 import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.emm.ManagedConfigurationsManager
 import com.wire.android.feature.NavigationSwitchAccountActions
@@ -376,35 +376,39 @@ class WireActivity : BaseActivity() {
         startDestinationBaseRoute: String,
         isUserUiBlocked: Boolean,
     ): WireActivityGraphContext? {
-        if (isUserUiBlocked) return null
-
-        val effectiveBaseRoute = currentBaseRoute ?: startDestinationBaseRoute
-        val sessionGraph = remember(
-            appGraph,
-            currentUserId,
-            currentBaseRoute,
-        ) {
-            when {
-                currentUserId != null -> appGraph.createSessionViewModelGraph(currentUserId)
-                currentBaseRoute in sessionBackedAuthenticationGraphRoutes -> appGraph.createCurrentSessionViewModelGraphOrNull()
+        var graphContext: WireActivityGraphContext? = null
+        if (!isUserUiBlocked) {
+            val effectiveBaseRoute = currentBaseRoute ?: startDestinationBaseRoute
+            val sessionGraph = remember(
+                appGraph,
+                currentUserId,
+                currentBaseRoute,
+            ) {
+                when {
+                    currentUserId != null -> appGraph.createSessionViewModelGraph(currentUserId)
+                    currentBaseRoute in sessionBackedAuthenticationGraphRoutes -> appGraph.createCurrentSessionViewModelGraphOrNull()
+                    else -> null
+                }
+            }
+            val graph = when {
+                sessionGraph != null -> sessionGraph
+                effectiveBaseRoute in authenticationGraphRoutes -> authenticationViewModelGraph
+                currentBaseRoute == null -> authenticationViewModelGraph
                 else -> null
             }
+            val activityViewModels = sessionGraph?.let {
+                wireActivityScopedViewModels(it)
+            }
+            graphContext = graph?.let {
+                WireActivityGraphContext(
+                    graph = it,
+                    viewModelFactory = (it as? ViewModelGraph)?.metroViewModelFactory ?: appGraph.metroViewModelFactory,
+                    sessionGraph = sessionGraph,
+                    activityViewModels = activityViewModels,
+                )
+            }
         }
-        val graph = when {
-            sessionGraph != null -> sessionGraph
-            effectiveBaseRoute in authenticationGraphRoutes -> authenticationViewModelGraph
-            currentBaseRoute == null -> authenticationViewModelGraph
-            else -> return null
-        }
-        val activityViewModels = sessionGraph?.let {
-            wireActivityScopedViewModels(it)
-        }
-        return WireActivityGraphContext(
-            graph = graph,
-            viewModelFactory = (graph as? ViewModelGraph)?.metroViewModelFactory ?: appGraph.metroViewModelFactory,
-            sessionGraph = sessionGraph,
-            activityViewModels = activityViewModels,
-        )
+        return graphContext
     }
 
     @Composable
@@ -429,7 +433,7 @@ class WireActivity : BaseActivity() {
         val scopeKey = graph.viewModelScopeKey
         return WireActivityScopedViewModels(
             callFeedbackViewModel = metroxViewModel(
-                key = scopedMetroViewModelKey(
+                key = sessionKeyedMetroViewModelKey(
                     defaultKey = CallFeedbackViewModel::class.qualifiedName,
                     key = null,
                     scopeKey = scopeKey,
@@ -921,11 +925,6 @@ private data class WireActivityGraphContext(
     val viewModelFactory: MetroViewModelFactory,
     val sessionGraph: AppSessionViewModelGraph?,
     val activityViewModels: WireActivityScopedViewModels?,
-)
-
-private val noSessionAuthenticationGraphRoutes = setOf(
-    NewLoginPasswordScreenDestination.baseRoute,
-    NewLoginVerificationCodeScreenDestination.baseRoute,
 )
 
 private val sessionBackedAuthenticationGraphRoutes = setOf(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelFactory.kt
@@ -53,6 +53,7 @@ import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.CountdownTimer
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
 import com.wire.kalium.logic.feature.auth.ValidateEmailUseCase
@@ -179,11 +180,12 @@ class AuthenticationViewModelFactory @Inject constructor(
         requestSecondFactorVerificationCodeUseCase = requestSecondFactorVerificationCode(),
     )
 
-    fun clearSessionViewModel() = ClearSessionViewModel(
+    fun clearSessionViewModel(cancelUserId: UserId? = null) = ClearSessionViewModel(
         currentSession = currentSession(),
         deleteSession = deleteSession(),
         switchAccount = switchAccount(),
         logout = logout(),
+        cancelUserId = cancelUserId,
     )
 
     fun createAccountUsernameViewModel() = CreateAccountUsernameViewModel(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelGraph.kt
@@ -27,7 +27,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.wire.android.di.metro.LocalWireViewModelScopeKey
 import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.scopedMetroViewModelKey
+import com.wire.android.di.metro.sessionKeyedMetroViewModelKey
 import com.wire.android.ui.authentication.create.code.CreateAccountCodeViewModel
 import com.wire.android.ui.authentication.create.details.CreateAccountDetailsViewModel
 import com.wire.android.ui.authentication.create.email.CreateAccountEmailViewModel
@@ -173,7 +173,7 @@ inline fun <reified VM : ViewModel> authenticationViewModelKey(
     viewModelStoreOwner: ViewModelStoreOwner,
     key: String? = null,
 ): String? =
-    scopedMetroViewModelKey(
+    sessionKeyedMetroViewModelKey(
         defaultKey = VM::class.qualifiedName,
         key = listOfNotNull(key, viewModelStoreOwner.hashCode().toString()).joinToString(":"),
         scopeKey = LocalWireViewModelScopeKey.current,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelGraph.kt
@@ -20,13 +20,14 @@
 package com.wire.android.ui.authentication
 
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.SavedStateHandle
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import com.wire.android.di.metro.LocalWireViewModelScopeKey
 import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.metroSavedStateViewModel
-import com.wire.android.di.metro.metroViewModel
+import com.wire.android.di.metro.scopedMetroViewModelKey
 import com.wire.android.ui.authentication.create.code.CreateAccountCodeViewModel
 import com.wire.android.ui.authentication.create.details.CreateAccountDetailsViewModel
 import com.wire.android.ui.authentication.create.email.CreateAccountEmailViewModel
@@ -44,9 +45,21 @@ import com.wire.android.ui.newauthentication.login.NewLoginViewModel
 import com.wire.android.ui.registration.code.CreateAccountVerificationCodeViewModel
 import com.wire.android.ui.registration.details.CreateAccountDataDetailViewModel
 import com.wire.android.ui.registration.selector.CreateAccountSelectorViewModel
+import com.wire.kalium.logic.data.user.UserId
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.assistedMetroViewModel
+import dev.zacsweers.metrox.viewmodel.metroViewModel as metroxViewModel
 
-interface AuthenticationViewModelGraph : MetroViewModelGraph {
-    val authenticationViewModelFactory: AuthenticationViewModelFactory
+interface AuthenticationViewModelGraph : MetroViewModelGraph
+
+interface AuthenticationManualViewModelFactory : ManualViewModelAssistedFactory {
+    fun loginEmailViewModel(loginNavArgs: LoginNavArgs, extras: CreationExtras): LoginEmailViewModel
+    fun loginSSOViewModel(loginNavArgs: LoginNavArgs, extras: CreationExtras): LoginSSOViewModel
+    fun clearSessionViewModel(cancelUserId: UserId?): ClearSessionViewModel
+}
+
+val LocalAuthenticationCancelUserId = staticCompositionLocalOf<UserId?> {
+    null
 }
 
 @Composable
@@ -55,35 +68,19 @@ inline fun <reified VM> authenticationViewModel(
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
     },
     key: String? = null,
-    crossinline create: AuthenticationViewModelFactory.() -> VM,
 ): VM where VM : ViewModel =
-    metroViewModel<AuthenticationViewModelGraph, VM>(
+    metroxViewModel(
         viewModelStoreOwner = viewModelStoreOwner,
-        key = key,
-    ) {
-        authenticationViewModelFactory.create()
-    }
+        key = authenticationViewModelKey<VM>(viewModelStoreOwner, key),
+    )
 
 @Composable
-inline fun <reified VM> authenticationSavedStateViewModel(
-    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
-        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
-    },
-    key: String? = null,
-    crossinline create: AuthenticationViewModelFactory.(SavedStateHandle) -> VM,
-): VM where VM : ViewModel =
-    metroSavedStateViewModel<AuthenticationViewModelGraph, VM>(
-        viewModelStoreOwner = viewModelStoreOwner,
-        key = key,
-    ) { savedStateHandle ->
-        authenticationViewModelFactory.create(savedStateHandle)
-    }
+fun welcomeViewModel(): WelcomeViewModel =
+    authenticationViewModel()
 
 @Composable
-fun welcomeViewModel(): WelcomeViewModel = authenticationSavedStateViewModel { welcomeViewModel(it) }
-
-@Composable
-fun newLoginViewModel(): NewLoginViewModel = authenticationSavedStateViewModel { newLoginViewModel(it) }
+fun newLoginViewModel(): NewLoginViewModel =
+    authenticationViewModel()
 
 @Composable
 fun loginEmailViewModel(
@@ -92,55 +89,92 @@ fun loginEmailViewModel(
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
     },
 ): LoginEmailViewModel =
-    authenticationSavedStateViewModel(viewModelStoreOwner = viewModelStoreOwner) {
-        loginEmailViewModel(loginNavArgs, it)
+    assistedMetroViewModel<LoginEmailViewModel, AuthenticationManualViewModelFactory>(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = authenticationViewModelKey<LoginEmailViewModel>(viewModelStoreOwner, loginNavArgs.toString()),
+    ) { extras ->
+        loginEmailViewModel(loginNavArgs, extras)
     }
 
 @Composable
-fun loginSSOViewModel(loginNavArgs: LoginNavArgs): LoginSSOViewModel =
-    authenticationSavedStateViewModel { loginSSOViewModel(loginNavArgs, it) }
+fun loginSSOViewModel(
+    loginNavArgs: LoginNavArgs,
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+): LoginSSOViewModel =
+    assistedMetroViewModel<LoginSSOViewModel, AuthenticationManualViewModelFactory>(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = authenticationViewModelKey<LoginSSOViewModel>(viewModelStoreOwner, loginNavArgs.toString()),
+    ) { extras ->
+        loginSSOViewModel(loginNavArgs, extras)
+    }
 
 @Composable
-fun registerDeviceViewModel(): RegisterDeviceViewModel = authenticationViewModel { registerDeviceViewModel() }
+fun registerDeviceViewModel(): RegisterDeviceViewModel =
+    authenticationViewModel()
 
 @Composable
-fun removeDeviceViewModel(): RemoveDeviceViewModel = authenticationViewModel { removeDeviceViewModel() }
+fun removeDeviceViewModel(): RemoveDeviceViewModel =
+    authenticationViewModel()
 
 @Composable
-fun clearSessionViewModel(): ClearSessionViewModel = authenticationViewModel { clearSessionViewModel() }
+fun clearSessionViewModel(): ClearSessionViewModel {
+    val cancelUserId = LocalAuthenticationCancelUserId.current
+    val viewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    }
+    return assistedMetroViewModel<ClearSessionViewModel, AuthenticationManualViewModelFactory>(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = authenticationViewModelKey<ClearSessionViewModel>(viewModelStoreOwner, cancelUserId?.toString()),
+    ) {
+        clearSessionViewModel(cancelUserId)
+    }
+}
 
 @Composable
 fun createAccountUsernameViewModel(): CreateAccountUsernameViewModel =
-    authenticationViewModel { createAccountUsernameViewModel() }
+    authenticationViewModel()
 
 @Composable
 fun createAccountOverviewViewModel(): CreateAccountOverviewViewModel =
-    authenticationSavedStateViewModel { createAccountOverviewViewModel(it) }
+    authenticationViewModel()
 
 @Composable
 fun createAccountEmailViewModel(): CreateAccountEmailViewModel =
-    authenticationSavedStateViewModel { createAccountEmailViewModel(it) }
+    authenticationViewModel()
 
 @Composable
 fun createAccountDetailsViewModel(): CreateAccountDetailsViewModel =
-    authenticationSavedStateViewModel { createAccountDetailsViewModel(it) }
+    authenticationViewModel()
 
 @Composable
 fun createAccountCodeViewModel(): CreateAccountCodeViewModel =
-    authenticationSavedStateViewModel { createAccountCodeViewModel(it) }
+    authenticationViewModel()
 
 @Composable
 fun createAccountSummaryViewModel(): CreateAccountSummaryViewModel =
-    authenticationSavedStateViewModel { createAccountSummaryViewModel(it) }
+    authenticationViewModel()
 
 @Composable
 fun createAccountSelectorViewModel(): CreateAccountSelectorViewModel =
-    authenticationSavedStateViewModel { createAccountSelectorViewModel(it) }
+    authenticationViewModel()
 
 @Composable
 fun createAccountDataDetailViewModel(): CreateAccountDataDetailViewModel =
-    authenticationSavedStateViewModel { createAccountDataDetailViewModel(it) }
+    authenticationViewModel()
 
 @Composable
 fun createAccountVerificationCodeViewModel(): CreateAccountVerificationCodeViewModel =
-    authenticationSavedStateViewModel { createAccountVerificationCodeViewModel(it) }
+    authenticationViewModel()
+
+@Composable
+inline fun <reified VM : ViewModel> authenticationViewModelKey(
+    viewModelStoreOwner: ViewModelStoreOwner,
+    key: String? = null,
+): String? =
+    scopedMetroViewModelKey(
+        defaultKey = VM::class.qualifiedName,
+        key = listOfNotNull(key, viewModelStoreOwner.hashCode().toString()).joinToString(":"),
+        scopeKey = LocalWireViewModelScopeKey.current,
+    )

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/common/ClearSessionViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/common/ClearSessionViewModel.kt
@@ -28,6 +28,7 @@ import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountActions
 import com.wire.android.feature.SwitchAccountParam
 import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
@@ -40,6 +41,7 @@ class ClearSessionViewModel @Inject constructor(
     private val deleteSession: DeleteSessionUseCase,
     private val switchAccount: AccountSwitchUseCase,
     private val logout: LogoutUseCase,
+    private val cancelUserId: UserId? = null,
 ) : ViewModel() {
     var state: ClearSessionState by mutableStateOf(
         ClearSessionState(showCancelLoginDialog = false)
@@ -57,21 +59,12 @@ class ClearSessionViewModel @Inject constructor(
     fun onCancelLoginClicked(switchAccountActions: SwitchAccountActions) {
         state = state.copy(showCancelLoginDialog = false)
         viewModelScope.launch {
-            currentSession().let {
-                when (it) {
-                    is CurrentSessionResult.Success -> {
-                        // logout to cancel all session-related actions, remove all sensitive data and free up resources
-                        logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
-                        // delete the session to make it seem like the session was never logged in
-                        deleteSession(it.accountInfo.userId)
-                    }
-                    is CurrentSessionResult.Failure.Generic -> {
-                        appLogger.e("$TAG: failed to get current session")
-                    }
-                    CurrentSessionResult.Failure.SessionNotFound -> {
-                        appLogger.e("$TAG: session not found")
-                    }
-                }
+            val userId = cancelUserId ?: currentSessionUserId()
+            if (userId != null) {
+                // logout to cancel all session-related actions, remove all sensitive data and free up resources
+                logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
+                // delete the session to make it seem like the session was never logged in
+                deleteSession(userId)
             }
         }.invokeOnCompletion {
             viewModelScope.launch {
@@ -80,6 +73,19 @@ class ClearSessionViewModel @Inject constructor(
             }
         }
     }
+
+    private suspend fun currentSessionUserId(): UserId? =
+        when (val result = currentSession()) {
+            is CurrentSessionResult.Success -> result.accountInfo.userId
+            is CurrentSessionResult.Failure.Generic -> {
+                appLogger.e("$TAG: failed to get current session")
+                null
+            }
+            CurrentSessionResult.Failure.SessionNotFound -> {
+                appLogger.e("$TAG: session not found")
+                null
+            }
+        }
 
     companion object {
         private const val TAG = "ClearSessionViewModel"

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceVerificationCodeScreen.kt
@@ -20,7 +20,6 @@ package com.wire.android.ui.authentication.devices.register
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
-import com.wire.android.ui.authentication.registerDeviceViewModel
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeScreenContent
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeState
 import com.wire.android.ui.theme.WireTheme
@@ -28,7 +27,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
 fun RegisterDeviceVerificationCodeScreen(
-    viewModel: RegisterDeviceViewModel = registerDeviceViewModel()
+    viewModel: RegisterDeviceViewModel
 ) = VerificationCodeScreenContent(
     viewModel.secondFactorVerificationCodeTextState,
     viewModel.secondFactorVerificationCodeState,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceVerificationCodeScreen.kt
@@ -18,12 +18,11 @@
 package com.wire.android.ui.authentication.devices.remove
 
 import androidx.compose.runtime.Composable
-import com.wire.android.ui.authentication.removeDeviceViewModel
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeScreenContent
 
 @Composable
 fun RemoveDeviceVerificationCodeScreen(
-    viewModel: RemoveDeviceViewModel = removeDeviceViewModel()
+    viewModel: RemoveDeviceViewModel
 ) = VerificationCodeScreenContent(
     viewModel.secondFactorVerificationCodeTextState,
     viewModel.secondFactorVerificationCodeState,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -70,9 +70,11 @@ import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.visbility.rememberVisibilityState
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.deeplink.DeepLinkResult
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import kotlinx.coroutines.launch
 
@@ -257,4 +259,20 @@ enum class LoginTabItem(@StringRes val titleResId: Int) : TabItem {
     SSO(R.string.login_tab_sso);
 
     override val title: UIText = UIText.StringResource(titleResId)
+}
+
+@PreviewMultipleThemes
+@Composable
+private fun PreviewLoginScreen() = WireTheme {
+    WireTheme {
+        MainLoginContent(
+            onBackPressed = {},
+            onSuccess = { _, _ -> },
+            onRemoveDeviceNeeded = {},
+            loginNavArgs = LoginNavArgs(),
+            loginEmailViewModel = loginEmailViewModel(LoginNavArgs()),
+            ssoLoginResult = null,
+            ssoCodeAutoLogin = null
+        )
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -70,11 +70,9 @@ import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.visbility.rememberVisibilityState
-import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.deeplink.DeepLinkResult
-import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import kotlinx.coroutines.launch
 
@@ -259,20 +257,4 @@ enum class LoginTabItem(@StringRes val titleResId: Int) : TabItem {
     SSO(R.string.login_tab_sso);
 
     override val title: UIText = UIText.StringResource(titleResId)
-}
-
-@PreviewMultipleThemes
-@Composable
-private fun PreviewLoginScreen() = WireTheme {
-    WireTheme {
-        MainLoginContent(
-            onBackPressed = {},
-            onSuccess = { _, _ -> },
-            onRemoveDeviceNeeded = {},
-            loginNavArgs = LoginNavArgs(),
-            loginEmailViewModel = loginEmailViewModel(LoginNavArgs()),
-            ssoLoginResult = null,
-            ssoCodeAutoLogin = null
-        )
-    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
@@ -40,8 +40,10 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.wire.android.appLogger
-import com.wire.android.di.metro.LocalMetroViewModelGraph
+import com.wire.android.di.metro.LocalWireViewModelScopeKey
+import com.wire.android.di.metro.createCurrentSessionViewModelGraph
 import com.wire.android.di.metro.wireApplicationGraph
+import com.wire.android.model.LocalWireSessionImageLoader
 import com.wire.android.ui.AppLockActivity
 import com.wire.android.ui.BaseActivity
 import com.wire.android.ui.LocalActivity
@@ -57,6 +59,7 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import dev.zacsweers.metro.HasMemberInjections
 import kotlinx.coroutines.launch
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 
 @HasMemberInjections
 abstract class CallActivity : BaseActivity() {
@@ -116,9 +119,12 @@ abstract class CallActivity : BaseActivity() {
 
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
+            val sessionViewModelGraph = remember { wireApplicationGraph.createCurrentSessionViewModelGraph() }
             CompositionLocalProvider(
                 LocalSnackbarHostState provides snackbarHostState,
-                LocalMetroViewModelGraph provides imageAssetViewModelGraph,
+                LocalMetroViewModelFactory provides wireApplicationGraph.metroViewModelFactory,
+                LocalWireViewModelScopeKey provides sessionViewModelGraph.viewModelScopeKey,
+                LocalWireSessionImageLoader provides sessionViewModelGraph.wireSessionImageLoader,
                 LocalActivity provides this
             ) {
                 WireTheme {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallingViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallingViewModelGraph.kt
@@ -19,8 +19,8 @@ package com.wire.android.ui.calling
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalInspectionMode
-import com.wire.android.di.metro.scopedAssistedMetroViewModel
-import com.wire.android.di.metro.scopedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedAssistedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedMetroViewModel
 import com.wire.android.ui.calling.common.SharedCallingViewModel
 import com.wire.android.ui.calling.incoming.IncomingCallViewModel
 import com.wire.android.ui.calling.ongoing.OngoingCallViewModel
@@ -47,7 +47,7 @@ interface CallingViewModelGraph {
 
 @Composable
 fun incomingCallViewModel(conversationId: ConversationId): IncomingCallViewModel =
-    scopedAssistedMetroViewModel<IncomingCallViewModel, CallingManualViewModelFactory>(
+    sessionKeyedAssistedMetroViewModel<IncomingCallViewModel, CallingManualViewModelFactory>(
         key = "incoming_$conversationId",
     ) {
         incomingCallViewModel(conversationId)
@@ -55,7 +55,7 @@ fun incomingCallViewModel(conversationId: ConversationId): IncomingCallViewModel
 
 @Composable
 fun outgoingCallViewModel(conversationId: ConversationId): OutgoingCallViewModel =
-    scopedAssistedMetroViewModel<OutgoingCallViewModel, CallingManualViewModelFactory>(
+    sessionKeyedAssistedMetroViewModel<OutgoingCallViewModel, CallingManualViewModelFactory>(
         key = "outgoing_$conversationId",
     ) {
         outgoingCallViewModel(conversationId)
@@ -63,7 +63,7 @@ fun outgoingCallViewModel(conversationId: ConversationId): OutgoingCallViewModel
 
 @Composable
 fun ongoingCallViewModel(conversationId: ConversationId): OngoingCallViewModel =
-    scopedAssistedMetroViewModel<OngoingCallViewModel, CallingManualViewModelFactory>(
+    sessionKeyedAssistedMetroViewModel<OngoingCallViewModel, CallingManualViewModelFactory>(
         key = "ongoing_$conversationId",
     ) {
         ongoingCallViewModel(conversationId)
@@ -71,7 +71,7 @@ fun ongoingCallViewModel(conversationId: ConversationId): OngoingCallViewModel =
 
 @Composable
 fun sharedCallingViewModel(conversationId: ConversationId): SharedCallingViewModel =
-    scopedAssistedMetroViewModel<SharedCallingViewModel, CallingManualViewModelFactory>(
+    sessionKeyedAssistedMetroViewModel<SharedCallingViewModel, CallingManualViewModelFactory>(
         key = "shared_$conversationId",
     ) {
         sharedCallingViewModel(conversationId)
@@ -84,5 +84,5 @@ fun conversationCallViewModel(): ConversationCallViewModel =
 @Composable
 fun conversationListCallViewModel(conversationsSource: ConversationsSource): ConversationListCallViewModel = when {
     LocalInspectionMode.current -> ConversationListCallViewModelPreview
-    else -> scopedMetroViewModel<ConversationListCallViewModelImpl>(key = "call_$conversationsSource")
+    else -> sessionKeyedMetroViewModel<ConversationListCallViewModelImpl>(key = "call_$conversationsSource")
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallingViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallingViewModelGraph.kt
@@ -19,9 +19,8 @@ package com.wire.android.ui.calling
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalInspectionMode
-import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.metroSavedStateViewModel
-import com.wire.android.di.metro.metroViewModel
+import com.wire.android.di.metro.scopedAssistedMetroViewModel
+import com.wire.android.di.metro.scopedMetroViewModel
 import com.wire.android.ui.calling.common.SharedCallingViewModel
 import com.wire.android.ui.calling.incoming.IncomingCallViewModel
 import com.wire.android.ui.calling.ongoing.OngoingCallViewModel
@@ -32,45 +31,58 @@ import com.wire.android.ui.home.conversationslist.ConversationListCallViewModelI
 import com.wire.android.ui.home.conversationslist.ConversationListCallViewModelPreview
 import com.wire.android.ui.home.conversationslist.model.ConversationsSource
 import com.wire.kalium.logic.data.id.ConversationId
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.metroViewModel as metroxViewModel
 
-interface CallingViewModelGraph : MetroViewModelGraph {
+interface CallingManualViewModelFactory : ManualViewModelAssistedFactory {
+    fun incomingCallViewModel(conversationId: ConversationId): IncomingCallViewModel
+    fun outgoingCallViewModel(conversationId: ConversationId): OutgoingCallViewModel
+    fun ongoingCallViewModel(conversationId: ConversationId): OngoingCallViewModel
+    fun sharedCallingViewModel(conversationId: ConversationId): SharedCallingViewModel
+}
+
+interface CallingViewModelGraph {
     val callingViewModelFactory: CallingViewModelFactory
 }
 
 @Composable
 fun incomingCallViewModel(conversationId: ConversationId): IncomingCallViewModel =
-    metroViewModel<CallingViewModelGraph, IncomingCallViewModel>(key = "incoming_$conversationId") {
-        callingViewModelFactory.incomingCallViewModel(conversationId)
+    scopedAssistedMetroViewModel<IncomingCallViewModel, CallingManualViewModelFactory>(
+        key = "incoming_$conversationId",
+    ) {
+        incomingCallViewModel(conversationId)
     }
 
 @Composable
 fun outgoingCallViewModel(conversationId: ConversationId): OutgoingCallViewModel =
-    metroViewModel<CallingViewModelGraph, OutgoingCallViewModel>(key = "outgoing_$conversationId") {
-        callingViewModelFactory.outgoingCallViewModel(conversationId)
+    scopedAssistedMetroViewModel<OutgoingCallViewModel, CallingManualViewModelFactory>(
+        key = "outgoing_$conversationId",
+    ) {
+        outgoingCallViewModel(conversationId)
     }
 
 @Composable
 fun ongoingCallViewModel(conversationId: ConversationId): OngoingCallViewModel =
-    metroViewModel<CallingViewModelGraph, OngoingCallViewModel>(key = "ongoing_$conversationId") {
-        callingViewModelFactory.ongoingCallViewModel(conversationId)
+    scopedAssistedMetroViewModel<OngoingCallViewModel, CallingManualViewModelFactory>(
+        key = "ongoing_$conversationId",
+    ) {
+        ongoingCallViewModel(conversationId)
     }
 
 @Composable
 fun sharedCallingViewModel(conversationId: ConversationId): SharedCallingViewModel =
-    metroViewModel<CallingViewModelGraph, SharedCallingViewModel>(key = "shared_$conversationId") {
-        callingViewModelFactory.sharedCallingViewModel(conversationId)
+    scopedAssistedMetroViewModel<SharedCallingViewModel, CallingManualViewModelFactory>(
+        key = "shared_$conversationId",
+    ) {
+        sharedCallingViewModel(conversationId)
     }
 
 @Composable
 fun conversationCallViewModel(): ConversationCallViewModel =
-    metroSavedStateViewModel<CallingViewModelGraph, ConversationCallViewModel> {
-        callingViewModelFactory.conversationCallViewModel(it)
-    }
+    metroxViewModel()
 
 @Composable
 fun conversationListCallViewModel(conversationsSource: ConversationsSource): ConversationListCallViewModel = when {
     LocalInspectionMode.current -> ConversationListCallViewModelPreview
-    else -> metroViewModel<CallingViewModelGraph, ConversationListCallViewModelImpl>(key = "call_$conversationsSource") {
-        callingViewModelFactory.conversationListCallViewModel()
-    }
+    else -> scopedMetroViewModel<ConversationListCallViewModelImpl>(key = "call_$conversationsSource")
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/CommonViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/CommonViewModelFactory.kt
@@ -102,11 +102,10 @@ fun connectionActionButtonViewModel(
 @Composable
 fun conversationOptionsMenuViewModel(): ConversationOptionsMenuViewModel =
     wireManualMetroViewModelScoped<
-            ConversationOptionsMenuViewModelImpl,
-            ConversationOptionsMenuViewModel,
-            CommonManualViewModelFactory
-            >(
-    ) {
+        ConversationOptionsMenuViewModelImpl,
+        ConversationOptionsMenuViewModel,
+        CommonManualViewModelFactory,
+    > {
         conversationOptionsMenuViewModel()
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/CommonViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/CommonViewModelFactory.kt
@@ -21,8 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.work.WorkManager
 import com.wire.android.di.CurrentAccount
 import com.wire.android.di.KaliumCoreLogic
-import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.wireMetroViewModelScoped
+import com.wire.android.di.wireManualMetroViewModelScoped
 import com.wire.android.ui.common.banner.SecurityClassificationArgs
 import com.wire.android.ui.common.banner.SecurityClassificationViewModel
 import com.wire.android.ui.common.banner.SecurityClassificationViewModelImpl
@@ -58,41 +57,57 @@ import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.user.IsPreventAdminlessGroupsEnabledUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
 
-interface CommonViewModelGraph : MetroViewModelGraph {
+internal interface CommonManualViewModelFactory : ManualViewModelAssistedFactory {
+    fun securityClassificationViewModel(args: SecurityClassificationArgs): SecurityClassificationViewModelImpl
+    fun connectionActionButtonViewModel(args: ConnectionActionButtonArgs): ConnectionActionButtonViewModelImpl
+    fun conversationOptionsMenuViewModel(): ConversationOptionsMenuViewModelImpl
+}
+
+interface CommonViewModelGraph {
     val commonViewModelFactory: CommonViewModelFactory
 }
 
 @Composable
-fun securityClassificationViewModel(args: SecurityClassificationArgs): SecurityClassificationViewModel =
-    wireMetroViewModelScoped<
-            CommonViewModelGraph,
+fun securityClassificationViewModel(
+    args: SecurityClassificationArgs,
+): SecurityClassificationViewModel =
+    wireManualMetroViewModelScoped<
             SecurityClassificationViewModelImpl,
             SecurityClassificationViewModel,
-            SecurityClassificationArgs
+            SecurityClassificationArgs,
+            CommonManualViewModelFactory
             >(
         arguments = args
     ) { _, arguments ->
-        commonViewModelFactory.securityClassificationViewModel(arguments)
+        securityClassificationViewModel(arguments)
     }
 
 @Composable
-fun connectionActionButtonViewModel(args: ConnectionActionButtonArgs): ConnectionActionButtonViewModel =
-    wireMetroViewModelScoped<
-            CommonViewModelGraph,
+fun connectionActionButtonViewModel(
+    args: ConnectionActionButtonArgs,
+): ConnectionActionButtonViewModel =
+    wireManualMetroViewModelScoped<
             ConnectionActionButtonViewModelImpl,
             ConnectionActionButtonViewModel,
-            ConnectionActionButtonArgs
+            ConnectionActionButtonArgs,
+            CommonManualViewModelFactory
             >(
         arguments = args
     ) { _, arguments ->
-        commonViewModelFactory.connectionActionButtonViewModel(arguments)
+        connectionActionButtonViewModel(arguments)
     }
 
 @Composable
 fun conversationOptionsMenuViewModel(): ConversationOptionsMenuViewModel =
-    wireMetroViewModelScoped<CommonViewModelGraph, ConversationOptionsMenuViewModelImpl, ConversationOptionsMenuViewModel> {
-        commonViewModelFactory.conversationOptionsMenuViewModel()
+    wireManualMetroViewModelScoped<
+            ConversationOptionsMenuViewModelImpl,
+            ConversationOptionsMenuViewModel,
+            CommonManualViewModelFactory
+            >(
+    ) {
+        conversationOptionsMenuViewModel()
     }
 
 @Suppress("LongParameterList")

--- a/app/src/main/kotlin/com/wire/android/ui/common/banner/SecurityClassificationBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/banner/SecurityClassificationBanner.kt
@@ -59,7 +59,9 @@ fun SecurityClassificationBannerForConversation(
     conversationId: ConversationId,
     modifier: Modifier = Modifier,
     viewModel: SecurityClassificationViewModel =
-        securityClassificationViewModel(SecurityClassificationArgs.Conversation(conversationId))
+        securityClassificationViewModel(
+            SecurityClassificationArgs.Conversation(conversationId)
+        )
 ) {
     SecurityClassificationBanner(
         state = viewModel.state(),
@@ -72,7 +74,9 @@ fun SecurityClassificationBannerForUser(
     userId: UserId,
     modifier: Modifier = Modifier,
     viewModel: SecurityClassificationViewModel =
-        securityClassificationViewModel(SecurityClassificationArgs.User(id = userId))
+        securityClassificationViewModel(
+            SecurityClassificationArgs.User(id = userId)
+        )
 ) {
     SecurityClassificationBanner(
         state = viewModel.state(),

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModel.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
@@ -37,6 +38,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.network.NetworkState
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
@@ -58,22 +60,30 @@ class CommonTopAppBarViewModel(
     private suspend fun currentScreenFlow() =
         currentScreenManager.observeCurrentScreen(viewModelScope)
 
-    private fun connectivityFlow(userId: UserId): Flow<Connectivity> =
-        coreLogic.value.sessionScope(userId) {
-            combine(observeSyncState(), coreLogic.value.networkStateObserver.observeNetworkState()) { syncState, networkState ->
-                when {
-                    // Waiting is a pure pre-initialization state: the sync worker has not been
-                    // scheduled yet. It carries no information about network health, so map it
-                    // to Idle (no banner) rather than WaitingConnection or Connecting.
-                    syncState is Waiting -> Connectivity.Idle
-                    syncState is Failed -> Connectivity.WaitingConnection(syncState.cause, syncState.retryDelay)
-                    networkState !is NetworkState.ConnectedWithInternet && params.showNoNetwork ->
-                        Connectivity.WaitingConnection(null, null)
-                    syncState is SlowSync && params.showSync -> Connectivity.Connecting
-                    syncState is GatheringPendingEvents && params.showSync -> Connectivity.Connecting
-                    else -> Connectivity.Connected
+    private suspend fun connectivityFlow(userId: UserId): Flow<Connectivity> =
+        runCatching {
+            coreLogic.value.sessionScope(userId) {
+                combine(observeSyncState(), coreLogic.value.networkStateObserver.observeNetworkState()) { syncState, networkState ->
+                    when {
+                        // Waiting is a pure pre-initialization state: the sync worker has not been
+                        // scheduled yet. It carries no information about network health, so map it
+                        // to Idle (no banner) rather than WaitingConnection or Connecting.
+                        syncState is Waiting -> Connectivity.Idle
+                        syncState is Failed -> Connectivity.WaitingConnection(syncState.cause, syncState.retryDelay)
+                        networkState !is NetworkState.ConnectedWithInternet && params.showNoNetwork ->
+                            Connectivity.WaitingConnection(null, null)
+                        syncState is SlowSync && params.showSync -> Connectivity.Connecting
+                        syncState is GatheringPendingEvents && params.showSync -> Connectivity.Connecting
+                        else -> Connectivity.Connected
+                    }
                 }
             }
+        }.getOrElse {
+            appLogger.e("$TAG: Failed to get connectivity session scope for current session: $userId")
+            flowOf(Connectivity.Idle)
+        }.catch {
+            appLogger.e("$TAG: Connectivity session flow failed for current session: $userId")
+            emit(Connectivity.Idle)
         }.debounce { connectivity ->
             when (connectivity) {
                 // Pass through immediately so the banner is dismissed without delay
@@ -91,14 +101,22 @@ class CommonTopAppBarViewModel(
     @VisibleForTesting
     internal suspend fun activeCallsFlow(userId: UserId): Flow<List<Call>> = when {
         !params.showActiveCalls -> flowOf(emptyList()) // assume list is always empty to not show it on the bar
-        else -> coreLogic.value.sessionScope(userId) { // otherwise observe real calls to show them on the bar
-            combine(
-                calls.establishedCall(),
-                calls.getIncomingCalls(),
-                calls.observeOutgoingCall(),
-            ) { establishedCall, incomingCalls, outgoingCalls ->
-                establishedCall + incomingCalls + outgoingCalls
-            }.distinctUntilChanged()
+        else -> runCatching {
+            coreLogic.value.sessionScope(userId) { // otherwise observe real calls to show them on the bar
+                combine(
+                    calls.establishedCall(),
+                    calls.getIncomingCalls(),
+                    calls.observeOutgoingCall(),
+                ) { establishedCall, incomingCalls, outgoingCalls ->
+                    establishedCall + incomingCalls + outgoingCalls
+                }.distinctUntilChanged()
+            }
+        }.getOrElse {
+            appLogger.e("$TAG: Failed to get calls session scope for current session: $userId")
+            flowOf(emptyList())
+        }.catch {
+            appLogger.e("$TAG: Calls session flow failed for current session: $userId")
+            emit(emptyList())
         }
     }
 
@@ -189,6 +207,7 @@ class CommonTopAppBarViewModel(
     }
 
     private companion object {
+        const val TAG = "CommonTopAppBarViewModel"
         const val CONNECTIVITY_STATE_DEBOUNCE_ONGOING_CALL = 600L
         const val CONNECTIVITY_STATE_DEBOUNCE_DEFAULT = 1000L
     }

--- a/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/connection/ConnectionActionButton.kt
@@ -73,7 +73,9 @@ fun ConnectionActionButton(
     onConnectionRequestIgnored: (String) -> Unit = {},
     onOpenConversation: (ConversationId) -> Unit = {},
     viewModel: ConnectionActionButtonViewModel =
-        connectionActionButtonViewModel(ConnectionActionButtonArgs(userId, userName)),
+        connectionActionButtonViewModel(
+            ConnectionActionButtonArgs(userId, userName)
+        ),
 ) {
     LocalSnackbarHostState.current.collectAndShowSnackbar(snackbarFlow = viewModel.infoMessage)
     val unblockUserDialogState = rememberVisibilityState<UnblockUserDialogState>()

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugDataOptions.kt
@@ -68,7 +68,7 @@ fun DebugDataOptions(
     onCopyText: (String) -> Unit,
     onShowFeatureFlags: () -> Unit,
     onShowCryptoStats: () -> Unit,
-    viewModel: DebugDataOptionsViewModel = debugDataOptionsViewModel()
+    viewModel: DebugDataOptionsViewModel,
 ) {
     LocalSnackbarHostState.current.collectAndShowSnackbar(snackbarFlow = viewModel.infoMessage)
     DebugDataOptionsContent(
@@ -90,7 +90,7 @@ fun DebugDataOptions(
         onEnableAsyncNotificationsChange = viewModel::enableAsyncNotifications,
         onShowFeatureFlags = onShowFeatureFlags,
         onShowCryptoStats = onShowCryptoStats,
-        onRepairFaultyRemovalKeys = viewModel::repairFaultRemovalKeys
+        onRepairFaultyRemovalKeys = viewModel::repairFaultRemovalKeys,
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugInfoViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugInfoViewModelGraph.kt
@@ -22,7 +22,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.scopedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedMetroViewModel
 import com.wire.android.ui.debug.conversation.DebugConversationViewModel
 import com.wire.android.ui.debug.cryptostats.ConversationCryptoStatsViewModel
 import com.wire.android.ui.debug.featureflags.DebugFeatureFlagsViewModel
@@ -42,7 +42,7 @@ inline fun <reified VM> debugInfoViewModel(
     },
     key: String? = null,
 ): VM where VM : ViewModel =
-    scopedMetroViewModel(
+    sessionKeyedMetroViewModel(
         viewModelStoreOwner = viewModelStoreOwner,
         key = key,
     )

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugInfoViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugInfoViewModelGraph.kt
@@ -18,13 +18,11 @@
 package com.wire.android.ui.debug
 
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.metroSavedStateViewModel
-import com.wire.android.di.metro.metroViewModel
+import com.wire.android.di.metro.scopedMetroViewModel
 import com.wire.android.ui.debug.conversation.DebugConversationViewModel
 import com.wire.android.ui.debug.cryptostats.ConversationCryptoStatsViewModel
 import com.wire.android.ui.debug.featureflags.DebugFeatureFlagsViewModel
@@ -43,64 +41,52 @@ inline fun <reified VM> debugInfoViewModel(
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
     },
     key: String? = null,
-    crossinline create: DebugInfoViewModelFactory.() -> VM,
 ): VM where VM : ViewModel =
-    metroViewModel<DebugInfoViewModelGraph, VM>(
+    scopedMetroViewModel(
         viewModelStoreOwner = viewModelStoreOwner,
         key = key,
-    ) {
-        debugInfoViewModelFactory.create()
-    }
+    )
 
 @Composable
-inline fun <reified VM> debugInfoSavedStateViewModel(
-    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
-        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
-    },
-    key: String? = null,
-    crossinline create: DebugInfoViewModelFactory.(SavedStateHandle) -> VM,
-): VM where VM : ViewModel =
-    metroSavedStateViewModel<DebugInfoViewModelGraph, VM>(
-        viewModelStoreOwner = viewModelStoreOwner,
-        key = key,
-    ) { savedStateHandle ->
-        debugInfoViewModelFactory.create(savedStateHandle)
-    }
+fun userDebugViewModel(): UserDebugViewModel =
+    debugInfoViewModel()
 
 @Composable
-fun userDebugViewModel(): UserDebugViewModel = debugInfoViewModel { userDebugViewModel() }
-
-@Composable
-fun logManagementViewModel(): LogManagementViewModel = debugInfoViewModel { logManagementViewModel() }
+fun logManagementViewModel(): LogManagementViewModel =
+    debugInfoViewModel()
 
 @Composable
 fun debugDataOptionsViewModel(): DebugDataOptionsViewModel =
-    debugInfoViewModel<DebugDataOptionsViewModelImpl> { debugDataOptionsViewModel() }
+    debugInfoViewModel<DebugDataOptionsViewModelImpl>()
 
 @Composable
 fun exportObfuscatedCopyViewModel(): ExportObfuscatedCopyViewModel =
-    debugInfoViewModel<ExportObfuscatedCopyViewModelImpl> { exportObfuscatedCopyViewModel() }
+    debugInfoViewModel<ExportObfuscatedCopyViewModelImpl>()
 
 @Composable
 fun debugConversationViewModel(): DebugConversationViewModel =
-    debugInfoSavedStateViewModel { debugConversationViewModel(it) }
+    debugInfoViewModel()
 
 @Composable
 fun conversationCryptoStatsViewModel(): ConversationCryptoStatsViewModel =
-    debugInfoViewModel { conversationCryptoStatsViewModel() }
+    debugInfoViewModel()
 
 @Composable
 fun debugFeatureFlagsViewModel(): DebugFeatureFlagsViewModel =
-    debugInfoViewModel { debugFeatureFlagsViewModel() }
+    debugInfoViewModel()
 
 @Composable
-fun whatsNewViewModel(): WhatsNewViewModel = debugInfoViewModel { whatsNewViewModel() }
+fun whatsNewViewModel(): WhatsNewViewModel =
+    debugInfoViewModel()
 
 @Composable
-fun aboutThisAppViewModel(): AboutThisAppViewModel = debugInfoViewModel { aboutThisAppViewModel() }
+fun aboutThisAppViewModel(): AboutThisAppViewModel =
+    debugInfoViewModel()
 
 @Composable
-fun dependenciesViewModel(): DependenciesViewModel = debugInfoViewModel { dependenciesViewModel() }
+fun dependenciesViewModel(): DependenciesViewModel =
+    debugInfoViewModel()
 
 @Composable
-fun licensesViewModel(): LicensesViewModel = debugInfoViewModel { licensesViewModel() }
+fun licensesViewModel(): LicensesViewModel =
+    debugInfoViewModel()

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
@@ -72,6 +72,8 @@ import java.io.File
 fun DebugScreen(
     navigator: Navigator,
     userDebugViewModel: UserDebugViewModel = userDebugViewModel(),
+    debugDataOptionsViewModel: DebugDataOptionsViewModel = debugDataOptionsViewModel(),
+    exportObfuscatedCopyViewModel: ExportObfuscatedCopyViewModel = exportObfuscatedCopyViewModel(),
 ) {
     UserDebugContent(
         onNavigationPressed = navigator::navigateBack,
@@ -85,7 +87,9 @@ fun DebugScreen(
         },
         onShowCryptoStats = {
             navigator.navigate(NavigationCommand(ConversationCryptoStatsScreenDestination))
-        }
+        },
+        debugDataOptionsViewModel = debugDataOptionsViewModel,
+        exportObfuscatedCopyViewModel = exportObfuscatedCopyViewModel,
     )
 }
 
@@ -99,8 +103,8 @@ internal fun UserDebugContent(
     onFlushLogs: () -> Deferred<Unit>,
     onShowFeatureFlags: () -> Unit,
     onShowCryptoStats: () -> Unit,
-    debugDataOptionsViewModel: DebugDataOptionsViewModel = debugDataOptionsViewModel(),
-    exportObfuscatedCopyViewModel: ExportObfuscatedCopyViewModel = exportObfuscatedCopyViewModel(),
+    debugDataOptionsViewModel: DebugDataOptionsViewModel,
+    exportObfuscatedCopyViewModel: ExportObfuscatedCopyViewModel,
 ) {
     val debugContentState: DebugContentState = rememberDebugContentState(state.logPath)
 
@@ -149,7 +153,7 @@ internal fun UserDebugContent(
 @Composable
 fun DangerOptions(
     modifier: Modifier = Modifier,
-    exportObfuscatedCopyViewModel: ExportObfuscatedCopyViewModel = exportObfuscatedCopyViewModel()
+    exportObfuscatedCopyViewModel: ExportObfuscatedCopyViewModel,
 ) {
 
     Column(modifier = modifier) {
@@ -255,5 +259,7 @@ internal fun PreviewUserDebugContent() = WireTheme {
         onDatabaseLoggerEnabledChanged = {},
         onShowFeatureFlags = {},
         onShowCryptoStats = {},
+        debugDataOptionsViewModel = object : DebugDataOptionsViewModel {},
+        exportObfuscatedCopyViewModel = object : ExportObfuscatedCopyViewModel {},
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
@@ -82,14 +82,23 @@ fun DebugScreen(
         onDeleteLogs = userDebugViewModel::deleteLogs,
         onFlushLogs = userDebugViewModel::flushLogs,
         onDatabaseLoggerEnabledChanged = userDebugViewModel::setDatabaseLoggerEnabledState,
-        onShowFeatureFlags = {
-            navigator.navigate(NavigationCommand(DebugFeatureFlagsScreenDestination))
+        debugDataOptionsContent = { debugContentState ->
+            DebugDataOptions(
+                appVersion = AppNameUtil.createAppName(),
+                buildVariant = "${BuildConfig.FLAVOR}${BuildConfig.BUILD_TYPE.replaceFirstChar { it.uppercase() }}",
+                onCopyText = debugContentState::copyToClipboard,
+                onShowFeatureFlags = {
+                    navigator.navigate(NavigationCommand(DebugFeatureFlagsScreenDestination))
+                },
+                onShowCryptoStats = {
+                    navigator.navigate(NavigationCommand(ConversationCryptoStatsScreenDestination))
+                },
+                viewModel = debugDataOptionsViewModel,
+            )
         },
-        onShowCryptoStats = {
-            navigator.navigate(NavigationCommand(ConversationCryptoStatsScreenDestination))
+        dangerOptionsContent = {
+            DangerOptions(exportObfuscatedCopyViewModel = exportObfuscatedCopyViewModel)
         },
-        debugDataOptionsViewModel = debugDataOptionsViewModel,
-        exportObfuscatedCopyViewModel = exportObfuscatedCopyViewModel,
     )
 }
 
@@ -101,10 +110,8 @@ internal fun UserDebugContent(
     onDatabaseLoggerEnabledChanged: (Boolean) -> Unit,
     onDeleteLogs: () -> Unit,
     onFlushLogs: () -> Deferred<Unit>,
-    onShowFeatureFlags: () -> Unit,
-    onShowCryptoStats: () -> Unit,
-    debugDataOptionsViewModel: DebugDataOptionsViewModel,
-    exportObfuscatedCopyViewModel: ExportObfuscatedCopyViewModel,
+    debugDataOptionsContent: @Composable (DebugContentState) -> Unit,
+    dangerOptionsContent: @Composable () -> Unit,
 ) {
     val debugContentState: DebugContentState = rememberDebugContentState(state.logPath)
 
@@ -134,16 +141,9 @@ internal fun UserDebugContent(
                     onDBLoggerEnabledChange = onDatabaseLoggerEnabledChanged,
                     isPrivateBuild = BuildConfig.PRIVATE_BUILD,
                 )
-                DebugDataOptions(
-                    appVersion = AppNameUtil.createAppName(),
-                    buildVariant = "${BuildConfig.FLAVOR}${BuildConfig.BUILD_TYPE.replaceFirstChar { it.uppercase() }}",
-                    onCopyText = debugContentState::copyToClipboard,
-                    onShowFeatureFlags = onShowFeatureFlags,
-                    onShowCryptoStats = onShowCryptoStats,
-                    viewModel = debugDataOptionsViewModel,
-                )
+                debugDataOptionsContent(debugContentState)
                 if (BuildConfig.PRIVATE_BUILD) {
-                    DangerOptions(exportObfuscatedCopyViewModel = exportObfuscatedCopyViewModel)
+                    dangerOptionsContent()
                 }
             }
         }
@@ -152,8 +152,8 @@ internal fun UserDebugContent(
 
 @Composable
 fun DangerOptions(
-    modifier: Modifier = Modifier,
     exportObfuscatedCopyViewModel: ExportObfuscatedCopyViewModel,
+    modifier: Modifier = Modifier,
 ) {
 
     Column(modifier = modifier) {
@@ -257,9 +257,18 @@ internal fun PreviewUserDebugContent() = WireTheme {
         onDeleteLogs = {},
         onFlushLogs = { CompletableDeferred(Unit) },
         onDatabaseLoggerEnabledChanged = {},
-        onShowFeatureFlags = {},
-        onShowCryptoStats = {},
-        debugDataOptionsViewModel = object : DebugDataOptionsViewModel {},
-        exportObfuscatedCopyViewModel = object : ExportObfuscatedCopyViewModel {},
+        debugDataOptionsContent = {
+            DebugDataOptions(
+                appVersion = AppNameUtil.createAppName(),
+                buildVariant = "${BuildConfig.FLAVOR}${BuildConfig.BUILD_TYPE.replaceFirstChar { it.uppercase() }}",
+                onCopyText = it::copyToClipboard,
+                onShowFeatureFlags = {},
+                onShowCryptoStats = {},
+                viewModel = object : DebugDataOptionsViewModel {},
+            )
+        },
+        dangerOptionsContent = {
+            DangerOptions(exportObfuscatedCopyViewModel = object : ExportObfuscatedCopyViewModel {})
+        },
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
@@ -117,7 +117,7 @@ private fun E2EIEnrollmentScreenContent(
     openCertificateDetails: () -> Unit,
     onBackButtonClicked: () -> Unit,
     onCancelEnrollmentClicked: () -> Unit,
-    onProceedEnrollmentClicked: () -> Unit
+    onProceedEnrollmentClicked: () -> Unit,
 ) {
     BackHandler {
         onBackButtonClicked()

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModelGraph.kt
@@ -21,9 +21,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.metroSavedStateViewModel
-import com.wire.android.di.metro.metroViewModel
+import com.wire.android.di.metro.scopedAssistedMetroViewModel
+import com.wire.android.di.metro.scopedMetroViewModel
 import com.wire.android.ui.home.conversationslist.ConversationListViewModel
 import com.wire.android.ui.home.conversationslist.ConversationListViewModelImpl
 import com.wire.android.ui.home.conversationslist.ConversationListViewModelPreview
@@ -31,28 +30,31 @@ import com.wire.android.ui.home.conversationslist.model.ConversationsSource
 import com.wire.android.ui.home.drawer.HomeDrawerViewModel
 import com.wire.android.ui.home.newconversation.NewConversationViewModel
 import com.wire.android.ui.home.sync.FeatureFlagNotificationViewModel
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
 
-interface HomeViewModelGraph : MetroViewModelGraph {
-    val homeViewModelFactory: HomeViewModelFactory
+interface HomeManualViewModelFactory : ManualViewModelAssistedFactory {
+    fun conversationListViewModel(conversationsSource: ConversationsSource): ConversationListViewModelImpl
 }
 
 @Composable
 fun homeViewModel(): HomeViewModel =
-    metroSavedStateViewModel<HomeViewModelGraph, HomeViewModel> { homeViewModelFactory.homeViewModel(it) }
+    scopedMetroViewModel()
 
 @Composable
 fun appSyncViewModel(): AppSyncViewModel =
-    metroViewModel<HomeViewModelGraph, AppSyncViewModel> { homeViewModelFactory.appSyncViewModel() }
+    scopedMetroViewModel()
 
 @Composable
 fun homeDrawerViewModel(): HomeDrawerViewModel =
-    metroSavedStateViewModel<HomeViewModelGraph, HomeDrawerViewModel> { homeViewModelFactory.homeDrawerViewModel(it) }
+    scopedMetroViewModel()
 
 @Composable
 fun conversationListViewModel(conversationsSource: ConversationsSource): ConversationListViewModel = when {
     LocalInspectionMode.current -> ConversationListViewModelPreview()
-    else -> metroViewModel<HomeViewModelGraph, ConversationListViewModelImpl>(key = "list_$conversationsSource") {
-        homeViewModelFactory.conversationListViewModel(conversationsSource)
+    else -> scopedAssistedMetroViewModel<ConversationListViewModelImpl, HomeManualViewModelFactory>(
+        key = "list_$conversationsSource",
+    ) {
+        conversationListViewModel(conversationsSource)
     }
 }
 
@@ -62,12 +64,10 @@ fun newConversationViewModel(
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
     },
 ): NewConversationViewModel =
-    metroViewModel<HomeViewModelGraph, NewConversationViewModel>(viewModelStoreOwner = viewModelStoreOwner) {
-        homeViewModelFactory.newConversationViewModel()
-    }
+    scopedMetroViewModel(
+        viewModelStoreOwner = viewModelStoreOwner,
+    )
 
 @Composable
 fun featureFlagNotificationViewModel(): FeatureFlagNotificationViewModel =
-    metroViewModel<HomeViewModelGraph, FeatureFlagNotificationViewModel> {
-        homeViewModelFactory.featureFlagNotificationViewModel()
-    }
+    scopedMetroViewModel()

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModelGraph.kt
@@ -15,14 +15,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+@file:Suppress("MatchingDeclarationName")
+
 package com.wire.android.ui.home
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-import com.wire.android.di.metro.scopedAssistedMetroViewModel
-import com.wire.android.di.metro.scopedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedAssistedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedMetroViewModel
 import com.wire.android.ui.home.conversationslist.ConversationListViewModel
 import com.wire.android.ui.home.conversationslist.ConversationListViewModelImpl
 import com.wire.android.ui.home.conversationslist.ConversationListViewModelPreview
@@ -38,20 +40,20 @@ interface HomeManualViewModelFactory : ManualViewModelAssistedFactory {
 
 @Composable
 fun homeViewModel(): HomeViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun appSyncViewModel(): AppSyncViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun homeDrawerViewModel(): HomeDrawerViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun conversationListViewModel(conversationsSource: ConversationsSource): ConversationListViewModel = when {
     LocalInspectionMode.current -> ConversationListViewModelPreview()
-    else -> scopedAssistedMetroViewModel<ConversationListViewModelImpl, HomeManualViewModelFactory>(
+    else -> sessionKeyedAssistedMetroViewModel<ConversationListViewModelImpl, HomeManualViewModelFactory>(
         key = "list_$conversationsSource",
     ) {
         conversationListViewModel(conversationsSource)
@@ -64,10 +66,10 @@ fun newConversationViewModel(
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
     },
 ): NewConversationViewModel =
-    scopedMetroViewModel(
+    sessionKeyedMetroViewModel(
         viewModelStoreOwner = viewModelStoreOwner,
     )
 
 @Composable
 fun featureFlagNotificationViewModel(): FeatureFlagNotificationViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelGraph.kt
@@ -1,4 +1,4 @@
-@file:Suppress("TooManyFunctions")
+@file:Suppress("MatchingDeclarationName", "TooManyFunctions")
 
 /*
  * Wire
@@ -22,8 +22,8 @@ package com.wire.android.ui.home.conversations
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.lifecycle.ViewModel
-import com.wire.android.di.metro.scopedAssistedMetroViewModel
-import com.wire.android.di.metro.scopedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedAssistedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedMetroViewModel
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.android.ui.home.conversations.attachment.MessageAttachmentsViewModel
 import com.wire.android.ui.home.conversations.banner.ConversationBannerViewModel
@@ -114,7 +114,7 @@ fun conversationInfoViewModel(): ConversationInfoViewModel =
 
 @Composable
 fun multipartAttachmentsViewModel(conversationId: ConversationId): MultipartAttachmentsViewModel =
-    scopedAssistedMetroViewModel<MultipartAttachmentsViewModelImpl, ConversationCoreManualViewModelFactory>(
+    sessionKeyedAssistedMetroViewModel<MultipartAttachmentsViewModelImpl, ConversationCoreManualViewModelFactory>(
         key = conversationId.value,
     ) {
         multipartAttachmentsViewModel(conversationId)
@@ -124,4 +124,4 @@ fun multipartAttachmentsViewModel(conversationId: ConversationId): MultipartAtta
 private inline fun <reified VM> conversationCoreViewModel(
     key: String? = null,
 ): VM where VM : ViewModel =
-    scopedMetroViewModel(key)
+    sessionKeyedMetroViewModel(key)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationCoreViewModelGraph.kt
@@ -21,11 +21,9 @@ package com.wire.android.ui.home.conversations
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.metroSavedStateViewModel
-import com.wire.android.di.metro.metroViewModel
+import com.wire.android.di.metro.scopedAssistedMetroViewModel
+import com.wire.android.di.metro.scopedMetroViewModel
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.android.ui.home.conversations.attachment.MessageAttachmentsViewModel
 import com.wire.android.ui.home.conversations.banner.ConversationBannerViewModel
@@ -46,94 +44,84 @@ import com.wire.android.ui.home.conversations.model.messagetypes.multipart.Multi
 import com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
 import com.wire.android.ui.home.gallery.MediaGalleryViewModel
 import com.wire.android.ui.home.messagecomposer.location.LocationPickerViewModel
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
 
-interface ConversationCoreViewModelGraph : MetroViewModelGraph {
-    val conversationCoreViewModelFactory: ConversationCoreViewModelFactory
+interface ConversationCoreManualViewModelFactory : ManualViewModelAssistedFactory {
+    fun multipartAttachmentsViewModel(conversationId: ConversationId): MultipartAttachmentsViewModelImpl
 }
 
 @Composable
 fun conversationMessagesViewModel(): ConversationMessagesViewModel =
-    conversationSavedStateViewModel { this.conversationMessagesViewModel(it) }
+    conversationCoreViewModel()
 
 @Composable
 fun messageComposerViewModel(): MessageComposerViewModel =
-    conversationSavedStateViewModel { this.messageComposerViewModel(it) }
+    conversationCoreViewModel()
 
 @Composable
 fun sendMessageViewModel(): SendMessageViewModel =
-    conversationSavedStateViewModel { this.sendMessageViewModel(it) }
+    conversationCoreViewModel()
 
 @Composable
 fun messageDraftViewModel(): MessageDraftViewModel =
-    conversationSavedStateViewModel { this.messageDraftViewModel(it) }
+    conversationCoreViewModel()
 
 @Composable
 fun messageAttachmentsViewModel(): MessageAttachmentsViewModel =
-    conversationSavedStateViewModel { this.messageAttachmentsViewModel(it) }
+    conversationCoreViewModel()
 
 @Composable
 fun conversationMigrationViewModel(): ConversationMigrationViewModel =
-    conversationSavedStateViewModel { this.conversationMigrationViewModel(it) }
+    conversationCoreViewModel()
 
 @Composable
 fun conversationAssetPathsViewModel(conversationKey: String): ConversationAssetPathsViewModel = when {
     LocalInspectionMode.current -> ConversationAssetPathsViewModelPreview
-    else -> conversationViewModel<ConversationAssetPathsViewModelImpl>(key = conversationKey) {
-        this.conversationAssetPathsViewModel()
-    }
+    else -> conversationCoreViewModel<ConversationAssetPathsViewModelImpl>(key = conversationKey)
 }
 
 @Composable
 fun mediaGalleryViewModel(): MediaGalleryViewModel =
-    conversationSavedStateViewModel { this.mediaGalleryViewModel(it) }
+    conversationCoreViewModel()
 
 @Composable
 fun locationPickerViewModel(): LocationPickerViewModel =
-    conversationViewModel { this.locationPickerViewModel() }
+    conversationCoreViewModel()
 
 @Composable
 fun conversationAssetMessagesViewModel(): ConversationAssetMessagesViewModel =
-    conversationSavedStateViewModel { this.conversationAssetMessagesViewModel(it) }
+    conversationCoreViewModel()
 
 @Composable
 fun imagesPreviewViewModel(): ImagesPreviewViewModel =
-    conversationSavedStateViewModel { this.imagesPreviewViewModel(it) }
+    conversationCoreViewModel()
 
 @Composable
 fun messageDetailsViewModel(): MessageDetailsViewModel =
-    conversationSavedStateViewModel { this.messageDetailsViewModel(it) }
+    conversationCoreViewModel()
 
 @Composable
 fun quotedMultipartMessageViewModel(conversationKey: String): QuotedMultipartMessageViewModel =
-    conversationViewModel(key = conversationKey) { this.quotedMultipartMessageViewModel() }
+    conversationCoreViewModel(key = conversationKey)
 
 @Composable
 fun conversationBannerViewModel(): ConversationBannerViewModel =
-    conversationSavedStateViewModel { this.conversationBannerViewModel(it) }
+    conversationCoreViewModel()
 
 @Composable
 fun conversationInfoViewModel(): ConversationInfoViewModel =
-    conversationSavedStateViewModel { this.conversationInfoViewModel(it) }
+    conversationCoreViewModel()
 
 @Composable
 fun multipartAttachmentsViewModel(conversationId: ConversationId): MultipartAttachmentsViewModel =
-    conversationViewModel<MultipartAttachmentsViewModelImpl>(key = conversationId.value) {
-        this.multipartAttachmentsViewModel(conversationId)
+    scopedAssistedMetroViewModel<MultipartAttachmentsViewModelImpl, ConversationCoreManualViewModelFactory>(
+        key = conversationId.value,
+    ) {
+        multipartAttachmentsViewModel(conversationId)
     }
 
 @Composable
-private inline fun <reified VM> conversationSavedStateViewModel(
-    crossinline create: ConversationCoreViewModelFactory.(SavedStateHandle) -> VM,
-): VM where VM : ViewModel =
-    metroSavedStateViewModel<ConversationCoreViewModelGraph, VM> {
-        conversationCoreViewModelFactory.create(it)
-    }
-
-@Composable
-private inline fun <reified VM> conversationViewModel(
+private inline fun <reified VM> conversationCoreViewModel(
     key: String? = null,
-    crossinline create: ConversationCoreViewModelFactory.() -> VM,
 ): VM where VM : ViewModel =
-    metroViewModel<ConversationCoreViewModelGraph, VM>(key = key) {
-        conversationCoreViewModelFactory.create()
-    }
+    scopedMetroViewModel(key)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationDetailsViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationDetailsViewModelGraph.kt
@@ -18,7 +18,7 @@
 package com.wire.android.ui.home.conversations
 
 import androidx.compose.runtime.Composable
-import com.wire.android.di.metro.scopedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedMetroViewModel
 import com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel
 import com.wire.android.ui.home.conversations.details.editguestaccess.EditGuestAccessViewModel
 import com.wire.android.ui.home.conversations.details.editguestaccess.createPasswordProtectedGuestLink.CreatePasswordGuestLinkViewModel
@@ -31,36 +31,36 @@ import com.wire.android.ui.home.conversations.media.CheckAssetRestrictionsViewMo
 
 @Composable
 fun groupConversationDetailsViewModel(): GroupConversationDetailsViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun groupConversationParticipantsViewModel(): GroupConversationParticipantsViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun editConversationMetadataViewModel(): EditConversationMetadataViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun editSelfDeletingMessagesViewModel(): EditSelfDeletingMessagesViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun updateChannelAccessViewModel(): UpdateChannelAccessViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun updateAppsAccessViewModel(): UpdateAppsAccessViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun editGuestAccessViewModel(): EditGuestAccessViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun createPasswordGuestLinkViewModel(): CreatePasswordGuestLinkViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun checkAssetRestrictionsViewModel(): CheckAssetRestrictionsViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationDetailsViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationDetailsViewModelGraph.kt
@@ -18,9 +18,7 @@
 package com.wire.android.ui.home.conversations
 
 import androidx.compose.runtime.Composable
-import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.metroSavedStateViewModel
-import com.wire.android.di.metro.metroViewModel
+import com.wire.android.di.metro.scopedMetroViewModel
 import com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel
 import com.wire.android.ui.home.conversations.details.editguestaccess.EditGuestAccessViewModel
 import com.wire.android.ui.home.conversations.details.editguestaccess.createPasswordProtectedGuestLink.CreatePasswordGuestLinkViewModel
@@ -31,60 +29,38 @@ import com.wire.android.ui.home.conversations.details.updateappsaccess.UpdateApp
 import com.wire.android.ui.home.conversations.details.updatechannelaccess.UpdateChannelAccessViewModel
 import com.wire.android.ui.home.conversations.media.CheckAssetRestrictionsViewModel
 
-interface ConversationDetailsViewModelGraph : MetroViewModelGraph {
-    val conversationDetailsViewModelFactory: ConversationDetailsViewModelFactory
-}
-
 @Composable
 fun groupConversationDetailsViewModel(): GroupConversationDetailsViewModel =
-    metroSavedStateViewModel<ConversationDetailsViewModelGraph, GroupConversationDetailsViewModel> {
-        conversationDetailsViewModelFactory.groupConversationDetailsViewModel(it)
-    }
+    scopedMetroViewModel()
 
 @Composable
 fun groupConversationParticipantsViewModel(): GroupConversationParticipantsViewModel =
-    metroSavedStateViewModel<ConversationDetailsViewModelGraph, GroupConversationParticipantsViewModel> {
-        conversationDetailsViewModelFactory.groupConversationParticipantsViewModel(it)
-    }
+    scopedMetroViewModel()
 
 @Composable
 fun editConversationMetadataViewModel(): EditConversationMetadataViewModel =
-    metroSavedStateViewModel<ConversationDetailsViewModelGraph, EditConversationMetadataViewModel> {
-        conversationDetailsViewModelFactory.editConversationMetadataViewModel(it)
-    }
+    scopedMetroViewModel()
 
 @Composable
 fun editSelfDeletingMessagesViewModel(): EditSelfDeletingMessagesViewModel =
-    metroSavedStateViewModel<ConversationDetailsViewModelGraph, EditSelfDeletingMessagesViewModel> {
-        conversationDetailsViewModelFactory.editSelfDeletingMessagesViewModel(it)
-    }
+    scopedMetroViewModel()
 
 @Composable
 fun updateChannelAccessViewModel(): UpdateChannelAccessViewModel =
-    metroSavedStateViewModel<ConversationDetailsViewModelGraph, UpdateChannelAccessViewModel> {
-        conversationDetailsViewModelFactory.updateChannelAccessViewModel(it)
-    }
+    scopedMetroViewModel()
 
 @Composable
 fun updateAppsAccessViewModel(): UpdateAppsAccessViewModel =
-    metroSavedStateViewModel<ConversationDetailsViewModelGraph, UpdateAppsAccessViewModel> {
-        conversationDetailsViewModelFactory.updateAppsAccessViewModel(it)
-    }
+    scopedMetroViewModel()
 
 @Composable
 fun editGuestAccessViewModel(): EditGuestAccessViewModel =
-    metroSavedStateViewModel<ConversationDetailsViewModelGraph, EditGuestAccessViewModel> {
-        conversationDetailsViewModelFactory.editGuestAccessViewModel(it)
-    }
+    scopedMetroViewModel()
 
 @Composable
 fun createPasswordGuestLinkViewModel(): CreatePasswordGuestLinkViewModel =
-    metroSavedStateViewModel<ConversationDetailsViewModelGraph, CreatePasswordGuestLinkViewModel> {
-        conversationDetailsViewModelFactory.createPasswordGuestLinkViewModel(it)
-    }
+    scopedMetroViewModel()
 
 @Composable
 fun checkAssetRestrictionsViewModel(): CheckAssetRestrictionsViewModel =
-    metroViewModel<ConversationDetailsViewModelGraph, CheckAssetRestrictionsViewModel> {
-        conversationDetailsViewModelFactory.checkAssetRestrictionsViewModel()
-    }
+    scopedMetroViewModel()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationSearchFolderViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationSearchFolderViewModelGraph.kt
@@ -18,9 +18,8 @@
 package com.wire.android.ui.home.conversations
 
 import androidx.compose.runtime.Composable
-import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.metroSavedStateViewModel
-import com.wire.android.di.metro.metroViewModel
+import com.wire.android.di.metro.scopedAssistedMetroViewModel
+import com.wire.android.di.metro.scopedMetroViewModel
 import com.wire.android.ui.home.conversations.folder.ConversationFoldersStateArgs
 import com.wire.android.ui.home.conversations.folder.ConversationFoldersVM
 import com.wire.android.ui.home.conversations.folder.ConversationFoldersVMImpl
@@ -34,61 +33,58 @@ import com.wire.android.ui.home.conversations.search.adddembertoconversation.Add
 import com.wire.android.ui.home.conversations.search.apps.SearchAppsViewModel
 import com.wire.android.ui.home.conversations.search.messages.SearchConversationMessagesViewModel
 import com.wire.kalium.logic.data.conversation.Conversation
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
 
-interface ConversationSearchFolderViewModelGraph : MetroViewModelGraph {
-    val conversationSearchFolderViewModelFactory: ConversationSearchFolderViewModelFactory
+interface ConversationSearchFolderManualViewModelFactory : ManualViewModelAssistedFactory {
+    fun conversationFoldersViewModel(args: ConversationFoldersStateArgs): ConversationFoldersVMImpl
+    fun moveConversationToFolderViewModel(args: MoveConversationToFolderArgs): MoveConversationToFolderVMImpl
+    fun searchAppsViewModel(protocolInfo: Conversation.ProtocolInfo?): SearchAppsViewModel
 }
 
 @Composable
-fun conversationFoldersViewModel(args: ConversationFoldersStateArgs): ConversationFoldersVM =
-    metroViewModel<ConversationSearchFolderViewModelGraph, ConversationFoldersVMImpl>(
+fun conversationFoldersViewModel(
+    args: ConversationFoldersStateArgs
+): ConversationFoldersVM =
+    scopedAssistedMetroViewModel<ConversationFoldersVMImpl, ConversationSearchFolderManualViewModelFactory>(
         key = "conversation_folders_${args.selectedFolderId}"
     ) {
-        conversationSearchFolderViewModelFactory.conversationFoldersViewModel(args)
+        conversationFoldersViewModel(args)
     }
 
 @Composable
-fun moveConversationToFolderViewModel(args: MoveConversationToFolderArgs): MoveConversationToFolderVM =
-    metroViewModel<ConversationSearchFolderViewModelGraph, MoveConversationToFolderVMImpl>(
+fun moveConversationToFolderViewModel(
+    args: MoveConversationToFolderArgs
+): MoveConversationToFolderVM =
+    scopedAssistedMetroViewModel<MoveConversationToFolderVMImpl, ConversationSearchFolderManualViewModelFactory>(
         key = "move_conversation_to_folder_${args.conversationId}_${args.currentFolderId}"
     ) {
-        conversationSearchFolderViewModelFactory.moveConversationToFolderViewModel(args)
+        moveConversationToFolderViewModel(args)
     }
 
 @Composable
 fun newFolderViewModel(): NewFolderViewModel =
-    metroViewModel<ConversationSearchFolderViewModelGraph, NewFolderViewModel> {
-        conversationSearchFolderViewModelFactory.newFolderViewModel()
-    }
+    scopedMetroViewModel()
 
 @Composable
 fun searchUserViewModel(): SearchUserViewModel =
-    metroSavedStateViewModel<ConversationSearchFolderViewModelGraph, SearchUserViewModel> {
-        conversationSearchFolderViewModelFactory.searchUserViewModel(it)
-    }
+    scopedMetroViewModel()
 
 @Composable
 fun addMembersToConversationViewModel(): AddMembersToConversationViewModel =
-    metroSavedStateViewModel<ConversationSearchFolderViewModelGraph, AddMembersToConversationViewModel> {
-        conversationSearchFolderViewModelFactory.addMembersToConversationViewModel(it)
-    }
+    scopedMetroViewModel()
 
 @Composable
 fun searchConversationMessagesViewModel(): SearchConversationMessagesViewModel =
-    metroSavedStateViewModel<ConversationSearchFolderViewModelGraph, SearchConversationMessagesViewModel> {
-        conversationSearchFolderViewModelFactory.searchConversationMessagesViewModel(it)
-    }
+    scopedMetroViewModel()
 
 @Composable
 fun searchAppsViewModel(protocolInfo: Conversation.ProtocolInfo?): SearchAppsViewModel =
-    metroViewModel<ConversationSearchFolderViewModelGraph, SearchAppsViewModel>(
+    scopedAssistedMetroViewModel<SearchAppsViewModel, ConversationSearchFolderManualViewModelFactory>(
         key = "search_apps_protocol_info_${protocolInfo?.name()}"
     ) {
-        conversationSearchFolderViewModelFactory.searchAppsViewModel(protocolInfo)
+        searchAppsViewModel(protocolInfo)
     }
 
 @Composable
 fun promoteAdminViewModel(): PromoteAdminViewModel =
-    metroSavedStateViewModel<ConversationSearchFolderViewModelGraph, PromoteAdminViewModel> {
-        conversationSearchFolderViewModelFactory.promoteAdminViewModel(it)
-    }
+    scopedMetroViewModel()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationSearchFolderViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationSearchFolderViewModelGraph.kt
@@ -15,11 +15,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+@file:Suppress("MatchingDeclarationName")
+
 package com.wire.android.ui.home.conversations
 
 import androidx.compose.runtime.Composable
-import com.wire.android.di.metro.scopedAssistedMetroViewModel
-import com.wire.android.di.metro.scopedMetroViewModel
+import com.wire.android.di.viewModelScopedPreviewOrNull
+import com.wire.android.di.metro.sessionKeyedAssistedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedAssistedMetroViewModelAs
+import com.wire.android.di.metro.sessionKeyedMetroViewModel
 import com.wire.android.ui.home.conversations.folder.ConversationFoldersStateArgs
 import com.wire.android.ui.home.conversations.folder.ConversationFoldersVM
 import com.wire.android.ui.home.conversations.folder.ConversationFoldersVMImpl
@@ -45,8 +49,13 @@ interface ConversationSearchFolderManualViewModelFactory : ManualViewModelAssist
 fun conversationFoldersViewModel(
     args: ConversationFoldersStateArgs
 ): ConversationFoldersVM =
-    scopedAssistedMetroViewModel<ConversationFoldersVMImpl, ConversationSearchFolderManualViewModelFactory>(
-        key = "conversation_folders_${args.selectedFolderId}"
+    sessionKeyedAssistedMetroViewModelAs<
+        ConversationFoldersVMImpl,
+        ConversationFoldersVM,
+        ConversationSearchFolderManualViewModelFactory,
+        >(
+        key = "conversation_folders_${args.selectedFolderId}",
+        previewProvider = { viewModelScopedPreviewOrNull<ConversationFoldersVM>() },
     ) {
         conversationFoldersViewModel(args)
     }
@@ -55,31 +64,36 @@ fun conversationFoldersViewModel(
 fun moveConversationToFolderViewModel(
     args: MoveConversationToFolderArgs
 ): MoveConversationToFolderVM =
-    scopedAssistedMetroViewModel<MoveConversationToFolderVMImpl, ConversationSearchFolderManualViewModelFactory>(
-        key = "move_conversation_to_folder_${args.conversationId}_${args.currentFolderId}"
+    sessionKeyedAssistedMetroViewModelAs<
+        MoveConversationToFolderVMImpl,
+        MoveConversationToFolderVM,
+        ConversationSearchFolderManualViewModelFactory,
+        >(
+        key = "move_conversation_to_folder_${args.conversationId}_${args.currentFolderId}",
+        previewProvider = { viewModelScopedPreviewOrNull<MoveConversationToFolderVM>() },
     ) {
         moveConversationToFolderViewModel(args)
     }
 
 @Composable
 fun newFolderViewModel(): NewFolderViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun searchUserViewModel(): SearchUserViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun addMembersToConversationViewModel(): AddMembersToConversationViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun searchConversationMessagesViewModel(): SearchConversationMessagesViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()
 
 @Composable
 fun searchAppsViewModel(protocolInfo: Conversation.ProtocolInfo?): SearchAppsViewModel =
-    scopedAssistedMetroViewModel<SearchAppsViewModel, ConversationSearchFolderManualViewModelFactory>(
+    sessionKeyedAssistedMetroViewModel<SearchAppsViewModel, ConversationSearchFolderManualViewModelFactory>(
         key = "search_apps_protocol_info_${protocolInfo?.name()}"
     ) {
         searchAppsViewModel(protocolInfo)
@@ -87,4 +101,4 @@ fun searchAppsViewModel(protocolInfo: Conversation.ProtocolInfo?): SearchAppsVie
 
 @Composable
 fun promoteAdminViewModel(): PromoteAdminViewModel =
-    scopedMetroViewModel()
+    sessionKeyedMetroViewModel()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ScopedMessageViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ScopedMessageViewModelGraph.kt
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+@file:Suppress("MatchingDeclarationName")
+
 package com.wire.android.ui.home.conversations
 
 import androidx.compose.runtime.Composable
@@ -162,8 +164,7 @@ fun isFileSharingEnabledViewModel(): IsFileSharingEnabledViewModel =
 
 @Composable
 fun recordAudioViewModel(): RecordAudioViewModel =
-    wireManualMetroViewModelScoped<RecordAudioViewModel, ScopedMessageManualViewModelFactory>(
-    ) {
+    wireManualMetroViewModelScoped<RecordAudioViewModel, ScopedMessageManualViewModelFactory> {
         recordAudioViewModel()
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ScopedMessageViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ScopedMessageViewModelGraph.kt
@@ -22,8 +22,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.sebaslogen.resaca.KeyInScopeResolver
 import com.wire.android.di.ScopedArgs
-import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.wireMetroViewModelScoped
+import com.wire.android.di.wireManualMetroViewModelScoped
 import com.wire.android.media.audiomessage.AudioMessageArgs
 import com.wire.android.media.audiomessage.AudioMessageViewModel
 import com.wire.android.media.audiomessage.AudioMessageViewModelImpl
@@ -43,10 +42,18 @@ import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActio
 import com.wire.android.ui.home.messagecomposer.attachments.IsFileSharingEnabledViewModel
 import com.wire.android.ui.home.messagecomposer.attachments.IsFileSharingEnabledViewModelImpl
 import com.wire.android.ui.home.messagecomposer.recordaudio.RecordAudioViewModel
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
 import kotlin.time.Duration
 
-interface ScopedMessageViewModelGraph : MetroViewModelGraph {
-    val scopedMessageViewModelFactory: ScopedMessageViewModelFactory
+internal interface ScopedMessageManualViewModelFactory : ManualViewModelAssistedFactory {
+    fun compositeMessageViewModel(savedStateHandle: SavedStateHandle, args: CompositeMessageArgs): CompositeMessageViewModelImpl
+    fun messageOptionsMenuViewModel(args: MessageOptionsMenuArgs): MessageOptionsMenuViewModelImpl
+    fun typingIndicatorViewModel(args: TypingIndicatorArgs): TypingIndicatorViewModelImpl
+    fun assetLocalPathViewModel(args: AssetLocalPathArgs): AssetLocalPathViewModelImpl
+    fun selfDeletingMessageActionViewModel(args: SelfDeletingMessageActionArgs): SelfDeletingMessageActionViewModelImpl
+    fun isFileSharingEnabledViewModel(): IsFileSharingEnabledViewModelImpl
+    fun recordAudioViewModel(): RecordAudioViewModel
+    fun audioMessageViewModel(args: AudioMessageArgs): AudioMessageViewModelImpl
 }
 
 @Composable
@@ -54,13 +61,13 @@ interface ScopedMessageViewModelGraph : MetroViewModelGraph {
 private inline fun <reified VM, reified S, reified R : ScopedArgs> scopedMessageViewModel(
     arguments: R,
     clearDelay: Duration? = null,
-    noinline create: ScopedMessageViewModelFactory.(SavedStateHandle, R) -> VM,
+    noinline create: ScopedMessageManualViewModelFactory.(SavedStateHandle, R) -> VM,
 ): S where VM : ViewModel, VM : S =
-    wireMetroViewModelScoped<ScopedMessageViewModelGraph, VM, S, R>(
+    wireManualMetroViewModelScoped<VM, S, R, ScopedMessageManualViewModelFactory>(
         arguments = arguments,
         clearDelay = clearDelay,
     ) { savedStateHandle, scopedArgs ->
-        scopedMessageViewModelFactory.create(savedStateHandle, scopedArgs)
+        create(savedStateHandle, scopedArgs)
     }
 
 @Composable
@@ -69,30 +76,32 @@ private inline fun <reified VM, reified S, reified R : ScopedArgs> scopedMessage
     arguments: R,
     noinline keyInScopeResolver: KeyInScopeResolver<String>,
     clearDelay: Duration? = null,
-    noinline create: ScopedMessageViewModelFactory.(SavedStateHandle, R) -> VM,
+    noinline create: ScopedMessageManualViewModelFactory.(SavedStateHandle, R) -> VM,
 ): S where VM : ViewModel, VM : S =
-    wireMetroViewModelScoped<ScopedMessageViewModelGraph, VM, S, R>(
+    wireManualMetroViewModelScoped<VM, S, R, ScopedMessageManualViewModelFactory>(
         arguments = arguments,
         keyInScopeResolver = keyInScopeResolver,
         clearDelay = clearDelay,
     ) { savedStateHandle, scopedArgs ->
-        scopedMessageViewModelFactory.create(savedStateHandle, scopedArgs)
+        create(savedStateHandle, scopedArgs)
     }
 
 @Composable
 @Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
 private inline fun <reified VM, reified S> scopedMessageViewModel(
     clearDelay: Duration? = null,
-    noinline create: ScopedMessageViewModelFactory.(SavedStateHandle) -> VM,
+    noinline create: ScopedMessageManualViewModelFactory.(SavedStateHandle) -> VM,
 ): S where VM : ViewModel, VM : S =
-    wireMetroViewModelScoped<ScopedMessageViewModelGraph, VM, S>(
+    wireManualMetroViewModelScoped<VM, S, ScopedMessageManualViewModelFactory>(
         clearDelay = clearDelay,
     ) { savedStateHandle ->
-        scopedMessageViewModelFactory.create(savedStateHandle)
+        create(savedStateHandle)
     }
 
 @Composable
-fun compositeMessageViewModel(args: CompositeMessageArgs): CompositeMessageViewModel =
+fun compositeMessageViewModel(
+    args: CompositeMessageArgs,
+): CompositeMessageViewModel =
     scopedMessageViewModel<CompositeMessageViewModelImpl, CompositeMessageViewModel, CompositeMessageArgs>(
         arguments = args,
     ) { savedStateHandle, scopedArgs ->
@@ -100,13 +109,17 @@ fun compositeMessageViewModel(args: CompositeMessageArgs): CompositeMessageViewM
     }
 
 @Composable
-fun messageOptionsMenuViewModel(args: MessageOptionsMenuArgs): MessageOptionsMenuViewModel =
+fun messageOptionsMenuViewModel(
+    args: MessageOptionsMenuArgs,
+): MessageOptionsMenuViewModel =
     scopedMessageViewModel<MessageOptionsMenuViewModelImpl, MessageOptionsMenuViewModel, MessageOptionsMenuArgs>(args) { _, scopedArgs ->
         messageOptionsMenuViewModel(scopedArgs)
     }
 
 @Composable
-fun typingIndicatorViewModel(args: TypingIndicatorArgs): TypingIndicatorViewModel =
+fun typingIndicatorViewModel(
+    args: TypingIndicatorArgs,
+): TypingIndicatorViewModel =
     scopedMessageViewModel<TypingIndicatorViewModelImpl, TypingIndicatorViewModel, TypingIndicatorArgs>(args) { _, scopedArgs ->
         typingIndicatorViewModel(scopedArgs)
     }
@@ -130,7 +143,9 @@ fun assetLocalPathViewModel(
     }
 
 @Composable
-fun selfDeletingMessageActionViewModel(args: SelfDeletingMessageActionArgs): SelfDeletingMessageActionViewModel =
+fun selfDeletingMessageActionViewModel(
+    args: SelfDeletingMessageActionArgs,
+): SelfDeletingMessageActionViewModel =
     scopedMessageViewModel<
             SelfDeletingMessageActionViewModelImpl,
             SelfDeletingMessageActionViewModel,
@@ -147,8 +162,9 @@ fun isFileSharingEnabledViewModel(): IsFileSharingEnabledViewModel =
 
 @Composable
 fun recordAudioViewModel(): RecordAudioViewModel =
-    wireMetroViewModelScoped<ScopedMessageViewModelGraph, RecordAudioViewModel> {
-        scopedMessageViewModelFactory.recordAudioViewModel()
+    wireManualMetroViewModelScoped<RecordAudioViewModel, ScopedMessageManualViewModelFactory>(
+    ) {
+        recordAudioViewModel()
     }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.ui.home.conversations.details
 
+import android.annotation.SuppressLint
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
@@ -135,6 +136,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 @Suppress("CyclomaticComplexMethod")
+@SuppressLint("ComposeViewModelForwarding")
 @WireRootDestination(
     navArgs = GroupConversationDetailsNavArgs::class,
     style = PopUpNavigationAnimation::class, // default should be PopUpNavigationAnimation
@@ -359,11 +361,11 @@ fun GroupConversationDetailsScreen(
 }
 
 @Suppress("CyclomaticComplexMethod")
+@SuppressLint("ComposeViewModelForwarding")
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun GroupConversationDetailsContent(
     groupConversationOptionsState: GroupConversationOptionsState,
-    viewModel: GroupConversationDetailsViewModel? = null,
     sheetState: WireModalSheetState<ConversationSheetState>,
     onBackPressed: () -> Unit,
     onProfilePressed: (UIParticipant) -> Unit,
@@ -378,6 +380,7 @@ private fun GroupConversationDetailsContent(
     isWireCellEnabled: Boolean,
     onSearchConversationMessagesClick: () -> Unit,
     onConversationMediaClick: () -> Unit,
+    viewModel: GroupConversationDetailsViewModel? = null,
     onMoveToFolder: (ConversationFoldersNavArgs) -> Unit = {},
     onLeftConversation: () -> Unit = {},
     onDeletedConversation: () -> Unit = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsScreen.kt
@@ -193,6 +193,7 @@ fun GroupConversationDetailsScreen(
     GroupConversationDetailsContent(
         sheetState = sheetState,
         groupConversationOptionsState = groupOptions,
+        viewModel = viewModel,
         onBackPressed = navigator::navigateBack,
         onProfilePressed = { participant ->
             when {
@@ -362,6 +363,7 @@ fun GroupConversationDetailsScreen(
 @Composable
 private fun GroupConversationDetailsContent(
     groupConversationOptionsState: GroupConversationOptionsState,
+    viewModel: GroupConversationDetailsViewModel? = null,
     sheetState: WireModalSheetState<ConversationSheetState>,
     onBackPressed: () -> Unit,
     onProfilePressed: (UIParticipant) -> Unit,
@@ -539,6 +541,9 @@ private fun GroupConversationDetailsContent(
                             onAppsAccessItemClicked = onAppsAccessItemClicked,
                             onChannelAccessItemClicked = onChannelAccessItemClicked,
                             onEditSelfDeletingMessages = onEditSelfDeletingMessages,
+                            viewModel = requireNotNull(viewModel) {
+                                "GroupConversationDetailsContent requires GroupConversationDetailsViewModel outside preview"
+                            },
                             onEditGroupName = onEditGroupName
                         )
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
@@ -44,6 +44,7 @@ import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
+import com.wire.android.navigation.rememberNavigator
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.dimensions
@@ -233,4 +234,10 @@ fun EditGuestAccessScreen(
             )
         }
     }
+}
+
+@Preview
+@Composable
+fun PreviewEditGuestAccessScreen() {
+    EditGuestAccessScreen(rememberNavigator {})
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/EditGuestAccessScreen.kt
@@ -44,7 +44,6 @@ import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
-import com.wire.android.navigation.rememberNavigator
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
 import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.dimensions
@@ -234,10 +233,4 @@ fun EditGuestAccessScreen(
             )
         }
     }
-}
-
-@Preview
-@Composable
-fun PreviewEditGuestAccessScreen() {
-    EditGuestAccessScreen(rememberNavigator {})
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
+import com.wire.android.navigation.rememberNavigator
 import com.wire.android.ui.common.button.WireButton
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.divider.WireDivider
@@ -164,6 +165,12 @@ fun SelectableSelfDeletingItem(
             color = MaterialTheme.wireColorScheme.onBackground
         )
     }
+}
+
+@Preview
+@Composable
+fun PreviewEditSelfDeletingMessagesScreen() {
+    EditSelfDeletingMessagesScreen(rememberNavigator {})
 }
 
 @Preview

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.navigation.style.SlideNavigationAnimation
 import com.wire.android.R
 import com.wire.android.navigation.Navigator
-import com.wire.android.navigation.rememberNavigator
 import com.wire.android.ui.common.button.WireButton
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.divider.WireDivider
@@ -165,12 +164,6 @@ fun SelectableSelfDeletingItem(
             color = MaterialTheme.wireColorScheme.onBackground
         )
     }
-}
-
-@Preview
-@Composable
-fun PreviewEditSelfDeletingMessagesScreen() {
-    EditSelfDeletingMessagesScreen(rememberNavigator {})
 }
 
 @Preview

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -20,7 +20,6 @@
 
 package com.wire.android.ui.home.conversations.details.options
 
-import com.wire.android.ui.home.conversations.groupConversationDetailsViewModel
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
@@ -72,7 +71,7 @@ fun GroupConversationOptions(
     onAppsAccessItemClicked: () -> Unit,
     onChannelAccessItemClicked: () -> Unit,
     onEditSelfDeletingMessages: () -> Unit,
-    viewModel: GroupConversationDetailsViewModel = groupConversationDetailsViewModel(),
+    viewModel: GroupConversationDetailsViewModel,
     onEditGroupName: () -> Unit
 ) {
     val state by viewModel.groupOptionsState.collectAsStateWithLifecycle()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -20,7 +20,6 @@
 
 package com.wire.android.ui.home.conversations.details.options
 
-
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
@@ -62,7 +62,9 @@ fun MessageOptionsModalSheetLayout(
     onDownloadAssetClick: (messageId: String) -> Unit,
     onOpenAssetClick: (messageId: String) -> Unit,
     viewModel: MessageOptionsMenuViewModel =
-        messageOptionsMenuViewModel(MessageOptionsMenuArgs(conversationId))
+        messageOptionsMenuViewModel(
+            args = MessageOptionsMenuArgs(conversationId)
+        )
 ) {
     val context = LocalContext.current
     val snackbarHostState = LocalSnackbarHostState.current

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMessage.kt
@@ -621,9 +621,14 @@ private fun QuotedImageThumbnail(
     val keyInScopeResolver = LocalAssetLocalPathKeyInScopeResolver.current
     val viewModel: AssetLocalPathViewModel =
         if (keyInScopeResolver != null && keyInScopeResolver(args.key)) {
-            assetLocalPathViewModel(args, keyInScopeResolver)
+            assetLocalPathViewModel(
+                args,
+                keyInScopeResolver
+            )
         } else {
-            assetLocalPathViewModel(args)
+            assetLocalPathViewModel(
+                args
+            )
         }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/QuotedMultipartMessage.kt
@@ -75,7 +75,9 @@ fun QuotedMultipartMessage(
     accent: Accent,
     clickable: Clickable?,
     modifier: Modifier = Modifier,
-    viewModel: QuotedMultipartMessageViewModel = quotedMultipartMessageViewModel(conversationId.toString()),
+    viewModel: QuotedMultipartMessageViewModel = quotedMultipartMessageViewModel(
+        conversationId.toString()
+    ),
     startContent: @Composable () -> Unit = {}
 ) {
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.media.audiomessage.AudioMessageArgs
@@ -77,7 +78,12 @@ internal fun UIMessage.Regular.MessageContentAndStatus(
     conversationDetailsData: ConversationDetailsData,
     accent: Accent = Accent.Unknown,
 ) {
-    val conversationAssetPathsViewModel = conversationAssetPathsViewModel(message.conversationId.toString())
+    val conversationAssetPathsViewModel = when {
+        LocalInspectionMode.current -> ConversationAssetPathsViewModelPreview
+        else -> conversationAssetPathsViewModel(
+            message.conversationId.toString()
+        )
+    }
 
     val onAssetClickable = remember(message) {
         Clickable(enabled = isAvailable, onClick = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -173,7 +173,9 @@ fun MessageButtonsContent(
     messageStyle: MessageStyle,
     modifier: Modifier = Modifier,
     viewModel: CompositeMessageViewModel =
-        compositeMessageViewModel(CompositeMessageArgs(messageId))
+        compositeMessageViewModel(
+            CompositeMessageArgs(messageId)
+        )
 ) {
     Column(
         modifier = modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationsScreenContent.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
@@ -93,8 +94,14 @@ fun ConversationsScreenContent(
     conversationsSource: ConversationsSource = ConversationsSource.MAIN,
     emptySearchResultFocusRequester: FocusRequester? = null,
     firstConversationFocusRequester: FocusRequester? = null,
-    conversationListCallViewModel: ConversationListCallViewModel = conversationListCallViewModel(conversationsSource),
-    conversationListViewModel: ConversationListViewModel = conversationListViewModel(conversationsSource),
+    conversationListCallViewModel: ConversationListCallViewModel = when {
+        LocalInspectionMode.current -> ConversationListCallViewModelPreview
+        else -> conversationListCallViewModel(conversationsSource)
+    },
+    conversationListViewModel: ConversationListViewModel = when {
+        LocalInspectionMode.current -> ConversationListViewModelPreview()
+        else -> conversationListViewModel(conversationsSource)
+    },
 ) {
     val sheetState = rememberWireModalSheetState<ConversationSheetState>()
     val permissionPermanentlyDeniedDialogState = rememberVisibilityState<PermissionPermanentlyDeniedDialogState>()

--- a/app/src/main/kotlin/com/wire/android/ui/home/meetings/MeetingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/meetings/MeetingsScreen.kt
@@ -31,7 +31,9 @@ import com.wire.android.ui.home.HomeStateHolder
 
 @WireHomeDestination
 @Composable
-fun MeetingsScreen(homeStateHolder: HomeStateHolder) {
+fun MeetingsScreen(
+    homeStateHolder: HomeStateHolder,
+) {
     AllMeetingsScreen(
         lazyListState = homeStateHolder.lazyListStateFor(HomeDestination.Meetings),
         contentPadding = PaddingValues(bottom = dimensions().spacing80x), // to ensure last item is not obscured by FAB

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/EnabledMessageComposer.kt
@@ -189,7 +189,9 @@ fun EnabledMessageComposer(
                 ) {
                     messageListContent()
                     if (!inputStateHolder.isTextExpanded) {
-                        UsersTypingIndicatorForConversation(conversationId = conversationId)
+                        UsersTypingIndicatorForConversation(
+                            conversationId = conversationId,
+                        )
                     }
                     if (!inputStateHolder.isTextExpanded && messageComposerViewState.value.mentionSearchResult.isNotEmpty()) {
                         MembersMentionList(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposeActions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposeActions.kt
@@ -113,7 +113,7 @@ private fun ComposingActions(
         with(localFeatureVisibilityFlags) {
             AdditionalOptionButton(
                 isSelected = attachmentsVisible,
-                onClick = onAdditionalOptionButtonClicked
+                onClick = onAdditionalOptionButtonClicked,
             )
             RichTextEditingAction(
                 isSelected = selectedOption == AdditionalOptionSelectItem.RichTextEditing,
@@ -244,7 +244,9 @@ fun SelfDeletingMessageAction(
     conversationId: ConversationId,
     onButtonClicked: (SelfDeletionTimer) -> Unit,
     viewModel: SelfDeletingMessageActionViewModel =
-        selfDeletingMessageActionViewModel(SelfDeletingMessageActionArgs(conversationId = conversationId)),
+        selfDeletingMessageActionViewModel(
+            SelfDeletingMessageActionArgs(conversationId = conversationId)
+        ),
 ) {
     when (val state = viewModel.state()) {
         SelfDeletionTimer.Disabled -> {}

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInput.kt
@@ -183,7 +183,9 @@ private fun InputContent(
     onPlusClick: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SelfDeletingMessageActionViewModel =
-        selfDeletingMessageActionViewModel(SelfDeletingMessageActionArgs(conversationId = conversationId)),
+        selfDeletingMessageActionViewModel(
+            SelfDeletingMessageActionArgs(conversationId = conversationId)
+        ),
 ) {
     ConstraintLayout(modifier = modifier) {
         val (additionalOptionButton, input, actions) = createRefs()
@@ -245,7 +247,9 @@ private fun InputContent(
         ) {
             if (isTextExpanded) {
                 Box(modifier = Modifier.align(Alignment.BottomCenter)) {
-                    UsersTypingIndicatorForConversation(conversationId = conversationId)
+                    UsersTypingIndicatorForConversation(
+                        conversationId = conversationId,
+                    )
                 }
             }
             // Only show send button when not in editing mode

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModelGraph.kt
@@ -20,13 +20,10 @@
 package com.wire.android.ui.home.settings
 
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.metroSavedStateViewModel
-import com.wire.android.di.metro.metroViewModel
+import com.wire.android.di.metro.scopedMetroViewModel
 import com.wire.android.ui.home.appLock.forgot.ForgotLockScreenViewModel
 import com.wire.android.ui.home.appLock.set.SetLockScreenViewModel
 import com.wire.android.ui.home.appLock.unlock.AppUnlockWithBiometricsViewModel
@@ -53,24 +50,17 @@ import com.wire.android.ui.userprofile.service.ServiceDetailsViewModel
 import com.wire.android.ui.userprofile.service.ServiceDetailsViewModelImpl
 import com.wire.android.ui.userprofile.teammigration.TeamMigrationViewModel
 
-interface SettingsViewModelGraph : MetroViewModelGraph {
-    val settingsViewModelFactory: SettingsViewModelFactory
-}
-
 @Composable
 inline fun <reified VM> settingsViewModel(
     viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
     },
     key: String? = null,
-    crossinline create: SettingsViewModelFactory.() -> VM,
 ): VM where VM : ViewModel =
-    metroViewModel<SettingsViewModelGraph, VM>(
+    scopedMetroViewModel(
         viewModelStoreOwner = viewModelStoreOwner,
         key = key,
-    ) {
-        settingsViewModelFactory.create()
-    }
+    )
 
 @Composable
 inline fun <reified VM> settingsSavedStateViewModel(
@@ -78,92 +68,104 @@ inline fun <reified VM> settingsSavedStateViewModel(
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
     },
     key: String? = null,
-    crossinline create: SettingsViewModelFactory.(SavedStateHandle) -> VM,
 ): VM where VM : ViewModel =
-    metroSavedStateViewModel<SettingsViewModelGraph, VM>(
+    settingsViewModel(
         viewModelStoreOwner = viewModelStoreOwner,
         key = key,
-    ) { savedStateHandle ->
-        settingsViewModelFactory.create(savedStateHandle)
-    }
+    )
 
 @Composable
-fun settingsScreenViewModel(): SettingsViewModel = settingsViewModel { settingsViewModel() }
+fun settingsScreenViewModel(): SettingsViewModel = settingsViewModel()
 
 @Composable
-fun myAccountViewModel(): MyAccountViewModel = settingsViewModel { myAccountViewModel() }
+fun myAccountViewModel(): MyAccountViewModel = settingsViewModel()
 
 @Composable
-fun deleteAccountViewModel(): DeleteAccountViewModel = settingsViewModel { deleteAccountViewModel() }
+fun deleteAccountViewModel(): DeleteAccountViewModel =
+    settingsViewModel()
 
 @Composable
-fun changeDisplayNameViewModel(): ChangeDisplayNameViewModel = settingsViewModel { changeDisplayNameViewModel() }
+fun changeDisplayNameViewModel(): ChangeDisplayNameViewModel =
+    settingsViewModel()
 
 @Composable
-fun changeUserColorViewModel(): ChangeUserColorViewModel = settingsViewModel { changeUserColorViewModel() }
+fun changeUserColorViewModel(): ChangeUserColorViewModel =
+    settingsViewModel()
 
 @Composable
-fun changeEmailViewModel(): ChangeEmailViewModel = settingsViewModel { changeEmailViewModel() }
+fun changeEmailViewModel(): ChangeEmailViewModel = settingsViewModel()
 
 @Composable
-fun verifyEmailViewModel(): VerifyEmailViewModel = settingsSavedStateViewModel { verifyEmailViewModel(it) }
+fun verifyEmailViewModel(): VerifyEmailViewModel =
+    settingsSavedStateViewModel()
 
 @Composable
-fun changeHandleViewModel(): ChangeHandleViewModel = settingsViewModel { changeHandleViewModel() }
+fun changeHandleViewModel(): ChangeHandleViewModel = settingsViewModel()
 
 @Composable
-fun customizationViewModel(): CustomizationViewModel = settingsViewModel { customizationViewModel() }
+fun customizationViewModel(): CustomizationViewModel =
+    settingsViewModel()
 
 @Composable
-fun networkSettingsViewModel(): NetworkSettingsViewModel = settingsViewModel { networkSettingsViewModel() }
+fun networkSettingsViewModel(): NetworkSettingsViewModel =
+    settingsViewModel()
 
 @Composable
-fun privacySettingsViewModel(): PrivacySettingsViewModel = settingsViewModel { privacySettingsViewModel() }
+fun privacySettingsViewModel(): PrivacySettingsViewModel =
+    settingsViewModel()
 
 @Composable
-fun backupAndRestoreViewModel(): BackupAndRestoreViewModel = settingsViewModel { backupAndRestoreViewModel() }
+fun backupAndRestoreViewModel(): BackupAndRestoreViewModel =
+    settingsViewModel()
 
 @Composable
-fun setLockScreenViewModel(): SetLockScreenViewModel = settingsViewModel { setLockScreenViewModel() }
+fun setLockScreenViewModel(): SetLockScreenViewModel =
+    settingsViewModel()
 
 @Composable
-fun forgotLockScreenViewModel(): ForgotLockScreenViewModel = settingsViewModel { forgotLockScreenViewModel() }
+fun forgotLockScreenViewModel(): ForgotLockScreenViewModel =
+    settingsViewModel()
 
 @Composable
 fun appUnlockWithBiometricsViewModel(): AppUnlockWithBiometricsViewModel =
-    settingsViewModel { appUnlockWithBiometricsViewModel() }
+    settingsViewModel()
 
 @Composable
-fun enterLockScreenViewModel(): EnterLockScreenViewModel = settingsViewModel { enterLockScreenViewModel() }
+fun enterLockScreenViewModel(): EnterLockScreenViewModel =
+    settingsViewModel()
 
 @Composable
-fun selfDevicesViewModel(): SelfDevicesViewModel = settingsViewModel { selfDevicesViewModel() }
+fun selfDevicesViewModel(): SelfDevicesViewModel = settingsViewModel()
 
 @Composable
-fun deviceDetailsViewModel(): DeviceDetailsViewModel = settingsSavedStateViewModel { deviceDetailsViewModel(it) }
+fun deviceDetailsViewModel(): DeviceDetailsViewModel =
+    settingsSavedStateViewModel()
 
 @Composable
 fun e2eiCertificateDetailsViewModel(): E2eiCertificateDetailsViewModel =
-    settingsSavedStateViewModel { e2eiCertificateDetailsViewModel(it) }
+    settingsSavedStateViewModel()
 
 @Composable
-fun avatarPickerViewModel(): AvatarPickerViewModel = settingsViewModel { avatarPickerViewModel() }
+fun avatarPickerViewModel(): AvatarPickerViewModel =
+    settingsViewModel()
 
 @Composable
-fun selfUserProfileViewModel(): SelfUserProfileViewModel = settingsViewModel { selfUserProfileViewModel() }
+fun selfUserProfileViewModel(): SelfUserProfileViewModel =
+    settingsViewModel()
 
 @Composable
-fun selfQRCodeViewModel(): SelfQRCodeViewModel = settingsSavedStateViewModel { selfQRCodeViewModel(it) }
+fun selfQRCodeViewModel(): SelfQRCodeViewModel =
+    settingsSavedStateViewModel()
 
 @Composable
 fun teamMigrationViewModel(
     viewModelStoreOwner: ViewModelStoreOwner,
-): TeamMigrationViewModel = settingsViewModel(viewModelStoreOwner = viewModelStoreOwner) { teamMigrationViewModel() }
+): TeamMigrationViewModel = settingsViewModel(viewModelStoreOwner = viewModelStoreOwner)
 
 @Composable
 fun otherUserProfileScreenViewModel(): OtherUserProfileScreenViewModel =
-    settingsSavedStateViewModel { otherUserProfileScreenViewModel(it) }
+    settingsSavedStateViewModel()
 
 @Composable
 fun serviceDetailsViewModel(): ServiceDetailsViewModel =
-    settingsSavedStateViewModel<ServiceDetailsViewModelImpl> { serviceDetailsViewModel(it) }
+    settingsSavedStateViewModel<ServiceDetailsViewModelImpl>()

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsViewModelGraph.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-import com.wire.android.di.metro.scopedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedMetroViewModel
 import com.wire.android.ui.home.appLock.forgot.ForgotLockScreenViewModel
 import com.wire.android.ui.home.appLock.set.SetLockScreenViewModel
 import com.wire.android.ui.home.appLock.unlock.AppUnlockWithBiometricsViewModel
@@ -57,7 +57,7 @@ inline fun <reified VM> settingsViewModel(
     },
     key: String? = null,
 ): VM where VM : ViewModel =
-    scopedMetroViewModel(
+    sessionKeyedMetroViewModel(
         viewModelStoreOwner = viewModelStoreOwner,
         key = key,
     )

--- a/app/src/main/kotlin/com/wire/android/ui/joinConversation/JoinConversationViaDeepLinkDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/joinConversation/JoinConversationViaDeepLinkDialog.kt
@@ -47,10 +47,12 @@ import com.wire.android.ui.common.textfield.DefaultPassword
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.wireDialogPropertiesBuilder
+import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.capitalizeFirstLetter
 import com.wire.android.util.toTitleCase
+import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.stringWithStyledArgs
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.conversation.CheckConversationInviteCodeUseCase
@@ -175,5 +177,18 @@ fun JoinConversationViaDeepLinkDialog(
             dismissOnBackPress = false,
             dismissOnClickOutside = false
         )
+    )
+}
+
+@PreviewMultipleThemes
+@Composable
+fun JoinConversationViaDeepLinkDialogPreview() = WireTheme {
+    JoinConversationViaDeepLinkDialog(
+        onFlowCompleted = { _ -> },
+        requirePassword = true,
+        name = "Test",
+        code = "123",
+        key = "123",
+        domain = "test.com"
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/joinConversation/JoinConversationViaDeepLinkDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/joinConversation/JoinConversationViaDeepLinkDialog.kt
@@ -47,12 +47,10 @@ import com.wire.android.ui.common.textfield.DefaultPassword
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.wireDialogPropertiesBuilder
-import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.capitalizeFirstLetter
 import com.wire.android.util.toTitleCase
-import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.stringWithStyledArgs
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.conversation.CheckConversationInviteCodeUseCase
@@ -177,18 +175,5 @@ fun JoinConversationViaDeepLinkDialog(
             dismissOnBackPress = false,
             dismissOnClickOutside = false
         )
-    )
-}
-
-@PreviewMultipleThemes
-@Composable
-fun JoinConversationViaDeepLinkDialogPreview() = WireTheme {
-    JoinConversationViaDeepLinkDialog(
-        onFlowCompleted = { _ -> },
-        requirePassword = true,
-        name = "Test",
-        code = "123",
-        key = "123",
-        domain = "test.com"
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -156,7 +156,7 @@ fun DeviceDetailsContent(
     onUpdateClientVerification: (Boolean) -> Unit = {},
     onEnrollE2EIErrorDismiss: () -> Unit = {},
     onEnrollE2EISuccessDismiss: () -> Unit = {},
-    onBreakSession: () -> Unit = {}
+    onBreakSession: () -> Unit = {},
 ) {
     val screenState = rememberConversationScreenState()
     WireScaffold(

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -151,7 +151,7 @@ fun ImportMediaScreen(
         is FeatureFlagState.FileSharingState.AllowSome -> {
             ImportMediaAuthenticatedContent(
                 navigator = navigator,
-                isRestrictedInTeam = fileSharingRestrictedState == FeatureFlagState.FileSharingState.DisabledByTeam,
+                                isRestrictedInTeam = fileSharingRestrictedState == FeatureFlagState.FileSharingState.DisabledByTeam,
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -145,7 +145,7 @@ fun OtherUserProfileScreen(
     OtherProfileScreenContent(
         scope = scope,
         state = viewModel.state,
-        conversationOptionsSheetState = conversationOptionsSheetState,
+                conversationOptionsSheetState = conversationOptionsSheetState,
         changeRoleSheetState = changeRoleSheetState,
         removeMemberDialogState = viewModel.removeConversationMemberDialogState,
         eventsHandler = viewModel as OtherUserProfileEventsHandler,
@@ -309,7 +309,7 @@ fun OtherProfileScreenContent(
         sheetState = conversationOptionsSheetState,
         openConversationFolders = onMoveToFolder,
         openConversationDebugMenu = openConversationDebugMenu,
-    )
+            )
     EditGroupRoleBottomSheet(
         sheetState = changeRoleSheetState,
         changeMemberRole = onChangeMemberRole,

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -560,13 +560,20 @@ public fun com.ramcosta.composedestinations.generated.app.destinations.WhatsNewS
   params:
 
 @Composable
-public fun com.wire.android.di.currentMetroViewModelGraph(): Graph of com.wire.android.di.currentMetroViewModelGraph
+internal fun com.wire.android.di.defaultViewModelCreationExtras(): androidx.lifecycle.viewmodel.CreationExtras
   skippable: true
   restartable: true
   params:
 
 @Composable
-public fun com.wire.android.di.wireMetroViewModelScoped(arguments: R of com.wire.android.di.wireMetroViewModelScoped, clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function3<Graph of com.wire.android.di.wireMetroViewModelScoped, androidx.lifecycle.SavedStateHandle, R of com.wire.android.di.wireMetroViewModelScoped, T of com.wire.android.di.wireMetroViewModelScoped>): S of com.wire.android.di.wireMetroViewModelScoped
+internal fun com.wire.android.di.manualScopedViewModelFactory(create: @[ExtensionFunctionType] kotlin.Function2<FactoryType of com.wire.android.di.manualScopedViewModelFactory, androidx.lifecycle.viewmodel.CreationExtras, T of com.wire.android.di.manualScopedViewModelFactory>): androidx.lifecycle.ViewModelProvider.Factory
+  skippable: true
+  restartable: true
+  params:
+    - create: STABLE (function type)
+
+@Composable
+public fun com.wire.android.di.wireManualMetroViewModelScoped(arguments: R of com.wire.android.di.wireManualMetroViewModelScoped, clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function3<FactoryType of com.wire.android.di.wireManualMetroViewModelScoped, androidx.lifecycle.SavedStateHandle, R of com.wire.android.di.wireManualMetroViewModelScoped, T of com.wire.android.di.wireManualMetroViewModelScoped>): S of com.wire.android.di.wireManualMetroViewModelScoped
   skippable: false
   restartable: true
   params:
@@ -575,7 +582,7 @@ public fun com.wire.android.di.wireMetroViewModelScoped(arguments: R of com.wire
     - create: STABLE (function type)
 
 @Composable
-public fun com.wire.android.di.wireMetroViewModelScoped(arguments: R of com.wire.android.di.wireMetroViewModelScoped, keyInScopeResolver: kotlin.Function1<@[ParameterName(name = \, clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function3<Graph of com.wire.android.di.wireMetroViewModelScoped, androidx.lifecycle.SavedStateHandle, R of com.wire.android.di.wireMetroViewModelScoped, T of com.wire.android.di.wireMetroViewModelScoped>): S of com.wire.android.di.wireMetroViewModelScoped
+public fun com.wire.android.di.wireManualMetroViewModelScoped(arguments: R of com.wire.android.di.wireManualMetroViewModelScoped, keyInScopeResolver: kotlin.Function1<@[ParameterName(name = \, clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function3<FactoryType of com.wire.android.di.wireManualMetroViewModelScoped, androidx.lifecycle.SavedStateHandle, R of com.wire.android.di.wireManualMetroViewModelScoped, T of com.wire.android.di.wireManualMetroViewModelScoped>): S of com.wire.android.di.wireManualMetroViewModelScoped
   skippable: false
   restartable: true
   params:
@@ -585,7 +592,7 @@ public fun com.wire.android.di.wireMetroViewModelScoped(arguments: R of com.wire
     - create: STABLE (function type)
 
 @Composable
-public fun com.wire.android.di.wireMetroViewModelScoped(clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function2<Graph of com.wire.android.di.wireMetroViewModelScoped, androidx.lifecycle.SavedStateHandle, T of com.wire.android.di.wireMetroViewModelScoped>): S of com.wire.android.di.wireMetroViewModelScoped
+public fun com.wire.android.di.wireManualMetroViewModelScoped(clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function2<FactoryType of com.wire.android.di.wireManualMetroViewModelScoped, androidx.lifecycle.SavedStateHandle, T of com.wire.android.di.wireManualMetroViewModelScoped>): S of com.wire.android.di.wireManualMetroViewModelScoped
   skippable: true
   restartable: true
   params:
@@ -593,7 +600,7 @@ public fun com.wire.android.di.wireMetroViewModelScoped(clearDelay: kotlin.time.
     - create: STABLE (function type)
 
 @Composable
-public fun com.wire.android.di.wireMetroViewModelScoped(clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function2<Graph of com.wire.android.di.wireMetroViewModelScoped, androidx.lifecycle.SavedStateHandle, T of com.wire.android.di.wireMetroViewModelScoped>): T of com.wire.android.di.wireMetroViewModelScoped
+public fun com.wire.android.di.wireManualMetroViewModelScoped(clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function2<FactoryType of com.wire.android.di.wireManualMetroViewModelScoped, androidx.lifecycle.SavedStateHandle, T of com.wire.android.di.wireManualMetroViewModelScoped>): T of com.wire.android.di.wireManualMetroViewModelScoped
   skippable: true
   restartable: true
   params:
@@ -611,7 +618,7 @@ public fun com.wire.android.navigation.MainNavHost(navigator: com.wire.android.n
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - loginTypeSelector: RUNTIME (requires runtime check)
     - startDestination: RUNTIME (requires runtime check)
     - modifier: STABLE (marked @Stable or @Immutable)
@@ -722,7 +729,7 @@ internal fun com.wire.android.ui.HandleViewActions(actions: kotlinx.coroutines.f
   restartable: true
   params:
     - actions: RUNTIME (requires runtime check)
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - loginTypeSelector: RUNTIME (requires runtime check)
 
 @Composable
@@ -783,7 +790,7 @@ private fun com.wire.android.ui.WireActivity.HandleDialogs(navigator: com.wire.a
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - activityViewModels: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -800,28 +807,37 @@ private fun com.wire.android.ui.WireActivity.HandleThemeChanges(themeOption: com
     - themeOption: STABLE (class with no mutable properties)
 
 @Composable
-private fun com.wire.android.ui.WireActivity.SetUpNavigation(navigator: com.wire.android.navigation.Navigator): kotlin.Unit
-  skippable: false
+private fun com.wire.android.ui.WireActivity.ProvideViewModelGraph(content: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - content: STABLE (composable function type)
 
 @Composable
-private fun com.wire.android.ui.WireActivity.rememberMetroViewModelGraph(currentBaseRoute: kotlin.String?, startDestinationBaseRoute: kotlin.String, sessionViewModelGraph: com.wire.android.di.metro.AppSessionViewModelGraph?, authenticationViewModelGraph: com.wire.android.di.metro.AppAuthenticationViewModelGraph): com.wire.android.di.metro.MetroViewModelGraph?
+private fun com.wire.android.ui.WireActivity.SetUpNavigation(navigator: com.wire.android.navigation.Navigator): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - navigator: STABLE (marked @Stable or @Immutable)
+
+@Composable
+private fun com.wire.android.ui.WireActivity.rememberWireActivityGraphContext(appGraph: com.wire.android.di.metro.WireApplicationGraph, authenticationViewModelGraph: com.wire.android.di.metro.AppAuthenticationViewModelGraph, currentUserId: com.wire.kalium.logic.data.id.QualifiedID?, currentBaseRoute: kotlin.String?, startDestinationBaseRoute: kotlin.String, isUserUiBlocked: kotlin.Boolean): com.wire.android.ui.WireActivityGraphContext?
   skippable: false
   restartable: true
   params:
+    - appGraph: RUNTIME (requires runtime check)
+    - authenticationViewModelGraph: STABLE (class with no mutable properties)
+    - currentUserId: UNSTABLE (has mutable properties or unstable members)
     - currentBaseRoute: STABLE (class with no mutable properties)
     - startDestinationBaseRoute: STABLE (String is immutable)
-    - sessionViewModelGraph: UNSTABLE (has mutable properties or unstable members)
-    - authenticationViewModelGraph: RUNTIME (requires runtime check)
+    - isUserUiBlocked: STABLE (primitive type)
 
 @Composable
 private fun com.wire.android.ui.WireActivity.wireActivityScopedViewModels(graph: com.wire.android.di.metro.AppSessionViewModelGraph): com.wire.android.ui.WireActivityScopedViewModels
   skippable: false
   restartable: true
   params:
-    - graph: UNSTABLE (has mutable properties or unstable members)
+    - graph: RUNTIME (requires runtime check)
 
 @Composable
 public fun com.wire.android.ui.analyticsUsageViewModel(): com.wire.android.ui.analytics.AnalyticsUsageViewModel
@@ -830,22 +846,20 @@ public fun com.wire.android.ui.analyticsUsageViewModel(): com.wire.android.ui.an
   params:
 
 @Composable
-public fun com.wire.android.ui.authentication.authenticationSavedStateViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function2<com.wire.android.ui.authentication.AuthenticationViewModelFactory, androidx.lifecycle.SavedStateHandle, VM of com.wire.android.ui.authentication.authenticationSavedStateViewModel>): VM of com.wire.android.ui.authentication.authenticationSavedStateViewModel
+public fun com.wire.android.ui.authentication.authenticationViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?): VM of com.wire.android.ui.authentication.authenticationViewModel
   skippable: false
   restartable: true
   params:
     - viewModelStoreOwner: RUNTIME (requires runtime check)
     - key: STABLE (class with no mutable properties)
-    - create: STABLE (function type)
 
 @Composable
-public fun com.wire.android.ui.authentication.authenticationViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function1<com.wire.android.ui.authentication.AuthenticationViewModelFactory, VM of com.wire.android.ui.authentication.authenticationViewModel>): VM of com.wire.android.ui.authentication.authenticationViewModel
+public fun com.wire.android.ui.authentication.authenticationViewModelKey(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?): kotlin.String?
   skippable: false
   restartable: true
   params:
     - viewModelStoreOwner: RUNTIME (requires runtime check)
     - key: STABLE (class with no mutable properties)
-    - create: STABLE (function type)
 
 @Composable
 public fun com.wire.android.ui.authentication.clearSessionViewModel(): com.wire.android.ui.authentication.devices.common.ClearSessionViewModel
@@ -869,7 +883,7 @@ public fun com.wire.android.ui.authentication.create.code.CreateAccountCodeScree
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - createAccountCodeViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -915,7 +929,7 @@ public fun com.wire.android.ui.authentication.create.details.CreateAccountDetail
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - createAccountDetailsViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -939,7 +953,7 @@ public fun com.wire.android.ui.authentication.create.email.CreateAccountEmailScr
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - createAccountEmailViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -988,7 +1002,7 @@ public fun com.wire.android.ui.authentication.create.overview.CreateAccountOverv
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - flowType: STABLE (class with no mutable properties)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -997,7 +1011,7 @@ public fun com.wire.android.ui.authentication.create.overview.CreatePersonalAcco
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -1005,7 +1019,7 @@ public fun com.wire.android.ui.authentication.create.overview.CreateTeamAccountO
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -1032,7 +1046,7 @@ public fun com.wire.android.ui.authentication.create.summary.CreateAccountSummar
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -1048,7 +1062,7 @@ public fun com.wire.android.ui.authentication.create.username.CreateAccountUsern
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -1208,7 +1222,7 @@ public fun com.wire.android.ui.authentication.devices.register.RegisterDeviceScr
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - loginTypeSelector: RUNTIME (requires runtime check)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
     - clearSessionViewModel: UNSTABLE (has mutable properties or unstable members)
@@ -1264,7 +1278,7 @@ public fun com.wire.android.ui.authentication.devices.remove.RemoveDeviceScreen(
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - loginTypeSelector: RUNTIME (requires runtime check)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
     - clearSessionViewModel: UNSTABLE (has mutable properties or unstable members)
@@ -1311,7 +1325,7 @@ public fun com.wire.android.ui.authentication.login.LoginScreen(navigator: com.w
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - loginNavArgs: UNSTABLE (has mutable properties or unstable members)
     - loginEmailViewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -1396,11 +1410,12 @@ public fun com.wire.android.ui.authentication.login.email.LoginEmailVerification
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
-private fun com.wire.android.ui.authentication.login.email.PasswordInput(passwordState: androidx.compose.foundation.text.input.TextFieldState, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+private fun com.wire.android.ui.authentication.login.email.PasswordInput(passwordState: androidx.compose.foundation.text.input.TextFieldState, state: com.wire.android.ui.common.textfield.WireTextFieldState, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - passwordState: STABLE (marked @Stable or @Immutable)
+    - state: STABLE (class with no mutable properties)
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
@@ -1432,14 +1447,20 @@ public fun com.wire.android.ui.authentication.login.email.ProxyScreen(proxyIdent
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-private fun com.wire.android.ui.authentication.login.email.UserIdentifierInput(userIdentifierState: androidx.compose.foundation.text.input.TextFieldState, error: kotlin.String?, isEnabled: kotlin.Boolean, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+private fun com.wire.android.ui.authentication.login.email.UserIdentifierInput(userIdentifierState: androidx.compose.foundation.text.input.TextFieldState, state: com.wire.android.ui.common.textfield.WireTextFieldState, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - userIdentifierState: STABLE (marked @Stable or @Immutable)
-    - error: STABLE (class with no mutable properties)
-    - isEnabled: STABLE (primitive type)
+    - state: STABLE (class with no mutable properties)
     - modifier: STABLE (marked @Stable or @Immutable)
+
+@Composable
+private fun com.wire.android.ui.authentication.login.email.userIdentifierInputState(loginEmailState: com.wire.android.ui.authentication.login.email.LoginEmailState): com.wire.android.ui.common.textfield.WireTextFieldState
+  skippable: true
+  restartable: true
+  params:
+    - loginEmailState: STABLE (class with no mutable properties)
 
 @Composable
 private fun com.wire.android.ui.authentication.login.sso.LoginButton(loading: kotlin.Boolean, enabled: kotlin.Boolean, onClick: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -1508,11 +1529,12 @@ public fun com.wire.android.ui.authentication.loginEmailViewModel(loginNavArgs: 
     - viewModelStoreOwner: RUNTIME (requires runtime check)
 
 @Composable
-public fun com.wire.android.ui.authentication.loginSSOViewModel(loginNavArgs: com.wire.android.ui.authentication.login.LoginNavArgs): com.wire.android.ui.authentication.login.sso.LoginSSOViewModel
+public fun com.wire.android.ui.authentication.loginSSOViewModel(loginNavArgs: com.wire.android.ui.authentication.login.LoginNavArgs, viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner): com.wire.android.ui.authentication.login.sso.LoginSSOViewModel
   skippable: false
   restartable: true
   params:
     - loginNavArgs: UNSTABLE (has mutable properties or unstable members)
+    - viewModelStoreOwner: RUNTIME (requires runtime check)
 
 @Composable
 public fun com.wire.android.ui.authentication.newLoginViewModel(): com.wire.android.ui.newauthentication.login.NewLoginViewModel
@@ -1650,7 +1672,7 @@ public fun com.wire.android.ui.authentication.welcome.WelcomeScreen(navigator: c
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -3758,12 +3780,12 @@ public fun com.wire.android.ui.debug.CreateObfuscatedCopyFlow(backUpAndRestoreSt
     - onPermissionPermanentlyDenied: STABLE (function type)
 
 @Composable
-public fun com.wire.android.ui.debug.DangerOptions(modifier: androidx.compose.ui.Modifier, exportObfuscatedCopyViewModel: com.wire.android.ui.debug.ExportObfuscatedCopyViewModel): kotlin.Unit
+public fun com.wire.android.ui.debug.DangerOptions(exportObfuscatedCopyViewModel: com.wire.android.ui.debug.ExportObfuscatedCopyViewModel, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: false
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
     - exportObfuscatedCopyViewModel: RUNTIME (requires runtime check)
+    - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.wire.android.ui.debug.DebugDataOptions(appVersion: kotlin.String, buildVariant: kotlin.String, onCopyText: kotlin.Function1<kotlin.String, kotlin.Unit>, onShowFeatureFlags: kotlin.Function0<kotlin.Unit>, onShowCryptoStats: kotlin.Function0<kotlin.Unit>, viewModel: com.wire.android.ui.debug.DebugDataOptionsViewModel): kotlin.Unit
@@ -3804,12 +3826,14 @@ public fun com.wire.android.ui.debug.DebugDataOptionsContent(state: com.wire.and
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.wire.android.ui.debug.DebugScreen(navigator: com.wire.android.navigation.Navigator, userDebugViewModel: com.wire.android.ui.debug.UserDebugViewModel): kotlin.Unit
+public fun com.wire.android.ui.debug.DebugScreen(navigator: com.wire.android.navigation.Navigator, userDebugViewModel: com.wire.android.ui.debug.UserDebugViewModel, debugDataOptionsViewModel: com.wire.android.ui.debug.DebugDataOptionsViewModel, exportObfuscatedCopyViewModel: com.wire.android.ui.debug.ExportObfuscatedCopyViewModel): kotlin.Unit
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - userDebugViewModel: UNSTABLE (has mutable properties or unstable members)
+    - debugDataOptionsViewModel: RUNTIME (requires runtime check)
+    - exportObfuscatedCopyViewModel: RUNTIME (requires runtime check)
 
 @Composable
 internal fun com.wire.android.ui.debug.DebugToolsOptions(isEventProcessingEnabled: kotlin.Boolean, onDisableEventProcessingChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onRestartSlowSyncForRecovery: kotlin.Function0<kotlin.Unit>, onForceUpdateApiVersions: kotlin.Function0<kotlin.Unit>, checkCrlRevocationList: kotlin.Function0<kotlin.Unit>, forceCRLExpirationAfterOneMinute: kotlin.Boolean, onForceCRLExpirationAfterOneMinuteChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onResendFCMToken: kotlin.Function0<kotlin.Unit>, isAsyncNotificationsEnabled: kotlin.Boolean, onEnableAsyncNotificationsChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>): kotlin.Unit
@@ -3880,7 +3904,7 @@ public fun com.wire.android.ui.debug.LogManagementScreen(navigator: com.wire.and
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -3952,8 +3976,8 @@ private fun com.wire.android.ui.debug.UserDataBaseProfileSwitch(isEnabled: kotli
     - onCheckedChange: STABLE (function type)
 
 @Composable
-internal fun com.wire.android.ui.debug.UserDebugContent(state: com.wire.android.ui.debug.UserDebugState, onNavigationPressed: kotlin.Function0<kotlin.Unit>, onLoggingEnabledChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onDatabaseLoggerEnabledChanged: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onDeleteLogs: kotlin.Function0<kotlin.Unit>, onFlushLogs: kotlin.Function0<kotlinx.coroutines.Deferred<kotlin.Unit>>, onShowFeatureFlags: kotlin.Function0<kotlin.Unit>, onShowCryptoStats: kotlin.Function0<kotlin.Unit>, debugDataOptionsViewModel: com.wire.android.ui.debug.DebugDataOptionsViewModel, exportObfuscatedCopyViewModel: com.wire.android.ui.debug.ExportObfuscatedCopyViewModel): kotlin.Unit
-  skippable: false
+internal fun com.wire.android.ui.debug.UserDebugContent(state: com.wire.android.ui.debug.UserDebugState, onNavigationPressed: kotlin.Function0<kotlin.Unit>, onLoggingEnabledChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onDatabaseLoggerEnabledChanged: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onDeleteLogs: kotlin.Function0<kotlin.Unit>, onFlushLogs: kotlin.Function0<kotlinx.coroutines.Deferred<kotlin.Unit>>, debugDataOptionsContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction1<com.wire.android.ui.debug.DebugContentState, kotlin.Unit>, dangerOptionsContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
     - state: STABLE (class with no mutable properties)
@@ -3962,10 +3986,8 @@ internal fun com.wire.android.ui.debug.UserDebugContent(state: com.wire.android.
     - onDatabaseLoggerEnabledChanged: STABLE (function type)
     - onDeleteLogs: STABLE (function type)
     - onFlushLogs: STABLE (function type)
-    - onShowFeatureFlags: STABLE (function type)
-    - onShowCryptoStats: STABLE (function type)
-    - debugDataOptionsViewModel: RUNTIME (requires runtime check)
-    - exportObfuscatedCopyViewModel: RUNTIME (requires runtime check)
+    - debugDataOptionsContent: STABLE (composable function type)
+    - dangerOptionsContent: STABLE (composable function type)
 
 @Composable
 public fun com.wire.android.ui.debug.aboutThisAppViewModel(): com.wire.android.ui.settings.about.AboutThisAppViewModel
@@ -4007,7 +4029,7 @@ public fun com.wire.android.ui.debug.conversation.DebugConversationScreen(naviga
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -4031,7 +4053,7 @@ public fun com.wire.android.ui.debug.cryptostats.ConversationCryptoStatsScreen(n
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -4085,22 +4107,12 @@ public fun com.wire.android.ui.debug.debugFeatureFlagsViewModel(): com.wire.andr
   params:
 
 @Composable
-public fun com.wire.android.ui.debug.debugInfoSavedStateViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function2<com.wire.android.ui.debug.DebugInfoViewModelFactory, androidx.lifecycle.SavedStateHandle, VM of com.wire.android.ui.debug.debugInfoSavedStateViewModel>): VM of com.wire.android.ui.debug.debugInfoSavedStateViewModel
+public fun com.wire.android.ui.debug.debugInfoViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?): VM of com.wire.android.ui.debug.debugInfoViewModel
   skippable: false
   restartable: true
   params:
     - viewModelStoreOwner: RUNTIME (requires runtime check)
     - key: STABLE (class with no mutable properties)
-    - create: STABLE (function type)
-
-@Composable
-public fun com.wire.android.ui.debug.debugInfoViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function1<com.wire.android.ui.debug.DebugInfoViewModelFactory, VM of com.wire.android.ui.debug.debugInfoViewModel>): VM of com.wire.android.ui.debug.debugInfoViewModel
-  skippable: false
-  restartable: true
-  params:
-    - viewModelStoreOwner: RUNTIME (requires runtime check)
-    - key: STABLE (class with no mutable properties)
-    - create: STABLE (function type)
 
 @Composable
 public fun com.wire.android.ui.debug.dependenciesViewModel(): com.wire.android.ui.home.settings.about.dependencies.DependenciesViewModel
@@ -4119,7 +4131,7 @@ public fun com.wire.android.ui.debug.featureflags.DebugFeatureFlagsScreen(naviga
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -4179,7 +4191,7 @@ public fun com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentScreen(navigator: co
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - loginTypeSelector: RUNTIME (requires runtime check)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
     - clearSessionViewModel: UNSTABLE (has mutable properties or unstable members)
@@ -4457,6 +4469,20 @@ public fun com.wire.android.ui.home.HomeContent(homeState: com.wire.android.ui.h
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
+internal fun com.wire.android.ui.home.HomeDrawerSheet(currentRoute: kotlin.String, homeDrawerState: com.wire.android.ui.home.drawer.HomeDrawerState, focusTrapState: com.wire.android.ui.home.HomeDrawerSheetFocusTrapState, focusTrapActions: com.wire.android.ui.home.HomeDrawerSheetFocusTrapActions, firstItemFocusRequester: androidx.compose.ui.focus.FocusRequester, lastItemFocusRequester: androidx.compose.ui.focus.FocusRequester, onNavigateToHomeItem: kotlin.Function1<com.wire.android.navigation.HomeDestination, kotlin.Unit>, onCloseDrawer: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - currentRoute: STABLE (String is immutable)
+    - homeDrawerState: STABLE (class with no mutable properties)
+    - focusTrapState: STABLE (class with no mutable properties)
+    - focusTrapActions: STABLE (class with no mutable properties)
+    - firstItemFocusRequester: STABLE (marked @Stable or @Immutable)
+    - lastItemFocusRequester: STABLE (marked @Stable or @Immutable)
+    - onNavigateToHomeItem: STABLE (function type)
+    - onCloseDrawer: STABLE (function type)
+
+@Composable
 private fun com.wire.android.ui.home.HomeFloatingActionButton(currentNavigationItem: com.wire.android.navigation.HomeDestination, fabFocusRequester: androidx.compose.ui.focus.FocusRequester, nextFocusRequester: androidx.compose.ui.focus.FocusRequester, onNewConversationClick: kotlin.Function0<kotlin.Unit>, onNewMeetingClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: false
   restartable: true
@@ -4468,11 +4494,38 @@ private fun com.wire.android.ui.home.HomeFloatingActionButton(currentNavigationI
     - onNewMeetingClick: STABLE (function type)
 
 @Composable
+private fun com.wire.android.ui.home.HomeNavHost(state: com.wire.android.ui.home.HomeScaffoldState): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - state: STABLE (marked @Stable or @Immutable)
+
+@Composable
+internal fun com.wire.android.ui.home.HomeScaffold(homeState: com.wire.android.ui.home.HomeState, state: com.wire.android.ui.home.HomeScaffoldState, drawerState: androidx.compose.material3.DrawerState, focusRequesters: com.wire.android.ui.home.HomeScaffoldFocusRequesters, actions: com.wire.android.ui.home.HomeScaffoldActions): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - homeState: STABLE (class with no mutable properties)
+    - state: STABLE (marked @Stable or @Immutable)
+    - drawerState: STABLE (marked @Stable or @Immutable)
+    - focusRequesters: STABLE (class with no mutable properties)
+    - actions: STABLE (class with no mutable properties)
+
+@Composable
+private fun com.wire.android.ui.home.HomeScaffoldFloatingActionButton(state: com.wire.android.ui.home.HomeScaffoldState, fabFocusRequester: androidx.compose.ui.focus.FocusRequester, onNewConversationClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - state: STABLE (marked @Stable or @Immutable)
+    - fabFocusRequester: STABLE (marked @Stable or @Immutable)
+    - onNewConversationClick: STABLE (function type)
+
+@Composable
 public fun com.wire.android.ui.home.HomeScreen(navigator: com.wire.android.navigation.Navigator, groupDetailsScreenResultRecipient: com.ramcosta.composedestinations.result.ResultRecipient<com.ramcosta.composedestinations.generated.app.destinations.ConversationScreenDestination, com.wire.android.ui.home.conversations.details.GroupConversationDetailsNavBackArgs>, otherUserProfileScreenResultRecipient: com.ramcosta.composedestinations.result.ResultRecipient<com.ramcosta.composedestinations.generated.app.destinations.OtherUserProfileScreenDestination, kotlin.String>, conversationFoldersScreenResultRecipient: com.ramcosta.composedestinations.result.ResultRecipient<com.ramcosta.composedestinations.generated.app.destinations.ConversationFoldersScreenDestination, com.wire.android.ui.home.conversations.folder.ConversationFoldersNavBackArgs>, homeViewModel: com.wire.android.ui.home.HomeViewModel, appSyncViewModel: com.wire.android.ui.home.AppSyncViewModel, homeDrawerViewModel: com.wire.android.ui.home.drawer.HomeDrawerViewModel, analyticsUsageViewModel: com.wire.android.ui.analytics.AnalyticsUsageViewModel): kotlin.Unit
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - groupDetailsScreenResultRecipient: STABLE (marked @Stable or @Immutable)
     - otherUserProfileScreenResultRecipient: STABLE (marked @Stable or @Immutable)
     - conversationFoldersScreenResultRecipient: STABLE (marked @Stable or @Immutable)
@@ -4480,6 +4533,15 @@ public fun com.wire.android.ui.home.HomeScreen(navigator: com.wire.android.navig
     - appSyncViewModel: UNSTABLE (has mutable properties or unstable members)
     - homeDrawerViewModel: UNSTABLE (has mutable properties or unstable members)
     - analyticsUsageViewModel: UNSTABLE (has mutable properties or unstable members)
+
+@Composable
+private fun com.wire.android.ui.home.HomeSearchTopBar(state: com.wire.android.ui.home.HomeScaffoldState, searchFocusRequester: androidx.compose.ui.focus.FocusRequester, fabFocusRequester: androidx.compose.ui.focus.FocusRequester): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - state: STABLE (marked @Stable or @Immutable)
+    - searchFocusRequester: STABLE (marked @Stable or @Immutable)
+    - fabFocusRequester: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.wire.android.ui.home.HomeTopBar(title: kotlin.String, currentConversationFilter: com.wire.kalium.logic.data.conversation.ConversationFilter, navigationItem: com.wire.android.navigation.HomeDestination, userAvatarData: com.wire.android.model.UserAvatarData, elevation: androidx.compose.ui.unit.Dp, withLegalHoldIndicator: kotlin.Boolean, shouldShowCreateTeamUnreadIndicator: kotlin.Boolean, onHamburgerMenuClick: kotlin.Function0<kotlin.Unit>, onNavigateToSelfUserProfile: kotlin.Function0<kotlin.Unit>, onOpenConversationFilter: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, nextFocusRequester: androidx.compose.ui.focus.FocusRequester?): kotlin.Unit
@@ -4498,6 +4560,17 @@ public fun com.wire.android.ui.home.HomeTopBar(title: kotlin.String, currentConv
     - onOpenConversationFilter: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)
     - nextFocusRequester: STABLE (marked @Stable or @Immutable)
+
+@Composable
+private fun com.wire.android.ui.home.HomeTopBarHeader(homeState: com.wire.android.ui.home.HomeState, state: com.wire.android.ui.home.HomeScaffoldState, searchFocusRequester: androidx.compose.ui.focus.FocusRequester, onSelfUserClick: kotlin.Function0<kotlin.Unit>, onHamburgerMenuClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - homeState: STABLE (class with no mutable properties)
+    - state: STABLE (marked @Stable or @Immutable)
+    - searchFocusRequester: STABLE (marked @Stable or @Immutable)
+    - onSelfUserClick: STABLE (function type)
+    - onHamburgerMenuClick: STABLE (function type)
 
 @Composable
 public fun com.wire.android.ui.home.appLock.forgot.ForgotLockCodeScreen(viewModel: com.wire.android.ui.home.appLock.forgot.ForgotLockScreenViewModel): kotlin.Unit
@@ -4554,7 +4627,7 @@ public fun com.wire.android.ui.home.appLock.set.SetLockCodeScreen(navigator: com
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -4562,7 +4635,7 @@ public fun com.wire.android.ui.home.appLock.set.SetLockCodeScreenContent(navigat
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - state: UNSTABLE (has mutable properties or unstable members)
     - passwordTextState: STABLE (marked @Stable or @Immutable)
     - scrollState: STABLE (marked @Stable or @Immutable)
@@ -4581,7 +4654,7 @@ public fun com.wire.android.ui.home.appLock.unlock.AppUnlockWithBiometricsScreen
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - appUnlockWithBiometricsViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -4598,7 +4671,7 @@ public fun com.wire.android.ui.home.appLock.unlock.EnterLockCodeScreen(navigator
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -4698,7 +4771,7 @@ public fun com.wire.android.ui.home.conversations.ConversationScreen(navigator: 
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - groupDetailsScreenResultRecipient: STABLE (marked @Stable or @Immutable)
     - mediaGalleryScreenResultRecipient: STABLE (marked @Stable or @Immutable)
     - imagePreviewScreenResultRecipient: STABLE (marked @Stable or @Immutable)
@@ -5047,10 +5120,10 @@ public fun com.wire.android.ui.home.conversations.channels.BrowseChannelsEmptySc
 
 @Composable
 public fun com.wire.android.ui.home.conversations.channels.BrowseChannelsScreen(navigator: com.wire.android.navigation.Navigator): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
 
 @Composable
 private fun com.wire.android.ui.home.conversations.channels.Content(searchQueryTextState: androidx.compose.foundation.text.input.TextFieldState, onCloseSearchClicked: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -5094,6 +5167,13 @@ public fun com.wire.android.ui.home.conversations.conversationBannerViewModel():
   params:
 
 @Composable
+private fun com.wire.android.ui.home.conversations.conversationCoreViewModel(key: kotlin.String?): VM of com.wire.android.ui.home.conversations.conversationCoreViewModel
+  skippable: true
+  restartable: true
+  params:
+    - key: STABLE (class with no mutable properties)
+
+@Composable
 public fun com.wire.android.ui.home.conversations.conversationFoldersViewModel(args: com.wire.android.ui.home.conversations.folder.ConversationFoldersStateArgs): com.wire.android.ui.home.conversations.folder.ConversationFoldersVM
   skippable: true
   restartable: true
@@ -5117,21 +5197,6 @@ public fun com.wire.android.ui.home.conversations.conversationMigrationViewModel
   skippable: true
   restartable: true
   params:
-
-@Composable
-private fun com.wire.android.ui.home.conversations.conversationSavedStateViewModel(create: @[ExtensionFunctionType] kotlin.Function2<com.wire.android.ui.home.conversations.ConversationCoreViewModelFactory, androidx.lifecycle.SavedStateHandle, VM of com.wire.android.ui.home.conversations.conversationSavedStateViewModel>): VM of com.wire.android.ui.home.conversations.conversationSavedStateViewModel
-  skippable: true
-  restartable: true
-  params:
-    - create: STABLE (function type)
-
-@Composable
-private fun com.wire.android.ui.home.conversations.conversationViewModel(key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function1<com.wire.android.ui.home.conversations.ConversationCoreViewModelFactory, VM of com.wire.android.ui.home.conversations.conversationViewModel>): VM of com.wire.android.ui.home.conversations.conversationViewModel
-  skippable: true
-  restartable: true
-  params:
-    - key: STABLE (class with no mutable properties)
-    - create: STABLE (function type)
 
 @Composable
 public fun com.wire.android.ui.home.conversations.createPasswordGuestLinkViewModel(): com.wire.android.ui.home.conversations.details.editguestaccess.createPasswordProtectedGuestLink.CreatePasswordGuestLinkViewModel
@@ -5167,7 +5232,7 @@ private fun com.wire.android.ui.home.conversations.delete.DeleteMessageForYourse
     - onDeleteForMe: STABLE (function type)
 
 @Composable
-private fun com.wire.android.ui.home.conversations.details.GroupConversationDetailsContent(groupConversationOptionsState: com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsState, sheetState: com.wire.android.ui.common.bottomsheet.WireModalSheetState<com.wire.android.ui.common.bottomsheet.conversation.ConversationSheetState>, onBackPressed: kotlin.Function0<kotlin.Unit>, onProfilePressed: kotlin.Function1<com.wire.android.ui.home.conversations.details.participants.model.UIParticipant, kotlin.Unit>, onAddParticipantsPressed: kotlin.Function0<kotlin.Unit>, onEditGuestAccess: kotlin.Function0<kotlin.Unit>, onAppsAccessItemClicked: kotlin.Function0<kotlin.Unit>, onChannelAccessItemClicked: kotlin.Function0<kotlin.Unit>, onEditSelfDeletingMessages: kotlin.Function0<kotlin.Unit>, onEditGroupName: kotlin.Function0<kotlin.Unit>, groupParticipantsState: com.wire.android.ui.home.conversations.details.participants.GroupConversationParticipantsState, isAbandonedOneOnOneConversation: kotlin.Boolean, isWireCellEnabled: kotlin.Boolean, onSearchConversationMessagesClick: kotlin.Function0<kotlin.Unit>, onConversationMediaClick: kotlin.Function0<kotlin.Unit>, onMoveToFolder: kotlin.Function1<com.wire.android.ui.home.conversations.folder.ConversationFoldersNavArgs, kotlin.Unit>, onLeftConversation: kotlin.Function0<kotlin.Unit>, onDeletedConversation: kotlin.Function0<kotlin.Unit>, onPromoteAdmin: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, openConversationDebugMenu: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, initialPageIndex: com.wire.android.ui.home.conversations.details.GroupConversationDetailsTabItem, isScreenLoading: kotlinx.coroutines.flow.StateFlow<kotlin.Boolean>): kotlin.Unit
+private fun com.wire.android.ui.home.conversations.details.GroupConversationDetailsContent(groupConversationOptionsState: com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsState, sheetState: com.wire.android.ui.common.bottomsheet.WireModalSheetState<com.wire.android.ui.common.bottomsheet.conversation.ConversationSheetState>, onBackPressed: kotlin.Function0<kotlin.Unit>, onProfilePressed: kotlin.Function1<com.wire.android.ui.home.conversations.details.participants.model.UIParticipant, kotlin.Unit>, onAddParticipantsPressed: kotlin.Function0<kotlin.Unit>, onEditGuestAccess: kotlin.Function0<kotlin.Unit>, onAppsAccessItemClicked: kotlin.Function0<kotlin.Unit>, onChannelAccessItemClicked: kotlin.Function0<kotlin.Unit>, onEditSelfDeletingMessages: kotlin.Function0<kotlin.Unit>, onEditGroupName: kotlin.Function0<kotlin.Unit>, groupParticipantsState: com.wire.android.ui.home.conversations.details.participants.GroupConversationParticipantsState, isAbandonedOneOnOneConversation: kotlin.Boolean, isWireCellEnabled: kotlin.Boolean, onSearchConversationMessagesClick: kotlin.Function0<kotlin.Unit>, onConversationMediaClick: kotlin.Function0<kotlin.Unit>, viewModel: com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel?, onMoveToFolder: kotlin.Function1<com.wire.android.ui.home.conversations.folder.ConversationFoldersNavArgs, kotlin.Unit>, onLeftConversation: kotlin.Function0<kotlin.Unit>, onDeletedConversation: kotlin.Function0<kotlin.Unit>, onPromoteAdmin: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, openConversationDebugMenu: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, initialPageIndex: com.wire.android.ui.home.conversations.details.GroupConversationDetailsTabItem, isScreenLoading: kotlinx.coroutines.flow.StateFlow<kotlin.Boolean>): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -5186,6 +5251,7 @@ private fun com.wire.android.ui.home.conversations.details.GroupConversationDeta
     - isWireCellEnabled: STABLE (primitive type)
     - onSearchConversationMessagesClick: STABLE (function type)
     - onConversationMediaClick: STABLE (function type)
+    - viewModel: UNSTABLE (has mutable properties or unstable members)
     - onMoveToFolder: STABLE (function type)
     - onLeftConversation: STABLE (function type)
     - onDeletedConversation: STABLE (function type)
@@ -5199,7 +5265,7 @@ public fun com.wire.android.ui.home.conversations.details.GroupConversationDetai
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - groupConversationDetailResultRecipient: STABLE (marked @Stable or @Immutable)
     - editChannelAccessResultRecipient: STABLE (marked @Stable or @Immutable)
@@ -5330,7 +5396,7 @@ public fun com.wire.android.ui.home.conversations.details.editguestaccess.EditGu
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - editGuestAccessViewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -5420,7 +5486,7 @@ public fun com.wire.android.ui.home.conversations.details.editguestaccess.create
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -5443,7 +5509,7 @@ public fun com.wire.android.ui.home.conversations.details.editselfdeletingmessag
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - editSelfDeletingMessagesViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -5517,7 +5583,7 @@ public fun com.wire.android.ui.home.conversations.details.metadata.EditConversat
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -5687,7 +5753,7 @@ public fun com.wire.android.ui.home.conversations.details.participants.GroupConv
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - navArgs: UNSTABLE (has mutable properties or unstable members)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -5748,7 +5814,7 @@ public fun com.wire.android.ui.home.conversations.details.updateappsaccess.Updat
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - updateAppsAccessViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -5912,7 +5978,7 @@ public fun com.wire.android.ui.home.conversations.folder.ConversationFoldersScre
   restartable: true
   params:
     - args: UNSTABLE (has mutable properties or unstable members)
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - resultRecipient: STABLE (marked @Stable or @Immutable)
     - foldersViewModel: RUNTIME (requires runtime check)
@@ -5923,7 +5989,7 @@ public fun com.wire.android.ui.home.conversations.folder.NewConversationFolderSc
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -6023,7 +6089,7 @@ public fun com.wire.android.ui.home.conversations.media.ConversationMediaScreen(
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - conversationAssetMessagesViewModel: UNSTABLE (has mutable properties or unstable members)
     - conversationMessagesViewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -6126,7 +6192,7 @@ public fun com.wire.android.ui.home.conversations.media.preview.ImagesPreviewScr
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - imagesPreviewViewModel: UNSTABLE (has mutable properties or unstable members)
     - checkAssetRestrictionsViewModel: UNSTABLE (has mutable properties or unstable members)
@@ -6225,7 +6291,7 @@ public fun com.wire.android.ui.home.conversations.messagedetails.MessageDetailsS
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -7522,11 +7588,11 @@ public fun com.wire.android.ui.home.conversations.moveConversationToFolderViewMo
     - args: STABLE (matched by stability configuration)
 
 @Composable
-public fun com.wire.android.ui.home.conversations.multipartAttachmentsViewModel(conversationKey: kotlin.String): com.wire.android.ui.home.conversations.model.messagetypes.multipart.MultipartAttachmentsViewModel
+public fun com.wire.android.ui.home.conversations.multipartAttachmentsViewModel(conversationId: com.wire.kalium.logic.data.id.QualifiedID): com.wire.android.ui.home.conversations.model.messagetypes.multipart.MultipartAttachmentsViewModel
   skippable: true
   restartable: true
   params:
-    - conversationKey: STABLE (String is immutable)
+    - conversationId: STABLE (matched by stability configuration)
 
 @Composable
 public fun com.wire.android.ui.home.conversations.newFolderViewModel(): com.wire.android.ui.home.conversations.folder.NewFolderViewModel
@@ -7556,7 +7622,7 @@ public fun com.wire.android.ui.home.conversations.promoteadmin.PromoteAdminScree
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -7590,7 +7656,7 @@ public fun com.wire.android.ui.home.conversations.rememberSelfDeletionTimer(expi
     - expirationStatus: STABLE (class with no mutable properties)
 
 @Composable
-private fun com.wire.android.ui.home.conversations.scopedMessageViewModel(arguments: R of com.wire.android.ui.home.conversations.scopedMessageViewModel, clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function3<com.wire.android.ui.home.conversations.ScopedMessageViewModelFactory, androidx.lifecycle.SavedStateHandle, R of com.wire.android.ui.home.conversations.scopedMessageViewModel, VM of com.wire.android.ui.home.conversations.scopedMessageViewModel>): S of com.wire.android.ui.home.conversations.scopedMessageViewModel
+private fun com.wire.android.ui.home.conversations.scopedMessageViewModel(arguments: R of com.wire.android.ui.home.conversations.scopedMessageViewModel, clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function3<com.wire.android.ui.home.conversations.ScopedMessageManualViewModelFactory, androidx.lifecycle.SavedStateHandle, R of com.wire.android.ui.home.conversations.scopedMessageViewModel, VM of com.wire.android.ui.home.conversations.scopedMessageViewModel>): S of com.wire.android.ui.home.conversations.scopedMessageViewModel
   skippable: false
   restartable: true
   params:
@@ -7599,7 +7665,7 @@ private fun com.wire.android.ui.home.conversations.scopedMessageViewModel(argume
     - create: STABLE (function type)
 
 @Composable
-private fun com.wire.android.ui.home.conversations.scopedMessageViewModel(arguments: R of com.wire.android.ui.home.conversations.scopedMessageViewModel, keyInScopeResolver: kotlin.Function1<@[ParameterName(name = \, clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function3<com.wire.android.ui.home.conversations.ScopedMessageViewModelFactory, androidx.lifecycle.SavedStateHandle, R of com.wire.android.ui.home.conversations.scopedMessageViewModel, VM of com.wire.android.ui.home.conversations.scopedMessageViewModel>): S of com.wire.android.ui.home.conversations.scopedMessageViewModel
+private fun com.wire.android.ui.home.conversations.scopedMessageViewModel(arguments: R of com.wire.android.ui.home.conversations.scopedMessageViewModel, keyInScopeResolver: kotlin.Function1<@[ParameterName(name = \, clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function3<com.wire.android.ui.home.conversations.ScopedMessageManualViewModelFactory, androidx.lifecycle.SavedStateHandle, R of com.wire.android.ui.home.conversations.scopedMessageViewModel, VM of com.wire.android.ui.home.conversations.scopedMessageViewModel>): S of com.wire.android.ui.home.conversations.scopedMessageViewModel
   skippable: false
   restartable: true
   params:
@@ -7609,7 +7675,7 @@ private fun com.wire.android.ui.home.conversations.scopedMessageViewModel(argume
     - create: STABLE (function type)
 
 @Composable
-private fun com.wire.android.ui.home.conversations.scopedMessageViewModel(clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function2<com.wire.android.ui.home.conversations.ScopedMessageViewModelFactory, androidx.lifecycle.SavedStateHandle, VM of com.wire.android.ui.home.conversations.scopedMessageViewModel>): S of com.wire.android.ui.home.conversations.scopedMessageViewModel
+private fun com.wire.android.ui.home.conversations.scopedMessageViewModel(clearDelay: kotlin.time.Duration?, create: @[ExtensionFunctionType] kotlin.Function2<com.wire.android.ui.home.conversations.ScopedMessageManualViewModelFactory, androidx.lifecycle.SavedStateHandle, VM of com.wire.android.ui.home.conversations.scopedMessageViewModel>): S of com.wire.android.ui.home.conversations.scopedMessageViewModel
   skippable: true
   restartable: true
   params:
@@ -7777,7 +7843,7 @@ public fun com.wire.android.ui.home.conversations.search.adddembertoconversation
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - navArgs: UNSTABLE (has mutable properties or unstable members)
     - addMembersToConversationViewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -7908,7 +7974,7 @@ public fun com.wire.android.ui.home.conversations.search.messages.SearchConversa
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - searchConversationMessagesViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -8014,7 +8080,7 @@ public fun com.wire.android.ui.home.conversationslist.ConversationsScreenContent
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - searchBarState: UNSTABLE (has mutable properties or unstable members)
     - modifier: STABLE (marked @Stable or @Immutable)
     - emptyListContent: STABLE (composable function type)
@@ -8039,7 +8105,7 @@ public fun com.wire.android.ui.home.conversationslist.all.ConversationsEmptyCont
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - filter: UNSTABLE (has mutable properties or unstable members)
     - domain: STABLE (String is immutable)
@@ -8050,7 +8116,7 @@ private fun com.wire.android.ui.home.conversationslist.all.EmptyContentFooter(cu
   restartable: true
   params:
     - currentFilter: UNSTABLE (has mutable properties or unstable members)
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
 
 @Composable
 private fun com.wire.android.ui.home.conversationslist.all.emptyDescription(backendName: kotlin.String): kotlin.String
@@ -8412,7 +8478,7 @@ public fun com.wire.android.ui.home.drawer.DrawerItem(destination: com.wire.andr
     - unreadCount: STABLE (primitive type)
 
 @Composable
-public fun com.wire.android.ui.home.drawer.HomeDrawer(homeDrawerState: com.wire.android.ui.home.drawer.HomeDrawerState, currentRoute: kotlin.String?, navigateToHomeItem: kotlin.Function1<com.wire.android.navigation.HomeDestination, kotlin.Unit>, onCloseDrawer: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.wire.android.ui.home.drawer.HomeDrawer(homeDrawerState: com.wire.android.ui.home.drawer.HomeDrawerState, currentRoute: kotlin.String?, navigateToHomeItem: kotlin.Function1<com.wire.android.navigation.HomeDestination, kotlin.Unit>, onCloseDrawer: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, isFocusTrapEnabled: kotlin.Boolean, firstItemFocusRequester: androidx.compose.ui.focus.FocusRequester?, lastItemFocusRequester: androidx.compose.ui.focus.FocusRequester?): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -8421,6 +8487,9 @@ public fun com.wire.android.ui.home.drawer.HomeDrawer(homeDrawerState: com.wire.
     - navigateToHomeItem: STABLE (function type)
     - onCloseDrawer: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)
+    - isFocusTrapEnabled: STABLE (primitive type)
+    - firstItemFocusRequester: STABLE (marked @Stable or @Immutable)
+    - lastItemFocusRequester: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.wire.android.ui.home.drawer.MapToDrawerItem(navigateToHomeItem: kotlin.Function1<com.wire.android.navigation.HomeDestination, kotlin.Unit>, onCloseDrawer: kotlin.Function0<kotlin.Unit>, currentRoute: kotlin.String?, drawerUiItem: com.wire.android.ui.home.drawer.DrawerUiItem): kotlin.Unit
@@ -8459,10 +8528,10 @@ private fun com.wire.android.ui.home.gallery.MediaGalleryOptionsBottomSheetLayou
 
 @Composable
 public fun com.wire.android.ui.home.gallery.MediaGalleryScreen(navigator: com.wire.android.navigation.Navigator, resultNavigator: com.ramcosta.composedestinations.result.ResultBackNavigator<com.wire.android.ui.home.gallery.MediaGalleryNavBackArgs>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
 
@@ -9257,10 +9326,10 @@ private fun com.wire.android.ui.home.newconversation.channelaccess.AccessSection
 
 @Composable
 public fun com.wire.android.ui.home.newconversation.channelaccess.ChannelAccessOnCreateScreen(navigator: com.wire.android.navigation.Navigator): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.wire.android.ui.home.newconversation.channelaccess.ChannelAccessScreenContent(internalPadding: androidx.compose.foundation.layout.PaddingValues, selectedAccess: com.wire.android.ui.home.newconversation.channelaccess.ChannelAccessType, selectedPermission: com.wire.android.ui.home.newconversation.channelaccess.ChannelAddPermissionType, modifier: androidx.compose.ui.Modifier, onAccessChange: kotlin.Function1<com.wire.android.ui.home.newconversation.channelaccess.ChannelAccessType, kotlin.Unit>, onPermissionChange: kotlin.Function1<com.wire.android.ui.home.newconversation.channelaccess.ChannelAddPermissionType, kotlin.Unit>): kotlin.Unit
@@ -9321,10 +9390,10 @@ private fun com.wire.android.ui.home.newconversation.channelhistory.ChannelHisto
 
 @Composable
 public fun com.wire.android.ui.home.newconversation.channelhistory.ChannelHistoryScreen(navigator: com.wire.android.navigation.Navigator, customResultRecipient: com.ramcosta.composedestinations.result.ResultRecipient<com.ramcosta.composedestinations.generated.app.destinations.ChannelHistoryCustomScreenDestination, com.wire.android.ui.home.newconversation.channelhistory.ChannelHistoryCustomNavBackArgs>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - customResultRecipient: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
 
@@ -9458,10 +9527,10 @@ private fun com.wire.android.ui.home.newconversation.groupOptions.EnableWireCell
 
 @Composable
 public fun com.wire.android.ui.home.newconversation.groupOptions.GroupOptionScreen(navigator: com.wire.android.navigation.Navigator): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
 
 @Composable
 private fun com.wire.android.ui.home.newconversation.groupOptions.GroupOptionScreenContent(groupOptionState: com.wire.android.ui.home.newconversation.groupOptions.GroupOptionState, createGroupState: com.wire.android.ui.home.newconversation.common.CreateGroupState, groupMetadataState: com.wire.android.ui.common.groupname.GroupMetadataState, onAccessClicked: kotlin.Function0<kotlin.Unit>, onHistoryClicked: kotlin.Function0<kotlin.Unit>, onAllowGuestChanged: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onAllowServicesChanged: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onReadReceiptChanged: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onEnableWireCellChanged: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onContinuePressed: kotlin.Function0<kotlin.Unit>, onAllowGuestsDialogDismissed: kotlin.Function0<kotlin.Unit>, onNotAllowGuestsClicked: kotlin.Function0<kotlin.Unit>, onAllowGuestsClicked: kotlin.Function0<kotlin.Unit>, onErrorDismissed: kotlin.Function0<kotlin.Unit>, onEditParticipantsClick: kotlin.Function0<kotlin.Unit>, onDiscardGroupCreationClick: kotlin.Function0<kotlin.Unit>, onBackPressed: kotlin.Function0<kotlin.Unit>, channelsHistoryOptionsEnabled: kotlin.Boolean, mlsReadReceiptsEnabled: kotlin.Boolean): kotlin.Unit
@@ -9533,17 +9602,17 @@ private fun com.wire.android.ui.home.newconversation.groupOptions.ReadReceiptsOp
 
 @Composable
 public fun com.wire.android.ui.home.newconversation.groupname.NewGroupNameScreen(navigator: com.wire.android.navigation.Navigator): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.wire.android.ui.home.newconversation.groupsearch.NewGroupConversationSearchPeopleScreen(navigator: com.wire.android.navigation.Navigator): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.wire.android.ui.home.newconversation.search.ChannelNotAvailableDialog(onCreateTeam: kotlin.Function0<kotlin.Unit>, onDismiss: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -9556,24 +9625,24 @@ public fun com.wire.android.ui.home.newconversation.search.ChannelNotAvailableDi
 
 @Composable
 public fun com.wire.android.ui.home.newconversation.search.NewConversationSearchPeopleScreen(navigator: com.wire.android.navigation.Navigator): kotlin.Unit
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.wire.android.ui.home.newconversation.sharedNewConversationViewModel(navigator: com.wire.android.navigation.Navigator): com.wire.android.ui.home.newconversation.NewConversationViewModel
-  skippable: false
+  skippable: true
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.wire.android.ui.home.rememberHomeScreenState(navigator: com.wire.android.navigation.Navigator, coroutineScope: kotlinx.coroutines.CoroutineScope, navController: androidx.navigation.NavHostController, drawerState: androidx.compose.material3.DrawerState): com.wire.android.ui.home.HomeStateHolder
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - coroutineScope: RUNTIME (requires runtime check)
     - navController: UNSTABLE (has mutable properties or unstable members)
     - drawerState: STABLE (marked @Stable or @Immutable)
@@ -9651,7 +9720,7 @@ public fun com.wire.android.ui.home.settings.about.dependencies.DependenciesScre
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -9678,7 +9747,7 @@ public fun com.wire.android.ui.home.settings.about.licenses.LicensesScreen(navig
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -9732,7 +9801,7 @@ public fun com.wire.android.ui.home.settings.account.MyAccountScreen(navigator: 
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - changeDisplayNameResultRecipient: STABLE (marked @Stable or @Immutable)
     - changeHandleResultRecipient: STABLE (marked @Stable or @Immutable)
     - changeUserColorResultRecipient: STABLE (marked @Stable or @Immutable)
@@ -9763,7 +9832,7 @@ public fun com.wire.android.ui.home.settings.account.color.ChangeUserColorScreen
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -9791,7 +9860,7 @@ public fun com.wire.android.ui.home.settings.account.displayname.ChangeDisplayNa
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -9818,7 +9887,7 @@ public fun com.wire.android.ui.home.settings.account.email.updateEmail.ChangeEma
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -9844,7 +9913,7 @@ public fun com.wire.android.ui.home.settings.account.email.verifyEmail.VerifyEma
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -9864,7 +9933,7 @@ public fun com.wire.android.ui.home.settings.account.handle.ChangeHandleScreen(n
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -9888,7 +9957,7 @@ public fun com.wire.android.ui.home.settings.appearance.CustomizationScreen(navi
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -9924,7 +9993,7 @@ public fun com.wire.android.ui.home.settings.appsettings.networkSettings.Network
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - networkSettingsViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -9969,7 +10038,7 @@ public fun com.wire.android.ui.home.settings.backup.BackupAndRestoreScreen(navig
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -10224,7 +10293,7 @@ public fun com.wire.android.ui.home.settings.privacy.PrivacySettingsConfigScreen
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -10281,13 +10350,12 @@ public fun com.wire.android.ui.home.settings.setLockScreenViewModel(): com.wire.
   params:
 
 @Composable
-public fun com.wire.android.ui.home.settings.settingsSavedStateViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function2<com.wire.android.ui.home.settings.SettingsViewModelFactory, androidx.lifecycle.SavedStateHandle, VM of com.wire.android.ui.home.settings.settingsSavedStateViewModel>): VM of com.wire.android.ui.home.settings.settingsSavedStateViewModel
+public fun com.wire.android.ui.home.settings.settingsSavedStateViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?): VM of com.wire.android.ui.home.settings.settingsSavedStateViewModel
   skippable: false
   restartable: true
   params:
     - viewModelStoreOwner: RUNTIME (requires runtime check)
     - key: STABLE (class with no mutable properties)
-    - create: STABLE (function type)
 
 @Composable
 public fun com.wire.android.ui.home.settings.settingsScreenViewModel(): com.wire.android.ui.home.settings.SettingsViewModel
@@ -10296,13 +10364,12 @@ public fun com.wire.android.ui.home.settings.settingsScreenViewModel(): com.wire
   params:
 
 @Composable
-public fun com.wire.android.ui.home.settings.settingsViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function1<com.wire.android.ui.home.settings.SettingsViewModelFactory, VM of com.wire.android.ui.home.settings.settingsViewModel>): VM of com.wire.android.ui.home.settings.settingsViewModel
+public fun com.wire.android.ui.home.settings.settingsViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?): VM of com.wire.android.ui.home.settings.settingsViewModel
   skippable: false
   restartable: true
   params:
     - viewModelStoreOwner: RUNTIME (requires runtime check)
     - key: STABLE (class with no mutable properties)
-    - create: STABLE (function type)
 
 @Composable
 public fun com.wire.android.ui.home.settings.teamMigrationViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner): com.wire.android.ui.userprofile.teammigration.TeamMigrationViewModel
@@ -10372,7 +10439,7 @@ public fun com.wire.android.ui.initialsync.InitialSyncScreen(navigator: com.wire
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -10682,6 +10749,12 @@ public fun com.wire.android.ui.markdown.MarkdownThematicBreak(messageStyle: com.
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
+public fun com.wire.android.ui.miscViewModel(): VM of com.wire.android.ui.miscViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 internal fun com.wire.android.ui.newauthentication.login.BackendSelectorDropDown(): kotlin.Unit
   skippable: true
   restartable: true
@@ -10772,7 +10845,7 @@ public fun com.wire.android.ui.newauthentication.login.NewLoginScreen(navigator:
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - navArgs: UNSTABLE (has mutable properties or unstable members)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -10794,7 +10867,7 @@ public fun com.wire.android.ui.newauthentication.login.code.NewLoginVerification
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - loginEmailViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -10838,23 +10911,24 @@ public fun com.wire.android.ui.newauthentication.login.password.LoginStateNaviga
   restartable: true
   params:
     - viewModel: UNSTABLE (has mutable properties or unstable members)
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.wire.android.ui.newauthentication.login.password.NewLoginPasswordScreen(navigator: com.wire.android.navigation.Navigator, navArgs: com.wire.android.ui.authentication.login.LoginNavArgs, loginEmailViewModel: com.wire.android.ui.authentication.login.email.LoginEmailViewModel): kotlin.Unit
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - navArgs: UNSTABLE (has mutable properties or unstable members)
     - loginEmailViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
-public fun com.wire.android.ui.newauthentication.login.password.PasswordInput(passwordState: androidx.compose.foundation.text.input.TextFieldState, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.wire.android.ui.newauthentication.login.password.PasswordInput(passwordState: androidx.compose.foundation.text.input.TextFieldState, state: com.wire.android.ui.common.textfield.WireTextFieldState, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - passwordState: STABLE (marked @Stable or @Immutable)
+    - state: STABLE (class with no mutable properties)
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
@@ -10879,7 +10953,7 @@ public fun com.wire.android.ui.newauthentication.welcome.WelcomeChooserScreen(na
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - loginTypeSelector: RUNTIME (requires runtime check)
 
 @Composable
@@ -10898,7 +10972,7 @@ public fun com.wire.android.ui.registration.code.CreateAccountVerificationCodeSc
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - createAccountCodeVerificationViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -10939,7 +11013,7 @@ public fun com.wire.android.ui.registration.details.CreateAccountDataDetailScree
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - createAccountDataDetailViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -10991,7 +11065,7 @@ public fun com.wire.android.ui.registration.selector.CreateAccountSelectorScreen
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -11037,7 +11111,7 @@ public fun com.wire.android.ui.settings.about.AboutThisAppScreen(navigator: com.
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -11098,7 +11172,7 @@ public fun com.wire.android.ui.settings.devices.DeviceDetailsScreen(navigator: c
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -11176,7 +11250,7 @@ public fun com.wire.android.ui.settings.devices.SelfDevicesScreen(navigator: com
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -11276,7 +11350,7 @@ public fun com.wire.android.ui.settings.devices.e2ei.E2eiCertificateDetailsScree
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - e2eiCertificateDetailsViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -11309,7 +11383,7 @@ private fun com.wire.android.ui.sharing.ImportMediaAuthenticatedContent(navigato
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - isRestrictedInTeam: STABLE (primitive type)
     - checkAssetRestrictionsViewModel: UNSTABLE (has mutable properties or unstable members)
     - importMediaViewModel: UNSTABLE (has mutable properties or unstable members)
@@ -11382,7 +11456,7 @@ public fun com.wire.android.ui.sharing.ImportMediaScreen(navigator: com.wire.and
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - loginTypeSelector: RUNTIME (requires runtime check)
     - featureFlagNotificationViewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -11447,7 +11521,7 @@ public fun com.wire.android.ui.userprofile.avatarpicker.AvatarPickerScreen(navig
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -11676,7 +11750,7 @@ public fun com.wire.android.ui.userprofile.other.OtherUserProfileScreen(navigato
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - navArgs: UNSTABLE (has mutable properties or unstable members)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - conversationFoldersScreenResultRecipient: STABLE (marked @Stable or @Immutable)
@@ -11805,7 +11879,7 @@ public fun com.wire.android.ui.userprofile.qr.SelfQRCodeScreen(navigator: com.wi
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -11913,7 +11987,7 @@ public fun com.wire.android.ui.userprofile.self.SelfUserProfileScreen(navigator:
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - loginTypeSelector: RUNTIME (requires runtime check)
     - avatarPickerResultRecipient: STABLE (marked @Stable or @Immutable)
     - viewModelSelf: UNSTABLE (has mutable properties or unstable members)
@@ -12021,7 +12095,7 @@ public fun com.wire.android.ui.userprofile.service.ServiceDetailsScreen(navigato
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - viewModel: RUNTIME (requires runtime check)
 
 @Composable
@@ -12116,7 +12190,7 @@ public fun com.wire.android.ui.userprofile.teammigration.step1.TeamMigrationTeam
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - teamMigrationViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -12133,7 +12207,7 @@ public fun com.wire.android.ui.userprofile.teammigration.step2.TeamMigrationTeam
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - teamMigrationViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -12178,7 +12252,7 @@ public fun com.wire.android.ui.userprofile.teammigration.step3.TeamMigrationConf
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - teamMigrationViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
@@ -12213,7 +12287,7 @@ public fun com.wire.android.ui.userprofile.teammigration.step4.TeamMigrationDone
   skippable: false
   restartable: true
   params:
-    - navigator: UNSTABLE (has mutable properties or unstable members)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - teamMigrationViewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable

--- a/core/di/build.gradle.kts
+++ b/core/di/build.gradle.kts
@@ -9,5 +9,6 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.compose.activity)
     implementation(libs.androidx.lifecycle.viewModelCompose)
+    implementation(libs.metrox.viewModelCompose)
     implementation(libs.compose.material3)
 }

--- a/core/di/src/main/kotlin/com/wire/android/di/metro/MetroViewModelGraph.kt
+++ b/core/di/src/main/kotlin/com/wire/android/di/metro/MetroViewModelGraph.kt
@@ -19,6 +19,7 @@ package com.wire.android.di.metro
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
@@ -35,7 +36,7 @@ val LocalWireViewModelScopeKey = staticCompositionLocalOf<String?> {
     null
 }
 
-fun scopedMetroViewModelKey(defaultKey: String?, key: String?, scopeKey: String?): String? {
+fun sessionKeyedMetroViewModelKey(defaultKey: String?, key: String?, scopeKey: String?): String? {
     if (scopeKey == null) return key
     return "${key ?: defaultKey}:$scopeKey"
 }
@@ -52,15 +53,42 @@ fun scopedMetroViewModelKey(defaultKey: String?, key: String?, scopeKey: String?
  * instance per tab, conversation, or picker target.
  */
 @Composable
-inline fun <reified VM> scopedMetroViewModel(
+inline fun <reified VM> sessionKeyedMetroViewModel(
     key: String? = null,
+    noinline previewProvider: (() -> VM?)? = null,
     viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
     },
 ): VM where VM : ViewModel =
-    metroViewModel(
+    metroPreviewViewModelOrNull(previewProvider) ?: metroViewModel(
         viewModelStoreOwner = viewModelStoreOwner,
-        key = scopedMetroViewModelKey(
+        key = sessionKeyedMetroViewModelKey(
+            defaultKey = VM::class.qualifiedName,
+            key = key,
+            scopeKey = LocalWireViewModelScopeKey.current,
+        ),
+    )
+
+/**
+ * Creates a Metro-backed ViewModel and exposes it as a narrower interface type.
+ *
+ * This mirrors the legacy Resaca helper shape where previews could use generated
+ * `@ViewModelScopedPreview` objects for the interface while runtime still creates the real
+ * ViewModel implementation. Prefer this overload when the screen depends on a ViewModel
+ * interface and has a generated preview implementation.
+ */
+@Composable
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
+inline fun <reified VM, reified S> sessionKeyedMetroViewModelAs(
+    key: String? = null,
+    noinline previewProvider: (() -> S?)? = null,
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+): S where VM : ViewModel, VM : S =
+    metroPreviewViewModelOrNull(previewProvider) ?: metroViewModel<VM>(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = sessionKeyedMetroViewModelKey(
             defaultKey = VM::class.qualifiedName,
             key = key,
             scopeKey = LocalWireViewModelScopeKey.current,
@@ -70,23 +98,57 @@ inline fun <reified VM> scopedMetroViewModel(
 /**
  * Creates an assisted Metro-backed ViewModel using the current Wire ViewModel scope key.
  *
- * This has the same account/session isolation guarantees as [scopedMetroViewModel], but it also
+ * This has the same account/session isolation guarantees as [sessionKeyedMetroViewModel], but it also
  * lets the caller pass runtime screen arguments through a [ManualViewModelAssistedFactory].
  *
  * Use this when the ViewModel constructor needs values that are only known by the screen route or
  * call site, such as conversation id, selected folder id, login arguments, or tab type.
  */
 @Composable
-inline fun <reified VM, reified Factory> scopedAssistedMetroViewModel(
+inline fun <reified VM, reified Factory> sessionKeyedAssistedMetroViewModel(
     key: String? = null,
+    noinline previewProvider: (() -> VM?)? = null,
     crossinline createViewModel: Factory.() -> VM,
 ): VM where VM : ViewModel, Factory : ManualViewModelAssistedFactory =
-    assistedMetroViewModel<VM, Factory>(
-        key = scopedMetroViewModelKey(
+    metroPreviewViewModelOrNull(previewProvider) ?: assistedMetroViewModel<VM, Factory>(
+        key = sessionKeyedMetroViewModelKey(
             defaultKey = VM::class.qualifiedName,
             key = key,
             scopeKey = LocalWireViewModelScopeKey.current,
         ),
     ) {
         createViewModel()
+    }
+
+/**
+ * Creates an assisted Metro-backed ViewModel and exposes it as a narrower interface type.
+ *
+ * Use this overload for ViewModels with runtime screen arguments when previews should keep using
+ * generated `@ViewModelScopedPreview` interface implementations. At runtime the real [VM] is still
+ * created through MetroX and the provided [Factory].
+ */
+@Composable
+@Suppress("BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER")
+inline fun <reified VM, reified S, reified Factory> sessionKeyedAssistedMetroViewModelAs(
+    key: String? = null,
+    noinline previewProvider: (() -> S?)? = null,
+    crossinline createViewModel: Factory.() -> VM,
+): S where VM : ViewModel, VM : S, Factory : ManualViewModelAssistedFactory =
+    metroPreviewViewModelOrNull(previewProvider) ?: assistedMetroViewModel<VM, Factory>(
+        key = sessionKeyedMetroViewModelKey(
+            defaultKey = VM::class.qualifiedName,
+            key = key,
+            scopeKey = LocalWireViewModelScopeKey.current,
+        ),
+    ) {
+        createViewModel()
+    }
+
+@Composable
+@PublishedApi
+internal fun <VM> metroPreviewViewModelOrNull(previewProvider: (() -> VM?)?): VM? =
+    if (LocalInspectionMode.current) {
+        previewProvider?.invoke()
+    } else {
+        null
     }

--- a/core/di/src/main/kotlin/com/wire/android/di/metro/MetroViewModelGraph.kt
+++ b/core/di/src/main/kotlin/com/wire/android/di/metro/MetroViewModelGraph.kt
@@ -18,96 +18,75 @@
 package com.wire.android.di.metro
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
-import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.assistedMetroViewModel
+import dev.zacsweers.metrox.viewmodel.metroViewModel
 
 interface MetroViewModelGraph {
     val viewModelScopeKey: String?
         get() = null
 }
 
-/**
- * Temporary Android Compose bridge used while moving ViewModel creation to Metro.
- *
- * Reusable UI should not treat this as a general DI entry point. The target direction is to keep
- * common UI components UI-only and pass state, callbacks, or narrow models from screen/container
- * code.
- */
-val LocalMetroViewModelGraph = staticCompositionLocalOf<MetroViewModelGraph?> {
+val LocalWireViewModelScopeKey = staticCompositionLocalOf<String?> {
     null
-}
-
-@Composable
-inline fun <reified Graph, reified VM> metroViewModel(
-    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
-        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
-    },
-    key: String? = null,
-    crossinline create: Graph.() -> VM,
-): VM where Graph : MetroViewModelGraph, VM : ViewModel {
-    val graph = checkNotNull(LocalMetroViewModelGraph.current as? Graph) {
-        "No Metro graph matching ${Graph::class.qualifiedName} was provided"
-    }
-    val scopedKey = scopedMetroViewModelKey(
-        defaultKey = VM::class.qualifiedName,
-        key = key,
-        scopeKey = graph.viewModelScopeKey,
-    )
-    val factory = remember(graph) {
-        viewModelFactory {
-            initializer {
-                graph.create()
-            }
-        }
-    }
-    return viewModel(
-        modelClass = VM::class,
-        viewModelStoreOwner = viewModelStoreOwner,
-        key = scopedKey,
-        factory = factory,
-    )
-}
-
-@Composable
-inline fun <reified Graph, reified VM> metroSavedStateViewModel(
-    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
-        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
-    },
-    key: String? = null,
-    crossinline create: Graph.(SavedStateHandle) -> VM,
-): VM where Graph : MetroViewModelGraph, VM : ViewModel {
-    val graph = checkNotNull(LocalMetroViewModelGraph.current as? Graph) {
-        "No Metro graph matching ${Graph::class.qualifiedName} was provided"
-    }
-    val scopedKey = scopedMetroViewModelKey(
-        defaultKey = VM::class.qualifiedName,
-        key = key,
-        scopeKey = graph.viewModelScopeKey,
-    )
-    val factory = remember(graph) {
-        viewModelFactory {
-            initializer {
-                graph.create(createSavedStateHandle())
-            }
-        }
-    }
-    return viewModel(
-        modelClass = VM::class,
-        viewModelStoreOwner = viewModelStoreOwner,
-        key = scopedKey,
-        factory = factory,
-    )
 }
 
 fun scopedMetroViewModelKey(defaultKey: String?, key: String?, scopeKey: String?): String? {
     if (scopeKey == null) return key
     return "${key ?: defaultKey}:$scopeKey"
 }
+
+/**
+ * Creates a Metro-backed ViewModel using the current Wire ViewModel scope key.
+ *
+ * Session screens provide [LocalWireViewModelScopeKey] from the active account/session graph.
+ * Including that value in the ViewModel key prevents Compose from reusing a ViewModel that was
+ * created for a different account after account switching, logout, or client removal.
+ *
+ * Use this for regular Metro ViewModels that do not need runtime screen arguments. Pass [key] only
+ * when the same ViewModel class can have multiple instances inside one scope, for example one
+ * instance per tab, conversation, or picker target.
+ */
+@Composable
+inline fun <reified VM> scopedMetroViewModel(
+    key: String? = null,
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+): VM where VM : ViewModel =
+    metroViewModel(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = scopedMetroViewModelKey(
+            defaultKey = VM::class.qualifiedName,
+            key = key,
+            scopeKey = LocalWireViewModelScopeKey.current,
+        ),
+    )
+
+/**
+ * Creates an assisted Metro-backed ViewModel using the current Wire ViewModel scope key.
+ *
+ * This has the same account/session isolation guarantees as [scopedMetroViewModel], but it also
+ * lets the caller pass runtime screen arguments through a [ManualViewModelAssistedFactory].
+ *
+ * Use this when the ViewModel constructor needs values that are only known by the screen route or
+ * call site, such as conversation id, selected folder id, login arguments, or tab type.
+ */
+@Composable
+inline fun <reified VM, reified Factory> scopedAssistedMetroViewModel(
+    key: String? = null,
+    crossinline createViewModel: Factory.() -> VM,
+): VM where VM : ViewModel, Factory : ManualViewModelAssistedFactory =
+    assistedMetroViewModel<VM, Factory>(
+        key = scopedMetroViewModelKey(
+            defaultKey = VM::class.qualifiedName,
+            key = key,
+            scopeKey = LocalWireViewModelScopeKey.current,
+        ),
+    ) {
+        createViewModel()
+    }

--- a/core/di/stability/di-debug.stability
+++ b/core/di/stability/di-debug.stability
@@ -5,20 +5,45 @@
 //   ./gradlew :di:stabilityDump
 
 @Composable
-public fun com.wire.android.di.metro.metroSavedStateViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function2<Graph of com.wire.android.di.metro.metroSavedStateViewModel, androidx.lifecycle.SavedStateHandle, VM of com.wire.android.di.metro.metroSavedStateViewModel>): VM of com.wire.android.di.metro.metroSavedStateViewModel
-  skippable: false
+internal fun com.wire.android.di.metro.metroPreviewViewModelOrNull(previewProvider: kotlin.Function0<VM of com.wire.android.di.metro.metroPreviewViewModelOrNull?>?): VM of com.wire.android.di.metro.metroPreviewViewModelOrNull?
+  skippable: true
   restartable: true
   params:
-    - viewModelStoreOwner: RUNTIME (requires runtime check)
-    - key: STABLE (class with no mutable properties)
-    - create: STABLE (function type)
+    - previewProvider: STABLE (function type)
 
 @Composable
-public fun com.wire.android.di.metro.metroViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function1<Graph of com.wire.android.di.metro.metroViewModel, VM of com.wire.android.di.metro.metroViewModel>): VM of com.wire.android.di.metro.metroViewModel
+public fun com.wire.android.di.metro.sessionKeyedAssistedMetroViewModel(key: kotlin.String?, previewProvider: kotlin.Function0<VM of com.wire.android.di.metro.sessionKeyedAssistedMetroViewModel?>?, createViewModel: @[ExtensionFunctionType] kotlin.Function1<Factory of com.wire.android.di.metro.sessionKeyedAssistedMetroViewModel, VM of com.wire.android.di.metro.sessionKeyedAssistedMetroViewModel>): VM of com.wire.android.di.metro.sessionKeyedAssistedMetroViewModel
+  skippable: true
+  restartable: true
+  params:
+    - key: STABLE (class with no mutable properties)
+    - previewProvider: STABLE (function type)
+    - createViewModel: STABLE (function type)
+
+@Composable
+public fun com.wire.android.di.metro.sessionKeyedAssistedMetroViewModelAs(key: kotlin.String?, previewProvider: kotlin.Function0<S of com.wire.android.di.metro.sessionKeyedAssistedMetroViewModelAs?>?, createViewModel: @[ExtensionFunctionType] kotlin.Function1<Factory of com.wire.android.di.metro.sessionKeyedAssistedMetroViewModelAs, VM of com.wire.android.di.metro.sessionKeyedAssistedMetroViewModelAs>): S of com.wire.android.di.metro.sessionKeyedAssistedMetroViewModelAs
+  skippable: true
+  restartable: true
+  params:
+    - key: STABLE (class with no mutable properties)
+    - previewProvider: STABLE (function type)
+    - createViewModel: STABLE (function type)
+
+@Composable
+public fun com.wire.android.di.metro.sessionKeyedMetroViewModel(key: kotlin.String?, previewProvider: kotlin.Function0<VM of com.wire.android.di.metro.sessionKeyedMetroViewModel?>?, viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner): VM of com.wire.android.di.metro.sessionKeyedMetroViewModel
   skippable: false
   restartable: true
   params:
-    - viewModelStoreOwner: RUNTIME (requires runtime check)
     - key: STABLE (class with no mutable properties)
-    - create: STABLE (function type)
+    - previewProvider: STABLE (function type)
+    - viewModelStoreOwner: RUNTIME (requires runtime check)
+
+@Composable
+public fun com.wire.android.di.metro.sessionKeyedMetroViewModelAs(key: kotlin.String?, previewProvider: kotlin.Function0<S of com.wire.android.di.metro.sessionKeyedMetroViewModelAs?>?, viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner): S of com.wire.android.di.metro.sessionKeyedMetroViewModelAs
+  skippable: false
+  restartable: true
+  params:
+    - key: STABLE (class with no mutable properties)
+    - previewProvider: STABLE (function type)
+    - viewModelStoreOwner: RUNTIME (requires runtime check)
 

--- a/core/ui-common/src/main/kotlin/com/wire/android/model/ImageAsset.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/model/ImageAsset.kt
@@ -20,11 +20,9 @@ package com.wire.android.model
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
-import androidx.lifecycle.ViewModel
-import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.metroViewModel
 import com.wire.android.ui.common.R
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.id.ConversationId
@@ -69,7 +67,9 @@ sealed class ImageAsset {
             withCrossfadeAnimation: Boolean = false
         ) = when {
             LocalInspectionMode.current -> painterResource(id = R.drawable.mock_image)
-            else -> remoteAssetImageViewModel().imageLoader
+            else -> checkNotNull(LocalWireSessionImageLoader.current) {
+                "No WireSessionImageLoader was provided"
+            }
                 .paint(asset = this, fallbackData = fallbackData, withCrossfadeAnimation = withCrossfadeAnimation)
         }
     }
@@ -110,14 +110,8 @@ object PathAsStringSerializer : KSerializer<Path> {
     override fun deserialize(decoder: Decoder): Path = decoder.decodeString().toPath(normalize = true)
 }
 
-interface ImageAssetViewModelGraph : MetroViewModelGraph {
-    val imageAssetViewModelFactory: ImageAssetViewModelFactory
+val LocalWireSessionImageLoader = staticCompositionLocalOf<WireSessionImageLoader?> {
+    null
 }
 
-@Composable
-private fun remoteAssetImageViewModel(): RemoteAssetImageViewModel =
-    metroViewModel<ImageAssetViewModelGraph, RemoteAssetImageViewModel> {
-        imageAssetViewModelFactory.create()
-    }
-
-class RemoteAssetImageViewModel(val imageLoader: WireSessionImageLoader) : ViewModel()
+class RemoteAssetImageViewModel(val imageLoader: WireSessionImageLoader)

--- a/features/cells/build.gradle.kts
+++ b/features/cells/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(libs.compose.material3)
     implementation(libs.androidx.lifecycle.viewModelCompose)
     implementation(libs.compose.ui.preview)
+    implementation(libs.metrox.viewModelCompose)
 
     implementation(libs.coil.core)
     implementation(libs.coil.gif)

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsMetroViewModelBindings.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsMetroViewModelBindings.kt
@@ -1,0 +1,112 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.cells.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.wire.android.feature.cells.ui.create.file.CreateFileViewModel
+import com.wire.android.feature.cells.ui.create.folder.CreateFolderViewModel
+import com.wire.android.feature.cells.ui.movetofolder.MoveToFolderViewModel
+import com.wire.android.feature.cells.ui.publiclink.PublicLinkViewModel
+import com.wire.android.feature.cells.ui.publiclink.settings.expiration.PublicLinkExpirationScreenViewModel
+import com.wire.android.feature.cells.ui.publiclink.settings.password.PublicLinkPasswordScreenViewModel
+import com.wire.android.feature.cells.ui.rename.RenameNodeViewModel
+import com.wire.android.feature.cells.ui.search.SearchScreenViewModel
+import com.wire.android.feature.cells.ui.tags.AddRemoveTagsViewModel
+import com.wire.android.feature.cells.ui.versioning.VersionHistoryViewModel
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.IntoMap
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
+
+@BindingContainer
+object CellsMetroViewModelBindings {
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(CellViewModel::class)
+    fun cellViewModel(factory: CellsViewModelFactory): ViewModelAssistedFactory =
+        savedStateViewModel { factory.cellViewModel(it.createSavedStateHandle()) }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(CreateFileViewModel::class)
+    fun createFileViewModel(factory: CellsViewModelFactory): ViewModelAssistedFactory =
+        savedStateViewModel { factory.createFileViewModel(it.createSavedStateHandle()) }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(CreateFolderViewModel::class)
+    fun createFolderViewModel(factory: CellsViewModelFactory): ViewModelAssistedFactory =
+        savedStateViewModel { factory.createFolderViewModel(it.createSavedStateHandle()) }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(MoveToFolderViewModel::class)
+    fun moveToFolderViewModel(factory: CellsViewModelFactory): ViewModelAssistedFactory =
+        savedStateViewModel { factory.moveToFolderViewModel(it.createSavedStateHandle()) }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(PublicLinkViewModel::class)
+    fun publicLinkViewModel(factory: CellsViewModelFactory): ViewModelAssistedFactory =
+        savedStateViewModel { factory.publicLinkViewModel(it.createSavedStateHandle()) }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(PublicLinkExpirationScreenViewModel::class)
+    fun publicLinkExpirationScreenViewModel(factory: CellsViewModelFactory): ViewModelAssistedFactory =
+        savedStateViewModel { factory.publicLinkExpirationScreenViewModel(it.createSavedStateHandle()) }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(PublicLinkPasswordScreenViewModel::class)
+    fun publicLinkPasswordScreenViewModel(factory: CellsViewModelFactory): ViewModelAssistedFactory =
+        savedStateViewModel { factory.publicLinkPasswordScreenViewModel(it.createSavedStateHandle()) }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(RenameNodeViewModel::class)
+    fun renameNodeViewModel(factory: CellsViewModelFactory): ViewModelAssistedFactory =
+        savedStateViewModel { factory.renameNodeViewModel(it.createSavedStateHandle()) }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(SearchScreenViewModel::class)
+    fun searchScreenViewModel(factory: CellsViewModelFactory): ViewModelAssistedFactory =
+        savedStateViewModel { factory.searchScreenViewModel(it.createSavedStateHandle()) }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(AddRemoveTagsViewModel::class)
+    fun addRemoveTagsViewModel(factory: CellsViewModelFactory): ViewModelAssistedFactory =
+        savedStateViewModel { factory.addRemoveTagsViewModel(it.createSavedStateHandle()) }
+
+    @Provides
+    @IntoMap
+    @ViewModelAssistedFactoryKey(VersionHistoryViewModel::class)
+    fun versionHistoryViewModel(factory: CellsViewModelFactory): ViewModelAssistedFactory =
+        savedStateViewModel { factory.versionHistoryViewModel(it.createSavedStateHandle()) }
+
+    private fun savedStateViewModel(create: (CreationExtras) -> ViewModel): ViewModelAssistedFactory =
+        object : ViewModelAssistedFactory {
+            override fun create(extras: CreationExtras): ViewModel = create(extras)
+        }
+}

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsViewModelGraph.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsViewModelGraph.kt
@@ -18,12 +18,10 @@
 package com.wire.android.feature.cells.ui
 
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.metroSavedStateViewModel
+import com.wire.android.di.metro.scopedMetroViewModel
 import com.wire.android.feature.cells.ui.create.file.CreateFileViewModel
 import com.wire.android.feature.cells.ui.create.folder.CreateFolderViewModel
 import com.wire.android.feature.cells.ui.movetofolder.MoveToFolderViewModel
@@ -35,60 +33,53 @@ import com.wire.android.feature.cells.ui.search.SearchScreenViewModel
 import com.wire.android.feature.cells.ui.tags.AddRemoveTagsViewModel
 import com.wire.android.feature.cells.ui.versioning.VersionHistoryViewModel
 
-interface CellsViewModelGraph : MetroViewModelGraph {
-    val cellsViewModelFactory: CellsViewModelFactory
-}
-
 @Composable
 inline fun <reified VM> cellsViewModel(
     viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
     },
     key: String? = null,
-    crossinline create: CellsViewModelFactory.(SavedStateHandle) -> VM,
 ): VM where VM : ViewModel =
-    metroSavedStateViewModel<CellsViewModelGraph, VM>(
+    scopedMetroViewModel(
         viewModelStoreOwner = viewModelStoreOwner,
         key = key,
-    ) { savedStateHandle ->
-        cellsViewModelFactory.create(savedStateHandle)
-    }
+    )
 
 @Composable
 fun cellViewModel(
     viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
     },
-): CellViewModel = cellsViewModel(viewModelStoreOwner = viewModelStoreOwner) { cellViewModel(it) }
+): CellViewModel = cellsViewModel(viewModelStoreOwner = viewModelStoreOwner)
 
 @Composable
-fun createFileViewModel(): CreateFileViewModel = cellsViewModel { createFileViewModel(it) }
+fun createFileViewModel(): CreateFileViewModel = cellsViewModel()
 
 @Composable
-fun createFolderViewModel(): CreateFolderViewModel = cellsViewModel { createFolderViewModel(it) }
+fun createFolderViewModel(): CreateFolderViewModel = cellsViewModel()
 
 @Composable
-fun moveToFolderViewModel(): MoveToFolderViewModel = cellsViewModel { moveToFolderViewModel(it) }
+fun moveToFolderViewModel(): MoveToFolderViewModel = cellsViewModel()
 
 @Composable
-fun publicLinkViewModel(): PublicLinkViewModel = cellsViewModel { publicLinkViewModel(it) }
+fun publicLinkViewModel(): PublicLinkViewModel = cellsViewModel()
 
 @Composable
 internal fun publicLinkExpirationScreenViewModel(): PublicLinkExpirationScreenViewModel =
-    cellsViewModel { publicLinkExpirationScreenViewModel(it) }
+    cellsViewModel()
 
 @Composable
 internal fun publicLinkPasswordScreenViewModel(): PublicLinkPasswordScreenViewModel =
-    cellsViewModel { publicLinkPasswordScreenViewModel(it) }
+    cellsViewModel()
 
 @Composable
-fun renameNodeViewModel(): RenameNodeViewModel = cellsViewModel { renameNodeViewModel(it) }
+fun renameNodeViewModel(): RenameNodeViewModel = cellsViewModel()
 
 @Composable
-fun searchScreenViewModel(): SearchScreenViewModel = cellsViewModel { searchScreenViewModel(it) }
+fun searchScreenViewModel(): SearchScreenViewModel = cellsViewModel()
 
 @Composable
-fun addRemoveTagsViewModel(): AddRemoveTagsViewModel = cellsViewModel { addRemoveTagsViewModel(it) }
+fun addRemoveTagsViewModel(): AddRemoveTagsViewModel = cellsViewModel()
 
 @Composable
-fun versionHistoryViewModel(): VersionHistoryViewModel = cellsViewModel { versionHistoryViewModel(it) }
+fun versionHistoryViewModel(): VersionHistoryViewModel = cellsViewModel()

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsViewModelGraph.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsViewModelGraph.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-import com.wire.android.di.metro.scopedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedMetroViewModel
 import com.wire.android.feature.cells.ui.create.file.CreateFileViewModel
 import com.wire.android.feature.cells.ui.create.folder.CreateFolderViewModel
 import com.wire.android.feature.cells.ui.movetofolder.MoveToFolderViewModel
@@ -40,7 +40,7 @@ inline fun <reified VM> cellsViewModel(
     },
     key: String? = null,
 ): VM where VM : ViewModel =
-    scopedMetroViewModel(
+    sessionKeyedMetroViewModel(
         viewModelStoreOwner = viewModelStoreOwner,
         key = key,
     )

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/file/CreateFileScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/file/CreateFileScreen.kt
@@ -64,7 +64,7 @@ fun CreateFileScreen(
     navigator: WireNavigator,
     resultNavigator: ResultBackNavigator<Boolean>,
     modifier: Modifier = Modifier,
-    createFileViewModel: CreateFileViewModel = createFileViewModel()
+    createFileViewModel: CreateFileViewModel = createFileViewModel(),
 ) {
     val showErrorDialog = remember { mutableStateOf(false) }
 

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/folder/CreateFolderScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/folder/CreateFolderScreen.kt
@@ -69,7 +69,7 @@ fun CreateFolderScreen(
     navigator: WireNavigator,
     resultNavigator: ResultBackNavigator<Boolean>,
     modifier: Modifier = Modifier,
-    createFolderViewModel: CreateFolderViewModel = createFolderViewModel()
+    createFolderViewModel: CreateFolderViewModel = createFolderViewModel(),
 ) {
     val showErrorDialog = remember { mutableStateOf(false) }
 

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/movetofolder/MoveToFolderScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/movetofolder/MoveToFolderScreen.kt
@@ -79,7 +79,7 @@ fun MoveToFolderScreen(
     navigator: WireNavigator,
     createFolderResultRecipient: ResultRecipient<CreateFolderScreenDestination, Boolean>,
     modifier: Modifier = Modifier,
-    moveToFolderViewModel: MoveToFolderViewModel = moveToFolderViewModel()
+    moveToFolderViewModel: MoveToFolderViewModel = moveToFolderViewModel(),
 ) {
     val context = LocalContext.current
     val viewState by moveToFolderViewModel.state.collectAsState()

--- a/features/cells/stability/cells-debug.stability
+++ b/features/cells/stability/cells-debug.stability
@@ -87,7 +87,7 @@ public fun com.wire.android.feature.cells.ui.AllFilesScreen(navigator: com.wire.
   skippable: false
   restartable: true
   params:
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -179,7 +179,7 @@ public fun com.wire.android.feature.cells.ui.ConversationFilesScreen(navigator: 
   skippable: false
   restartable: true
   params:
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - animatedVisibilityScope: RUNTIME (requires runtime check)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -189,7 +189,7 @@ internal fun com.wire.android.feature.cells.ui.ConversationFilesScreenContent(an
   restartable: true
   params:
     - animatedVisibilityScope: RUNTIME (requires runtime check)
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - currentNodeUuid: STABLE (class with no mutable properties)
     - isSearchResult: STABLE (primitive type)
     - actions: RUNTIME (requires runtime check)
@@ -213,7 +213,7 @@ public fun com.wire.android.feature.cells.ui.ConversationFilesWithSlideInTransit
   skippable: false
   restartable: true
   params:
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - cellFilesNavArgs: UNSTABLE (has mutable properties or unstable members)
     - animatedVisibilityScope: RUNTIME (requires runtime check)
     - viewModel: UNSTABLE (has mutable properties or unstable members)
@@ -299,13 +299,12 @@ public fun com.wire.android.feature.cells.ui.cellViewModel(viewModelStoreOwner: 
     - viewModelStoreOwner: RUNTIME (requires runtime check)
 
 @Composable
-public fun com.wire.android.feature.cells.ui.cellsViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?, create: @[ExtensionFunctionType] kotlin.Function2<com.wire.android.feature.cells.ui.CellsViewModelFactory, androidx.lifecycle.SavedStateHandle, VM of com.wire.android.feature.cells.ui.cellsViewModel>): VM of com.wire.android.feature.cells.ui.cellsViewModel
+public fun com.wire.android.feature.cells.ui.cellsViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?): VM of com.wire.android.feature.cells.ui.cellsViewModel
   skippable: false
   restartable: true
   params:
     - viewModelStoreOwner: RUNTIME (requires runtime check)
     - key: STABLE (class with no mutable properties)
-    - create: STABLE (function type)
 
 @Composable
 public fun com.wire.android.feature.cells.ui.common.Breadcrumbs(pathSegments: kotlin.Array<kotlin.String>, modifier: androidx.compose.ui.Modifier, isRecycleBin: kotlin.Boolean, onBreadcrumbsFolderClick: kotlin.Function1<@[ParameterName(name = \): kotlin.Unit
@@ -391,7 +390,7 @@ public fun com.wire.android.feature.cells.ui.create.file.CreateFileScreen(naviga
   skippable: false
   restartable: true
   params:
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - createFileViewModel: UNSTABLE (has mutable properties or unstable members)
@@ -408,7 +407,7 @@ public fun com.wire.android.feature.cells.ui.create.folder.CreateFolderScreen(na
   skippable: false
   restartable: true
   params:
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - resultNavigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - createFolderViewModel: UNSTABLE (has mutable properties or unstable members)
@@ -549,7 +548,7 @@ public fun com.wire.android.feature.cells.ui.movetofolder.MoveToFolderScreen(nav
   skippable: false
   restartable: true
   params:
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - createFolderResultRecipient: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - moveToFolderViewModel: UNSTABLE (has mutable properties or unstable members)
@@ -611,7 +610,7 @@ public fun com.wire.android.feature.cells.ui.publiclink.PublicLinkScreen(navigat
   skippable: false
   restartable: true
   params:
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - onPasswordChange: STABLE (marked @Stable or @Immutable)
     - onExpirationChange: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
@@ -828,7 +827,7 @@ public fun com.wire.android.feature.cells.ui.recyclebin.RecycleBinScreen(navigat
   skippable: false
   restartable: true
   params:
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - cellViewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -866,7 +865,7 @@ public fun com.wire.android.feature.cells.ui.rename.RenameNodeScreen(navigator: 
   skippable: false
   restartable: true
   params:
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - renameNodeViewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -889,7 +888,7 @@ public fun com.wire.android.feature.cells.ui.search.SearchScreen(navigator: com.
   skippable: false
   restartable: true
   params:
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - animatedVisibilityScope: RUNTIME (requires runtime check)
     - cellViewModel: UNSTABLE (has mutable properties or unstable members)
     - modifier: STABLE (marked @Stable or @Immutable)
@@ -1083,7 +1082,7 @@ public fun com.wire.android.feature.cells.ui.tags.AddRemoveTagsScreen(navigator:
   skippable: false
   restartable: true
   params:
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - addRemoveTagsViewModel: UNSTABLE (has mutable properties or unstable members)
 
@@ -1153,7 +1152,7 @@ public fun com.wire.android.feature.cells.ui.versioning.VersionHistoryScreen(nav
   skippable: false
   restartable: true
   params:
-    - navigator: RUNTIME (requires runtime check)
+    - navigator: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - versionHistoryViewModel: UNSTABLE (has mutable properties or unstable members)
 

--- a/features/meetings/build.gradle.kts
+++ b/features/meetings/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(libs.compose.material3)
     implementation(libs.androidx.lifecycle.viewModelCompose)
     implementation(libs.compose.ui.preview)
+    implementation(libs.metrox.viewModelCompose)
 
     implementation(libs.ktx.dateTime)
 

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/MeetingsMetroViewModelBindings.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/MeetingsMetroViewModelBindings.kt
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.meetings.ui
+
+import androidx.lifecycle.ViewModel
+import com.wire.android.feature.meetings.ui.create.NewMeetingType
+import com.wire.android.feature.meetings.ui.create.NewMeetingViewModelImpl
+import com.wire.android.feature.meetings.ui.list.MeetingListViewModelImpl
+import com.wire.android.feature.meetings.ui.options.MeetingOptionsMenuViewModelImpl
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.IntoMap
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactoryKey
+import dev.zacsweers.metrox.viewmodel.ViewModelKey
+
+@BindingContainer
+object MeetingsMetroViewModelBindings {
+
+    @Provides
+    @IntoMap
+    @ManualViewModelAssistedFactoryKey(MeetingsManualViewModelFactory::class)
+    fun meetingsManualViewModelFactory(factory: MeetingsViewModelFactory): ManualViewModelAssistedFactory =
+        object : MeetingsManualViewModelFactory {
+            override fun meetingListViewModel(type: MeetingsTabItem): MeetingListViewModelImpl =
+                factory.meetingListViewModel(type)
+
+            override fun newMeetingViewModel(type: NewMeetingType): NewMeetingViewModelImpl =
+                factory.newMeetingViewModel(type)
+        }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(MeetingOptionsMenuViewModelImpl::class)
+    fun meetingOptionsMenuViewModel(factory: MeetingsViewModelFactory): ViewModel =
+        factory.meetingOptionsMenuViewModel()
+}

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/MeetingsViewModelGraph.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/MeetingsViewModelGraph.kt
@@ -18,8 +18,8 @@
 package com.wire.android.feature.meetings.ui
 
 import androidx.compose.runtime.Composable
-import com.wire.android.di.metro.MetroViewModelGraph
-import com.wire.android.di.metro.metroViewModel
+import com.wire.android.di.metro.scopedAssistedMetroViewModel
+import com.wire.android.di.metro.scopedMetroViewModel
 import com.wire.android.feature.meetings.ui.create.NewMeetingType
 import com.wire.android.feature.meetings.ui.create.NewMeetingViewModel
 import com.wire.android.feature.meetings.ui.create.NewMeetingViewModelImpl
@@ -27,25 +27,31 @@ import com.wire.android.feature.meetings.ui.list.MeetingListViewModel
 import com.wire.android.feature.meetings.ui.list.MeetingListViewModelImpl
 import com.wire.android.feature.meetings.ui.options.MeetingOptionsMenuViewModel
 import com.wire.android.feature.meetings.ui.options.MeetingOptionsMenuViewModelImpl
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
 
-interface MeetingsViewModelGraph : MetroViewModelGraph {
-    val meetingsViewModelFactory: MeetingsViewModelFactory
+interface MeetingsManualViewModelFactory : ManualViewModelAssistedFactory {
+    fun meetingListViewModel(type: MeetingsTabItem): MeetingListViewModelImpl
+    fun newMeetingViewModel(type: NewMeetingType): NewMeetingViewModelImpl
 }
 
 @Composable
-fun meetingListViewModel(type: MeetingsTabItem): MeetingListViewModel =
-    metroViewModel<MeetingsViewModelGraph, MeetingListViewModelImpl>(key = "meeting_list_${type.name}") {
-        meetingsViewModelFactory.meetingListViewModel(type)
+fun meetingListViewModel(
+    type: MeetingsTabItem,
+): MeetingListViewModel =
+    scopedAssistedMetroViewModel<MeetingListViewModelImpl, MeetingsManualViewModelFactory>(
+        key = "meeting_list_${type.name}",
+    ) {
+        meetingListViewModel(type)
     }
 
 @Composable
 fun meetingOptionsMenuListViewModel(): MeetingOptionsMenuViewModel =
-    metroViewModel<MeetingsViewModelGraph, MeetingOptionsMenuViewModelImpl> {
-        meetingsViewModelFactory.meetingOptionsMenuViewModel()
-    }
+    scopedMetroViewModel<MeetingOptionsMenuViewModelImpl>()
 
 @Composable
 fun newMeetingViewModel(type: NewMeetingType): NewMeetingViewModel =
-    metroViewModel<MeetingsViewModelGraph, NewMeetingViewModelImpl>(key = "new_meeting_${type.name}") {
-        meetingsViewModelFactory.newMeetingViewModel(type)
+    scopedAssistedMetroViewModel<NewMeetingViewModelImpl, MeetingsManualViewModelFactory>(
+        key = "new_meeting_${type.name}",
+    ) {
+        newMeetingViewModel(type)
     }

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/MeetingsViewModelGraph.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/MeetingsViewModelGraph.kt
@@ -15,11 +15,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+@file:Suppress("MatchingDeclarationName")
+
 package com.wire.android.feature.meetings.ui
 
 import androidx.compose.runtime.Composable
-import com.wire.android.di.metro.scopedAssistedMetroViewModel
-import com.wire.android.di.metro.scopedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedAssistedMetroViewModel
+import com.wire.android.di.metro.sessionKeyedMetroViewModel
 import com.wire.android.feature.meetings.ui.create.NewMeetingType
 import com.wire.android.feature.meetings.ui.create.NewMeetingViewModel
 import com.wire.android.feature.meetings.ui.create.NewMeetingViewModelImpl
@@ -38,7 +40,7 @@ interface MeetingsManualViewModelFactory : ManualViewModelAssistedFactory {
 fun meetingListViewModel(
     type: MeetingsTabItem,
 ): MeetingListViewModel =
-    scopedAssistedMetroViewModel<MeetingListViewModelImpl, MeetingsManualViewModelFactory>(
+    sessionKeyedAssistedMetroViewModel<MeetingListViewModelImpl, MeetingsManualViewModelFactory>(
         key = "meeting_list_${type.name}",
     ) {
         meetingListViewModel(type)
@@ -46,11 +48,11 @@ fun meetingListViewModel(
 
 @Composable
 fun meetingOptionsMenuListViewModel(): MeetingOptionsMenuViewModel =
-    scopedMetroViewModel<MeetingOptionsMenuViewModelImpl>()
+    sessionKeyedMetroViewModel<MeetingOptionsMenuViewModelImpl>()
 
 @Composable
 fun newMeetingViewModel(type: NewMeetingType): NewMeetingViewModel =
-    scopedAssistedMetroViewModel<NewMeetingViewModelImpl, MeetingsManualViewModelFactory>(
+    sessionKeyedAssistedMetroViewModel<NewMeetingViewModelImpl, MeetingsManualViewModelFactory>(
         key = "new_meeting_${type.name}",
     ) {
         newMeetingViewModel(type)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -163,6 +163,7 @@ googleGms-location = { module = "com.google.android.gms:play-services-location",
 aboutLibraries-gradlePlugin = { module = "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin", version.ref = "aboutLibraries" }
 kover-gradlePlugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
 metro-gradlePlugin = { module = "dev.zacsweers.metro:dev.zacsweers.metro.gradle.plugin", version.ref = "metro" }
+metrox-viewModelCompose = { module = "dev.zacsweers.metro:metrox-viewmodel-compose", version.ref = "metro" }
 ktx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "ktx-serialization" }
 ktx-dateTime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "ktx-dateTime" }
 ktx-immutableCollections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "ktx-immutableCollections" }
@@ -189,6 +190,7 @@ android-desugarJdkLibs = { module = "com.android.tools:desugar_jdk_libs", versio
 squareup-javapoet = { module = "com.squareup:javapoet", version.ref = "squareup-javapoet" }
 visibilityModifiers = { module = "io.github.esentsov:kotlin-visibility", version.ref = "visibilityModifiers" }
 resaca-core = { module = "io.github.sebaslogen:resaca", version.ref = "resaca" }
+resaca-metro = { module = "io.github.sebaslogen:resacametro", version.ref = "resaca" }
 bundlizer-core = { module = "dev.ahmedmourad.bundlizer:bundlizer-core", version.ref = "bundlizer" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBOM" }
 firebase-fcm = { module = "com.google.firebase:firebase-messaging" }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25946
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

## What's new

Migrates ViewModel creation to Metro/MetroX.

This introduces shared Metro-backed ViewModel factory/bindings and updates app, Cells, and Meetings ViewModel call sites to resolve ViewModels through Metro-backed APIs.

## Why

This moves us closer to the final Metro DI model where ViewModel construction is handled by Metro scopes instead of Hilt-style/manual bridge objects.

The important part is scope-safe ViewModel lookup. Session ViewModels must include the current session/account scope in their key, otherwise Compose can reuse a ViewModel created for another account after account switching, logout, or client removal.

## Changes

- Added shared Metro ViewModel factory wiring.
- Added app-level ViewModel bindings.
- Added Cells and Meetings ViewModel bindings.
- Added `scopedMetroViewModel` and `scopedAssistedMetroViewModel` helpers with KDoc.
- Updated ViewModel helper functions to use Metro/MetroX with scoped keys.
- Preserved special auth key handling for login/remove-device flows that use route args or `ViewModelStoreOwner`.
- Included feature module ViewModel binding containers in the root `WireApplicationGraph`, so the app-level `MetroViewModelFactory` can resolve Cells and Meetings ViewModels.
