### PR TITLE
fix: metro session runtime stability [WPB-26140] [WPB-26134]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -29,6 +29,7 @@ import com.ramcosta.composedestinations.spec.DestinationSpec
 import com.ramcosta.composedestinations.spec.Direction
 import com.ramcosta.composedestinations.spec.NavGraphSpec
 import com.ramcosta.composedestinations.spec.Route
+import com.ramcosta.composedestinations.utils.destination
 import com.ramcosta.composedestinations.utils.findDestination
 import com.ramcosta.composedestinations.utils.navGraph
 import com.ramcosta.composedestinations.utils.route
@@ -40,8 +41,8 @@ import com.wire.android.util.CustomTabsHelper
 @Suppress("CyclomaticComplexMethod")
 internal fun NavController.navigateToItem(command: NavigationCommand) {
 
-    fun firstDestination() = currentBackStack.value.firstOrNull { it.route() is DestinationSpec }
-    fun lastDestination() = currentBackStack.value.lastOrNull { it.route() is DestinationSpec }
+    fun firstDestination() = currentBackStack.value.firstOrNull { it.safeRoute() is DestinationSpec }
+    fun lastDestination() = currentBackStack.value.lastOrNull { it.safeRoute() is DestinationSpec }
     fun lastNestedGraph() = lastDestination()?.takeIf { it.navGraph() != navGraph }?.navGraph()
     fun firstDestinationWithRoute(route: String) =
         currentBackStack.value.firstOrNull { it.destination.route?.getBaseRoute() == route.getBaseRoute() }
@@ -62,7 +63,7 @@ internal fun NavController.navigateToItem(command: NavigationCommand) {
 
             BackStackMode.REMOVE_CURRENT_NESTED_GRAPH -> {
                 popUpTo(
-                    getInclusive = { it.route() is NavGraphSpec },
+                    getInclusive = { it.safeRoute() is NavGraphSpec },
                     getNavBackStackEntry = { lastNestedGraph()?.let { lastDestinationFromOtherGraph(it) } }
                 )
             }
@@ -102,8 +103,10 @@ private fun DestinationsNavOptionsBuilder.popUpTo(
 ) {
     getNavBackStackEntry()?.let { entry ->
         appLogger.d("[$TAG] -> popUpTo:${entry.destination.route?.getBaseRoute()} inclusive:${getInclusive(entry)}")
-        popUpTo(entry.route()) {
-            this.inclusive = getInclusive(entry)
+        entry.safeRoute()?.let { route ->
+            popUpTo(route) {
+                this.inclusive = getInclusive(entry)
+            }
         }
     }
 }
@@ -133,6 +136,10 @@ fun Direction.handleNavigation(context: Context, handleOtherDirection: (Directio
 }
 
 @SuppressLint("RestrictedApi")
-fun NavController.startDestination() = currentBackStack.value.firstOrNull { it.route() is DestinationSpec }
+fun NavController.startDestination() = currentBackStack.value.firstOrNull { it.safeRoute() is DestinationSpec }
+
+internal fun NavBackStackEntry.safeRoute(): Route? = runCatching { route() }.getOrNull()
+
+internal fun NavBackStackEntry.safeDestination(): DestinationSpec? = runCatching { destination() }.getOrNull()
 
 private const val TAG = "NavigationUtils"

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -132,6 +132,7 @@ import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedViewMode
 import com.wire.android.ui.settings.devices.e2ei.E2EICertificateDetails
 import com.wire.android.ui.theme.ThemeOption
 import com.wire.android.ui.theme.WireTheme
+import com.wire.android.ui.userprofile.self.LocalSelfUserProfileLogoutAction
 import com.wire.android.ui.userprofile.self.dialog.LogoutOptionsDialog
 import com.wire.android.ui.userprofile.self.dialog.LogoutOptionsDialogState
 import com.wire.android.util.CurrentScreenManager
@@ -270,6 +271,7 @@ class WireActivity : BaseActivity() {
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
             val currentUserId = viewModel.globalAppState.currentUserId
+            val isSessionTransitionInProgress = viewModel.globalAppState.isSessionTransitionInProgress
             val context = LocalContext.current
             val appGraph = context.wireApplicationGraph
             val authenticationViewModelGraph = remember(appGraph) {
@@ -309,6 +311,7 @@ class WireActivity : BaseActivity() {
                         ?.route
                         ?.getBaseRoute()
                     val isUserUiBlocked = viewModel.globalAppState.blockUserUI != null
+                    val isAuthenticationRoute = currentBaseRoute in authenticationGraphRoutes
                     val graphContext = rememberWireActivityGraphContext(
                         appGraph = appGraph,
                         authenticationViewModelGraph = authenticationViewModelGraph,
@@ -316,17 +319,59 @@ class WireActivity : BaseActivity() {
                         currentBaseRoute = currentBaseRoute,
                         startDestinationBaseRoute = startDestination.baseRoute,
                         isUserUiBlocked = isUserUiBlocked,
+                        isSessionTransitionInProgress = isSessionTransitionInProgress,
                     )
                     graphContext?.activityViewModels?.let {
                         LaunchedEffect(it.legalHoldRequestedViewModel) {
                             it.legalHoldRequestedViewModel.observeLegalHoldRequest()
                         }
                     }
-                    LaunchedEffect(currentUserId, currentBaseRoute) {
-                        val isAuthenticationRoute = currentBaseRoute in authenticationGraphRoutes
-                        if (!isUserUiBlocked && currentUserId == null && currentBaseRoute != null && !isAuthenticationRoute) {
+                    LaunchedEffect(currentBaseRoute, currentUserId, graphContext?.sessionGraph) {
+                        if (currentBaseRoute in sessionBackedAuthenticationGraphRoutes && currentUserId == null) {
+                            appLogger.i("$TAG session-backed auth route=$currentBaseRoute without user id, resolving current session")
+                            viewModel.resolveCurrentSessionUserId()
+                        }
+                        appLogger.i(
+                            "$TAG graph route=$currentBaseRoute userId=$currentUserId " +
+                                    "sessionGraph=${graphContext?.sessionGraph != null} " +
+                                    "selected=${graphContext?.graph?.viewModelScopeKey}"
+                        )
+                    }
+                    LaunchedEffect(isSessionTransitionInProgress, isAuthenticationRoute) {
+                        if (isSessionTransitionInProgress && isAuthenticationRoute) {
+                            viewModel.finishSessionTransition()
+                        }
+                    }
+                    LaunchedEffect(currentUserId, currentBaseRoute, isSessionTransitionInProgress, isUserUiBlocked) {
+                        if (isUserUiBlocked) {
+                            appLogger.i("$TAG blocking session dialog visible on route=$currentBaseRoute, waiting for user action")
+                            return@LaunchedEffect
+                        }
+                        if (isSessionTransitionInProgress) {
+                            if (
+                                currentBaseRoute != null &&
+                                !isAuthenticationRoute &&
+                                viewModel.globalAppState.sessionTransitionReason != SessionTransitionReason.SELF_LOGOUT
+                            ) {
+                                appLogger.i("$TAG session transition on route=$currentBaseRoute, resolving current session")
+                                viewModel.resolveMissingCurrentSession(
+                                    NavigationSwitchAccountActions(
+                                        navigate = navigator::navigate,
+                                        canUseNewLogin = loginTypeSelector::canUseNewLogin
+                                    )
+                                )
+                            }
+                            return@LaunchedEffect
+                        }
+                        if (currentUserId != null && currentBaseRoute == NewWelcomeEmptyStartScreenDestination.baseRoute) {
+                            appLogger.i("$TAG valid session on empty auth start, navigating to home")
+                            navigator.navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
+                        } else if (currentUserId == null && currentBaseRoute == NewWelcomeEmptyStartScreenDestination.baseRoute) {
+                            appLogger.i("$TAG no session left on empty auth start, navigating to login")
+                            navigator.navigate(NavigationCommand(NewLoginScreenDestination(), BackStackMode.CLEAR_WHOLE))
+                        } else if (currentUserId == null && currentBaseRoute != null && !isAuthenticationRoute) {
                             appLogger.i("$TAG no session left on route=$currentBaseRoute, trying to switch account")
-                            viewModel.tryToSwitchAccount(
+                            viewModel.resolveMissingCurrentSession(
                                 NavigationSwitchAccountActions(
                                     navigate = navigator::navigate,
                                     canUseNewLogin = loginTypeSelector::canUseNewLogin
@@ -345,7 +390,18 @@ class WireActivity : BaseActivity() {
                         WireAuthBackgroundLayout()
                     }
                     if (graphContext != null) {
-                        graphContext.ProvideViewModelGraph {
+                        graphContext.ProvideViewModelGraph(
+                            logoutAction = { wipeData ->
+                                viewModel.doHardLogout(
+                                    clearUserData = { userId -> UserDataStore(context, userId) },
+                                    switchAccountActions = NavigationSwitchAccountActions(
+                                        navigate = navigator::navigate,
+                                        canUseNewLogin = loginTypeSelector::canUseNewLogin
+                                    ),
+                                    wipeData = wipeData
+                                )
+                            }
+                        ) {
                             Column(
                                 modifier = Modifier
                                     .semantics { testTagsAsResourceId = true }
@@ -387,25 +443,30 @@ class WireActivity : BaseActivity() {
         currentBaseRoute: String?,
         startDestinationBaseRoute: String,
         isUserUiBlocked: Boolean,
+        isSessionTransitionInProgress: Boolean,
     ): WireActivityGraphContext? {
         var graphContext: WireActivityGraphContext? = null
         if (!isUserUiBlocked) {
             val effectiveBaseRoute = currentBaseRoute ?: startDestinationBaseRoute
             val usesNoSessionAuthenticationGraph = effectiveBaseRoute in noSessionAuthenticationGraphRoutes
+            val usesAuthenticationGraph = effectiveBaseRoute in authenticationGraphRoutes
             val sessionGraph = remember(
                 appGraph,
                 currentUserId,
                 currentBaseRoute,
                 usesNoSessionAuthenticationGraph,
+                isSessionTransitionInProgress,
             ) {
                 when {
                     usesNoSessionAuthenticationGraph -> null
+                    isSessionTransitionInProgress -> null
                     currentUserId != null -> appGraph.createSessionViewModelGraph(currentUserId)
                     currentBaseRoute in sessionBackedAuthenticationGraphRoutes -> appGraph.createCurrentSessionViewModelGraphOrNull()
                     else -> null
                 }
             }
             val graph = when {
+                isSessionTransitionInProgress && !usesAuthenticationGraph -> null
                 usesNoSessionAuthenticationGraph -> authenticationViewModelGraph
                 sessionGraph != null -> sessionGraph
                 effectiveBaseRoute in authenticationGraphRoutes -> authenticationViewModelGraph
@@ -428,12 +489,16 @@ class WireActivity : BaseActivity() {
     }
 
     @Composable
-    private fun WireActivityGraphContext.ProvideViewModelGraph(content: @Composable () -> Unit) {
+    private fun WireActivityGraphContext.ProvideViewModelGraph(
+        logoutAction: (wipeData: Boolean) -> Unit,
+        content: @Composable () -> Unit
+    ) {
         CompositionLocalProvider(
             LocalMetroViewModelFactory provides viewModelFactory,
             LocalWireViewModelScopeKey provides graph.viewModelScopeKey,
             LocalAuthenticationCancelUserId provides sessionGraph?.currentAccount,
             LocalWireSessionImageLoader provides sessionGraph?.wireSessionImageLoader,
+            LocalSelfUserProfileLogoutAction provides logoutAction,
         ) {
             content()
         }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -343,41 +343,16 @@ class WireActivity : BaseActivity() {
                         }
                     }
                     LaunchedEffect(currentUserId, currentBaseRoute, isSessionTransitionInProgress, isUserUiBlocked) {
-                        if (isUserUiBlocked) {
-                            appLogger.i("$TAG blocking session dialog visible on route=$currentBaseRoute, waiting for user action")
-                            return@LaunchedEffect
-                        }
-                        if (isSessionTransitionInProgress) {
-                            if (
-                                currentBaseRoute != null &&
-                                !isAuthenticationRoute &&
-                                viewModel.globalAppState.sessionTransitionReason != SessionTransitionReason.SELF_LOGOUT
-                            ) {
-                                appLogger.i("$TAG session transition on route=$currentBaseRoute, resolving current session")
-                                viewModel.resolveMissingCurrentSession(
-                                    NavigationSwitchAccountActions(
-                                        navigate = navigator::navigate,
-                                        canUseNewLogin = loginTypeSelector::canUseNewLogin
-                                    )
-                                )
-                            }
-                            return@LaunchedEffect
-                        }
-                        if (currentUserId != null && currentBaseRoute == NewWelcomeEmptyStartScreenDestination.baseRoute) {
-                            appLogger.i("$TAG valid session on empty auth start, navigating to home")
-                            navigator.navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
-                        } else if (currentUserId == null && currentBaseRoute == NewWelcomeEmptyStartScreenDestination.baseRoute) {
-                            appLogger.i("$TAG no session left on empty auth start, navigating to login")
-                            navigator.navigate(NavigationCommand(NewLoginScreenDestination(), BackStackMode.CLEAR_WHOLE))
-                        } else if (currentUserId == null && currentBaseRoute != null && !isAuthenticationRoute) {
-                            appLogger.i("$TAG no session left on route=$currentBaseRoute, trying to switch account")
-                            viewModel.resolveMissingCurrentSession(
-                                NavigationSwitchAccountActions(
-                                    navigate = navigator::navigate,
-                                    canUseNewLogin = loginTypeSelector::canUseNewLogin
-                                )
-                            )
-                        }
+                        handleSessionNavigationState(
+                            SessionNavigationState(
+                                currentUserId = currentUserId,
+                                currentBaseRoute = currentBaseRoute,
+                                isAuthenticationRoute = isAuthenticationRoute,
+                                isUserUiBlocked = isUserUiBlocked,
+                                isSessionTransitionInProgress = isSessionTransitionInProgress,
+                            ),
+                            navigator = navigator,
+                        )
                     }
                     val backgroundType by remember {
                         derivedStateOf {
@@ -445,53 +420,125 @@ class WireActivity : BaseActivity() {
         isUserUiBlocked: Boolean,
         isSessionTransitionInProgress: Boolean,
     ): WireActivityGraphContext? {
-        var graphContext: WireActivityGraphContext? = null
-        if (!isUserUiBlocked) {
-            val effectiveBaseRoute = currentBaseRoute ?: startDestinationBaseRoute
-            val usesNoSessionAuthenticationGraph = effectiveBaseRoute in noSessionAuthenticationGraphRoutes
-            val usesAuthenticationGraph = effectiveBaseRoute in authenticationGraphRoutes
-            val sessionGraph = remember(
-                appGraph,
-                currentUserId,
-                currentBaseRoute,
-                usesNoSessionAuthenticationGraph,
-                isSessionTransitionInProgress,
-            ) {
-                when {
-                    usesNoSessionAuthenticationGraph -> null
-                    isSessionTransitionInProgress -> null
-                    currentUserId != null -> appGraph.createSessionViewModelGraph(currentUserId)
-                    currentBaseRoute in sessionBackedAuthenticationGraphRoutes -> appGraph.createCurrentSessionViewModelGraphOrNull()
-                    else -> null
-                }
+        if (isUserUiBlocked) return null
+
+        val effectiveBaseRoute = currentBaseRoute ?: startDestinationBaseRoute
+        val usesNoSessionAuthenticationGraph = effectiveBaseRoute in noSessionAuthenticationGraphRoutes
+        val usesAuthenticationGraph = effectiveBaseRoute in authenticationGraphRoutes
+        val sessionGraph = remember(
+            appGraph,
+            currentUserId,
+            currentBaseRoute,
+            usesNoSessionAuthenticationGraph,
+            isSessionTransitionInProgress,
+        ) {
+            appGraph.resolveSessionGraph(
+                currentUserId = currentUserId,
+                currentBaseRoute = currentBaseRoute,
+                usesNoSessionAuthenticationGraph = usesNoSessionAuthenticationGraph,
+                isSessionTransitionInProgress = isSessionTransitionInProgress,
+            )
+        }
+        val graph = resolveActiveGraph(
+            ActiveGraphRequest(
+                authenticationViewModelGraph = authenticationViewModelGraph,
+                sessionGraph = sessionGraph,
+                effectiveBaseRoute = effectiveBaseRoute,
+                currentBaseRoute = currentBaseRoute,
+                usesAuthenticationGraph = usesAuthenticationGraph,
+                usesNoSessionAuthenticationGraph = usesNoSessionAuthenticationGraph,
+                isSessionTransitionInProgress = isSessionTransitionInProgress,
+            )
+        )
+        val activityViewModels = sessionGraph?.let {
+            wireActivityScopedViewModels(it)
+        }
+        return graph?.let {
+            WireActivityGraphContext(
+                graph = it,
+                viewModelFactory = (it as? ViewModelGraph)?.metroViewModelFactory ?: appGraph.metroViewModelFactory,
+                sessionGraph = sessionGraph,
+                activityViewModels = activityViewModels,
+            )
+        }
+    }
+
+    private fun WireApplicationGraph.resolveSessionGraph(
+        currentUserId: UserId?,
+        currentBaseRoute: String?,
+        usesNoSessionAuthenticationGraph: Boolean,
+        isSessionTransitionInProgress: Boolean,
+    ): AppSessionViewModelGraph? = when {
+        usesNoSessionAuthenticationGraph -> null
+        isSessionTransitionInProgress -> null
+        currentUserId != null -> createSessionViewModelGraph(currentUserId)
+        currentBaseRoute in sessionBackedAuthenticationGraphRoutes -> createCurrentSessionViewModelGraphOrNull()
+        else -> null
+    }
+
+    private fun resolveActiveGraph(request: ActiveGraphRequest): MetroViewModelGraph? = when {
+        request.isSessionTransitionInProgress && !request.usesAuthenticationGraph -> null
+        request.usesNoSessionAuthenticationGraph -> request.authenticationViewModelGraph
+        request.sessionGraph != null -> request.sessionGraph
+        request.effectiveBaseRoute in authenticationGraphRoutes -> request.authenticationViewModelGraph
+        request.currentBaseRoute == null -> request.authenticationViewModelGraph
+        else -> null
+    }
+
+    private fun handleSessionNavigationState(
+        state: SessionNavigationState,
+        navigator: Navigator,
+    ) {
+        when {
+            state.isUserUiBlocked -> {
+                appLogger.i("$TAG blocking session dialog visible on route=${state.currentBaseRoute}, waiting for user action")
             }
-            val graph = when {
-                isSessionTransitionInProgress && !usesAuthenticationGraph -> null
-                usesNoSessionAuthenticationGraph -> authenticationViewModelGraph
-                sessionGraph != null -> sessionGraph
-                effectiveBaseRoute in authenticationGraphRoutes -> authenticationViewModelGraph
-                currentBaseRoute == null -> authenticationViewModelGraph
-                else -> null
+            state.isSessionTransitionInProgress -> {
+                handleSessionTransition(state.currentBaseRoute, state.isAuthenticationRoute, navigator)
             }
-            val activityViewModels = sessionGraph?.let {
-                wireActivityScopedViewModels(it)
+            state.currentUserId != null && state.currentBaseRoute == NewWelcomeEmptyStartScreenDestination.baseRoute -> {
+                appLogger.i("$TAG valid session on empty auth start, navigating to home")
+                navigator.navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
             }
-            graphContext = graph?.let {
-                WireActivityGraphContext(
-                    graph = it,
-                    viewModelFactory = (it as? ViewModelGraph)?.metroViewModelFactory ?: appGraph.metroViewModelFactory,
-                    sessionGraph = sessionGraph,
-                    activityViewModels = activityViewModels,
-                )
+            state.currentUserId == null && state.currentBaseRoute == NewWelcomeEmptyStartScreenDestination.baseRoute -> {
+                appLogger.i("$TAG no session left on empty auth start, navigating to login")
+                navigator.navigate(NavigationCommand(NewLoginScreenDestination(), BackStackMode.CLEAR_WHOLE))
+            }
+            state.currentUserId == null && state.currentBaseRoute != null && !state.isAuthenticationRoute -> {
+                appLogger.i("$TAG no session left on route=${state.currentBaseRoute}, trying to switch account")
+                resolveMissingCurrentSession(navigator)
             }
         }
-        return graphContext
+    }
+
+    private fun handleSessionTransition(
+        currentBaseRoute: String?,
+        isAuthenticationRoute: Boolean,
+        navigator: Navigator,
+    ) {
+        if (
+            currentBaseRoute != null &&
+            !isAuthenticationRoute &&
+            viewModel.globalAppState.sessionTransitionReason != SessionTransitionReason.SELF_LOGOUT
+        ) {
+            appLogger.i("$TAG session transition on route=$currentBaseRoute, resolving current session")
+            resolveMissingCurrentSession(navigator)
+        }
+    }
+
+    private fun resolveMissingCurrentSession(navigator: Navigator) {
+        viewModel.resolveMissingCurrentSession(
+            NavigationSwitchAccountActions(
+                navigate = navigator::navigate,
+                canUseNewLogin = loginTypeSelector::canUseNewLogin,
+            )
+        )
     }
 
     @Composable
     private fun WireActivityGraphContext.ProvideViewModelGraph(
         logoutAction: (wipeData: Boolean) -> Unit,
-        content: @Composable () -> Unit
+        content: @Composable () -> Unit,
     ) {
         CompositionLocalProvider(
             LocalMetroViewModelFactory provides viewModelFactory,
@@ -1011,6 +1058,24 @@ private data class WireActivityGraphContext(
     val viewModelFactory: MetroViewModelFactory,
     val sessionGraph: AppSessionViewModelGraph?,
     val activityViewModels: WireActivityScopedViewModels?,
+)
+
+private data class ActiveGraphRequest(
+    val authenticationViewModelGraph: AppAuthenticationViewModelGraph,
+    val sessionGraph: AppSessionViewModelGraph?,
+    val effectiveBaseRoute: String,
+    val currentBaseRoute: String?,
+    val usesAuthenticationGraph: Boolean,
+    val usesNoSessionAuthenticationGraph: Boolean,
+    val isSessionTransitionInProgress: Boolean,
+)
+
+private data class SessionNavigationState(
+    val currentUserId: UserId?,
+    val currentBaseRoute: String?,
+    val isAuthenticationRoute: Boolean,
+    val isUserUiBlocked: Boolean,
+    val isSessionTransitionInProgress: Boolean,
 )
 
 private val noSessionAuthenticationGraphRoutes = setOf(

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -18,6 +18,7 @@
 
 package com.wire.android.ui
 
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -266,146 +267,199 @@ class WireActivity : BaseActivity() {
         newIntents.send(intent to savedInstanceState)
     }
 
-    @Suppress("LongMethod")
     private fun setComposableContent(startDestination: Direction) {
         setContent {
-            val snackbarHostState = remember { SnackbarHostState() }
-            val currentUserId = viewModel.globalAppState.currentUserId
-            val isSessionTransitionInProgress = viewModel.globalAppState.isSessionTransitionInProgress
-            val context = LocalContext.current
-            val appGraph = context.wireApplicationGraph
-            val authenticationViewModelGraph = remember(appGraph) {
-                appGraph.authenticationViewModelGraph
+            WireActivityRoot(startDestination)
+        }
+    }
+
+    @Composable
+    private fun WireActivityRoot(startDestination: Direction) {
+        val snackbarHostState = remember { SnackbarHostState() }
+        val context = LocalContext.current
+        val appGraph = context.wireApplicationGraph
+        val authenticationViewModelGraph = remember(appGraph) {
+            appGraph.authenticationViewModelGraph
+        }
+
+        CompositionLocalProvider(
+            LocalMetroViewModelFactory provides appGraph.metroViewModelFactory,
+            LocalWireViewModelScopeKey provides null,
+            LocalFeatureVisibilityFlags provides FeatureVisibilityFlags,
+            LocalSyncStateObserver provides SyncStateObserver(viewModel.observeSyncFlowState),
+            LocalCustomUiConfigurationProvider provides CustomUiConfigurationProvider,
+            LocalSnackbarHostState provides snackbarHostState,
+            LocalActivity provides this
+        ) {
+            HandleThemeChanges(viewModel.globalAppState.themeOption)
+            WireTheme(accent = viewModel.globalAppState.userAccent) {
+                WireActivityThemedContent(
+                    startDestination = startDestination,
+                    appGraph = appGraph,
+                    authenticationViewModelGraph = authenticationViewModelGraph,
+                    context = context,
+                )
             }
-            CompositionLocalProvider(
-                LocalMetroViewModelFactory provides appGraph.metroViewModelFactory,
-                LocalWireViewModelScopeKey provides null,
-                LocalFeatureVisibilityFlags provides FeatureVisibilityFlags,
-                LocalSyncStateObserver provides SyncStateObserver(viewModel.observeSyncFlowState),
-                LocalCustomUiConfigurationProvider provides CustomUiConfigurationProvider,
-                LocalSnackbarHostState provides snackbarHostState,
-                LocalActivity provides this
-            ) {
-                HandleThemeChanges(viewModel.globalAppState.themeOption)
+        }
+    }
 
-                WireTheme(accent = viewModel.globalAppState.userAccent) {
-                    val navigator = rememberNavigator(
-                        finish = this@WireActivity::finish,
-                        isAllowedToNavigate = { navigationCommand ->
-                            when {
-                                navigationCommand.destination.baseRoute == NewLoginScreenDestination.baseRoute -> {
-                                    /**
-                                     * This is a case when the app tries to open the "enterprise login" screen so first it needs to verify
-                                     * whether it's possible to have another session, if not then do not navigate and show proper dialog.
-                                     */
-                                    viewModel.checkNumberOfSessions()
-                                }
-
-                                else -> true
-                            }
-                        }
-                    )
-                    val currentBackStackEntryState = navigator.navController.currentBackStackEntryAsState()
-                    val currentBaseRoute = currentBackStackEntryState.value
-                        ?.destination
-                        ?.route
-                        ?.getBaseRoute()
-                    val isUserUiBlocked = viewModel.globalAppState.blockUserUI != null
-                    val isAuthenticationRoute = currentBaseRoute in authenticationGraphRoutes
-                    val graphContext = rememberWireActivityGraphContext(
-                        appGraph = appGraph,
-                        authenticationViewModelGraph = authenticationViewModelGraph,
-                        currentUserId = currentUserId,
-                        currentBaseRoute = currentBaseRoute,
-                        startDestinationBaseRoute = startDestination.baseRoute,
-                        isUserUiBlocked = isUserUiBlocked,
-                        isSessionTransitionInProgress = isSessionTransitionInProgress,
-                    )
-                    graphContext?.activityViewModels?.let {
-                        LaunchedEffect(it.legalHoldRequestedViewModel) {
-                            it.legalHoldRequestedViewModel.observeLegalHoldRequest()
-                        }
-                    }
-                    LaunchedEffect(currentBaseRoute, currentUserId, graphContext?.sessionGraph) {
-                        if (currentBaseRoute in sessionBackedAuthenticationGraphRoutes && currentUserId == null) {
-                            appLogger.i("$TAG session-backed auth route=$currentBaseRoute without user id, resolving current session")
-                            viewModel.resolveCurrentSessionUserId()
-                        }
-                        appLogger.i(
-                            "$TAG graph route=$currentBaseRoute userId=$currentUserId " +
-                                    "sessionGraph=${graphContext?.sessionGraph != null} " +
-                                    "selected=${graphContext?.graph?.viewModelScopeKey}"
-                        )
-                    }
-                    LaunchedEffect(isSessionTransitionInProgress, isAuthenticationRoute) {
-                        if (isSessionTransitionInProgress && isAuthenticationRoute) {
-                            viewModel.finishSessionTransition()
-                        }
-                    }
-                    LaunchedEffect(currentUserId, currentBaseRoute, isSessionTransitionInProgress, isUserUiBlocked) {
-                        handleSessionNavigationState(
-                            SessionNavigationState(
-                                currentUserId = currentUserId,
-                                currentBaseRoute = currentBaseRoute,
-                                isAuthenticationRoute = isAuthenticationRoute,
-                                isUserUiBlocked = isUserUiBlocked,
-                                isSessionTransitionInProgress = isSessionTransitionInProgress,
-                            ),
-                            navigator = navigator,
-                        )
-                    }
-                    val backgroundType by remember {
-                        derivedStateOf {
-                            currentBackStackEntryState.value?.safeDestination()?.style.let {
-                                (it as? BackgroundStyle)?.backgroundType() ?: BackgroundType.Default
-                            }
-                        }
-                    }
-                    if (backgroundType == BackgroundType.Auth) {
-                        WireAuthBackgroundLayout()
-                    }
-                    if (graphContext != null) {
-                        graphContext.ProvideViewModelGraph(
-                            logoutAction = { wipeData ->
-                                viewModel.doHardLogout(
-                                    clearUserData = { userId -> UserDataStore(context, userId) },
-                                    switchAccountActions = NavigationSwitchAccountActions(
-                                        navigate = navigator::navigate,
-                                        canUseNewLogin = loginTypeSelector::canUseNewLogin
-                                    ),
-                                    wipeData = wipeData
-                                )
-                            }
-                        ) {
-                            Column(
-                                modifier = Modifier
-                                    .semantics { testTagsAsResourceId = true }
-                            ) {
-                                WireTopAppBar(
-                                    commonTopAppBarState = graphContext.activityViewModels
-                                        ?.commonTopAppBarViewModel
-                                        ?.state ?: CommonTopAppBarState(),
-                                    backgroundType = backgroundType,
-                                )
-                                MainNavHost(
-                                    navigator = navigator,
-                                    loginTypeSelector = loginTypeSelector,
-                                    startDestination = startDestination,
-                                    modifier = Modifier.consumeWindowInsets(WindowInsets.statusBars)
-                                )
-
-                                // Navigation graph creation is async enough that commands issued too early
-                                // can crash before the graph is fully built.
-                                SetUpNavigation(navigator)
-                                HandleScreenshotCensoring()
-                                HandleDialogs(navigator, graphContext.activityViewModels)
-                                HandleViewActions(viewModel.actions, navigator, loginTypeSelector)
-                            }
-                        }
-                    } else {
-                        HandleDialogs(navigator, null)
-                    }
+    @Composable
+    private fun WireActivityThemedContent(
+        startDestination: Direction,
+        appGraph: WireApplicationGraph,
+        authenticationViewModelGraph: AppAuthenticationViewModelGraph,
+        context: Context,
+    ) {
+        val navigator = rememberNavigator(
+            finish = this@WireActivity::finish,
+            isAllowedToNavigate = ::isNavigationAllowed
+        )
+        val currentBackStackEntryState = navigator.navController.currentBackStackEntryAsState()
+        val currentBaseRoute = currentBackStackEntryState.value
+            ?.destination
+            ?.route
+            ?.getBaseRoute()
+        val currentUserId = viewModel.globalAppState.currentUserId
+        val isUserUiBlocked = viewModel.globalAppState.blockUserUI != null
+        val isAuthenticationRoute = currentBaseRoute in authenticationGraphRoutes
+        val isSessionTransitionInProgress = viewModel.globalAppState.isSessionTransitionInProgress
+        val graphContext = rememberWireActivityGraphContext(
+            appGraph = appGraph,
+            authenticationViewModelGraph = authenticationViewModelGraph,
+            currentUserId = currentUserId,
+            currentBaseRoute = currentBaseRoute,
+            startDestinationBaseRoute = startDestination.baseRoute,
+            isUserUiBlocked = isUserUiBlocked,
+            isSessionTransitionInProgress = isSessionTransitionInProgress,
+        )
+        val backgroundType by remember {
+            derivedStateOf {
+                currentBackStackEntryState.value?.safeDestination()?.style.let {
+                    (it as? BackgroundStyle)?.backgroundType() ?: BackgroundType.Default
                 }
+            }
+        }
+
+        HandleSessionGraphEffects(
+            currentUserId = currentUserId,
+            currentBaseRoute = currentBaseRoute,
+            isAuthenticationRoute = isAuthenticationRoute,
+            isUserUiBlocked = isUserUiBlocked,
+            isSessionTransitionInProgress = isSessionTransitionInProgress,
+            graphContext = graphContext,
+            navigator = navigator,
+        )
+        WireActivityMainContent(
+            startDestination = startDestination,
+            navigator = navigator,
+            graphContext = graphContext,
+            backgroundType = backgroundType,
+            context = context,
+        )
+    }
+
+    private fun isNavigationAllowed(navigationCommand: NavigationCommand): Boolean {
+        if (navigationCommand.destination.baseRoute != NewLoginScreenDestination.baseRoute) return true
+
+        // Enterprise login first needs to verify whether another session can be created.
+        return viewModel.checkNumberOfSessions()
+    }
+
+    @Composable
+    private fun HandleSessionGraphEffects(
+        currentUserId: UserId?,
+        currentBaseRoute: String?,
+        isAuthenticationRoute: Boolean,
+        isUserUiBlocked: Boolean,
+        isSessionTransitionInProgress: Boolean,
+        graphContext: WireActivityGraphContext?,
+        navigator: Navigator,
+    ) {
+        graphContext?.activityViewModels?.let {
+            LaunchedEffect(it.legalHoldRequestedViewModel) {
+                it.legalHoldRequestedViewModel.observeLegalHoldRequest()
+            }
+        }
+        LaunchedEffect(currentBaseRoute, currentUserId, graphContext?.sessionGraph) {
+            if (currentBaseRoute in sessionBackedAuthenticationGraphRoutes && currentUserId == null) {
+                appLogger.i("$TAG session-backed auth route=$currentBaseRoute without user id, resolving current session")
+                viewModel.resolveCurrentSessionUserId()
+            }
+            appLogger.i(
+                "$TAG graph route=$currentBaseRoute userId=$currentUserId " +
+                        "sessionGraph=${graphContext?.sessionGraph != null} " +
+                        "selected=${graphContext?.graph?.viewModelScopeKey}"
+            )
+        }
+        LaunchedEffect(isSessionTransitionInProgress, isAuthenticationRoute) {
+            if (isSessionTransitionInProgress && isAuthenticationRoute) {
+                viewModel.finishSessionTransition()
+            }
+        }
+        LaunchedEffect(currentUserId, currentBaseRoute, isSessionTransitionInProgress, isUserUiBlocked) {
+            handleSessionNavigationState(
+                SessionNavigationState(
+                    currentUserId = currentUserId,
+                    currentBaseRoute = currentBaseRoute,
+                    isAuthenticationRoute = isAuthenticationRoute,
+                    isUserUiBlocked = isUserUiBlocked,
+                    isSessionTransitionInProgress = isSessionTransitionInProgress,
+                ),
+                navigator = navigator,
+            )
+        }
+    }
+
+    @Composable
+    private fun WireActivityMainContent(
+        startDestination: Direction,
+        navigator: Navigator,
+        graphContext: WireActivityGraphContext?,
+        backgroundType: BackgroundType,
+        context: Context,
+    ) {
+        if (backgroundType == BackgroundType.Auth) {
+            WireAuthBackgroundLayout()
+        }
+        if (graphContext == null) {
+            HandleDialogs(navigator, null)
+            return
+        }
+        graphContext.ProvideViewModelGraph(
+            logoutAction = { wipeData ->
+                viewModel.doHardLogout(
+                    clearUserData = { userId -> UserDataStore(context, userId) },
+                    switchAccountActions = NavigationSwitchAccountActions(
+                        navigate = navigator::navigate,
+                        canUseNewLogin = loginTypeSelector::canUseNewLogin
+                    ),
+                    wipeData = wipeData
+                )
+            }
+        ) {
+            Column(
+                modifier = Modifier
+                    .semantics { testTagsAsResourceId = true }
+            ) {
+                WireTopAppBar(
+                    commonTopAppBarState = graphContext.activityViewModels
+                        ?.commonTopAppBarViewModel
+                        ?.state ?: CommonTopAppBarState(),
+                    backgroundType = backgroundType,
+                )
+                MainNavHost(
+                    navigator = navigator,
+                    loginTypeSelector = loginTypeSelector,
+                    startDestination = startDestination,
+                    modifier = Modifier.consumeWindowInsets(WindowInsets.statusBars)
+                )
+
+                // Navigation graph creation is async enough that commands issued too early
+                // can crash before the graph is fully built.
+                SetUpNavigation(navigator)
+                HandleScreenshotCensoring()
+                HandleDialogs(navigator, graphContext.activityViewModels)
+                HandleViewActions(viewModel.actions, navigator, loginTypeSelector)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -72,8 +72,6 @@ import com.ramcosta.composedestinations.generated.app.destinations.SelfDevicesSc
 import com.ramcosta.composedestinations.generated.app.destinations.SelfUserProfileScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.WelcomeScreenDestination
 import com.ramcosta.composedestinations.spec.Direction
-import com.ramcosta.composedestinations.utils.destination
-import com.ramcosta.composedestinations.utils.route
 import com.wire.android.BuildConfig
 import com.wire.android.appLogger
 import com.wire.android.config.CustomUiConfigurationProvider
@@ -99,6 +97,8 @@ import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.baseRoute
 import com.wire.android.navigation.getBaseRoute
 import com.wire.android.navigation.rememberNavigator
+import com.wire.android.navigation.safeDestination
+import com.wire.android.navigation.safeRoute
 import com.wire.android.navigation.startDestination
 import com.wire.android.navigation.style.BackgroundStyle
 import com.wire.android.navigation.style.BackgroundType
@@ -322,9 +322,21 @@ class WireActivity : BaseActivity() {
                             it.legalHoldRequestedViewModel.observeLegalHoldRequest()
                         }
                     }
+                    LaunchedEffect(currentUserId, currentBaseRoute) {
+                        val isAuthenticationRoute = currentBaseRoute in authenticationGraphRoutes
+                        if (!isUserUiBlocked && currentUserId == null && currentBaseRoute != null && !isAuthenticationRoute) {
+                            appLogger.i("$TAG no session left on route=$currentBaseRoute, trying to switch account")
+                            viewModel.tryToSwitchAccount(
+                                NavigationSwitchAccountActions(
+                                    navigate = navigator::navigate,
+                                    canUseNewLogin = loginTypeSelector::canUseNewLogin
+                                )
+                            )
+                        }
+                    }
                     val backgroundType by remember {
                         derivedStateOf {
-                            currentBackStackEntryState.value?.destination()?.style.let {
+                            currentBackStackEntryState.value?.safeDestination()?.style.let {
                                 (it as? BackgroundStyle)?.backgroundType() ?: BackgroundType.Default
                             }
                         }
@@ -587,6 +599,11 @@ class WireActivity : BaseActivity() {
                 },
                 onDismiss = viewModel::dismissMaxAccountDialog
             )
+            AccountLoggedOutDialog(
+                viewModel.globalAppState.blockUserUI
+            ) {
+                viewModel.tryToSwitchAccount(NavigationSwitchAccountActions(navigate, loginTypeSelector::canUseNewLogin))
+            }
             return
         }
         val callFeedbackViewModel = activityViewModels.callFeedbackViewModel
@@ -954,7 +971,7 @@ private val authenticationGraphRoutes = setOf(
 )
 
 internal fun Navigator.shouldReplaceWelcomeLoginStartDestination(): Boolean {
-    val firstDestinationBaseRoute = navController.startDestination()?.route()?.baseRoute
+    val firstDestinationBaseRoute = navController.startDestination()?.safeRoute()?.baseRoute
     val welcomeScreens = listOf(WelcomeScreenDestination, NewWelcomeEmptyStartScreenDestination)
     val loginScreens = listOf(LoginScreenDestination, NewLoginScreenDestination)
     val welcomeAndLoginBaseRoutes = (welcomeScreens + loginScreens).map { it.baseRoute }
@@ -962,7 +979,7 @@ internal fun Navigator.shouldReplaceWelcomeLoginStartDestination(): Boolean {
 }
 
 internal fun Navigator.isEmptyWelcomeStartDestination(): Boolean {
-    val firstDestinationBaseRoute = navController.startDestination()?.route()?.baseRoute
+    val firstDestinationBaseRoute = navController.startDestination()?.safeRoute()?.baseRoute
     return firstDestinationBaseRoute == NewWelcomeEmptyStartScreenDestination.baseRoute
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -379,18 +379,22 @@ class WireActivity : BaseActivity() {
         var graphContext: WireActivityGraphContext? = null
         if (!isUserUiBlocked) {
             val effectiveBaseRoute = currentBaseRoute ?: startDestinationBaseRoute
+            val usesNoSessionAuthenticationGraph = effectiveBaseRoute in noSessionAuthenticationGraphRoutes
             val sessionGraph = remember(
                 appGraph,
                 currentUserId,
                 currentBaseRoute,
+                usesNoSessionAuthenticationGraph,
             ) {
                 when {
+                    usesNoSessionAuthenticationGraph -> null
                     currentUserId != null -> appGraph.createSessionViewModelGraph(currentUserId)
                     currentBaseRoute in sessionBackedAuthenticationGraphRoutes -> appGraph.createCurrentSessionViewModelGraphOrNull()
                     else -> null
                 }
             }
             val graph = when {
+                usesNoSessionAuthenticationGraph -> authenticationViewModelGraph
                 sessionGraph != null -> sessionGraph
                 effectiveBaseRoute in authenticationGraphRoutes -> authenticationViewModelGraph
                 currentBaseRoute == null -> authenticationViewModelGraph
@@ -925,6 +929,11 @@ private data class WireActivityGraphContext(
     val viewModelFactory: MetroViewModelFactory,
     val sessionGraph: AppSessionViewModelGraph?,
     val activityViewModels: WireActivityScopedViewModels?,
+)
+
+private val noSessionAuthenticationGraphRoutes = setOf(
+    NewLoginPasswordScreenDestination.baseRoute,
+    NewLoginVerificationCodeScreenDestination.baseRoute,
 )
 
 private val sessionBackedAuthenticationGraphRoutes = setOf(

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityActionsHandler.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityActionsHandler.kt
@@ -21,12 +21,12 @@ import android.content.Context
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
-import com.ramcosta.composedestinations.utils.destination
 import com.wire.android.R
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
+import com.wire.android.navigation.safeRoute
 import com.wire.android.ui.authentication.login.PreFilledUserIdentifierType
 import com.wire.android.ui.authentication.login.SSOCodeAutoLogin
 import com.wire.android.ui.common.HandleActions
@@ -94,7 +94,7 @@ private fun openImportMediaScreen(navigator: Navigator) {
 }
 
 private fun openSsoLogin(navigator: Navigator, action: OnSSOLogin) {
-    when (navigator.navController.currentBackStackEntry?.destination()?.baseRoute) {
+    when (navigator.navController.currentBackStackEntry?.safeRoute()?.baseRoute) {
         // if SSO login started from new login screen, deliver result via savedStateHandle
         // to avoid recreating the ViewModel (which would happen with UPDATE_EXISTED + new nav args)
         NewLoginScreenDestination.baseRoute -> {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -99,16 +99,19 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.InputStream
 import java.io.InputStreamReader
 import dev.zacsweers.metro.Inject
@@ -620,11 +623,11 @@ class WireActivityViewModel @Inject constructor(
 
     fun resolveMissingCurrentSession(actions: SwitchAccountActions) {
         viewModelScope.launch {
-            syncCurrentUserIdFromSession(retries = CURRENT_SESSION_RESOLUTION_RETRIES)
+            syncCurrentUserIdFromSession(awaitValidSession = true)
             if (globalAppState.currentUserId == null) {
                 globalAppState = globalAppState.copy(blockUserUI = null)
                 val result = accountSwitch.value.invoke(SwitchAccountParam.TryToSwitchToNextAccount)
-                syncCurrentUserIdFromSession(retries = CURRENT_SESSION_RESOLUTION_RETRIES)
+                syncCurrentUserIdFromSession(awaitValidSession = true)
                 result.callAction(actions)
             }
         }
@@ -632,7 +635,7 @@ class WireActivityViewModel @Inject constructor(
 
     fun resolveCurrentSessionUserId() {
         viewModelScope.launch {
-            syncCurrentUserIdFromSession(retries = CURRENT_SESSION_RESOLUTION_RETRIES)
+            syncCurrentUserIdFromSession(awaitValidSession = true)
         }
     }
 
@@ -735,18 +738,9 @@ class WireActivityViewModel @Inject constructor(
             ?.takeIf { it.isValid() }
             ?.userId
 
-    private suspend fun syncCurrentUserIdFromSession(retries: Int = 0) {
+    private suspend fun syncCurrentUserIdFromSession(awaitValidSession: Boolean = false) {
         val userId = withContext(dispatchers.io()) {
-            var resolvedUserId = currentSessionUserId()
-            repeat(retries) { attempt ->
-                if (resolvedUserId != null) return@repeat
-                delay(CURRENT_SESSION_RESOLUTION_RETRY_DELAY_MS)
-                resolvedUserId = currentSessionUserId()
-                if (resolvedUserId != null) {
-                    appLogger.i("Resolved current session after retry ${attempt + 1}")
-                }
-            }
-            resolvedUserId
+            resolveCurrentSessionUserId(awaitValidSession)
         }
         withContext(dispatchers.main()) {
             globalAppState = globalAppState.copy(
@@ -762,6 +756,22 @@ class WireActivityViewModel @Inject constructor(
                     globalAppState.sessionTransitionReason
                 },
             )
+        }
+    }
+
+    private suspend fun resolveCurrentSessionUserId(awaitValidSession: Boolean): UserId? {
+        val currentUserId = currentSessionUserId()
+        return if (currentUserId != null || !awaitValidSession) {
+            currentUserId
+        } else {
+            withTimeoutOrNull(CURRENT_SESSION_RESOLUTION_TIMEOUT_MS) {
+                coreLogic.value.getGlobalScope().session.currentSessionFlow()
+                    .filterIsInstance<CurrentSessionResult.Success>()
+                    .map { it.accountInfo }
+                    .filter { it.isValid() }
+                    .firstOrNull()
+                    ?.userId
+            }
         }
     }
 
@@ -848,8 +858,7 @@ class WireActivityViewModel @Inject constructor(
     }
 }
 
-private const val CURRENT_SESSION_RESOLUTION_RETRIES = 50
-private const val CURRENT_SESSION_RESOLUTION_RETRY_DELAY_MS = 100L
+private const val CURRENT_SESSION_RESOLUTION_TIMEOUT_MS = 5_000L
 
 sealed class CurrentSessionErrorState {
     data object RemovedClient : CurrentSessionErrorState()

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -106,6 +106,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.InputStream
@@ -168,6 +169,14 @@ class WireActivityViewModel @Inject constructor(
         .flowOn(dispatchers.io())
         .shareIn(viewModelScope, SharingStarted.WhileSubscribed(), 1)
 
+    private val observeCurrentUserId: SharedFlow<UserId?> = observeCurrentAccountInfo
+        .map {
+            if (it?.isValid() == true) it.userId else null
+        }
+        .distinctUntilChanged()
+        .flowOn(dispatchers.io())
+        .shareIn(viewModelScope, SharingStarted.WhileSubscribed(), 1)
+
     private lateinit var validSessions: StateFlow<List<AccountInfo>>
 
     init {
@@ -175,7 +184,7 @@ class WireActivityViewModel @Inject constructor(
         observeUpdateAppState()
         observeNewClientState()
         observeScreenshotCensoringConfigState()
-        observeCurrentValidUserState()
+        observeCurrentUserState()
         observeAppThemeState()
         observeSelectedAccent()
         observeLogoutState()
@@ -229,10 +238,22 @@ class WireActivityViewModel @Inject constructor(
         }
     }
 
-    private fun observeCurrentValidUserState() {
+    private fun observeCurrentUserState() {
         viewModelScope.launch(dispatchers.io()) {
-            observeCurrentValidUserId.collectLatest {
-                globalAppState = globalAppState.copy(currentUserId = it)
+            observeCurrentUserId.collectLatest {
+                globalAppState = globalAppState.copy(
+                    currentUserId = it,
+                    isSessionTransitionInProgress = if (it != null) {
+                        false
+                    } else {
+                        globalAppState.isSessionTransitionInProgress
+                    },
+                    sessionTransitionReason = if (it != null) {
+                        null
+                    } else {
+                        globalAppState.sessionTransitionReason
+                    },
+                )
             }
         }
     }
@@ -323,24 +344,42 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private suspend fun handleInvalidSession(logoutReason: LogoutReason) {
-        withContext(dispatchers.main()) {
-            when (logoutReason) {
-                LogoutReason.SELF_SOFT_LOGOUT, LogoutReason.SELF_HARD_LOGOUT -> {
-                    // Self logout is handled from the Self user profile screen directly
-                }
-
-                LogoutReason.MIGRATION_TO_CC_FAILED, LogoutReason.REMOVED_CLIENT ->
-                    globalAppState =
-                        globalAppState.copy(blockUserUI = CurrentSessionErrorState.RemovedClient)
-
-                LogoutReason.DELETED_ACCOUNT ->
-                    globalAppState =
-                        globalAppState.copy(blockUserUI = CurrentSessionErrorState.DeletedAccount)
-
-                LogoutReason.SESSION_EXPIRED ->
-                    globalAppState =
-                        globalAppState.copy(blockUserUI = CurrentSessionErrorState.SessionExpired)
+        when (logoutReason) {
+            LogoutReason.SELF_SOFT_LOGOUT, LogoutReason.SELF_HARD_LOGOUT -> {
+                // Self logout is handled from the Self user profile screen directly.
             }
+
+            LogoutReason.REMOVED_CLIENT -> recoverFromRemovedClient()
+
+            LogoutReason.MIGRATION_TO_CC_FAILED ->
+                setCurrentSessionError(CurrentSessionErrorState.RemovedClient)
+
+            LogoutReason.DELETED_ACCOUNT ->
+                setCurrentSessionError(CurrentSessionErrorState.DeletedAccount)
+
+            LogoutReason.SESSION_EXPIRED ->
+                setCurrentSessionError(CurrentSessionErrorState.SessionExpired)
+        }
+    }
+
+    private suspend fun recoverFromRemovedClient() {
+        withContext(dispatchers.main()) {
+            globalAppState = globalAppState.copy(
+                currentUserId = null,
+                blockUserUI = CurrentSessionErrorState.RemovedClient,
+                isSessionTransitionInProgress = false,
+                sessionTransitionReason = SessionTransitionReason.REMOVED_CLIENT,
+            )
+        }
+    }
+
+    private suspend fun setCurrentSessionError(errorState: CurrentSessionErrorState) {
+        withContext(dispatchers.main()) {
+            globalAppState = globalAppState.copy(
+                blockUserUI = errorState,
+                isSessionTransitionInProgress = false,
+                sessionTransitionReason = null,
+            )
         }
     }
 
@@ -521,21 +560,32 @@ class WireActivityViewModel @Inject constructor(
     // TODO: needs to be covered with test once hard logout is validated to be used
     fun doHardLogout(
         clearUserData: (userId: UserId) -> Unit,
-        switchAccountActions: SwitchAccountActions
+        switchAccountActions: SwitchAccountActions,
+        wipeData: Boolean = true
     ) {
         viewModelScope.launch {
+            globalAppState = globalAppState.copy(
+                currentUserId = null,
+                isSessionTransitionInProgress = true,
+                sessionTransitionReason = SessionTransitionReason.SELF_LOGOUT,
+            )
             coreLogic.value.getGlobalScope().session.currentSession().takeIf {
                 it is CurrentSessionResult.Success
             }?.let {
                 val currentUserId = (it as CurrentSessionResult.Success).accountInfo.userId
-                coreLogic.value.getSessionScope(currentUserId).logout(LogoutReason.SELF_HARD_LOGOUT)
-                clearUserData(currentUserId)
-            }
-            accountSwitch.value.invoke(SwitchAccountParam.TryToSwitchToNextAccount).also {
-                if (it == SwitchAccountResult.NoOtherAccountToSwitch) {
-                    globalDataStore.value.clearAppLockPasscode()
+                val switchResult = accountSwitch.value.invoke(SwitchAccountParam.TryToSwitchToNextAccount).also { switchResult ->
+                    if (switchResult == SwitchAccountResult.NoOtherAccountToSwitch) {
+                        globalDataStore.value.clearAppLockPasscode()
+                    }
                 }
-            }.callAction(switchAccountActions)
+                val logoutReason = if (wipeData) LogoutReason.SELF_HARD_LOGOUT else LogoutReason.SELF_SOFT_LOGOUT
+                coreLogic.value.getSessionScope(currentUserId).logout(logoutReason)
+                if (wipeData) {
+                    clearUserData(currentUserId)
+                }
+                syncCurrentUserIdFromSession()
+                switchResult.callAction(switchAccountActions)
+            }
         }
     }
 
@@ -552,17 +602,37 @@ class WireActivityViewModel @Inject constructor(
 
     fun switchAccount(userId: UserId, actions: SwitchAccountActions, onComplete: () -> Unit) {
         viewModelScope.launch {
-            accountSwitch.value.invoke(SwitchAccountParam.SwitchToAccount(userId))
-                .callAction(actions)
+            val result = accountSwitch.value.invoke(SwitchAccountParam.SwitchToAccount(userId))
+            syncCurrentUserIdFromSession()
+            result.callAction(actions)
             onComplete()
         }
     }
 
     fun tryToSwitchAccount(actions: SwitchAccountActions) {
         viewModelScope.launch {
+            val result = accountSwitch.value.invoke(SwitchAccountParam.TryToSwitchToNextAccount)
+            syncCurrentUserIdFromSession()
+            result.callAction(actions)
             globalAppState = globalAppState.copy(blockUserUI = null)
-            accountSwitch.value.invoke(SwitchAccountParam.TryToSwitchToNextAccount)
-                .callAction(actions)
+        }
+    }
+
+    fun resolveMissingCurrentSession(actions: SwitchAccountActions) {
+        viewModelScope.launch {
+            syncCurrentUserIdFromSession(retries = CURRENT_SESSION_RESOLUTION_RETRIES)
+            if (globalAppState.currentUserId == null) {
+                globalAppState = globalAppState.copy(blockUserUI = null)
+                val result = accountSwitch.value.invoke(SwitchAccountParam.TryToSwitchToNextAccount)
+                syncCurrentUserIdFromSession(retries = CURRENT_SESSION_RESOLUTION_RETRIES)
+                result.callAction(actions)
+            }
+        }
+    }
+
+    fun resolveCurrentSessionUserId() {
+        viewModelScope.launch {
+            syncCurrentUserIdFromSession(retries = CURRENT_SESSION_RESOLUTION_RETRIES)
         }
     }
 
@@ -659,6 +729,49 @@ class WireActivityViewModel @Inject constructor(
             ?.takeIf { it.isValid() }
             ?.userId
 
+    private suspend fun currentSessionUserId(): UserId? =
+        (coreLogic.value.getGlobalScope().session.currentSession() as? CurrentSessionResult.Success)
+            ?.accountInfo
+            ?.takeIf { it.isValid() }
+            ?.userId
+
+    private suspend fun syncCurrentUserIdFromSession(retries: Int = 0) {
+        val userId = withContext(dispatchers.io()) {
+            var resolvedUserId = currentSessionUserId()
+            repeat(retries) { attempt ->
+                if (resolvedUserId != null) return@repeat
+                delay(CURRENT_SESSION_RESOLUTION_RETRY_DELAY_MS)
+                resolvedUserId = currentSessionUserId()
+                if (resolvedUserId != null) {
+                    appLogger.i("Resolved current session after retry ${attempt + 1}")
+                }
+            }
+            resolvedUserId
+        }
+        withContext(dispatchers.main()) {
+            globalAppState = globalAppState.copy(
+                currentUserId = userId,
+                isSessionTransitionInProgress = if (userId != null) {
+                    false
+                } else {
+                    globalAppState.isSessionTransitionInProgress
+                },
+                sessionTransitionReason = if (userId != null) {
+                    null
+                } else {
+                    globalAppState.sessionTransitionReason
+                },
+            )
+        }
+    }
+
+    fun finishSessionTransition() {
+        globalAppState = globalAppState.copy(
+            isSessionTransitionInProgress = false,
+            sessionTransitionReason = null,
+        )
+    }
+
     fun dismissMaxAccountDialog() {
         globalAppState = globalAppState.copy(maxAccountDialog = false)
     }
@@ -735,6 +848,9 @@ class WireActivityViewModel @Inject constructor(
     }
 }
 
+private const val CURRENT_SESSION_RESOLUTION_RETRIES = 50
+private const val CURRENT_SESSION_RESOLUTION_RETRY_DELAY_MS = 100L
+
 sealed class CurrentSessionErrorState {
     data object RemovedClient : CurrentSessionErrorState()
     data object DeletedAccount : CurrentSessionErrorState()
@@ -797,8 +913,15 @@ data class GlobalAppState(
     val newClientDialog: NewClientsData? = null,
     val screenshotCensoringEnabled: Boolean = true,
     val themeOption: ThemeOption = ThemeOption.SYSTEM,
-    val userAccent: Accent = Accent.Unknown
+    val userAccent: Accent = Accent.Unknown,
+    val isSessionTransitionInProgress: Boolean = false,
+    val sessionTransitionReason: SessionTransitionReason? = null,
 )
+
+enum class SessionTransitionReason {
+    SELF_LOGOUT,
+    REMOVED_CLIENT,
+}
 
 enum class InitialAppState {
     NOT_LOGGED_IN, LOGGED_IN, ENROLL_E2EI

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -115,7 +115,7 @@ import dev.zacsweers.metro.Inject
 
 private const val AUTOMATED_NOMAD_COOKIE_LABEL = "shared-device"
 
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("LongParameterList", "TooManyFunctions", "LargeClass")
 @OptIn(ExperimentalCoroutinesApi::class)
 class WireActivityViewModel @Inject constructor(
     @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SharedNewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SharedNewConversationViewModel.kt
@@ -18,6 +18,8 @@
 package com.wire.android.ui.home.newconversation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import com.ramcosta.composedestinations.generated.app.navgraphs.NewConversationGraph
 import com.wire.android.navigation.Navigator
@@ -30,7 +32,13 @@ fun sharedNewConversationViewModel(navigator: Navigator): NewConversationViewMod
         checkNotNull(navController.currentBackStackEntry)
     }
     val parentEntry = remember(currentEntry) {
-        navController.getBackStackEntry(NewConversationGraph.route)
+        runCatching { navController.getBackStackEntry(NewConversationGraph.route) }.getOrNull()
     }
-    return newConversationViewModel(parentEntry)
+    val rememberedParentEntry = remember { mutableStateOf(parentEntry) }
+    SideEffect {
+        parentEntry?.let { rememberedParentEntry.value = it }
+    }
+    return newConversationViewModel(checkNotNull(parentEntry ?: rememberedParentEntry.value) {
+        "NewConversationGraph back stack entry is missing"
+    })
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SharedNewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SharedNewConversationViewModel.kt
@@ -38,7 +38,9 @@ fun sharedNewConversationViewModel(navigator: Navigator): NewConversationViewMod
     SideEffect {
         parentEntry?.let { rememberedParentEntry.value = it }
     }
-    return newConversationViewModel(checkNotNull(parentEntry ?: rememberedParentEntry.value) {
-        "NewConversationGraph back stack entry is missing"
-    })
+    return newConversationViewModel(
+        checkNotNull(parentEntry ?: rememberedParentEntry.value) {
+            "NewConversationGraph back stack entry is missing"
+        }
+    )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/deactivated/LegalHoldDeactivatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/deactivated/LegalHoldDeactivatedViewModel.kt
@@ -55,7 +55,13 @@ class LegalHoldDeactivatedViewModel(
 
                     CurrentSessionResult.Failure.SessionNotFound -> flowOf(noSession)
                     is CurrentSessionResult.Success ->
-                        currentSessionResult.accountInfo.userId.let { coreLogic.value.getSessionScope(it).session(it) }
+                        currentSessionResult.accountInfo.userId.let { userId ->
+                            runCatching { coreLogic.value.getSessionScope(userId).session(userId) }
+                                .getOrElse {
+                                    appLogger.e("$TAG: Failed to get session scope for current session: $userId")
+                                    flowOf(noSession)
+                                }
+                        }
                 }
             }
 
@@ -74,7 +80,7 @@ class LegalHoldDeactivatedViewModel(
                                 when (it.legalHoldState) {
                                     is LegalHoldState.Disabled -> LegalHoldDeactivatedState.Visible(userId)
                                     is LegalHoldState.Enabled -> { // for enabled we don't show the dialog, just mark as already notified
-                                        coreLogic.value.getSessionScope(userId).markLegalHoldChangeAsNotifiedForSelf()
+                                        markLegalHoldChangeAsNotified(userId)
                                         LegalHoldDeactivatedState.Hidden
                                     }
                                 }
@@ -87,14 +93,23 @@ class LegalHoldDeactivatedViewModel(
     fun dismiss() {
         viewModelScope.launch {
             (state as? LegalHoldDeactivatedState.Visible)?.let {
-                coreLogic.value.getSessionScope(it.userId).markLegalHoldChangeAsNotifiedForSelf().let {
-                    if (it is MarkLegalHoldChangeAsNotifiedForSelfUseCase.Result.Success) {
+                markLegalHoldChangeAsNotified(it.userId).let { result ->
+                    if (result is MarkLegalHoldChangeAsNotifiedForSelfUseCase.Result.Success) {
                         state = LegalHoldDeactivatedState.Hidden
                     }
                 }
             }
         }
     }
+
+    private suspend fun markLegalHoldChangeAsNotified(
+        userId: UserId
+    ): MarkLegalHoldChangeAsNotifiedForSelfUseCase.Result? =
+        runCatching { coreLogic.value.getSessionScope(userId).markLegalHoldChangeAsNotifiedForSelf() }
+            .getOrElse {
+                appLogger.e("$TAG: Failed to mark legal hold change as notified because session scope is not available")
+                null
+            }
 
     companion object {
         private const val TAG = "LegalHoldDeactivatedViewModel"

--- a/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/legalhold/dialog/requested/LegalHoldRequestedViewModel.kt
@@ -97,7 +97,13 @@ class LegalHoldRequestedViewModel(
 
                     CurrentSessionResult.Failure.SessionNotFound -> flowOf(noSession)
                     is CurrentSessionResult.Success ->
-                        currentSessionResult.accountInfo.userId.let { coreLogic.value.getSessionScope(it).session(it) }
+                        currentSessionResult.accountInfo.userId.let { userId ->
+                            runCatching { coreLogic.value.getSessionScope(userId).session(userId) }
+                                .getOrElse {
+                                    appLogger.e("$TAG: Failed to get session scope for current session: $userId")
+                                    flowOf(noSession)
+                                }
+                        }
                 }
             }
 
@@ -150,34 +156,39 @@ class LegalHoldRequestedViewModel(
             } else {
                 val password = if (it.requiresPassword) passwordTextState.text.toString() else null
                 viewModelScope.launch {
-                    coreLogic.value.sessionScope(it.userId) {
-                        approveLegalHoldRequest(password).let { approveLegalHoldResult ->
-                            state = when (approveLegalHoldResult) {
-                                is ApproveLegalHoldRequestUseCase.Result.Success ->
-                                    LegalHoldRequestedState.Hidden
+                    runCatching {
+                        coreLogic.value.sessionScope(it.userId) {
+                            approveLegalHoldRequest(password).let { approveLegalHoldResult ->
+                                state = when (approveLegalHoldResult) {
+                                    is ApproveLegalHoldRequestUseCase.Result.Success ->
+                                        LegalHoldRequestedState.Hidden
 
-                                ApproveLegalHoldRequestUseCase.Result.Failure.InvalidPassword ->
-                                    it.copy(
-                                        loading = false,
-                                        error = LegalHoldRequestedError.InvalidCredentialsError
-                                    )
+                                    ApproveLegalHoldRequestUseCase.Result.Failure.InvalidPassword ->
+                                        it.copy(
+                                            loading = false,
+                                            error = LegalHoldRequestedError.InvalidCredentialsError
+                                        )
 
-                                ApproveLegalHoldRequestUseCase.Result.Failure.PasswordRequired ->
-                                    it.copy(
-                                        loading = false,
-                                        requiresPassword = true,
-                                        error = LegalHoldRequestedError.InvalidCredentialsError
-                                    )
+                                    ApproveLegalHoldRequestUseCase.Result.Failure.PasswordRequired ->
+                                        it.copy(
+                                            loading = false,
+                                            requiresPassword = true,
+                                            error = LegalHoldRequestedError.InvalidCredentialsError
+                                        )
 
-                                is ApproveLegalHoldRequestUseCase.Result.Failure.GenericFailure -> {
-                                    appLogger.e("$TAG: Failed to approve legal hold: ${approveLegalHoldResult.coreFailure}")
-                                    it.copy(
-                                        loading = false,
-                                        error = LegalHoldRequestedError.GenericError(approveLegalHoldResult.coreFailure)
-                                    )
+                                    is ApproveLegalHoldRequestUseCase.Result.Failure.GenericFailure -> {
+                                        appLogger.e("$TAG: Failed to approve legal hold: ${approveLegalHoldResult.coreFailure}")
+                                        it.copy(
+                                            loading = false,
+                                            error = LegalHoldRequestedError.GenericError(approveLegalHoldResult.coreFailure)
+                                        )
+                                    }
                                 }
                             }
                         }
+                    }.onFailure {
+                        appLogger.e("$TAG: Failed to approve legal hold because session scope is not available")
+                        state = LegalHoldRequestedState.Hidden
                     }
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/self/SelfUserProfileScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -105,6 +106,10 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 
+val LocalSelfUserProfileLogoutAction = staticCompositionLocalOf<((wipeData: Boolean) -> Unit)?> {
+    null
+}
+
 @WireRootDestination(
     style = PopUpNavigationAnimation::class, // default should be PopUpNavigationAnimation
 )
@@ -118,6 +123,7 @@ fun SelfUserProfileScreen(
     legalHoldRequestedViewModel: LegalHoldRequestedViewModel = legalHoldRequestedViewModel()
 ) {
     val legalHoldSubjectDialogState = rememberVisibilityState<Unit>()
+    val logoutAction = LocalSelfUserProfileLogoutAction.current
 
     LaunchedEffect(Unit) {
         // Check if the user is able to migrate to a team account, every time the screen is shown
@@ -128,7 +134,8 @@ fun SelfUserProfileScreen(
         state = viewModelSelf.userProfileState,
         onCloseClick = navigator::navigateBack,
         logout = {
-            viewModelSelf.logout(it, NavigationSwitchAccountActions(navigator::navigate, loginTypeSelector::canUseNewLogin))
+            logoutAction?.invoke(it)
+                ?: viewModelSelf.logout(it, NavigationSwitchAccountActions(navigator::navigate, loginTypeSelector::canUseNewLogin))
         },
         onChangeUserProfilePicture = {
             navigator.navigate(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26140
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR fixes runtime regressions introduced while moving ViewModel creation to Metro-backed graphs.

The main issue was that some session-backed UI could keep using stale or missing session graph state during account transitions, logout, removed-client events, and authentication edge cases. That caused blank screens, wrong session reuse, or crashes when the current account disappeared while UI was still composing session-scoped ViewModels.

**What changed**
- Preserves session transition state while logout/account removal is in progress.
- Handles removed-session navigation more defensively.
- Keeps the login password flow on the no-session graph where appropriate.
- Refactors `WireActivity` session graph resolution into smaller helpers.
- Guards session-backed UI from creating current-session ViewModels when there is no valid current session.
- Updates validation/stability changes needed for the Metro session flow.

**Why**
Metro does not magically mirror Hilt’s activity/session scoping unless the graph lifecycle is modeled explicitly. This PR tightens that lifecycle so session-scoped ViewModels are recreated or dropped consistently when the active account changes.

**Side Note**
This is a stabilization step for the transitional Hilt-to-Metro phase. The long-term target is to simplify this further once all session-scoped ViewModels are owned by an explicit SessionGraph(userId) and the remaining legacy current-session assumptions are removed.

**Manual QA focus**
- App startup with existing accounts.
- Switching between two logged-in accounts.
- Add new account flow.
- Too many devices flow: open, cancel/back, remove device.
- Logout with one account and with multiple accounts.
- Removed-client event with one account and with multiple accounts.
- Login after returning from account/session edge cases.
- Conversation list and open conversation after account transitions.