### PR TITLE
feat: restrict login to different backend (WPB-26152)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/KaliumConfigsModule.kt
@@ -59,7 +59,8 @@ class KaliumConfigsModule {
             collaboraIntegration = BuildConfig.COLLABORA_INTEGRATION_ENABLED,
             dbInvalidationControlEnabled = BuildConfig.DB_INVALIDATION_CONTROL_ENABLED,
             domainWithFaultyKeysMap = BuildConfig.DOMAIN_REMOVAL_KEYS_FOR_REPAIR,
-            isDebug = BuildConfig.DEBUG
+            isDebug = BuildConfig.DEBUG,
+            blockCrossBackendLogin = BuildConfig.BLOCK_CROSS_BACKEND_LOGIN,
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -805,6 +805,10 @@ class WireActivity : BaseActivity() {
             ) {
                 viewModel.tryToSwitchAccount(NavigationSwitchAccountActions(navigate, loginTypeSelector::canUseNewLogin))
             }
+            CrossBackendLoginBlockedDialog(
+                shouldShow = viewModel.globalAppState.crossBackendLoginBlockedDialog,
+                onDismiss = viewModel::dismissCrossBackendLoginBlockedDialog
+            )
             return
         }
         val callFeedbackViewModel = activityViewModels.callFeedbackViewModel
@@ -959,6 +963,10 @@ class WireActivity : BaseActivity() {
                         navigate(NavigationCommand(SelfUserProfileScreenDestination))
                     },
                     onDismiss = viewModel::dismissMaxAccountDialog
+                )
+                CrossBackendLoginBlockedDialog(
+                    shouldShow = viewModel.globalAppState.crossBackendLoginBlockedDialog,
+                    onDismiss = viewModel::dismissCrossBackendLoginBlockedDialog
                 )
                 AccountLoggedOutDialog(
                     viewModel.globalAppState.blockUserUI

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityDialogs.kt
@@ -289,6 +289,22 @@ fun MaxAccountDialog(shouldShow: Boolean, onConfirm: () -> Unit, onDismiss: () -
 }
 
 @Composable
+fun CrossBackendLoginBlockedDialog(shouldShow: Boolean, onDismiss: () -> Unit) {
+    if (shouldShow) {
+        WireDialog(
+            title = stringResource(id = R.string.cross_backend_login_blocked_title),
+            text = stringResource(id = R.string.cross_backend_login_blocked_message),
+            onDismiss = onDismiss,
+            optionButton1Properties = WireDialogButtonProperties(
+                text = stringResource(R.string.label_ok),
+                onClick = onDismiss,
+                type = WireDialogButtonType.Primary
+            )
+        )
+    }
+}
+
+@Composable
 fun AccountLoggedOutDialog(blockUserUI: CurrentSessionErrorState?, navigateAway: () -> Unit) {
     blockUserUI?.let {
         AccountLoggedOutDialogContent(reason = it, navigateAway)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -81,6 +81,7 @@ import com.wire.kalium.logic.feature.conversation.CheckConversationInviteCodeUse
 import com.wire.kalium.logic.feature.debug.SynchronizeExternalDataResult
 import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
+import com.wire.kalium.logic.feature.server.IsCrossBackendLoginBlockedUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.DoesValidNomadAccountExistUseCase
@@ -416,7 +417,16 @@ class WireActivityViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             when (val result = deepLinkProcessor.value.invoke(intent?.data, intent?.action)) {
                 DeepLinkResult.AuthorizationNeeded -> sendAction(OnAuthorizationNeeded)
-                is DeepLinkResult.SSOLogin -> sendAction(OnSSOLogin(result))
+                is DeepLinkResult.SSOLogin -> {
+                    if (result is DeepLinkResult.SSOLogin.Success &&
+                        isCrossBackendLoginBlocked(IsCrossBackendLoginBlockedUseCase.Target.SsoConfigId(result.serverConfigId))
+                    ) {
+                        appLogger.w("Cross-backend SSO login blocked: deeplink target differs from active session backend")
+                        globalAppState = globalAppState.copy(crossBackendLoginBlockedDialog = true)
+                    } else {
+                        sendAction(OnSSOLogin(result))
+                    }
+                }
                 is DeepLinkResult.CustomServerConfig -> onCustomServerConfig(result.url, result.loginType)
                 is DeepLinkResult.SwitchAccountFailure.OngoingCall -> sendAction(ShowToast(R.string.cant_switch_account_in_call))
                 is DeepLinkResult.SwitchAccountFailure.Unknown -> appLogger.e("unknown deeplink failure")
@@ -667,8 +677,17 @@ class WireActivityViewModel @Inject constructor(
 
     fun onCustomServerConfig(customServerUrl: String, loginType: LoginType) {
         viewModelScope.launch(dispatchers.io()) {
-            val customBackendDialogData = loadServerConfig(customServerUrl)
-                ?.let { serverLinks -> CustomServerDetailsDialogState(serverLinks = serverLinks, loginType = loginType) }
+            val serverLinks = loadServerConfig(customServerUrl)
+            if (serverLinks != null &&
+                isCrossBackendLoginBlocked(IsCrossBackendLoginBlockedUseCase.Target.Links(serverLinks))
+            ) {
+                appLogger.w("Cross-backend login blocked: deeplink target differs from active session backend")
+                globalAppState = globalAppState.copy(crossBackendLoginBlockedDialog = true)
+                return@launch
+            }
+
+            val customBackendDialogData = serverLinks
+                ?.let { CustomServerDetailsDialogState(serverLinks = it, loginType = loginType) }
                 ?: CustomServerNoNetworkDialogState(customServerUrl = customServerUrl, loginType = loginType)
 
             globalAppState = globalAppState.copy(
@@ -676,6 +695,9 @@ class WireActivityViewModel @Inject constructor(
             )
         }
     }
+
+    private suspend fun isCrossBackendLoginBlocked(target: IsCrossBackendLoginBlockedUseCase.Target): Boolean =
+        coreLogic.value.getGlobalScope().isCrossBackendLoginBlocked(target)
 
     private suspend fun onConversationInviteDeepLink(
         code: String,
@@ -773,6 +795,10 @@ class WireActivityViewModel @Inject constructor(
 
     fun dismissMaxAccountDialog() {
         globalAppState = globalAppState.copy(maxAccountDialog = false)
+    }
+
+    fun dismissCrossBackendLoginBlockedDialog() {
+        globalAppState = globalAppState.copy(crossBackendLoginBlockedDialog = false)
     }
 
     fun applyPersistentWebSocketConfigFromMDM() {
@@ -903,6 +929,7 @@ data class GlobalAppState(
     val currentUserId: UserId? = null,
     val customBackendDialog: CustomServerDialogState? = null,
     val maxAccountDialog: Boolean = false,
+    val crossBackendLoginBlockedDialog: Boolean = false,
     val blockUserUI: CurrentSessionErrorState? = null,
     val updateAppDialog: Boolean = false,
     val conversationJoinedDialog: JoinConversationViaCodeState? = null,

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/ZoomableImage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/ZoomableImage.kt
@@ -63,7 +63,7 @@ fun ZoomableImage(
     }
 
     ZoomableImageContainer(
-        painter = painter,
+        painter = { painter },
         contentDescription = contentDescription,
         modifier = modifier
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1323,6 +1323,8 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="nomad_account_blocks_login_title">Login Blocked</string>
     <string name="nomad_account_blocks_login_message">A managed profile is currently logged in. Please log out first before adding another account.</string>
     <string name="cant_switch_account_in_call">You can\'t switch accounts while in a call</string>
+    <string name="cross_backend_login_blocked_title">Switching backends is blocked</string>
+    <string name="cross_backend_login_blocked_message">You can\'t log in to a different backend at this point. Log out first, then log in to another backend.</string>
     <string name="deeplink_authorization_needed">You must login to perform this action</string>
     <string name="custom_backend_dialog_title">Redirect to an on-premises backend?</string>
     <string name="custom_backend_dialog_body">If you proceed, your client will be redirected to the following on-premises backend:</string>

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -85,6 +85,7 @@ import com.wire.kalium.logic.feature.conversation.CheckConversationInviteCodeUse
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
+import com.wire.kalium.logic.feature.server.IsCrossBackendLoginBlockedUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionFlowUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
@@ -1072,6 +1073,9 @@ class WireActivityViewModelTest {
             coEvery { isNomadProfilesEnabledUseCase() } returns IsNomadProfilesEnabledUseCase.Result.Success(true)
             coEvery { loginTypeSelector.canUseNewLogin(any()) } returns true
             coEvery { doesValidNomadAccountExist() } returns false
+            coEvery {
+                coreLogic.getGlobalScope().isCrossBackendLoginBlocked(any<IsCrossBackendLoginBlockedUseCase.Target>())
+            } returns false
         }
 
         @MockK

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -155,5 +155,7 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
 
     CALL_QUALITY_MENU_ENABLED("call_quality_menu_enabled", ConfigType.BOOLEAN),
 
-    CALL_REACTIONS_ENABLED("call_reactions_enabled", ConfigType.BOOLEAN)
+    CALL_REACTIONS_ENABLED("call_reactions_enabled", ConfigType.BOOLEAN),
+
+    BLOCK_CROSS_BACKEND_LOGIN("block_cross_backend_login", ConfigType.BOOLEAN)
 }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/image/ZoomableImageContainer.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/image/ZoomableImageContainer.kt
@@ -36,7 +36,7 @@ import com.wire.android.ui.common.preview.MultipleThemePreviews
 
 @Composable
 fun ZoomableImageContainer(
-    painter: Painter,
+    painter: () -> Painter,
     contentDescription: String,
     modifier: Modifier = Modifier,
 ) {
@@ -48,7 +48,7 @@ fun ZoomableImageContainer(
     val maxScale = 3f
 
     Image(
-        painter = painter,
+        painter = painter(),
         contentDescription = contentDescription,
         contentScale = ContentScale.Fit,
         modifier = modifier
@@ -78,8 +78,9 @@ fun ZoomableImageContainer(
 @MultipleThemePreviews
 @Composable
 fun ZoomableImageContainerPreview() {
+    val painter = painterResource(id = R.drawable.mock_image)
     ZoomableImageContainer(
-        painter = painterResource(id = R.drawable.mock_image),
+        painter = { painter },
         contentDescription = "Placeholder image"
     )
 }

--- a/default.json
+++ b/default.json
@@ -174,5 +174,6 @@
     "enforce_configuration_signature": true,
     "call_quality_menu_enabled": true,
     "call_reactions_enabled": true,
-    "nomad_profiles_enabled": true
+    "nomad_profiles_enabled": true,
+    "block_cross_backend_login": false
 }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/imageviewer/CellImageViewerScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/imageviewer/CellImageViewerScreen.kt
@@ -142,7 +142,7 @@ fun CellZoomableImage(
     }
 
     ZoomableImageContainer(
-        painter = painter,
+        painter = { painter },
         contentDescription = contentDescription,
         modifier = modifier
     )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26152
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-26152
----

# What's new in this PR?

### Restrict users login to backend which is different from current session backend
- New feature flag to enable the feature
- KaliumConfigs update to expose the flag to kalium use cases
- Call new use case in regular and SSO login flows.