### PR TITLE
fix: allow keyboard focus on search back action [WPB-14778]

### DIFF
--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchTopBar.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchTopBar.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isAltPressed
 import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
@@ -273,10 +274,29 @@ private fun ActiveSearchBarInput(
             .focusRequester(focusRequester)
             .focusProperties {
                 previous = backButtonFocusRequester
+                left = backButtonFocusRequester
                 if (hasSearchQuery) {
                     next = clearButtonFocusRequester
                 } else {
                     nextFocusRequester?.let { next = it }
+                }
+            }
+            .onPreviewKeyEvent { event ->
+                val isCursorAtStart = textState.selection.start == 0 && textState.selection.end == 0
+                val shouldFocusBackButton = if (event.type == KeyEventType.KeyDown) {
+                    when (event.key) {
+                        Key.Tab -> event.isShiftPressed
+                        Key.DirectionLeft -> isCursorAtStart && !event.hasModifierPressed
+                        else -> false
+                    }
+                } else {
+                    false
+                }
+                if (shouldFocusBackButton) {
+                    backButtonFocusRequester.requestFocus()
+                    true
+                } else {
+                    false
                 }
             }
             .onEscapeOrBackKey(
@@ -507,6 +527,9 @@ private val navigationKeys = setOf(
 
 private val KeyEvent.isSearchActivationKey: Boolean
     get() = type == KeyEventType.KeyDown && (key == Key.Enter || key == Key.Spacebar)
+
+private val KeyEvent.hasModifierPressed: Boolean
+    get() = isCtrlPressed || isMetaPressed || isAltPressed || isShiftPressed
 
 private val KeyEvent.printableCharacter: String?
     get() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-14778
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixed keyboard navigation in active search fields so the back arrow can be focused and activated without using a mouse.

### Issues

When searching for people, keyboard users could type and clear text, but could not move focus to the search back arrow. The only keyboard way to exit search was `Esc`.

### Solutions

Updated `SearchTopBar` so active search input can move focus to the back arrow with keyboard navigation, including `Shift+Tab` and left arrow when the cursor is at the start of the text.
