### PR TITLE
fix: accessibility heading semantics [WPB-14776]

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/ui/common/HeadingSemanticsTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/common/HeadingSemanticsTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui.common
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.wire.android.ui.WireTestTheme
+import com.wire.android.ui.common.rowitem.BigSectionHeader
+import com.wire.android.ui.common.rowitem.EmptyListContent
+import com.wire.android.ui.common.rowitem.SectionHeader
+import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.newauthentication.login.NewAuthTitle
+import org.junit.Rule
+import org.junit.Test
+
+class HeadingSemanticsTest {
+
+    @get:Rule
+    val composeTestRule by lazy { createComposeRule() }
+
+    @Test
+    fun givenTopAppBarTitle_whenRendered_thenSemanticsHeadingIsSet() {
+        composeTestRule.setContent {
+            WireTestTheme {
+                WireCenterAlignedTopAppBar(title = "Conversations")
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText("Conversations")
+            .assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.Heading))
+    }
+
+    @Test
+    fun givenSectionHeader_whenRendered_thenSemanticsHeadingIsSet() {
+        composeTestRule.setContent {
+            WireTestTheme {
+                SectionHeader(name = "Settings")
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText("SETTINGS")
+            .assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.Heading))
+    }
+
+    @Test
+    fun givenBigSectionHeader_whenRendered_thenSemanticsHeadingIsSet() {
+        composeTestRule.setContent {
+            WireTestTheme {
+                BigSectionHeader(name = "Today")
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText("Today")
+            .assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.Heading))
+    }
+
+    @Test
+    fun givenEmptyListTitle_whenRendered_thenSemanticsHeadingIsSet() {
+        composeTestRule.setContent {
+            WireTestTheme {
+                EmptyListContent(
+                    title = "No conversations yet",
+                    text = "Start a conversation",
+                    footer = {},
+                    modifier = Modifier
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText("No conversations yet")
+            .assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.Heading))
+    }
+
+    @Test
+    fun givenNewAuthTitle_whenRendered_thenSemanticsHeadingIsSet() {
+        composeTestRule.setContent {
+            WireTestTheme {
+                NewAuthTitle(title = "Log in")
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText("Log in")
+            .assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.Heading))
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/common/ServerTitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/common/ServerTitle.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.TextStyle
@@ -108,7 +110,7 @@ fun ServerTitle(
         maxLines = if (titleResId != null) Int.MAX_VALUE else 1,
         overflow = TextOverflow.Ellipsis,
         inlineContent = inlineContent,
-        modifier = modifier,
+        modifier = modifier.semantics { heading() },
     )
 
     if (serverFullDetailsDialogState) {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreatePersonalAccountOverviewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreatePersonalAccountOverviewScreen.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
@@ -181,7 +183,7 @@ private fun OverviewTexts(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(bottom = MaterialTheme.wireDimensions.spacing8x)
-                    .clearAndSetSemantics {}
+                    .semantics { heading() }
             )
         }
         Text(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/username/CreateAccountUsernameScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/username/CreateAccountUsernameScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import com.wire.android.ui.authentication.createAccountUsernameViewModel
 import com.wire.android.R
 import com.wire.android.navigation.BackStackMode
@@ -93,6 +95,7 @@ private fun UsernameContent(
                     Text(
                         text = stringResource(id = R.string.create_account_set_username_title),
                         style = MaterialTheme.wireTypography.title01,
+                        modifier = Modifier.semantics { heading() }
                     )
                 },
                 canNavigateBack = false

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
@@ -166,6 +167,7 @@ private fun LoginEmailContent(
                         .padding(
                             vertical = MaterialTheme.wireDimensions.spacing16x
                         )
+                        .semantics { heading() }
                 )
             }
             val invalidCredentialsErrorText = if (loginEmailState.showInvalidCredentialsError) {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/ProxyScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/ProxyScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.Dp
 import com.wire.android.R
@@ -70,6 +72,7 @@ fun ProxyScreen(
                 .padding(
                     vertical = MaterialTheme.wireDimensions.spacing16x
                 )
+                .semantics { heading() }
         )
 
         apiProxyUrl?.let {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallerDetails.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallerDetails.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import com.wire.android.R
@@ -114,6 +116,7 @@ fun CallerDetails(
                 },
                 color = colorsScheme().onBackground,
                 style = MaterialTheme.wireTypography.title01,
+                modifier = Modifier.semantics { heading() }
             )
 
             ConversationVerificationIcons(

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -676,7 +677,8 @@ private fun OngoingCallTopBar(
                         text = conversationName,
                         style = MaterialTheme.wireTypography.title02,
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.semantics { heading() }
                     )
                     ConversationVerificationIcons(
                         protocolInfo,

--- a/app/src/main/kotlin/com/wire/android/ui/home/archive/ArchiveEmptyContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/archive/ArchiveEmptyContent.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import com.wire.android.R
 import com.wire.android.ui.common.dimensions
@@ -44,9 +46,11 @@ fun ArchiveEmptyContent(modifier: Modifier = Modifier) {
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            modifier = Modifier.padding(
-                bottom = dimensions().spacing24x,
-            ),
+            modifier = Modifier
+                .padding(
+                    bottom = dimensions().spacing24x,
+                )
+                .semantics { heading() },
             text = stringResource(R.string.archive_screen_empty_state_title),
             style = MaterialTheme.wireTypography.title01,
             color = MaterialTheme.wireColorScheme.onSurface,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
@@ -143,7 +145,9 @@ private fun ConversationScreenTopAppBarContent(
                     style = MaterialTheme.wireTypography.title02,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(weight = 1f, fill = false)
+                    modifier = Modifier
+                        .weight(weight = 1f, fill = false)
+                        .semantics { heading() }
                 )
                 ConversationVerificationIcons(
                     conversationInfoViewState.protocolInfo,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsTopBarCollapsing.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsTopBarCollapsing.kt
@@ -36,6 +36,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.wire.android.R
@@ -111,6 +113,7 @@ fun GroupConversationDetailsTopBarCollapsing(
                             horizontal = dimensions().spacing16x,
                             vertical = dimensions().spacing4x
                         )
+                        .semantics { heading() }
                 )
                 Text(
                     text = stringResource(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/PasswordProtectedLinkBanner.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editguestaccess/PasswordProtectedLinkBanner.kt
@@ -34,6 +34,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.ui.common.colorsScheme
@@ -68,6 +70,7 @@ fun PasswordProtectedLinkBanner(modifier: Modifier = Modifier) {
                 Text(
                     text = stringResource(id = R.string.password_protected_link_banner_title),
                     style = MaterialTheme.wireTypography.title02,
+                    modifier = Modifier.semantics { heading() }
                 )
                 Spacer(modifier = Modifier.width(4.dp))
                 Icon(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/AppSettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appsettings/AppSettingsScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -44,7 +46,10 @@ fun AppSettingsScreen() {
             text = "Settings is under construction",
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onBackground,
-            modifier = Modifier.align(Alignment.CenterHorizontally).padding(16.dp),
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(16.dp)
+                .semantics { heading() },
             textAlign = TextAlign.Center,
             fontSize = 18.sp
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -246,6 +248,7 @@ private fun BackupAndRestoreText(lastBackupTime: Long?, modifier: Modifier = Mod
             color = MaterialTheme.wireColorScheme.secondaryText,
             modifier = Modifier
                 .padding(top = MaterialTheme.wireDimensions.spacing32x)
+                .semantics { heading() }
         )
         Text(
             text = lastBackupText,

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginContainer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginContainer.kt
@@ -39,6 +39,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import com.wire.android.BuildConfig
@@ -145,6 +147,7 @@ fun NewAuthTitle(
         textAlign = TextAlign.Center,
         modifier = modifier
             .padding(vertical = verticalPadding)
+            .semantics { heading() }
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.ui.authentication.createAccountVerificationCodeViewModel
 import com.wire.android.R
@@ -154,6 +156,7 @@ private fun CodeContent(
                     Text(
                         text = stringResource(id = R.string.create_personal_account_title),
                         style = MaterialTheme.wireTypography.title01,
+                        modifier = Modifier.semantics { heading() }
                     )
                     if (serverConfig.isOnPremises == true) {
                         ServerTitle(

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
@@ -162,7 +164,8 @@ private fun AccountDetailsContent(
                 title = {
                     Text(
                         text = stringResource(id = R.string.create_personal_account_title),
-                        style = MaterialTheme.wireTypography.title01
+                        style = MaterialTheme.wireTypography.title01,
+                        modifier = Modifier.semantics { heading() }
                     )
                     if (serverConfig.isOnPremises) {
                         ServerTitle(

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.core.net.toUri
 import com.wire.android.ui.authentication.createAccountSelectorViewModel
@@ -138,7 +140,8 @@ fun CreateAccountSelectorContent(
                 title = {
                     Text(
                         text = stringResource(id = R.string.create_account_selector_title),
-                        style = MaterialTheme.wireTypography.title01
+                        style = MaterialTheme.wireTypography.title01,
+                        modifier = Modifier.semantics { heading() }
                     )
                     if (customServerLinks?.isOnPremises == true) {
                         ServerTitle(
@@ -226,6 +229,7 @@ private fun AccountType(
                 modifier = Modifier
                     .padding(horizontal = dimensions().spacing8x)
                     .fillMaxWidth()
+                    .semantics { heading() }
             )
             Text(
                 text = subtitle,

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/EndToEndIdentityCertificateItem.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import com.wire.android.R
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
@@ -73,7 +75,8 @@ fun EndToEndIdentityCertificateItem(
         Text(
             text = stringResource(id = R.string.item_title_e2ei_certificate),
             style = MaterialTheme.wireTypography.title02,
-            color = MaterialTheme.wireColorScheme.onBackground
+            color = MaterialTheme.wireColorScheme.onBackground,
+            modifier = Modifier.semantics { heading() }
         )
         Text(
             modifier = Modifier.padding(

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Placeholder
@@ -211,7 +212,10 @@ fun UserProfileInfo(
                         start.linkTo(parent.start)
                         end.linkTo(parent.end)
                     }
-                    .semantics(mergeDescendants = true) { contentDescription = profileNameDescription },
+                    .semantics(mergeDescendants = true) {
+                        contentDescription = profileNameDescription
+                        heading()
+                    },
                 text = text,
                 // TODO. replace with MIDDLE_ELLIPSIS when available see https://issuetracker.google.com/issues/185418980
                 overflow = TextOverflow.Visible,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserConnectionStatusInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserConnectionStatusInfo.kt
@@ -29,6 +29,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
@@ -53,7 +55,8 @@ fun OtherUserConnectionStatusInfo(connectionStatus: ConnectionState, membership:
                     text = stringResource(R.string.connection_label_user_wants_to_conect),
                     textAlign = TextAlign.Center,
                     color = MaterialTheme.wireColorScheme.onSurface,
-                    style = MaterialTheme.wireTypography.title02
+                    style = MaterialTheme.wireTypography.title02,
+                    modifier = Modifier.semantics { heading() }
                 )
             }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/qr/SelfQRCodeScreen.kt
@@ -50,6 +50,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
@@ -187,7 +189,8 @@ private fun SelfQRCodeContent(
                 Text(
                     text = state.handle.ifNotEmpty { "@${state.handle}" },
                     style = MaterialTheme.wireTypography.title01,
-                    color = Color.Black
+                    color = Color.Black,
+                    modifier = Modifier.semantics { heading() }
                 )
 
                 // Full Link

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsNotFoundScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsNotFoundScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import com.wire.android.R
 import com.wire.android.model.Clickable
@@ -79,7 +81,8 @@ fun ServiceDetailsNotFoundScreen(
                     overflow = TextOverflow.Visible,
                     maxLines = 1,
                     style = MaterialTheme.wireTypography.title02,
-                    color = MaterialTheme.colorScheme.onBackground
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.semantics { heading() }
                 )
             }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/service/ServiceDetailsScreen.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import com.ramcosta.composedestinations.generated.app.destinations.ConversationScreenDestination
@@ -197,6 +199,7 @@ private fun ServiceDetailsProfileInfo(state: ServiceDetailsState) {
                         color = MaterialTheme.colorScheme.onBackground,
                         overflow = TextOverflow.Visible,
                         maxLines = 1,
+                        modifier = Modifier.semantics { heading() }
                     )
                     UserBadge(
                         membership = Membership.Service,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step1/TeamMigrationTeamPlanStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step1/TeamMigrationTeamPlanStepScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -118,7 +120,8 @@ private fun TeamMigrationTeamPlanStepScreenContent(
                         top = dimensions().spacing8x,
                         bottom = dimensions().spacing56x
                     )
-                    .align(alignment = Alignment.CenterHorizontally),
+                    .align(alignment = Alignment.CenterHorizontally)
+                    .semantics { heading() },
                 text = stringResource(R.string.personal_to_team_migration_team_plan_step),
                 style = MaterialTheme.wireTypography.title01,
                 color = colorsScheme().onBackground

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step2/TeamMigrationTeamNameStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step2/TeamMigrationTeamNameStepScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import com.wire.android.R
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
@@ -112,7 +114,8 @@ private fun TeamMigrationTeamNameStepScreenContent(
                         top = dimensions().spacing8x,
                         bottom = dimensions().spacing56x
                     )
-                    .align(alignment = Alignment.CenterHorizontally),
+                    .align(alignment = Alignment.CenterHorizontally)
+                    .semantics { heading() },
                 text = stringResource(R.string.personal_to_team_migration_team_name_step),
                 style = MaterialTheme.wireTypography.title01,
                 color = colorsScheme().onBackground

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step3/TeamMigrationConfirmationStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step3/TeamMigrationConfirmationStepScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
@@ -217,7 +219,8 @@ private fun TeamMigrationConfirmationStepScreenContent(
                         top = dimensions().spacing8x,
                         bottom = dimensions().spacing56x
                     )
-                    .align(alignment = Alignment.CenterHorizontally),
+                    .align(alignment = Alignment.CenterHorizontally)
+                    .semantics { heading() },
                 text = stringResource(R.string.personal_to_team_migration_confirmation_step),
                 style = MaterialTheme.wireTypography.title01,
                 color = colorsScheme().onBackground

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step4/TeamMigrationDoneStepScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/teammigration/step4/TeamMigrationDoneStepScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import com.wire.android.R
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -120,7 +122,8 @@ private fun TeamMigrationDoneStepContent(
                         top = dimensions().spacing8x,
                         bottom = dimensions().spacing56x
                     )
-                    .align(alignment = Alignment.CenterHorizontally),
+                    .align(alignment = Alignment.CenterHorizontally)
+                    .semantics { heading() },
                 text = stringResource(R.string.personal_to_team_migration_done_step, username),
                 style = MaterialTheme.wireTypography.title01,
                 color = colorsScheme().onBackground

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/rowitem/EmptyListContent.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/rowitem/EmptyListContent.kt
@@ -28,6 +28,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import com.wire.android.ui.common.R
 import com.wire.android.ui.common.dimensions
@@ -52,10 +54,12 @@ fun EmptyListContent(
     ) {
         title?.let { title ->
             Text(
-                modifier = Modifier.padding(
-                    bottom = dimensions().spacing16x,
-                    top = dimensions().spacing100x
-                ),
+                modifier = Modifier
+                    .padding(
+                        bottom = dimensions().spacing16x,
+                        top = dimensions().spacing100x
+                    )
+                    .semantics { heading() },
                 text = title,
                 style = MaterialTheme.wireTypography.title01,
                 color = MaterialTheme.wireColorScheme.onSurface,

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/rowitem/SectionHeader.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/rowitem/SectionHeader.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import com.wire.android.ui.common.R
 import com.wire.android.ui.common.dimensions
@@ -67,7 +69,9 @@ fun SectionHeader(
 ) {
     Text(
         text = name.uppercase(),
-        modifier = modifier.padding(padding),
+        modifier = modifier
+            .padding(padding)
+            .semantics { heading() },
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
         style = MaterialTheme.wireTypography.title03,
@@ -117,7 +121,9 @@ fun BigSectionHeader(
 ) {
     Text(
         text = name,
-        modifier = modifier.padding(padding),
+        modifier = modifier
+            .padding(padding)
+            .semantics { heading() },
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
         style = MaterialTheme.wireTypography.body02,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-14776
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Marked visual screen titles and section labels as accessibility headings across login/onboarding, conversations, archive, settings, user profile, conversation details, and call-related screens.
- Added heading semantics to shared UI components such as section headers and empty-state titles so reused views expose the correct structure to TalkBack.
- Added Compose instrumentation coverage to verify key heading components expose `SemanticsProperties.Heading`.