### PR TITLE
fix: session auth navigation after Metro migration [WPB-26324] [WPB-26330] [WPB-26328] [WPB-26333]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -93,6 +93,7 @@ import com.wire.kalium.logic.util.RandomPassword
 import com.wire.kalium.network.NetworkStateObserver
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.runBlocking
 import dev.zacsweers.metro.Qualifier
 import dev.zacsweers.metro.AppScope
@@ -109,6 +110,18 @@ annotation class NoSession
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class DefaultWebSocketEnabledByDefault
+
+@SingleIn(AppScope::class)
+class LastKnownCurrentAccount @Inject constructor() {
+    @Volatile
+    private var userId: UserId? = null
+
+    fun update(userId: UserId) {
+        this.userId = userId
+    }
+
+    fun get(): UserId? = userId
+}
 
 @BindingContainer
 class CoreLogicModule {
@@ -186,16 +199,21 @@ class CoreLogicModule {
 
 @BindingContainer
 class SessionModule {
-    // TODO: can be improved by caching the current session in kalium or changing the scope to ActivityRetainedScoped
+    // TODO: remove this fallback once root/auth ViewModel graphs no longer include session ViewModel bindings.
 
     @CurrentAccount
     @Provides
-    fun provideCurrentSession(@KaliumCoreLogic coreLogic: CoreLogic): UserId {
+    fun provideCurrentSession(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        lastKnownCurrentAccount: LastKnownCurrentAccount,
+    ): UserId {
         return runBlocking {
             return@runBlocking when (val result = coreLogic.getGlobalScope().session.currentSession.invoke()) {
-                is CurrentSessionResult.Success -> result.accountInfo.userId
+                is CurrentSessionResult.Success -> result.accountInfo.userId.also(lastKnownCurrentAccount::update)
                 else -> {
-                    throw IllegalStateException("no current session was found")
+                    // During logout, Compose may still dispose/move old session content and ask the root factory for
+                    // account-scoped dependencies after Kalium has already cleared the current session.
+                    lastKnownCurrentAccount.get() ?: throw IllegalStateException("no current session was found")
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/di/metro/AppSessionViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/AppSessionViewModelGraph.kt
@@ -28,6 +28,8 @@ import com.wire.android.ui.common.CommonViewModelFactory
 import com.wire.android.ui.common.CommonViewModelGraph
 import com.wire.android.ui.debug.DebugInfoViewModelFactory
 import com.wire.android.ui.debug.DebugInfoViewModelGraph
+import com.wire.android.ui.home.HomeViewModelFactory
+import com.wire.android.ui.home.HomeViewModelGraph
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.user.UserId
 import dev.zacsweers.metro.AppScope
@@ -48,6 +50,7 @@ interface AppSessionViewModelGraph :
     AuthenticationViewModelGraph,
     CallingViewModelGraph,
     DebugInfoViewModelGraph,
+    HomeViewModelGraph,
     CommonViewModelGraph {
     @get:CurrentAccount
     val currentAccount: UserId
@@ -60,6 +63,7 @@ interface AppSessionViewModelGraph :
     override val miscViewModelFactory: MiscViewModelFactory
     override val callingViewModelFactory: CallingViewModelFactory
     override val debugInfoViewModelFactory: DebugInfoViewModelFactory
+    override val homeViewModelFactory: HomeViewModelFactory
     override val commonViewModelFactory: CommonViewModelFactory
 
     @ContributesTo(AppScope::class)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -90,13 +91,13 @@ import com.wire.android.appLogger
 import com.wire.android.config.CustomUiConfigurationProvider
 import com.wire.android.config.LocalCustomUiConfigurationProvider
 import com.wire.android.datastore.UserDataStore
+import com.wire.android.di.LastKnownCurrentAccount
 import com.wire.android.di.metro.AppAuthenticationViewModelGraph
 import com.wire.android.di.metro.AppSessionViewModelGraph
 import com.wire.android.di.metro.LocalWireViewModelScopeKey
 import com.wire.android.di.metro.MetroViewModelGraph
 import com.wire.android.di.metro.WireApplicationGraph
 import com.wire.android.di.metro.createSessionViewModelGraph
-import com.wire.android.di.metro.sessionKeyedMetroViewModelKey
 import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.emm.ManagedConfigurationsManager
 import com.wire.android.feature.NavigationSwitchAccountActions
@@ -134,7 +135,6 @@ import com.wire.android.ui.home.E2EIResultDialog
 import com.wire.android.ui.home.E2EISnoozeDialog
 import com.wire.android.ui.home.FeatureFlagState
 import com.wire.android.ui.home.appLock.LockCodeTimeManager
-import com.wire.android.ui.home.featureFlagNotificationViewModel
 import com.wire.android.ui.home.sync.FeatureFlagNotificationViewModel
 import com.wire.android.ui.legalhold.dialog.deactivated.LegalHoldDeactivatedDialog
 import com.wire.android.ui.legalhold.dialog.deactivated.LegalHoldDeactivatedState
@@ -168,7 +168,6 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
 import dev.zacsweers.metrox.viewmodel.ViewModelGraph
-import dev.zacsweers.metrox.viewmodel.metroViewModel as metroxViewModel
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Suppress("TooManyFunctions", "LargeClass")
@@ -191,6 +190,9 @@ class WireActivity : BaseActivity() {
 
     @Inject
     lateinit var managedConfigurationsManager: ManagedConfigurationsManager
+
+    @Inject
+    lateinit var lastKnownCurrentAccount: LastKnownCurrentAccount
 
     private val viewModel: WireActivityViewModel by viewModels {
         viewModelFactory {
@@ -352,6 +354,9 @@ class WireActivity : BaseActivity() {
         val isUserUiBlocked = viewModel.globalAppState.blockUserUI != null
         val isAuthenticationRoute = currentBaseRoute in authenticationGraphRoutes
         val isSessionTransitionInProgress = viewModel.globalAppState.isSessionTransitionInProgress
+        LaunchedEffect(currentUserId) {
+            currentUserId?.let(lastKnownCurrentAccount::update)
+        }
         val graphContext = rememberWireActivityGraphContext(
             appGraph = appGraph,
             authenticationViewModelGraph = authenticationViewModelGraph,
@@ -367,10 +372,13 @@ class WireActivity : BaseActivity() {
         if (graphContext?.sessionGraph != null) {
             lastSessionGraphContext.value = graphContext
         }
+        val canRenderSessionBackedRoute = currentUserId != null || sessionBackedAuthenticationUserId != null
+        val canRetainSessionGraphForContent = !isAuthenticationRoute && canRenderSessionBackedRoute
         val contentGraphContext = graphContext ?: when {
-            currentBaseRoute != null && !isAuthenticationRoute -> lastSessionGraphContext.value
+            currentBaseRoute != null && canRetainSessionGraphForContent -> lastSessionGraphContext.value
             else -> null
         }
+        val navHostStartDestination = resolveNavHostStartDestination(startDestination, currentUserId)
         val backgroundType by remember {
             derivedStateOf {
                 currentBackStackEntryState.value?.safeDestination()?.style.let {
@@ -390,13 +398,26 @@ class WireActivity : BaseActivity() {
             navigator = navigator,
         )
         WireActivityMainContent(
-            startDestination = startDestination,
+            startDestination = navHostStartDestination,
             navigator = navigator,
             graphContext = contentGraphContext,
             backgroundType = backgroundType,
             context = context,
         )
     }
+
+    private fun resolveNavHostStartDestination(
+        initialStartDestination: Direction,
+        currentUserId: UserId?,
+    ): Direction =
+        if (currentUserId == null && initialStartDestination.baseRoute !in authenticationGraphRoutes) {
+            when (loginTypeSelector.canUseNewLogin()) {
+                true -> NewLoginScreenDestination()
+                false -> WelcomeScreenDestination()
+            }
+        } else {
+            initialStartDestination
+        }
 
     private fun isNavigationAllowed(navigationCommand: NavigationCommand): Boolean {
         if (navigationCommand.destination.baseRoute != NewLoginScreenDestination.baseRoute) return true
@@ -439,6 +460,7 @@ class WireActivity : BaseActivity() {
                     currentUserId = currentUserId,
                     currentBaseRoute = currentBaseRoute,
                     isAuthenticationRoute = isAuthenticationRoute,
+                    isSessionBackedAuthenticationRoute = currentBaseRoute in sessionBackedAuthenticationGraphRoutes,
                     isUserUiBlocked = isUserUiBlocked,
                     isSessionTransitionInProgress = isSessionTransitionInProgress,
                 ),
@@ -484,12 +506,14 @@ class WireActivity : BaseActivity() {
                         ?.state ?: CommonTopAppBarState(),
                     backgroundType = backgroundType,
                 )
-                MainNavHost(
-                    navigator = navigator,
-                    loginTypeSelector = loginTypeSelector,
-                    startDestination = startDestination,
-                    modifier = Modifier.consumeWindowInsets(WindowInsets.statusBars)
-                )
+                key(startDestination.route) {
+                    MainNavHost(
+                        navigator = navigator,
+                        loginTypeSelector = loginTypeSelector,
+                        startDestination = startDestination,
+                        modifier = Modifier.consumeWindowInsets(WindowInsets.statusBars)
+                    )
+                }
 
                 // Navigation graph creation is async enough that commands issued too early
                 // can crash before the graph is fully built.
@@ -518,17 +542,21 @@ class WireActivity : BaseActivity() {
         val effectiveBaseRoute = currentBaseRoute ?: startDestinationBaseRoute
         val usesNoSessionAuthenticationGraph = effectiveBaseRoute in noSessionAuthenticationGraphRoutes
         val usesAuthenticationGraph = effectiveBaseRoute in authenticationGraphRoutes
+        val usesSessionBackedAuthenticationGraph = effectiveBaseRoute in sessionBackedAuthenticationGraphRoutes
+        val usesInvalidSessionBackedAuthenticationGraph = usesSessionBackedAuthenticationGraph && currentUserId == null
         val sessionGraph = remember(
             appGraph,
             currentUserId,
             sessionBackedAuthenticationUserId,
             usesNoSessionAuthenticationGraph,
+            usesInvalidSessionBackedAuthenticationGraph,
             isSessionTransitionInProgress,
         ) {
             sessionGraphStore.resolveSessionGraph(
                 currentUserId = currentUserId,
                 sessionBackedAuthenticationUserId = sessionBackedAuthenticationUserId,
                 usesNoSessionAuthenticationGraph = usesNoSessionAuthenticationGraph,
+                usesInvalidSessionBackedAuthenticationGraph = usesInvalidSessionBackedAuthenticationGraph,
                 isSessionTransitionInProgress = isSessionTransitionInProgress,
             )
         }
@@ -540,6 +568,7 @@ class WireActivity : BaseActivity() {
                 currentBaseRoute = currentBaseRoute,
                 usesAuthenticationGraph = usesAuthenticationGraph,
                 usesNoSessionAuthenticationGraph = usesNoSessionAuthenticationGraph,
+                usesInvalidSessionBackedAuthenticationGraph = usesInvalidSessionBackedAuthenticationGraph,
                 isSessionTransitionInProgress = isSessionTransitionInProgress,
             )
         )
@@ -560,9 +589,11 @@ class WireActivity : BaseActivity() {
         currentUserId: UserId?,
         sessionBackedAuthenticationUserId: UserId?,
         usesNoSessionAuthenticationGraph: Boolean,
+        usesInvalidSessionBackedAuthenticationGraph: Boolean,
         isSessionTransitionInProgress: Boolean,
     ): AppSessionViewModelGraph? = when {
         usesNoSessionAuthenticationGraph -> null
+        usesInvalidSessionBackedAuthenticationGraph -> null
         isSessionTransitionInProgress -> null
         sessionBackedAuthenticationUserId != null -> graphFor(sessionBackedAuthenticationUserId)
         currentUserId != null -> graphFor(currentUserId)
@@ -570,6 +601,7 @@ class WireActivity : BaseActivity() {
     }
 
     private fun resolveActiveGraph(request: ActiveGraphRequest): MetroViewModelGraph? = when {
+        request.usesInvalidSessionBackedAuthenticationGraph -> null
         request.isSessionTransitionInProgress && !request.usesAuthenticationGraph -> null
         request.usesNoSessionAuthenticationGraph -> request.authenticationViewModelGraph
         request.sessionGraph != null -> request.sessionGraph
@@ -586,9 +618,6 @@ class WireActivity : BaseActivity() {
             state.isUserUiBlocked -> {
                 appLogger.i("$TAG blocking session dialog visible on route=${state.currentBaseRoute}, waiting for user action")
             }
-            state.isSessionTransitionInProgress -> {
-                handleSessionTransition(state.currentBaseRoute, state.isAuthenticationRoute, navigator)
-            }
             state.currentUserId != null && state.currentBaseRoute == NewWelcomeEmptyStartScreenDestination.baseRoute -> {
                 appLogger.i("$TAG valid session on empty auth start, navigating to home")
                 navigator.navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
@@ -596,6 +625,13 @@ class WireActivity : BaseActivity() {
             state.currentUserId == null && state.currentBaseRoute == NewWelcomeEmptyStartScreenDestination.baseRoute -> {
                 appLogger.i("$TAG no session left on empty auth start, navigating to login")
                 navigator.navigate(NavigationCommand(NewLoginScreenDestination(), BackStackMode.CLEAR_WHOLE))
+            }
+            state.currentUserId == null && state.isSessionBackedAuthenticationRoute -> {
+                appLogger.i("$TAG no session left on session-backed auth route=${state.currentBaseRoute}, trying to switch account")
+                resolveMissingCurrentSession(navigator)
+            }
+            state.isSessionTransitionInProgress -> {
+                handleSessionTransition(state.currentBaseRoute, state.isAuthenticationRoute, navigator)
             }
             state.currentUserId == null && state.currentBaseRoute != null && !state.isAuthenticationRoute -> {
                 appLogger.i("$TAG no session left on route=${state.currentBaseRoute}, trying to switch account")
@@ -649,14 +685,22 @@ class WireActivity : BaseActivity() {
     private fun wireActivityScopedViewModels(graph: AppSessionViewModelGraph): WireActivityScopedViewModels {
         val scopeKey = graph.viewModelScopeKey
         return WireActivityScopedViewModels(
-            callFeedbackViewModel = metroxViewModel(
-                key = sessionKeyedMetroViewModelKey(
-                    defaultKey = CallFeedbackViewModel::class.qualifiedName,
-                    key = null,
-                    scopeKey = scopeKey,
-                ),
+            callFeedbackViewModel = viewModel(
+                key = "CallFeedbackViewModel:$scopeKey",
+                factory = viewModelFactory {
+                    initializer {
+                        graph.callingViewModelFactory.callFeedbackViewModel()
+                    }
+                }
             ),
-            featureFlagNotificationViewModel = featureFlagNotificationViewModel(),
+            featureFlagNotificationViewModel = viewModel(
+                key = "FeatureFlagNotificationViewModel:$scopeKey",
+                factory = viewModelFactory {
+                    initializer {
+                        graph.homeViewModelFactory.featureFlagNotificationViewModel()
+                    }
+                }
+            ),
             commonTopAppBarViewModel = viewModel(
                 key = "CommonTopAppBarViewModel:$scopeKey",
                 factory = viewModelFactory {
@@ -1184,6 +1228,7 @@ private data class ActiveGraphRequest(
     val currentBaseRoute: String?,
     val usesAuthenticationGraph: Boolean,
     val usesNoSessionAuthenticationGraph: Boolean,
+    val usesInvalidSessionBackedAuthenticationGraph: Boolean,
     val isSessionTransitionInProgress: Boolean,
 )
 
@@ -1191,6 +1236,7 @@ private data class SessionNavigationState(
     val currentUserId: UserId?,
     val currentBaseRoute: String?,
     val isAuthenticationRoute: Boolean,
+    val isSessionBackedAuthenticationRoute: Boolean,
     val isUserUiBlocked: Boolean,
     val isSessionTransitionInProgress: Boolean,
 )

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModelGraph.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import com.wire.android.di.metro.MetroViewModelGraph
 import com.wire.android.di.metro.sessionKeyedAssistedMetroViewModel
 import com.wire.android.di.metro.sessionKeyedMetroViewModel
 import com.wire.android.ui.home.conversationslist.ConversationListViewModel
@@ -36,6 +37,10 @@ import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
 
 interface HomeManualViewModelFactory : ManualViewModelAssistedFactory {
     fun conversationListViewModel(conversationsSource: ConversationsSource): ConversationListViewModelImpl
+}
+
+interface HomeViewModelGraph : MetroViewModelGraph {
+    val homeViewModelFactory: HomeViewModelFactory
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -229,7 +229,7 @@ class NewLoginViewModel(
                                     NewLoginAction.EmailPassword(
                                         userIdentifier = email,
                                         loginPasswordPath = LoginPasswordPath(
-                                            customServerConfig = loginNavArgs.loginPasswordPath?.customServerConfig,
+                                            customServerConfig = serverConfig,
                                             isCloudAccountCreationPossible = loginRedirectPath.isCloudAccountCreationPossible,
                                         )
                                     )
@@ -242,7 +242,7 @@ class NewLoginViewModel(
                                     NewLoginAction.EmailPassword(
                                         userIdentifier = email,
                                         loginPasswordPath = LoginPasswordPath(
-                                            customServerConfig = loginNavArgs.loginPasswordPath?.customServerConfig,
+                                            customServerConfig = serverConfig,
                                             isCloudAccountCreationPossible = loginRedirectPath.isCloudAccountCreationPossible,
                                             isDomainClaimedByOrg = DomainClaimedByOrg.Claimed(
                                                 loginRedirectPath.domain

--- a/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/selector/CreateAccountSelectorScreen.kt
@@ -55,6 +55,8 @@ import com.wire.android.navigation.style.AuthPopUpNavigationAnimation
 import com.wire.android.ui.authentication.create.common.CreateAccountDataNavArgs
 import com.wire.android.ui.authentication.create.common.ServerTitle
 import com.wire.android.ui.authentication.create.common.UserRegistrationInfo
+import com.wire.android.ui.authentication.login.LoginNavArgs
+import com.wire.android.ui.authentication.login.LoginPasswordPath
 import com.wire.android.ui.authentication.login.PreFilledUserIdentifierType
 import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
 import com.wire.android.ui.common.button.WirePrimaryButton
@@ -94,10 +96,14 @@ fun CreateAccountSelectorScreen(
     }
 
     val startForResult = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { _ ->
+        val loginNavArgs = LoginNavArgs(
+            userHandle = PreFilledUserIdentifierType.PreFilled(viewModel.email),
+            loginPasswordPath = LoginPasswordPath(customServerConfig = viewModel.serverConfig)
+        )
         navigator.navigate(
             NavigationCommand(
-                NewLoginPasswordScreenDestination(PreFilledUserIdentifierType.PreFilled(viewModel.email)),
-                BackStackMode.REMOVE_CURRENT_NESTED_GRAPH
+                NewLoginPasswordScreenDestination(loginNavArgs),
+                BackStackMode.UPDATE_EXISTED
             )
         )
     }

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -504,14 +504,26 @@ class NewLoginViewModelTest {
     fun `given default path, when enterprise login, then call EmailPassword action with creation`() =
         testEnterpriseLoginActions(
             result = EnterpriseLoginResult.Success(LoginRedirectPath.Default),
-            expected = NewLoginAction.EmailPassword(email, LoginPasswordPath(isCloudAccountCreationPossible = true)),
+            expected = NewLoginAction.EmailPassword(
+                email,
+                LoginPasswordPath(
+                    customServerConfig = ServerConfig.STAGING,
+                    isCloudAccountCreationPossible = true
+                )
+            ),
         )
 
     @Test
     fun `given no registration path, when enterprise login, then call EmailPassword action with no creation`() =
         testEnterpriseLoginActions(
             result = EnterpriseLoginResult.Success(LoginRedirectPath.NoRegistration),
-            expected = NewLoginAction.EmailPassword(email, LoginPasswordPath(isCloudAccountCreationPossible = false)),
+            expected = NewLoginAction.EmailPassword(
+                email,
+                LoginPasswordPath(
+                    customServerConfig = ServerConfig.STAGING,
+                    isCloudAccountCreationPossible = false
+                )
+            ),
         )
 
     @Test
@@ -521,6 +533,7 @@ class NewLoginViewModelTest {
             expected = NewLoginAction.EmailPassword(
                 userIdentifier = email,
                 loginPasswordPath = LoginPasswordPath(
+                    customServerConfig = ServerConfig.STAGING,
                     isCloudAccountCreationPossible = false,
                     isDomainClaimedByOrg = DomainClaimedByOrg.Claimed("claimed-domain"),
                 )

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/TeamCreationPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/TeamCreationPage.kt
@@ -20,6 +20,7 @@ package com.wire.android.tests.core.pages
 import android.view.KeyEvent
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.UiSelector
 import org.junit.Assert.assertTrue
 import uiautomatorutils.UiSelectorParams
@@ -66,14 +67,14 @@ class TeamCreationPage(private val device: UiDevice) {
     }
 
     fun enterPassword(password: String?): TeamCreationPage {
-        val passwordField = device.findObjects(By.clazz("android.widget.EditText"))[3]
+        val passwordField = passwordTextFields().first()
         passwordField.click()
         passwordField.text = password
         return this
     }
 
     fun enterConfirmPassword(password: String?): TeamCreationPage {
-        val confirmPasswordField = device.findObjects(By.clazz("android.widget.EditText"))[4]
+        val confirmPasswordField = passwordTextFields().last()
         confirmPasswordField.click()
         confirmPasswordField.text = password
         return this
@@ -135,5 +136,22 @@ class TeamCreationPage(private val device: UiDevice) {
         if (!checkbox.isChecked) {
             checkbox.click()
         }
+    }
+
+    private fun passwordTextFields(): List<UiObject2> {
+        val textFields = sortedTextFields()
+        if (textFields.size < PASSWORD_FIELD_COUNT) {
+            throw AssertionError("Expected at least $PASSWORD_FIELD_COUNT text fields on Create a team page, but found ${textFields.size}")
+        }
+        return textFields.takeLast(PASSWORD_FIELD_COUNT)
+    }
+
+    private fun sortedTextFields(): List<UiObject2> =
+        device.findObjects(By.clazz("android.widget.EditText"))
+            .filter { !it.visibleBounds.isEmpty }
+            .sortedWith(compareBy({ it.visibleBounds.top }, { it.visibleBounds.left }))
+
+    private companion object {
+        const val PASSWORD_FIELD_COUNT = 2
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26324
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Keep session graph handling stable when the current session disappears.
- Fix logout with clear data so the last account returns to login instead of home/splash.
- Fix Too Many Devices cancel behavior for second-account login.
- Preserve custom server config when returning from team creation to password login.
- Make the invalid-email UI test less flaky by selecting password fields dynamically.