### PR TITLE
fix: logout start destination and cells search VM scope [WPB-26334] [WPB-26330]

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -72,7 +72,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -110,7 +110,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -146,7 +146,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -217,7 +217,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/app/src/main/kotlin/com/wire/android/navigation/MainNavHost.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/MainNavHost.kt
@@ -38,6 +38,8 @@ import com.ramcosta.composedestinations.generated.app.navgraphs.WireRootGraph
 import com.ramcosta.composedestinations.generated.app.navtype.groupConversationDetailsNavBackArgsNavType
 import com.ramcosta.composedestinations.generated.app.navtype.imagesPreviewNavBackArgsNavType
 import com.ramcosta.composedestinations.generated.app.navtype.mediaGalleryNavBackArgsNavType
+import com.ramcosta.composedestinations.generated.cells.destinations.ConversationFilesScreenDestination
+import com.ramcosta.composedestinations.generated.cells.destinations.ConversationFilesWithSlideInTransitionScreenDestination
 import com.ramcosta.composedestinations.generated.cells.destinations.SearchScreenDestination
 import com.ramcosta.composedestinations.generated.meetings.navgraphs.NewMeetingGraph
 import com.ramcosta.composedestinations.generated.sketch.destinations.DrawingCanvasScreenDestination
@@ -119,10 +121,15 @@ fun MainNavHost(
 
                     // 👇 To reuse CellViewModel from the parent screen on SearchScreen
                     destination(SearchScreenDestination) {
-                        val parentEntry = remember(navBackStackEntry) {
-                            navController.previousBackStackEntry
+                        val cellViewModelOwner = remember(navBackStackEntry) {
+                            val previousEntry = navController.previousBackStackEntry
+                            when (previousEntry?.safeRoute()?.baseRoute) {
+                                ConversationFilesScreenDestination.baseRoute,
+                                ConversationFilesWithSlideInTransitionScreenDestination.baseRoute -> previousEntry
+                                else -> navBackStackEntry
+                            }
                         }
-                        dependency(cellViewModel(parentEntry ?: navBackStackEntry))
+                        dependency(cellViewModel(cellViewModelOwner))
                     }
 
                     // 👇 To tie NewConversationViewModel to NewConversationGraph,

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -378,7 +378,7 @@ class WireActivity : BaseActivity() {
             currentBaseRoute != null && canRetainSessionGraphForContent -> lastSessionGraphContext.value
             else -> null
         }
-        val navHostStartDestination = resolveNavHostStartDestination(startDestination, currentUserId)
+        val navHostStartDestination = resolveNavHostStartDestination(startDestination, currentUserId, currentBaseRoute)
         val backgroundType by remember {
             derivedStateOf {
                 currentBackStackEntryState.value?.safeDestination()?.style.let {
@@ -409,14 +409,25 @@ class WireActivity : BaseActivity() {
     private fun resolveNavHostStartDestination(
         initialStartDestination: Direction,
         currentUserId: UserId?,
-    ): Direction =
-        if (currentUserId == null && initialStartDestination.baseRoute !in authenticationGraphRoutes) {
-            when (loginTypeSelector.canUseNewLogin()) {
-                true -> NewLoginScreenDestination()
-                false -> WelcomeScreenDestination()
-            }
-        } else {
-            initialStartDestination
+        currentBaseRoute: String?,
+    ): Direction {
+        if (currentUserId != null || initialStartDestination.baseRoute in authenticationGraphRoutes) {
+            return initialStartDestination
+        }
+        return when (currentBaseRoute) {
+            NewLoginScreenDestination.baseRoute -> NewLoginScreenDestination()
+            LoginScreenDestination.baseRoute -> WelcomeScreenDestination()
+            WelcomeScreenDestination.baseRoute -> WelcomeScreenDestination()
+            NewWelcomeEmptyStartScreenDestination.baseRoute,
+            null -> loggedOutStartDestination()
+            else -> initialStartDestination
+        }
+    }
+
+    private fun loggedOutStartDestination(): Direction =
+        when (loginTypeSelector.canUseNewLogin()) {
+            true -> NewWelcomeEmptyStartScreenDestination()
+            false -> WelcomeScreenDestination()
         }
 
     private fun isNavigationAllowed(navigationCommand: NavigationCommand): Boolean {

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
@@ -109,12 +109,16 @@ class CellViewModel(
     private val getUserName: GetUserNameUseCase,
 ) : ActionsViewModel<CellViewAction>() {
 
-    private val navArgs: CellFilesNavArgs = ConversationFilesScreenDestination.argsFrom(savedStateHandle)
     private val searchNavArgs: SearchNavArgs? = try {
         SearchScreenDestination.argsFrom(savedStateHandle)
     } catch (_: RuntimeException) {
         // Not coming from Search screen, ignore
         null
+    }
+    private val navArgs: CellFilesNavArgs = try {
+        ConversationFilesScreenDestination.argsFrom(savedStateHandle)
+    } catch (_: RuntimeException) {
+        searchNavArgs?.toCellFilesNavArgs() ?: CellFilesNavArgs()
     }
 
     // Show menu with actions for the selected file.
@@ -650,5 +654,8 @@ data class MenuOptions(
     val node: CellNodeUi,
     val actions: List<NodeBottomSheetAction>
 )
+
+private fun SearchNavArgs.toCellFilesNavArgs(): CellFilesNavArgs =
+    CellFilesNavArgs(conversationId = conversationId)
 
 private const val RESTORE_DELAY_MS = 300L

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
@@ -24,10 +24,12 @@ import androidx.paging.PagingData
 import androidx.paging.testing.asSnapshot
 import app.cash.turbine.test
 import com.ramcosta.composedestinations.generated.cells.destinations.ConversationFilesScreenDestination
+import com.ramcosta.composedestinations.generated.cells.destinations.SearchScreenDestination
 import com.wire.android.config.NavigationTestExtension
 import com.wire.android.feature.cells.ui.edit.OnlineEditor
 import com.wire.android.feature.cells.ui.model.OpenLoadState
 import com.wire.android.feature.cells.ui.model.toUiModel
+import com.wire.android.feature.cells.ui.search.SearchNavArgs
 import com.wire.android.feature.cells.util.FileHelper
 import com.wire.android.feature.cells.util.FileNameResolver
 import com.wire.kalium.cells.domain.model.Node
@@ -128,6 +130,17 @@ class CellViewModelTest {
         assertEquals(items.size, 2)
 
         coVerify(exactly = 1) { arrangement.getCellFilesPagedUseCase(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `given search screen args when conversation files args are missing then conversation id is used`() = runTest {
+        val conversationId = "conversationId"
+        val (_, viewModel) = Arrangement()
+            .withConversationId(conversationId)
+            .withSearchScreenArgsOnly()
+            .arrange()
+
+        assertEquals(conversationId, viewModel.currentNodeUuid())
     }
 
     @Test
@@ -303,7 +316,7 @@ class CellViewModelTest {
         }
     }
 
-    private class Arrangement(conversationId: String? = null) {
+    private class Arrangement(private var conversationId: String? = null) {
 
         @MockK
         lateinit var savedStateHandle: SavedStateHandle
@@ -366,6 +379,8 @@ class CellViewModelTest {
             MockKAnnotations.init(this, relaxUnitFun = true)
 
             mockkObject(ConversationFilesScreenDestination)
+            mockkObject(SearchScreenDestination)
+            every { SearchScreenDestination.argsFrom(savedStateHandle) } throws RuntimeException("Not a search screen")
             every { ConversationFilesScreenDestination.argsFrom(savedStateHandle) } returns CellFilesNavArgs(
                 conversationId = conversationId
             )
@@ -425,6 +440,19 @@ class CellViewModelTest {
 
         fun withNoCellsAvailable() = apply {
             coEvery { isCellAvailableUseCase.invoke() } returns false.right()
+        }
+
+        fun withConversationId(conversationId: String) = apply {
+            this.conversationId = conversationId
+            every { savedStateHandle.get<String>(any()) } returns conversationId
+            every { savedStateHandle.get<String>("conversationId") } returns conversationId
+        }
+
+        fun withSearchScreenArgsOnly() = apply {
+            every { SearchScreenDestination.argsFrom(savedStateHandle) } returns SearchNavArgs(
+                conversationId = conversationId
+            )
+            every { ConversationFilesScreenDestination.argsFrom(savedStateHandle) } throws RuntimeException("Not a files screen")
         }
 
         fun arrange(): Pair<Arrangement, CellViewModel> {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26334
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixes two navigation-related crashes/regressions:

- Prevents invalid auth graph startup state after logout / clear data by resolving the logged-out start destination based on the current route and login flow.
- Fixes Cells “Search files” crash by only reusing `CellViewModel` from conversation files routes and falling back to search args when files args are unavailable.
