### PR TITLE
fix: add semantic roles to list and menu controls [WPB-14783]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
@@ -135,7 +136,8 @@ private fun ConversationScreenTopAppBarContent(
                     .clickable(
                         onClick = onDropDownClick,
                         enabled = isDropDownEnabled && isInteractionEnabled,
-                        onClickLabel = stringResource(R.string.content_description_conversation_open_details_label)
+                        onClickLabel = stringResource(R.string.content_description_conversation_open_details_label),
+                        role = Role.Button
                     )
             ) {
                 val conversationAvatar: ConversationAvatar = conversationInfoViewState.conversationAvatar

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/editselfdeletingmessages/EditSelfDeletingMessagesScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.navigation.style.SlideNavigationAnimation
@@ -152,7 +153,11 @@ fun SelectableSelfDeletingItem(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .selectableBackground(isSelected, onClick = { onSelfDeletionDurationSelected(duration) })
+            .selectableBackground(
+                isSelected = isSelected,
+                role = Role.RadioButton,
+                onClick = { onSelfDeletionDurationSelected(duration) }
+            )
             .background(color = MaterialTheme.wireColorScheme.surface)
             .padding(all = MaterialTheme.wireDimensions.spacing16x)
     ) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
@@ -76,7 +77,7 @@ fun GroupConversationOptionsItem(
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
-            .clickable(clickable)
+            .clickable(clickable, role = Role.Button)
             .semantics { contentDescription?.let { this.contentDescription = contentDescription } }
             .padding(
                 top = MaterialTheme.wireDimensions.spacing12x,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/channelaccess/PermissionItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/channelaccess/PermissionItem.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.selectableBackground
 import com.wire.android.ui.theme.WireTheme
@@ -48,7 +49,11 @@ fun PermissionItem(
         modifier = modifier
             .fillMaxWidth()
             .padding(bottom = dimensions().spacing1x)
-            .selectableBackground(isSelected, onClick = { onItemClicked(channelAddPermissionType) })
+            .selectableBackground(
+                isSelected = isSelected,
+                role = Role.RadioButton,
+                onClick = { onItemClicked(channelAddPermissionType) }
+            )
             .background(color = MaterialTheme.wireColorScheme.surface),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,7 +120,7 @@
     <string name="content_description_new_meeting">Start or schedule a new Wire Meeting</string>
     <string name="content_description_back_button">Back</string>
     <string name="content_description_send_button">Send</string>
-    <string name="content_description_timed_message_button">Self-deleting messages, button</string>
+    <string name="content_description_timed_message_button">Self-deleting messages</string>
     <string name="content_description_close_button">Close</string>
     <string name="content_description_menu_button">Main navigation</string>
     <string name="content_description_drop_down_icon">Drop down arrow</string>
@@ -181,7 +181,7 @@
     <string name="content_description_calling_call_unmuted">Call Unmuted</string>
     <string name="content_description_calling_call_paused_camera">Paused Camera</string>
     <string name="content_description_more_emojis">More emojis</string>
-    <string name="content_description_self_deletion_selector_button">Toggle self deletion mode, button</string>
+    <string name="content_description_self_deletion_selector_button">Toggle self deletion mode</string>
     <string name="content_description_message_sending_status">Message sending status</string>
     <string name="content_description_message_sent_status">Message sent status</string>
     <string name="content_description_message_error_status">Message error status</string>

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/AppExtensions.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/AppExtensions.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.lifecycle.Lifecycle
@@ -43,6 +44,7 @@ import java.util.Locale
 fun Modifier.selectableBackground(
     isSelected: Boolean,
     onClickDescription: String = stringResource(id = R.string.content_description_select_label),
+    role: Role? = null,
     onClick: () -> Unit
 ): Modifier {
     val onItemClick = Clickable(
@@ -52,7 +54,7 @@ fun Modifier.selectableBackground(
     )
 
     return this
-        .clickable(onItemClick)
+        .clickable(onItemClick, role = role)
         .semantics {
             if (isSelected) selected = true // So TalkBack ignores selection when it's not selected
         }

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/rowitem/RowItem.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/rowitem/RowItem.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.Dp
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.SurfaceBackgroundWrapper
@@ -55,7 +56,7 @@ fun RowItem(
             Row(
                 verticalAlignment = verticalAlignment,
                 modifier = Modifier
-                    .clickable(clickable)
+                    .clickable(clickable, role = Role.Button)
                     .then(
                         modifier
                             .defaultMinSize(minHeight = MaterialTheme.wireDimensions.conversationItemRowHeight)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-14783
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Controls in list rows, menu rows, and selectable rows did not always expose a semantic role to accessibility services.
- Some content descriptions included role words like “button”, which could cause duplicate TalkBack announcements once semantic roles are provided.

### Causes (Optional)

- Shared clickable row components used `clickable` semantics without an explicit role.
- A couple of accessibility strings encoded the control role in user-facing text instead of relying on platform semantics.

### Solutions

- Added explicit semantic roles to shared clickable list/menu row components.
- Added explicit `RadioButton` roles only at selectable row call sites that actually render radio buttons.
- Removed role words from affected content descriptions across localized resources.