### PR TITLE
fix: stabilize old login completion navigation [WPB-26470]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -572,7 +572,7 @@ class WireActivity : BaseActivity() {
             )
         }
         val graph = resolveActiveGraph(
-            ActiveGraphRequest(
+            WireActivityActiveGraphRequest(
                 authenticationViewModelGraph = authenticationViewModelGraph,
                 sessionGraph = sessionGraph,
                 effectiveBaseRoute = effectiveBaseRoute,
@@ -611,15 +611,8 @@ class WireActivity : BaseActivity() {
         else -> null
     }
 
-    private fun resolveActiveGraph(request: ActiveGraphRequest): MetroViewModelGraph? = when {
-        request.usesInvalidSessionBackedAuthenticationGraph -> null
-        request.isSessionTransitionInProgress && !request.usesAuthenticationGraph -> null
-        request.usesNoSessionAuthenticationGraph -> request.authenticationViewModelGraph
-        request.sessionGraph != null -> request.sessionGraph
-        request.effectiveBaseRoute in authenticationGraphRoutes -> request.authenticationViewModelGraph
-        request.currentBaseRoute == null -> request.authenticationViewModelGraph
-        else -> null
-    }
+    private fun resolveActiveGraph(request: WireActivityActiveGraphRequest): MetroViewModelGraph? =
+        resolveWireActivityActiveGraph(request)
 
     private fun handleSessionNavigationState(
         state: SessionNavigationState,
@@ -1232,7 +1225,7 @@ private class SessionGraphStoreViewModel(
         }
 }
 
-private data class ActiveGraphRequest(
+internal data class WireActivityActiveGraphRequest(
     val authenticationViewModelGraph: AppAuthenticationViewModelGraph,
     val sessionGraph: AppSessionViewModelGraph?,
     val effectiveBaseRoute: String,
@@ -1284,6 +1277,17 @@ private val authenticationGraphRoutes = setOf(
     LoginScreenDestination.baseRoute,
     NewLoginScreenDestination.baseRoute,
 ) + noSessionAuthenticationGraphRoutes + sessionBackedAuthenticationGraphRoutes
+
+internal fun resolveWireActivityActiveGraph(request: WireActivityActiveGraphRequest): MetroViewModelGraph? = when {
+    request.usesInvalidSessionBackedAuthenticationGraph -> null
+    request.isSessionTransitionInProgress && !request.usesAuthenticationGraph -> null
+    request.usesNoSessionAuthenticationGraph -> request.authenticationViewModelGraph
+    request.effectiveBaseRoute in authenticationGraphRoutes &&
+            request.effectiveBaseRoute !in sessionBackedAuthenticationGraphRoutes -> request.authenticationViewModelGraph
+    request.sessionGraph != null -> request.sessionGraph
+    request.currentBaseRoute == null -> request.authenticationViewModelGraph
+    else -> null
+}
 
 private fun Bundle.sessionBackedAuthenticationUserId(): UserId? {
     val value = getString(SessionBackedAuthenticationNavArgs.USER_ID_VALUE_KEY)

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.ui.common.R as commonR
+import com.wire.android.ui.authentication.login.DomainClaimedByOrg
 import com.wire.android.ui.authentication.login.LoginErrorDialog
 import com.wire.android.ui.authentication.login.LoginState
 import com.wire.android.ui.authentication.login.isProxyAuthRequired
@@ -65,6 +66,7 @@ import com.wire.android.ui.authentication.login.toLoginDialogErrorData
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.dialogs.EmailAlreadyInUseClaimedDomainDialog
 import com.wire.android.ui.common.textfield.DefaultEmailNext
 import com.wire.android.ui.common.textfield.DefaultPassword
 import com.wire.android.ui.common.textfield.WireAutoFillType
@@ -72,6 +74,7 @@ import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.textfield.clearAutofillTree
+import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -103,22 +106,19 @@ fun LoginEmailScreen(
         passwordTextState = loginEmailViewModel.passwordTextState,
         isProxyAuthRequired = loginEmailViewModel.serverConfig.isProxyAuthRequired,
         apiProxyUrl = loginEmailViewModel.serverConfig.apiProxy?.host,
-        onDialogDismiss = loginEmailViewModel::clearLoginErrors,
-        onRemoveDeviceOpen = { userId ->
-            loginEmailViewModel.clearLoginErrors()
-            onRemoveDeviceNeeded(userId)
-        },
         onLoginButtonClick = loginEmailViewModel::login,
         forgotPasswordUrl = loginEmailViewModel.serverConfig.forgotPassword,
         scope = scope,
         fillMaxHeight = fillMaxHeight,
     )
 
-    LaunchedEffect(loginEmailViewModel.loginState.flowState) {
-        (loginEmailViewModel.loginState.flowState as? LoginState.Success)?.let {
-            onSuccess(it.initialSyncCompleted, it.isE2EIRequired, it.userId)
-        }
-    }
+    LoginEmailStateNavigationAndDialogs(
+        state = loginEmailViewModel.loginState.flowState,
+        domainClaimedByOrg = loginEmailViewModel.loginNavArgs.loginPasswordPath?.isDomainClaimedByOrg,
+        onClearLoginErrors = loginEmailViewModel::clearLoginErrors,
+        onSuccess = onSuccess,
+        onRemoveDeviceNeeded = onRemoveDeviceNeeded,
+    )
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -132,8 +132,6 @@ private fun LoginEmailContent(
     loginEmailState: LoginEmailState,
     isProxyAuthRequired: Boolean,
     apiProxyUrl: String?,
-    onDialogDismiss: () -> Unit,
-    onRemoveDeviceOpen: (UserId) -> Unit,
     onLoginButtonClick: () -> Unit,
     forgotPasswordUrl: String,
     scope: CoroutineScope,
@@ -241,12 +239,49 @@ private fun LoginEmailContent(
             }
         }
     }
+}
 
-    if (loginEmailState.flowState is LoginState.Error.DialogError) {
-        LoginErrorDialog(loginEmailState.flowState.toLoginDialogErrorData(), onDialogDismiss)
-    } else if (loginEmailState.flowState is LoginState.Error.TooManyDevicesError) {
-        onRemoveDeviceOpen(loginEmailState.flowState.userId)
+@Composable
+private fun LoginEmailStateNavigationAndDialogs(
+    state: LoginState,
+    domainClaimedByOrg: DomainClaimedByOrg?,
+    onClearLoginErrors: () -> Unit,
+    onSuccess: (initialSyncCompleted: Boolean, isE2EIRequired: Boolean, userId: UserId) -> Unit,
+    onRemoveDeviceNeeded: (UserId) -> Unit,
+) {
+    val emailAlreadyInUseClaimedDomainDialogState = rememberVisibilityState<DomainClaimedByOrg.Claimed>()
+    val handleLoginStateNavigation: (LoginState) -> Unit = {
+        when (it) {
+            is LoginState.Success -> onSuccess(it.initialSyncCompleted, it.isE2EIRequired, it.userId)
+            is LoginState.Error.TooManyDevicesError -> {
+                onClearLoginErrors()
+                onRemoveDeviceNeeded(it.userId)
+            }
+            else -> {
+                /* do nothing */
+            }
+        }
     }
+
+    LaunchedEffect(state) {
+        val isStateCompleted = state is LoginState.Success || state is LoginState.Error.TooManyDevicesError
+        if (isStateCompleted && domainClaimedByOrg is DomainClaimedByOrg.Claimed) {
+            emailAlreadyInUseClaimedDomainDialogState.show(domainClaimedByOrg)
+        } else {
+            handleLoginStateNavigation(state)
+        }
+    }
+
+    if (state is LoginState.Error.DialogError) {
+        LoginErrorDialog(state.toLoginDialogErrorData(), onClearLoginErrors)
+    }
+    EmailAlreadyInUseClaimedDomainDialog(
+        dialogState = emailAlreadyInUseClaimedDomainDialogState,
+        onDismiss = {
+            emailAlreadyInUseClaimedDomainDialogState.dismiss()
+            handleLoginStateNavigation(state)
+        }
+    )
 }
 
 @Composable
@@ -362,8 +397,6 @@ fun PreviewLoginEmailScreen() = WireTheme {
         proxyPasswordState = TextFieldState(),
         isProxyAuthRequired = true,
         apiProxyUrl = "",
-        onDialogDismiss = { },
-        onRemoveDeviceOpen = { },
         onLoginButtonClick = { },
         forgotPasswordUrl = "",
         scope = rememberCoroutineScope()

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityActiveGraphResolverTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityActiveGraphResolverTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui
+
+import com.ramcosta.composedestinations.generated.app.destinations.LoginScreenDestination
+import com.ramcosta.composedestinations.generated.app.destinations.RegisterDeviceScreenDestination
+import com.wire.android.di.metro.AppAuthenticationViewModelGraph
+import com.wire.android.di.metro.AppSessionViewModelGraph
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class WireActivityActiveGraphResolverTest {
+
+    private val authenticationViewModelGraph = AppAuthenticationViewModelGraph()
+    private val sessionGraph = mockk<AppSessionViewModelGraph>()
+
+    @Test
+    fun givenOldLoginRouteHasSessionGraph_whenResolvingActiveGraph_thenAuthenticationGraphIsUsed() {
+        val graph = resolveWireActivityActiveGraph(
+            WireActivityActiveGraphRequest(
+                authenticationViewModelGraph = authenticationViewModelGraph,
+                sessionGraph = sessionGraph,
+                effectiveBaseRoute = LoginScreenDestination.baseRoute,
+                currentBaseRoute = LoginScreenDestination.baseRoute,
+                usesAuthenticationGraph = true,
+                usesNoSessionAuthenticationGraph = false,
+                usesInvalidSessionBackedAuthenticationGraph = false,
+                isSessionTransitionInProgress = false,
+            )
+        )
+
+        assertSame(authenticationViewModelGraph, graph)
+    }
+
+    @Test
+    fun givenSessionBackedAuthenticationRouteHasSessionGraph_whenResolvingActiveGraph_thenSessionGraphIsUsed() {
+        val graph = resolveWireActivityActiveGraph(
+            WireActivityActiveGraphRequest(
+                authenticationViewModelGraph = authenticationViewModelGraph,
+                sessionGraph = sessionGraph,
+                effectiveBaseRoute = RegisterDeviceScreenDestination.baseRoute,
+                currentBaseRoute = RegisterDeviceScreenDestination.baseRoute,
+                usesAuthenticationGraph = true,
+                usesNoSessionAuthenticationGraph = false,
+                usesInvalidSessionBackedAuthenticationGraph = false,
+                isSessionTransitionInProgress = false,
+            )
+        )
+
+        assertSame(sessionGraph, graph)
+    }
+}

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -1375,7 +1375,7 @@ public fun com.wire.android.ui.authentication.login.email.LoginButton(loading: k
     - onClick: STABLE (function type)
 
 @Composable
-private fun com.wire.android.ui.authentication.login.email.LoginEmailContent(scrollState: androidx.compose.foundation.ScrollState, userIdentifierTextState: androidx.compose.foundation.text.input.TextFieldState, passwordTextState: androidx.compose.foundation.text.input.TextFieldState, proxyIdentifierState: androidx.compose.foundation.text.input.TextFieldState, proxyPasswordState: androidx.compose.foundation.text.input.TextFieldState, loginEmailState: com.wire.android.ui.authentication.login.email.LoginEmailState, isProxyAuthRequired: kotlin.Boolean, apiProxyUrl: kotlin.String?, onDialogDismiss: kotlin.Function0<kotlin.Unit>, onRemoveDeviceOpen: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID?, kotlin.Unit>, onLoginButtonClick: kotlin.Function0<kotlin.Unit>, forgotPasswordUrl: kotlin.String, scope: kotlinx.coroutines.CoroutineScope, fillMaxHeight: kotlin.Boolean): kotlin.Unit
+private fun com.wire.android.ui.authentication.login.email.LoginEmailContent(scrollState: androidx.compose.foundation.ScrollState, userIdentifierTextState: androidx.compose.foundation.text.input.TextFieldState, passwordTextState: androidx.compose.foundation.text.input.TextFieldState, proxyIdentifierState: androidx.compose.foundation.text.input.TextFieldState, proxyPasswordState: androidx.compose.foundation.text.input.TextFieldState, loginEmailState: com.wire.android.ui.authentication.login.email.LoginEmailState, isProxyAuthRequired: kotlin.Boolean, apiProxyUrl: kotlin.String?, onLoginButtonClick: kotlin.Function0<kotlin.Unit>, forgotPasswordUrl: kotlin.String, scope: kotlinx.coroutines.CoroutineScope, fillMaxHeight: kotlin.Boolean): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -1387,8 +1387,6 @@ private fun com.wire.android.ui.authentication.login.email.LoginEmailContent(scr
     - loginEmailState: STABLE (class with no mutable properties)
     - isProxyAuthRequired: STABLE (primitive type)
     - apiProxyUrl: STABLE (class with no mutable properties)
-    - onDialogDismiss: STABLE (function type)
-    - onRemoveDeviceOpen: STABLE (function type)
     - onLoginButtonClick: STABLE (function type)
     - forgotPasswordUrl: STABLE (String is immutable)
     - scope: RUNTIME (requires runtime check)

--- a/core/navigation/src/main/kotlin/com/wire/android/navigation/style/WireDestinationStyleAnimated.kt
+++ b/core/navigation/src/main/kotlin/com/wire/android/navigation/style/WireDestinationStyleAnimated.kt
@@ -35,24 +35,27 @@ abstract class WireDestinationStyleAnimated : DestinationStyle.Animated() {
     private fun TypedDestinationSpec<*>.getAnimationTypeStyle() =
         (this.style as? WireDestinationStyleAnimated)?.animationType() ?: animationType()
 
+    private fun NavBackStackEntry.getAnimationTypeStyleOrDefault() =
+        runCatching { destination().getAnimationTypeStyle() }.getOrDefault(animationType())
+
     override val enterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition
         get() = {
-            targetState.destination().getAnimationTypeStyle().enterTransition
+            targetState.getAnimationTypeStyleOrDefault().enterTransition
         }
 
     override val exitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition
         get() = {
-            targetState.destination().getAnimationTypeStyle().exitTransition
+            targetState.getAnimationTypeStyleOrDefault().exitTransition
         }
 
     override val popEnterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition
         get() = {
-            initialState.destination().getAnimationTypeStyle().popEnterTransition
+            initialState.getAnimationTypeStyleOrDefault().popEnterTransition
         }
 
     override val popExitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition
         get() = {
-            initialState.destination().getAnimationTypeStyle().popExitTransition
+            initialState.getAnimationTypeStyleOrDefault().popExitTransition
         }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26470
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Fixed old login flow getting stuck after password submit when session creation starts slow sync.
- Kept regular authentication routes on the auth ViewModel graph while preserving session graph usage for session-backed auth screens.
- Moved old login success / too-many-devices navigation into state-driven side effects.
- Added a safe fallback for navigation transition style lookup.
- Added regression coverage for auth graph selection.