### PR TITLE
fix: customization option padding  [WPB-26516]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/appearance/CustomizationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/appearance/CustomizationScreen.kt
@@ -174,7 +174,8 @@ fun ThemeOptionItem(
                 role = Role.RadioButton,
                 onClick = { onItemClicked(themeOption) }
             )
-            .background(color = MaterialTheme.wireColorScheme.surface),
+            .background(color = MaterialTheme.wireColorScheme.surface)
+            .padding(horizontal = dimensions().spacing16x),
         verticalAlignment = Alignment.CenterVertically
     ) {
         RadioButton(selected = isSelected, onClick = null)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26516
<!--jira-description-action-hidden-marker-end-->
## Summary
- Add horizontal content padding to customization theme option rows.
- Align radio option content with the existing settings switch row inset.

## Root cause
Theme option rows only applied bottom padding at the row level and vertical padding on the label, leaving the leading radio button flush with the screen edge.

## Validation
- `./gradlew :app:testDevDebugUnitTest`