### PR TITLE
feat: gate offline files behind a feature flag (WPB-23968)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/AppModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/AppModule.kt
@@ -123,6 +123,10 @@ object AppModule {
     fun provideUseNewLoginForDefaultBackend(): Boolean = BuildConfig.USE_NEW_LOGIN_FOR_DEFAULT_BACKEND
 
     @Provides
+    @Named("offlineFilesEnabled")
+    fun provideOfflineFilesEnabled(): Boolean = BuildConfig.OFFLINE_FILES_ENABLED
+
+    @Provides
     @Singleton
     fun provideMessageSharedState(): MessageSharedState = MessageSharedState()
 

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -7368,7 +7368,7 @@ private fun com.wire.android.ui.home.conversations.stringResourceProvider(): com
   params:
 
 @Composable
-public fun com.wire.android.ui.home.conversationslist.ConversationsScreenContent(navigator: com.wire.android.navigation.Navigator, searchBarState: com.wire.android.ui.common.search.SearchBarState, modifier: androidx.compose.ui.Modifier, emptyListContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction1<@[ParameterName(name = \, lazyListState: androidx.compose.foundation.lazy.LazyListState, loadingListContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, conversationsSource: com.wire.android.ui.home.conversationslist.model.ConversationsSource, emptySearchResultFocusRequester: androidx.compose.ui.focus.FocusRequester?, firstConversationFocusRequester: androidx.compose.ui.focus.FocusRequester?, conversationListViewModel: com.wire.android.ui.home.conversationslist.ConversationListViewModel, conversationListCallViewModel: com.wire.android.ui.home.conversationslist.ConversationListCallViewModel): kotlin.Unit
+public fun com.wire.android.ui.home.conversationslist.ConversationsScreenContent(navigator: com.wire.android.navigation.Navigator, searchBarState: com.wire.android.ui.common.search.SearchBarState, modifier: androidx.compose.ui.Modifier, emptyListContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction1<@[ParameterName(name = \, lazyListState: androidx.compose.foundation.lazy.LazyListState, loadingListContent: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, conversationsSource: com.wire.android.ui.home.conversationslist.model.ConversationsSource, emptySearchResultFocusRequester: androidx.compose.ui.focus.FocusRequester?, firstConversationFocusRequester: androidx.compose.ui.focus.FocusRequester?, onConversationOpened: kotlin.Function0<kotlin.Unit>, conversationListViewModel: com.wire.android.ui.home.conversationslist.ConversationListViewModel, conversationListCallViewModel: com.wire.android.ui.home.conversationslist.ConversationListCallViewModel): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -7381,6 +7381,7 @@ public fun com.wire.android.ui.home.conversationslist.ConversationsScreenContent
     - conversationsSource: STABLE (class with no mutable properties)
     - emptySearchResultFocusRequester: STABLE (marked @Stable or @Immutable)
     - firstConversationFocusRequester: STABLE (marked @Stable or @Immutable)
+    - onConversationOpened: STABLE (function type)
     - conversationListViewModel: RUNTIME (requires runtime check)
     - conversationListCallViewModel: RUNTIME (requires runtime check)
 

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -145,6 +145,8 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
 
     COLLABORA_INTEGRATION_ENABLED("collabora_integration", ConfigType.BOOLEAN),
 
+    OFFLINE_FILES_ENABLED("offline_files_enabled", ConfigType.BOOLEAN),
+
     DB_INVALIDATION_CONTROL_ENABLED("db_invalidation_control_enabled", ConfigType.BOOLEAN),
 
     CONFIGURATION_SIGNATURE_KEYS("configuration_signature_keys", ConfigType.MapOfStrings),

--- a/default.json
+++ b/default.json
@@ -18,6 +18,7 @@
             "logging_enabled": true,
             "application_is_private_build": true,
             "development_api_enabled": true,
+            "offline_files_enabled": true,
             "ignore_ssl_certificates": true,
             "firebase_push_sender_id": "723990470614",
             "firebase_app_id": "1:723990470614:android:10cf802bfcc7bb71d28e77",
@@ -83,6 +84,7 @@
             "logging_enabled": true,
             "application_is_private_build": true,
             "development_api_enabled": false,
+            "offline_files_enabled": true,
             "analytics_enabled": true,
             "analytics_app_key": "8ffae535f1836ed5f58fd5c8a11c00eca07c5438",
             "analytics_server_url": "https://wire.count.ly/",
@@ -169,6 +171,7 @@
     "background_notification_stay_alive_seconds": 3,
     "is_bubble_ui_enabled": true,
     "collabora_integration": true,
+    "offline_files_enabled": false,
     "db_invalidation_control_enabled": false,
     "configuration_signature_keys": {
         "0": "MCowBQYDK2VwAyEAxPrvUdt+531eDcnAFfLAv9K9gkxPDBMVEz75BkNgd1E=",

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/AllFilesScreen.kt
@@ -51,7 +51,9 @@ fun AllFilesScreen(
 ) {
 
     val pagingListItems = viewModel.nodesFlow.collectAsLazyPagingItems()
-    val isOnline by viewModel.isOnline.collectAsState()
+    val isOnlineState by viewModel.isOnline.collectAsState()
+    // When offline files are disabled, never enter offline mode so all offline UI stays hidden.
+    val isOnline = isOnlineState || !viewModel.offlineFilesEnabled
 
     WireScaffold(
         modifier = modifier,

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellFileActionsMenu.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellFileActionsMenu.kt
@@ -23,10 +23,12 @@ import com.wire.android.feature.cells.ui.model.isEditSupported
 import com.wire.android.feature.cells.ui.model.localFileAvailable
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import javax.inject.Inject
+import javax.inject.Named
 
 @Suppress("CyclomaticComplexMethod", "LongParameterList")
 class CellFileActionsMenu @Inject constructor(
-    private val featureFlags: KaliumConfigs
+    private val featureFlags: KaliumConfigs,
+    @Named("offlineFilesEnabled") private val offlineFilesEnabled: Boolean,
 ) {
     internal fun buildMenu(
         cellNode: CellNodeUi,
@@ -37,7 +39,7 @@ class CellFileActionsMenu @Inject constructor(
         isCollaboraEnabled: Boolean,
         isOnline: Boolean = true,
     ): List<NodeBottomSheetAction> {
-        if (!isOnline) {
+        if (offlineFilesEnabled && !isOnline) {
             return buildList {
                 val canOpenOffline = cellNode is CellNodeUi.Folder ||
                         (cellNode is CellNodeUi.File && cellNode.localFileAvailable())
@@ -104,13 +106,15 @@ class CellFileActionsMenu @Inject constructor(
                         add(NodeBottomSheetAction.SHARE)
                     }
 
-                    add(
-                        if (cellNode.isAvailableOffline) {
-                            NodeBottomSheetAction.REMOVE_OFFLINE_ACCESS
-                        } else {
-                            NodeBottomSheetAction.MAKE_AVAILABLE_OFFLINE
-                        },
-                    )
+                    if (offlineFilesEnabled) {
+                        add(
+                            if (cellNode.isAvailableOffline) {
+                                NodeBottomSheetAction.REMOVE_OFFLINE_ACCESS
+                            } else {
+                                NodeBottomSheetAction.MAKE_AVAILABLE_OFFLINE
+                            },
+                        )
+                    }
                 }
             }
         } else {

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
@@ -86,6 +86,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okio.Path.Companion.toPath
 import javax.inject.Inject
+import javax.inject.Named
 import java.io.File
 
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -110,6 +111,8 @@ class CellViewModel @Inject constructor(
     private val networkStateObserver: NetworkStateObserver,
     private val getConversationName: GetConversationNameUseCase,
     private val getUserName: GetUserNameUseCase,
+    /** When disabled, all offline-files UI (save actions, offline banner, offline browsing) is hidden. */
+    @Named("offlineFilesEnabled") val offlineFilesEnabled: Boolean,
 ) : ActionsViewModel<CellViewAction>() {
 
     private val navArgs: CellFilesNavArgs = ConversationFilesScreenDestination.argsFrom(savedStateHandle)
@@ -272,7 +275,7 @@ class CellViewModel @Inject constructor(
     }.flatMapLatest { (cellAvailable, online) ->
         when {
             !cellAvailable || searchNavArgs != null -> flowOf(emptyData)
-            !online -> offlineNodesFlow
+            offlineFilesEnabled && !online -> offlineNodesFlow
             else -> sharedNodesFlow
         }
     }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/ConversationFilesScreen.kt
@@ -105,7 +105,9 @@ fun ConversationFilesScreen(
     animatedVisibilityScope: AnimatedVisibilityScope,
     viewModel: CellViewModel = hiltViewModel(),
 ) {
-    val isOnline by viewModel.isOnline.collectAsState()
+    val isOnlineState by viewModel.isOnline.collectAsState()
+    // When offline files are disabled, never enter offline mode so all offline UI stays hidden.
+    val isOnline = isOnlineState || !viewModel.offlineFilesEnabled
 
     ConversationFilesScreenContent(
         animatedVisibilityScope = animatedVisibilityScope,

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/search/SearchScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/search/SearchScreen.kt
@@ -83,7 +83,9 @@ fun SearchScreen(
     searchScreenViewModel: SearchScreenViewModel = hiltViewModel(),
 ) {
     val uiState by searchScreenViewModel.uiState.collectAsStateWithLifecycle()
-    val isOnline by cellViewModel.isOnline.collectAsState()
+    val isOnlineState by cellViewModel.isOnline.collectAsState()
+    // When offline files are disabled, never enter offline mode so all offline UI stays hidden.
+    val isOnline = isOnlineState || !cellViewModel.offlineFilesEnabled
 
     val filterTypeSheetState = rememberWireModalSheetState<Unit>(WireSheetValue.Hidden)
     val filterTagsSheetState = rememberWireModalSheetState<Unit>(WireSheetValue.Hidden)

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellFileActionsMenuTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellFileActionsMenuTest.kt
@@ -537,29 +537,123 @@ class CellFileActionsMenuTest {
             )
         }
 
+    @Test
+    fun `GIVEN offline files disabled WHEN building allFiles menu THEN no offline action is added`() =
+        runTest {
+            // WHEN
+            val items = buildMenu(
+                isAllFiles = true,
+                offlineFilesEnabled = false,
+            )
+
+            // THEN
+            assertEquals(
+                listOf(
+                    NodeBottomSheetAction.OPEN,
+                    NodeBottomSheetAction.SHARE,
+                ),
+                items
+            )
+        }
+
+    @Test
+    fun `GIVEN offline files disabled AND file available offline WHEN building conversation menu THEN no offline action is added`() =
+        runTest {
+            // WHEN
+            val items = buildMenu(
+                fileNode = fileNode.copy(isAvailableOffline = true),
+                isConversationFiles = true,
+                offlineFilesEnabled = false,
+            )
+
+            // THEN
+            assertEquals(
+                listOf(
+                    NodeBottomSheetAction.OPEN,
+                    NodeBottomSheetAction.SHARE,
+                    NodeBottomSheetAction.ADD_REMOVE_TAGS,
+                    NodeBottomSheetAction.PUBLIC_LINK,
+                    NodeBottomSheetAction.MOVE,
+                    NodeBottomSheetAction.RENAME,
+                    NodeBottomSheetAction.DELETE,
+                ),
+                items
+            )
+        }
+
+    @Test
+    fun `GIVEN offline files enabled AND offline AND file available offline WHEN building menu THEN emits OPEN and REMOVE_OFFLINE_ACCESS`() =
+        runTest {
+            // WHEN
+            val items = buildMenu(
+                fileNode = fileNode.copy(isAvailableOffline = true),
+                isConversationFiles = true,
+                isOnline = false,
+            )
+
+            // THEN
+            assertEquals(
+                listOf(
+                    NodeBottomSheetAction.OPEN,
+                    NodeBottomSheetAction.REMOVE_OFFLINE_ACCESS,
+                ),
+                items
+            )
+        }
+
+    @Test
+    fun `GIVEN offline files disabled AND offline WHEN building menu THEN falls through to online menu`() =
+        runTest {
+            // WHEN
+            val items = buildMenu(
+                isConversationFiles = true,
+                isOnline = false,
+                offlineFilesEnabled = false,
+            )
+
+            // THEN - offline branch skipped, normal conversation menu without offline action
+            assertEquals(
+                listOf(
+                    NodeBottomSheetAction.OPEN,
+                    NodeBottomSheetAction.SHARE,
+                    NodeBottomSheetAction.ADD_REMOVE_TAGS,
+                    NodeBottomSheetAction.PUBLIC_LINK,
+                    NodeBottomSheetAction.MOVE,
+                    NodeBottomSheetAction.RENAME,
+                    NodeBottomSheetAction.DELETE,
+                ),
+                items
+            )
+        }
+
     private fun actionsMenu(
         withCollaboraIntegration: Boolean = false,
+        offlineFilesEnabled: Boolean = true,
     ) = CellFileActionsMenu(
         featureFlags = KaliumConfigs(
-            collaboraIntegration = withCollaboraIntegration
-        )
+            collaboraIntegration = withCollaboraIntegration,
+        ),
+        offlineFilesEnabled = offlineFilesEnabled,
     )
 
     @Suppress("LongParameterList")
     private fun buildMenu(
         fileNode: CellNodeUi = Companion.fileNode,
         withCollaboraIntegration: Boolean = false,
+        offlineFilesEnabled: Boolean = true,
         isRecycleBin: Boolean = false,
         isConversationFiles: Boolean = false,
         isAllFiles: Boolean = false,
         isSearching: Boolean = false,
         isCollaboraEnabled: Boolean = false,
+        isOnline: Boolean = true,
     ): List<NodeBottomSheetAction> =
         CellFileActionsMenu(
             featureFlags = KaliumConfigs(
-                collaboraIntegration = withCollaboraIntegration
-            )
-        ).buildMenu(fileNode, isRecycleBin, isConversationFiles, isAllFiles, isSearching, isCollaboraEnabled)
+                collaboraIntegration = withCollaboraIntegration,
+            ),
+            offlineFilesEnabled = offlineFilesEnabled,
+        ).buildMenu(fileNode, isRecycleBin, isConversationFiles, isAllFiles, isSearching, isCollaboraEnabled, isOnline)
 
     private companion object {
         val fileNode = CellNodeUi.File(

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
@@ -430,6 +430,7 @@ class CellViewModelTest {
                 networkStateObserver = networkStateObserver,
                 getConversationName = getConversationNames,
                 getUserName = getUserNames,
+                offlineFilesEnabled = true,
             )
         }
     }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23968
<!--jira-description-action-hidden-marker-end-->

## What

Puts the Wire Cells **offline files** feature behind a per-flavor, build-time feature flag (`OFFLINE_FILES_ENABLED`) so it can ship disabled until it's ready. Enabled on `dev` and `internal`; disabled on `staging`, `beta`, `prod`, and `fdroid`.

## How the flag is wired

- `OFFLINE_FILES_ENABLED` added to `FeatureConfigs` + `default.json` → generates a flavor-aware field on the **app** module's `BuildConfig`.
- Provided via Hilt `@Named("offlineFilesEnabled")` from `AppModule` (mirrors the existing `useNewLoginForDefaultBackend` pattern).
- Injected directly into `CellViewModel` and `CellFileActionsMenu`.

## What is hidden when the flag is OFF

When disabled, the feature is fully invisible and the cells screens behave as they did before the feature existed:

- **Bottom-sheet menu actions** — `Make available offline` and `Remove offline access` are no longer added to the file actions menu.
- **Offline browsing mode** — the offline-only menu branch is skipped; the screens never switch into offline mode.
- **Offline banner** — the "You're offline and can see only saved files" banner is hidden on the All Files, Conversation Files, and Search screens.
- **Offline data source** — `CellViewModel` no longer switches `nodesFlow` to the offline (saved-files) source when the device goes offline.

When enabled (`dev`/`internal`), behaviour is unchanged.

## Tests

- `CellFileActionsMenuTest` — added coverage for flag on/off, including the offline-only branch and that no offline action appears when disabled.
- `CellViewModelTest` — updated for the injected flag.
- Verified: `:features:cells:testDebugUnitTest`, `:app:hiltJavaCompileDevDebug` (cross-module DI resolves), and `staticCodeAnalysis` all green.

## Notes

- Base is `main` because the offline files feature it gates lives on `main` and is not yet on `develop`.