### PR TITLE
fix: accessibility and alpha landscape support [WPB-9784] [WPB-15178]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/ActivityExtensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/ActivityExtensions.kt
@@ -20,21 +20,17 @@ package com.wire.android.ui.common
 
 import android.app.Activity
 import android.content.pm.ActivityInfo
+import com.wire.android.BuildConfig
 
 /**
- * Sets up screen orientation based on device type.
- * - Tablets (smallestScreenWidthDp >= 600dp): Can rotate freely in all orientations
- * - Phones (smallestScreenWidthDp < 600dp): Locked to portrait orientation only
- *
- * This uses the same 600dp threshold that the app uses throughout its UI system
- * for determining tablet vs phone layouts.
+ * Sets up screen orientation based on device type and build configuration.
  */
 fun Activity.setupOrientationForDevice() {
     val isTablet = resources.configuration.smallestScreenWidthDp >= TABLET_MIN_SCREEN_WIDTH_DP
-    requestedOrientation = if (isTablet) {
-        ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
-    } else {
-        ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    requestedOrientation = when {
+        isTablet -> ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
+        BuildConfig.PHONE_LANDSCAPE_ENABLED -> ActivityInfo.SCREEN_ORIENTATION_USER
+        else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -37,12 +37,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -1058,6 +1062,7 @@ private fun ConversationScreen(
                     }
                 )
             },
+            contentWindowInsets = WindowInsets.systemBars.only(WindowInsetsSides.Vertical),
             content = { internalPadding ->
                 Box(
                     modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationTopAppBar.kt
@@ -22,10 +22,14 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -206,7 +210,8 @@ private fun ConversationScreenTopAppBarContent(
             titleContentColor = MaterialTheme.colorScheme.onBackground,
             actionIconContentColor = MaterialTheme.colorScheme.onBackground,
             navigationIconContentColor = MaterialTheme.colorScheme.onBackground
-        )
+        ),
+        windowInsets = WindowInsets.statusBars.only(WindowInsetsSides.Top)
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageActions.kt
@@ -63,13 +63,15 @@ fun MessageSendActions(
         modifier = modifier,
     ) {
         if (selfDeletionTimer.duration != null) {
+            val selfDeletionDuration = selfDeletionTimer.duration.toSelfDeletionDuration()
             WireTertiaryButton(
                 minSize = MaterialTheme.wireDimensions.buttonCircleMinSize,
                 minClickableSize = MaterialTheme.wireDimensions.buttonCircleMinSize,
                 shape = CircleShape,
                 contentPadding = PaddingValues(horizontal = dimensions().spacing4x, vertical = dimensions().spacing8x),
                 onClick = { onChangeSelfDeletionClicked(selfDeletionTimer) },
-                text = selfDeletionTimer.duration.toSelfDeletionDuration().shortLabel.asString(),
+                text = selfDeletionDuration.shortLabel.asString(),
+                description = selfDeletionDuration.longLabel.asString(),
                 textStyle = typography().label02,
                 fillMaxWidth = false,
                 state = if (!selfDeletionTimer.isEnforced) WireButtonState.Default else WireButtonState.Disabled,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SendContentButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SendContentButton.kt
@@ -32,6 +32,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
 import com.wire.android.R
 import com.wire.android.model.ClickBlockParams
 import com.wire.android.ui.common.button.WireButtonState
@@ -100,17 +109,33 @@ fun SelfDeletionTimerIcon(
     onSelfDeletionTimerClicked: () -> Unit
 ) {
     val isSelected = selfDeletionTimer is SelfDeletionTimer.Enabled && selfDeletionTimer.duration != null
+    val contentDescription = stringResource(id = R.string.content_description_self_deletion_selector_button)
+    val toggleActionDescription = stringResource(id = R.string.content_description_toggle_setting_label)
+    val stateDescription = stringResource(
+        id = if (isSelected) R.string.content_description_switch_on else R.string.content_description_switch_off
+    )
+
     Box(
         modifier = modifier
             .padding(start = dimensions().spacing16x)
             .size(dimensions().spacing48x)
             .clip(RoundedCornerShape(size = dimensions().onMoreOptionsButtonCornerRadius))
+            .semantics {
+                this.contentDescription = contentDescription
+                this.role = Role.Switch
+                this.stateDescription = stateDescription
+                this.toggleableState = ToggleableState(isSelected)
+                onClick(toggleActionDescription) {
+                    onSelfDeletionTimerClicked()
+                    true
+                }
+            }
     ) {
         WireSecondaryButton(
             leadingIcon = {
                 Image(
                     painter = painterResource(id = R.drawable.ic_timer),
-                    contentDescription = stringResource(id = R.string.content_description_self_deletion_selector_button),
+                    contentDescription = null,
                     colorFilter = ColorFilter.tint(
                         when {
                             isDisabled -> colorsScheme().onPrimaryButtonDisabled
@@ -130,6 +155,7 @@ fun SelfDeletionTimerIcon(
                 selected = colorsScheme().secondaryButtonSelected,
                 selectedOutline = colorsScheme().primaryButtonEnabled,
             ),
+            modifier = Modifier.clearAndSetSemantics { },
             onClick = onSelfDeletionTimerClicked,
             shape = RoundedCornerShape(size = dimensions().onMoreOptionsButtonCornerRadius),
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SendContentButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/SendContentButton.kt
@@ -49,9 +49,11 @@ import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.button.wireSecondaryButtonColors
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionMapper.toSelfDeletionDuration
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
+import com.wire.kalium.logic.util.isPositiveNotNull
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -65,6 +67,11 @@ fun SendContentButton(
     modifier: Modifier = Modifier,
     selfDeletionTimer: SelfDeletionTimer = SelfDeletionTimer.Disabled
 ) {
+    val mainButtonDescription = selfDeletionTimer.duration?.takeIf { it.isPositiveNotNull() }?.let {
+        val selfDeletionDuration = it.toSelfDeletionDuration()
+        "${stringResource(id = R.string.self_deleting_message_label)} (${selfDeletionDuration.longLabel.asString()})"
+    }
+
     Row(
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
@@ -90,6 +97,7 @@ fun SendContentButton(
             },
             state = if (count > 0) WireButtonState.Default else WireButtonState.Disabled,
             clickBlockParams = ClickBlockParams(blockWhenSyncing = true, blockWhenConnecting = true),
+            description = mainButtonDescription,
             modifier = Modifier
                 .weight(1f)
         )
@@ -109,7 +117,7 @@ fun SelfDeletionTimerIcon(
     onSelfDeletionTimerClicked: () -> Unit
 ) {
     val isSelected = selfDeletionTimer is SelfDeletionTimer.Enabled && selfDeletionTimer.duration != null
-    val contentDescription = stringResource(id = R.string.content_description_self_deletion_selector_button)
+    val contentDescription = stringResource(id = R.string.content_description_conversation_details_self_deleting_action)
     val toggleActionDescription = stringResource(id = R.string.content_description_toggle_setting_label)
     val stateDescription = stringResource(
         id = if (isSelected) R.string.content_description_switch_on else R.string.content_description_switch_off

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -464,9 +464,9 @@ private fun ImportMediaBottomBar(
     checkRestrictionsAndSendImportedMedia: () -> Unit,
 ) {
     val selfDeletionTimer = state.selfDeletingTimer
-    val shortDurationLabel = selfDeletionTimer.duration.toSelfDeletionDuration().shortLabel
+    val selfDeletionDuration = selfDeletionTimer.duration.toSelfDeletionDuration()
     val mainButtonText = if (selfDeletionTimer.duration.isPositiveNotNull()) {
-        "${stringResource(id = R.string.self_deleting_message_label)} (${shortDurationLabel.asString()})"
+        "${stringResource(id = R.string.self_deleting_message_label)} (${selfDeletionDuration.shortLabel.asString()})"
     } else {
         stringResource(id = R.string.import_media_send_button_title)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,7 +181,7 @@
     <string name="content_description_calling_call_unmuted">Call Unmuted</string>
     <string name="content_description_calling_call_paused_camera">Paused Camera</string>
     <string name="content_description_more_emojis">More emojis</string>
-    <string name="content_description_self_deletion_selector_button">Toggle self deletion mode</string>
+    <string name="content_description_self_deletion_selector_button">Switch button, toggle self deletion mode</string>
     <string name="content_description_message_sending_status">Message sending status</string>
     <string name="content_description_message_sent_status">Message sent status</string>
     <string name="content_description_message_error_status">Message error status</string>
@@ -218,6 +218,8 @@
     <string name="content_description_edit_label">edit</string>
     <string name="content_description_selected_label">selected</string>
     <string name="content_description_toggle_setting_label">toggle setting</string>
+    <string name="content_description_switch_on">on</string>
+    <string name="content_description_switch_off">off</string>
     <string name="content_description_edit_guests_option_back_btn">Go back to conversation details</string>
     <string name="content_description_edit_self_delete_back_btn">Go back to conversation details</string>
     <string name="content_description_accept_or_ignore_connection_label">accept or ignore the request</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,7 +181,7 @@
     <string name="content_description_calling_call_unmuted">Call Unmuted</string>
     <string name="content_description_calling_call_paused_camera">Paused Camera</string>
     <string name="content_description_more_emojis">More emojis</string>
-    <string name="content_description_self_deletion_selector_button">Switch button, toggle self deletion mode</string>
+    <string name="content_description_self_deletion_selector_button">Toggle self deletion mode, button</string>
     <string name="content_description_message_sending_status">Message sending status</string>
     <string name="content_description_message_sent_status">Message sent status</string>
     <string name="content_description_message_error_status">Message error status</string>

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -111,6 +111,7 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
     LIMIT_TEAM_MEMBERS_FETCH_DURING_SLOW_SYNC("limit_team_members_fetch_during_slow_sync", ConfigType.INT),
 
     PICTURE_IN_PICTURE_ENABLED("picture_in_picture_enabled", ConfigType.BOOLEAN),
+    PHONE_LANDSCAPE_ENABLED("phone_landscape_enabled", ConfigType.BOOLEAN),
     PAGINATED_CONVERSATION_LIST_ENABLED("paginated_conversation_list_enabled", ConfigType.BOOLEAN),
 
     PUBLIC_CHANNELS_ENABLED("public_channels_enabled", ConfigType.BOOLEAN),

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/scaffold/WireScaffold.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/scaffold/WireScaffold.kt
@@ -20,8 +20,11 @@ package com.wire.android.ui.common.scaffold
 import com.wire.android.ui.common.snackbar.SwipeableSnackbar
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -66,7 +69,7 @@ fun WireScaffold(
     Scaffold(
         modifier = modifier
             .imePadding()
-            .systemBarsPadding(),
+            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Vertical)),
         topBar = topBar,
         bottomBar = bottomBar,
         snackbarHost = snackbarHost,

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/topappbar/WireCenterAlignedTopAppBar.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/topappbar/WireCenterAlignedTopAppBar.kt
@@ -23,7 +23,11 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -123,6 +127,7 @@ fun WireCenterAlignedTopAppBar(
                 },
                 colors = wireTopAppBarColors(),
                 actions = actions,
+                windowInsets = WindowInsets.statusBars.only(WindowInsetsSides.Top),
                 modifier = Modifier
                     // TopAppBarHorizontalPadding is 4.dp so another 4.dp needs to be added to match 8.dp from designs
                     .padding(end = dimensions().spacing4x),

--- a/default.json
+++ b/default.json
@@ -37,6 +37,7 @@
             "enable_new_registration": true,
             "channels_history_options_enabled": true,
             "meetings_enabled": true,
+            "phone_landscape_enabled": true,
             "conversation_feeder_enabled": true,
             "db_invalidation_control_enabled": true,
             "enforce_configuration_signature": false,
@@ -91,6 +92,7 @@
             "enable_new_registration": true,
             "enforce_configuration_signature": true,
             "use_strict_mls_filter": false,
+            "phone_landscape_enabled": true,
             "conversation_feeder_enabled": true,
             "db_invalidation_control_enabled": false,
             "pending_messages": true
@@ -154,6 +156,7 @@
     "max_remote_search_result_count": 30,
     "limit_team_members_fetch_during_slow_sync": 2000,
     "picture_in_picture_enabled": false,
+    "phone_landscape_enabled": false,
     "paginated_conversation_list_enabled": true,
     "should_display_release_notes": true,
     "public_channels_enabled": false,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-9784
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- The self-deletion timer controls did not expose the intended accessibility labels/states consistently.
- Short self-deletion durations like `1m` could be read by TalkBack as “one meter”.
- Phone landscape support needed to be limited to selected internal builds.

### Causes (Optional)

- Some controls reused visible short labels directly for accessibility.
- Phone orientation handling was not guarded by a build-time flag.

### Solutions

- Reuse the conversation details accessibility label for the self-deletion timer control.
- Keep short duration labels visible in UI, but expose long duration labels to accessibility.
- Add `phone_landscape_enabled`, enabled only for `dev` and `alpha`, with default disabled behavior.