### PR TITLE
feat: meeting schedule design fixes [WPB-25048]

### DIFF
--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/create/NewMeetingScreen.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/create/NewMeetingScreen.kt
@@ -211,6 +211,7 @@ fun NewMeetingContent(
                     RepeatingIntervalDropDown(
                         repeatingInterval = state.repeatingInterval,
                         onRepeatingIntervalChanged = onRepeatingIntervalChanged,
+                        items = MeetingItem.RepeatingInterval.entries.minus(MeetingItem.RepeatingInterval.Annually),
                     )
                 }
                 VerticalSpace.x24()

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/create/NewMeetingViewModel.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/create/NewMeetingViewModel.kt
@@ -113,7 +113,11 @@ class NewMeetingViewModelImpl(
     }
 
     override fun updateStartTime(startTime: Instant) {
-        state = state.copy(startTime = startTime)
+        val currentDuration = state.endTime - state.startTime
+        state = state.copy(
+            startTime = startTime,
+            endTime = startTime.plus(currentDuration) // adjust end time based on the new start time but keep the same duration
+        )
         validateStartAndEndTime()
     }
 
@@ -170,12 +174,9 @@ class NewMeetingViewModelImpl(
 }
 
 internal fun getNextFullHour(now: Instant, timeZone: TimeZone = TimeZone.currentSystemDefault()): Instant {
-    val localNow = now.toLocalDateTime(timeZone)
-    val hasPassedTime = localNow.minute > 0 || localNow.second > 0 || localNow.nanosecond > 0
-    val targetDateTime = if (hasPassedTime) {
-        val futureHour = now.plus(1, DateTimeUnit.HOUR, timeZone)
-        val localFuture = futureHour.toLocalDateTime(timeZone)
-        LocalDateTime(
+    val futureHour = now.plus(1, DateTimeUnit.HOUR, timeZone)
+    val localFuture = futureHour.toLocalDateTime(timeZone)
+    return LocalDateTime(
             year = localFuture.year,
             monthNumber = localFuture.monthNumber,
             dayOfMonth = localFuture.dayOfMonth,
@@ -183,11 +184,7 @@ internal fun getNextFullHour(now: Instant, timeZone: TimeZone = TimeZone.current
             minute = 0,
             second = 0,
             nanosecond = 0
-        )
-    } else {
-        localNow
-    }
-    return targetDateTime.toInstant(timeZone)
+        ).toInstant(timeZone)
 }
 
 @Stable

--- a/features/meetings/src/main/res/values/strings.xml
+++ b/features/meetings/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="meeting_repeating_never">Never</string>
     <string name="meeting_repeating_daily">Daily</string>
     <string name="meeting_repeating_weekly">Weekly</string>
-    <string name="meeting_repeating_biweekly">Biweekly</string>
+    <string name="meeting_repeating_biweekly">Every 2 weeks</string>
     <string name="meeting_repeating_monthly">Monthly</string>
     <string name="meeting_repeating_annually">Annually</string>
     <string name="meeting_started_at">Started at %1$s</string>

--- a/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/create/NewMeetingViewModelTest.kt
+++ b/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/create/NewMeetingViewModelTest.kt
@@ -77,8 +77,8 @@ class NewMeetingViewModelTest {
         )
 
         assertEquals(NewMeetingType.Schedule, viewModel.type)
-        assertEquals(currentTime, viewModel.state.startTime)
-        assertEquals(currentTime + 1.hours, viewModel.state.endTime)
+        assertEquals(currentTime + 1.hours, viewModel.state.startTime) // next full hour
+        assertEquals(currentTime + 2.hours, viewModel.state.endTime) // start time + 1 hour
         assertFalse(viewModel.state.continueButtonEnabled)
         assertNull(viewModel.state.titleError)
         assertNull(viewModel.state.startTimeError)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25048
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

During the design review, three issues were identified:
- "Annually" option should be removed
- "Biweekly" should be named “Every 2 weeks” (biweekly is an ambiguous term)
- Changing the start time should also move the end time to the same day to reduce errors being shown

### Solutions

- "Annually" option hidden from the "schedule a meeting" option chooser
- "Biweekly" label changed to "Every 2 weeks"
- Date changing logic changed in a way that when the start time is changed, then end time is changed accordingly as well, keeping the same duration of the meeting, so it works the same as on Google Calendar

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Open `dev` build, go to meetings, click "new" and "schedule" and play around with the form

### Attachments (Optional)

https://github.com/user-attachments/assets/d37fb822-1da9-46fd-8447-9f0cd71b6056

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
