### PR TITLE
feat: join meeting action: start/join/return to call [WPB-25067]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/CallsModule.kt
@@ -51,6 +51,7 @@ import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveActiveCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.video.SetVideoSendStateUseCase
 import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
 import dev.zacsweers.metro.BindingContainer
@@ -113,6 +114,10 @@ class CallsModule {
         callsScope: CallsScope
     ): ObserveOutgoingCallUseCase =
         callsScope.observeOutgoingCall
+
+    @Provides
+    fun provideActiveCallsUseCase(callsScope: CallsScope): ObserveActiveCallsUseCase =
+        callsScope.observeActiveCalls
 
     @Provides
     fun provideStartCallUseCase(callsScope: CallsScope): StartCallUseCase =

--- a/app/src/main/kotlin/com/wire/android/di/metro/WireMetroViewModelBindings.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/WireMetroViewModelBindings.kt
@@ -154,6 +154,7 @@ import com.wire.android.ui.home.conversations.messages.item.AssetLocalPathViewMo
 import com.wire.android.ui.home.conversations.model.CompositeMessageArgs
 import com.wire.android.ui.home.conversations.typing.TypingIndicatorArgs
 import com.wire.android.ui.home.conversations.typing.TypingIndicatorViewModelImpl
+import com.wire.android.ui.home.meetings.MeetingsCallViewModel
 import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionArgs
 import com.wire.android.ui.home.messagecomposer.actions.SelfDeletingMessageActionViewModelImpl
 import com.wire.android.ui.home.messagecomposer.attachments.IsFileSharingEnabledViewModelImpl
@@ -228,6 +229,12 @@ object WireMetroViewModelBindings {
             override fun create(extras: CreationExtras): ViewModel =
                 factory.conversationCallViewModel(extras.createSavedStateHandle())
         }
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(MeetingsCallViewModel::class)
+    fun joinOrStartCallViewModel(factory: CallingViewModelFactory): ViewModel =
+        factory.meetingsCallViewModel()
 
     @Provides
     @IntoMap

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallingViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallingViewModelFactory.kt
@@ -39,6 +39,7 @@ import com.wire.android.ui.home.appLock.LockCodeTimeManager
 import com.wire.android.ui.home.conversations.call.ConversationCallViewModel
 import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
 import com.wire.android.ui.home.conversationslist.ConversationListCallViewModelImpl
+import com.wire.android.ui.home.meetings.MeetingsCallViewModel
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.ConversationId
@@ -229,6 +230,19 @@ class CallingViewModelFactory @Inject constructor(
         setUserInformedAboutVerification = setUserInformedAboutVerification,
         observeDegradedConversationNotified = observeDegradedConversationNotified,
         observeConferenceCallingEnabled = observeConferenceCallingEnabled,
+        observeSelf = observeSelf,
+    )
+
+    fun meetingsCallViewModel() = MeetingsCallViewModel(
+        currentAccount = currentAccount,
+        observeEstablishedCalls = observeEstablishedCalls,
+        observeParticipantsForConversation = observeParticipantsForConversation,
+        answerCall = answerCall,
+        endCall = endCall,
+        observeSyncState = observeSyncState,
+        isConferenceCallingEnabled = isConferenceCallingEnabled,
+        setUserInformedAboutVerification = setUserInformedAboutVerification,
+        observeDegradedConversationNotified = observeDegradedConversationNotified,
         observeSelf = observeSelf,
     )
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallingViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallingViewModelGraph.kt
@@ -30,6 +30,7 @@ import com.wire.android.ui.home.conversationslist.ConversationListCallViewModel
 import com.wire.android.ui.home.conversationslist.ConversationListCallViewModelImpl
 import com.wire.android.ui.home.conversationslist.ConversationListCallViewModelPreview
 import com.wire.android.ui.home.conversationslist.model.ConversationsSource
+import com.wire.android.ui.home.meetings.MeetingsCallViewModel
 import com.wire.kalium.logic.data.id.ConversationId
 import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
 import dev.zacsweers.metrox.viewmodel.metroViewModel as metroxViewModel
@@ -86,3 +87,6 @@ fun conversationListCallViewModel(conversationsSource: ConversationsSource): Con
     LocalInspectionMode.current -> ConversationListCallViewModelPreview
     else -> sessionKeyedMetroViewModel<ConversationListCallViewModelImpl>(key = "call_$conversationsSource")
 }
+
+@Composable
+fun meetingsCallViewModel(): MeetingsCallViewModel = sessionKeyedMetroViewModel()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -291,8 +291,6 @@ fun ConversationScreen(
     // then ViewModel also detects it's removed and calls onNotFound which can execute navigateBack again and close the app
     var alreadyDeletedByUser by rememberSaveable { mutableStateOf(false) }
 
-    val context = LocalContext.current
-
     LaunchedEffect(conversationScreenState.isAnySheetVisible) {
         with(messageComposerStateHolder) {
             if (conversationScreenState.isAnySheetVisible) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -43,9 +43,9 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -105,8 +105,6 @@ import com.sebaslogen.resaca.rememberKeysInScope
 import com.wire.android.BuildConfig.IS_BUBBLE_UI_ENABLED
 import com.wire.android.R
 import com.wire.android.appLogger
-import com.wire.android.feature.analytics.AnonymousAnalyticsManagerImpl
-import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.feature.cells.ui.dialog.IncompatibleFileNameDialog
 import com.wire.android.feature.sketch.model.DrawingCanvasNavArgs
 import com.wire.android.feature.sketch.model.DrawingCanvasNavBackArgs
@@ -119,9 +117,6 @@ import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.annotation.app.WireRootDestination
 import com.wire.android.ui.calling.conversationCallViewModel
-import com.wire.android.ui.calling.getOutgoingCallIntent
-import com.wire.android.ui.calling.ongoing.getOngoingCallIntent
-import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.PageLoadingIndicator
 import com.wire.android.ui.common.attachmentdraft.model.AttachmentDraftUi
 import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
@@ -148,8 +143,8 @@ import com.wire.android.ui.home.conversations.banner.ConversationBanner
 import com.wire.android.ui.home.conversations.banner.ConversationBannerViewModel
 import com.wire.android.ui.home.conversations.call.ConversationCallViewModel
 import com.wire.android.ui.home.conversations.call.ConversationCallViewState
+import com.wire.android.ui.home.conversations.call.HandleActions
 import com.wire.android.ui.home.conversations.call.HandleJoinOrStartCallScreenDialogs
-import com.wire.android.ui.home.conversations.call.JoinOrStartCallViewActions
 import com.wire.android.ui.home.conversations.composer.MessageComposerViewModel
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogState
@@ -344,20 +339,6 @@ fun ConversationScreen(
         }
     }
 
-    HandleActions(conversationCallViewModel.callManager.actions) { action ->
-        when (action) {
-            is JoinOrStartCallViewActions.InitiatedCall -> {
-                context.startActivity(getOutgoingCallIntent(context, action.conversationId.toString(), action.userId.toString()))
-                AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallInitiated)
-            }
-
-            is JoinOrStartCallViewActions.JoinedCall -> {
-                context.startActivity(getOngoingCallIntent(context, action.conversationId.toString(), action.userId.toString()))
-                AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallJoined)
-            }
-        }
-    }
-
     conversationMigrationViewModel.migratedConversationId?.let { migratedConversationId ->
         navigator.navigate(
             NavigationCommand(
@@ -390,6 +371,7 @@ fun ConversationScreen(
         ConversationScreenDialogType.NONE -> {}
     }
 
+    conversationCallViewModel.callManager.actions.HandleActions()
     conversationCallViewModel.callManager.HandleJoinOrStartCallScreenDialogs()
 
     ConversationScreen(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallManager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallManager.kt
@@ -184,19 +184,17 @@ class JoinOrStartCallManager(
             shouldInformAboutVerification(conversationId) ->
                 JoinOrStartCallScreenDialogType.VerificationDegraded(conversationId, conversationType)
             else -> dialogTypeForCallAvailability(conversationId, conversationType)
-        }.also {
-            updateDialogType(it)
-            if (it == JoinOrStartCallScreenDialogType.None) {
-                initiateCallInternal(conversationId)
-            }
-        }
+        }.also(::updateDialogType)
     }
 
     private suspend fun dialogTypeForCallAvailability(
         conversationId: ConversationId,
         conversationType: Conversation.Type,
     ) = when (isConferenceCallingEnabled(conversationId, conversationType)) {
-        ConferenceCallingResult.Enabled -> JoinOrStartCallScreenDialogType.None
+        ConferenceCallingResult.Enabled -> {
+            initiateCallInternal(conversationId)
+            JoinOrStartCallScreenDialogType.None
+        }
 
         ConferenceCallingResult.Disabled.Established -> {
             sendAction(JoinOrStartCallViewActions.JoinedCall(conversationId, currentAccount))

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallManager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallManager.kt
@@ -44,6 +44,7 @@ import com.wire.kalium.logic.feature.conversation.ObserveDegradedConversationNot
 import com.wire.kalium.logic.feature.conversation.SetUserInformedAboutVerificationUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
+import io.github.esentsov.PackagePrivate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
@@ -53,7 +54,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
 @Suppress("LongParameterList", "TooManyFunctions")
-open class JoinOrStartCallManager(
+class JoinOrStartCallManager(
     private val scope: CoroutineScope,
     val currentAccount: UserId,
     private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
@@ -102,7 +103,8 @@ open class JoinOrStartCallManager(
             }
     }
 
-    fun joinAnyway(conversationId: ConversationId) {
+    @PackagePrivate
+    internal fun joinAnyway(conversationId: ConversationId) {
         scope.launch {
             establishedCallConversationId?.let {
                 endCall(it)
@@ -128,7 +130,8 @@ open class JoinOrStartCallManager(
         sendAction(JoinOrStartCallViewActions.JoinedCall(conversationId, currentAccount))
     }
 
-    fun initiateCall(conversationId: ConversationId) {
+    @PackagePrivate
+    internal fun initiateCall(conversationId: ConversationId) {
         scope.launch {
             initiateCallInternal(conversationId)
         }
@@ -141,54 +144,59 @@ open class JoinOrStartCallManager(
         sendAction(JoinOrStartCallViewActions.InitiatedCall(conversationId, currentAccount))
     }
 
-    fun startCallIfPossible(conversationId: ConversationId, conversationType: Conversation.Type) {
-        scope.launch {
-            startCallIfPossible(conversationId, conversationType, shouldCheckParticipantCount = true, shouldCheckVerification = true)
-        }
-    }
-
-    fun startCallAfterDegradedVerification(conversationId: ConversationId, conversationType: Conversation.Type) {
-        scope.launch {
-            onApplyConversationDegradation(conversationId)
-            startCallIfPossible(conversationId, conversationType, shouldCheckParticipantCount = true, shouldCheckVerification = false)
-        }
-    }
-
-    fun startCallAfterConfirming(conversationId: ConversationId, conversationType: Conversation.Type) {
-        scope.launch {
-            startCallIfPossible(conversationId, conversationType, shouldCheckParticipantCount = false, shouldCheckVerification = false)
-        }
-    }
-
-    private suspend fun startCallIfPossible(
+    fun startCallIfPossible(
         conversationId: ConversationId,
         conversationType: Conversation.Type,
         shouldCheckParticipantCount: Boolean = true,
-        shouldCheckVerification: Boolean = true,
-    ) = updateDialogType(
+    ) = scope.launch {
+        startCallOrShowDialog(
+            conversationId = conversationId,
+            conversationType = conversationType,
+            shouldCheckParticipantCount = shouldCheckParticipantCount
+        )
+    }
+
+    @PackagePrivate
+    internal fun startCallAfterDegradedVerification(conversationId: ConversationId, conversationType: Conversation.Type) {
+        scope.launch {
+            onApplyConversationDegradation(conversationId)
+            startCallOrShowDialog(conversationId = conversationId, conversationType = conversationType, shouldCheckParticipantCount = true)
+        }
+    }
+
+    @PackagePrivate
+    internal fun startCallAfterConfirmingParticipantsCount(conversationId: ConversationId, conversationType: Conversation.Type) {
+        scope.launch {
+            startCallIfPossible(conversationId = conversationId, conversationType = conversationType, shouldCheckParticipantCount = false)
+        }
+    }
+
+    private suspend fun startCallOrShowDialog(
+        conversationId: ConversationId,
+        conversationType: Conversation.Type,
+        shouldCheckParticipantCount: Boolean = true,
+    ) {
+        val participantsCount = if (shouldCheckParticipantCount) participantsCountForConversation(conversationId) else null
         when {
             !hasStableConnectivity() -> JoinOrStartCallScreenDialogType.NoConnectivity
-            shouldCheckVerification && shouldInformAboutVerification(conversationId) ->
+            participantsCount != null && participantsCount > MAX_GROUP_SIZE_FOR_CALL_WITHOUT_ALERT ->
+                JoinOrStartCallScreenDialogType.CallConfirmation(conversationId, participantsCount, conversationType)
+            shouldInformAboutVerification(conversationId) ->
                 JoinOrStartCallScreenDialogType.VerificationDegraded(conversationId, conversationType)
-
-            else -> dialogTypeForCallAvailability(conversationId, conversationType, shouldCheckParticipantCount)
+            else -> dialogTypeForCallAvailability(conversationId, conversationType)
+        }.also {
+            updateDialogType(it)
+            if (it == JoinOrStartCallScreenDialogType.None) {
+                initiateCallInternal(conversationId)
+            }
         }
-    )
+    }
 
     private suspend fun dialogTypeForCallAvailability(
         conversationId: ConversationId,
         conversationType: Conversation.Type,
-        shouldCheckParticipantCount: Boolean = true,
     ) = when (isConferenceCallingEnabled(conversationId, conversationType)) {
-        ConferenceCallingResult.Enabled -> {
-            val participantsCount = if (shouldCheckParticipantCount) participantsCountForConversation(conversationId) else null
-            if (participantsCount != null && participantsCount > MAX_GROUP_SIZE_FOR_CALL_WITHOUT_ALERT) {
-                JoinOrStartCallScreenDialogType.CallConfirmation(conversationId, participantsCount, conversationType)
-            } else {
-                initiateCallInternal(conversationId)
-                JoinOrStartCallScreenDialogType.None
-            }
-        }
+        ConferenceCallingResult.Enabled -> JoinOrStartCallScreenDialogType.None
 
         ConferenceCallingResult.Disabled.Established -> {
             sendAction(JoinOrStartCallViewActions.JoinedCall(conversationId, currentAccount))
@@ -227,7 +235,8 @@ open class JoinOrStartCallManager(
         joinOrStartCallViewState = joinOrStartCallViewState.copy(dialogType = dialogType)
     }
 
-    fun dismissDialog() = updateDialogType(JoinOrStartCallScreenDialogType.None)
+    @PackagePrivate
+    internal fun dismissDialog() = updateDialogType(JoinOrStartCallScreenDialogType.None)
 
     companion object {
         const val DELAY_END_CALL = 200L

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallManager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallManager.kt
@@ -218,7 +218,7 @@ class JoinOrStartCallManager(
         }
     } ?: false
 
-    internal open suspend fun participantsCountForConversation(conversationId: ConversationId): Int =
+    private suspend fun participantsCountForConversation(conversationId: ConversationId): Int =
         observeParticipantsForConversation(conversationId).firstOrNull()?.allCount ?: 0
 
     private suspend fun isConferenceCallingEnabled(conversationId: ConversationId, conversationType: Conversation.Type) =

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallScreenDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallScreenDialogs.kt
@@ -67,7 +67,6 @@ fun JoinOrStartCallManager.HandleJoinOrStartCallScreenDialogs() = when (val dial
     is JoinOrStartCallScreenDialogType.OngoingActiveCall -> OngoingActiveCallDialog(
         onInitiateCallAnyway = {
             initiateCall(dialogType.conversationId)
-            dismissDialog()
         },
         onDialogDismiss = ::dismissDialog
     )
@@ -79,7 +78,7 @@ fun JoinOrStartCallManager.HandleJoinOrStartCallScreenDialogs() = when (val dial
 
     is JoinOrStartCallScreenDialogType.CallConfirmation -> ConfirmStartCallDialog(
         participantsCount = dialogType.participantsCount,
-        onConfirm = { startCallAfterConfirming(dialogType.conversationId, dialogType.conversationType) },
+        onConfirm = { startCallAfterConfirmingParticipantsCount(dialogType.conversationId, dialogType.conversationType) },
         onDialogDismiss = ::dismissDialog
     )
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallViewActions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallViewActions.kt
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.home.conversations.call
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import com.wire.android.feature.analytics.AnonymousAnalyticsManagerImpl
+import com.wire.android.feature.analytics.model.AnalyticsEvent
+import com.wire.android.ui.calling.getOutgoingCallIntent
+import com.wire.android.ui.calling.ongoing.getOngoingCallIntent
+import com.wire.android.ui.common.HandleActions
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
+import kotlinx.coroutines.flow.Flow
+
+sealed interface JoinOrStartCallViewActions {
+    data class JoinedCall(val conversationId: ConversationId, val userId: UserId) : JoinOrStartCallViewActions
+    data class InitiatedCall(val conversationId: ConversationId, val userId: UserId) : JoinOrStartCallViewActions
+}
+
+@Composable
+fun Flow<JoinOrStartCallViewActions>.HandleActions() {
+    val context = LocalContext.current
+    HandleActions(this) { action ->
+        when (action) {
+            is JoinOrStartCallViewActions.InitiatedCall -> {
+                context.startActivity(getOutgoingCallIntent(context, action.conversationId.toString(), action.userId.toString()))
+                AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallInitiated)
+            }
+
+            is JoinOrStartCallViewActions.JoinedCall -> {
+                context.startActivity(getOngoingCallIntent(context, action.conversationId.toString(), action.userId.toString()))
+                AnonymousAnalyticsManagerImpl.sendEvent(event = AnalyticsEvent.CallJoined)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallViewState.kt
@@ -17,15 +17,7 @@
  */
 package com.wire.android.ui.home.conversations.call
 
-import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.user.UserId
-
 data class JoinOrStartCallViewState(
     val hasEstablishedCall: Boolean = false,
     val dialogType: JoinOrStartCallScreenDialogType = JoinOrStartCallScreenDialogType.None
 )
-
-sealed interface JoinOrStartCallViewActions {
-    data class JoinedCall(val conversationId: ConversationId, val userId: UserId) : JoinOrStartCallViewActions
-    data class InitiatedCall(val conversationId: ConversationId, val userId: UserId) : JoinOrStartCallViewActions
-}

--- a/app/src/main/kotlin/com/wire/android/ui/home/meetings/MeetingsCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/meetings/MeetingsCallViewModel.kt
@@ -1,0 +1,61 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.home.meetings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.ui.home.conversations.call.JoinOrStartCallManager
+import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.IsEligibleToStartCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveDegradedConversationNotifiedUseCase
+import com.wire.kalium.logic.feature.conversation.SetUserInformedAboutVerificationUseCase
+import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
+import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
+
+@Suppress("LongParameterList", "TooManyFunctions")
+class MeetingsCallViewModel(
+    currentAccount: UserId,
+    private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
+    private val observeParticipantsForConversation: ObserveParticipantsForConversationUseCase,
+    private val answerCall: AnswerCallUseCase,
+    private val endCall: EndCallUseCase,
+    private val observeSyncState: ObserveSyncStateUseCase,
+    private val isConferenceCallingEnabled: IsEligibleToStartCallUseCase,
+    private val setUserInformedAboutVerification: SetUserInformedAboutVerificationUseCase,
+    private val observeDegradedConversationNotified: ObserveDegradedConversationNotifiedUseCase,
+    private val observeSelf: ObserveSelfUserUseCase
+) : ViewModel() {
+    val callManager = JoinOrStartCallManager(
+        scope = viewModelScope,
+        currentAccount = currentAccount,
+        observeEstablishedCalls = observeEstablishedCalls,
+        observeParticipantsForConversation = observeParticipantsForConversation,
+        answerCall = answerCall,
+        endCall = endCall,
+        observeSyncState = observeSyncState,
+        isEligibleToStartCall = isConferenceCallingEnabled,
+        setUserInformedAboutVerification = setUserInformedAboutVerification,
+        observeDegradedConversationNotified = observeDegradedConversationNotified,
+        observeSelf = observeSelf,
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/meetings/MeetingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/meetings/MeetingsScreen.kt
@@ -19,6 +19,7 @@ package com.wire.android.ui.home.meetings
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import com.ramcosta.composedestinations.generated.meetings.destinations.NewMeetingScreenDestination
 import com.wire.android.feature.meetings.ui.AllMeetingsScreen
 import com.wire.android.feature.meetings.ui.NewMeetingBottomSheet
@@ -27,17 +28,46 @@ import com.wire.android.navigation.annotation.app.WireHomeDestination
 import com.wire.android.ui.common.dimensions
 import com.wire.android.feature.meetings.ui.create.NewMeetingType
 import com.wire.android.navigation.NavigationCommand
+import com.wire.android.ui.calling.meetingsCallViewModel
+import com.wire.android.ui.calling.ongoing.getOngoingCallIntent
 import com.wire.android.ui.home.HomeStateHolder
+import com.wire.android.ui.home.conversations.call.HandleActions
+import com.wire.android.ui.home.conversations.call.HandleJoinOrStartCallScreenDialogs
+import com.wire.kalium.logic.data.conversation.Conversation
 
 @WireHomeDestination
 @Composable
 fun MeetingsScreen(
     homeStateHolder: HomeStateHolder,
+    viewModel: MeetingsCallViewModel = meetingsCallViewModel()
 ) {
+    val context = LocalContext.current
     AllMeetingsScreen(
         lazyListState = homeStateHolder.lazyListStateFor(HomeDestination.Meetings),
         contentPadding = PaddingValues(bottom = dimensions().spacing80x), // to ensure last item is not obscured by FAB
+        startCall = { conversationId ->
+            viewModel.callManager.startCallIfPossible(
+                conversationId = conversationId,
+                conversationType = Conversation.Type.Group.Regular,
+                shouldCheckParticipantCount = false, // since this is a meeting, we don't need to check participant count
+            )
+        },
+        joinCall = { conversationId ->
+            viewModel.callManager.joinOngoingCall(conversationId = conversationId)
+        },
+        returnToCall = { conversationId ->
+            context.startActivity(
+                getOngoingCallIntent(
+                    context = context,
+                    conversationId = conversationId.toString(),
+                    userId = viewModel.callManager.currentAccount.toString(),
+                )
+            )
+        },
     )
+
+    viewModel.callManager.actions.HandleActions()
+    viewModel.callManager.HandleJoinOrStartCallScreenDialogs()
 
     NewMeetingBottomSheet(
         sheetState = homeStateHolder.newMeetingBottomSheetState,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallManagerTest.kt
@@ -264,7 +264,7 @@ class JoinOrStartCallManagerTest {
         val (arrangement, viewModel) = Arrangement().arrange()
 
         viewModel.actions.test {
-            viewModel.startCallAfterConfirming(conversationId, Conversation.Type.Group.Regular)
+            viewModel.startCallAfterConfirmingParticipantsCount(conversationId, Conversation.Type.Group.Regular)
             advanceUntilIdle()
 
             assertEquals(JoinOrStartCallViewActions.InitiatedCall(conversationId, currentAccount), awaitItem())

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/call/JoinOrStartCallManagerTest.kt
@@ -214,7 +214,7 @@ class JoinOrStartCallManagerTest {
     @Test
     fun `given degraded verification confirmed, when starting call, then mark user informed and initiate call`() = runTest {
         val (arrangement, viewModel) = Arrangement()
-            .withDegradedConversationNotified(false)
+            .withDegradedConversationNotified(true)
             .arrange()
 
         viewModel.actions.test {
@@ -223,7 +223,6 @@ class JoinOrStartCallManagerTest {
 
             assertEquals(JoinOrStartCallViewActions.InitiatedCall(conversationId, currentAccount), awaitItem())
             coVerify(exactly = 1) { arrangement.setUserInformedAboutVerification(conversationId) }
-            coVerify(exactly = 0) { arrangement.observeDegradedConversationNotified(any()) }
             assertIs<JoinOrStartCallScreenDialogType.None>(viewModel.joinOrStartCallViewState.dialogType)
         }
     }

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -1964,6 +1964,12 @@ public fun com.wire.android.ui.calling.incomingCallViewModel(conversationId: com
     - conversationId: STABLE (matched by stability configuration)
 
 @Composable
+public fun com.wire.android.ui.calling.meetingsCallViewModel(): com.wire.android.ui.home.meetings.MeetingsCallViewModel
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 private fun com.wire.android.ui.calling.ongoing.CallingControls(conversationId: com.wire.kalium.logic.data.id.QualifiedID, isMuted: kotlin.Boolean, isCameraOn: kotlin.Boolean, isSpeakerOn: kotlin.Boolean, isShowingCallReactions: kotlin.Boolean, isConnecting: kotlin.Boolean, inCallReactionsEnabled: kotlin.Boolean, toggleSpeaker: kotlin.Function0<kotlin.Unit>, toggleMute: kotlin.Function0<kotlin.Unit>, onHangUpCall: kotlin.Function0<kotlin.Unit>, onToggleVideo: kotlin.Function0<kotlin.Unit>, onCallReactionsClick: kotlin.Function0<kotlin.Unit>, onCameraPermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
@@ -4872,6 +4878,12 @@ private fun com.wire.android.ui.home.conversations.banner.styleBannerText(uiText
   params:
     - uiText: STABLE (class with no mutable properties)
     - spannedTexts: RUNTIME (requires runtime check)
+
+@Composable
+public fun com.wire.android.ui.home.conversations.call.HandleActions(): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
 
 @Composable
 public fun com.wire.android.ui.home.conversations.call.HandleJoinOrStartCallScreenDialogs(): kotlin.Unit
@@ -8020,11 +8032,12 @@ public fun com.wire.android.ui.home.homeViewModel(): com.wire.android.ui.home.Ho
   params:
 
 @Composable
-public fun com.wire.android.ui.home.meetings.MeetingsScreen(homeStateHolder: com.wire.android.ui.home.HomeStateHolder): kotlin.Unit
+public fun com.wire.android.ui.home.meetings.MeetingsScreen(homeStateHolder: com.wire.android.ui.home.HomeStateHolder, viewModel: com.wire.android.ui.home.meetings.MeetingsCallViewModel): kotlin.Unit
   skippable: false
   restartable: true
   params:
     - homeStateHolder: UNSTABLE (has mutable properties or unstable members)
+    - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
 public fun com.wire.android.ui.home.messagecomposer.ActiveMessageComposerInput(conversationId: com.wire.kalium.logic.data.id.QualifiedID, messageComposition: com.wire.android.ui.home.messagecomposer.model.MessageComposition, messageTextState: androidx.compose.foundation.text.input.TextFieldState, isTextExpanded: kotlin.Boolean, inputType: com.wire.android.ui.home.messagecomposer.state.InputType, focusRequester: androidx.compose.ui.focus.FocusRequester, keyboardOptions: androidx.compose.foundation.text.KeyboardOptions, onKeyboardAction: androidx.compose.foundation.text.input.KeyboardActionHandler?, canSendMessage: kotlin.Boolean, onSendButtonClicked: kotlin.Function0<kotlin.Unit>, onEditButtonClicked: kotlin.Function0<kotlin.Unit>, onChangeSelfDeletionClicked: kotlin.Function1<@[ParameterName(name = \, onToggleInputSize: kotlin.Function0<kotlin.Unit>, onCancelReply: kotlin.Function0<kotlin.Unit>, onCancelEdit: kotlin.Function0<kotlin.Unit>, onFocused: kotlin.Function0<kotlin.Unit>, onSelectedLineIndexChanged: kotlin.Function1<kotlin.Int, kotlin.Unit>, onLineBottomYCoordinateChanged: kotlin.Function1<kotlin.Float, kotlin.Unit>, showOptions: kotlin.Boolean, optionsSelected: kotlin.Boolean, onPlusClick: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit

--- a/features/meetings/build.gradle.kts
+++ b/features/meetings/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 dependencies {
     implementation("com.wire.kalium:kalium-common")
     implementation("com.wire.kalium:kalium-logic")
+    implementation("com.wire.kalium:kalium-util")
     implementation(projects.core.di)
     implementation(projects.core.uiCommon)
     implementation(projects.core.search)

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/mapper/MeetingMapper.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/mapper/MeetingMapper.kt
@@ -20,24 +20,53 @@ package com.wire.android.feature.meetings.mapper
 import com.wire.android.feature.meetings.model.MeetingItem
 import com.wire.android.feature.meetings.model.MeetingItem.Status
 import com.wire.android.feature.meetings.ui.mock.Meeting
+import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.util.DateTimeUtil
 import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.minutes
 
 private val BUFFER_TIME = 5.minutes
 
-fun Meeting.toMeetingItem(time: Instant): MeetingItem = MeetingItem(
+fun Meeting.toMeetingItem(time: Instant, ongoingCallStatus: MeetingItem.OngoingCallStatus?): MeetingItem = MeetingItem(
     meetingId = meetingId,
     conversationId = conversationId,
     belongingType = belongingType,
     repeatingInterval = repeatingInterval,
     title = title,
     status = when {
-        startTime > time && endTime != null -> Status.Scheduled(startTime = startTime, endTime = endTime)
-        startTime < time && endTime != null && endTime + BUFFER_TIME < time -> Status.Ended(startTime = startTime, endTime = endTime)
-        else -> Status.Ongoing(startTime = startTime, scheduledEndTime = endTime, ongoingCallStatus = ongoingCallStatus)
+        startTime > time && endTime != null -> Status.Scheduled(
+            startTime = startTime,
+            endTime = endTime
+        )
+
+        startTime < time && endTime != null && endTime + BUFFER_TIME < time -> Status.Ended(
+            startTime = startTime,
+            endTime = endTime
+        )
+
+        else -> Status.Ongoing(
+            startTime = startTime,
+            scheduledEndTime = endTime,
+            ongoingCallStatus = ongoingCallStatus
+        )
     },
     selfRole = selfRole,
 )
+
+fun Call.toOngoingCallStatus() = when (status) {
+    CallStatus.STARTED,
+    CallStatus.ANSWERED,
+    CallStatus.ESTABLISHED,
+    CallStatus.INCOMING,
+    CallStatus.STILL_ONGOING -> MeetingItem.OngoingCallStatus(
+        currentCallEstablishedTime = establishedTime?.let {
+            Instant.fromEpochMilliseconds(DateTimeUtil.fromIsoDateTimeStringToEpochMillis(it))
+        },
+        isSelfUserAttending = status in listOf(CallStatus.STARTED, CallStatus.ANSWERED, CallStatus.ESTABLISHED),
+    )
+    else -> null // only calls in these states above are considered ongoing, other statuses mean the call is closed
+}
 
 fun MeetingItem.toMeeting(): Meeting = Meeting(
     meetingId = meetingId,
@@ -51,6 +80,5 @@ fun MeetingItem.toMeeting(): Meeting = Meeting(
         is Status.Ended -> status.endTime
     },
     repeatingInterval = repeatingInterval,
-    ongoingCallStatus = (status as? Status.Ongoing)?.ongoingCallStatus,
     selfRole = selfRole
 )

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/model/MeetingItem.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/model/MeetingItem.kt
@@ -84,7 +84,7 @@ data class MeetingItem(
 
     @Stable
     data class OngoingCallStatus(
-        val currentCallStartedTime: Instant, // time when the current call started (there can be many calls one after another in a meeting)
+        val currentCallEstablishedTime: Instant?, // there can be many calls one after another in a meeting, so take the current one
         val isSelfUserAttending: Boolean // is the current user attending the ongoing call
     )
 

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/AllMeetingsScreen.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/AllMeetingsScreen.kt
@@ -47,6 +47,7 @@ import com.wire.android.ui.common.rememberTopBarElevationState
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.rememberLazyListStateProvider
+import com.wire.kalium.logic.data.id.ConversationId
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
@@ -58,6 +59,9 @@ fun AllMeetingsScreen(
     contentPadding: PaddingValues = PaddingValues(),
     tabs: ImmutableList<MeetingsTabItem> = persistentListOf(MeetingsTabItem.NEXT), // history is not available yet, only "Next" for now
     initialTab: MeetingsTabItem = MeetingsTabItem.NEXT,
+    startCall: (conversationId: ConversationId) -> Unit = {},
+    joinCall: (conversationId: ConversationId) -> Unit = {},
+    returnToCall: (conversationId: ConversationId) -> Unit = {},
 ) {
     Column(
         modifier = Modifier.fillMaxSize()
@@ -98,7 +102,10 @@ fun AllMeetingsScreen(
                 contentPadding = contentPadding,
                 openMeetingOptions = { meetingId ->
                     meetingOptionsSheetState.show(meetingId)
-                }
+                },
+                startCall = startCall,
+                joinCall = joinCall,
+                returnToCall = returnToCall,
             )
         }
 

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/MeetingsViewModelFactory.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/MeetingsViewModelFactory.kt
@@ -25,6 +25,7 @@ import com.wire.android.feature.meetings.ui.usecase.GetMeetingUseCase
 import com.wire.android.feature.meetings.ui.usecase.GetMeetingsPaginatedUseCase
 import com.wire.android.util.CurrentTimeProvider
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.feature.call.usecase.ObserveActiveCallsUseCase
 import dev.zacsweers.metro.Inject
 
 class MeetingsViewModelFactory @Inject constructor(
@@ -32,11 +33,13 @@ class MeetingsViewModelFactory @Inject constructor(
     private val dispatcher: DispatcherProvider,
     private val getMeetingsPaginated: GetMeetingsPaginatedUseCase,
     private val getMeeting: GetMeetingUseCase,
+    private val observeActiveCalls: ObserveActiveCallsUseCase,
 ) {
     internal fun meetingListViewModel(type: MeetingsTabItem) = MeetingListViewModelImpl(
         type = type,
         currentTimeProvider = currentTimeProvider,
         getMeetingsPaginated = getMeetingsPaginated,
+        observeActiveCalls = observeActiveCalls,
         dispatcher = dispatcher,
     )
 

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingItem.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingItem.kt
@@ -62,7 +62,7 @@ import com.wire.android.feature.meetings.ui.mock.ongoingAttendingOneOnOneMeeting
 import com.wire.android.feature.meetings.ui.mock.scheduledChannelMeetingStartingSoon
 import com.wire.android.feature.meetings.ui.mock.scheduledRepeatingGroupMeeting
 import com.wire.android.feature.meetings.ui.util.PreviewMultipleThemes
-import com.wire.android.util.rememberCurrentTimeProvider
+import com.wire.android.ui.common.VisibilityState
 import com.wire.android.ui.common.avatar.UserProfileAvatar
 import com.wire.android.ui.common.avatar.UserProfileAvatarsRow
 import com.wire.android.ui.common.button.WireItemLabel
@@ -72,17 +72,21 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.rowitem.RowItemDivider
 import com.wire.android.ui.common.rowitem.RowItemTemplate
 import com.wire.android.ui.common.typography
+import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.wire.android.ui.home.conversationslist.common.ChannelConversationAvatar
 import com.wire.android.ui.home.conversationslist.common.RegularGroupConversationAvatar
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.DateAndTimeParsers
+import com.wire.android.util.permission.PermissionsDeniedRequestDialog
+import com.wire.android.util.permission.RequestLauncher
+import com.wire.android.util.permission.rememberRecordAudioPermissionFlow
+import com.wire.android.util.rememberCurrentTimeProvider
 import com.wire.kalium.logic.data.id.ConversationId
 import kotlinx.coroutines.delay
 import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
-import com.wire.android.ui.common.R as UICommonR
 import com.wire.android.ui.common.R as commonR
 
 @Composable
@@ -168,7 +172,7 @@ private fun MeetingItemDivider() {
 @Composable
 internal fun VideoCallIcon(tint: Color, modifier: Modifier = Modifier) {
     Icon(
-        painter = painterResource(id = UICommonR.drawable.ic_video_call),
+        painter = painterResource(id = commonR.drawable.ic_video_call),
         contentDescription = null,
         tint = tint,
         modifier = modifier
@@ -180,7 +184,7 @@ internal fun VideoCallIcon(tint: Color, modifier: Modifier = Modifier) {
 @Composable
 internal fun CalendarIcon(tint: Color, modifier: Modifier = Modifier) {
     Icon(
-        painter = painterResource(id = UICommonR.drawable.ic_calendar),
+        painter = painterResource(id = commonR.drawable.ic_calendar),
         contentDescription = null,
         tint = tint,
         modifier = modifier.size(dimensions().spacing16x)
@@ -311,12 +315,13 @@ private fun MeetingBelongingInfoRow(conversationId: ConversationId, type: Belong
 
 @Composable
 private fun JoinMeetingPrimaryButton(onClick: () -> Unit) {
+    val audioPermissionCheck = audioPermissionCheckFlow(onPermissionGranted = onClick)
     WirePrimaryButton(
         fillMaxWidth = false,
         minSize = dimensions().buttonMediumMinSize,
         minClickableSize = dimensions().buttonMediumMinSize.plus(DpSize(dimensions().spacing0x, dimensions().spacing16x)),
         contentPadding = PaddingValues(dimensions().spacing8x),
-        onClick = onClick,
+        onClick = audioPermissionCheck::launch,
         leadingIcon = {
             VideoCallIcon(
                 tint = colorsScheme().onPrimary,
@@ -398,7 +403,7 @@ private fun MeetingOngoingAttendingRow(
 
                 status.ongoingCallStatus != null -> {
                     // there is an ongoing call but the user is not attending, show option to join the call
-                    JoinMeetingPrimaryButton(onClick = { joinCall(conversationId) }) // TODO handle permissions!!
+                    JoinMeetingPrimaryButton(onClick = { joinCall(conversationId) })
                 }
 
                 else -> {
@@ -429,6 +434,25 @@ private fun PrimaryBodyText(text: String) {
         style = typography().body03,
         color = colorsScheme().primary,
         modifier = Modifier.padding(vertical = dimensions().spacing8x),
+    )
+}
+
+@Composable
+private fun audioPermissionCheckFlow(onPermissionGranted: () -> Unit): RequestLauncher {
+    val audioPermissionPermanentlyDeniedDialogState = rememberVisibilityState<Unit>()
+    VisibilityState(audioPermissionPermanentlyDeniedDialogState) {
+        PermissionsDeniedRequestDialog(
+            title = commonR.string.app_permission_dialog_title,
+            body = R.string.meeting_audio_permission_dialog_description,
+            onDismiss = audioPermissionPermanentlyDeniedDialogState::dismiss
+        )
+    }
+    return rememberRecordAudioPermissionFlow(
+        onPermissionGranted = onPermissionGranted,
+        onPermissionDenied = { },
+        onPermissionPermanentlyDenied = {
+            audioPermissionPermanentlyDeniedDialogState.show(Unit)
+        }
     )
 }
 

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingItem.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingItem.kt
@@ -45,8 +45,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import com.wire.android.feature.meetings.R
 import com.wire.android.feature.meetings.model.MeetingItem
@@ -87,6 +90,9 @@ fun MeetingItem(
     meeting: MeetingItem,
     modifier: Modifier = Modifier,
     openMeetingOptions: (meetingId: String) -> Unit = {},
+    startCall: (conversationId: ConversationId) -> Unit = {},
+    joinCall: (conversationId: ConversationId) -> Unit = {},
+    returnToCall: (conversationId: ConversationId) -> Unit = {},
 ) {
     RowItemTemplate(
         modifier = modifier.padding(start = dimensions().spacing8x),
@@ -108,9 +114,21 @@ fun MeetingItem(
         },
         subtitle = {
             Column {
-                MeetingTimeInfoRow(status = meeting.status, repeatingInterval = meeting.repeatingInterval)
-                MeetingBelongingInfoRow(conversationId = meeting.conversationId, type = meeting.belongingType)
-                MeetingOngoingAttendingRow(status = meeting.status, onJoinClick = { /* TODO */ })
+                MeetingTimeInfoRow(
+                    status = meeting.status,
+                    repeatingInterval = meeting.repeatingInterval
+                )
+                MeetingBelongingInfoRow(
+                    conversationId = meeting.conversationId,
+                    type = meeting.belongingType
+                )
+                MeetingOngoingAttendingRow(
+                    conversationId = meeting.conversationId,
+                    status = meeting.status,
+                    startCall = startCall,
+                    joinCall = joinCall,
+                    returnToCall = returnToCall,
+                )
             }
         },
         actions = {
@@ -151,7 +169,7 @@ private fun MeetingItemDivider() {
 internal fun VideoCallIcon(tint: Color, modifier: Modifier = Modifier) {
     Icon(
         painter = painterResource(id = UICommonR.drawable.ic_video_call),
-        contentDescription = stringResource(R.string.content_description_meeting_icon),
+        contentDescription = null,
         tint = tint,
         modifier = modifier
             .padding(start = dimensions().spacing2x) // visually center the icon as it is not perfectly centered in the asset
@@ -163,7 +181,7 @@ internal fun VideoCallIcon(tint: Color, modifier: Modifier = Modifier) {
 internal fun CalendarIcon(tint: Color, modifier: Modifier = Modifier) {
     Icon(
         painter = painterResource(id = UICommonR.drawable.ic_calendar),
-        contentDescription = stringResource(R.string.content_description_meeting_icon),
+        contentDescription = null,
         tint = tint,
         modifier = modifier.size(dimensions().spacing16x)
     )
@@ -308,14 +326,29 @@ private fun JoinMeetingPrimaryButton(onClick: () -> Unit) {
             )
         },
         text = stringResource(R.string.meeting_join_button),
+        onClickDescription = stringResource(R.string.content_description_join_meeting_label),
     )
 }
 
 @Composable
-private fun MeetingAttendingPrimaryBodyText() {
+private fun MeetingAttendingPrimaryBodyText(onClick: () -> Unit, startNegativePadding: Dp = dimensions().spacing4x) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(dimensions().spacing4x)
+        horizontalArrangement = Arrangement.spacedBy(dimensions().spacing4x),
+        modifier = Modifier
+            .layout { measurable, constraints ->
+                val placeable = measurable.measure(constraints)
+                layout(placeable.width, placeable.height) {
+                    placeable.placeRelative(-startNegativePadding.roundToPx(), 0)
+                }
+            }
+            .clip(RoundedCornerShape(dimensions().buttonCornerSize))
+            .clickable(
+                onClick = onClick,
+                onClickLabel = stringResource(R.string.content_description_attending_meeting_label),
+                role = Role.Button,
+            )
+            .padding(horizontal = startNegativePadding)
     ) {
         VideoCallIcon(tint = colorsScheme().primary)
         PrimaryBodyText(text = stringResource(R.string.meeting_attending))
@@ -348,13 +381,30 @@ private fun MeetingStartingInPrimaryBodyText(startTime: Instant) {
 }
 
 @Composable
-private fun MeetingOngoingAttendingRow(status: Status, onJoinClick: () -> Unit) {
+private fun MeetingOngoingAttendingRow(
+    conversationId: ConversationId,
+    status: Status,
+    joinCall: (conversationId: ConversationId) -> Unit,
+    startCall: (conversationId: ConversationId) -> Unit,
+    returnToCall: (conversationId: ConversationId) -> Unit,
+) {
     Box(modifier = Modifier.heightIn(min = dimensions().spacing8x)) {
         if (status is Status.Ongoing) {
-            if (status.ongoingCallStatus?.isSelfUserAttending == true) {
-                MeetingAttendingPrimaryBodyText()
-            } else {
-                JoinMeetingPrimaryButton(onClick = onJoinClick)
+            when {
+                status.ongoingCallStatus?.isSelfUserAttending == true -> {
+                    // user is attending the ongoing call, show "Attending" text with option to return to the call
+                    MeetingAttendingPrimaryBodyText(onClick = { returnToCall(conversationId) })
+                }
+
+                status.ongoingCallStatus != null -> {
+                    // there is an ongoing call but the user is not attending, show option to join the call
+                    JoinMeetingPrimaryButton(onClick = { joinCall(conversationId) }) // TODO handle permissions!!
+                }
+
+                else -> {
+                    // there is no ongoing call, show option to start the call
+                    JoinMeetingPrimaryButton(onClick = { startCall(conversationId) })
+                }
             }
         } else if (status is Status.Scheduled) {
             MeetingStartingInPrimaryBodyText(startTime = status.startTime)

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingList.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingList.kt
@@ -42,6 +42,7 @@ import com.wire.android.ui.common.rowitem.EmptyListArrowFooter
 import com.wire.android.ui.common.rowitem.EmptyListContent
 import com.wire.android.ui.common.rowitem.LoadingListContent
 import com.wire.android.ui.theme.WireTheme
+import com.wire.kalium.logic.data.id.ConversationId
 
 @Suppress("CyclomaticComplexMethod")
 @Composable
@@ -51,6 +52,9 @@ fun MeetingList(
     contentPadding: PaddingValues = PaddingValues(),
     lazyListState: LazyListState = rememberLazyListState(),
     openMeetingOptions: (meetingId: String) -> Unit = {},
+    startCall: (conversationId: ConversationId) -> Unit = {},
+    joinCall: (conversationId: ConversationId) -> Unit = {},
+    returnToCall: (conversationId: ConversationId) -> Unit = {},
 ) {
     val meetingListViewModel: MeetingListViewModel = when {
         LocalInspectionMode.current -> remember(type) { MeetingListViewModelPreview(type = type) }
@@ -99,7 +103,10 @@ fun MeetingList(
                             is MeetingItem -> MeetingItem(
                                 meeting = item,
                                 modifier = Modifier.animateItem(),
-                                openMeetingOptions = openMeetingOptions
+                                openMeetingOptions = openMeetingOptions,
+                                startCall = startCall,
+                                joinCall = joinCall,
+                                returnToCall = returnToCall,
                             )
                         }
                     }

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingListViewModel.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingListViewModel.kt
@@ -26,6 +26,7 @@ import androidx.paging.cachedIn
 import androidx.paging.insertSeparators
 import androidx.paging.map
 import com.wire.android.feature.meetings.mapper.toMeetingItem
+import com.wire.android.feature.meetings.mapper.toOngoingCallStatus
 import com.wire.android.feature.meetings.model.MeetingHeader
 import com.wire.android.feature.meetings.model.MeetingItem
 import com.wire.android.feature.meetings.model.MeetingListItem
@@ -34,6 +35,7 @@ import com.wire.android.feature.meetings.ui.mock.MeetingMocksProvider
 import com.wire.android.feature.meetings.ui.usecase.GetMeetingsPaginatedUseCase
 import com.wire.android.util.CurrentTimeProvider
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.feature.call.usecase.ObserveActiveCallsUseCase
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -75,6 +77,7 @@ class MeetingListViewModelImpl(
     val type: MeetingsTabItem,
     override val currentTimeProvider: CurrentTimeProvider,
     getMeetingsPaginated: GetMeetingsPaginatedUseCase,
+    observeActiveCalls: ObserveActiveCallsUseCase,
     dispatcher: DispatcherProvider,
 ) : ViewModel(), MeetingListViewModel {
     override val isShowingAll = MutableStateFlow(type == MeetingsTabItem.PAST) // for PAST always show all, for NEXT start with false
@@ -93,10 +96,15 @@ class MeetingListViewModelImpl(
         .flowOn(dispatcher.io())
         .cachedIn(viewModelScope)
 
-    override val meetings: Flow<PagingData<MeetingListItem>> = combine(pagingDataFlow, alignedTickerFlow) { pagingData, currentTime ->
+    override val meetings: Flow<PagingData<MeetingListItem>> = combine(
+        pagingDataFlow,
+        observeActiveCalls(),
+        alignedTickerFlow
+    ) { pagingData, activeCalls, currentTime ->
         pagingData
             .map { rawMeeting ->
-                rawMeeting.toMeetingItem(time = currentTime)
+                val activeCall = activeCalls.find { it.conversationId == rawMeeting.conversationId }
+                rawMeeting.toMeetingItem(time = currentTime, ongoingCallStatus = activeCall?.toOngoingCallStatus())
             }
             .insertHeaders(type = type)
     }

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/mock/MeetingItemMocks.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/mock/MeetingItemMocks.kt
@@ -73,7 +73,7 @@ val CurrentTimeProvider.ongoingAttendingOneOnOneMeeting
             startTime = currentTime().fullMinutes().minus(15.minutes),
             scheduledEndTime = currentTime().fullMinutes().plus(45.minutes),
             ongoingCallStatus = MeetingItem.OngoingCallStatus(
-                currentCallStartedTime = currentTime().fullMinutes().minus(15.minutes),
+                currentCallEstablishedTime = currentTime().fullMinutes().minus(15.minutes),
                 isSelfUserAttending = true,
             )
         )
@@ -331,6 +331,5 @@ data class Meeting(
     val startTime: Instant,
     val endTime: Instant?,
     val repeatingInterval: MeetingItem.RepeatingInterval,
-    val ongoingCallStatus: MeetingItem.OngoingCallStatus?,
     val selfRole: SelfRole,
 )

--- a/features/meetings/src/main/res/values/strings.xml
+++ b/features/meetings/src/main/res/values/strings.xml
@@ -77,6 +77,8 @@
     <string name="new_meeting_repeats_input_label">Repeats</string>
     <string name="content_description_new_meeting_repeating_options">Select repeat option</string>
     <string name="new_meeting_allow_guests_label">Allow guests</string>
+    <string name="content_description_join_meeting_label">join a meeting call</string>
+    <string name="content_description_attending_meeting_label">return to a meeting call</string>
 
     <plurals name="new_meeting_participants_input_more_suffix">
         <item quantity="one">+%1$d more</item>

--- a/features/meetings/src/main/res/values/strings.xml
+++ b/features/meetings/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="new_meeting_allow_guests_label">Allow guests</string>
     <string name="content_description_join_meeting_label">join a meeting call</string>
     <string name="content_description_attending_meeting_label">return to a meeting call</string>
+    <string name="meeting_audio_permission_dialog_description">To join a meeting, allow Wire to access your microphone in your device settings.</string>
 
     <plurals name="new_meeting_participants_input_more_suffix">
         <item quantity="one">+%1$d more</item>

--- a/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/mapper/MeetingMapperTest.kt
+++ b/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/mapper/MeetingMapperTest.kt
@@ -26,7 +26,11 @@ import com.wire.android.feature.meetings.model.MeetingItem.Status.Ended
 import com.wire.android.feature.meetings.model.MeetingItem.Status.Ongoing
 import com.wire.android.feature.meetings.model.MeetingItem.Status.Scheduled
 import com.wire.android.feature.meetings.ui.mock.Meeting
+import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedID
 import kotlinx.datetime.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -39,7 +43,7 @@ class MeetingMapperTest {
         val startTime = currentTime + 10.minutes
         val endTime = currentTime + 40.minutes
         val expected = meetingItem(Scheduled(startTime = startTime, endTime = endTime))
-        val result = meeting(startTime = startTime, endTime = endTime).toMeetingItem(currentTime)
+        val result = meeting(startTime = startTime, endTime = endTime).toMeetingItem(time = currentTime, ongoingCallStatus = null)
         assertEquals(expected, result)
     }
 
@@ -48,7 +52,7 @@ class MeetingMapperTest {
         val startTime = currentTime - 30.minutes
         val endTime = currentTime - 5.minutes
         val expected = meetingItem(Ongoing(startTime = startTime, scheduledEndTime = endTime, ongoingCallStatus = ongoingCall))
-        val result = meeting(startTime = startTime, endTime = endTime, ongoingCallStatus = ongoingCall).toMeetingItem(currentTime)
+        val result = meeting(startTime = startTime, endTime = endTime).toMeetingItem(time = currentTime, ongoingCallStatus = ongoingCall)
         assertEquals(expected, result)
     }
 
@@ -56,7 +60,7 @@ class MeetingMapperTest {
     fun givenMeetingHasNoEndTime_whenMappingToMeetingItem_thenStatusIsOngoing() {
         val startTime = currentTime - 30.minutes
         val expected = meetingItem(Ongoing(startTime = startTime, scheduledEndTime = null, ongoingCallStatus = ongoingCall))
-        val result = meeting(startTime = startTime, endTime = null, ongoingCallStatus = ongoingCall).toMeetingItem(currentTime)
+        val result = meeting(startTime = startTime, endTime = null).toMeetingItem(time = currentTime, ongoingCallStatus = ongoingCall)
         assertEquals(expected, result)
     }
 
@@ -65,7 +69,7 @@ class MeetingMapperTest {
         val startTime = currentTime - 60.minutes
         val endTime = currentTime - 10.minutes
         val expected = meetingItem(Ended(startTime = startTime, endTime = endTime))
-        val result = meeting(startTime = startTime, endTime = endTime).toMeetingItem(currentTime)
+        val result = meeting(startTime = startTime, endTime = endTime).toMeetingItem(time = currentTime, ongoingCallStatus = ongoingCall)
         assertEquals(expected, result)
     }
 
@@ -82,7 +86,7 @@ class MeetingMapperTest {
     fun givenOngoingMeetingItem_whenMappingToMeeting_thenMeetingHasScheduledEndTimeAndCallStatus() {
         val startTime = currentTime - 30.minutes
         val endTime = currentTime + 30.minutes
-        val expected = meeting(startTime = startTime, endTime = endTime, ongoingCallStatus = ongoingCall)
+        val expected = meeting(startTime = startTime, endTime = endTime)
         val result = meetingItem(Ongoing(startTime = startTime, scheduledEndTime = endTime, ongoingCallStatus = ongoingCall)).toMeeting()
         assertEquals(expected, result)
     }
@@ -96,7 +100,50 @@ class MeetingMapperTest {
         assertEquals(expected, result)
     }
 
-    private fun meeting(startTime: Instant, endTime: Instant?, ongoingCallStatus: OngoingCallStatus? = null) = Meeting(
+    @Test
+    fun givenCallHasEstablishedTime_whenMappingToOngoingCallStatus_thenCurrentCallEstablishedTimeIsMapped() {
+        val expected = OngoingCallStatus(currentCallEstablishedTime = currentTime - 20.minutes, isSelfUserAttending = true)
+        val result = call(establishedTime = ESTABLISHED_TIME).toOngoingCallStatus()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun givenCallHasNoEstablishedTime_whenMappingToOngoingCallStatus_thenCurrentCallEstablishedTimeIsNull() {
+        val expected = OngoingCallStatus(currentCallEstablishedTime = null, isSelfUserAttending = true)
+        val result = call(establishedTime = null).toOngoingCallStatus()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun givenActiveCallStatusMeaningSelfUserIsAttending_whenMappingToOngoingCallStatus_thenSelfUserIsAttending() {
+        // for these three statuses, the self user always is participating in the call
+        listOf(CallStatus.STARTED, CallStatus.ANSWERED, CallStatus.ESTABLISHED).forEach { callStatus ->
+            val expected = OngoingCallStatus(currentCallEstablishedTime = currentTime - 20.minutes, isSelfUserAttending = true)
+            val result = call(status = callStatus).toOngoingCallStatus()
+            assertEquals(expected, result, "Failed for $callStatus")
+        }
+    }
+
+    @Test
+    fun givenActiveCallStatusMeaningSelfUserIsNotAttending_whenMappingToOngoingCallStatus_thenSelfUserIsNotAttending() {
+        // for these two statuses, the self user is not participating in the call but the call is still ongoing, meaning the user can join
+        listOf(CallStatus.INCOMING, CallStatus.STILL_ONGOING).forEach { callStatus ->
+            val expected = OngoingCallStatus(currentCallEstablishedTime = currentTime - 20.minutes, isSelfUserAttending = false)
+            val result = call(status = callStatus).toOngoingCallStatus()
+            assertEquals(expected, result, "Failed for $callStatus")
+        }
+    }
+
+    @Test
+    fun givenClosedCallStatus_whenMappingToOngoingCallStatus_thenStatusIsNull() {
+        // for these statuses, the call is closed, meaning it's not ongoing and the user cannot join anymore
+        listOf(CallStatus.MISSED, CallStatus.CLOSED_INTERNALLY, CallStatus.CLOSED, CallStatus.REJECTED).forEach { callStatus ->
+            val result = call(status = callStatus).toOngoingCallStatus()
+            assertEquals(null, result, "Failed for $callStatus")
+        }
+    }
+
+    private fun meeting(startTime: Instant, endTime: Instant?) = Meeting(
         meetingId = MEETING_ID,
         conversationId = CONVERSATION_ID,
         belongingType = BELONGING_TYPE,
@@ -104,7 +151,6 @@ class MeetingMapperTest {
         startTime = startTime,
         endTime = endTime,
         repeatingInterval = RepeatingInterval.Weekly,
-        ongoingCallStatus = ongoingCallStatus,
         selfRole = SelfRole.Admin,
     )
 
@@ -118,12 +164,30 @@ class MeetingMapperTest {
         selfRole = SelfRole.Admin,
     )
 
+    private fun call(
+        status: CallStatus = CallStatus.ESTABLISHED,
+        establishedTime: String? = ESTABLISHED_TIME
+    ) = Call(
+        conversationId = CONVERSATION_ID,
+        status = status,
+        isMuted = false,
+        isCameraOn = true,
+        isCbrEnabled = false,
+        callerId = QualifiedID("some_id", "some_domain"),
+        conversationName = "some_name",
+        conversationType = Conversation.Type.Group.Regular,
+        callerName = "some_name",
+        callerTeamName = "some_team_name",
+        establishedTime = establishedTime,
+    )
+
     private companion object {
         const val MEETING_ID = "meeting-id"
         const val TITLE = "Engineering sync"
+        const val ESTABLISHED_TIME = "2026-01-01T11:40:00.000Z"
         val currentTime = Instant.parse("2026-01-01T12:00:00Z")
         val CONVERSATION_ID = ConversationId(value = "conversation-id", domain = "wire.com")
         val BELONGING_TYPE = BelongingType.Group(name = "Engineering")
-        val ongoingCall = OngoingCallStatus(currentCallStartedTime = currentTime - 20.minutes, isSelfUserAttending = true)
+        val ongoingCall = OngoingCallStatus(currentCallEstablishedTime = currentTime - 20.minutes, isSelfUserAttending = true)
     }
 }

--- a/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/list/MeetingListViewModelTest.kt
+++ b/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/list/MeetingListViewModelTest.kt
@@ -27,7 +27,11 @@ import com.wire.android.feature.meetings.ui.MeetingsTabItem
 import com.wire.android.feature.meetings.ui.mock.Meeting
 import com.wire.android.feature.meetings.ui.usecase.GetMeetingsPaginatedUseCase
 import com.wire.android.util.CurrentTimeProvider
+import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.feature.call.usecase.ObserveActiveCallsUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.clearMocks
@@ -36,6 +40,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
@@ -144,17 +149,99 @@ class MeetingListViewModelTest {
         }
     }
 
-    private fun List<MeetingListItem>.meetingItem() = filterIsInstance<MeetingItem>().single()
+    @Test
+    fun givenSomeMeetingsHaveActiveCalls_whenMeetingsAreCollected_thenMatchingMeetingsContainOngoingCallStatus() = runTest(dispatcher) {
+        val currentTime = Instant.parse("2026-01-01T12:00:00Z")
+        val meetingWithActiveCall = meeting(
+            meetingId = "active-meeting",
+            conversationId = ConversationId("conversation-with-call", "domain"),
+            startTime = currentTime - 10.minutes
+        )
+        val meetingWithoutActiveCall = meeting(
+            meetingId = "inactive-meeting",
+            conversationId = ConversationId("conversation-without-call", "domain"),
+            startTime = currentTime - 5.minutes
+        )
+        val activeCall = call(
+            conversationId = meetingWithActiveCall.conversationId,
+            establishedTime = "2026-01-01T11:55:00.000Z"
+        )
+        val (_, viewModel) = Arrangement(dispatcher)
+            .withCurrentTimeProvider { currentTime }
+            .withGetMeetingsPaginated(showingAll = false, meetings = listOf(meetingWithActiveCall, meetingWithoutActiveCall))
+            .withObserveActiveCalls(listOf(activeCall))
+            .arrange()
+
+        val meetingItems = viewModel.meetings.first().items().meetingItems()
+
+        assertEquals(
+            MeetingItem.OngoingCallStatus(
+                currentCallEstablishedTime = Instant.parse("2026-01-01T11:55:00Z"),
+                isSelfUserAttending = true
+            ),
+            meetingItems.single { it.meetingId == meetingWithActiveCall.meetingId }.ongoingStatus().ongoingCallStatus
+        )
+        assertEquals(
+            null,
+            meetingItems.single { it.meetingId == meetingWithoutActiveCall.meetingId }.ongoingStatus().ongoingCallStatus
+        )
+    }
+
+    @Test
+    fun givenNoActiveCalls_whenMeetingsAreCollected_thenMeetingsDoNotContainOngoingCallStatus() = runTest(dispatcher) {
+        val currentTime = Instant.parse("2026-01-01T12:00:00Z")
+        val meetings = listOf(
+            meeting(meetingId = "first-meeting", startTime = currentTime - 10.minutes),
+            meeting(meetingId = "second-meeting", startTime = currentTime - 5.minutes)
+        )
+        val (_, viewModel) = Arrangement(dispatcher)
+            .withCurrentTimeProvider { currentTime }
+            .withGetMeetingsPaginated(showingAll = false, meetings = meetings)
+            .withObserveActiveCalls(emptyList())
+            .arrange()
+
+        val meetingItems = viewModel.meetings.first().items().meetingItems()
+
+        assertEquals(
+            listOf(null, null),
+            meetingItems.map { it.ongoingStatus().ongoingCallStatus }
+        )
+    }
+
+    private fun List<MeetingListItem>.meetingItem() = meetingItems().single()
+    private fun List<MeetingListItem>.meetingItems() = filterIsInstance<MeetingItem>()
+    private fun MeetingItem.ongoingStatus() = status as MeetingItem.Status.Ongoing
     private suspend fun PagingData<MeetingListItem>.items(): List<MeetingListItem> = flowOf(this).asSnapshot()
-    private fun meeting(meetingId: String = "meeting-id", startTime: Instant) = Meeting(
+    private fun meeting(
+        meetingId: String = "meeting-id",
+        startTime: Instant,
+        conversationId: ConversationId = ConversationId("conversation-id", "domain"),
+    ) = Meeting(
         meetingId = meetingId,
-        conversationId = ConversationId("conversation-id", "domain"),
+        conversationId = conversationId,
         belongingType = MeetingItem.BelongingType.Group("group"),
         title = "Meeting",
         startTime = startTime,
         endTime = startTime + 30.minutes,
         repeatingInterval = MeetingItem.RepeatingInterval.Never,
         selfRole = MeetingItem.SelfRole.Admin,
+    )
+    private fun call(
+        conversationId: ConversationId,
+        status: CallStatus = CallStatus.ESTABLISHED,
+        establishedTime: String? = null,
+    ) = Call(
+        conversationId = conversationId,
+        status = status,
+        isMuted = false,
+        isCameraOn = false,
+        isCbrEnabled = false,
+        callerId = QualifiedID("caller-id", "domain"),
+        conversationName = "Meeting",
+        conversationType = Conversation.Type.Group.Regular,
+        callerName = "Caller",
+        callerTeamName = "Team",
+        establishedTime = establishedTime,
     )
 
     private class Arrangement(private val dispatcher: TestDispatcher) {
@@ -180,6 +267,9 @@ class MeetingListViewModelTest {
             every { getMeetingsPaginated(showingAll = showingAll, type = type) } returns flowOf(
                 PagingData.from(meetings)
             )
+        }
+        fun withObserveActiveCalls(activeCalls: List<Call>) = apply {
+            every { observeActiveCalls() } returns flowOf(activeCalls)
         }
         fun arrange() = this to MeetingListViewModelImpl(
             type = type,

--- a/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/list/MeetingListViewModelTest.kt
+++ b/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/list/MeetingListViewModelTest.kt
@@ -45,8 +45,8 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.Instant
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
@@ -171,6 +171,7 @@ class MeetingListViewModelTest {
 
         init {
             MockKAnnotations.init(this)
+            every { observeActiveCalls() } returns flowOf(emptyList())
         }
         fun withCurrentTimeProvider(currentTime: () -> Instant) = apply {
             currentTimeProvider = CurrentTimeProvider(currentTime)

--- a/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/list/MeetingListViewModelTest.kt
+++ b/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/list/MeetingListViewModelTest.kt
@@ -28,6 +28,7 @@ import com.wire.android.feature.meetings.ui.mock.Meeting
 import com.wire.android.feature.meetings.ui.usecase.GetMeetingsPaginatedUseCase
 import com.wire.android.util.CurrentTimeProvider
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.call.usecase.ObserveActiveCallsUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.clearMocks
 import io.mockk.every
@@ -44,8 +45,8 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.Instant
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
@@ -153,7 +154,6 @@ class MeetingListViewModelTest {
         startTime = startTime,
         endTime = startTime + 30.minutes,
         repeatingInterval = MeetingItem.RepeatingInterval.Never,
-        ongoingCallStatus = null,
         selfRole = MeetingItem.SelfRole.Admin,
     )
 
@@ -165,6 +165,9 @@ class MeetingListViewModelTest {
 
         @MockK
         lateinit var getMeetingsPaginated: GetMeetingsPaginatedUseCase
+
+        @MockK
+        lateinit var observeActiveCalls: ObserveActiveCallsUseCase
 
         init {
             MockKAnnotations.init(this)
@@ -182,6 +185,7 @@ class MeetingListViewModelTest {
             dispatcher = TestDispatcherProvider(dispatcher),
             currentTimeProvider = currentTimeProvider,
             getMeetingsPaginated = getMeetingsPaginated,
+            observeActiveCalls = observeActiveCalls,
         )
     }
 }

--- a/features/meetings/stability/meetings-debug.stability
+++ b/features/meetings/stability/meetings-debug.stability
@@ -17,7 +17,7 @@ public fun com.ramcosta.composedestinations.generated.meetings.destinations.NewM
   params:
 
 @Composable
-public fun com.wire.android.feature.meetings.ui.AllMeetingsScreen(lazyListState: androidx.compose.foundation.lazy.LazyListState, contentPadding: androidx.compose.foundation.layout.PaddingValues, tabs: kotlinx.collections.immutable.ImmutableList<com.wire.android.feature.meetings.ui.MeetingsTabItem>, initialTab: com.wire.android.feature.meetings.ui.MeetingsTabItem): kotlin.Unit
+public fun com.wire.android.feature.meetings.ui.AllMeetingsScreen(lazyListState: androidx.compose.foundation.lazy.LazyListState, contentPadding: androidx.compose.foundation.layout.PaddingValues, tabs: kotlinx.collections.immutable.ImmutableList<com.wire.android.feature.meetings.ui.MeetingsTabItem>, initialTab: com.wire.android.feature.meetings.ui.MeetingsTabItem, startCall: kotlin.Function1<@[ParameterName(name = \, joinCall: kotlin.Function1<@[ParameterName(name = \, returnToCall: kotlin.Function1<@[ParameterName(name = \): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -25,6 +25,9 @@ public fun com.wire.android.feature.meetings.ui.AllMeetingsScreen(lazyListState:
     - contentPadding: STABLE (marked @Stable or @Immutable)
     - tabs: STABLE (known stable type)
     - initialTab: STABLE (class with no mutable properties)
+    - startCall: STABLE (function type)
+    - joinCall: STABLE (function type)
+    - returnToCall: STABLE (function type)
 
 @Composable
 public fun com.wire.android.feature.meetings.ui.NewMeetingBottomSheet(sheetState: com.wire.android.ui.common.bottomsheet.WireModalSheetState<kotlin.Unit>, onMeetNowClick: kotlin.Function0<kotlin.Unit>, onScheduleClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
@@ -140,10 +143,12 @@ private fun com.wire.android.feature.meetings.ui.list.JoinMeetingPrimaryButton(o
     - onClick: STABLE (function type)
 
 @Composable
-private fun com.wire.android.feature.meetings.ui.list.MeetingAttendingPrimaryBodyText(): kotlin.Unit
+private fun com.wire.android.feature.meetings.ui.list.MeetingAttendingPrimaryBodyText(onClick: kotlin.Function0<kotlin.Unit>, startNegativePadding: androidx.compose.ui.unit.Dp): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - onClick: STABLE (function type)
+    - startNegativePadding: STABLE (marked @Stable or @Immutable)
 
 @Composable
 private fun com.wire.android.feature.meetings.ui.list.MeetingBelongingInfoRow(conversationId: com.wire.kalium.logic.data.id.QualifiedID, type: com.wire.android.feature.meetings.model.MeetingItem.BelongingType): kotlin.Unit
@@ -162,13 +167,16 @@ public fun com.wire.android.feature.meetings.ui.list.MeetingHeader(header: com.w
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.wire.android.feature.meetings.ui.list.MeetingItem(meeting: com.wire.android.feature.meetings.model.MeetingItem, modifier: androidx.compose.ui.Modifier, openMeetingOptions: kotlin.Function1<@[ParameterName(name = \): kotlin.Unit
+public fun com.wire.android.feature.meetings.ui.list.MeetingItem(meeting: com.wire.android.feature.meetings.model.MeetingItem, modifier: androidx.compose.ui.Modifier, openMeetingOptions: kotlin.Function1<@[ParameterName(name = \, startCall: kotlin.Function1<@[ParameterName(name = \, joinCall: kotlin.Function1<@[ParameterName(name = \, returnToCall: kotlin.Function1<@[ParameterName(name = \): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - meeting: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
     - openMeetingOptions: STABLE (function type)
+    - startCall: STABLE (function type)
+    - joinCall: STABLE (function type)
+    - returnToCall: STABLE (function type)
 
 @Composable
 private fun com.wire.android.feature.meetings.ui.list.MeetingItemDivider(): kotlin.Unit
@@ -183,7 +191,7 @@ internal fun com.wire.android.feature.meetings.ui.list.MeetingLeadingIcon(): kot
   params:
 
 @Composable
-public fun com.wire.android.feature.meetings.ui.list.MeetingList(type: com.wire.android.feature.meetings.ui.MeetingsTabItem, modifier: androidx.compose.ui.Modifier, contentPadding: androidx.compose.foundation.layout.PaddingValues, lazyListState: androidx.compose.foundation.lazy.LazyListState, openMeetingOptions: kotlin.Function1<@[ParameterName(name = \): kotlin.Unit
+public fun com.wire.android.feature.meetings.ui.list.MeetingList(type: com.wire.android.feature.meetings.ui.MeetingsTabItem, modifier: androidx.compose.ui.Modifier, contentPadding: androidx.compose.foundation.layout.PaddingValues, lazyListState: androidx.compose.foundation.lazy.LazyListState, openMeetingOptions: kotlin.Function1<@[ParameterName(name = \, startCall: kotlin.Function1<@[ParameterName(name = \, joinCall: kotlin.Function1<@[ParameterName(name = \, returnToCall: kotlin.Function1<@[ParameterName(name = \): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -192,6 +200,9 @@ public fun com.wire.android.feature.meetings.ui.list.MeetingList(type: com.wire.
     - contentPadding: STABLE (marked @Stable or @Immutable)
     - lazyListState: STABLE (marked @Stable or @Immutable)
     - openMeetingOptions: STABLE (function type)
+    - startCall: STABLE (function type)
+    - joinCall: STABLE (function type)
+    - returnToCall: STABLE (function type)
 
 @Composable
 public fun com.wire.android.feature.meetings.ui.list.MeetingLoadMoreFooter(modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -208,12 +219,15 @@ private fun com.wire.android.feature.meetings.ui.list.MeetingMoreButton(onMenuCl
     - onMenuClick: STABLE (function type)
 
 @Composable
-private fun com.wire.android.feature.meetings.ui.list.MeetingOngoingAttendingRow(status: com.wire.android.feature.meetings.model.MeetingItem.Status, onJoinClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+private fun com.wire.android.feature.meetings.ui.list.MeetingOngoingAttendingRow(conversationId: com.wire.kalium.logic.data.id.QualifiedID, status: com.wire.android.feature.meetings.model.MeetingItem.Status, joinCall: kotlin.Function1<@[ParameterName(name = \, startCall: kotlin.Function1<@[ParameterName(name = \, returnToCall: kotlin.Function1<@[ParameterName(name = \): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - conversationId: STABLE (matched by stability configuration)
     - status: STABLE (marked @Stable or @Immutable)
-    - onJoinClick: STABLE (function type)
+    - joinCall: STABLE (function type)
+    - startCall: STABLE (function type)
+    - returnToCall: STABLE (function type)
 
 @Composable
 private fun com.wire.android.feature.meetings.ui.list.MeetingOngoingDurationTimeSublineText(startedTime: kotlinx.datetime.Instant): kotlin.Unit


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25067
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Logic for starting, joining and returning to a call for the meeting item "join" and "attending" buttons.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Currently not possible to test without manually changing the meeting's conversation ids as it still uses mocked values. Can be tested manually after fetching and storing real meetings data is implemented in the app.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
