### PR TITLE
build: enforce Compose BOM versions [WPB-26684]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -261,7 +261,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewModelSavedState)
 
     // Compose
-    val composeBom = platform(libs.compose.bom)
+    val composeBom = enforcedPlatform(libs.compose.bom)
     implementation(composeBom)
     androidTestImplementation(composeBom)
 

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallerDetails.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallerDetails.kt
@@ -59,7 +59,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.call.ConversationTypeForCall
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
-import java.util.Locale
+import androidx.compose.ui.platform.LocalLocale
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -101,7 +101,7 @@ fun CallerDetails(
         if (isCbrEnabled) {
             Text(
                 text = stringResource(id = R.string.calling_constant_bit_rate_indication).uppercase(
-                    Locale.getDefault()
+                    LocalLocale.current.platformLocale
                 ),
                 color = colorsScheme().secondaryText,
                 style = MaterialTheme.wireTypography.title03,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallScreen.kt
@@ -151,7 +151,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import java.util.Locale
+import androidx.compose.ui.platform.LocalLocale
 
 @Suppress("ParameterWrapping", "CyclomaticComplexMethod")
 @Composable
@@ -703,7 +703,7 @@ private fun OngoingCallTopBar(
                     .offset(y = -(5).dp),
                 textAlign = TextAlign.Center,
                 text = stringResource(id = R.string.calling_constant_bit_rate_indication).uppercase(
-                    Locale.getDefault()
+                    LocalLocale.current.platformLocale
                 ),
                 color = colorsScheme().secondaryText,
                 style = MaterialTheme.wireTypography.title03,

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
@@ -155,7 +155,8 @@ fun SetLockCodeScreenContent(
                     state = WireTextFieldState.Default,
                     autoFill = false,
                     placeholderText = stringResource(R.string.settings_set_lock_screen_passcode_label),
-                    labelText = stringResource(R.string.settings_set_lock_screen_passcode_label).uppercase(LocalLocale.current.platformLocale)
+                    labelText = stringResource(R.string.settings_set_lock_screen_passcode_label)
+                        .uppercase(LocalLocale.current.platformLocale)
                 )
                 VerticalSpace.x24()
                 PasswordVerificationGroup(state.passwordValidation)

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/set/SetLockCodeScreen.kt
@@ -72,7 +72,7 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.toTimeLongLabelUiText
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
-import java.util.Locale
+import androidx.compose.ui.platform.LocalLocale
 
 @WireRootDestination
 @Composable
@@ -155,7 +155,7 @@ fun SetLockCodeScreenContent(
                     state = WireTextFieldState.Default,
                     autoFill = false,
                     placeholderText = stringResource(R.string.settings_set_lock_screen_passcode_label),
-                    labelText = stringResource(R.string.settings_set_lock_screen_passcode_label).uppercase(Locale.getDefault())
+                    labelText = stringResource(R.string.settings_set_lock_screen_passcode_label).uppercase(LocalLocale.current.platformLocale)
                 )
                 VerticalSpace.x24()
                 PasswordVerificationGroup(state.passwordValidation)

--- a/app/src/main/kotlin/com/wire/android/ui/home/appLock/unlock/EnterLockCodeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/appLock/unlock/EnterLockCodeScreen.kt
@@ -68,7 +68,7 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
-import java.util.Locale
+import androidx.compose.ui.platform.LocalLocale
 
 @WireRootDestination
 @Composable
@@ -152,7 +152,7 @@ fun EnterLockCodeScreenContent(
                     autoFill = false,
                     placeholderText = stringResource(R.string.settings_set_lock_screen_passcode_label),
                     labelText = stringResource(R.string.settings_set_lock_screen_passcode_label).uppercase(
-                        Locale.getDefault()
+                        LocalLocale.current.platformLocale
                     )
                 )
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -214,9 +214,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
 import java.util.Date
-import java.util.Locale
 import kotlin.time.Duration.Companion.milliseconds
 import com.wire.android.ui.common.R as commonR
+import androidx.compose.ui.platform.LocalLocale
 
 /**
  * The maximum number of messages the user can scroll while still
@@ -1632,7 +1632,7 @@ private fun MessageGroupDateTime(
             HorizontalDivider(modifier = Modifier.weight(1F), color = colorsScheme().outline)
             HorizontalSpace.x4()
             Text(
-                text = timeString.uppercase(Locale.getDefault()),
+                text = timeString.uppercase(LocalLocale.current.platformLocale),
                 maxLines = 1,
                 color = colorsScheme().onBackground,
                 style = MaterialTheme.wireTypography.label02,
@@ -1656,7 +1656,7 @@ private fun MessageGroupDateTime(
                 )
         ) {
             Text(
-                text = timeString.uppercase(Locale.getDefault()),
+                text = timeString.uppercase(LocalLocale.current.platformLocale),
                 color = colorsScheme().secondaryText,
                 style = MaterialTheme.wireTypography.title03,
             )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/AssetFilePreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/AssetFilePreview.kt
@@ -44,7 +44,7 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.FileSizeFormatter
-import java.util.Locale
+import androidx.compose.ui.platform.LocalLocale
 
 @Composable
 fun AssetFilePreview(assetName: String, sizeInBytes: Long, modifier: Modifier = Modifier) {
@@ -65,7 +65,7 @@ fun AssetFilePreview(assetName: String, sizeInBytes: Long, modifier: Modifier = 
             )
             Text(
                 modifier = Modifier.padding(bottom = dimensions().spacing8x),
-                text = assetName.split(".").last().uppercase(Locale.getDefault()),
+                text = assetName.split(".").last().uppercase(LocalLocale.current.platformLocale),
                 color = MaterialTheme.colorScheme.onPrimary,
                 style = MaterialTheme.wireTypography.title05
             )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/AssetTilePreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/AssetTilePreview.kt
@@ -52,7 +52,7 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.asset.AttachmentType
 import okio.Path.Companion.toPath
-import java.util.Locale
+import androidx.compose.ui.platform.LocalLocale
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -108,7 +108,7 @@ fun AssetTilePreview(
 @Composable
 fun AssetExtensionPreviewTile(assetName: String, modifier: Modifier = Modifier) {
     Text(
-        text = assetName.split(".").last().uppercase(Locale.getDefault()),
+        text = assetName.split(".").last().uppercase(LocalLocale.current.platformLocale),
         style = MaterialTheme.wireTypography.title05,
         color = MaterialTheme.wireColorScheme.secondaryText,
         modifier = modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/create/CreateBackupDialogs.kt
@@ -48,8 +48,8 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.permission.rememberCreateFileFlow
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.feature.auth.ValidatePasswordResult
-import java.util.Locale
 import kotlin.math.roundToInt
+import androidx.compose.ui.platform.LocalLocale
 
 @Composable
 fun SetBackupPasswordDialog(
@@ -79,7 +79,7 @@ fun SetBackupPasswordDialog(
     ) {
         WirePasswordTextField(
             modifier = Modifier.padding(bottom = dimensions().spacing16x),
-            labelText = stringResource(R.string.label_textfield_optional_password).uppercase(Locale.getDefault()),
+            labelText = stringResource(R.string.label_textfield_optional_password).uppercase(LocalLocale.current.platformLocale),
             descriptionText = stringResource(R.string.create_account_details_password_description),
             state = if (passwordValidation.isValid) WireTextFieldState.Default else WireTextFieldState.Error(),
             textState = backupPasswordTextState,

--- a/core/analytics-disabled/build.gradle.kts
+++ b/core/analytics-disabled/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
     api(project(":core:analytics"))
 
-    val composeBom = platform(libs.compose.bom)
+    val composeBom = enforcedPlatform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
 

--- a/core/analytics-enabled/build.gradle.kts
+++ b/core/analytics-enabled/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation("com.wire.kalium:kalium-data")
     api(project(":core:analytics"))
 
-    val composeBom = platform(libs.compose.bom)
+    val composeBom = enforcedPlatform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
 

--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
     implementation("com.wire.kalium:kalium-data")
 
-    val composeBom = platform(libs.compose.bom)
+    val composeBom = enforcedPlatform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
 

--- a/core/search/build.gradle.kts
+++ b/core/search/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation(libs.bundlizer.core)
     implementation(libs.coroutines.android)
 
-    val composeBom = enforcedP latform(libs.compose.bom)
+    val composeBom = enforcedPlatform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.graphics)

--- a/core/search/build.gradle.kts
+++ b/core/search/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation(libs.bundlizer.core)
     implementation(libs.coroutines.android)
 
-    val composeBom = platform(libs.compose.bom)
+    val composeBom = enforcedP latform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.graphics)

--- a/core/ui-common/build.gradle.kts
+++ b/core/ui-common/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     implementation(libs.coroutines.android)
     implementation(libs.ktx.immutableCollections)
 
-    val composeBom = platform(libs.compose.bom)
+    val composeBom = enforcedPlatform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.graphics)

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/datetime/WireDatePickerDialog.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/datetime/WireDatePickerDialog.kt
@@ -49,7 +49,7 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.PreviewMultipleThemes
 import java.time.LocalDate
 import java.time.ZoneOffset
-import java.util.Locale
+import androidx.compose.ui.platform.LocalLocale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -92,7 +92,7 @@ private fun DatePickerDialogContent(
         selectableDates = selectableDates
     )
     val dateFormatter: DatePickerFormatter = remember { DatePickerDefaults.dateFormatter() }
-    val formattedDate = dateFormatter.formatDate(datePickerState.selectedDateMillis, Locale.getDefault())
+    val formattedDate = dateFormatter.formatDate(datePickerState.selectedDateMillis, LocalLocale.current.platformLocale)
 
     LaunchedEffect(Unit) {
         datePickerState.selectedDateMillis = selectedDateMillis

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/textfield/WirePasswordTextField.kt
@@ -62,7 +62,7 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.EMPTY
 import com.wire.android.util.PreviewMultipleThemes
-import java.util.Locale
+import androidx.compose.ui.platform.LocalLocale
 
 @Composable
 fun WirePasswordTextField(
@@ -93,7 +93,7 @@ fun WirePasswordTextField(
     WireTextFieldLayout(
         shouldShowPlaceholder = textState.text.isEmpty(),
         placeholderText = placeholderText,
-        labelText = labelText?.uppercase(Locale.getDefault()),
+        labelText = labelText?.uppercase(LocalLocale.current.platformLocale),
         labelMandatoryIcon = labelMandatoryIcon,
         descriptionText = descriptionText,
         semanticDescription = semanticDescription,

--- a/features/cells/build.gradle.kts
+++ b/features/cells/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     implementation(libs.ktx.immutableCollections)
     implementation(libs.ktx.serialization)
 
-    val composeBom = platform(libs.compose.bom)
+    val composeBom = enforcedPlatform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.graphics)

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/file/CreateFileScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/file/CreateFileScreen.kt
@@ -53,7 +53,7 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
-import java.util.Locale
+  import androidx.compose.ui.platform.LocalLocale
 
 @WireCellsDestination(
     style = PopUpNavigationAnimation::class,
@@ -123,7 +123,7 @@ fun CreateFileScreen(
         WireTextField(
             textState = createFileViewModel.fileNameTextFieldState,
             placeholderText = stringResource(R.string.cell_file_name),
-            labelText = stringResource(R.string.cell_file_name).uppercase(Locale.getDefault()),
+            labelText = stringResource(R.string.cell_file_name).uppercase(LocalLocale.current.platformLocale),
             modifier = Modifier
                 .padding(it)
                 .padding(

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/folder/CreateFolderScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/folder/CreateFolderScreen.kt
@@ -58,7 +58,6 @@ import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
-import java.util.Locale
 import androidx.compose.ui.platform.LocalLocale
 
 @WireCellsDestination(

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/folder/CreateFolderScreen.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/create/folder/CreateFolderScreen.kt
@@ -59,6 +59,7 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import java.util.Locale
+import androidx.compose.ui.platform.LocalLocale
 
 @WireCellsDestination(
     style = PopUpNavigationAnimation::class,
@@ -136,7 +137,7 @@ fun CreateFolderScreen(
         WireTextField(
             textState = createFolderViewModel.folderNameTextFieldState,
             placeholderText = stringResource(R.string.cells_folder_name),
-            labelText = stringResource(R.string.cells_folder_name).uppercase(Locale.getDefault()),
+            labelText = stringResource(R.string.cells_folder_name).uppercase(LocalLocale.current.platformLocale),
             modifier = Modifier
                 .padding(it)
                 .padding(

--- a/features/meetings/build.gradle.kts
+++ b/features/meetings/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation(libs.ktx.immutableCollections)
     implementation(libs.ktx.serialization)
 
-    val composeBom = platform(libs.compose.bom)
+    val composeBom = enforcedPlatform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.graphics)

--- a/features/sketch/build.gradle.kts
+++ b/features/sketch/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.ktx.immutableCollections)
 
-    val composeBom = platform(libs.compose.bom)
+    val composeBom = enforcedPlatform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.graphics)

--- a/features/sync/build.gradle.kts
+++ b/features/sync/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     implementation(libs.resaca.core)
     implementation(libs.bundlizer.core)
 
-    val composeBom = platform(libs.compose.bom)
+    val composeBom = enforcedPlatform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.graphics)

--- a/features/template/build.gradle.kts
+++ b/features/template/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.androidx.appcompat)
 
-    val composeBom = platform(libs.compose.bom)
+    val composeBom = enforcedPlatform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
     implementation(libs.compose.foundation)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ compose-qr = "1.0.1"
 enterprise-feedback = "1.1.0"
 
 # Compose
-composeBom = "2026.01.01"
+composeBom = "2026.06.00"
 compose-activity = "1.13.0"
 compose-constraint = "1.1.1"
 compose-navigation = "2.9.5" # aligned with compose-destinations 2.3.0

--- a/tests/testsCore/build.gradle.kts
+++ b/tests/testsCore/build.gradle.kts
@@ -23,7 +23,7 @@ android {
 }
 dependencies {
     implementation(libs.androidx.rules)
-    val composeBom = platform(libs.compose.bom)
+    val composeBom = enforcedPlatform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.compose.ui)
     androidTestImplementation(libs.androidx.test.runner)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26684
<!--jira-description-action-hidden-marker-end-->
This PR updates the Compose BOM and makes it the source of truth for Compose dependency versions.
Before this change, Gradle could pick a newer Compose version from a transitive dependency, even when the BOM requested another version. That happened with Compose Foundation. Since the BOM is meant to keep Compose libraries on versions that are tested together, we now use enforcedPlatform(libs.compose.bom).

Changes:
Updated Compose BOM from 2026.01.01 to 2026.06.00.
Replaced platform(libs.compose.bom) with enforcedPlatform(libs.compose.bom) in Compose modules.
Verified Compose Foundation and UI Text resolve to 1.11.3.