### PR TITLE
fix: update ci runner for 4.11 [WPB-26586]

### DIFF
--- a/.github/workflows/build-beta-app.yml
+++ b/.github/workflows/build-beta-app.yml
@@ -37,7 +37,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/build-develop-app.yml
+++ b/.github/workflows/build-develop-app.yml
@@ -33,7 +33,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/build-edge-env.yml
+++ b/.github/workflows/build-edge-env.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -53,7 +53,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/build-fdroid-app.yml
+++ b/.github/workflows/build-fdroid-app.yml
@@ -26,7 +26,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/build-prod-app.yml
+++ b/.github/workflows/build-prod-app.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/build-rc-app.yml
+++ b/.github/workflows/build-rc-app.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -90,7 +90,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-2404-x64-8x
     # Add a bit more Metaspace size as it tends to fail on GH runner when running linter,
     # Reduce a bit the memory allocation pool, as the 8GB set in gradle.properties is too much for CI
     # AboutLibraries seems to go crazy when running lint checks. So we explicitly don't run it.
@@ -21,7 +21,7 @@ jobs:
               submodules: recursive # Needed in order to fetch Kalium sources for building
               fetch-depth: 0
         - name: Set up JDK 17
-          uses: buildjet/setup-java@v4
+          uses: actions/setup-java@v5
           with:
               java-version: '17'
               distribution: 'temurin'
@@ -40,7 +40,7 @@ jobs:
               rm -f ~/.gradle/caches/modules-2/gc.properties
 
   style:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-2404-x64-2x
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   generate-screenshots:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-2404-x64-8x
 
     if: github.ref == 'refs/heads/develop'
 
@@ -24,14 +24,22 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+
+      - uses: WarpBuilds/cache@v1
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v6
 
       - name: Install Git LFS
         run: |
@@ -71,7 +79,7 @@ jobs:
       - name: Clear changes before generating new screenshots
         run: |
           git reset --hard HEAD
-          git clean -fd        
+          git clean -fd
 
       - name: Update Screenshot Reference Images
         run: ./gradlew updateInternalDebugScreenshotTest

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   ui-tests:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: warp-ubuntu-latest-x64-8x
     strategy:
       matrix:
         api-level: [ 29 ]
@@ -21,23 +21,39 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+
+      - uses: WarpBuilds/cache@v1
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v6
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: AVD cache
-        uses: buildjet/cache@v4
+        uses: WarpBuilds/cache@v1
         id: avd-cache
         with:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+          key: ${{ runner.os }}-avd-${{ matrix.api-level }}
+          restore-keys: |
+            ${{ runner.os }}-avd-
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -10,7 +10,9 @@ env:
 
 jobs:
   coverage:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    env:
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=2g -Xmx4G"'
+    runs-on: warp-ubuntu-2404-x64-8x
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,13 +21,20 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: buildjet/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+      - uses: WarpBuilds/cache@v1
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v6
 
       - name: Test Build Logic
         run: |


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26586" title="WPB-26586" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26586</a>  [Android] Support default-backend-none for Gov
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Updates 4.11 CI workflows to use the current runner/setup configuration from develop.

Changes:
- replace BuildJet Java setup with actions/setup-java@v5
- move affected jobs to Warp runners
- update Gradle wrapper validation to v6
- use Warp cache for Gradle/AVD where needed