### PR TITLE
feat: default backend none [WPB-26206] [WPB-26586] [WPB-26624]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/config/ServerConfigProvider.kt
+++ b/app/src/main/kotlin/com/wire/android/config/ServerConfigProvider.kt
@@ -39,7 +39,8 @@ class ServerConfigProvider @Inject constructor() {
                     website = endpoints.websiteURL,
                     title = title,
                     isOnPremises = true, // EMM configuration always treated as on-premises
-                    apiProxy = null
+                    apiProxy = null,
+                    supportEmail = supportEmail,
                 )
             }
         } else if (!BuildConfig.DEFAULT_BACKEND_ENABLED) {

--- a/app/src/main/kotlin/com/wire/android/config/ServerConfigProvider.kt
+++ b/app/src/main/kotlin/com/wire/android/config/ServerConfigProvider.kt
@@ -27,7 +27,7 @@ import dev.zacsweers.metro.SingleIn
 @SingleIn(AppScope::class)
 class ServerConfigProvider @Inject constructor() {
 
-    fun getDefaultServerConfig(managedServerConfig: ManagedServerConfig? = null): ServerConfig.Links {
+    fun getDefaultServerConfigOrNull(managedServerConfig: ManagedServerConfig? = null): ServerConfig.Links? {
         return if (managedServerConfig != null) {
             with(managedServerConfig) {
                 ServerConfig.Links(
@@ -42,6 +42,8 @@ class ServerConfigProvider @Inject constructor() {
                     apiProxy = null
                 )
             }
+        } else if (!BuildConfig.DEFAULT_BACKEND_ENABLED) {
+            null
         } else {
             ServerConfig.Links(
                 api = BuildConfig.DEFAULT_BACKEND_URL_BASE_API,
@@ -55,6 +57,23 @@ class ServerConfigProvider @Inject constructor() {
                 apiProxy = null
             )
         }
+    }
+
+    fun getDefaultServerConfig(managedServerConfig: ManagedServerConfig? = null): ServerConfig.Links =
+        getDefaultServerConfigOrNull(managedServerConfig) ?: EmptyServerConfig
+
+    companion object {
+        val EmptyServerConfig = ServerConfig.Links(
+            api = "",
+            accounts = "",
+            webSocket = "",
+            teams = "",
+            blackList = "",
+            website = "",
+            title = "",
+            isOnPremises = false,
+            apiProxy = null
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
+++ b/app/src/main/kotlin/com/wire/android/datastore/GlobalDataStore.kt
@@ -66,6 +66,9 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
 
         private fun userDoubleTapToastStatusKey(userId: String): Preferences.Key<Boolean> =
             booleanPreferencesKey("$SHOW_CALLING_DOUBLE_TAP_TOAST$userId")
+
+        private fun backendSupportEmailKey(backendApiUrl: String): Preferences.Key<String> =
+            stringPreferencesKey("backend_support_email_${backendApiUrl.sha256()}")
     }
 
     suspend fun clear() {
@@ -214,4 +217,26 @@ class GlobalDataStore @Inject constructor(@ApplicationContext private val contex
     suspend fun setPersistentWebSocketEnforcedByMDM(enforced: Boolean) {
         context.dataStore.edit { it[PERSISTENT_WEBSOCKET_ENFORCED_BY_MDM] = enforced }
     }
+
+    suspend fun setBackendSupportEmail(backendApiUrl: String, supportEmail: String?) {
+        if (backendApiUrl.isBlank()) return
+
+        context.dataStore.edit {
+            val key = backendSupportEmailKey(backendApiUrl)
+            val normalizedSupportEmail = supportEmail?.trim().orEmpty()
+            if (normalizedSupportEmail.isBlank()) {
+                it.remove(key)
+            } else {
+                it[key] = normalizedSupportEmail
+            }
+        }
+    }
+
+    suspend fun getBackendSupportEmail(backendApiUrl: String): String? =
+        if (backendApiUrl.isBlank()) {
+            null
+        } else {
+            context.dataStore.data.firstOrNull()?.get(backendSupportEmailKey(backendApiUrl))
+                ?.takeIf { it.isNotBlank() }
+        }
 }

--- a/app/src/main/kotlin/com/wire/android/di/ManagedConfigurationsModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/ManagedConfigurationsModule.kt
@@ -78,10 +78,22 @@ class ManagedConfigurationsModule {
     ): ServerConfig.Links {
         return if (BuildConfig.EMM_SUPPORT_ENABLED) {
             // Returns the current resolved server configuration links, which could be either managed or default
-            managedConfigurationsManager.currentServerConfig
+            managedConfigurationsManager.currentServerConfig ?: ServerConfigProvider.EmptyServerConfig
         } else {
             // If EMM support is disabled, always return the static default server configuration links
             provideServerConfigProvider().getDefaultServerConfig(null)
+        }
+    }
+
+    @Provides
+    @Named("isDefaultBackendConfigured")
+    fun provideIsDefaultBackendConfigured(
+        managedConfigurationsManager: ManagedConfigurationsManager
+    ): Boolean {
+        return if (BuildConfig.EMM_SUPPORT_ENABLED) {
+            managedConfigurationsManager.currentServerConfig != null
+        } else {
+            BuildConfig.DEFAULT_BACKEND_ENABLED
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsManager.kt
+++ b/app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsManager.kt
@@ -22,6 +22,7 @@ import android.content.RestrictionsManager
 import com.wire.android.appLogger
 import com.wire.android.config.ServerConfigProvider
 import com.wire.android.datastore.GlobalDataStore
+import com.wire.android.util.BackendSupportConfig
 import com.wire.android.util.EMPTY
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.configuration.server.ServerConfig
@@ -125,6 +126,7 @@ internal class ManagedConfigurationsManagerImpl(
             )
         }
         _currentServerConfig.set(serverConfig)
+        serverConfig?.let { BackendSupportConfig.storeFromServerLinks(globalDataStore, it) }
         logger.i("Server config refreshed: $serverConfig")
         managedServerConfig
     }

--- a/app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsManager.kt
+++ b/app/src/main/kotlin/com/wire/android/emm/ManagedConfigurationsManager.kt
@@ -40,7 +40,7 @@ interface ManagedConfigurationsManager {
      *
      * @see refreshServerConfig
      */
-    val currentServerConfig: ServerConfig.Links
+    val currentServerConfig: ServerConfig.Links?
 
     /**
      * Current SSO code if provided via managed configurations, empty string otherwise.
@@ -53,10 +53,10 @@ interface ManagedConfigurationsManager {
      * This should be called when the app starts, resumes, or when broadcast receiver triggers.
      *
      * The result indicates whether a valid config was found or if there was an error.
-     * Nevertheless, the config is either updated or defaulted to [ServerConfigProvider.getDefaultServerConfig()].
+     * Nevertheless, the config is either updated or defaulted to [ServerConfigProvider.getDefaultServerConfigOrNull()].
      *
      * @return result of the update attempt, either success with the config,
-     * default [ServerConfigProvider.getDefaultServerConfig()] if no config found or cleared, or failure with reason.
+     * default [ServerConfigProvider.getDefaultServerConfigOrNull()] if no config found or cleared, or failure with reason.
      */
     suspend fun refreshServerConfig(): ServerConfigResult
 
@@ -105,8 +105,8 @@ internal class ManagedConfigurationsManagerImpl(
         MutableStateFlow(runBlocking { globalDataStore.isPersistentWebSocketEnforcedByMDM().first() })
     }
 
-    override val currentServerConfig: ServerConfig.Links
-        get() = _currentServerConfig.get() ?: serverConfigProvider.getDefaultServerConfig()
+    override val currentServerConfig: ServerConfig.Links?
+        get() = _currentServerConfig.get() ?: serverConfigProvider.getDefaultServerConfigOrNull()
 
     override val currentSSOCodeConfig: String
         get() = _currentSSOCodeConfig.get()
@@ -116,11 +116,11 @@ internal class ManagedConfigurationsManagerImpl(
 
     override suspend fun refreshServerConfig(): ServerConfigResult = withContext(dispatchers.io()) {
         val managedServerConfig = getServerConfig()
-        val serverConfig: ServerConfig.Links = when (managedServerConfig) {
+        val serverConfig: ServerConfig.Links? = when (managedServerConfig) {
             is ServerConfigResult.Empty,
-            is ServerConfigResult.Failure -> serverConfigProvider.getDefaultServerConfig(null)
+            is ServerConfigResult.Failure -> serverConfigProvider.getDefaultServerConfigOrNull(null)
 
-            is ServerConfigResult.Success -> serverConfigProvider.getDefaultServerConfig(
+            is ServerConfigResult.Success -> serverConfigProvider.getDefaultServerConfigOrNull(
                 managedServerConfig.config
             )
         }

--- a/app/src/main/kotlin/com/wire/android/emm/ManagedServerConfig.kt
+++ b/app/src/main/kotlin/com/wire/android/emm/ManagedServerConfig.kt
@@ -27,7 +27,9 @@ data class ManagedServerConfig(
     @SerialName("title")
     val title: String,
     @SerialName("endpoints")
-    val endpoints: ManagedServerLinks
+    val endpoints: ManagedServerLinks,
+    @SerialName("supportEmail")
+    val supportEmail: String? = null
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -133,7 +133,7 @@ fun Direction.handleNavigation(
     handleOtherDirection: (Direction) -> Unit
 ) = when (this) {
     is ExternalUriDirection -> CustomTabsHelper.launchUri(context, this.uri)
-    is ExternalUriStringResDirection -> CustomTabsHelper.launchUri(context, this.getUri(context.resources))
+    is ExternalUriStringResDirection -> CustomTabsHelper.launchUrl(context, context.resources.getString(this.uriStringRes))
     is IntentDirection -> context.startActivity(this.intent(context))
     else -> handleOtherDirection(this)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityActionsHandler.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityActionsHandler.kt
@@ -200,7 +200,10 @@ private fun onCustomBackendLogin(
     action: OnCustomBackendLogin
 ) {
     val destination = when (action.useNewLogin) {
-        true -> NewLoginScreenDestination(loginPasswordPath = LoginPasswordPath(action.serverLinks))
+        true -> NewLoginScreenDestination(
+            loginPasswordPath = LoginPasswordPath(action.serverLinks),
+            showBackendConfigSuccess = true
+        )
         false -> WelcomeScreenDestination(customServerConfig = action.serverLinks)
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -52,8 +52,10 @@ import com.wire.android.ui.common.dialogs.CustomServerNoNetworkDialogState
 import com.wire.android.ui.joinConversation.JoinConversationViaCodeState
 import com.wire.android.ui.theme.Accent
 import com.wire.android.ui.theme.ThemeOption
+import com.wire.android.util.BackendSupportConfig
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
+import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.deeplink.DeepLinkProcessor
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.deeplink.LoginType
@@ -89,6 +91,7 @@ import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.ObserveSessionsUseCase
+import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
@@ -189,6 +192,7 @@ class WireActivityViewModel @Inject constructor(
         observeAppThemeState()
         observeSelectedAccent()
         observeLogoutState()
+        observeBackendWebsiteUrl()
         resetNewRegistrationAnalyticsState()
         viewModelScope.launch(dispatchers.io()) { monitorSyncWorkUseCase() }
     }
@@ -220,6 +224,25 @@ class WireActivityViewModel @Inject constructor(
                 .collectLatest {
                     globalAppState = globalAppState.copy(userAccent = it)
                 }
+        }
+    }
+
+    private fun observeBackendWebsiteUrl() {
+        viewModelScope.launch(dispatchers.io()) {
+            observeCurrentValidUserId.collectLatest { userId ->
+                val serverLinks = userId?.let {
+                    runCatching {
+                        when (val result = coreLogic.value.getSessionScope(it).users.serverLinks()) {
+                            is SelfServerConfigUseCase.Result.Success -> result.serverLinks.links
+                            is SelfServerConfigUseCase.Result.Failure -> null
+                        }
+                    }.getOrNull()
+                }
+                serverLinks?.let(BackendSupportConfig::setCurrentBackend)
+                val websiteUrl = serverLinks?.website ?: managedConfigurationsManager.currentServerConfig?.website
+
+                CustomTabsHelper.setBackendWebsiteUrl(websiteUrl)
+            }
         }
     }
 
@@ -659,7 +682,10 @@ class WireActivityViewModel @Inject constructor(
 
     private suspend fun loadServerConfig(url: String): ServerConfig.Links? =
         when (val result = getServerConfigUseCase.value.invoke(url)) {
-            is GetServerConfigResult.Success -> result.serverConfigLinks
+            is GetServerConfigResult.Success -> result.serverConfigLinks.also {
+                CustomTabsHelper.setBackendWebsiteUrl(it.website)
+                BackendSupportConfig.storeFromConfigUrl(globalDataStore.value, it, url)
+            }
             is GetServerConfigResult.Failure.Generic -> {
                 appLogger.e("something went wrong during handling the custom server deep link: ${result.genericFailure}")
                 null

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -684,7 +684,7 @@ class WireActivityViewModel @Inject constructor(
         when (val result = getServerConfigUseCase.value.invoke(url)) {
             is GetServerConfigResult.Success -> result.serverConfigLinks.also {
                 CustomTabsHelper.setBackendWebsiteUrl(it.website)
-                BackendSupportConfig.storeFromConfigUrl(globalDataStore.value, it, url)
+                BackendSupportConfig.storeFromServerLinks(globalDataStore.value, it)
             }
             is GetServerConfigResult.Failure.Generic -> {
                 appLogger.e("something went wrong during handling the custom server deep link: ${result.genericFailure}")

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelFactory.kt
@@ -63,6 +63,7 @@ import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerifi
 import com.wire.kalium.logic.feature.client.DeleteClientUseCase
 import com.wire.kalium.logic.feature.client.FetchSelfClientsFromRemoteUseCase
 import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
+import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
 import com.wire.kalium.logic.feature.session.DoesValidNomadAccountExistUseCase
@@ -83,6 +84,7 @@ class AuthenticationViewModelFactory @Inject constructor(
     private val defaultServerConfig: Provider<ServerConfig.Links>,
     @DefaultWebSocketEnabledByDefault private val defaultWebSocketEnabledByDefault: Provider<Boolean>,
     @Named("ssoCodeConfig") private val defaultSSOCodeConfig: Provider<String>,
+    @Named("isDefaultBackendConfigured") private val isDefaultBackendConfigured: Provider<Boolean>,
     private val addAuthenticatedUser: Provider<AddAuthenticatedUserUseCase>,
     private val clientScopeProviderFactory: Provider<ClientScopeProvider.Factory>,
     private val dispatchers: Provider<DispatcherProvider>,
@@ -106,6 +108,7 @@ class AuthenticationViewModelFactory @Inject constructor(
     private val countdownTimer: Provider<CountdownTimer>,
     private val fetchSelfClientsFromRemote: Provider<FetchSelfClientsFromRemoteUseCase>,
     private val deleteClient: Provider<DeleteClientUseCase>,
+    private val getServerConfigUseCase: Provider<GetServerConfigUseCase>,
 ) {
     fun welcomeViewModel(savedStateHandle: SavedStateHandle) = WelcomeViewModel(
         savedStateHandle = savedStateHandle,
@@ -129,6 +132,9 @@ class AuthenticationViewModelFactory @Inject constructor(
         dispatchers = dispatchers(),
         defaultServerConfig = defaultServerConfig(),
         defaultSSOCodeConfig = defaultSSOCodeConfig(),
+        isDefaultBackendConfigured = isDefaultBackendConfigured(),
+        getServerConfigUseCase = lazy { getServerConfigUseCase() },
+        globalDataStore = lazy { globalDataStore() },
     )
 
     fun loginEmailViewModel(loginNavArgs: LoginNavArgs, savedStateHandle: SavedStateHandle) = LoginEmailViewModel(
@@ -142,6 +148,9 @@ class AuthenticationViewModelFactory @Inject constructor(
         dispatchers = dispatchers(),
         defaultServerConfig = defaultServerConfig(),
         defaultWebSocketEnabledByDefault = defaultWebSocketEnabledByDefault(),
+        isDefaultBackendConfigured = isDefaultBackendConfigured(),
+        getServerConfigUseCase = lazy { getServerConfigUseCase() },
+        globalDataStore = lazy { globalDataStore() },
     )
 
     fun loginSSOViewModel(loginNavArgs: LoginNavArgs, savedStateHandle: SavedStateHandle) = LoginSSOViewModel(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/BackendConfigSetup.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/BackendConfigSetup.kt
@@ -59,6 +59,9 @@ import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.typography
 import com.wire.android.ui.theme.wireTypography
 import com.wire.kalium.logic.configuration.server.ServerConfig
+import java.net.URI
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets.UTF_8
 import kotlinx.coroutines.launch
 import com.wire.android.ui.common.R as CommonR
 
@@ -198,8 +201,12 @@ fun String.toBackendConfigUrl(): String? {
     }
 
     return runCatching {
-        Uri.parse(sanitizedInput)
-            .getQueryParameter(BACKEND_CONFIG_QUERY_PARAMETER)
+        URI.create(sanitizedInput)
+            .rawQuery
+            ?.split('&')
+            ?.firstOrNull { it.substringBefore('=') == BACKEND_CONFIG_QUERY_PARAMETER }
+            ?.substringAfter('=', missingDelimiterValue = "")
+            ?.let { URLDecoder.decode(it, UTF_8.name()) }
             ?.takeIf(String::isNotBlank)
     }.getOrNull()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/BackendConfigSetup.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/BackendConfigSetup.kt
@@ -50,18 +50,17 @@ import com.wire.android.ui.WireActivity
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.spacers.HorizontalSpace
 import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.common.textfield.WireTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.typography
-import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.kalium.logic.configuration.server.ServerConfig
-import com.wire.android.ui.common.R as CommonR
 import kotlinx.coroutines.launch
-import java.net.URLDecoder
+import com.wire.android.ui.common.R as CommonR
 
 @Composable
 fun MissingBackendConfigContent(
@@ -76,7 +75,7 @@ fun MissingBackendConfigContent(
     val context = LocalContext.current
     val snackbarHostState = LocalSnackbarHostState.current
     val coroutineScope = rememberCoroutineScope()
-    val noCameraAppMessage = stringResource(R.string.no_camera_app)
+    val noCameraAppMessage = stringResource(CommonR.string.no_camera_app)
     val backendConfigTextState = remember { TextFieldState() }
     val isConfigInputEmpty = backendConfigTextState.text.isBlank()
     val textAlign = if (centerText) TextAlign.Center else TextAlign.Start
@@ -109,7 +108,7 @@ fun MissingBackendConfigContent(
             labelText = stringResource(R.string.missing_backend_config_input_label),
             state = errorText?.let(WireTextFieldState::Error) ?: WireTextFieldState.Default,
             keyboardOptions = KeyboardOptions.Default,
-            modifier = Modifier.testTag("backendConfigInput"),
+            modifier = Modifier.testTag("backendConfigInputField"),
             testTag = "backendConfigInput",
             trailingIcon = {
                 IconButton(
@@ -133,7 +132,11 @@ fun MissingBackendConfigContent(
         WirePrimaryButton(
             text = stringResource(R.string.missing_backend_config_button_setup),
             fillMaxWidth = true,
-            state = if (isConfigInputEmpty || isLoading) WireButtonState.Disabled else WireButtonState.Default,
+            state = if (isConfigInputEmpty || isLoading || onConfigurationLinkEntered == null) {
+                WireButtonState.Disabled
+            } else {
+                WireButtonState.Default
+            },
             onClick = { (onConfigurationLinkEntered ?: context::openBackendConfig)(backendConfigTextState.text.toString()) },
             modifier = Modifier.testTag("backendConfigContinueButton"),
         )
@@ -186,18 +189,19 @@ fun BackendConfigSuccessContent(
 
 fun ServerConfig.Links.isConfigured() = api.isNotBlank()
 
+@Suppress("ReturnCount")
 fun String.toBackendConfigUrl(): String? {
-    val sanitizedInput = trim().takeIf { it.isNotBlank() } ?: return null
-    return if (sanitizedInput.startsWith(WIRE_ACCESS_DEEPLINK_PREFIX)) {
-        runCatching {
-            URLDecoder.decode(
-                sanitizedInput.removePrefix(WIRE_ACCESS_DEEPLINK_PREFIX).substringBefore("&"),
-                Charsets.UTF_8.name()
-            )
-        }.getOrNull()
-    } else {
-        sanitizedInput
-    }?.takeIf { it.isNotBlank() }
+    val sanitizedInput = trim().takeIf(String::isNotBlank) ?: return null
+
+    if (!sanitizedInput.startsWith(WIRE_ACCESS_DEEPLINK_BASE)) {
+        return sanitizedInput
+    }
+
+    return runCatching {
+        Uri.parse(sanitizedInput)
+            .getQueryParameter(BACKEND_CONFIG_QUERY_PARAMETER)
+            ?.takeIf(String::isNotBlank)
+    }.getOrNull()
 }
 
 fun Context.openBackendConfig(input: String) {
@@ -226,4 +230,6 @@ fun Context.openExternalCamera(): Boolean {
     }
 }
 
-private const val WIRE_ACCESS_DEEPLINK_PREFIX = "wire://access/?config="
+private const val WIRE_ACCESS_DEEPLINK_BASE = "wire://access/"
+private const val BACKEND_CONFIG_QUERY_PARAMETER = "config"
+private const val WIRE_ACCESS_DEEPLINK_PREFIX = "$WIRE_ACCESS_DEEPLINK_BASE?$BACKEND_CONFIG_QUERY_PARAMETER="

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/BackendConfigSetup.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/BackendConfigSetup.kt
@@ -1,0 +1,229 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui.authentication
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.MediaStore
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
+import com.wire.android.R
+import com.wire.android.ui.WireActivity
+import com.wire.android.ui.common.button.WireButtonState
+import com.wire.android.ui.common.button.WirePrimaryButton
+import com.wire.android.ui.common.colorsScheme
+import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
+import com.wire.android.ui.common.spacers.HorizontalSpace
+import com.wire.android.ui.common.spacers.VerticalSpace
+import com.wire.android.ui.common.textfield.WireTextField
+import com.wire.android.ui.common.textfield.WireTextFieldState
+import com.wire.android.ui.common.typography
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireTypography
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.android.ui.common.R as CommonR
+import kotlinx.coroutines.launch
+import java.net.URLDecoder
+
+@Composable
+fun MissingBackendConfigContent(
+    modifier: Modifier = Modifier,
+    showTitle: Boolean = false,
+    centerText: Boolean = false,
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    errorText: String? = null,
+    isLoading: Boolean = false,
+    onConfigurationLinkEntered: ((String) -> Unit)? = null,
+) {
+    val context = LocalContext.current
+    val snackbarHostState = LocalSnackbarHostState.current
+    val coroutineScope = rememberCoroutineScope()
+    val noCameraAppMessage = stringResource(R.string.no_camera_app)
+    val backendConfigTextState = remember { TextFieldState() }
+    val isConfigInputEmpty = backendConfigTextState.text.isBlank()
+    val textAlign = if (centerText) TextAlign.Center else TextAlign.Start
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = verticalArrangement,
+    ) {
+        if (showTitle) {
+            Text(
+                text = stringResource(R.string.missing_backend_config_title),
+                style = MaterialTheme.wireTypography.title01,
+                color = MaterialTheme.colorScheme.onBackground,
+                textAlign = textAlign,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            VerticalSpace.x16()
+        }
+        Text(
+            text = stringResource(R.string.missing_backend_config_description),
+            style = typography().body01,
+            color = colorsScheme().secondaryText,
+            textAlign = textAlign,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        VerticalSpace.x16()
+        WireTextField(
+            textState = backendConfigTextState,
+            placeholderText = stringResource(R.string.missing_backend_config_input_placeholder),
+            labelText = stringResource(R.string.missing_backend_config_input_label),
+            state = errorText?.let(WireTextFieldState::Error) ?: WireTextFieldState.Default,
+            keyboardOptions = KeyboardOptions.Default,
+            modifier = Modifier.testTag("backendConfigInput"),
+            testTag = "backendConfigInput",
+            trailingIcon = {
+                IconButton(
+                    onClick = {
+                        if (!context.openExternalCamera()) {
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar(noCameraAppMessage)
+                            }
+                        }
+                    },
+                    modifier = Modifier.testTag("backendConfigCameraButton")
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(id = CommonR.drawable.ic_qr_code_scanner),
+                        contentDescription = stringResource(R.string.content_description_backend_config_camera_button),
+                    )
+                }
+            },
+        )
+        VerticalSpace.x8()
+        WirePrimaryButton(
+            text = stringResource(R.string.missing_backend_config_button_setup),
+            fillMaxWidth = true,
+            state = if (isConfigInputEmpty || isLoading) WireButtonState.Disabled else WireButtonState.Default,
+            onClick = { (onConfigurationLinkEntered ?: context::openBackendConfig)(backendConfigTextState.text.toString()) },
+            modifier = Modifier.testTag("backendConfigContinueButton"),
+        )
+    }
+}
+
+@Composable
+fun BackendConfigSuccessContent(
+    modifier: Modifier = Modifier,
+    onContinue: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        VerticalSpace.x16()
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_validation_check),
+                tint = colorsScheme().positive,
+                contentDescription = null,
+                modifier = Modifier.size(dimensions().spacing16x)
+            )
+            HorizontalSpace.x8()
+            Text(
+                text = stringResource(R.string.backend_config_success_title),
+                style = typography().body01,
+                color = colorsScheme().onSurface,
+            )
+        }
+        VerticalSpace.x8()
+        Text(
+            text = stringResource(R.string.backend_config_success_description),
+            style = typography().body01,
+            color = colorsScheme().secondaryText,
+        )
+        VerticalSpace.x24()
+        WirePrimaryButton(
+            text = stringResource(R.string.label_continue),
+            onClick = onContinue,
+            fillMaxWidth = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("backendConfigSuccessContinueButton")
+        )
+    }
+}
+
+fun ServerConfig.Links.isConfigured() = api.isNotBlank()
+
+fun String.toBackendConfigUrl(): String? {
+    val sanitizedInput = trim().takeIf { it.isNotBlank() } ?: return null
+    return if (sanitizedInput.startsWith(WIRE_ACCESS_DEEPLINK_PREFIX)) {
+        runCatching {
+            URLDecoder.decode(
+                sanitizedInput.removePrefix(WIRE_ACCESS_DEEPLINK_PREFIX).substringBefore("&"),
+                Charsets.UTF_8.name()
+            )
+        }.getOrNull()
+    } else {
+        sanitizedInput
+    }?.takeIf { it.isNotBlank() }
+}
+
+fun Context.openBackendConfig(input: String) {
+    val sanitizedInput = input.trim()
+    if (sanitizedInput.isEmpty()) return
+
+    val deepLinkUri = if (sanitizedInput.startsWith(WIRE_ACCESS_DEEPLINK_PREFIX)) {
+        Uri.parse(sanitizedInput)
+    } else {
+        Uri.parse("$WIRE_ACCESS_DEEPLINK_PREFIX${Uri.encode(sanitizedInput)}")
+    }
+
+    startActivity(
+        Intent(this, WireActivity::class.java).apply {
+            data = deepLinkUri
+        }
+    )
+}
+
+fun Context.openExternalCamera(): Boolean {
+    return try {
+        startActivity(Intent(MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA))
+        true
+    } catch (_: ActivityNotFoundException) {
+        false
+    }
+}
+
+private const val WIRE_ACCESS_DEEPLINK_PREFIX = "wire://access/?config="

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginNavArgs.kt
@@ -27,6 +27,7 @@ data class LoginNavArgs(
     val ssoLoginResult: DeepLinkResult.SSOLogin? = null,
     val loginPasswordPath: LoginPasswordPath? = null,
     val ssoCodeAutoLogin: SSOCodeAutoLogin? = null,
+    val showBackendConfigSuccess: Boolean = false,
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -162,6 +162,7 @@ private fun LoginContent(
 }
 
 @OptIn(ExperimentalFoundationApi::class)
+@Suppress("CyclomaticComplexMethod")
 @Composable
 private fun MainLoginContent(
     onBackPressed: () -> Unit,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginScreen.kt
@@ -55,9 +55,12 @@ import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.annotation.app.WireLoginDestination
 import com.wire.android.navigation.style.TransitionAnimationType
+import com.wire.android.ui.authentication.BackendConfigSuccessContent
+import com.wire.android.ui.authentication.MissingBackendConfigContent
 import com.wire.android.ui.authentication.create.common.ServerTitle
 import com.wire.android.ui.authentication.devices.common.SessionBackedAuthenticationNavArgs
 import com.wire.android.ui.authentication.login.email.LoginEmailScreen
+import com.wire.android.ui.authentication.login.email.LoginEmailState
 import com.wire.android.ui.authentication.login.email.LoginEmailVerificationCodeScreen
 import com.wire.android.ui.authentication.login.email.LoginEmailViewModel
 import com.wire.android.ui.authentication.login.sso.LoginSSOScreen
@@ -172,6 +175,9 @@ private fun MainLoginContent(
 
     val scope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
+    val isBackendConfigured = loginEmailViewModel.isBackendConfigured
+    val backendConfigState = loginEmailViewModel.loginState.backendConfigState
+    val shouldShowBackendSetup = !isBackendConfigured || backendConfigState == LoginEmailState.BackendConfigState.Success
     // Show SSO tab if we have either ssoLoginResult or ssoCodeAutoLogin
     val initialPageIndex = if (ssoLoginResult != null || ssoCodeAutoLogin != null) {
         LoginTabItem.SSO.ordinal
@@ -190,9 +196,15 @@ private fun MainLoginContent(
         topBar = {
             WireCenterAlignedTopAppBar(
                 elevation = scrollState.rememberTopBarElevationState().value,
-                title = stringResource(R.string.login_title),
+                title = stringResource(
+                    if (!shouldShowBackendSetup) {
+                        R.string.login_title
+                    } else {
+                        R.string.missing_backend_config_title
+                    }
+                ),
                 subtitleContent = {
-                    if (loginEmailViewModel.serverConfig.isOnPremises) {
+                    if (!shouldShowBackendSetup && loginEmailViewModel.serverConfig.isOnPremises) {
                         ServerTitle(
                             serverLinks = loginEmailViewModel.serverConfig,
                             style = MaterialTheme.wireTypography.body01
@@ -202,28 +214,30 @@ private fun MainLoginContent(
                 onNavigationPressed = onBackPressed,
                 navigationIconType = NavigationIconType.Back(R.string.content_description_login_back_btn)
             ) {
-                WireTabRow(
-                    tabs = LoginTabItem.values().toList(),
-                    selectedTabIndex = pagerState.calculateCurrentTab(),
-                    onTabChange = {
+                if (!shouldShowBackendSetup) {
+                    WireTabRow(
+                        tabs = LoginTabItem.values().toList(),
+                        selectedTabIndex = pagerState.calculateCurrentTab(),
+                        onTabChange = {
 
-                        if (loginEmailViewModel.serverConfig.isProxyEnabled) {
-                            if (pagerState.currentPage != LoginTabItem.SSO.ordinal) {
-                                ssoDisabledWithProxyDialogState.show(
-                                    ssoDisabledWithProxyDialogState.savedState ?: FeatureDisabledWithProxyDialogState(
-                                        R.string.sso_not_supported_dialog_description
+                            if (loginEmailViewModel.serverConfig.isProxyEnabled) {
+                                if (pagerState.currentPage != LoginTabItem.SSO.ordinal) {
+                                    ssoDisabledWithProxyDialogState.show(
+                                        ssoDisabledWithProxyDialogState.savedState ?: FeatureDisabledWithProxyDialogState(
+                                            R.string.sso_not_supported_dialog_description
+                                        )
                                     )
-                                )
+                                }
+                            } else {
+                                scope.launch { pagerState.animateScrollToPage(it) }
                             }
-                        } else {
-                            scope.launch { pagerState.animateScrollToPage(it) }
-                        }
-                    },
-                    modifier = Modifier.padding(
-                        start = MaterialTheme.wireDimensions.spacing16x,
-                        end = MaterialTheme.wireDimensions.spacing16x
-                    ),
-                )
+                        },
+                        modifier = Modifier.padding(
+                            start = MaterialTheme.wireDimensions.spacing16x,
+                            end = MaterialTheme.wireDimensions.spacing16x
+                        ),
+                    )
+                }
             }
         },
         modifier = Modifier.fillMaxHeight(),
@@ -232,30 +246,56 @@ private fun MainLoginContent(
         val keyboardController = LocalSoftwareKeyboardController.current
         val focusManager = LocalFocusManager.current
 
-        CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
-            HorizontalPager(
-                state = pagerState,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(internalPadding)
-            ) { pageIndex ->
-                when (LoginTabItem.values()[pageIndex]) {
-                    LoginTabItem.EMAIL -> LoginEmailScreen(onSuccess, onRemoveDeviceNeeded, loginEmailViewModel, scrollState)
-                    LoginTabItem.SSO -> LoginSSOScreen(
-                        onSuccess,
-                        onRemoveDeviceNeeded,
-                        loginNavArgs,
-                        ssoLoginResult,
-                        ssoCodeAutoLogin,
-                    )
+        if (!shouldShowBackendSetup) {
+            CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
+                HorizontalPager(
+                    state = pagerState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(internalPadding)
+                ) { pageIndex ->
+                    when (LoginTabItem.values()[pageIndex]) {
+                        LoginTabItem.EMAIL -> LoginEmailScreen(onSuccess, onRemoveDeviceNeeded, loginEmailViewModel, scrollState)
+                        LoginTabItem.SSO -> LoginSSOScreen(
+                            onSuccess,
+                            onRemoveDeviceNeeded,
+                            loginNavArgs,
+                            ssoLoginResult,
+                            ssoCodeAutoLogin,
+                        )
+                    }
+                }
+                if (!pagerState.isScrollInProgress && focusedTabIndex != pagerState.currentPage) {
+                    LaunchedEffect(Unit) {
+                        keyboardController?.hide()
+                        focusManager.clearFocus()
+                        focusedTabIndex = pagerState.currentPage
+                    }
                 }
             }
-            if (!pagerState.isScrollInProgress && focusedTabIndex != pagerState.currentPage) {
-                LaunchedEffect(Unit) {
-                    keyboardController?.hide()
-                    focusManager.clearFocus()
-                    focusedTabIndex = pagerState.currentPage
-                }
+        } else {
+            if (backendConfigState == LoginEmailState.BackendConfigState.Success) {
+                BackendConfigSuccessContent(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(internalPadding)
+                        .padding(MaterialTheme.wireDimensions.spacing16x),
+                    onContinue = loginEmailViewModel::onBackendConfigSuccessContinue,
+                )
+            } else {
+                MissingBackendConfigContent(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(internalPadding)
+                        .padding(MaterialTheme.wireDimensions.spacing16x),
+                    errorText = if (backendConfigState == LoginEmailState.BackendConfigState.Error) {
+                        stringResource(R.string.missing_backend_config_error)
+                    } else {
+                        null
+                    },
+                    isLoading = backendConfigState == LoginEmailState.BackendConfigState.Loading,
+                    onConfigurationLinkEntered = loginEmailViewModel::onBackendConfigLinkEntered,
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -47,8 +47,9 @@ open class LoginViewModel(
 
     var serverConfig: ServerConfig.Links by mutableStateOf(loginNavArgs.loginPasswordPath?.customServerConfig ?: defaultServerConfig)
         protected set
-    var isBackendConfigured: Boolean by mutableStateOf(isDefaultBackendConfigured ||
-            loginNavArgs.loginPasswordPath?.customServerConfig?.api?.isNotBlank() == true
+    var isBackendConfigured: Boolean by mutableStateOf(
+        isDefaultBackendConfigured ||
+                loginNavArgs.loginPasswordPath?.customServerConfig?.api?.isNotBlank() == true
     )
         protected set
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -19,6 +19,9 @@
 package com.wire.android.ui.authentication.login
 
 import androidx.lifecycle.ViewModel
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.ClientScopeProvider
 import com.wire.kalium.common.error.CoreFailure
@@ -38,10 +41,16 @@ open class LoginViewModel(
     val userDataStoreProvider: UserDataStoreProvider,
     val coreLogic: CoreLogic,
     private val loginExtension: LoginViewModelExtension,
-    defaultServerConfig: ServerConfig.Links
+    defaultServerConfig: ServerConfig.Links,
+    isDefaultBackendConfigured: Boolean = true,
 ) : ViewModel() {
 
-    val serverConfig: ServerConfig.Links = loginNavArgs.loginPasswordPath?.customServerConfig ?: defaultServerConfig
+    var serverConfig: ServerConfig.Links by mutableStateOf(loginNavArgs.loginPasswordPath?.customServerConfig ?: defaultServerConfig)
+        protected set
+    var isBackendConfigured: Boolean by mutableStateOf(isDefaultBackendConfigured ||
+            loginNavArgs.loginPasswordPath?.customServerConfig?.api?.isNotBlank() == true
+    )
+        protected set
 
     suspend fun registerClient(
         userId: UserId,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailState.kt
@@ -23,5 +23,13 @@ data class LoginEmailState(
     val userIdentifierEnabled: Boolean = true,
     val loginEnabled: Boolean = false,
     val flowState: LoginState = LoginState.Default,
+    val backendConfigState: BackendConfigState = BackendConfigState.Missing,
     val showInvalidCredentialsError: Boolean = false,
-)
+) {
+    enum class BackendConfigState {
+        Missing,
+        Loading,
+        Error,
+        Success,
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -170,7 +170,7 @@ class LoginEmailViewModel @AssistedInject constructor(
                 is GetServerConfigResult.Success -> {
                     CustomTabsHelper.setBackendWebsiteUrl(result.serverConfigLinks.website)
                     globalDataStore?.let {
-                        BackendSupportConfig.storeFromConfigUrl(it.value, result.serverConfigLinks, configUrl)
+                        BackendSupportConfig.storeFromServerLinks(it.value, result.serverConfigLinks)
                     }
                     withContext(dispatchers.main()) {
                         serverConfig = result.serverConfigLinks

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -27,9 +27,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
 import com.wire.android.datastore.UserDataStoreProvider
+import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.ClientScopeProvider
 import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.ui.authentication.toBackendConfigUrl
 import com.wire.android.ui.authentication.login.LoginNavArgs
 import com.wire.android.ui.authentication.login.LoginSavedInputStore
 import com.wire.android.ui.authentication.login.LoginState
@@ -41,6 +43,8 @@ import com.wire.android.ui.authentication.login.toLoginError
 import com.wire.android.ui.authentication.verificationcode.VerificationCodeState
 import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.util.EMPTY
+import com.wire.android.util.BackendSupportConfig
+import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.CountdownTimer
 import com.wire.kalium.logic.CoreLogic
@@ -57,6 +61,8 @@ import com.wire.kalium.logic.feature.auth.PersistSelfUserEmailResult
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
 import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerificationCodeUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
+import com.wire.kalium.logic.feature.server.GetServerConfigResult
+import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
@@ -83,13 +89,17 @@ class LoginEmailViewModel @AssistedInject constructor(
     private val dispatchers: DispatcherProvider,
     defaultServerConfig: ServerConfig.Links,
     @DefaultWebSocketEnabledByDefault private val defaultWebSocketEnabledByDefault: Boolean,
+    isDefaultBackendConfigured: Boolean = true,
+    private val getServerConfigUseCase: Lazy<GetServerConfigUseCase>? = null,
+    private val globalDataStore: Lazy<GlobalDataStore>? = null,
 ) : LoginViewModel(
     loginNavArgs,
     clientScopeProviderFactory,
     userDataStoreProvider,
     coreLogic,
     LoginViewModelExtension(clientScopeProviderFactory, userDataStoreProvider),
-    defaultServerConfig
+    defaultServerConfig,
+    isDefaultBackendConfigured,
 ) {
     private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle ?: PreFilledUserIdentifierType.None
 
@@ -141,6 +151,48 @@ class LoginEmailViewModel @AssistedInject constructor(
                 }
             }
         }
+    }
+
+    fun onBackendConfigLinkEntered(input: String) {
+        viewModelScope.launch(dispatchers.io()) {
+            val configUrl = input.toBackendConfigUrl()
+            if (configUrl == null) {
+                withContext(dispatchers.main()) {
+                    updateBackendConfigState(LoginEmailState.BackendConfigState.Error)
+                }
+                return@launch
+            }
+
+            withContext(dispatchers.main()) {
+                updateBackendConfigState(LoginEmailState.BackendConfigState.Loading)
+            }
+            when (val result = getServerConfigUseCase?.value?.invoke(configUrl)) {
+                is GetServerConfigResult.Success -> {
+                    CustomTabsHelper.setBackendWebsiteUrl(result.serverConfigLinks.website)
+                    globalDataStore?.let {
+                        BackendSupportConfig.storeFromConfigUrl(it.value, result.serverConfigLinks, configUrl)
+                    }
+                    withContext(dispatchers.main()) {
+                        serverConfig = result.serverConfigLinks
+                        isBackendConfigured = true
+                        updateBackendConfigState(LoginEmailState.BackendConfigState.Success)
+                    }
+                }
+
+                is GetServerConfigResult.Failure.Generic,
+                null -> withContext(dispatchers.main()) {
+                    updateBackendConfigState(LoginEmailState.BackendConfigState.Error)
+                }
+            }
+        }
+    }
+
+    fun onBackendConfigSuccessContinue() {
+        updateBackendConfigState(LoginEmailState.BackendConfigState.Missing)
+    }
+
+    private fun updateBackendConfigState(state: LoginEmailState.BackendConfigState) {
+        loginState = loginState.copy(backendConfigState = state)
     }
 
     private fun updateEmailFlowState(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/WelcomeScreen.kt
@@ -74,8 +74,10 @@ import com.wire.android.config.LocalCustomUiConfigurationProvider
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.style.PopUpNavigationAnimation
+import com.wire.android.ui.authentication.MissingBackendConfigContent
 import com.wire.android.ui.authentication.create.common.CreateAccountDataNavArgs
 import com.wire.android.ui.authentication.create.common.ServerTitle
+import com.wire.android.ui.authentication.isConfigured
 import com.wire.android.ui.authentication.login.LoginPasswordPath
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
@@ -163,6 +165,19 @@ private fun WelcomeContent(
             NomadAccountBlocksLoginDialog(dialogState = nomadBlocksLoginDialogState) { navigateBack() }
             if (nomadAccountBlocksLogin) {
                 nomadBlocksLoginDialogState.show(nomadBlocksLoginDialogState.savedState ?: NomadAccountBlocksLoginDialogState)
+            }
+
+            if (!state.isConfigured()) {
+                MissingBackendConfigContent(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = MaterialTheme.wireDimensions.welcomeButtonHorizontalPadding)
+                        .weight(1f, true),
+                    showTitle = true,
+                    centerText = true,
+                    verticalArrangement = Arrangement.Center,
+                )
+                return@Column
             }
 
             Icon(

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/SettingsScreen.kt
@@ -187,7 +187,9 @@ fun SettingsScreenContent(
                     if (BuildConfig.DEBUG_SCREEN_ENABLED) {
                         add(SettingsItem.DebugSettings)
                     }
-                    add(SettingsItem.GiveFeedback)
+                    if (BuildConfig.FEEDBACK_MENU_ITEM_ENABLED) {
+                        add(SettingsItem.GiveFeedback)
+                    }
                     add(SettingsItem.ReportBug)
                     add(SettingsItem.AboutApp)
                 },

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/BackendSelectorDropDown.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/BackendSelectorDropDown.kt
@@ -51,7 +51,9 @@ import com.wire.android.ui.common.textfield.forceLowercase
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
-internal fun BackendSelectorDropDown() {
+internal fun BackendSelectorDropDown(
+    onNoBackendSelected: () -> Unit = {},
+) {
 
     val context = LocalContext.current
     var showCustomBackendDialog by remember { mutableStateOf(false) }
@@ -64,16 +66,15 @@ internal fun BackendSelectorDropDown() {
     ) {
         WireDropDown(
             modifier = Modifier.alpha(0.5f),
-            items = backendConfigs.map { it.first }.toImmutableList(),
+            items = backendConfigs.map { it.name }.toImmutableList(),
             label = null,
             autoUpdateSelection = false,
             placeholder = "Change application backend",
             onSelected = { index ->
-                val backend = backendConfigs[index].second
-                if (backend.isNotEmpty()) {
-                    openConfigUrl(context, backend)
-                } else {
-                    showCustomBackendDialog = true
+                when (val backend = backendConfigs[index]) {
+                    BackendConfig.Custom -> showCustomBackendDialog = true
+                    BackendConfig.NoBackend -> onNoBackendSelected()
+                    is BackendConfig.Predefined -> openConfigUrl(context, backend.configUrl)
                 }
             },
         )
@@ -146,16 +147,34 @@ private fun openConfigUrl(context: Context, configUrl: String) {
     )
 }
 
+private sealed interface BackendConfig {
+    val name: String
+
+    data class Predefined(
+        override val name: String,
+        val configUrl: String,
+    ) : BackendConfig
+
+    data object Custom : BackendConfig {
+        override val name: String = "Custom"
+    }
+
+    data object NoBackend : BackendConfig {
+        override val name: String = "No backend"
+    }
+}
+
 private val backendConfigs = listOf(
-    "Production" to "https://prod-nginz-https.wire.com/deeplink.json",
-    "Staging" to "https://staging-nginz-https.zinfra.io/deeplink.json",
-    "Anta" to "https://nginz-https.anta.wire.link/deeplink.json",
-    "Bella" to "https://nginz-https.bella.wire.link/deeplink.json",
-    "Chala" to "https://nginz-https.chala.wire.link/deeplink.json",
-    "Elna" to "https://nginz-https.elna.wire.link/deeplink.json",
-    "Foma" to "https://nginz-https.foma.wire.link/deeplink.json",
-    "Imai" to "https://nginz-https.imai.wire.link/deeplink.json",
-    "Fulu" to "https://nginz-https.fulu.wire.link/deeplink.json",
-    "Mira" to "https://nginz-https.mira.wire.link/deeplink.json",
-    "Custom" to "",
+    BackendConfig.Predefined("Production", "https://prod-nginz-https.wire.com/deeplink.json"),
+    BackendConfig.Predefined("Staging", "https://staging-nginz-https.zinfra.io/deeplink.json"),
+    BackendConfig.Predefined("Anta", "https://nginz-https.anta.wire.link/deeplink.json"),
+    BackendConfig.Predefined("Bella", "https://nginz-https.bella.wire.link/deeplink.json"),
+    BackendConfig.Predefined("Chala", "https://nginz-https.chala.wire.link/deeplink.json"),
+    BackendConfig.Predefined("Elna", "https://nginz-https.elna.wire.link/deeplink.json"),
+    BackendConfig.Predefined("Foma", "https://nginz-https.foma.wire.link/deeplink.json"),
+    BackendConfig.Predefined("Imai", "https://nginz-https.imai.wire.link/deeplink.json"),
+    BackendConfig.Predefined("Fulu", "https://nginz-https.fulu.wire.link/deeplink.json"),
+    BackendConfig.Predefined("Mira", "https://nginz-https.mira.wire.link/deeplink.json"),
+    BackendConfig.NoBackend,
+    BackendConfig.Custom,
 )

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginContainer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginContainer.kt
@@ -63,6 +63,8 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 fun NewAuthContainer(
     header: @Composable () -> Unit = {},
     contentPadding: Dp = dimensions().spacing24x,
+    showBackendSelector: Boolean = false,
+    onNoBackendSelected: () -> Unit = {},
     content: @Composable () -> Unit
 ) {
     val scrollState = rememberScrollState()
@@ -70,8 +72,8 @@ fun NewAuthContainer(
     WireScaffold(
         containerColor = Color.Transparent,
         topBar = {
-            if (BuildConfig.PRIVATE_BUILD) {
-                BackendSelectorDropDown()
+            if (BuildConfig.PRIVATE_BUILD && showBackendSelector) {
+                BackendSelectorDropDown(onNoBackendSelected = onNoBackendSelected)
             }
         },
         bottomBar = {

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginFlowState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginFlowState.kt
@@ -26,6 +26,10 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 sealed class NewLoginFlowState {
     data object Default : NewLoginFlowState()
     data object Loading : NewLoginFlowState()
+    data object MissingBackendConfig : NewLoginFlowState()
+    data object LoadingBackendConfig : NewLoginFlowState()
+    data object BackendConfigError : NewLoginFlowState()
+    data object BackendConfigSuccess : NewLoginFlowState()
     data class CustomConfigDialog(val serverLinks: ServerConfig.Links) : NewLoginFlowState()
     sealed class Error : NewLoginFlowState() {
         sealed class TextFieldError : Error() {

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
@@ -204,11 +204,11 @@ private fun LoginContent(
     loginEmailSSOState: NewLoginScreenState,
     userIdentifierState: TextFieldState,
     serverConfig: ServerConfig.Links,
+    canNavigateBack: Boolean,
     onNextClicked: () -> Unit,
     onBackendConfigLinkEntered: (String) -> Unit,
     onBackendConfigSuccessContinue: () -> Unit,
     onNoBackendSelected: () -> Unit = {},
-    canNavigateBack: Boolean,
     navigateBack: () -> Unit,
 ) {
     val isBackendConfigSetup = loginEmailSSOState.flowState == NewLoginFlowState.MissingBackendConfig ||

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
@@ -71,6 +71,8 @@ import com.wire.android.ui.authentication.login.PreFilledUserIdentifierType
 import com.wire.android.ui.authentication.login.WireAuthBackgroundLayout
 import com.wire.android.ui.authentication.login.toLoginDialogErrorData
 import com.ramcosta.composedestinations.spec.Direction
+import com.wire.android.ui.authentication.BackendConfigSuccessContent
+import com.wire.android.ui.authentication.MissingBackendConfigContent
 import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
@@ -176,6 +178,8 @@ fun NewLoginScreen(
         onNextClicked = {
             viewModel.onLoginStarted()
         },
+        onBackendConfigLinkEntered = viewModel::onBackendConfigLinkEntered,
+        onBackendConfigSuccessContinue = viewModel::onBackendConfigSuccessContinue,
         canNavigateBack = navigator.navController.previousBackStackEntry != null, // if there is a previous screen to navigate back to
         navigateBack = navigator::navigateBack,
     )
@@ -199,9 +203,16 @@ private fun LoginContent(
     userIdentifierState: TextFieldState,
     serverConfig: ServerConfig.Links,
     onNextClicked: () -> Unit,
+    onBackendConfigLinkEntered: (String) -> Unit,
+    onBackendConfigSuccessContinue: () -> Unit,
     canNavigateBack: Boolean,
     navigateBack: () -> Unit,
 ) {
+    val isBackendConfigSetup = loginEmailSSOState.flowState == NewLoginFlowState.MissingBackendConfig ||
+            loginEmailSSOState.flowState == NewLoginFlowState.LoadingBackendConfig ||
+            loginEmailSSOState.flowState == NewLoginFlowState.BackendConfigError
+    val isBackendConfigSuccess = loginEmailSSOState.flowState == NewLoginFlowState.BackendConfigSuccess
+    val showCredentialsSubtitle = !isBackendConfigSetup && !isBackendConfigSuccess
     NewAuthContainer(
         header = {
             NewAuthHeader(
@@ -212,11 +223,17 @@ private fun LoginContent(
                             style = typography().title01,
                             textColor = colorsScheme().onSurface,
                             titleResId = R.string.enterprise_login_on_prem_welcome_title,
-                            modifier = Modifier.padding(bottom = dimensions().spacing24x),
+                            modifier = if (showCredentialsSubtitle) {
+                                Modifier.padding(bottom = dimensions().spacing24x)
+                            } else {
+                                Modifier
+                            },
                         )
-                        NewAuthSubtitle(
-                            title = stringResource(id = R.string.enterprise_login_credentials_title),
-                        )
+                        if (showCredentialsSubtitle) {
+                            NewAuthSubtitle(
+                                title = stringResource(id = R.string.enterprise_login_credentials_title),
+                            )
+                        }
                     } else {
                         Icon(
                             imageVector = ImageVector.vectorResource(id = R.drawable.ic_wire_logo),
@@ -227,7 +244,11 @@ private fun LoginContent(
                                 .size(dimensions().spacing120x)
                         )
                         NewAuthSubtitle(
-                            title = stringResource(R.string.enterprise_login_welcome),
+                            title = when {
+                                isBackendConfigSetup -> stringResource(R.string.missing_backend_config_title)
+                                isBackendConfigSuccess -> ""
+                                else -> stringResource(R.string.enterprise_login_welcome)
+                            },
                             modifier = Modifier.padding(top = dimensions().spacing16x)
                         )
                     }
@@ -249,19 +270,33 @@ private fun LoginContent(
                         testTagsAsResourceId = true
                     }
             ) {
-                val error = when (loginEmailSSOState.flowState) {
-                    is NewLoginFlowState.Error.TextFieldError.InvalidValue ->
-                        stringResource(R.string.enterprise_login_error_invalid_user_identifier)
+                if (isBackendConfigSuccess) {
+                    BackendConfigSuccessContent(onContinue = onBackendConfigSuccessContinue)
+                } else if (isBackendConfigSetup) {
+                    MissingBackendConfigContent(
+                        errorText = if (loginEmailSSOState.flowState == NewLoginFlowState.BackendConfigError) {
+                            stringResource(R.string.missing_backend_config_error)
+                        } else {
+                            null
+                        },
+                        isLoading = loginEmailSSOState.flowState == NewLoginFlowState.LoadingBackendConfig,
+                        onConfigurationLinkEntered = onBackendConfigLinkEntered,
+                    )
+                } else {
+                    val error = when (loginEmailSSOState.flowState) {
+                        is NewLoginFlowState.Error.TextFieldError.InvalidValue ->
+                            stringResource(R.string.enterprise_login_error_invalid_user_identifier)
 
-                    else -> null
+                        else -> null
+                    }
+                    EmailOrSSOCodeInput(userIdentifierState, error)
+                    VerticalSpace.x8()
+                    LoginNextButton(
+                        loading = loginEmailSSOState.flowState is NewLoginFlowState.Loading,
+                        enabled = loginEmailSSOState.nextEnabled,
+                        onClick = onNextClicked,
+                    )
                 }
-                EmailOrSSOCodeInput(userIdentifierState, error)
-                VerticalSpace.x8()
-                LoginNextButton(
-                    loading = loginEmailSSOState.flowState is NewLoginFlowState.Loading,
-                    enabled = loginEmailSSOState.nextEnabled,
-                    onClick = onNextClicked,
-                )
             }
         }
     }
@@ -320,6 +355,8 @@ fun PreviewNewLoginScreen() = WireTheme {
                 userIdentifierState = TextFieldState(),
                 serverConfig = ServerConfig.DEFAULT.copy(isOnPremises = false),
                 onNextClicked = {},
+                onBackendConfigLinkEntered = {},
+                onBackendConfigSuccessContinue = {},
                 canNavigateBack = false,
                 navigateBack = {},
             )
@@ -337,6 +374,46 @@ fun PreviewNewLoginScreenCustomConfig() = WireTheme {
                 userIdentifierState = TextFieldState(),
                 serverConfig = ServerConfig.DEFAULT.copy(isOnPremises = true),
                 onNextClicked = {},
+                onBackendConfigLinkEntered = {},
+                onBackendConfigSuccessContinue = {},
+                canNavigateBack = false,
+                navigateBack = {},
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewNewLoginScreenMissingBackendConfig() = WireTheme {
+    EdgeToEdgePreview(useDarkIcons = false) {
+        WireAuthBackgroundLayout {
+            LoginContent(
+                loginEmailSSOState = NewLoginScreenState(flowState = NewLoginFlowState.MissingBackendConfig),
+                userIdentifierState = TextFieldState(),
+                serverConfig = ServerConfig.DEFAULT.copy(isOnPremises = false),
+                onNextClicked = {},
+                onBackendConfigLinkEntered = {},
+                onBackendConfigSuccessContinue = {},
+                canNavigateBack = false,
+                navigateBack = {},
+            )
+        }
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewNewLoginScreenBackendConfigSuccess() = WireTheme {
+    EdgeToEdgePreview(useDarkIcons = false) {
+        WireAuthBackgroundLayout {
+            LoginContent(
+                loginEmailSSOState = NewLoginScreenState(flowState = NewLoginFlowState.BackendConfigSuccess),
+                userIdentifierState = TextFieldState(),
+                serverConfig = ServerConfig.DEFAULT.copy(isOnPremises = false),
+                onNextClicked = {},
+                onBackendConfigLinkEntered = {},
+                onBackendConfigSuccessContinue = {},
                 canNavigateBack = false,
                 navigateBack = {},
             )

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginScreen.kt
@@ -180,6 +180,7 @@ fun NewLoginScreen(
         },
         onBackendConfigLinkEntered = viewModel::onBackendConfigLinkEntered,
         onBackendConfigSuccessContinue = viewModel::onBackendConfigSuccessContinue,
+        onNoBackendSelected = viewModel::onNoBackendSelected,
         canNavigateBack = navigator.navController.previousBackStackEntry != null, // if there is a previous screen to navigate back to
         navigateBack = navigator::navigateBack,
     )
@@ -197,6 +198,7 @@ private fun NewLoginAction.Success.NextStep.toDestination(): Direction = when (t
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
+@Suppress("CyclomaticComplexMethod")
 @Composable
 private fun LoginContent(
     loginEmailSSOState: NewLoginScreenState,
@@ -205,6 +207,7 @@ private fun LoginContent(
     onNextClicked: () -> Unit,
     onBackendConfigLinkEntered: (String) -> Unit,
     onBackendConfigSuccessContinue: () -> Unit,
+    onNoBackendSelected: () -> Unit = {},
     canNavigateBack: Boolean,
     navigateBack: () -> Unit,
 ) {
@@ -214,6 +217,8 @@ private fun LoginContent(
     val isBackendConfigSuccess = loginEmailSSOState.flowState == NewLoginFlowState.BackendConfigSuccess
     val showCredentialsSubtitle = !isBackendConfigSetup && !isBackendConfigSuccess
     NewAuthContainer(
+        showBackendSelector = true,
+        onNoBackendSelected = onNoBackendSelected,
         header = {
             NewAuthHeader(
                 title = {

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.appLogger
+import com.wire.android.config.ServerConfigProvider
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.ClientScopeProvider
@@ -132,10 +133,18 @@ class NewLoginViewModel(
     private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle ?: PreFilledUserIdentifierType.None
     private var pendingNomadServiceUrl: String? = loginNavArgs.ssoCodeAutoLogin?.nomadServiceUrl
     private var pendingCookieLabel: String? = loginNavArgs.ssoCodeAutoLogin?.cookieLabel
-    private val isCustomServerDeepLink = loginNavArgs.loginPasswordPath?.customServerConfig != null
-    private val shouldShowBackendConfigSuccess = loginNavArgs.showBackendConfigSuccess && isCustomServerDeepLink
-    private var canUseBackend by mutableStateOf(isCustomServerDeepLink || isDefaultBackendConfigured)
-    var serverConfig: ServerConfig.Links by mutableStateOf(loginNavArgs.loginPasswordPath?.customServerConfig ?: defaultServerConfig)
+    private val customServerConfig = loginNavArgs.loginPasswordPath?.customServerConfig
+    private val isCustomServerConfigured = customServerConfig?.api?.isNotBlank() == true
+    private val isDefaultServerConfigured = isDefaultBackendConfigured && defaultServerConfig.api.isNotBlank()
+    private val shouldShowBackendConfigSuccess = loginNavArgs.showBackendConfigSuccess && isCustomServerConfigured
+    private var canUseBackend by mutableStateOf(
+        if (customServerConfig != null) {
+            isCustomServerConfigured
+        } else {
+            isDefaultServerConfigured
+        }
+    )
+    var serverConfig: ServerConfig.Links by mutableStateOf(customServerConfig ?: defaultServerConfig)
         private set
 
     var state by mutableStateOf(NewLoginScreenState())
@@ -146,7 +155,7 @@ class NewLoginViewModel(
         userIdentifierTextState.setTextAndPlaceCursorAtEnd(
             if (preFilledUserIdentifier is PreFilledUserIdentifierType.PreFilled) {
                 preFilledUserIdentifier.userIdentifier
-            } else if (defaultSSOCodeConfig.isNotEmpty() && !isCustomServerDeepLink) {
+            } else if (defaultSSOCodeConfig.isNotEmpty() && customServerConfig == null) {
                 defaultSSOCodeConfig.ssoCodeWithPrefix()
             } else {
                 savedStateHandle[USER_IDENTIFIER_SAVED_STATE_KEY] ?: String.EMPTY
@@ -187,6 +196,13 @@ class NewLoginViewModel(
         if (userIdentifierTextState.text.isEmpty() && preFilledUserIdentifier is PreFilledUserIdentifierType.None) {
             fetchDefaultSSOCodeIfNeeded()
         }
+    }
+
+    fun onNoBackendSelected() {
+        serverConfig = ServerConfigProvider.EmptyServerConfig
+        canUseBackend = false
+        CustomTabsHelper.setBackendWebsiteUrl(null)
+        updateLoginFlowState(NewLoginFlowState.MissingBackendConfig)
     }
 
     fun onBackendConfigLinkEntered(input: String) {

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.appLogger
+import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.ClientScopeProvider
 import com.wire.android.di.DefaultWebSocketEnabledByDefault
@@ -42,8 +43,11 @@ import com.wire.android.ui.authentication.login.email.LoginEmailViewModel.Compan
 import com.wire.android.ui.authentication.login.sso.LoginSSOViewModelExtension
 import com.wire.android.ui.authentication.login.sso.SSOUrlConfig
 import com.wire.android.ui.authentication.login.sso.ssoCodeWithPrefix
+import com.wire.android.ui.authentication.toBackendConfigUrl
 import com.wire.android.ui.common.ActionsViewModel
 import com.wire.android.ui.common.textfield.textAsFlow
+import com.wire.android.util.BackendSupportConfig
+import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.EMPTY
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.dispatchers.DispatcherProvider
@@ -61,6 +65,8 @@ import com.wire.kalium.logic.feature.auth.sso.SSOInitiateLoginResult
 import com.wire.kalium.logic.feature.auth.sso.SSOLoginSessionResult
 import com.wire.kalium.logic.feature.backup.RestoreCryptoStateResult
 import com.wire.kalium.logic.feature.client.RegisterClientResult
+import com.wire.kalium.logic.feature.server.GetServerConfigResult
+import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.collectLatest
@@ -86,6 +92,9 @@ class NewLoginViewModel(
     private val dispatchers: DispatcherProvider,
     defaultServerConfig: ServerConfig.Links,
     defaultSSOCodeConfig: String,
+    private val isDefaultBackendConfigured: Boolean,
+    private val getServerConfigUseCase: Lazy<GetServerConfigUseCase>? = null,
+    private val globalDataStore: Lazy<GlobalDataStore>? = null,
 ) : ActionsViewModel<NewLoginAction>() {
 
     @Inject
@@ -98,7 +107,10 @@ class NewLoginViewModel(
         userDataStoreProvider: UserDataStoreProvider,
         dispatchers: DispatcherProvider,
         defaultServerConfig: ServerConfig.Links,
+        getServerConfigUseCase: Lazy<GetServerConfigUseCase>,
+        globalDataStore: Lazy<GlobalDataStore>,
         @Named("ssoCodeConfig") defaultSSOCodeConfig: String,
+        @Named("isDefaultBackendConfigured") isDefaultBackendConfigured: Boolean,
         @DefaultWebSocketEnabledByDefault defaultWebSocketEnabledByDefault: Boolean,
     ) : this(
         validateEmailOrSSOCode,
@@ -110,13 +122,19 @@ class NewLoginViewModel(
         LoginSSOViewModelExtension(addAuthenticatedUser, coreLogic, defaultWebSocketEnabledByDefault),
         dispatchers,
         defaultServerConfig,
-        defaultSSOCodeConfig
+        defaultSSOCodeConfig,
+        isDefaultBackendConfigured,
+        getServerConfigUseCase,
+        globalDataStore,
     )
 
     private val loginNavArgs: LoginNavArgs = savedStateHandle.navArgs()
     private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle ?: PreFilledUserIdentifierType.None
     private var pendingNomadServiceUrl: String? = loginNavArgs.ssoCodeAutoLogin?.nomadServiceUrl
     private var pendingCookieLabel: String? = loginNavArgs.ssoCodeAutoLogin?.cookieLabel
+    private val isCustomServerDeepLink = loginNavArgs.loginPasswordPath?.customServerConfig != null
+    private val shouldShowBackendConfigSuccess = loginNavArgs.showBackendConfigSuccess && isCustomServerDeepLink
+    private var canUseBackend by mutableStateOf(isCustomServerDeepLink || isDefaultBackendConfigured)
     var serverConfig: ServerConfig.Links by mutableStateOf(loginNavArgs.loginPasswordPath?.customServerConfig ?: defaultServerConfig)
         private set
 
@@ -125,7 +143,6 @@ class NewLoginViewModel(
     val userIdentifierTextState: TextFieldState = TextFieldState()
 
     init {
-        val isCustomServerDeepLink = loginNavArgs.loginPasswordPath?.customServerConfig != null
         userIdentifierTextState.setTextAndPlaceCursorAtEnd(
             if (preFilledUserIdentifier is PreFilledUserIdentifierType.PreFilled) {
                 preFilledUserIdentifier.userIdentifier
@@ -140,35 +157,67 @@ class NewLoginViewModel(
                 savedStateHandle[USER_IDENTIFIER_SAVED_STATE_KEY] = it.toString()
             }.collectLatest {
                 getAndUpdateLoginFlowState { currentState: NewLoginFlowState ->
-                    if (currentState is NewLoginFlowState.Error.TextFieldError) NewLoginFlowState.Default else currentState
+                    if (!canUseBackend) {
+                        when (currentState) {
+                            NewLoginFlowState.LoadingBackendConfig,
+                            NewLoginFlowState.BackendConfigError,
+                            NewLoginFlowState.BackendConfigSuccess -> currentState
+                            else -> NewLoginFlowState.MissingBackendConfig
+                        }
+                    } else if (currentState is NewLoginFlowState.Error.TextFieldError) {
+                        NewLoginFlowState.Default
+                    } else {
+                        currentState
+                    }
                 }
             }
         }
 
-        // Fetch default SSO code for the server configuration
+        if (!canUseBackend) {
+            updateLoginFlowState(NewLoginFlowState.MissingBackendConfig)
+        } else if (shouldShowBackendConfigSuccess) {
+            updateLoginFlowState(NewLoginFlowState.BackendConfigSuccess)
+        } else if (userIdentifierTextState.text.isEmpty() && preFilledUserIdentifier is PreFilledUserIdentifierType.None) {
+            fetchDefaultSSOCodeIfNeeded(savedStateHandle)
+        }
+    }
+
+    fun onBackendConfigSuccessContinue() {
+        updateLoginFlowState(NewLoginFlowState.Default)
         if (userIdentifierTextState.text.isEmpty() && preFilledUserIdentifier is PreFilledUserIdentifierType.None) {
-            viewModelScope.launch(dispatchers.io()) {
-                appLogger.d("$TAG Fetching default SSO code for server")
-                ssoExtension.fetchDefaultSSOCode(
-                    serverConfig = serverConfig,
-                    onAuthScopeFailure = { error ->
-                        appLogger.e("$TAG Failed to create auth scope for SSO settings: $error")
-                    },
-                    onFetchSSOSettingsFailure = { error ->
-                        appLogger.e("$TAG Failed to fetch SSO settings: $error")
-                    },
-                    onSuccess = { defaultSSOCode ->
-                        if (defaultSSOCode != null && userIdentifierTextState.text.isEmpty()) {
-                            appLogger.d("$TAG Successfully fetched default SSO code")
-                            withContext(dispatchers.main()) {
-                                userIdentifierTextState.setTextAndPlaceCursorAtEnd(defaultSSOCode)
-                                savedStateHandle[USER_IDENTIFIER_SAVED_STATE_KEY] = defaultSSOCode
-                            }
-                        } else {
-                            appLogger.d("$TAG No default SSO code configured for this server")
-                        }
+            fetchDefaultSSOCodeIfNeeded()
+        }
+    }
+
+    fun onBackendConfigLinkEntered(input: String) {
+        viewModelScope.launch(dispatchers.io()) {
+            val configUrl = input.toBackendConfigUrl()
+            if (configUrl == null) {
+                updateLoginFlowState(NewLoginFlowState.BackendConfigError)
+                return@launch
+            }
+
+            updateLoginFlowState(NewLoginFlowState.LoadingBackendConfig)
+            when (val result = getServerConfigUseCase?.value?.invoke(configUrl)) {
+                is GetServerConfigResult.Success -> {
+                    CustomTabsHelper.setBackendWebsiteUrl(result.serverConfigLinks.website)
+                    globalDataStore?.let {
+                        BackendSupportConfig.storeFromConfigUrl(it.value, result.serverConfigLinks, configUrl)
                     }
-                )
+                    withContext(dispatchers.main()) {
+                        serverConfig = result.serverConfigLinks
+                        canUseBackend = true
+                    }
+                    updateLoginFlowState(NewLoginFlowState.BackendConfigSuccess)
+                }
+
+                is GetServerConfigResult.Failure.Generic,
+                null -> {
+                    if (result is GetServerConfigResult.Failure.Generic) {
+                        appLogger.e("$TAG Failed to load backend config from setup screen: ${result.genericFailure}")
+                    }
+                    updateLoginFlowState(NewLoginFlowState.BackendConfigError)
+                }
             }
         }
     }
@@ -178,6 +227,10 @@ class NewLoginViewModel(
      */
     fun onLoginStarted() {
         viewModelScope.launch(dispatchers.io()) {
+            if (!canUseBackend) {
+                updateLoginFlowState(NewLoginFlowState.MissingBackendConfig)
+                return@launch
+            }
             updateLoginFlowState(NewLoginFlowState.Loading)
             val sanitizedInput = userIdentifierTextState.text.trim().toString()
             when (validateEmailOrSSOCode(sanitizedInput)) {
@@ -474,8 +527,39 @@ class NewLoginViewModel(
         val currentUserLoginInput = userIdentifierTextState.text
         state = state.copy(
             flowState = newState,
-            nextEnabled = newState !is NewLoginFlowState.Loading && currentUserLoginInput.isNotEmpty()
+            nextEnabled = newState !is NewLoginFlowState.Loading &&
+                    newState !is NewLoginFlowState.MissingBackendConfig &&
+                    newState !is NewLoginFlowState.LoadingBackendConfig &&
+                    newState !is NewLoginFlowState.BackendConfigError &&
+                    newState !is NewLoginFlowState.BackendConfigSuccess &&
+                    currentUserLoginInput.isNotEmpty()
         )
+    }
+
+    private fun fetchDefaultSSOCodeIfNeeded(savedStateHandle: SavedStateHandle? = null) {
+        viewModelScope.launch(dispatchers.io()) {
+            appLogger.d("$TAG Fetching default SSO code for server")
+            ssoExtension.fetchDefaultSSOCode(
+                serverConfig = serverConfig,
+                onAuthScopeFailure = { error ->
+                    appLogger.e("$TAG Failed to create auth scope for SSO settings: $error")
+                },
+                onFetchSSOSettingsFailure = { error ->
+                    appLogger.e("$TAG Failed to fetch SSO settings: $error")
+                },
+                onSuccess = { defaultSSOCode ->
+                    if (defaultSSOCode != null && userIdentifierTextState.text.isEmpty()) {
+                        appLogger.d("$TAG Successfully fetched default SSO code")
+                        withContext(dispatchers.main()) {
+                            userIdentifierTextState.setTextAndPlaceCursorAtEnd(defaultSSOCode)
+                            savedStateHandle?.set(USER_IDENTIFIER_SAVED_STATE_KEY, defaultSSOCode)
+                        }
+                    } else {
+                        appLogger.d("$TAG No default SSO code configured for this server")
+                    }
+                }
+            )
+        }
     }
 
     private fun consumePendingNomadServiceUrl(): String? = pendingNomadServiceUrl.also {

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -218,7 +218,7 @@ class NewLoginViewModel(
                 is GetServerConfigResult.Success -> {
                     CustomTabsHelper.setBackendWebsiteUrl(result.serverConfigLinks.website)
                     globalDataStore?.let {
-                        BackendSupportConfig.storeFromConfigUrl(it.value, result.serverConfigLinks, configUrl)
+                        BackendSupportConfig.storeFromServerLinks(it.value, result.serverConfigLinks)
                     }
                     withContext(dispatchers.main()) {
                         serverConfig = result.serverConfigLinks

--- a/app/src/main/kotlin/com/wire/android/util/BackendSupportConfig.kt
+++ b/app/src/main/kotlin/com/wire/android/util/BackendSupportConfig.kt
@@ -57,6 +57,7 @@ object BackendSupportConfig {
         )
     }
 
+    @Suppress("ReturnCount")
     suspend fun resolveEmail(context: Context, staticSupportEmail: String): String? {
         val staticEmail = staticSupportEmail.trim()
         if (staticEmail.isNotBlank()) return staticEmail

--- a/app/src/main/kotlin/com/wire/android/util/BackendSupportConfig.kt
+++ b/app/src/main/kotlin/com/wire/android/util/BackendSupportConfig.kt
@@ -1,0 +1,99 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import com.wire.android.appLogger
+import com.wire.android.datastore.GlobalDataStore
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.net.HttpURLConnection
+import java.net.URL
+
+object BackendSupportConfig {
+
+    private const val CONNECT_TIMEOUT_MILLIS = 5_000
+    private const val READ_TIMEOUT_MILLIS = 5_000
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Volatile
+    private var currentBackendApiUrl: String? = null
+
+    fun setCurrentBackend(serverLinks: ServerConfig.Links) {
+        currentBackendApiUrl = serverLinks.api.takeIf { it.isNotBlank() }
+    }
+
+    suspend fun storeFromConfigUrl(
+        globalDataStore: GlobalDataStore,
+        serverLinks: ServerConfig.Links,
+        configUrl: String
+    ) {
+        setCurrentBackend(serverLinks)
+        globalDataStore.setBackendSupportEmail(
+            backendApiUrl = serverLinks.api,
+            supportEmail = fetchSupportEmail(configUrl)
+        )
+    }
+
+    suspend fun resolveEmail(context: Context, staticSupportEmail: String): String? {
+        val staticEmail = staticSupportEmail.trim()
+        if (staticEmail.isNotBlank()) return staticEmail
+
+        val backendApiUrl = currentBackendApiUrl ?: return null
+        return GlobalDataStore(context.applicationContext).getBackendSupportEmail(backendApiUrl)
+    }
+
+    fun supportPageIntent(): Intent? =
+        CustomTabsHelper.resolveUrl("")?.let {
+            Intent(Intent.ACTION_VIEW, Uri.parse(it))
+        }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun fetchSupportEmail(configUrl: String): String? = withContext(Dispatchers.IO) {
+        try {
+            val connection = URL(configUrl).openConnection() as HttpURLConnection
+            connection.connectTimeout = CONNECT_TIMEOUT_MILLIS
+            connection.readTimeout = READ_TIMEOUT_MILLIS
+            try {
+                connection.inputStream.bufferedReader().use { reader ->
+                    json.decodeFromString(SupportConfig.serializer(), reader.readText()).supportEmail
+                        ?.trim()
+                        ?.takeIf { it.isNotBlank() }
+                }
+            } finally {
+                connection.disconnect()
+            }
+        } catch (exception: Exception) {
+            appLogger.w("Failed to read backend support email from config", exception)
+            null
+        }
+    }
+
+    @Serializable
+    private data class SupportConfig(
+        @SerialName("supportEmail")
+        val supportEmail: String? = null
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/util/BackendSupportConfig.kt
+++ b/app/src/main/kotlin/com/wire/android/util/BackendSupportConfig.kt
@@ -20,23 +20,10 @@ package com.wire.android.util
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.kalium.logic.configuration.server.ServerConfig
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
-import java.net.HttpURLConnection
-import java.net.URL
 
 object BackendSupportConfig {
-
-    private const val CONNECT_TIMEOUT_MILLIS = 5_000
-    private const val READ_TIMEOUT_MILLIS = 5_000
-
-    private val json = Json { ignoreUnknownKeys = true }
 
     @Volatile
     private var currentBackendApiUrl: String? = null
@@ -45,15 +32,14 @@ object BackendSupportConfig {
         currentBackendApiUrl = serverLinks.api.takeIf { it.isNotBlank() }
     }
 
-    suspend fun storeFromConfigUrl(
+    suspend fun storeFromServerLinks(
         globalDataStore: GlobalDataStore,
-        serverLinks: ServerConfig.Links,
-        configUrl: String
+        serverLinks: ServerConfig.Links
     ) {
         setCurrentBackend(serverLinks)
         globalDataStore.setBackendSupportEmail(
             backendApiUrl = serverLinks.api,
-            supportEmail = fetchSupportEmail(configUrl)
+            supportEmail = serverLinks.supportEmail
         )
     }
 
@@ -70,31 +56,4 @@ object BackendSupportConfig {
         CustomTabsHelper.resolveUrl("")?.let {
             Intent(Intent.ACTION_VIEW, Uri.parse(it))
         }
-
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun fetchSupportEmail(configUrl: String): String? = withContext(Dispatchers.IO) {
-        try {
-            val connection = URL(configUrl).openConnection() as HttpURLConnection
-            connection.connectTimeout = CONNECT_TIMEOUT_MILLIS
-            connection.readTimeout = READ_TIMEOUT_MILLIS
-            try {
-                connection.inputStream.bufferedReader().use { reader ->
-                    json.decodeFromString(SupportConfig.serializer(), reader.readText()).supportEmail
-                        ?.trim()
-                        ?.takeIf { it.isNotBlank() }
-                }
-            } finally {
-                connection.disconnect()
-            }
-        } catch (exception: Exception) {
-            appLogger.w("Failed to read backend support email from config", exception)
-            null
-        }
-    }
-
-    @Serializable
-    private data class SupportConfig(
-        @SerialName("supportEmail")
-        val supportEmail: String? = null
-    )
 }

--- a/app/src/main/kotlin/com/wire/android/util/logging/LogSharing.kt
+++ b/app/src/main/kotlin/com/wire/android/util/logging/LogSharing.kt
@@ -24,6 +24,7 @@ import android.net.Uri
 import androidx.core.content.FileProvider
 import com.wire.android.R
 import com.wire.android.appLogger
+import com.wire.android.util.BackendSupportConfig
 import com.wire.android.util.EmailComposer
 import com.wire.android.util.getDeviceIdString
 import com.wire.android.util.getGitBuildId
@@ -82,7 +83,7 @@ class LogShareLauncher(
     private fun share(
         logsDirectory: File,
         flushLogs: suspend () -> Unit,
-        intent: (File) -> Intent
+        intent: suspend (File) -> Intent
     ) {
         coroutineScope.launch {
             runCatching {
@@ -124,9 +125,20 @@ fun Context.logsSharingIntent(archiveFile: File): Intent {
     }
 }
 
-fun Context.bugReportLogsSharingIntent(archiveFile: File): Intent {
+@Suppress("ReturnCount")
+suspend fun Context.bugReportLogsSharingIntent(archiveFile: File): Intent {
+    val supportEmail = BackendSupportConfig.resolveEmail(this, getString(R.string.send_bug_report_email))
+    if (supportEmail == null) {
+        BackendSupportConfig.supportPageIntent()?.let { return it }
+        getString(R.string.url_support).takeIf { it.isNotBlank() }?.let {
+            return Intent(Intent.ACTION_VIEW, Uri.parse(it))
+        }
+    }
+
     val intent = logsSharingIntent(archiveFile).apply {
-        putExtra(Intent.EXTRA_EMAIL, arrayOf(getString(R.string.send_bug_report_email)))
+        supportEmail?.let {
+            putExtra(Intent.EXTRA_EMAIL, arrayOf(it))
+        }
         putExtra(Intent.EXTRA_SUBJECT, getString(R.string.send_bug_report_subject))
         putExtra(
             Intent.EXTRA_TEXT,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -238,6 +238,7 @@
     <string name="content_description_login_user_identifier_field">Geben Sie Ihre E-Mail-Adresse oder Ihren Benutzernamen ein</string>
     <string name="content_description_login_email_field">Geben Sie Ihre E-Mail-Adresse ein</string>
     <string name="content_description_enterprise_login_email_field">Geben Sie Ihre E-Mail-Adresse oder Ihren SSO-Code ein</string>
+    <string name="content_description_backend_config_camera_button">QR-Code scannen</string>
     <string name="content_description_login_password_field">Geben Sie Ihr Passwort ein</string>
     <string name="content_description_login_sso_code_field">Geben Sie Ihren SSO-Code oder Wire E-Mail-Adresse ein</string>
     <string name="content_description_whats_new_welcome_item">Willkommen bei der Android-App, Link zur Support-Seite</string>
@@ -334,6 +335,14 @@
     <string name="enterprise_login_verification_code_title">Posteingang prüfen</string>
     <!-- Login -->
     <string name="login_title">Anmelden</string>
+    <string name="missing_backend_config_title">Richten Sie Ihre App ein</string>
+    <string name="missing_backend_config_description">Geben Sie den von Ihrer Verwaltung bereitgestellten Link ein oder scannen Sie den QR-Code.</string>
+    <string name="missing_backend_config_input_label">Konfigurationslink</string>
+    <string name="missing_backend_config_input_placeholder">Link eingeben oder QR-Code scannen</string>
+    <string name="missing_backend_config_button_setup">Einrichten</string>
+    <string name="missing_backend_config_error">Es ist ein Fehler aufgetreten. Überprüfen Sie den Link sowie Ihre Internetverbindung und versuchen Sie es dann erneut.</string>
+    <string name="backend_config_success_title">Ihre App ist eingerichtet</string>
+    <string name="backend_config_success_description">Im nächsten Schritt können Sie sich anmelden</string>
     <string name="login_forgot_password">Passwort vergessen?</string>
     <string name="login_user_identifier_placeholder">max@example.com oder max.müller</string>
     <string name="login_email_placeholder">max@beispiel.com</string>
@@ -1267,7 +1276,7 @@ Bei Gruppenunterhaltungen kann der Gruppen-Admin diese Einstellung überschreibe
     <string name="custom_backend_dialog_body_backend_website">Website-URL:</string>
     <string name="custom_backend_dialog_body_backend_websocket">Backend-WSURL:</string>
     <string name="custom_backend_error_title">Ein Fehler ist aufgetreten</string>
-    <string name="custom_backend_error_no_internet_connection_body">Die Weiterleitung zu einem lokalen Backend war nicht möglich. Sie scheinen nicht mit dem Internet verbunden zu sein.\n\nStellen Sie eine Internetverbindung her und versuchen Sie es erneut.</string>
+    <string name="custom_backend_error_no_internet_connection_body">Es ist ein Fehler aufgetreten. Überprüfen Sie den Link sowie Ihre Internetverbindung und versuchen Sie es dann erneut.</string>
     <string name="custom_backend_error_no_internet_connection_try_again">Erneut versuchen</string>
     <string name="label_fetching_your_messages">Empfang von neuen Nachrichten</string>
     <string name="label_text_copied">Text in Zwischenablage kopiert</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,6 +253,7 @@
     <string name="content_description_login_user_identifier_field">enter your email or username</string>
     <string name="content_description_login_email_field">enter your email</string>
     <string name="content_description_enterprise_login_email_field">enter your email or sso code</string>
+    <string name="content_description_backend_config_camera_button">Open camera to scan backend configuration QR code</string>
     <string name="content_description_login_password_field">enter your password</string>
     <string name="content_description_login_sso_code_field">enter your SSO code or Wire email</string>
     <string name="content_description_whats_new_welcome_item">Welcome to Wire\'s New Android App, link to support page</string>
@@ -1885,6 +1886,15 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="restriction_keep_websocket_title">Keep WebSocket Connection</string>
     <string name="restriction_keep_websocket_description">Force persistent WebSocket connection for all users</string>
     <string name="settings_keep_websocket_enforced_by_organization">This setting is managed by your organization.</string>
+    <string name="enterprise_login_error_missing_backend_config">Backend configuration is required. Open a configuration link or contact your administrator.</string>
+    <string name="missing_backend_config_title">Set up your app</string>
+    <string name="missing_backend_config_description">To get started, enter the link or scan the QR code provided by your administration.</string>
+    <string name="missing_backend_config_input_label">CONFIGURATION LINK</string>
+    <string name="missing_backend_config_input_placeholder"></string>
+    <string name="missing_backend_config_button_setup">Set Up</string>
+    <string name="missing_backend_config_error">Something went wrong. Check the link and your connection and try again.</string>
+    <string name="backend_config_success_title">Configuration successful</string>
+    <string name="backend_config_success_description">You can now log in</string>
 
     <!--    channel not available dialog-->
     <string name="channel_not_available_dialog_title">Channels are available for team members.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,7 +253,7 @@
     <string name="content_description_login_user_identifier_field">enter your email or username</string>
     <string name="content_description_login_email_field">enter your email</string>
     <string name="content_description_enterprise_login_email_field">enter your email or sso code</string>
-    <string name="content_description_backend_config_camera_button">Open camera to scan backend configuration QR code</string>
+    <string name="content_description_backend_config_camera_button">Scan QR code</string>
     <string name="content_description_login_password_field">enter your password</string>
     <string name="content_description_login_sso_code_field">enter your SSO code or Wire email</string>
     <string name="content_description_whats_new_welcome_item">Welcome to Wire\'s New Android App, link to support page</string>
@@ -1336,7 +1336,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="custom_backend_dialog_body_backend_website">Website URL:</string>
     <string name="custom_backend_dialog_body_backend_websocket">Backend WSURL:</string>
     <string name="custom_backend_error_title">An error occurred</string>
-    <string name="custom_backend_error_no_internet_connection_body">Redirecting to an on-premises backend was not possible, you don’t seem to be connected to the internet.\n\nEstablish an internet connection and try again.</string>
+    <string name="custom_backend_error_no_internet_connection_body">Something went wrong. Check the link and your connection, then try again.</string>
     <string name="custom_backend_error_no_internet_connection_try_again">Try again</string>
     <string name="label_fetching_your_messages">Receiving new messages</string>
     <string name="label_text_copied">Text copied to clipboard</string>
@@ -1889,12 +1889,12 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="enterprise_login_error_missing_backend_config">Backend configuration is required. Open a configuration link or contact your administrator.</string>
     <string name="missing_backend_config_title">Set up your app</string>
     <string name="missing_backend_config_description">To get started, enter the link or scan the QR code provided by your administration.</string>
-    <string name="missing_backend_config_input_label">CONFIGURATION LINK</string>
-    <string name="missing_backend_config_input_placeholder"></string>
+    <string name="missing_backend_config_input_label">Configuration link</string>
+    <string name="missing_backend_config_input_placeholder">Enter link or scan QR code</string>
     <string name="missing_backend_config_button_setup">Set Up</string>
-    <string name="missing_backend_config_error">Something went wrong. Check the link and your connection and try again.</string>
-    <string name="backend_config_success_title">Configuration successful</string>
-    <string name="backend_config_success_description">You can now log in</string>
+    <string name="missing_backend_config_error">Something went wrong. Check the link and your connection, then try again.</string>
+    <string name="backend_config_success_title">Your app is set up</string>
+    <string name="backend_config_success_description">In the next step, you can log in</string>
 
     <!--    channel not available dialog-->
     <string name="channel_not_available_dialog_title">Channels are available for team members.</string>

--- a/app/src/test/kotlin/com/wire/android/emm/ManagedConfigurationsManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/emm/ManagedConfigurationsManagerTest.kt
@@ -53,9 +53,10 @@ class ManagedConfigurationsManagerTest {
                     teamsURL = "https://teams.anta.wire.link",
                     websiteURL = "https://wire.com"
                 ),
-                title = "anta.wire.link"
+                title = "anta.wire.link",
+                supportEmail = "support@anta.wire.link"
             )
-            val (_, manager) = Arrangement()
+            val (arrangement, manager) = Arrangement()
                 .withRestrictions(mapOf(ManagedConfigurationsKeys.DEFAULT_SERVER_URLS.asKey() to validServerConfigJson))
                 .arrange()
 
@@ -70,6 +71,8 @@ class ManagedConfigurationsManagerTest {
             assertEquals(expected.endpoints.blackListURL, serverConfig.blackList)
             assertEquals(expected.endpoints.teamsURL, serverConfig.teams)
             assertEquals(expected.endpoints.websiteURL, serverConfig.website)
+            assertEquals(expected.supportEmail, serverConfig.supportEmail)
+            assertEquals(expected.supportEmail, arrangement.getStoredSupportEmail(serverConfig.api))
         }
 
     @Test
@@ -197,6 +200,7 @@ class ManagedConfigurationsManagerTest {
             val serverConfig = requireNotNull(manager.currentServerConfig)
             assertEquals("Secure Server", serverConfig.title)
             assertEquals("https://secure-account.wire.link", serverConfig.accounts)
+            assertEquals("secure-support@example.com", serverConfig.supportEmail)
         }
 
     @Test
@@ -327,6 +331,9 @@ class ManagedConfigurationsManagerTest {
                 configParser = configParser
             )
         }
+
+        suspend fun getStoredSupportEmail(backendApiUrl: String): String? =
+            GlobalDataStore(context).getBackendSupportEmail(backendApiUrl)
     }
 
     companion object {
@@ -340,7 +347,8 @@ class ManagedConfigurationsManagerTest {
                 "teamsURL": "https://teams.anta.wire.link",
                 "websiteURL": "https://wire.com"
               },
-              "title": "anta.wire.link"
+              "title": "anta.wire.link",
+              "supportEmail": "support@anta.wire.link"
             }
         """.trimIndent()
 
@@ -374,6 +382,7 @@ class ManagedConfigurationsManagerTest {
             {
               "0": {
                 "title": "Secure Server",
+                "supportEmail": "secure-support@example.com",
                 "endpoints": {
                   "accountsURL": "https://secure-account.wire.link",
                   "backendURL": "https://secure-api.wire.link",
@@ -385,6 +394,7 @@ class ManagedConfigurationsManagerTest {
               },
               "default": {
                 "title": "General Server",
+                "supportEmail": "general-support@example.com",
                 "endpoints": {
                   "accountsURL": "https://general-account.wire.link",
                   "backendURL": "https://general-api.wire.link",

--- a/app/src/test/kotlin/com/wire/android/emm/ManagedConfigurationsManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/emm/ManagedConfigurationsManagerTest.kt
@@ -62,7 +62,7 @@ class ManagedConfigurationsManagerTest {
             val result = manager.refreshServerConfig()
             assertInstanceOf<ServerConfigResult.Success>(result)
 
-            val serverConfig = manager.currentServerConfig
+            val serverConfig = requireNotNull(manager.currentServerConfig)
             assertEquals(expected.title, serverConfig.title)
             assertEquals(expected.endpoints.accountsURL, serverConfig.accounts)
             assertEquals(expected.endpoints.backendURL, serverConfig.api)
@@ -80,7 +80,7 @@ class ManagedConfigurationsManagerTest {
 
         val result = manager.refreshServerConfig()
         assertInstanceOf<ServerConfigResult.Failure>(result)
-        val serverConfig = manager.currentServerConfig
+        val serverConfig = requireNotNull(manager.currentServerConfig)
         assertEquals(ServerConfigProvider().getDefaultServerConfig(), serverConfig)
     }
 
@@ -92,7 +92,7 @@ class ManagedConfigurationsManagerTest {
 
         val result = manager.refreshServerConfig()
         assertInstanceOf<ServerConfigResult.Failure>(result)
-        val serverConfig = manager.currentServerConfig
+        val serverConfig = requireNotNull(manager.currentServerConfig)
         assertEquals(ServerConfigProvider().getDefaultServerConfig(), serverConfig)
     }
 
@@ -142,7 +142,7 @@ class ManagedConfigurationsManagerTest {
 
         val result = manager.refreshServerConfig()
         assertInstanceOf<ServerConfigResult.Empty>(result)
-        val serverConfig = manager.currentServerConfig
+        val serverConfig = requireNotNull(manager.currentServerConfig)
         assertEquals(ServerConfigProvider().getDefaultServerConfig(), serverConfig)
     }
 
@@ -194,7 +194,7 @@ class ManagedConfigurationsManagerTest {
             val result = manager.refreshServerConfig()
             assertInstanceOf<ServerConfigResult.Success>(result)
 
-            val serverConfig = manager.currentServerConfig
+            val serverConfig = requireNotNull(manager.currentServerConfig)
             assertEquals("Secure Server", serverConfig.title)
             assertEquals("https://secure-account.wire.link", serverConfig.accounts)
         }
@@ -210,7 +210,7 @@ class ManagedConfigurationsManagerTest {
             val result = manager.refreshServerConfig()
             assertInstanceOf<ServerConfigResult.Success>(result)
 
-            val serverConfig = manager.currentServerConfig
+            val serverConfig = requireNotNull(manager.currentServerConfig)
             assertEquals("General Server", serverConfig.title)
             assertEquals("https://general-account.wire.link", serverConfig.accounts)
         }
@@ -226,7 +226,7 @@ class ManagedConfigurationsManagerTest {
             val result = manager.refreshServerConfig()
             assertInstanceOf<ServerConfigResult.Empty>(result)
 
-            val serverConfig = manager.currentServerConfig
+            val serverConfig = requireNotNull(manager.currentServerConfig)
             assertEquals(ServerConfigProvider().getDefaultServerConfig(), serverConfig)
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -6,6 +6,7 @@ import app.cash.turbine.test
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
+import com.wire.android.config.ServerConfigProvider
 import com.wire.android.config.SnapshotExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.datastore.UserDataStoreProvider
@@ -872,6 +873,16 @@ class NewLoginViewModelTest {
             )
         }
 
+        fun withEmptyCustomServerConfig() = apply {
+            every {
+                savedStateHandle.navArgs<LoginNavArgs>()
+            } returns LoginNavArgs(
+                loginPasswordPath = LoginPasswordPath(
+                    customServerConfig = ServerConfigProvider.EmptyServerConfig
+                )
+            )
+        }
+
         fun withRestoreCryptoStateReturning(result: RestoreCryptoStateResult) = apply {
             every { coreLogic.getSessionScope(any()).backup.restoreCryptoState } returns restoreCryptoStateUseCase
             coEvery { restoreCryptoStateUseCase() } returns result
@@ -974,6 +985,48 @@ class NewLoginViewModelTest {
             }
             coVerify(exactly = 0) {
                 arrangement.authenticationScope.getLoginFlowForDomainUseCase(any())
+            }
+        }
+
+    @Test
+    fun `given configured backend, when no backend is selected, then switch to missing backend config`() =
+        runTest(dispatchers.main()) {
+            val (arrangement, viewModel) = Arrangement()
+                .withUserIdentifierAlreadySet("user@example.com")
+                .arrange()
+
+            viewModel.onNoBackendSelected()
+            advanceUntilIdle()
+            viewModel.onLoginStarted()
+            advanceUntilIdle()
+
+            assertEquals(ServerConfigProvider.EmptyServerConfig, viewModel.serverConfig)
+            assertEquals(NewLoginFlowState.MissingBackendConfig, viewModel.state.flowState)
+            assertEquals(false, viewModel.state.nextEnabled)
+            verify(exactly = 0) {
+                arrangement.validateEmailOrSSOCodeUseCase(any())
+            }
+            coVerify(exactly = 0) {
+                arrangement.authenticationScope.getLoginFlowForDomainUseCase(any())
+            }
+        }
+
+    @Test
+    fun `given empty custom server config, when initializing view model, then block login and do not fetch default SSO code`() =
+        runTest(dispatchers.main()) {
+            val (arrangement, viewModel) = Arrangement()
+                .withEmptyCustomServerConfig()
+                .withDefaultSSOCodeConfig("default-sso-code")
+                .withFetchDefaultSSOCodeSuccess("default-sso-code")
+                .arrange()
+
+            advanceUntilIdle()
+
+            assertEquals(ServerConfigProvider.EmptyServerConfig, viewModel.serverConfig)
+            assertEquals(NewLoginFlowState.MissingBackendConfig, viewModel.state.flowState)
+            assertEquals(String.EMPTY, viewModel.userIdentifierTextState.text.toString())
+            coVerify(exactly = 0) {
+                arrangement.loginSSOViewModelExtension.fetchDefaultSSOCode(any(), any(), any(), any())
             }
         }
 

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -45,6 +45,8 @@ import com.wire.kalium.logic.feature.backup.SetLastDeviceIdResult
 import com.wire.kalium.logic.feature.backup.SetLastDeviceIdUseCase
 import android.database.sqlite.SQLiteException
 import com.wire.kalium.logic.feature.client.RegisterClientResult
+import com.wire.kalium.logic.feature.server.GetServerConfigResult
+import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
@@ -55,6 +57,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -668,6 +671,9 @@ class NewLoginViewModelTest {
         @MockK
         lateinit var setLastDeviceIdUseCase: SetLastDeviceIdUseCase
 
+        @MockK
+        lateinit var getServerConfigUseCase: GetServerConfigUseCase
+
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
             every {
@@ -876,6 +882,10 @@ class NewLoginViewModelTest {
             coEvery { setLastDeviceIdUseCase(any()) } returns SetLastDeviceIdResult.Success
         }
 
+        fun withGetServerConfigReturning(result: GetServerConfigResult) = apply {
+            coEvery { getServerConfigUseCase(any()) } returns result
+        }
+
         fun withRevertSSOSessionSuccess() = apply {
             coEvery { logoutUseCase(any(), any()) } returns Unit
             coEvery { deleteSessionUseCase(any()) } returns DeleteSessionUseCase.Result.Success
@@ -892,6 +902,11 @@ class NewLoginViewModelTest {
         }
 
         private var defaultSSOCodeConfig: String = String.EMPTY
+        private var isDefaultBackendConfigured: Boolean = true
+
+        fun withDefaultBackendConfigured(configured: Boolean) = apply {
+            isDefaultBackendConfigured = configured
+        }
 
         fun arrange() = this to NewLoginViewModel(
             validateEmailOrSSOCodeUseCase,
@@ -903,7 +918,9 @@ class NewLoginViewModelTest {
             loginSSOViewModelExtension,
             dispatchers,
             ServerConfig.STAGING,
-            defaultSSOCodeConfig
+            defaultSSOCodeConfig,
+            isDefaultBackendConfigured,
+            lazy { getServerConfigUseCase },
         )
     }
 
@@ -920,6 +937,126 @@ class NewLoginViewModelTest {
 
             coVerify(exactly = 1) {
                 arrangement.loginSSOViewModelExtension.fetchDefaultSSOCode(any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `given default backend is not configured, when initializing view model, then block login and do not fetch default SSO code`() =
+        runTest(dispatchers.main()) {
+            val (arrangement, viewModel) = Arrangement()
+                .withDefaultBackendConfigured(false)
+                .withEmptyUserIdentifierAndNoPreFilledIdentifier()
+                .arrange()
+
+            advanceUntilIdle()
+
+            assertEquals(NewLoginFlowState.MissingBackendConfig, viewModel.state.flowState)
+            assertEquals(false, viewModel.state.nextEnabled)
+            coVerify(exactly = 0) {
+                arrangement.loginSSOViewModelExtension.fetchDefaultSSOCode(any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `given default backend is not configured, when login is started, then do not proceed to login flow`() =
+        runTest(dispatchers.main()) {
+            val (arrangement, viewModel) = Arrangement()
+                .withDefaultBackendConfigured(false)
+                .withUserIdentifierAlreadySet("user@example.com")
+                .arrange()
+
+            viewModel.onLoginStarted()
+            advanceUntilIdle()
+
+            assertEquals(NewLoginFlowState.MissingBackendConfig, viewModel.state.flowState)
+            verify(exactly = 0) {
+                arrangement.validateEmailOrSSOCodeUseCase(any())
+            }
+            coVerify(exactly = 0) {
+                arrangement.authenticationScope.getLoginFlowForDomainUseCase(any())
+            }
+        }
+
+    @Test
+    fun `given default backend is not configured, when raw config link is entered, then load backend config and show success`() =
+        runTest(dispatchers.main()) {
+            val configUrl = "https://example.com/deeplink.json"
+            val serverConfig = newServerConfig(1).links
+            val (arrangement, viewModel) = Arrangement()
+                .withDefaultBackendConfigured(false)
+                .withGetServerConfigReturning(GetServerConfigResult.Success(serverConfig))
+                .arrange()
+
+            viewModel.onBackendConfigLinkEntered(configUrl)
+            advanceUntilIdle()
+
+            assertEquals(serverConfig, viewModel.serverConfig)
+            assertEquals(NewLoginFlowState.BackendConfigSuccess, viewModel.state.flowState)
+            coVerify(exactly = 1) {
+                arrangement.getServerConfigUseCase(configUrl)
+            }
+        }
+
+    @Test
+    fun `given backend config was loaded, when success is continued and login starts, then proceed to login flow`() =
+        runTest(dispatchers.main()) {
+            val configUrl = "https://example.com/deeplink.json"
+            val serverConfig = newServerConfig(1).links
+            val (arrangement, viewModel) = Arrangement()
+                .withDefaultBackendConfigured(false)
+                .withUserIdentifierAlreadySet("user@example.com")
+                .withGetServerConfigReturning(GetServerConfigResult.Success(serverConfig))
+                .withEmailOrSSOCodeValidatorReturning(ValidateEmailOrSSOCodeUseCase.Result.ValidEmail)
+                .withAuthenticationScopeSuccess()
+                .withGetLoginFlowForDomainReturning(EnterpriseLoginResult.Success(LoginRedirectPath.Default))
+                .arrange()
+
+            viewModel.onBackendConfigLinkEntered(configUrl)
+            advanceUntilIdle()
+            viewModel.onBackendConfigSuccessContinue()
+            viewModel.onLoginStarted()
+            advanceUntilIdle()
+
+            assertEquals(serverConfig, viewModel.serverConfig)
+            coVerify(exactly = 1) {
+                arrangement.authenticationScope.getLoginFlowForDomainUseCase("user@example.com")
+            }
+        }
+
+    @Test
+    fun `given default backend is not configured, when mobile deeplink is entered, then load config url from deeplink`() =
+        runTest(dispatchers.main()) {
+            val configUrl = "https://example.com/deeplink.json"
+            val deepLink = "wire://access/?config=https%3A%2F%2Fexample.com%2Fdeeplink.json"
+            val serverConfig = newServerConfig(1).links
+            val (arrangement, viewModel) = Arrangement()
+                .withDefaultBackendConfigured(false)
+                .withGetServerConfigReturning(GetServerConfigResult.Success(serverConfig))
+                .arrange()
+
+            viewModel.onBackendConfigLinkEntered(deepLink)
+            advanceUntilIdle()
+
+            assertEquals(NewLoginFlowState.BackendConfigSuccess, viewModel.state.flowState)
+            coVerify(exactly = 1) {
+                arrangement.getServerConfigUseCase(configUrl)
+            }
+        }
+
+    @Test
+    fun `given default backend is not configured, when config loading fails, then show setup error`() =
+        runTest(dispatchers.main()) {
+            val (arrangement, viewModel) = Arrangement()
+                .withDefaultBackendConfigured(false)
+                .withGetServerConfigReturning(GetServerConfigResult.Failure.Generic(CoreFailure.Unknown(Throwable())))
+                .arrange()
+
+            viewModel.onBackendConfigLinkEntered("https://example.com/deeplink.json")
+            advanceUntilIdle()
+
+            assertEquals(NewLoginFlowState.BackendConfigError, viewModel.state.flowState)
+            coVerify(exactly = 1) {
+                arrangement.getServerConfigUseCase(any())
             }
         }
 

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -855,6 +855,27 @@ public fun com.wire.android.ui.analyticsUsageViewModel(): com.wire.android.ui.an
   params:
 
 @Composable
+public fun com.wire.android.ui.authentication.BackendConfigSuccessContent(modifier: androidx.compose.ui.Modifier, onContinue: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - modifier: STABLE (marked @Stable or @Immutable)
+    - onContinue: STABLE (function type)
+
+@Composable
+public fun com.wire.android.ui.authentication.MissingBackendConfigContent(modifier: androidx.compose.ui.Modifier, showTitle: kotlin.Boolean, centerText: kotlin.Boolean, verticalArrangement: androidx.compose.foundation.layout.Arrangement.Vertical, errorText: kotlin.String?, isLoading: kotlin.Boolean, onConfigurationLinkEntered: kotlin.Function1<kotlin.String, kotlin.Unit>?): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - modifier: STABLE (marked @Stable or @Immutable)
+    - showTitle: STABLE (primitive type)
+    - centerText: STABLE (primitive type)
+    - verticalArrangement: STABLE (marked @Stable or @Immutable)
+    - errorText: STABLE (class with no mutable properties)
+    - isLoading: STABLE (primitive type)
+    - onConfigurationLinkEntered: STABLE (function type)
+
+@Composable
 public fun com.wire.android.ui.authentication.authenticationViewModel(viewModelStoreOwner: androidx.lifecycle.ViewModelStoreOwner, key: kotlin.String?): VM of com.wire.android.ui.authentication.authenticationViewModel
   skippable: false
   restartable: true
@@ -2337,13 +2358,12 @@ public fun com.wire.android.ui.calling.ongoing.participantslist.ParticipantList(
     - lazyListState: STABLE (marked @Stable or @Immutable)
 
 @Composable
-private fun com.wire.android.ui.calling.ongoing.participantsview.AvatarTile(avatar: com.wire.android.model.UserAvatarData, modifier: androidx.compose.ui.Modifier, isOnPiPMode: kotlin.Boolean): kotlin.Unit
+private fun com.wire.android.ui.calling.ongoing.participantsview.AvatarTile(avatar: com.wire.android.model.UserAvatarData, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - avatar: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
-    - isOnPiPMode: STABLE (primitive type)
 
 @Composable
 private fun com.wire.android.ui.calling.ongoing.participantsview.BottomRow(participantTitleState: com.wire.android.ui.calling.model.UICallParticipant, isSelfUserMuted: kotlin.Boolean, modifier: androidx.compose.ui.Modifier): kotlin.Unit
@@ -2973,7 +2993,7 @@ internal fun com.wire.android.ui.common.bottomsheet.conversation.ConversationMai
     - openDebugMenu: STABLE (function type)
 
 @Composable
-public fun com.wire.android.ui.common.bottomsheet.conversation.ConversationOptionsModalSheetLayout(sheetState: com.wire.android.ui.common.bottomsheet.WireModalSheetState<com.wire.android.ui.common.bottomsheet.conversation.ConversationSheetState>, openConversationFolders: kotlin.Function1<com.wire.android.ui.home.conversations.folder.ConversationFoldersNavArgs, kotlin.Unit>, onLeftConversation: kotlin.Function0<kotlin.Unit>, onDeletedConversation: kotlin.Function0<kotlin.Unit>, onDeletedConversationLocally: kotlin.Function0<kotlin.Unit>, onPromoteAdmin: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, openConversationDebugMenu: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, viewModel: com.wire.android.ui.common.bottomsheet.conversation.ConversationOptionsMenuViewModel): kotlin.Unit
+public fun com.wire.android.ui.common.bottomsheet.conversation.ConversationOptionsModalSheetLayout(sheetState: com.wire.android.ui.common.bottomsheet.WireModalSheetState<com.wire.android.ui.common.bottomsheet.conversation.ConversationSheetState>, openConversationFolders: kotlin.Function1<com.wire.android.ui.home.conversations.folder.ConversationFoldersNavArgs, kotlin.Unit>, onLeftConversation: kotlin.Function0<kotlin.Unit>, onDeletedConversation: kotlin.Function0<kotlin.Unit>, onDeletedConversationLocally: kotlin.Function0<kotlin.Unit>, onPromoteAdmin: kotlin.Function2<com.wire.kalium.logic.data.id.QualifiedID, kotlin.collections.List<com.wire.kalium.logic.data.id.QualifiedID>, kotlin.Unit>, openConversationDebugMenu: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, viewModel: com.wire.android.ui.common.bottomsheet.conversation.ConversationOptionsMenuViewModel): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -3534,7 +3554,7 @@ public fun com.wire.android.ui.debug.DebugDataOptions(appVersion: kotlin.String,
     - viewModel: RUNTIME (requires runtime check)
 
 @Composable
-public fun com.wire.android.ui.debug.DebugDataOptionsContent(state: com.wire.android.ui.debug.DebugDataOptionsState, appVersion: kotlin.String, buildVariant: kotlin.String, onCopyText: kotlin.Function1<kotlin.String, kotlin.Unit>, onDisableEventProcessingChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onEnableAsyncNotificationsChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onRestartSlowSyncForRecovery: kotlin.Function0<kotlin.Unit>, onForceUpdateApiVersions: kotlin.Function0<kotlin.Unit>, enrollE2EICertificate: kotlin.Function0<kotlin.Unit>, e2eiCertificateExpirationInputState: androidx.compose.foundation.text.input.TextFieldState, handleE2EIEnrollmentResult: kotlin.Function1<com.wire.kalium.logic.feature.e2ei.usecase.FinalizeEnrollmentResult, kotlin.Unit>, dismissCertificateDialog: kotlin.Function0<kotlin.Unit>, checkCrlRevocationList: kotlin.Function0<kotlin.Unit>, forceCRLExpirationAfterOneMinute: kotlin.Boolean, onForceCRLExpirationAfterOneMinuteChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onResendFCMToken: kotlin.Function0<kotlin.Unit>, onShowFeatureFlags: kotlin.Function0<kotlin.Unit>, onShowCryptoStats: kotlin.Function0<kotlin.Unit>, onRepairFaultyRemovalKeys: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.wire.android.ui.debug.DebugDataOptionsContent(state: com.wire.android.ui.debug.DebugDataOptionsState, appVersion: kotlin.String, buildVariant: kotlin.String, onCopyText: kotlin.Function1<kotlin.String, kotlin.Unit>, onDisableEventProcessingChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onRestartSlowSyncForRecovery: kotlin.Function0<kotlin.Unit>, onForceUpdateApiVersions: kotlin.Function0<kotlin.Unit>, enrollE2EICertificate: kotlin.Function0<kotlin.Unit>, e2eiCertificateExpirationInputState: androidx.compose.foundation.text.input.TextFieldState, handleE2EIEnrollmentResult: kotlin.Function1<com.wire.kalium.logic.feature.e2ei.usecase.FinalizeEnrollmentResult, kotlin.Unit>, dismissCertificateDialog: kotlin.Function0<kotlin.Unit>, checkCrlRevocationList: kotlin.Function0<kotlin.Unit>, forceCRLExpirationAfterOneMinute: kotlin.Boolean, onForceCRLExpirationAfterOneMinuteChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onResendFCMToken: kotlin.Function0<kotlin.Unit>, onShowFeatureFlags: kotlin.Function0<kotlin.Unit>, onShowCryptoStats: kotlin.Function0<kotlin.Unit>, onRepairFaultyRemovalKeys: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -3543,7 +3563,6 @@ public fun com.wire.android.ui.debug.DebugDataOptionsContent(state: com.wire.and
     - buildVariant: STABLE (String is immutable)
     - onCopyText: STABLE (function type)
     - onDisableEventProcessingChange: STABLE (function type)
-    - onEnableAsyncNotificationsChange: STABLE (function type)
     - onRestartSlowSyncForRecovery: STABLE (function type)
     - onForceUpdateApiVersions: STABLE (function type)
     - enrollE2EICertificate: STABLE (function type)
@@ -3570,7 +3589,7 @@ public fun com.wire.android.ui.debug.DebugScreen(navigator: com.wire.android.nav
     - exportObfuscatedCopyViewModel: RUNTIME (requires runtime check)
 
 @Composable
-internal fun com.wire.android.ui.debug.DebugToolsOptions(isEventProcessingEnabled: kotlin.Boolean, onDisableEventProcessingChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onRestartSlowSyncForRecovery: kotlin.Function0<kotlin.Unit>, onForceUpdateApiVersions: kotlin.Function0<kotlin.Unit>, checkCrlRevocationList: kotlin.Function0<kotlin.Unit>, forceCRLExpirationAfterOneMinute: kotlin.Boolean, onForceCRLExpirationAfterOneMinuteChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onResendFCMToken: kotlin.Function0<kotlin.Unit>, isAsyncNotificationsEnabled: kotlin.Boolean, onEnableAsyncNotificationsChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>): kotlin.Unit
+internal fun com.wire.android.ui.debug.DebugToolsOptions(isEventProcessingEnabled: kotlin.Boolean, onDisableEventProcessingChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onRestartSlowSyncForRecovery: kotlin.Function0<kotlin.Unit>, onForceUpdateApiVersions: kotlin.Function0<kotlin.Unit>, checkCrlRevocationList: kotlin.Function0<kotlin.Unit>, forceCRLExpirationAfterOneMinute: kotlin.Boolean, onForceCRLExpirationAfterOneMinuteChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onResendFCMToken: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -3582,8 +3601,6 @@ internal fun com.wire.android.ui.debug.DebugToolsOptions(isEventProcessingEnable
     - forceCRLExpirationAfterOneMinute: STABLE (primitive type)
     - onForceCRLExpirationAfterOneMinuteChange: STABLE (function type)
     - onResendFCMToken: STABLE (function type)
-    - isAsyncNotificationsEnabled: STABLE (primitive type)
-    - onEnableAsyncNotificationsChange: STABLE (function type)
 
 @Composable
 private fun com.wire.android.ui.debug.DisableEventProcessingSwitch(isEnabled: kotlin.Boolean, onCheckedChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>?): kotlin.Unit
@@ -3600,14 +3617,6 @@ private fun com.wire.android.ui.debug.E2EICertificateEnrollmentSection(expiratio
   params:
     - expirationInputState: STABLE (marked @Stable or @Immutable)
     - enrollE2EI: STABLE (function type)
-
-@Composable
-private fun com.wire.android.ui.debug.EnableAsyncNotifications(isEnabled: kotlin.Boolean, onCheckedChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>?): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
-    - isEnabled: STABLE (primitive type)
-    - onCheckedChange: STABLE (function type)
 
 @Composable
 private fun com.wire.android.ui.debug.EnableLoggingSwitch(onCheckedChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>?, modifier: androidx.compose.ui.Modifier, isEnabled: kotlin.Boolean): kotlin.Unit
@@ -3666,7 +3675,7 @@ private fun com.wire.android.ui.debug.MLSOptions(mlsInfoState: com.wire.android.
     - onRepairFaultyRemovalKeys: STABLE (function type)
 
 @Composable
-private fun com.wire.android.ui.debug.PrivateBuildDebugToolsOptions(isEventProcessingEnabled: kotlin.Boolean, onDisableEventProcessingChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onRestartSlowSyncForRecovery: kotlin.Function0<kotlin.Unit>, onForceUpdateApiVersions: kotlin.Function0<kotlin.Unit>, checkCrlRevocationList: kotlin.Function0<kotlin.Unit>, forceCRLExpirationAfterOneMinute: kotlin.Boolean, onForceCRLExpirationAfterOneMinuteChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, isAsyncNotificationsEnabled: kotlin.Boolean, onEnableAsyncNotificationsChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>): kotlin.Unit
+private fun com.wire.android.ui.debug.PrivateBuildDebugToolsOptions(isEventProcessingEnabled: kotlin.Boolean, onDisableEventProcessingChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onRestartSlowSyncForRecovery: kotlin.Function0<kotlin.Unit>, onForceUpdateApiVersions: kotlin.Function0<kotlin.Unit>, checkCrlRevocationList: kotlin.Function0<kotlin.Unit>, forceCRLExpirationAfterOneMinute: kotlin.Boolean, onForceCRLExpirationAfterOneMinuteChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -3677,8 +3686,6 @@ private fun com.wire.android.ui.debug.PrivateBuildDebugToolsOptions(isEventProce
     - checkCrlRevocationList: STABLE (function type)
     - forceCRLExpirationAfterOneMinute: STABLE (primitive type)
     - onForceCRLExpirationAfterOneMinuteChange: STABLE (function type)
-    - isAsyncNotificationsEnabled: STABLE (primitive type)
-    - onEnableAsyncNotificationsChange: STABLE (function type)
 
 @Composable
 private fun com.wire.android.ui.debug.ProductionDebugToolsOptions(onResendFCMToken: kotlin.Function0<kotlin.Unit>): kotlin.Unit
@@ -4980,7 +4987,7 @@ private fun com.wire.android.ui.home.conversations.delete.DeleteMessageForYourse
     - onDeleteForMe: STABLE (function type)
 
 @Composable
-private fun com.wire.android.ui.home.conversations.details.GroupConversationDetailsContent(groupConversationOptionsState: com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsState, sheetState: com.wire.android.ui.common.bottomsheet.WireModalSheetState<com.wire.android.ui.common.bottomsheet.conversation.ConversationSheetState>, onBackPressed: kotlin.Function0<kotlin.Unit>, onProfilePressed: kotlin.Function1<com.wire.android.ui.home.conversations.details.participants.model.UIParticipant, kotlin.Unit>, onAddParticipantsPressed: kotlin.Function0<kotlin.Unit>, onEditGuestAccess: kotlin.Function0<kotlin.Unit>, onAppsAccessItemClicked: kotlin.Function0<kotlin.Unit>, onChannelAccessItemClicked: kotlin.Function0<kotlin.Unit>, onEditSelfDeletingMessages: kotlin.Function0<kotlin.Unit>, onEditGroupName: kotlin.Function0<kotlin.Unit>, groupParticipantsState: com.wire.android.ui.home.conversations.details.participants.GroupConversationParticipantsState, isAbandonedOneOnOneConversation: kotlin.Boolean, isWireCellEnabled: kotlin.Boolean, onSearchConversationMessagesClick: kotlin.Function0<kotlin.Unit>, onConversationMediaClick: kotlin.Function0<kotlin.Unit>, viewModel: com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel?, onMoveToFolder: kotlin.Function1<com.wire.android.ui.home.conversations.folder.ConversationFoldersNavArgs, kotlin.Unit>, onLeftConversation: kotlin.Function0<kotlin.Unit>, onDeletedConversation: kotlin.Function0<kotlin.Unit>, onPromoteAdmin: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, openConversationDebugMenu: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, initialPageIndex: com.wire.android.ui.home.conversations.details.GroupConversationDetailsTabItem, isScreenLoading: kotlinx.coroutines.flow.StateFlow<kotlin.Boolean>): kotlin.Unit
+private fun com.wire.android.ui.home.conversations.details.GroupConversationDetailsContent(groupConversationOptionsState: com.wire.android.ui.home.conversations.details.options.GroupConversationOptionsState, sheetState: com.wire.android.ui.common.bottomsheet.WireModalSheetState<com.wire.android.ui.common.bottomsheet.conversation.ConversationSheetState>, onBackPressed: kotlin.Function0<kotlin.Unit>, onProfilePressed: kotlin.Function1<com.wire.android.ui.home.conversations.details.participants.model.UIParticipant, kotlin.Unit>, onAddParticipantsPressed: kotlin.Function0<kotlin.Unit>, onEditGuestAccess: kotlin.Function0<kotlin.Unit>, onAppsAccessItemClicked: kotlin.Function0<kotlin.Unit>, onChannelAccessItemClicked: kotlin.Function0<kotlin.Unit>, onEditSelfDeletingMessages: kotlin.Function0<kotlin.Unit>, onEditGroupName: kotlin.Function0<kotlin.Unit>, groupParticipantsState: com.wire.android.ui.home.conversations.details.participants.GroupConversationParticipantsState, isAbandonedOneOnOneConversation: kotlin.Boolean, isWireCellEnabled: kotlin.Boolean, onSearchConversationMessagesClick: kotlin.Function0<kotlin.Unit>, onConversationMediaClick: kotlin.Function0<kotlin.Unit>, viewModel: com.wire.android.ui.home.conversations.details.GroupConversationDetailsViewModel?, onMoveToFolder: kotlin.Function1<com.wire.android.ui.home.conversations.folder.ConversationFoldersNavArgs, kotlin.Unit>, onLeftConversation: kotlin.Function0<kotlin.Unit>, onDeletedConversation: kotlin.Function0<kotlin.Unit>, onPromoteAdmin: kotlin.Function2<com.wire.kalium.logic.data.id.QualifiedID, kotlin.collections.List<com.wire.kalium.logic.data.id.QualifiedID>, kotlin.Unit>, openConversationDebugMenu: kotlin.Function1<com.wire.kalium.logic.data.id.QualifiedID, kotlin.Unit>, initialPageIndex: com.wire.android.ui.home.conversations.details.GroupConversationDetailsTabItem, isScreenLoading: kotlinx.coroutines.flow.StateFlow<kotlin.Boolean>): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -10209,10 +10216,11 @@ public fun com.wire.android.ui.miscViewModel(): VM of com.wire.android.ui.miscVi
   params:
 
 @Composable
-internal fun com.wire.android.ui.newauthentication.login.BackendSelectorDropDown(): kotlin.Unit
+internal fun com.wire.android.ui.newauthentication.login.BackendSelectorDropDown(onNoBackendSelected: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - onNoBackendSelected: STABLE (function type)
 
 @Composable
 private fun com.wire.android.ui.newauthentication.login.EmailOrSSOCodeInput(userIdentifierState: androidx.compose.foundation.text.input.TextFieldState, error: kotlin.String?): kotlin.Unit
@@ -10231,7 +10239,7 @@ private fun com.wire.android.ui.newauthentication.login.EnterBackendNameDialog(o
     - onDismiss: STABLE (function type)
 
 @Composable
-private fun com.wire.android.ui.newauthentication.login.LoginContent(loginEmailSSOState: com.wire.android.ui.newauthentication.login.NewLoginScreenState, userIdentifierState: androidx.compose.foundation.text.input.TextFieldState, serverConfig: com.wire.kalium.logic.configuration.server.ServerConfig.Links, onNextClicked: kotlin.Function0<kotlin.Unit>, canNavigateBack: kotlin.Boolean, navigateBack: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+private fun com.wire.android.ui.newauthentication.login.LoginContent(loginEmailSSOState: com.wire.android.ui.newauthentication.login.NewLoginScreenState, userIdentifierState: androidx.compose.foundation.text.input.TextFieldState, serverConfig: com.wire.kalium.logic.configuration.server.ServerConfig.Links, onNextClicked: kotlin.Function0<kotlin.Unit>, onBackendConfigLinkEntered: kotlin.Function1<kotlin.String, kotlin.Unit>, onBackendConfigSuccessContinue: kotlin.Function0<kotlin.Unit>, onNoBackendSelected: kotlin.Function0<kotlin.Unit>, canNavigateBack: kotlin.Boolean, navigateBack: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -10239,6 +10247,9 @@ private fun com.wire.android.ui.newauthentication.login.LoginContent(loginEmailS
     - userIdentifierState: STABLE (marked @Stable or @Immutable)
     - serverConfig: UNSTABLE (has mutable properties or unstable members)
     - onNextClicked: STABLE (function type)
+    - onBackendConfigLinkEntered: STABLE (function type)
+    - onBackendConfigSuccessContinue: STABLE (function type)
+    - onNoBackendSelected: STABLE (function type)
     - canNavigateBack: STABLE (primitive type)
     - navigateBack: STABLE (function type)
 
@@ -10259,12 +10270,14 @@ private fun com.wire.android.ui.newauthentication.login.NavigationBarBackground(
   params:
 
 @Composable
-public fun com.wire.android.ui.newauthentication.login.NewAuthContainer(header: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, contentPadding: androidx.compose.ui.unit.Dp, content: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>): kotlin.Unit
+public fun com.wire.android.ui.newauthentication.login.NewAuthContainer(header: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, contentPadding: androidx.compose.ui.unit.Dp, showBackendSelector: kotlin.Boolean, onNoBackendSelected: kotlin.Function0<kotlin.Unit>, content: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - header: STABLE (composable function type)
     - contentPadding: STABLE (marked @Stable or @Immutable)
+    - showBackendSelector: STABLE (primitive type)
+    - onNoBackendSelected: STABLE (function type)
     - content: STABLE (composable function type)
 
 @Composable
@@ -11766,3 +11779,4 @@ public fun com.wire.android.util.ui.WireScrollableThemePreview(content: @[Compos
   restartable: true
   params:
     - content: STABLE (composable function type)
+

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -99,6 +99,7 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
     DEFAULT_BACKEND_URL_BLACKLIST("default_backend_url_blacklist", ConfigType.STRING),
     DEFAULT_BACKEND_URL_WEBSITE("default_backend_url_website", ConfigType.STRING),
     DEFAULT_BACKEND_TITLE("default_backend_title", ConfigType.STRING),
+    DEFAULT_BACKEND_ENABLED("default_backend_enabled", ConfigType.BOOLEAN),
 
     CERTIFICATE_PINNING_CONFIG("cert_pinning_config", ConfigType.MapOfStringToListOfStrings),
     // TODO: Add support for default proxy configs

--- a/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
+++ b/buildSrc/src/main/kotlin/customization/FeatureConfigs.kt
@@ -83,6 +83,7 @@ enum class FeatureConfigs(val value: String, val configType: ConfigType) {
     DEVELOPER_FEATURES_ENABLED("developer_features_enabled", ConfigType.BOOLEAN),
     DEVELOPMENT_API_ENABLED("development_api_enabled", ConfigType.BOOLEAN),
     REPORT_BUG_MENU_ITEM_ENABLED("report_bug_menu_item_enabled", ConfigType.BOOLEAN),
+    FEEDBACK_MENU_ITEM_ENABLED("feedback_menu_item_enabled", ConfigType.BOOLEAN),
 
     URL_SUPPORT("url_support", ConfigType.STRING),
     URL_RSS_RELEASE_NOTES("url_rss_release_notes", ConfigType.STRING),

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
@@ -39,7 +39,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.paneTitle
@@ -53,6 +53,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
+import com.wire.android.util.CustomTabsHelper
 import com.wire.android.ui.common.button.WireTertiaryButton
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.theme.isTablet
@@ -177,7 +178,7 @@ fun WireDialogContent(
     centerContent: Boolean = false,
     content: @Composable (() -> Unit)? = null
 ) {
-    val uriHandler = LocalUriHandler.current
+    val context = LocalContext.current
 
     Surface(
         modifier = modifier.padding(MaterialTheme.wireDimensions.dialogCardMargin),
@@ -211,7 +212,7 @@ fun WireDialogContent(
                         TextWithLinkSuffix(
                             text = text,
                             linkText = textSuffixLink?.linkText,
-                            onLinkClick = { textSuffixLink?.linkUrl?.let { uriHandler.openUri(it) } },
+                            onLinkClick = { textSuffixLink?.linkUrl?.let { CustomTabsHelper.launchUrl(context, it) } },
                             modifier = Modifier.padding(bottom = MaterialTheme.wireDimensions.dialogTextsSpacing)
                         )
                     }

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/CustomTabsHelper.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/CustomTabsHelper.kt
@@ -29,7 +29,19 @@ import com.wire.kalium.logger.KaliumLogLevel
 
 object CustomTabsHelper {
 
-    fun launchUrl(context: Context, url: String) = launchUri(context, Uri.parse(url))
+    private const val SUPPORT_PATH = "support"
+
+    @Volatile
+    private var backendWebsiteUrl: String? = null
+
+    fun setBackendWebsiteUrl(url: String?) {
+        backendWebsiteUrl = url?.takeIf { it.isNotBlank() }
+    }
+
+    fun launchUrl(context: Context, url: String) {
+        val resolvedUrl = resolveUrl(url) ?: return
+        launchUri(context, Uri.parse(resolvedUrl))
+    }
 
     @JvmStatic
     fun launchUri(context: Context, uri: Uri) {
@@ -45,6 +57,11 @@ object CustomTabsHelper {
             )
         }
     }
+
+    fun resolveUrl(url: String): String? =
+        url.ifBlank {
+            backendWebsiteUrl?.trimEnd('/')?.let { "$it/$SUPPORT_PATH" }
+        }
 
     fun buildCustomTabIntent(context: Context): CustomTabsIntent {
         val customTabsIntent = CustomTabsIntent.Builder()

--- a/core/ui-common/src/main/res/drawable/ic_qr_code_scanner.xml
+++ b/core/ui-common/src/main/res/drawable/ic_qr_code_scanner.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M12.28,12.28H13.54V13.54H12.28V12.28ZM12.28,9.76H13.54V11.02H12.28V9.76ZM11.02,11.02H12.28V12.28H11.02V11.02ZM9.76,12.28H11.02V13.54H9.76V12.28ZM8.5,11.02H9.76V12.28H8.5V11.02ZM11.02,8.5H12.28V9.76H11.02V8.5ZM9.76,9.76H11.02V11.02H9.76V9.76ZM8.5,8.5H9.76V9.76H8.5V8.5Z" />
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M0,3.46V0H3.46V1.2H1.2V3.46H0ZM0,16V12.54H1.2V14.8H3.46V16H0ZM12.54,16V14.8H14.8V12.54H16V16H12.54ZM14.8,3.46V1.2H12.54V0H16V3.46H14.8Z" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M3.25,3.25H6.75V6.75H3.25Z"
+        android:strokeColor="@android:color/black"
+        android:strokeWidth="1.5" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M3.25,9.25H6.75V12.75H3.25Z"
+        android:strokeColor="@android:color/black"
+        android:strokeWidth="1.5" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M9.25,3.25H12.75V6.75H9.25Z"
+        android:strokeColor="@android:color/black"
+        android:strokeWidth="1.5" />
+</vector>

--- a/core/ui-common/src/test/kotlin/com/wire/android/util/CustomTabsHelperTest.kt
+++ b/core/ui-common/src/test/kotlin/com/wire/android/util/CustomTabsHelperTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class CustomTabsHelperTest {
+
+    @Test
+    fun `given empty url and backend website, when resolving url, then return backend support url`() {
+        CustomTabsHelper.setBackendWebsiteUrl("https://example.com")
+
+        val result = CustomTabsHelper.resolveUrl("")
+
+        assertEquals("https://example.com/support", result)
+    }
+
+    @Test
+    fun `given empty url and backend website with trailing slash, when resolving url, then return backend support url`() {
+        CustomTabsHelper.setBackendWebsiteUrl("https://example.com/")
+
+        val result = CustomTabsHelper.resolveUrl("")
+
+        assertEquals("https://example.com/support", result)
+    }
+
+    @Test
+    fun `given non empty url, when resolving url, then keep original url`() {
+        CustomTabsHelper.setBackendWebsiteUrl("https://example.com")
+
+        val result = CustomTabsHelper.resolveUrl("not a valid url")
+
+        assertEquals("not a valid url", result)
+    }
+
+    @Test
+    fun `given empty url and no backend website, when resolving url, then return null`() {
+        CustomTabsHelper.setBackendWebsiteUrl(null)
+
+        val result = CustomTabsHelper.resolveUrl("")
+
+        assertNull(result)
+    }
+}

--- a/default.json
+++ b/default.json
@@ -131,6 +131,7 @@
     "google_api_key": "AIzaSyBXtNKuX6GCKv2jDtsFImUaxCRL21DTLEQ",
     "fcm_project_id": "w966768976",
     "report_bug_menu_item_enabled": true,
+    "feedback_menu_item_enabled": true,
     "debug_screen_enabled": true,
     "update_app_url": "https://wire.com/en/download/",
     "default_backend_url_base_api": "https://prod-nginz-https.wire.com",

--- a/default.json
+++ b/default.json
@@ -140,6 +140,7 @@
     "default_backend_url_blacklist": "https://clientblacklist.wire.com/prod",
     "default_backend_url_website": "https://wire.com",
     "default_backend_title": "wire-production",
+    "default_backend_enabled": true,
     "cert_pinning_config": {
         "sha256/fnBeCwh0imI9t46Onid49IwvsB5vcf7RCvafRRdCyRE=": [
             "**.prod-nginz-https.wire.com",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26206
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Adds support for app builds that do not ship with a preconfigured default backend. When no backend is configured, the app shows a setup screen and waits for backend configuration from supported configuration sources.

## Changes

- Add `default_backend_enabled` config flag.
- Support empty default backend configuration.
- Show setup landing page when no backend is configured.
- Support backend setup through:
  - MDM / managed configuration
  - configuration deeplink
  - manually entered configuration link
  - QR code scanned externally by the system camera app
- Show success state after backend configuration is applied.
- Continue to the regular login flow after setup.
- Add support link fallback for empty support URLs using backend `websiteURL/support`.
- Support optional `supportEmail` from the configuration payload without DB migration.
- Add `feedback_menu_item_enabled` flag to hide the generic feedback menu item.
- Update setup/login copy and DE translations.

## Validation

- Setup flow tested with configuration deeplink.
- Success page verified before login form.
- Support URL fallback covered by unit test.
- Static analysis/lint passed before final copy updates.
