### PR TITLE
test: respect selected backend (WPB-26824)

### DIFF
--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/BaseUiTest.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/BaseUiTest.kt
@@ -168,9 +168,18 @@ abstract class BaseUiTest : KoinTest {
      */
     protected open val deletePersonalUsersAfterTest: Boolean = false
 
-    protected fun initCommonTestHelpers() {
+    protected fun initCommonTestHelpers(backendName: String = DEFAULT_BACKEND_NAME) {
+        initCommonTestHelpers(BackendClient.loadBackend(backendName))
+    }
+
+    protected fun initCommonTestHelpers(backendClient: BackendClient) {
         context = InstrumentationRegistry.getInstrumentation().context
-        clientUserManager = ClientUserManager(useSpecialEmail = false)
+        this.backendClient = backendClient
+        // The selected backend is passed into ClientUserManager, which stamps it onto generated users.
+        clientUserManager = ClientUserManager(
+            useSpecialEmail = false,
+            backendClient = backendClient
+        )
         backendSetupHelper = BackendSetupHelper(clientUserManager)
         testServiceHelper = TestServiceHelper(clientUserManager)
     }
@@ -184,5 +193,9 @@ abstract class BaseUiTest : KoinTest {
                 deletePersonalUsers = deletePersonalUsersAfterTest
             )
         }
+    }
+
+    private companion object {
+        const val DEFAULT_BACKEND_NAME = "STAGING"
     }
 }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/AccountManagement.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/AccountManagement.kt
@@ -19,7 +19,6 @@ package com.wire.android.tests.core.criticalFlows
 
 import InbucketClient
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
@@ -45,7 +44,6 @@ class AccountManagement : BaseUiTest() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
         appPackage = UiAutomatorSetup.appPackage
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
         @Suppress("LongMethod", "CyclomaticComplexMethod")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/FileSharingBetweenTeams.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/FileSharingBetweenTeams.kt
@@ -19,7 +19,6 @@
 package com.wire.android.tests.core.criticalFlows
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
@@ -47,7 +46,6 @@ class FileSharingBetweenTeams : BaseUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     @After

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupCallChat.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupCallChat.kt
@@ -19,7 +19,6 @@ package com.wire.android.tests.core.criticalFlows
 
 import QrCodeTestUtils.createQrImageInDeviceDownloadsFolder
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import com.wire.android.tests.core.BaseCallUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
@@ -43,7 +42,6 @@ class GroupCallChat : BaseCallUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
         initCallTestHelpers()
     }
 

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupInteraction.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupInteraction.kt
@@ -18,7 +18,6 @@
 package com.wire.android.tests.core.criticalFlows
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
@@ -40,7 +39,6 @@ class GroupInteraction : BaseUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupMessaging.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupMessaging.kt
@@ -18,7 +18,6 @@
 package com.wire.android.tests.core.criticalFlows
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
@@ -40,7 +39,6 @@ class GroupMessaging : BaseUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupVideoCall.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/GroupVideoCall.kt
@@ -18,7 +18,6 @@
 package com.wire.android.tests.core.criticalFlows
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import com.wire.android.tests.core.BaseCallUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
@@ -46,7 +45,6 @@ class GroupVideoCall : BaseCallUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
         initCallTestHelpers()
     }
 

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/NewMemberMessaging.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/NewMemberMessaging.kt
@@ -18,7 +18,6 @@
 package com.wire.android.tests.core.criticalFlows
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
@@ -41,7 +40,6 @@ class NewMemberMessaging : BaseUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/PersonalAccountLifeCycle.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/PersonalAccountLifeCycle.kt
@@ -19,7 +19,6 @@ package com.wire.android.tests.core.criticalFlows
 
 import InbucketClient
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
 import com.wire.android.tests.support.tags.Category
@@ -47,7 +46,6 @@ class PersonalAccountLifeCycle : BaseUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/SSODeviceBackup.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/criticalFlows/SSODeviceBackup.kt
@@ -22,7 +22,6 @@ import SSOServiceHelper.thereIsASSOTeamOwnerForOkta
 import SSOServiceHelper.userAddsOktaUser
 import SSOServiceHelper.userXIsMe
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
 import com.wire.android.tests.support.tags.Category
@@ -49,7 +48,6 @@ class SSODeviceBackup : BaseUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
         SSOServiceHelper.clientUserManager = clientUserManager
         oktaApiClient = OktaApiClient()
     }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/ApplockTest.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/ApplockTest.kt
@@ -18,7 +18,6 @@
 package com.wire.android.tests.core.e2eTests
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
@@ -44,7 +43,6 @@ class ApplockTest : BaseUiTest() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
         appPackage = UiAutomatorSetup.appPackage
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/AudioMessages.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/AudioMessages.kt
@@ -19,7 +19,6 @@ package com.wire.android.tests.core.e2eTests
 
 import android.Manifest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
@@ -43,7 +42,6 @@ class AudioMessages : BaseUiTest() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
         grantRuntimePermsForForegroundApp(device, Manifest.permission.RECORD_AUDIO)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/BlockTests.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/BlockTests.kt
@@ -18,7 +18,6 @@
 package com.wire.android.tests.core.e2eTests
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import backendUtils.team.updateUserProfileImage
 import com.wire.android.tests.core.BaseUiTest
@@ -48,7 +47,6 @@ class BlockTests : BaseUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/ChannelTest.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/ChannelTest.kt
@@ -18,7 +18,6 @@
 package com.wire.android.tests.core.e2eTests
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
@@ -44,7 +43,6 @@ class ChannelTest : BaseUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/GdprTest.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/GdprTest.kt
@@ -18,7 +18,6 @@
 package com.wire.android.tests.core.e2eTests
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
 import com.wire.android.tests.support.tags.Category
@@ -41,7 +40,6 @@ class GdprTest : BaseUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     @TestCaseId("TC-8705")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/MultiAccountSessionScope.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/MultiAccountSessionScope.kt
@@ -18,7 +18,6 @@
 package com.wire.android.tests.core.e2eTests
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import backendUtils.client.getBackendClientIds
 import backendUtils.client.removeBackendClient
 import backendUtils.team.TeamRoles
@@ -45,7 +44,6 @@ class MultiAccountSessionScope : BaseUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     @TestCaseId("TC-11259")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/PersonalUserRegistrationTest.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/PersonalUserRegistrationTest.kt
@@ -19,7 +19,6 @@ package com.wire.android.tests.core.e2eTests
 
 import InbucketClient
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
 import com.wire.android.tests.support.tags.Category
@@ -41,8 +40,8 @@ This test works on the following conditions:
 class PersonalUserRegistrationTest : BaseUiTest() {
     @Before
     fun setUp() {
+        initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     @Suppress("LongMethod")

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/TeamCreationTest.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/TeamCreationTest.kt
@@ -19,7 +19,6 @@ package com.wire.android.tests.core.e2eTests
 
 import InbucketClient
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import backendUtils.BackendClient
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
 import com.wire.android.tests.support.tags.Category
@@ -41,7 +40,6 @@ class TeamCreationTest : BaseUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     private fun registerTeamOwnerForCleanup(userInfo: ClientUser) {

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/UpgradeVersion.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/UpgradeVersion.kt
@@ -19,7 +19,6 @@ package com.wire.android.tests.core.e2eTests
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
@@ -40,7 +39,6 @@ class UpgradeVersion : BaseUiTest() {
     fun setUp() {
         initCommonTestHelpers()
         device = UiAutomatorSetup.start(UiAutomatorSetup.APP_ALPHA)
-        backendClient = BackendClient.loadBackend("STAGING")
     }
 
     /**

--- a/tests/testsSupport/build.gradle.kts
+++ b/tests/testsSupport/build.gradle.kts
@@ -1,5 +1,6 @@
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
+import org.gradle.api.tasks.PathSensitivity
 import java.util.Properties
 
 // Apply your test library plugin
@@ -74,6 +75,15 @@ android {
 
     buildFeatures {
         buildConfig = true  // Enable generation of BuildConfig class
+    }
+}
+
+// Regenerate BuildConfig when backend secrets change, for example when a new backend is added.
+if (secretsJson.exists()) {
+    tasks.matching { it.name.startsWith("generate") && it.name.endsWith("BuildConfig") }.configureEach {
+        inputs.file(secretsJson)
+            .withPropertyName("secretsJson")
+            .withPathSensitivity(PathSensitivity.RELATIVE)
     }
 }
 

--- a/tests/testsSupport/src/main/backendUtils/BackendClient.kt
+++ b/tests/testsSupport/src/main/backendUtils/BackendClient.kt
@@ -25,6 +25,7 @@ package backendUtils
 
 import CredentialsManager
 import com.wire.android.testSupport.BuildConfig
+import network.NetworkBackendClient
 import user.utils.BasicAuth
 import java.net.Authenticator
 import java.net.InetSocketAddress
@@ -48,20 +49,7 @@ class BackendClient(
     val acmeDiscoveryUrl: String,
     val k8sNamespace: String,
     val socksProxy: String,
-    var proxy: Proxy? = if (socksProxy.isNotEmpty()) {
-
-        Authenticator.setDefault(object : Authenticator() {
-            override fun getPasswordAuthentication(): PasswordAuthentication {
-                return PasswordAuthentication(
-                    "qa",
-                    BuildConfig.SOCKS_PROXY_PASSWORD_PASSWORD.toCharArray()
-                )
-            }
-        })
-        Proxy(Proxy.Type.SOCKS, InetSocketAddress("socks.wire.link", 1080))
-    } else {
-        null
-    }
+    var proxy: Proxy? = null
 ) {
 
     fun hasInbucketSetup() = inbucketUrl.isNotEmpty()
@@ -71,6 +59,7 @@ class BackendClient(
         const val accept = "Accept"
         const val applicationJson = "application/json"
         const val AUTHORIZATION = "Authorization"
+        private const val DEFAULT_BACKEND_NAME = "STAGING"
 
         data class BackendSecrets(
             val backendUrl: String,
@@ -91,8 +80,9 @@ class BackendClient(
         )
 
         private fun loadSecrets(connectionName: String): BackendSecrets {
+            val parentKey = buildConfigParentKey(connectionName)
             fun field(name: String): String? =
-                CredentialsManager.getSecretFieldValue("BACKENDCONNECTION_$connectionName", name.uppercase())
+                CredentialsManager.getSecretFieldValue(parentKey, name.toBuildConfigKeySegment())
 
             return BackendSecrets(
                 backendUrl = field("backendUrl") ?: "",
@@ -113,6 +103,23 @@ class BackendClient(
             )
         }
 
+        // Backend names can contain hyphens, while generated BuildConfig keys use underscores.
+        private fun String.toBuildConfigKeySegment(): String =
+            replace("[.\\-\\s]+".toRegex(), "_").uppercase()
+
+        private fun buildConfigParentKey(connectionName: String): String =
+            "BACKENDCONNECTION_${connectionName.toBuildConfigKeySegment()}"
+
+        private fun validateRequiredSecrets(connectionName: String, secrets: BackendSecrets) {
+            if (secrets.backendUrl.isNotBlank()) return
+
+            throw IllegalStateException(
+                "Backend '$connectionName' is missing required field 'backendUrl'. " +
+                        "Expected generated BuildConfig prefix '${buildConfigParentKey(connectionName)}'. " +
+                        "Check that secrets.json contains a matching BackendConnection item and rebuild the test APK."
+            )
+        }
+
         private fun buildBasicAuth(username: String?, password: String?, fallback: String): BasicAuth {
             return if (!username.isNullOrEmpty() && !password.isNullOrEmpty()) {
                 BasicAuth(username, password)
@@ -121,12 +128,11 @@ class BackendClient(
             }
         }
 
-        fun getDefault(): BackendClient? {
-            return loadBackend("STAGING")
-        }
+        fun getDefault(): BackendClient? = loadBackend(DEFAULT_BACKEND_NAME)
 
         fun loadBackend(connectionName: String): BackendClient {
             val secrets = loadSecrets(connectionName)
+            validateRequiredSecrets(connectionName, secrets)
 
             return BackendClient(
                 name = connectionName,
@@ -167,8 +173,13 @@ class BackendClient(
                     )
                 }
             })
-            this.proxy = Proxy(Proxy.Type.SOCKS, InetSocketAddress("socks.wire.link", 1080))
+            if (proxy == null) {
+                proxy = Proxy(Proxy.Type.SOCKS, InetSocketAddress("socks.wire.link", 1080))
+            }
         }
+        // Register both backend and Inbucket origins so shared requests can use SOCKS when needed.
+        NetworkBackendClient.registerProxy(backendUrl, proxy)
+        NetworkBackendClient.registerProxy(inbucketUrl, proxy)
     }
 
     fun String.composeCompleteUrl(): String {

--- a/tests/testsSupport/src/main/backendUtils/user/BackendUserExtensions.kt
+++ b/tests/testsSupport/src/main/backendUtils/user/BackendUserExtensions.kt
@@ -31,7 +31,6 @@ import org.json.JSONObject
 import user.utils.AccessCookie
 import user.utils.AccessCredentials
 import user.utils.ClientUser
-import java.net.HttpCookie
 import java.net.HttpURLConnection
 import java.net.URI
 import java.net.URL
@@ -79,20 +78,16 @@ fun BackendClient.createWirelessUserViaBackend(user: ClientUser): ClientUser {
         requestBody.put("expires_in", user.expiresIn!!.seconds)
     }
 
-    val response = NetworkBackendClient.sendJsonRequest(
+    val response = NetworkBackendClient.sendJsonRequestWithCookies(
         url = url,
         method = "POST",
         body = requestBody.toString(),
         headers = mapOf(BackendClient.contentType to BackendClient.applicationJson)
     )
 
-    val connection = url.openConnection() as HttpURLConnection
-    val cookiesHeader = connection.getHeaderField("Set-Cookie")
-    val cookies = HttpCookie.parse(cookiesHeader).toList()
-
-    val json = JSONObject(response)
+    val json = JSONObject(response.body)
     user.id = json.getString("id")
-    val accessCookie = AccessCookie("zuid", cookies)
+    val accessCookie = AccessCookie("zuid", response.cookies)
     user.accessCredentials = AccessCredentials(null, accessCookie)
 
     val activationCode = getActivationCodeForEmail(user.email.orEmpty())

--- a/tests/testsSupport/src/main/network/ApiNetworkClient.kt
+++ b/tests/testsSupport/src/main/network/ApiNetworkClient.kt
@@ -24,10 +24,12 @@ import user.utils.AccessToken
 import java.io.ByteArrayOutputStream
 import java.net.HttpCookie
 import java.net.HttpURLConnection
+import java.net.Proxy
 import java.net.URL
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
 
 sealed interface NumberSequence {
     data class Range(val range: IntRange) : NumberSequence
@@ -67,10 +69,24 @@ object WireTestLogger {
 data class RequestOptions(
     val expectedResponseCodes: NumberSequence = NumberSequence.Range(200..299),
     val accessToken: AccessToken? = null,
-    val cookie: AccessCookie? = null
+    val cookie: AccessCookie? = null,
+    val proxy: Proxy? = null
 )
 
 object NetworkBackendClient {
+    // Proxies are keyed by origin to avoid passing proxy options through every backend helper call.
+    private val proxiesByOrigin = ConcurrentHashMap<String, Proxy>()
+
+    fun registerProxy(baseUrl: String, proxy: Proxy?) {
+        if (baseUrl.isBlank()) return
+
+        val origin = runCatching { URL(baseUrl).proxyOrigin() }.getOrNull() ?: return
+        if (proxy == null) {
+            proxiesByOrigin.remove(origin)
+        } else {
+            proxiesByOrigin[origin] = proxy
+        }
+    }
 
     @Suppress("MagicNumber")
     fun makeRequest(
@@ -81,7 +97,7 @@ object NetworkBackendClient {
         options: RequestOptions = RequestOptions()
     ): HttpURLConnection {
 
-        val connection = (url.openConnection() as HttpURLConnection).apply {
+        val connection = (url.openConfiguredConnection(options) as HttpURLConnection).apply {
             requestMethod = method
             doInput = true
             if (method != "GET") {
@@ -109,6 +125,21 @@ object NetworkBackendClient {
         handleResponseError(connection, options.expectedResponseCodes)
 
         return connection
+    }
+
+    private fun URL.openConfiguredConnection(options: RequestOptions) =
+        (options.proxy ?: proxiesByOrigin[proxyOrigin()])?.let { proxy ->
+            openConnection(proxy)
+        } ?: openConnection()
+
+    private fun URL.proxyOrigin(): String {
+        val resolvedPort = when {
+            port != -1 -> port
+            defaultPort != -1 -> defaultPort
+            else -> null
+        }
+        val normalizedOrigin = "${protocol.lowercase()}://${host.lowercase()}"
+        return resolvedPort?.let { "$normalizedOrigin:$it" } ?: normalizedOrigin
     }
 
     private fun writeRequestBody(connection: HttpURLConnection, body: Any?) {

--- a/tests/testsSupport/src/main/network/ApiNetworkClient.kt
+++ b/tests/testsSupport/src/main/network/ApiNetworkClient.kt
@@ -24,6 +24,7 @@ import user.utils.AccessToken
 import java.io.ByteArrayOutputStream
 import java.net.HttpCookie
 import java.net.HttpURLConnection
+import java.net.URI
 import java.net.Proxy
 import java.net.URL
 import java.security.MessageDigest
@@ -80,7 +81,7 @@ object NetworkBackendClient {
     fun registerProxy(baseUrl: String, proxy: Proxy?) {
         if (baseUrl.isBlank()) return
 
-        val origin = runCatching { URL(baseUrl).proxyOrigin() }.getOrNull() ?: return
+        val origin = runCatching { URI(baseUrl).toURL().proxyOrigin() }.getOrNull() ?: return
         if (proxy == null) {
             proxiesByOrigin.remove(origin)
         } else {

--- a/tests/testsSupport/src/main/user/usermanager/ClientUserManager.kt
+++ b/tests/testsSupport/src/main/user/usermanager/ClientUserManager.kt
@@ -18,7 +18,6 @@
 package user.usermanager
 
 import android.content.Context
-import android.util.Log
 import backendUtils.BackendClient
 import backendUtils.team.TeamRoles
 import backendUtils.team.createTeamOwnerViaBackend
@@ -52,7 +51,8 @@ import java.util.stream.Collectors
 
 @Suppress("TooManyFunctions")
 class ClientUserManager(
-    private val useSpecialEmail: Boolean = false
+    private val useSpecialEmail: Boolean = false,
+    private val backendClient: BackendClient? = BackendClient.getDefault()
 ) {
     private val usersMap: MutableMap<UserState, MutableList<ClientUser>> =
         ConcurrentHashMap<UserState, MutableList<ClientUser>>()
@@ -115,12 +115,7 @@ class ClientUserManager(
         usersMap[UserState.Created] = ArrayList()
         usersMap[UserState.NotCreated] = ArrayList()
 
-        // Workaround for federation tests (can be deleted when inbucket is rolled out completely)
-        val actualUseSpecialEmail = if (BackendClient.getDefault() == null || BackendClient.getDefault()?.hasInbucketSetup() == true) {
-            false
-        } else {
-            useSpecialEmail
-        }
+        actualUseSpecialEmail = shouldUseSpecialEmail()
 
         for (userIdx in 0 until MAX_USERS) {
             val pendingUser = ClientUser()
@@ -138,6 +133,9 @@ class ClientUserManager(
         return "$uniqueUserName+$userNumber@wire.engineering"
     }
 
+    private fun shouldUseSpecialEmail(): Boolean =
+        useSpecialEmail && backendClient?.hasInbucketSetup() == false
+
     /**
      * Sets default values and aliases for a user based on their index.
      * @param user The ClientUser object to modify
@@ -145,6 +143,9 @@ class ClientUserManager(
      * @param useSpecialEmail Whether to use special email generation
      */
     private fun setUserDefaults(user: ClientUser, userIdx: Int, useSpecialEmail: Boolean) {
+        // Helpers resolve backend from user.backendName, so this prevents hidden STAGING fallback.
+        user.backendName = backendClient?.name
+
         // If special email flag is set, generate a unique email and password
         if (useSpecialEmail) {
             user.email = generateIndexedEmail(user.uniqueUsername ?: user.email.orEmpty(), userIdx + 1)
@@ -571,22 +572,9 @@ class ClientUserManager(
     /**
      * Initialize users on first access if not already initialized
      */
-    @Suppress("TooGenericExceptionCaught")
     private fun ensureUsersInitialized() {
         if (usersMap[UserState.NotCreated].isNullOrEmpty()) {
-            // Workaround for federation tests (can be deleted when inbucket is rolled out completely)
-            val hasInbucketSetup = try {
-                BackendClient.getDefault()?.hasInbucketSetup() == true
-            } catch (e: Exception) {
-                Log.d("Debug", "Failed to check Inbucket setup: ${e.message}")
-                false
-            }
-
-            actualUseSpecialEmail = if (BackendClient.getDefault() == null || hasInbucketSetup) {
-                false
-            } else {
-                useSpecialEmail
-            }
+            actualUseSpecialEmail = shouldUseSpecialEmail()
 
             for (userIdx in 0 until MAX_USERS) {
                 val pendingUser = ClientUser()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26824
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- This PR updates test backend initialization so the backend selected during common test setup is respected consistently across backend helpers.
- Previously, many tests initialized common helpers and then manually reassigned: **backendClient = BackendClient.loadBackend("STAGING")**
- That worked for staging, but it made custom backend tests easy to misconfigure because ClientUserManager, BackendSetupHelper, and TestServiceHelper could already be initialized before the desired backend was loaded.
- The new flow is:  **initCommonTestHelpers("mobtown-lemon")**  or, for staging: **initCommonTestHelpers()**
- initCommonTestHelpers() still defaults to STAGING, but now it is the single place where the backend is loaded and passed into user setup.
- Fixed backend secret lookup for hyphenated names like mobtown-lemon by normalizing backend names to generated BuildConfig key format.
- Added secrets.json as an input to BuildConfig generation so newly added backend secrets are picked up reliably.
- Wired SOCKS proxy use into NetworkBackendClient for backends whose secret config has socksProxy.

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

The issue was caused by  UI tests loading a desired backend in the test, while some helper setup still relied on the default STAGING backend. This meant generated users and later helper calls could silently fall back to STAGING, even when the test intended to use a Mobtown backend.
The fix passes the selected BackendClient into ClientUserManager, stamps generated users with the selected backendName, and lets BackendSetupHelper / TestServiceHelper resolve the correct backend from those users. The PR also registers SOCKS proxy configuration for backend  when the backend config requires it.

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
