### PR TITLE
fix: legacy SSO login (WPB-26810)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/AuthenticationViewModelGraph.kt
@@ -105,7 +105,7 @@ fun loginSSOViewModel(
 ): LoginSSOViewModel =
     assistedMetroViewModel<LoginSSOViewModel, AuthenticationManualViewModelFactory>(
         viewModelStoreOwner = viewModelStoreOwner,
-        key = authenticationViewModelKey<LoginSSOViewModel>(viewModelStoreOwner, loginNavArgs.toString()),
+        key = authenticationViewModelKey<LoginSSOViewModel>(viewModelStoreOwner, loginNavArgs.ssoViewModelKey()),
     ) { extras ->
         loginSSOViewModel(loginNavArgs, extras)
     }
@@ -178,3 +178,5 @@ inline fun <reified VM : ViewModel> authenticationViewModelKey(
         key = listOfNotNull(key, viewModelStoreOwner.hashCode().toString()).joinToString(":"),
         scopeKey = LocalWireViewModelScopeKey.current,
     )
+
+private fun LoginNavArgs.ssoViewModelKey(): String = copy(ssoLoginResult = null).toString()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26810
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-26810
----

# What's new in this PR?

### Issues
SSO Login via legacy login screen failed.

### Causes (Optional)
After returning SSO result from browser a new instance of LoginSSOViewModel was created and result passed to it.

### Solutions
Update the LoginSSOViewModel key to deliver SSO result correctly back to original view model.

