### PR TITLE
feat: Split Asset Share Actions PR 3 [WPB-26687]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/edit/ShareAssetMenuOption.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/edit/ShareAssetMenuOption.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
 import com.wire.android.ui.common.bottomsheet.MenuItemIcon
+import com.wire.android.util.supportsTrustedWireShareCaller
 
 @Composable
 fun ShareAssetMenuOption(onShareAsset: () -> Unit) {
@@ -33,6 +34,47 @@ fun ShareAssetMenuOption(onShareAsset: () -> Unit) {
             )
         },
         title = stringResource(R.string.label_share),
+        onItemClick = onShareAsset
+    )
+}
+
+fun shareAssetMenuOptions(
+    onShareAssetExternally: () -> Unit,
+    onShareAssetViaWire: () -> Unit
+): List<@Composable () -> Unit> =
+    if (supportsTrustedWireShareCaller()) {
+        listOf({ ShareAssetMenuOption(onShareAssetExternally) })
+    } else {
+        listOf(
+            { ShareAssetViaWireMenuOption(onShareAssetViaWire) },
+            { ShareAssetExternallyMenuOption(onShareAssetExternally) }
+        )
+    }
+
+@Composable
+fun ShareAssetViaWireMenuOption(onShareAsset: () -> Unit) {
+    MenuBottomSheetItem(
+        leading = {
+            MenuItemIcon(
+                id = R.drawable.ic_share_file,
+                contentDescription = stringResource(R.string.content_description_share_the_file),
+            )
+        },
+        title = stringResource(R.string.label_share_via_wire),
+        onItemClick = onShareAsset
+    )
+}
+
+@Composable
+fun ShareAssetExternallyMenuOption(onShareAsset: () -> Unit) {
+    MenuBottomSheetItem(
+        leading = {
+            MenuItemIcon(
+                id = R.drawable.ic_share_file,
+                contentDescription = stringResource(R.string.content_description_share_the_file),
+            )
+        },
+        title = stringResource(R.string.label_share_externally),
         onItemClick = onShareAsset
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -256,7 +256,8 @@ fun ConversationScreen(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val uriHandler = LocalUriHandler.current
-    val resources = LocalContext.current.resources
+    val context = LocalContext.current
+    val resources = context.resources
     val showDialog = remember { mutableStateOf(ConversationScreenDialogType.NONE) }
     val messageComposerViewState = messageComposerViewModel.messageComposerViewState
     val messageComposerStateHolder = rememberMessageComposerStateHolder(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -90,6 +90,7 @@ import androidx.paging.compose.itemKey
 import com.ramcosta.composedestinations.generated.app.destinations.ConversationScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.GroupConversationDetailsScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.ImagesPreviewScreenDestination
+import com.ramcosta.composedestinations.generated.app.destinations.ImportMediaScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.MediaGalleryScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.MessageDetailsScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.OtherUserProfileScreenDestination
@@ -186,12 +187,14 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.ui.userprofile.service.ServiceDetailsNavArgs
 import com.wire.android.util.DateAndTimeParsers
+import com.wire.android.util.fileShareUri
 import com.wire.android.util.normalizeLink
 import com.wire.android.util.openDownloadFolder
 import com.wire.android.util.serverDate
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.collectAsLazyPagingItemsWithLifecycle
+import com.wire.android.ui.sharing.ImportMediaNavArgs
 import com.wire.kalium.logic.data.conversation.Conversation.TypingIndicatorMode
 import com.wire.kalium.logic.data.conversation.InteractionAvailability
 import com.wire.kalium.logic.data.id.ConversationId
@@ -535,7 +538,19 @@ fun ConversationScreen(
         },
         composerMessages = sendMessageViewModel.infoMessage,
         conversationMessages = conversationMessagesViewModel.infoMessage,
-        shareAsset = conversationMessagesViewModel::shareAsset,
+        shareAssetExternally = conversationMessagesViewModel::shareAsset,
+        shareAssetViaWire = { messageId ->
+            conversationMessagesViewModel.shareAssetViaWire(messageId) { path, assetName ->
+                navigator.navigate(
+                    NavigationCommand(
+                        ImportMediaScreenDestination(
+                            ImportMediaNavArgs(arrayListOf(context.fileShareUri(path, assetName)))
+                        ),
+                        BackStackMode.UPDATE_EXISTED
+                    )
+                )
+            }
+        },
         onDownloadAssetClick = conversationMessagesViewModel::openOrFetchAsset,
         onOpenAssetClick = conversationMessagesViewModel::downloadAndOpenAsset,
         onNavigateToReplyOriginalMessage = conversationMessagesViewModel::navigateToReplyOriginalMessage,
@@ -800,7 +815,8 @@ private fun ConversationScreen(
     onBackButtonClick: () -> Unit,
     composerMessages: SharedFlow<SnackBarMessage>,
     conversationMessages: SharedFlow<SnackBarMessage>,
-    shareAsset: (Context, messageId: String) -> Unit,
+    shareAssetExternally: (Context, messageId: String) -> Unit,
+    shareAssetViaWire: (messageId: String) -> Unit,
     onDownloadAssetClick: (messageId: String) -> Unit,
     onOpenAssetClick: (messageId: String) -> Unit,
     onNavigateToReplyOriginalMessage: (UIMessage) -> Unit,
@@ -943,7 +959,8 @@ private fun ConversationScreen(
             onDetailsClick = onMessageDetailsClick,
             onReplyClick = messageComposerStateHolder::toReply,
             onEditClick = messageComposerStateHolder::toEdit,
-            onShareAssetClick = { shareAsset(context, it) },
+            onShareAssetExternallyClick = { shareAssetExternally(context, it) },
+            onShareAssetViaWireClick = shareAssetViaWire,
             onDownloadAssetClick = onDownloadAssetClick,
             onOpenAssetClick = onOpenAssetClick,
         )
@@ -1810,7 +1827,8 @@ fun PreviewConversationScreen() = WireTheme {
         onBackButtonClick = {},
         composerMessages = MutableStateFlow(ConversationSnackbarMessages.ErrorDownloadingAsset),
         conversationMessages = MutableStateFlow(ConversationSnackbarMessages.ErrorDownloadingAsset),
-        shareAsset = { _, _ -> },
+        shareAssetExternally = { _, _ -> },
+        shareAssetViaWire = {},
         onOpenAssetClick = {},
         onDownloadAssetClick = {},
         onNavigateToReplyOriginalMessage = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/AssetOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/AssetOptionsMenuItems.kt
@@ -24,7 +24,7 @@ import com.wire.android.ui.edit.MessageDetailsMenuOption
 import com.wire.android.ui.edit.OpenAssetExternallyOption
 import com.wire.android.ui.edit.ReactionOption
 import com.wire.android.ui.edit.ReplyMessageOption
-import com.wire.android.ui.edit.ShareAssetMenuOption
+import com.wire.android.ui.edit.shareAssetMenuOptions
 
 // menu items with both asset options enabled (like share, download, etc.) and message options enabled (like reply, reaction, etc.)
 @Composable
@@ -33,7 +33,8 @@ fun assetMessageOptionsMenuItems(
     ownReactions: Set<String>,
     onDeleteClick: () -> Unit,
     onDetailsClick: () -> Unit,
-    onShareAsset: () -> Unit,
+    onShareAssetExternally: () -> Unit,
+    onShareAssetViaWire: () -> Unit,
     onDownloadAsset: () -> Unit,
     onReplyClick: () -> Unit,
     onReactionClick: (emoji: String) -> Unit,
@@ -59,7 +60,7 @@ fun assetMessageOptionsMenuItems(
                 add { MessageDetailsMenuOption(onDetailsClick) }
                 add { ReplyMessageOption(onReplyClick) }
                 add { DownloadAssetExternallyOption(onDownloadAsset) }
-                add { ShareAssetMenuOption(onShareAsset) }
+                addAll(shareAssetMenuOptions(onShareAssetExternally, onShareAssetViaWire))
                 if (isOpenable) add { OpenAssetExternallyOption(onOpenAsset) }
                 add { DeleteItemMenuOption(onDeleteClick) }
             }
@@ -72,7 +73,8 @@ fun assetMessageOptionsMenuItems(
 fun assetOptionsMenuItems(
     isEphemeral: Boolean,
     onDeleteClick: () -> Unit,
-    onShareAsset: () -> Unit,
+    onShareAssetExternally: () -> Unit,
+    onShareAssetViaWire: () -> Unit,
     onDownloadAsset: () -> Unit,
     isOpenable: Boolean = false,
     onOpenAsset: () -> Unit = {},
@@ -80,7 +82,9 @@ fun assetOptionsMenuItems(
 ): List<@Composable () -> Unit> = buildList {
     if (!isUploading) {
         add { DownloadAssetExternallyOption(onDownloadAsset) }
-        if (!isEphemeral) add { ShareAssetMenuOption(onShareAsset) }
+        if (!isEphemeral) {
+            addAll(shareAssetMenuOptions(onShareAssetExternally, onShareAssetViaWire))
+        }
         if (isOpenable) add { OpenAssetExternallyOption(onOpenAsset) }
     }
     add { DeleteItemMenuOption(onDeleteClick) }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsMenuItems.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsMenuItems.kt
@@ -36,7 +36,8 @@ fun messageOptionsMenuItems(
     onDetailsClick: () -> Unit,
     onReplyClick: () -> Unit,
     onEditClick: () -> Unit,
-    onShareAssetClick: () -> Unit,
+    onShareAssetExternallyClick: () -> Unit,
+    onShareAssetViaWireClick: () -> Unit,
     onDownloadAssetClick: () -> Unit,
     onOpenAssetClick: () -> Unit
 ): List<@Composable () -> Unit> {
@@ -48,7 +49,8 @@ fun messageOptionsMenuItems(
             isOpenable = isOpenable,
             onDeleteClick = onDeleteClick,
             onDetailsClick = onDetailsClick,
-            onShareAsset = onShareAssetClick,
+            onShareAssetExternally = onShareAssetExternallyClick,
+            onShareAssetViaWire = onShareAssetViaWireClick,
             onDownloadAsset = onDownloadAssetClick,
             onReplyClick = onReplyClick,
             onReactionClick = onReactionClick,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/edit/MessageOptionsModalSheetLayout.kt
@@ -60,7 +60,8 @@ fun MessageOptionsModalSheetLayout(
     onDetailsClick: (messageId: String, isSelfMessage: Boolean) -> Unit,
     onReplyClick: (UIMessage.Regular) -> Unit,
     onEditClick: (messageId: String, messageBody: String, mentions: List<MessageMention>, isMultipart: Boolean) -> Unit,
-    onShareAssetClick: (messageId: String) -> Unit,
+    onShareAssetExternallyClick: (messageId: String) -> Unit,
+    onShareAssetViaWireClick: (messageId: String) -> Unit,
     onDownloadAssetClick: (messageId: String) -> Unit,
     onOpenAssetClick: (messageId: String) -> Unit,
     viewModel: MessageOptionsMenuViewModel =
@@ -84,7 +85,8 @@ fun MessageOptionsModalSheetLayout(
                     onDetailsClick = onDetailsClick,
                     onReplyClick = onReplyClick,
                     onEditClick = onEditClick,
-                    onShareAssetClick = onShareAssetClick,
+                    onShareAssetExternallyClick = onShareAssetExternallyClick,
+                    onShareAssetViaWireClick = onShareAssetViaWireClick,
                     onDownloadAssetClick = onDownloadAssetClick,
                     onOpenAssetClick = onOpenAssetClick
                 ).also {
@@ -118,7 +120,8 @@ private fun MessageOptionsModalContent(
     onDetailsClick: (messageId: String, isSelfMessage: Boolean) -> Unit,
     onReplyClick: (UIMessage.Regular) -> Unit,
     onEditClick: (messageId: String, messageBody: String, mentions: List<MessageMention>, isMultipart: Boolean) -> Unit,
-    onShareAssetClick: (messageId: String) -> Unit,
+    onShareAssetExternallyClick: (messageId: String) -> Unit,
+    onShareAssetViaWireClick: (messageId: String) -> Unit,
     onDownloadAssetClick: (messageId: String) -> Unit,
     onOpenAssetClick: (messageId: String) -> Unit,
 ) {
@@ -214,10 +217,17 @@ private fun MessageOptionsModalContent(
                     }
                 }
             },
-            onShareAssetClick = remember(message.header.messageId) {
+            onShareAssetExternallyClick = remember(message.header.messageId) {
                 {
                     sheetState.hide {
-                        onShareAssetClick(message.header.messageId)
+                        onShareAssetExternallyClick(message.header.messageId)
+                    }
+                }
+            },
+            onShareAssetViaWireClick = remember(message.header.messageId) {
+                {
+                    sheetState.hide {
+                        onShareAssetViaWireClick(message.header.messageId)
                     }
                 }
             },
@@ -284,7 +294,8 @@ fun PreviewMessageOptionsModalSheetLayout() = WireTheme {
         onDetailsClick = { _, _ -> },
         onReplyClick = { },
         onEditClick = { _, _, _, _ -> },
-        onShareAssetClick = { },
+        onShareAssetExternallyClick = { },
+        onShareAssetViaWireClick = { },
         onDownloadAssetClick = { },
         onOpenAssetClick = { }
     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
@@ -63,6 +63,7 @@ import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.visbility.rememberVisibilityState
 import com.ramcosta.composedestinations.generated.app.destinations.MediaGalleryScreenDestination
+import com.ramcosta.composedestinations.generated.app.destinations.ImportMediaScreenDestination
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages
 import com.wire.android.ui.home.conversations.DownloadedAssetDialog
 import com.wire.android.ui.home.conversations.PermissionPermanentlyDeniedDialogState
@@ -72,8 +73,10 @@ import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogState
 import com.wire.android.ui.home.conversations.edit.assetOptionsMenuItems
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
+import com.wire.android.ui.sharing.ImportMediaNavArgs
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.util.fileShareUri
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.SnackBarMessageHandler
 import com.wire.android.util.ui.UIText
@@ -127,7 +130,18 @@ fun ConversationMediaScreen(
             conversationMessagesViewModel.deleteMessageDialogState
                 .show(DeleteMessageDialogState(deleteForEveryone, messageId, conversationMessagesViewModel.conversationId))
         },
-        shareAsset = remember { { conversationMessagesViewModel.shareAsset(context, it) } },
+        shareAssetExternally = { conversationMessagesViewModel.shareAsset(context, it) },
+        shareAssetViaWire = { messageId ->
+            conversationMessagesViewModel.shareAssetViaWire(messageId) { path, assetName ->
+                navigator.navigate(
+                    NavigationCommand(
+                        ImportMediaScreenDestination(
+                            ImportMediaNavArgs(arrayListOf(context.fileShareUri(path, assetName)))
+                        )
+                    )
+                )
+            }
+        },
         downloadAsset = conversationMessagesViewModel::openOrFetchAsset,
     )
 
@@ -248,7 +262,8 @@ private fun Content(
 private fun AssetOptionsModalSheetLayout(
     sheetState: WireModalSheetState<AssetOptionsData>,
     deleteAsset: (messageId: String, isMyMessage: Boolean) -> Unit,
-    shareAsset: (messageId: String) -> Unit,
+    shareAssetExternally: (messageId: String) -> Unit,
+    shareAssetViaWire: (messageId: String) -> Unit,
     downloadAsset: (messageId: String) -> Unit,
 ) {
     WireModalSheetLayout(
@@ -259,7 +274,8 @@ private fun AssetOptionsModalSheetLayout(
                     isUploading = false, // only uploaded assets
                     isEphemeral = false, // only non-self-deleting assets
                     onDeleteClick = remember { { sheetState.hide { deleteAsset(messageId, isMyMessage) } } },
-                    onShareAsset = remember { { sheetState.hide { shareAsset(messageId) } } },
+                    onShareAssetExternally = remember { { sheetState.hide { shareAssetExternally(messageId) } } },
+                    onShareAssetViaWire = remember { { sheetState.hide { shareAssetViaWire(messageId) } } },
                     onDownloadAsset = remember { { sheetState.hide { downloadAsset(messageId) } } },
                 )
             )
@@ -321,7 +337,8 @@ fun PreviewAssetOptionsModalSheetLayout() = WireTheme {
             )
         ),
         deleteAsset = { _, _ -> },
-        shareAsset = { },
+        shareAssetExternally = { },
+        shareAssetViaWire = { },
         downloadAsset = { }
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -433,6 +433,14 @@ class ConversationMessagesViewModel(
         }
     }
 
+    fun shareAssetViaWire(messageId: String, onAssetReady: (Path, String) -> Unit) {
+        viewModelScope.launch {
+            assetDataPath(conversationId, messageId)?.run {
+                onAssetReady(first, second)
+            }
+        }
+    }
+
     private suspend fun assetDataPath(conversationId: QualifiedID, messageId: String): Pair<Path, String>? =
         getMessageAsset(conversationId, messageId).await().run {
             return when (this) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryScreen.kt
@@ -37,6 +37,7 @@ import com.ramcosta.composedestinations.result.ResultBackNavigator
 import com.wire.android.R
 import com.wire.android.ui.common.R as commonR
 import com.ramcosta.composedestinations.generated.cells.destinations.PublicLinkScreenDestination
+import com.ramcosta.composedestinations.generated.app.destinations.ImportMediaScreenDestination
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.navigation.style.PopUpNavigationAnimation
@@ -56,15 +57,20 @@ import com.wire.android.ui.edit.MessageDetailsMenuOption
 import com.wire.android.ui.edit.ReactionOption
 import com.wire.android.ui.edit.ReplyMessageOption
 import com.wire.android.ui.edit.ShareAssetMenuOption
+import com.wire.android.ui.edit.ShareAssetExternallyMenuOption
+import com.wire.android.ui.edit.ShareAssetViaWireMenuOption
 import com.wire.android.ui.edit.SharePublicLinkMenuOption
 import com.wire.android.ui.home.conversations.MediaGallerySnackbarMessages
 import com.wire.android.ui.home.conversations.PermissionPermanentlyDeniedDialogState
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
 import com.wire.android.ui.home.conversations.mediaGalleryViewModel
 import com.wire.android.ui.home.conversations.mock.mockedPrivateAsset
+import com.wire.android.ui.sharing.ImportMediaNavArgs
 import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.fileShareUri
 import com.wire.android.util.permission.rememberWriteStoragePermissionFlow
 import com.wire.android.util.startFileShareIntent
+import com.wire.android.util.supportsTrustedWireShareCaller
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.SnackBarMessageHandler
 import com.wire.android.util.openDownloadFolder
@@ -136,7 +142,15 @@ fun MediaGalleryScreen(
 
     HandleActions(mediaGalleryViewModel.actions) { action ->
         when (action) {
-            is MediaGalleryAction.Share -> context.startFileShareIntent(action.path, action.assetName)
+            is MediaGalleryAction.ShareExternally -> context.startFileShareIntent(action.path, action.assetName)
+            is MediaGalleryAction.ShareViaWire -> navigator.navigate(
+                NavigationCommand(
+                    ImportMediaScreenDestination(
+                        ImportMediaNavArgs(arrayListOf(context.fileShareUri(action.path, action.assetName)))
+                    )
+                )
+            )
+
             is MediaGalleryAction.ShowDetails -> {
                 resultNavigator.setResult(
                     MediaGalleryNavBackArgs(
@@ -240,6 +254,9 @@ private fun MediaGalleryOptionsBottomSheetLayout(
 
     val sheetState: WireModalSheetState<Unit> = rememberWireModalSheetState(WireSheetValue.Expanded(Unit))
     val onOptionsClick: (MenuIntent) -> Unit = remember { { sheetState.hide { onMenuIntent(it) } } }
+    val collapseShareOptions = supportsTrustedWireShareCaller() &&
+        menuItems.contains(MediaGalleryMenuItem.SHARE_VIA_WIRE) &&
+        menuItems.contains(MediaGalleryMenuItem.SHARE_EXTERNALLY)
 
     val menuItems: List<@Composable () -> Unit> = buildList {
         menuItems.forEach { item ->
@@ -256,11 +273,20 @@ private fun MediaGalleryOptionsBottomSheetLayout(
                 MediaGalleryMenuItem.DOWNLOAD -> add {
                     DownloadAssetExternallyOption { onOptionsClick(MenuIntent.Download) }
                 }
-                MediaGalleryMenuItem.SHARE -> add {
-                    ShareAssetMenuOption { onOptionsClick(MenuIntent.Share) }
+                MediaGalleryMenuItem.SHARE_EXTERNALLY -> if (!collapseShareOptions) {
+                    add {
+                        ShareAssetExternallyMenuOption { onOptionsClick(MenuIntent.ShareExternally) }
+                    }
+                }
+                MediaGalleryMenuItem.SHARE_VIA_WIRE -> add {
+                    if (collapseShareOptions) {
+                        ShareAssetMenuOption { onOptionsClick(MenuIntent.ShareExternally) }
+                    } else {
+                        ShareAssetViaWireMenuOption { onOptionsClick(MenuIntent.ShareViaWire) }
+                    }
                 }
                 MediaGalleryMenuItem.SHARE_PUBLIC_LINK -> add {
-                    SharePublicLinkMenuOption { onOptionsClick(MenuIntent.Share) }
+                    SharePublicLinkMenuOption { onOptionsClick(MenuIntent.ShareExternally) }
                 }
                 MediaGalleryMenuItem.DELETE -> add {
                     DeleteItemMenuOption { onOptionsClick(MenuIntent.Delete) }

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
@@ -121,7 +121,7 @@ class MediaGalleryViewModel(
     private fun shareAsset() = viewModelScope.launch {
         if (cellAssetId == null) {
             assetDataPath(conversationId, messageId)?.run {
-                sendAction(MediaGalleryAction.Share(first, second))
+                sendAction(MediaGalleryAction.ShareExternally(first, second))
             }
         } else {
             getCellNode(cellAssetId)
@@ -189,6 +189,14 @@ class MediaGalleryViewModel(
         }
     }
 
+    private fun shareAssetViaWire() = viewModelScope.launch {
+        if (cellAssetId == null) {
+            assetDataPath(conversationId, messageId)?.run {
+                sendAction(MediaGalleryAction.ShareViaWire(first, second))
+            }
+        }
+    }
+
     private fun onSnackbarMessage(messageCode: MediaGallerySnackbarMessages) {
         viewModelScope.launch {
             _snackbarMessage.emit(messageCode)
@@ -227,7 +235,8 @@ class MediaGalleryViewModel(
 
             MenuIntent.Download -> sendAction(MediaGalleryAction.Download)
 
-            MenuIntent.Share -> shareAsset()
+            MenuIntent.ShareExternally -> shareAsset()
+            MenuIntent.ShareViaWire -> shareAssetViaWire()
 
             MenuIntent.Delete -> {
                 deleteMessageDialogState.show(
@@ -272,13 +281,17 @@ class MediaGalleryViewModel(
                     add(MediaGalleryMenuItem.SHOW_DETAILS)
                     add(MediaGalleryMenuItem.REPLY)
                     add(MediaGalleryMenuItem.DOWNLOAD)
-                    add(MediaGalleryMenuItem.SHARE)
+                    add(MediaGalleryMenuItem.SHARE_VIA_WIRE)
+                    add(MediaGalleryMenuItem.SHARE_EXTERNALLY)
                     add(MediaGalleryMenuItem.DELETE)
                 }
             }
         } else if (cellAssetId == null) {
             add(MediaGalleryMenuItem.DOWNLOAD)
-            if (!mediaGalleryNavArgs.isEphemeral) add(MediaGalleryMenuItem.SHARE)
+            if (!mediaGalleryNavArgs.isEphemeral) {
+                add(MediaGalleryMenuItem.SHARE_VIA_WIRE)
+                add(MediaGalleryMenuItem.SHARE_EXTERNALLY)
+            }
             add(MediaGalleryMenuItem.DELETE)
         }
     }
@@ -298,7 +311,8 @@ class MediaGalleryViewModel(
 
 sealed interface MediaGalleryAction {
     data class ShowDetails(val messageId: String, val isSelfAsset: Boolean) : MediaGalleryAction
-    data class Share(val path: Path, val assetName: String) : MediaGalleryAction
+    data class ShareExternally(val path: Path, val assetName: String) : MediaGalleryAction
+    data class ShareViaWire(val path: Path, val assetName: String) : MediaGalleryAction
     data class React(val messageId: String, val emoji: String) : MediaGalleryAction
     data class Reply(val messageId: String) : MediaGalleryAction
     data object Download : MediaGalleryAction
@@ -312,7 +326,8 @@ sealed interface MenuIntent {
     data object ShowDetails : MenuIntent
     data object Reply : MenuIntent
     data object Download : MenuIntent
-    data object Share : MenuIntent
+    data object ShareExternally : MenuIntent
+    data object ShareViaWire : MenuIntent
     data object Delete : MenuIntent
 }
 
@@ -321,7 +336,8 @@ enum class MediaGalleryMenuItem {
     SHOW_DETAILS,
     REPLY,
     DOWNLOAD,
-    SHARE,
+    SHARE_EXTERNALLY,
+    SHARE_VIA_WIRE,
     SHARE_PUBLIC_LINK,
     DELETE
 }

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaAuthenticatedViewModel.kt
@@ -251,8 +251,12 @@ class ImportMediaAuthenticatedViewModel(
             }
         }
 
-    private suspend fun handleImportedAsset(uri: Uri): ImportedMediaAsset? =
-        withContext(dispatchers.io()) {
+    private suspend fun handleImportedAsset(uri: Uri, rejectOwnFileProviderUri: Boolean): ImportedMediaAsset? {
+        if (rejectOwnFileProviderUri) {
+            appLogger.w("$TAG: Ignoring shared URI from Wire's own file provider")
+            return null
+        }
+        return withContext(dispatchers.io()) {
             when (val result = handleUriAsset.invoke(uri, saveToDeviceIfInvalid = false)) {
                 is HandleUriAssetUseCase.Result.Failure.AssetTooLarge -> {
                     appLogger.w("$TAG: Failed to import asset message: Asset too large")
@@ -267,6 +271,7 @@ class ImportMediaAuthenticatedViewModel(
                 is HandleUriAssetUseCase.Result.Success -> ImportedMediaAsset(result.assetBundle, null)
             }
         }
+    }
 
     private fun onSnackbarMessage(type: SnackBarMessage) = viewModelScope.launch {
         _infoMessage.emit(type)

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -271,6 +271,8 @@ private fun ImportMediaAuthenticatedContent(
     }
 }
 
+private fun ImportMediaNavArgs.isInternalShare(): Boolean = internalAssetUriList.isNotEmpty()
+
 @Composable
 fun ImportMediaRestrictedContent(
     importMediaAuthenticatedState: ImportMediaAuthenticatedState,

--- a/app/src/main/kotlin/com/wire/android/util/AvatarImageManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/AvatarImageManager.kt
@@ -20,7 +20,6 @@ package com.wire.android.util
 
 import android.content.Context
 import android.net.Uri
-import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import okio.Path
 import dev.zacsweers.metro.Inject
@@ -32,11 +31,7 @@ class AvatarImageManager @Inject constructor(val context: Context) {
         return file.toUri()
     }
 
-    /**
-     * Creates a temporary URI that the camera app writes the captured avatar into.
-     */
-    fun createCameraOutputAvatarUri(filePath: Path): Uri {
-        val cameraOutputFile = context.fileProviderSharedCacheFile(filePath.name)
-        return FileProvider.getUriForFile(context, context.getProviderAuthority(), cameraOutputFile)
+    fun getShareableTempAvatarUri(filePath: Path): Uri {
+        return context.shareableFileProviderUri(context.fileProviderSharedCacheFile(filePath.name))
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -270,7 +270,8 @@ class MediaGalleryViewModelTest {
         assertEquals(
             listOf(
                 MediaGalleryMenuItem.DOWNLOAD,
-                MediaGalleryMenuItem.SHARE,
+                MediaGalleryMenuItem.SHARE_VIA_WIRE,
+                MediaGalleryMenuItem.SHARE_EXTERNALLY,
                 MediaGalleryMenuItem.DELETE,
             ),
             state.menuItems
@@ -371,7 +372,8 @@ class MediaGalleryViewModelTest {
                 MediaGalleryMenuItem.SHOW_DETAILS,
                 MediaGalleryMenuItem.REPLY,
                 MediaGalleryMenuItem.DOWNLOAD,
-                MediaGalleryMenuItem.SHARE,
+                MediaGalleryMenuItem.SHARE_VIA_WIRE,
+                MediaGalleryMenuItem.SHARE_EXTERNALLY,
                 MediaGalleryMenuItem.DELETE,
             ),
             state.menuItems


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26687
<!--jira-description-action-hidden-marker-end-->
## Summary
- Splits asset sharing into “Share via Wire” and “Share externally” where needed.
- Keeps direct external sharing on Android versions that support trusted Wire share identity.
- Wires conversation, message options, conversation media, and gallery entry points into the internal import flow.
- Fixes the conversation screen context lookup used when forwarding assets via Wire.

## General Idea

This stack separates “share externally” from “forward/share inside Wire” while keeping the behavior different per Android version:

- On Android 15+ we can rely on trusted share caller identity, so Wire can stay in the normal Android share sheet safely.
- On older Android versions we cannot reliably know that an incoming Wire FileProvider URI came from Wire itself, so we avoid routing Wire-internal files through the public share sheet.
- For older Android versions, internal Wire forwarding uses an explicit in-app navigation path into the import media flow.
- External sharing uses Android chooser intents and excludes Wire where needed to prevent re-importing internal Wire files.

```mermaid
flowchart TD
    A["User taps Share"] --> B{"Android 15+?"}

    B -- "Yes" --> C["Use Android share sheet"]
    C --> D["Enable share identity"]
    D --> E["Wire target can be trusted"]

    B -- "No" --> F{"Target action"}
    F -- "Share externally" --> G["Open external chooser"]
    G --> H["Exclude Wire targets"]

    F -- "Share via Wire" --> I["Create shared-cache FileProvider URI"]
    I --> J["Navigate directly to ImportMediaScreen"]
    J --> K["Validate URI is from Wire shared_files root"]
    K --> L["Import as pending asset"]
```

## Stack

This PR is part of a stacked series:

1. `mo/share-forward-01-share-plumbing`  
   Share-safe FileProvider helpers and chooser behavior.

2. `mo/share-forward-02-import-safety`  
   Incoming share validation and trusted Wire caller handling.

3. `mo/share-forward-03-asset-actions`  
   UI split between “Share via Wire” and “Share externally”.

4. `mo/share-forward-04-log-sharing`  
   Share logs as one archive, either externally or via Wire.

5. `mo/share-forward-05-stability-baselines`  
   Generated stability baseline updates.