### PR TITLE
feat: share logs via Wire PR 4 [WPB-26687]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugScreen.kt
@@ -20,6 +20,7 @@ package com.wire.android.ui.debug
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
@@ -51,10 +52,12 @@ import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.ramcosta.composedestinations.generated.app.destinations.ConversationCryptoStatsScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.DebugFeatureFlagsScreenDestination
+import com.ramcosta.composedestinations.generated.app.destinations.ImportMediaScreenDestination
 import com.wire.android.ui.common.rowitem.SectionHeader
 import com.wire.android.ui.home.settings.SettingsItem
 import com.wire.android.ui.home.settings.backup.BackupAndRestoreDialog
 import com.wire.android.ui.home.settings.backup.rememberBackUpAndRestoreStateHolder
+import com.wire.android.ui.sharing.ImportMediaNavArgs
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.AppNameUtil
 import com.wire.android.util.logging.LogShareLauncher
@@ -94,6 +97,13 @@ fun DebugScreen(
         dangerOptionsContent = {
             DangerOptions(exportObfuscatedCopyViewModel = exportObfuscatedCopyViewModel)
         },
+        onShareLogsViaWire = { uri ->
+            navigator.navigate(
+                NavigationCommand(
+                    ImportMediaScreenDestination(ImportMediaNavArgs(arrayListOf(uri)))
+                )
+            )
+        },
     )
 }
 
@@ -105,6 +115,7 @@ internal fun UserDebugContent(
     onDatabaseLoggerEnabledChanged: (Boolean) -> Unit,
     onDeleteLogs: () -> Unit,
     onFlushLogs: () -> Deferred<Unit>,
+    onShareLogsViaWire: (Uri) -> Unit,
     debugDataOptionsContent: @Composable (DebugContentState) -> Unit,
     dangerOptionsContent: @Composable () -> Unit,
 ) {
@@ -131,7 +142,8 @@ internal fun UserDebugContent(
                     isLoggingEnabled = isLoggingEnabled,
                     onLoggingEnabledChange = onLoggingEnabledChange,
                     onDeleteLogs = onDeleteLogs,
-                    onShareLogs = { debugContentState.shareLogs(onFlushLogs) },
+                    onShareLogsExternally = { debugContentState.shareLogsExternally(onFlushLogs) },
+                    onShareLogsViaWire = { debugContentState.shareLogsViaWire(onFlushLogs, onShareLogsViaWire) },
                     isDBLoggerEnabled = state.isDBLoggingEnabled,
                     onDBLoggerEnabledChange = onDatabaseLoggerEnabledChanged,
                     isPrivateBuild = BuildConfig.PRIVATE_BUILD,
@@ -230,10 +242,23 @@ data class DebugContentState(
         ).show()
     }
 
-    fun shareLogs(onFlushLogs: () -> Deferred<Unit>) {
+    fun shareLogsExternally(onFlushLogs: () -> Deferred<Unit>) {
         val dir = File(logPath).parentFile
         if (dir != null && dir.exists()) {
             logShareLauncher.shareLogs(dir) {
+                // Flush any buffered logs before sharing to ensure completeness.
+                onFlushLogs().await()
+            }
+        }
+    }
+
+    fun shareLogsViaWire(onFlushLogs: () -> Deferred<Unit>, onShareUri: (Uri) -> Unit) {
+        val dir = File(logPath).parentFile
+        if (dir != null && dir.exists()) {
+            logShareLauncher.shareLogsViaWire(
+                logsDirectory = dir,
+                onShareUri = onShareUri
+            ) {
                 // Flush any buffered logs before sharing to ensure completeness.
                 onFlushLogs().await()
             }
@@ -253,6 +278,7 @@ internal fun PreviewUserDebugContent() = WireTheme {
         onLoggingEnabledChange = {},
         onDeleteLogs = {},
         onFlushLogs = { CompletableDeferred(Unit) },
+        onShareLogsViaWire = {},
         onDatabaseLoggerEnabledChanged = {},
         debugDataOptionsContent = {
             DebugDataOptions(

--- a/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementScreen.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.android.ui.debug
 
+import com.ramcosta.composedestinations.generated.app.destinations.ImportMediaScreenDestination
 import com.wire.android.navigation.annotation.app.WireRootDestination
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -26,11 +27,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
+import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.Navigator
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.scaffold.WireScaffold
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.sharing.ImportMediaNavArgs
 
 @WireRootDestination
 @Composable
@@ -63,7 +66,16 @@ fun LogManagementScreen(
                 isLoggingEnabled = state.isLoggingEnabled,
                 onLoggingEnabledChange = viewModel::setLoggingEnabledState,
                 onDeleteLogs = viewModel::deleteLogs,
-                onShareLogs = { contentState.shareLogs(viewModel::flushLogs) },
+                onShareLogsExternally = { contentState.shareLogsExternally(viewModel::flushLogs) },
+                onShareLogsViaWire = {
+                    contentState.shareLogsViaWire(viewModel::flushLogs) { uri ->
+                        navigator.navigate(
+                            NavigationCommand(
+                                ImportMediaScreenDestination(ImportMediaNavArgs(arrayListOf(uri)))
+                            )
+                        )
+                    }
+                },
                 isDBLoggerEnabled = false,
                 onDBLoggerEnabledChange = {},
                 isPrivateBuild = false

--- a/app/src/main/kotlin/com/wire/android/ui/debug/LogOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/LogOptions.kt
@@ -34,6 +34,13 @@ import androidx.compose.ui.res.stringResource
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.SurfaceBackgroundWrapper
+import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
+import com.wire.android.ui.common.bottomsheet.MenuItemIcon
+import com.wire.android.ui.common.bottomsheet.MenuModalSheetHeader
+import com.wire.android.ui.common.bottomsheet.WireMenuModalSheetContent
+import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
+import com.wire.android.ui.common.bottomsheet.rememberWireModalSheetState
+import com.wire.android.ui.common.bottomsheet.show
 import com.wire.android.ui.common.button.WireSwitch
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
@@ -44,6 +51,7 @@ import com.wire.android.ui.home.settings.SettingsItem
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.supportsTrustedWireShareCaller
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
@@ -53,10 +61,21 @@ fun LogOptions(
     isDBLoggerEnabled: Boolean,
     onDBLoggerEnabledChange: (Boolean) -> Unit,
     onDeleteLogs: () -> Unit,
-    onShareLogs: () -> Unit,
+    onShareLogsExternally: () -> Unit,
+    onShareLogsViaWire: () -> Unit,
     isPrivateBuild: Boolean,
     modifier: Modifier = Modifier
 ) {
+    val shareLogsSheetState = rememberWireModalSheetState<Unit>()
+    val shareLogsDirectly = supportsTrustedWireShareCaller()
+    val onShareLogsClick: () -> Unit = {
+        if (shareLogsDirectly) {
+            onShareLogsExternally()
+        } else {
+            shareLogsSheetState.show()
+        }
+    }
+
     Column(modifier = modifier) {
         SectionHeader(stringResource(R.string.label_logs_option_title))
         EnableLoggingSwitch(
@@ -74,9 +93,13 @@ fun LogOptions(
             SettingsItem(
                 text = stringResource(R.string.label_share_logs),
                 trailingIcon = R.drawable.ic_entypo_share,
+                onRowPressed = Clickable(
+                    enabled = true,
+                    onClick = onShareLogsClick
+                ),
                 onIconPressed = Clickable(
                     enabled = true,
-                    onClick = onShareLogs
+                    onClick = onShareLogsClick
                 )
             )
 
@@ -90,6 +113,64 @@ fun LogOptions(
             )
         }
     }
+
+    if (!shareLogsDirectly) {
+        WireModalSheetLayout(
+            sheetState = shareLogsSheetState,
+            sheetContent = {
+                WireMenuModalSheetContent(
+                    header = MenuModalSheetHeader.Visible(
+                        title = stringResource(R.string.label_share_logs)
+                    ),
+                    menuItems = shareLogsMenuItems(
+                        onShareLogsExternally = {
+                            shareLogsSheetState.hide { onShareLogsExternally() }
+                        },
+                        onShareLogsViaWire = {
+                            shareLogsSheetState.hide { onShareLogsViaWire() }
+                        }
+                    )
+                )
+            }
+        )
+    }
+}
+
+private fun shareLogsMenuItems(
+    onShareLogsExternally: () -> Unit,
+    onShareLogsViaWire: () -> Unit
+): List<@Composable () -> Unit> =
+    listOf(
+        { ShareLogsInWireOption(onShareLogsViaWire) },
+        { ShareLogsExternallyOption(onShareLogsExternally) }
+    )
+
+@Composable
+private fun ShareLogsInWireOption(onClick: () -> Unit) {
+    MenuBottomSheetItem(
+        leading = {
+            MenuItemIcon(
+                id = R.drawable.ic_share_file,
+                contentDescription = stringResource(R.string.content_description_share_the_file),
+            )
+        },
+        title = stringResource(R.string.label_share_logs_via_wire),
+        onItemClick = onClick
+    )
+}
+
+@Composable
+private fun ShareLogsExternallyOption(onClick: () -> Unit) {
+    MenuBottomSheetItem(
+        leading = {
+            MenuItemIcon(
+                id = R.drawable.ic_entypo_share,
+                contentDescription = stringResource(R.string.content_description_share_the_file),
+            )
+        },
+        title = stringResource(R.string.label_share_logs_externally),
+        onItemClick = onClick
+    )
 }
 
 @Composable
@@ -172,7 +253,8 @@ fun PreviewLoggingOptionsPublicBuild() {
         isDBLoggerEnabled = true,
         onDBLoggerEnabledChange = {},
         onDeleteLogs = {},
-        onShareLogs = {},
+        onShareLogsExternally = {},
+        onShareLogsViaWire = {},
         isPrivateBuild = false,
     )
 }
@@ -186,7 +268,8 @@ fun PreviewLoggingOptionsPrivateBuild() {
         isDBLoggerEnabled = true,
         onDBLoggerEnabledChange = {},
         onDeleteLogs = {},
-        onShareLogs = {},
+        onShareLogsExternally = {},
+        onShareLogsViaWire = {},
         isPrivateBuild = true,
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -541,7 +541,7 @@ fun ConversationScreen(
         conversationMessages = conversationMessagesViewModel.infoMessage,
         shareAssetExternally = conversationMessagesViewModel::shareAsset,
         shareAssetViaWire = { messageId ->
-            conversationMessagesViewModel.shareAssetViaWire(messageId) { path, assetName ->
+            conversationMessagesViewModel.prepareAssetForWireShare(messageId) { path, assetName ->
                 navigator.navigate(
                     NavigationCommand(
                         ImportMediaScreenDestination(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/ConversationMediaScreen.kt
@@ -132,7 +132,7 @@ fun ConversationMediaScreen(
         },
         shareAssetExternally = { conversationMessagesViewModel.shareAsset(context, it) },
         shareAssetViaWire = { messageId ->
-            conversationMessagesViewModel.shareAssetViaWire(messageId) { path, assetName ->
+            conversationMessagesViewModel.prepareAssetForWireShare(messageId) { path, assetName ->
                 navigator.navigate(
                     NavigationCommand(
                         ImportMediaScreenDestination(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -433,7 +433,7 @@ class ConversationMessagesViewModel(
         }
     }
 
-    fun shareAssetViaWire(messageId: String, onAssetReady: (Path, String) -> Unit) {
+    fun prepareAssetForWireShare(messageId: String, onAssetReady: (Path, String) -> Unit) {
         viewModelScope.launch {
             assetDataPath(conversationId, messageId)?.run {
                 onAssetReady(first, second)

--- a/app/src/main/kotlin/com/wire/android/util/logging/LogSharing.kt
+++ b/app/src/main/kotlin/com/wire/android/util/logging/LogSharing.kt
@@ -21,14 +21,15 @@ import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import androidx.core.content.FileProvider
 import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.util.EmailComposer
+import com.wire.android.util.externalShareChooserIntent
 import com.wire.android.util.getDeviceIdString
 import com.wire.android.util.getGitBuildId
-import com.wire.android.util.getProviderAuthority
 import com.wire.android.util.sha256
+import com.wire.android.util.shareableFileProviderUri
+import com.wire.android.util.startShareIntentWithTrustedWireTarget
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -65,7 +66,21 @@ class LogShareLauncher(
         share(
             logsDirectory = logsDirectory,
             flushLogs = flushLogs,
-            intent = { archive -> context.logsSharingIntent(archive) }
+            shareArchive = { archive ->
+                context.startShareIntentWithTrustedWireTarget(context.logsSharingIntent(archive))
+            }
+        )
+    }
+
+    fun shareLogsViaWire(
+        logsDirectory: File,
+        onShareUri: (Uri) -> Unit,
+        flushLogs: suspend () -> Unit = {}
+    ) {
+        share(
+            logsDirectory = logsDirectory,
+            flushLogs = flushLogs,
+            shareArchive = { archive -> onShareUri(context.logsSharingUri(archive)) }
         )
     }
 
@@ -75,20 +90,20 @@ class LogShareLauncher(
         share(
             logsDirectory = LogFileWriter.logsDirectory(context),
             flushLogs = flushLogs,
-            intent = { archive -> context.bugReportLogsSharingIntent(archive) }
+            shareArchive = { archive -> context.startActivity(context.bugReportLogsSharingIntent(archive)) }
         )
     }
 
     private fun share(
         logsDirectory: File,
         flushLogs: suspend () -> Unit,
-        intent: (File) -> Intent
+        shareArchive: (File) -> Unit
     ) {
         coroutineScope.launch {
             runCatching {
                 flushLogs()
                 val archive = archiveCreator.create(logsDirectory)
-                context.startActivity(intent(archive))
+                shareArchive(archive)
             }.onFailure { error ->
                 appLogger.e("Failed to prepare logs for sharing", error)
                 onFailure(error)
@@ -114,8 +129,10 @@ class CompressedLogsArchiveCreator(
     }
 }
 
+fun Context.logsSharingUri(archiveFile: File): Uri = shareableFileProviderUri(archiveFile)
+
 fun Context.logsSharingIntent(archiveFile: File): Intent {
-    val archiveUri = FileProvider.getUriForFile(this, getProviderAuthority(), archiveFile)
+    val archiveUri = logsSharingUri(archiveFile)
     return Intent(Intent.ACTION_SEND).apply {
         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         type = LOGS_ARCHIVE_MIME_TYPE
@@ -137,7 +154,7 @@ fun Context.bugReportLogsSharingIntent(archiveFile: File): Intent {
         )
         selector = Intent(Intent.ACTION_SENDTO).setData(Uri.parse("mailto:"))
     }
-    return Intent.createChooser(intent, getString(R.string.send_feedback_choose_email))
+    return externalShareChooserIntent(intent, getString(R.string.send_feedback_choose_email))
 }
 
 internal fun deleteStaleCompressedLogsArchives(

--- a/core/search/stability/search-debug.stability
+++ b/core/search/stability/search-debug.stability
@@ -180,13 +180,14 @@ private fun com.wire.android.search.users.ShowButton(isShownAll: kotlin.Boolean,
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.wire.android.search.widget.HighlightName(name: kotlin.String, searchQuery: kotlin.String, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.wire.android.search.widget.HighlightName(name: kotlin.String, searchQuery: kotlin.String, modifier: androidx.compose.ui.Modifier, maxLines: kotlin.Int): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - name: STABLE (String is immutable)
     - searchQuery: STABLE (String is immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
+    - maxLines: STABLE (primitive type)
 
 @Composable
 public fun com.wire.android.search.widget.HighlightSubtitle(subTitle: kotlin.String, modifier: androidx.compose.ui.Modifier, searchQuery: kotlin.String, prefix: kotlin.String): kotlin.Unit

--- a/core/ui-common/stability/ui-common-debug.stability
+++ b/core/ui-common/stability/ui-common-debug.stability
@@ -907,11 +907,12 @@ public fun com.wire.android.ui.common.button.WireButton(onClick: kotlin.Function
     - description: STABLE (class with no mutable properties)
 
 @Composable
-public fun com.wire.android.ui.common.button.WireButtonColors.containerColor(state: com.wire.android.ui.common.button.WireButtonState): androidx.compose.runtime.State<androidx.compose.ui.graphics.Color>
+public fun com.wire.android.ui.common.button.WireButtonColors.containerColor(state: com.wire.android.ui.common.button.WireButtonState, isFocused: kotlin.Boolean): androidx.compose.runtime.State<androidx.compose.ui.graphics.Color>
   skippable: true
   restartable: true
   params:
     - state: STABLE (class with no mutable properties)
+    - isFocused: STABLE (primitive type)
 
 @Composable
 public fun com.wire.android.ui.common.button.WireButtonColors.contentColor(state: com.wire.android.ui.common.button.WireButtonState): androidx.compose.runtime.State<androidx.compose.ui.graphics.Color>
@@ -921,11 +922,12 @@ public fun com.wire.android.ui.common.button.WireButtonColors.contentColor(state
     - state: STABLE (class with no mutable properties)
 
 @Composable
-public fun com.wire.android.ui.common.button.WireButtonColors.outlineColor(state: com.wire.android.ui.common.button.WireButtonState): androidx.compose.runtime.State<androidx.compose.ui.graphics.Color>
+public fun com.wire.android.ui.common.button.WireButtonColors.outlineColor(state: com.wire.android.ui.common.button.WireButtonState, isFocused: kotlin.Boolean): androidx.compose.runtime.State<androidx.compose.ui.graphics.Color>
   skippable: true
   restartable: true
   params:
     - state: STABLE (class with no mutable properties)
+    - isFocused: STABLE (primitive type)
 
 @Composable
 public fun com.wire.android.ui.common.button.WireButtonColors.rippleColor(state: com.wire.android.ui.common.button.WireButtonState): androidx.compose.runtime.State<androidx.compose.ui.graphics.Color>
@@ -1106,7 +1108,7 @@ public fun com.wire.android.ui.common.button.secondaryButtonColors(): com.wire.a
   params:
 
 @Composable
-private fun com.wire.android.ui.common.button.wireButtonColors(enabled: androidx.compose.ui.graphics.Color, onEnabled: androidx.compose.ui.graphics.Color, enabledOutline: androidx.compose.ui.graphics.Color, enabledRipple: androidx.compose.ui.graphics.Color, disabled: androidx.compose.ui.graphics.Color, onDisabled: androidx.compose.ui.graphics.Color, disabledOutline: androidx.compose.ui.graphics.Color, disabledRipple: androidx.compose.ui.graphics.Color, selected: androidx.compose.ui.graphics.Color, onSelected: androidx.compose.ui.graphics.Color, selectedOutline: androidx.compose.ui.graphics.Color, selectedRipple: androidx.compose.ui.graphics.Color, error: androidx.compose.ui.graphics.Color, onError: androidx.compose.ui.graphics.Color, errorOutline: androidx.compose.ui.graphics.Color, errorRipple: androidx.compose.ui.graphics.Color, positive: androidx.compose.ui.graphics.Color, onPositive: androidx.compose.ui.graphics.Color, positiveOutline: androidx.compose.ui.graphics.Color, positiveRipple: androidx.compose.ui.graphics.Color): com.wire.android.ui.common.button.WireButtonColors
+private fun com.wire.android.ui.common.button.wireButtonColors(enabled: androidx.compose.ui.graphics.Color, onEnabled: androidx.compose.ui.graphics.Color, enabledOutline: androidx.compose.ui.graphics.Color, enabledRipple: androidx.compose.ui.graphics.Color, disabled: androidx.compose.ui.graphics.Color, onDisabled: androidx.compose.ui.graphics.Color, disabledOutline: androidx.compose.ui.graphics.Color, disabledRipple: androidx.compose.ui.graphics.Color, selected: androidx.compose.ui.graphics.Color, onSelected: androidx.compose.ui.graphics.Color, selectedOutline: androidx.compose.ui.graphics.Color, selectedRipple: androidx.compose.ui.graphics.Color, error: androidx.compose.ui.graphics.Color, onError: androidx.compose.ui.graphics.Color, errorOutline: androidx.compose.ui.graphics.Color, errorRipple: androidx.compose.ui.graphics.Color, positive: androidx.compose.ui.graphics.Color, onPositive: androidx.compose.ui.graphics.Color, positiveOutline: androidx.compose.ui.graphics.Color, positiveRipple: androidx.compose.ui.graphics.Color, focused: androidx.compose.ui.graphics.Color, focusedOutline: androidx.compose.ui.graphics.Color): com.wire.android.ui.common.button.WireButtonColors
   skippable: true
   restartable: true
   params:
@@ -1130,6 +1132,8 @@ private fun com.wire.android.ui.common.button.wireButtonColors(enabled: androidx
     - onPositive: STABLE (marked @Stable or @Immutable)
     - positiveOutline: STABLE (marked @Stable or @Immutable)
     - positiveRipple: STABLE (marked @Stable or @Immutable)
+    - focused: STABLE (marked @Stable or @Immutable)
+    - focusedOutline: STABLE (marked @Stable or @Immutable)
 
 @Composable
 public fun com.wire.android.ui.common.button.wireCheckBoxColors(): androidx.compose.material3.CheckboxColors
@@ -1383,6 +1387,13 @@ public fun com.wire.android.ui.common.fixedColorsScheme(): com.wire.android.ui.t
   params:
 
 @Composable
+public fun com.wire.android.ui.common.focusedBorder(isFocused: kotlin.Boolean): androidx.compose.ui.Modifier
+  skippable: true
+  restartable: true
+  params:
+    - isFocused: STABLE (primitive type)
+
+@Composable
 private fun com.wire.android.ui.common.getButton(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
@@ -1433,6 +1444,12 @@ public fun com.wire.android.ui.common.legalhold.dialog.connectionfailed.LegalHol
 
 @Composable
 public fun com.wire.android.ui.common.lightColorsScheme(): com.wire.android.ui.theme.WireColorScheme
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.wire.android.ui.common.maxTitleLines(): kotlin.Int
   skippable: true
   restartable: true
   params:

--- a/features/meetings/stability/meetings-debug.stability
+++ b/features/meetings/stability/meetings-debug.stability
@@ -289,6 +289,13 @@ internal fun com.wire.android.feature.meetings.ui.list.VideoCallIcon(tint: andro
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
+private fun com.wire.android.feature.meetings.ui.list.audioPermissionCheckFlow(onPermissionGranted: kotlin.Function0<kotlin.Unit>): com.wire.android.util.permission.RequestLauncher
+  skippable: true
+  restartable: true
+  params:
+    - onPermissionGranted: STABLE (function type)
+
+@Composable
 private fun com.wire.android.feature.meetings.ui.list.getDateHeaderString(time: kotlinx.datetime.Instant): kotlin.String
   skippable: true
   restartable: true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26687
<!--jira-description-action-hidden-marker-end-->
## Summary
- Packages logs into a single zip archive before sharing.
- Adds separate log share actions for Wire and external targets on older Android versions.
- Reuses the internal import flow for sharing logs into Wire.
- Updates Debug and Log Management screens to expose the new flow.

## General Idea

This stack separates “share externally” from “forward/share inside Wire” while keeping the behavior different per Android version:

- On Android 15+ we can rely on trusted share caller identity, so Wire can stay in the normal Android share sheet safely.
- On older Android versions we cannot reliably know that an incoming Wire FileProvider URI came from Wire itself, so we avoid routing Wire-internal files through the public share sheet.
- For older Android versions, internal Wire forwarding uses an explicit in-app navigation path into the import media flow.
- External sharing uses Android chooser intents and excludes Wire where needed to prevent re-importing internal Wire files.

```mermaid
flowchart TD
    A["User taps Share"] --> B{"Android 15+?"}

    B -- "Yes" --> C["Use Android share sheet"]
    C --> D["Enable share identity"]
    D --> E["Wire target can be trusted"]

    B -- "No" --> F{"Target action"}
    F -- "Share externally" --> G["Open external chooser"]
    G --> H["Exclude Wire targets"]

    F -- "Share via Wire" --> I["Create shared-cache FileProvider URI"]
    I --> J["Navigate directly to ImportMediaScreen"]
    J --> K["Validate URI is from Wire shared_files root"]
    K --> L["Import as pending asset"]
```

## Stack

This PR is part of a stacked series:

1. `mo/share-forward-01-share-plumbing`  
   Share-safe FileProvider helpers and chooser behavior.

2. `mo/share-forward-02-import-safety`  
   Incoming share validation and trusted Wire caller handling.

3. `mo/share-forward-03-asset-actions`  
   UI split between “Share via Wire” and “Share externally”.

4. `mo/share-forward-04-log-sharing`  
   Share logs as one archive, either externally or via Wire.

5. `mo/share-forward-05-stability-baselines`  
   Generated stability baseline updates.