### PR TITLE
refactor: prepare log file writer contract

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementViewModel.kt
@@ -62,7 +62,9 @@ class LogManagementViewModel(
     }
 
     fun deleteLogs() {
-        logFileWriter.deleteAllLogFiles()
+        viewModelScope.launch {
+            logFileWriter.deleteAllLogFiles()
+        }
     }
 
     fun flushLogs(): Deferred<Unit> {

--- a/app/src/main/kotlin/com/wire/android/ui/debug/UserDebugViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/UserDebugViewModel.kt
@@ -81,7 +81,9 @@ class UserDebugViewModel(
     }
 
     fun deleteLogs() {
-        logFileWriter.deleteAllLogFiles()
+        viewModelScope.launch {
+            logFileWriter.deleteAllLogFiles()
+        }
     }
 
     fun flushLogs(): Deferred<Unit> {

--- a/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriter.kt
+++ b/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriter.kt
@@ -19,6 +19,7 @@
 package com.wire.android.util.logging
 
 import android.content.Context
+import co.touchlab.kermit.LogWriter
 import java.io.File
 
 /**
@@ -31,6 +32,11 @@ interface LogFileWriter {
      * The active logging file where logs are currently being written
      */
     val activeLoggingFile: File
+
+    /**
+     * Kermit sink that writes log entries into [activeLoggingFile] while this writer is started.
+     */
+    val logWriter: LogWriter
 
     /**
      * Starts the log collection system
@@ -51,7 +57,7 @@ interface LogFileWriter {
      * Deletes all log files including active and compressed files
      *
      */
-    fun deleteAllLogFiles()
+    suspend fun deleteAllLogFiles()
 
     companion object {
         fun logsDirectory(context: Context) = File(context.cacheDir, "logs")

--- a/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriterImpl.kt
+++ b/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriterImpl.kt
@@ -19,6 +19,8 @@
 package com.wire.android.util.logging
 
 import android.util.Log
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
 import com.wire.android.appLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -72,6 +74,11 @@ class LogFileWriterImpl(
 
     // Process management
     private var logcatProcess: Process? = null
+
+    override val logWriter: LogWriter = object : LogWriter() {
+        @Suppress("UnusedParameter")
+        override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) = Unit
+    }
 
     /**
      * Initializes logging, waiting until the logger is actually initialized before returning.
@@ -324,11 +331,13 @@ class LogFileWriterImpl(
         }
     }
 
-    override fun deleteAllLogFiles() {
-        clearActiveLoggingFileContent()
-        logsDirectory.listFiles()?.filter {
-            it.extension.lowercase(Locale.ROOT) == LOG_COMPRESSED_FILE_EXTENSION
-        }?.forEach { it.delete() }
+    override suspend fun deleteAllLogFiles() {
+        withContext(Dispatchers.IO) {
+            clearActiveLoggingFileContent()
+            logsDirectory.listFiles()?.filter {
+                it.extension.lowercase(Locale.ROOT) == LOG_COMPRESSED_FILE_EXTENSION
+            }?.forEach { it.delete() }
+        }
     }
 
     private fun getCompressedFilesList() = (logsDirectory.listFiles() ?: emptyArray()).filter {

--- a/app/src/test/kotlin/com/wire/android/util/logging/LogFileWriterImplTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/logging/LogFileWriterImplTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util.logging
+
+import co.touchlab.kermit.Severity
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class LogFileWriterImplTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun givenFileWriterIsStopped_whenKermitEmitsLog_thenActiveFileIsNotCreated() {
+        val writer = LogFileWriterImpl(logsDirectory = logsDirectory())
+
+        writer.logWriter.log(Severity.Info, "ignored", "TestTag", null)
+
+        assertFalse(writer.activeLoggingFile.exists())
+    }
+
+    @Test
+    fun givenFileWriterIsNotStarted_whenDeletingAllLogs_thenActiveAndCompressedLogsAreDeleted() = runBlocking {
+        val writer = LogFileWriterImpl(logsDirectory = logsDirectory())
+        val compressedFile = logsDirectory().resolve("old-log.gz")
+        logsDirectory().mkdirs()
+        writer.activeLoggingFile.writeText("active")
+        compressedFile.writeText("compressed")
+
+        writer.deleteAllLogFiles()
+
+        assertEquals("", writer.activeLoggingFile.readText())
+        assertFalse(compressedFile.exists())
+    }
+
+    private fun logsDirectory() = tempDir.resolve("logs")
+}


### PR DESCRIPTION
## Summary

Some devices have logcat disabled, which can leave the shared log file at 0B. This stack prepares a platform-independent logger that does not depend on logcat.

This first PR keeps behavior unchanged and prepares the existing file logger abstraction for the new implementation:

- adds a Kermit `LogWriter` sink to `LogFileWriter`
- makes log deletion suspendable
- adapts the existing logcat-backed writer with a no-op sink
- updates debug log deletion call sites for the suspend API

```mermaid
flowchart LR
  A[Debug UI] --> B[LogFileWriter]
  C[Existing logcat writer] --> B
  D[Future platform-independent writer] --> B
```