### PR TITLE
feat: manual mls migration [WPB-8645]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/ConversationModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/ConversationModule.kt
@@ -65,6 +65,7 @@ import com.wire.kalium.logic.feature.conversation.UpdateConversationArchivedStat
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
 import com.wire.kalium.logic.feature.conversation.MarkConversationAsReadLocallyUseCase
+import com.wire.kalium.logic.feature.conversation.MigrateConversationToMLSUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReadDateUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationReceiptModeUseCase
 import com.wire.kalium.logic.feature.conversation.apps.ChangeAccessForAppsInConversationUseCase
@@ -356,6 +357,12 @@ class ConversationModule {
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
     ): ResetMLSConversationUseCase = coreLogic.getSessionScope(currentAccount).resetMlsConversation
+
+    @Provides
+    fun provideMigrateConversationToMLSUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): MigrateConversationToMLSUseCase = coreLogic.getSessionScope(currentAccount).migrateConversationToMLS
 
     @Provides
     fun provideFetchConversationUseCase(

--- a/app/src/main/kotlin/com/wire/android/ui/debug/DebugInfoViewModelFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/DebugInfoViewModelFactory.kt
@@ -59,6 +59,7 @@ import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import com.wire.kalium.logic.sync.periodic.UpdateApiVersionsScheduler
 import com.wire.kalium.logic.sync.slow.RestartSlowSyncProcessForRecoveryUseCase
 import com.wire.android.di.ApplicationContext
+import com.wire.kalium.logic.feature.conversation.MigrateConversationToMLSUseCase
 import dev.zacsweers.metro.Inject
 
 @Suppress("LongParameterList")
@@ -90,6 +91,7 @@ class DebugInfoViewModelFactory @Inject constructor(
     private val fileManager: FileManager,
     private val conversationDetails: ObserveConversationDetailsUseCase,
     private val resetMLSConversation: ResetMLSConversationUseCase,
+    private val migrateConversationToMLS: MigrateConversationToMLSUseCase,
     private val fetchConversation: FetchConversationUseCase,
     private val feedConversation: DebugFeedConversationUseCase,
     private val getConversationEpochFromCC: GetConversationEpochFromCCUseCase,
@@ -144,6 +146,7 @@ class DebugInfoViewModelFactory @Inject constructor(
         feedConversation = feedConversation,
         getConversationEpochFromCC = getConversationEpochFromCC,
         savedStateHandle = savedStateHandle,
+        migrateConversationToMLSUseCase = migrateConversationToMLS
     )
 
     fun conversationCryptoStatsViewModel() = ConversationCryptoStatsViewModel(

--- a/app/src/main/kotlin/com/wire/android/ui/debug/conversation/DebugConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/conversation/DebugConversationScreen.kt
@@ -115,6 +115,7 @@ fun DebugConversationScreen(
                     state = state,
                     onUpdate = { viewModel.updateConversation() },
                     onReset = { viewModel.resetMLSConversation() },
+                    onMigrateToMLS = { viewModel.migrateConversationToMLS() },
                 )
                 if (BuildConfig.CONVERSATION_FEEDER_ENABLED) {
                     SectionHeader("Feeders / performance config")
@@ -146,6 +147,7 @@ private fun ConversationActionsView(
     state: DebugConversationViewState,
     onUpdate: () -> Unit,
     onReset: () -> Unit,
+    onMigrateToMLS: () -> Unit,
 ) {
     RowItemTemplate(
         title = {
@@ -177,6 +179,23 @@ private fun ConversationActionsView(
                 onClick = onReset,
                 text = "Reset now",
                 fillMaxWidth = false,
+            )
+        })
+    }
+    if (state.canMigrateToMLS) {
+        RowItemTemplate(modifier = Modifier.wrapContentWidth(), title = {
+            Text(
+                style = MaterialTheme.wireTypography.body01,
+                color = MaterialTheme.wireColorScheme.onBackground,
+                text = "Migrate conversation protocol",
+                modifier = Modifier.padding(start = dimensions().spacing8x)
+            )
+        }, actions = {
+            WirePrimaryButton(
+                onClick = onMigrateToMLS,
+                text = "Migrate to MLS",
+                fillMaxWidth = false,
+                loading = state.isMigratingToMLS,
             )
         })
     }

--- a/app/src/main/kotlin/com/wire/android/ui/debug/conversation/DebugConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/conversation/DebugConversationViewModel.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
 import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
+import com.wire.kalium.logic.feature.conversation.MigrateConversationToMLSUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.debug.DebugFeedConfig
 import com.wire.kalium.logic.feature.debug.DebugFeedConversationUseCase
@@ -44,6 +45,7 @@ class DebugConversationViewModel(
     private val fetchConversation: FetchConversationUseCase,
     private val feedConversation: DebugFeedConversationUseCase,
     private val getConversationEpochFromCC: GetConversationEpochFromCCUseCase,
+    private val migrateConversationToMLSUseCase: MigrateConversationToMLSUseCase,
     savedStateHandle: SavedStateHandle,
 ) : ActionsViewModel<DebugConversationScreenAction>() {
 
@@ -69,6 +71,7 @@ class DebugConversationViewModel(
                             conversationName = result.conversationDetails.conversation.name,
                             teamId = result.conversationDetails.conversation.teamId?.value,
                             mlsProtocolInfo = result.conversationDetails.conversation.protocol as? Conversation.ProtocolInfo.MLSCapable,
+                            canMigrateToMLS = result.conversationDetails.conversation.protocol !is Conversation.ProtocolInfo.MLS,
                         )
                     }
 
@@ -102,6 +105,23 @@ class DebugConversationViewModel(
             .onFailure { error ->
                 appLogger.e("MLS conversation fetch failed: $error")
             }
+    }
+
+    fun migrateConversationToMLS() = viewModelScope.launch {
+        _state.update { it.copy(isMigratingToMLS = true) }
+
+        when (val result = migrateConversationToMLSUseCase(conversationId)) {
+            MigrateConversationToMLSUseCase.Result.Success -> {
+                _state.update { it.copy(isMigratingToMLS = false) }
+                sendAction(ShowMessage("Conversation migrated to MLS successfully."))
+            }
+
+            is MigrateConversationToMLSUseCase.Result.Failure -> {
+                appLogger.e("Conversation migration to MLS failed: ${result.cause}")
+                _state.update { it.copy(isMigratingToMLS = false) }
+                sendAction(ShowMessage("Conversation migration to MLS failed."))
+            }
+        }
     }
 
     fun refreshConversationEpochFromCC() = viewModelScope.launch {
@@ -227,6 +247,8 @@ data class DebugConversationViewState(
     val conversationName: String? = null,
     val teamId: String? = null,
     val mlsProtocolInfo: Conversation.ProtocolInfo.MLSCapable? = null,
+    val canMigrateToMLS: Boolean = false,
+    val isMigratingToMLS: Boolean = false,
     val ccEpoch: ULong? = null,
     val isRefreshingCCEpoch: Boolean = false,
     val feedConfig: DebugFeedConfigUiState = DebugFeedConfigUiState(),

--- a/app/src/test/kotlin/com/wire/android/ui/debug/conversation/DebugConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/debug/conversation/DebugConversationViewModelTest.kt
@@ -31,6 +31,8 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
 import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.mls.CipherSuite
+import com.wire.kalium.logic.feature.conversation.MigrateConversationToMLSUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.debug.DebugFeedConversationUseCase
 import com.wire.kalium.logic.feature.debug.GetConversationEpochFromCCResult
@@ -43,6 +45,7 @@ import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -61,6 +64,7 @@ class DebugConversationViewModelTest {
         advanceUntilIdle()
 
         assertEquals(TestConversation.MLS_PROTOCOL_INFO, viewModel.state.value.mlsProtocolInfo)
+        assertEquals(false, viewModel.state.value.canMigrateToMLS)
         assertEquals(CC_EPOCH, viewModel.state.value.ccEpoch)
         coVerify(exactly = 1) {
             arrangement.getConversationEpochFromCCUseCase(arrangement.conversationId)
@@ -91,6 +95,50 @@ class DebugConversationViewModelTest {
             arrangement.getConversationEpochFromCCUseCase(arrangement.conversationId)
         }
     }
+
+    @Test
+    fun givenProteusConversation_whenInitialising_thenMigrationActionIsAvailable() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withConversationDetails(proteusConversationDetails())
+            .arrange()
+
+        advanceUntilIdle()
+
+        assertEquals(true, viewModel.state.value.canMigrateToMLS)
+        assertEquals(null, viewModel.state.value.mlsProtocolInfo)
+    }
+
+    @Test
+    fun givenMixedConversation_whenInitialising_thenMigrationActionIsAvailable() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withConversationDetails(mixedConversationDetails())
+            .withCCEpochResult(GetConversationEpochFromCCResult.Success(CC_EPOCH))
+            .arrange()
+
+        advanceUntilIdle()
+
+        assertEquals(true, viewModel.state.value.canMigrateToMLS)
+        assertEquals(MIXED_PROTOCOL_INFO, viewModel.state.value.mlsProtocolInfo)
+    }
+
+    @Test
+    fun givenProteusConversation_whenMigratingToMLS_thenInvokeUseCaseAndShowSuccessMessage() = runTest {
+        val (arrangement, viewModel) = Arrangement()
+            .withConversationDetails(proteusConversationDetails())
+            .withMigrateConversationToMLSResult(MigrateConversationToMLSUseCase.Result.Success)
+            .arrange()
+
+        viewModel.actions.test {
+            viewModel.migrateConversationToMLS()
+            assertEquals(ShowMessage("Conversation migrated to MLS successfully."), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertEquals(false, viewModel.state.value.isMigratingToMLS)
+        coVerify(exactly = 1) {
+            arrangement.migrateConversationToMLSUseCase(arrangement.conversationId)
+        }
+    }
 }
 
 private class Arrangement {
@@ -113,6 +161,9 @@ private class Arrangement {
     @MockK
     lateinit var getConversationEpochFromCCUseCase: GetConversationEpochFromCCUseCase
 
+    @MockK
+    lateinit var migrateConversationToMLSUseCase: MigrateConversationToMLSUseCase
+
     val conversationId = ConversationId("debug-conversation-id", "wire.com")
 
     init {
@@ -122,6 +173,7 @@ private class Arrangement {
         } returns DebugConversationScreenNavArgs(conversationId)
         coEvery { observeConversationDetailsUseCase(any()) } returns flowOf<ObserveConversationDetailsUseCase.Result>()
         coEvery { getConversationEpochFromCCUseCase(any()) } returns GetConversationEpochFromCCResult.Failure.NotMlsConversation
+        coEvery { migrateConversationToMLSUseCase(any()) } returns MigrateConversationToMLSUseCase.Result.Success
     }
 
     suspend fun withConversationDetails(conversationDetails: ConversationDetails) = apply {
@@ -138,12 +190,17 @@ private class Arrangement {
         coEvery { getConversationEpochFromCCUseCase(any()) } returnsMany results.toList()
     }
 
+    suspend fun withMigrateConversationToMLSResult(result: MigrateConversationToMLSUseCase.Result) = apply {
+        coEvery { migrateConversationToMLSUseCase(any()) } returns result
+    }
+
     fun arrange() = this to DebugConversationViewModel(
         conversationDetails = observeConversationDetailsUseCase,
         resetMLSConversation = resetMLSConversationUseCase,
         fetchConversation = fetchConversationUseCase,
         feedConversation = debugFeedConversationUseCase,
         getConversationEpochFromCC = getConversationEpochFromCCUseCase,
+        migrateConversationToMLSUseCase = migrateConversationToMLSUseCase,
         savedStateHandle = savedStateHandle,
     )
 }
@@ -155,5 +212,29 @@ private fun mlsConversationDetails(): ConversationDetails.Group.Regular =
         selfRole = Conversation.Member.Role.Member,
         wireCell = null,
     )
+
+private fun proteusConversationDetails(): ConversationDetails.Group.Regular =
+    ConversationDetails.Group.Regular(
+        conversation = TestConversation.GROUP(Conversation.ProtocolInfo.Proteus),
+        isSelfUserMember = true,
+        selfRole = Conversation.Member.Role.Member,
+        wireCell = null,
+    )
+
+private fun mixedConversationDetails(): ConversationDetails.Group.Regular =
+    ConversationDetails.Group.Regular(
+        conversation = TestConversation.GROUP(MIXED_PROTOCOL_INFO),
+        isSelfUserMember = true,
+        selfRole = Conversation.Member.Role.Member,
+        wireCell = null,
+    )
+
+private val MIXED_PROTOCOL_INFO = Conversation.ProtocolInfo.Mixed(
+    groupId = TestConversation.GROUP_ID,
+    groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+    epoch = 0UL,
+    keyingMaterialLastUpdate = Instant.parse("2021-03-30T15:36:00.000Z"),
+    cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+)
 
 private const val CC_EPOCH = 42UL

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -1362,24 +1362,24 @@ public fun com.wire.android.ui.authentication.login.WireAuthBackgroundLayout(mod
     - content: STABLE (composable function type)
 
 @Composable
-public fun com.wire.android.ui.authentication.login.email.ForgotPasswordLabel(forgotPasswordUrl: kotlin.String, textColor: androidx.compose.ui.graphics.Color, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.wire.android.ui.authentication.login.email.ForgotPasswordLabel(forgotPasswordUrl: kotlin.String, modifier: androidx.compose.ui.Modifier, textColor: androidx.compose.ui.graphics.Color): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - forgotPasswordUrl: STABLE (String is immutable)
-    - textColor: STABLE (marked @Stable or @Immutable)
     - modifier: STABLE (marked @Stable or @Immutable)
+    - textColor: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.wire.android.ui.authentication.login.email.LoginButton(loading: kotlin.Boolean, enabled: kotlin.Boolean, text: kotlin.String, loadingText: kotlin.String, modifier: androidx.compose.ui.Modifier, onClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.wire.android.ui.authentication.login.email.LoginButton(loading: kotlin.Boolean, enabled: kotlin.Boolean, modifier: androidx.compose.ui.Modifier, text: kotlin.String, loadingText: kotlin.String, onClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - loading: STABLE (primitive type)
     - enabled: STABLE (primitive type)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - text: STABLE (String is immutable)
     - loadingText: STABLE (String is immutable)
-    - modifier: STABLE (marked @Stable or @Immutable)
     - onClick: STABLE (function type)
 
 @Composable
@@ -3763,13 +3763,14 @@ public fun com.wire.android.ui.debug.aboutThisAppViewModel(): com.wire.android.u
   params:
 
 @Composable
-private fun com.wire.android.ui.debug.conversation.ConversationActionsView(state: com.wire.android.ui.debug.conversation.DebugConversationViewState, onUpdate: kotlin.Function0<kotlin.Unit>, onReset: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+private fun com.wire.android.ui.debug.conversation.ConversationActionsView(state: com.wire.android.ui.debug.conversation.DebugConversationViewState, onUpdate: kotlin.Function0<kotlin.Unit>, onReset: kotlin.Function0<kotlin.Unit>, onMigrateToMLS: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: false
   restartable: true
   params:
     - state: UNSTABLE (has mutable properties or unstable members)
     - onUpdate: STABLE (function type)
     - onReset: STABLE (function type)
+    - onMigrateToMLS: STABLE (function type)
 
 @Composable
 private fun com.wire.android.ui.debug.conversation.ConversationDetailsView(state: com.wire.android.ui.debug.conversation.DebugConversationViewState): kotlin.Unit
@@ -10206,6 +10207,13 @@ public fun com.wire.android.ui.markdown.MarkdownThematicBreak(messageStyle: com.
   params:
     - messageStyle: STABLE (class with no mutable properties)
     - modifier: STABLE (marked @Stable or @Immutable)
+
+@Composable
+private fun com.wire.android.ui.markdown.getMentions(onOpenProfile: kotlin.Function1<@[ParameterName(name = \): kotlin.collections.List<androidx.compose.ui.semantics.CustomAccessibilityAction>
+  skippable: true
+  restartable: true
+  params:
+    - onOpenProfile: STABLE (function type)
 
 @Composable
 public fun com.wire.android.ui.miscViewModel(): VM of com.wire.android.ui.miscViewModel


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add support for manually initiating the MLS migration from the conversation debug screen.

### Dependencies

Needs releases with:

- [x] https://github.com/wireapp/kalium/pull/4103

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

- Enable the `mlsMigration` feature enabled but without any startTime specified.
- Enable the `mls` feature with the default protocol set to `proteus`
- Create a proteus conversation 
- Navigate to the conversation and open the debug screen from the conversation details
- Press "migrate to MLS"

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
