### PR TITLE
ci: configure Android device groups [WPB-27197]

### DIFF
--- a/.github/workflows/qa-android-critical-flow-tests.yml
+++ b/.github/workflows/qa-android-critical-flow-tests.yml
@@ -1,10 +1,9 @@
 name: QA Android Critical Flow Tests
 
-# Concurrency lock:
-# - If androidDeviceId is set, we lock per-device so only one run can use that specific phone at a time (other devices can run in parallel).
-# - If androidDeviceId is empty ("auto"), we lock the shared device pool so only one auto-run uses the farm at a time (other auto-runs queue).
+# Lock each configured device group independently. Groups must be disjoint, so
+# criticalFlow, e2eTests, GrapheneOS, and future pools can run concurrently.
 concurrency:
-  group: qa-android-ui-tests-office-${{ github.event_name == 'workflow_dispatch' && inputs.androidDeviceId || 'auto' }}
+  group: qa-android-ui-tests-office-${{ inputs.androidDeviceGroup || 'criticalFlow' }}
   cancel-in-progress: false
 
 on:
@@ -70,9 +69,15 @@ on:
         type: string
 
       androidDeviceId:
-        description: "androidDeviceId. Target a specific device. Leave empty for auto."
+        description: "Target one device from androidDeviceGroup. Leave empty to use the group."
         required: false
         default: ""
+        type: string
+
+      androidDeviceGroup:
+        description: "Named group from the ANDROID_DEVICE_GROUPS_JSON repository variable."
+        required: true
+        default: "criticalFlow"
         type: string
 
       rerunFailedEnabled:
@@ -105,6 +110,7 @@ jobs:
       resolvedTags: ${{ steps.resolve_run_inputs.outputs.TAGS }}
       resolvedTestinyRunName: ${{ steps.resolve_run_inputs.outputs.testinyRunName }}
       resolvedAndroidDeviceId: ${{ steps.resolve_run_inputs.outputs.androidDeviceId }}
+      resolvedAndroidDeviceGroup: ${{ steps.resolve_run_inputs.outputs.androidDeviceGroup }}
       resolvedRerunFailedEnabled: ${{ steps.resolve_run_inputs.outputs.rerunFailedEnabled }}
       resolvedRerunFailedCount: ${{ steps.resolve_run_inputs.outputs.rerunFailedCount }}
       resolvedTestCaseId: ${{ steps.resolve_selector.outputs.testCaseId }}
@@ -128,6 +134,7 @@ jobs:
           TAGS_INPUT: ${{ inputs.TAGS }}
           TESTINY_RUN_NAME_INPUT: ${{ inputs.testinyRunName }}
           ANDROID_DEVICE_ID_INPUT: ${{ inputs.androidDeviceId }}
+          ANDROID_DEVICE_GROUP_INPUT: ${{ inputs.androidDeviceGroup }}
           RERUN_FAILED_ENABLED_INPUT: ${{ inputs.rerunFailedEnabled }}
           RERUN_FAILED_COUNT_INPUT: ${{ inputs.rerunFailedCount }}
         run: |
@@ -149,6 +156,7 @@ jobs:
               echo "TAGS=${TAGS_INPUT}"
               echo "testinyRunName=${testiny_run_name}"
               echo "androidDeviceId=${ANDROID_DEVICE_ID_INPUT}"
+              echo "androidDeviceGroup=${ANDROID_DEVICE_GROUP_INPUT}"
               echo "rerunFailedEnabled=${RERUN_FAILED_ENABLED_INPUT}"
               echo "rerunFailedCount=${RERUN_FAILED_COUNT_INPUT}"
             } >> "${GITHUB_OUTPUT}"
@@ -164,6 +172,7 @@ jobs:
             echo "TAGS=@criticalFlow"
             echo "testinyRunName="
             echo "androidDeviceId="
+            echo "androidDeviceGroup=criticalFlow"
             echo "rerunFailedEnabled=true"
             echo "rerunFailedCount=1"
           } >> "${GITHUB_OUTPUT}"
@@ -221,6 +230,7 @@ jobs:
       AWS_REGION: eu-west-1
       OP_VAULT: "Test Automation"
       FLAVORS_CONFIG_PATH: "/etc/android-qa/flavors.json"
+      DEVICE_GROUPS_JSON: ${{ vars.ANDROID_DEVICE_GROUPS_JSON }}
 
     defaults:
       run:
@@ -276,6 +286,7 @@ jobs:
       - name: Detect target device(s)
         env:
           TARGET_DEVICE_ID: ${{ needs.validate-and-resolve-inputs.outputs.resolvedAndroidDeviceId }}
+          TARGET_DEVICE_GROUP: ${{ needs.validate-and-resolve-inputs.outputs.resolvedAndroidDeviceGroup }}
           RESOLVED_TESTCASE_ID: ${{ needs.validate-and-resolve-inputs.outputs.resolvedTestCaseId }}
         run: bash scripts/qa_android_ui_tests/execution_setup.sh detect-target-devices
 
@@ -406,6 +417,7 @@ jobs:
           ENFORCE_APP_INSTALL: ${{ needs.validate-and-resolve-inputs.outputs.resolvedEnforceAppInstall }}
           TESTINY_RUN_NAME: ${{ needs.validate-and-resolve-inputs.outputs.resolvedTestinyRunName }}
           ANDROID_DEVICE_ID: ${{ needs.validate-and-resolve-inputs.outputs.resolvedAndroidDeviceId }}
+          ANDROID_DEVICE_GROUP: ${{ needs.validate-and-resolve-inputs.outputs.resolvedAndroidDeviceGroup }}
           RERUN_FAILED_ENABLED: ${{ needs.validate-and-resolve-inputs.outputs.resolvedRerunFailedEnabled }}
           RERUN_FAILED_COUNT: ${{ needs.validate-and-resolve-inputs.outputs.resolvedRerunFailedCount }}
         run: bash scripts/qa_android_ui_tests/reporting.sh prepare-deflake-bundle

--- a/.github/workflows/qa-android-ui-test-manual-deflake.yml
+++ b/.github/workflows/qa-android-ui-test-manual-deflake.yml
@@ -1,9 +1,9 @@
 name: QA Android UI Test Manual Deflake
 
-# Keep manual deflake on the shared auto-run lock so it does not compete with
-# other QA office workflows for the same device pool at the same time.
+# The group is an input because concurrency is evaluated before the downloaded
+# deflake metadata is available. Use the same group as the source run.
 concurrency:
-  group: qa-android-ui-tests-office-auto
+  group: qa-android-ui-tests-office-${{ inputs.androidDeviceGroup || 'criticalFlow' }}
   cancel-in-progress: false
 
 on:
@@ -18,6 +18,12 @@ on:
         description: "TESTINY_RUN_NAME override. Leave empty to reuse the selected run value."
         required: false
         default: ""
+        type: string
+
+      androidDeviceGroup:
+        description: "Device group used by the source run."
+        required: true
+        default: "criticalFlow"
         type: string
 
 permissions:
@@ -42,6 +48,7 @@ jobs:
       AWS_REGION: eu-west-1
       OP_VAULT: "Test Automation"
       FLAVORS_CONFIG_PATH: "/etc/android-qa/flavors.json"
+      DEVICE_GROUPS_JSON: ${{ vars.ANDROID_DEVICE_GROUPS_JSON }}
 
     defaults:
       run:
@@ -87,6 +94,16 @@ jobs:
           TESTINY_RUN_NAME_OVERRIDE: ${{ inputs.testinyRunName }}
         run: python3 scripts/qa_android_ui_tests/inspect_deflake_bundle.py
 
+      - name: Validate source device group
+        env:
+          SOURCE_DEVICE_GROUP: ${{ steps.validate_deflake_input.outputs.androidDeviceGroup }}
+          REQUESTED_DEVICE_GROUP: ${{ inputs.androidDeviceGroup }}
+        run: |
+          if [[ -n "${SOURCE_DEVICE_GROUP}" && "${SOURCE_DEVICE_GROUP}" != "${REQUESTED_DEVICE_GROUP}" ]]; then
+            echo "ERROR: Source run used device group '${SOURCE_DEVICE_GROUP}', but this deflake requested '${REQUESTED_DEVICE_GROUP}'."
+            exit 1
+          fi
+
       # Reuse the same input validators here so malformed selected-run metadata fails
       # before the runner spends time on APK, device, or report setup.
       - name: Validate upgrade inputs
@@ -129,6 +146,7 @@ jobs:
       - name: Detect target device(s)
         env:
           TARGET_DEVICE_ID: ${{ steps.validate_deflake_input.outputs.androidDeviceId }}
+          TARGET_DEVICE_GROUP: ${{ inputs.androidDeviceGroup }}
           RESOLVED_TESTCASE_ID: ${{ steps.validate_deflake_input.outputs.selectorType == 'testCaseId' && steps.validate_deflake_input.outputs.selectorValue || '' }}
         run: bash scripts/qa_android_ui_tests/execution_setup.sh detect-target-devices
 
@@ -244,6 +262,7 @@ jobs:
           ENFORCE_APP_INSTALL: ${{ steps.validate_deflake_input.outputs.enforceAppInstall }}
           TESTINY_RUN_NAME: ${{ steps.validate_deflake_input.outputs.effectiveTestinyRunName }}
           ANDROID_DEVICE_ID: ${{ steps.validate_deflake_input.outputs.androidDeviceId }}
+          ANDROID_DEVICE_GROUP: ${{ inputs.androidDeviceGroup }}
           RERUN_FAILED_ENABLED: ${{ steps.validate_deflake_input.outputs.rerunFailedEnabled }}
           RERUN_FAILED_COUNT: ${{ steps.validate_deflake_input.outputs.rerunFailedCount }}
         run: bash scripts/qa_android_ui_tests/reporting.sh prepare-deflake-bundle

--- a/scripts/qa_android_ui_tests/README.md
+++ b/scripts/qa_android_ui_tests/README.md
@@ -20,7 +20,7 @@ Main critical-flow workflow.
   - upgrade mode enabled
   - `alpha release candidate`
   - `@criticalFlow`
-  - auto device selection
+  - `criticalFlow` device group
   - failed-test rerun enabled with count `1`
 - Exports one standard deflake artifact for later manual reruns.
 
@@ -65,6 +65,55 @@ Bundle contents:
 - device selection
 - rerun configuration
 - Testiny run name
+
+## Device Groups
+
+Physical devices are allocated through named, disjoint groups stored in the
+GitHub repository variable `ANDROID_DEVICE_GROUPS_JSON`. Workflows select a
+group through `androidDeviceGroup`; the critical-flow default is
+`criticalFlow`.
+
+Example repository-variable value:
+
+```json
+{
+  "criticalFlow": [
+    "device-serial-01",
+    "device-serial-02"
+  ],
+  "e2eTests": [
+    "device-serial-03",
+    "device-serial-04"
+  ],
+  "GrapheneOS": [
+    "device-serial-05"
+  ]
+}
+```
+
+Device selection works as follows:
+
+1. Parse and validate the requested group from `ANDROID_DEVICE_GROUPS_JSON`.
+2. Reject configurations that assign one serial to more than one group. This
+   guarantees that independently locked group workflows cannot share a phone.
+3. Intersect the configured group with devices currently online in `adb`.
+4. Warn and continue when only part of the group is online; fail when none of
+   the configured devices are online.
+5. If `androidDeviceId` is set, require that device to be online and belong to
+   the selected group.
+6. If a single testcase is selected, use the first online device in configured
+   group order. Otherwise shard across every online device in the group.
+
+Concurrency is locked by group name, allowing disjoint groups such as
+`criticalFlow`, `e2eTests`, and `GrapheneOS` to run at the same time. Adding,
+removing, or moving a device does not require a repository change: update the
+GitHub repository variable. Group names passed to workflows must match the JSON
+keys.
+
+Manual deflake asks for the group because GitHub evaluates concurrency before
+the source artifact can be downloaded. It validates that the requested group
+matches group metadata from newer source runs. For artifacts created before
+device groups were introduced, select the appropriate group manually.
 
 ## Flavor Resolution Source
 

--- a/scripts/qa_android_ui_tests/execution_setup.sh
+++ b/scripts/qa_android_ui_tests/execution_setup.sh
@@ -166,22 +166,36 @@ detect_target_devices() {
   fi
 
   local target="${TARGET_DEVICE_ID:-}"
+  local target_group="${TARGET_DEVICE_GROUP:-}"
+  local eligible_device_lines="${device_lines}"
+  if [[ -n "${target_group}" ]]; then
+    local grouped_device_list
+    grouped_device_list="$(
+      DEVICE_GROUP="${target_group}" \
+        DEVICE_GROUPS_JSON="${DEVICE_GROUPS_JSON:-}" \
+        ONLINE_DEVICE_IDS="${device_lines}" \
+        python3 scripts/qa_android_ui_tests/resolve_device_group.py
+    )"
+    eligible_device_lines="$(tr ' ' '\n' <<< "${grouped_device_list}")"
+    echo "Using configured device group '${target_group}': ${grouped_device_list}"
+  fi
+
   local device_list
   if [[ -n "${target}" ]]; then
-    # Explicit device targeting keeps retries and manual investigations pinned
-    # to one known phone instead of the shared auto-selected pool.
-    if ! printf '%s\n' "$device_lines" | grep -qx "$target"; then
-      echo "ERROR: androidDeviceId '$target' not found in adb devices."
+    # Explicit targets remain constrained to the requested group. This keeps a
+    # manual run from borrowing a phone locked by another device group.
+    if ! printf '%s\n' "${eligible_device_lines}" | grep -qx "${target}"; then
+      echo "ERROR: androidDeviceId '${target}' is not online in device group '${target_group:-all-online-devices}'."
       exit 1
     fi
     device_list="$target"
   elif [[ -n "${RESOLVED_TESTCASE_ID:-}" ]]; then
     # Single-testcase runs stay on one device so the same test is not fanned
     # out across multiple phones by the default sharding logic.
-    device_list="$(printf '%s\n' "$device_lines" | head -n 1)"
+    device_list="$(printf '%s\n' "${eligible_device_lines}" | head -n 1)"
     echo "Single-testcase mode (${RESOLVED_TESTCASE_ID}): selected device ${device_list}"
   else
-    device_list="$(printf '%s\n' "$device_lines" | xargs)"
+    device_list="$(printf '%s\n' "${eligible_device_lines}" | xargs)"
   fi
 
   local device_count

--- a/scripts/qa_android_ui_tests/inspect_deflake_bundle.py
+++ b/scripts/qa_android_ui_tests/inspect_deflake_bundle.py
@@ -87,6 +87,7 @@ print(f"Selected run id: {metadata['source_run_id']}")
 print(f"Selected ref: {metadata['source_ref_name']}")
 print(f"Flavor: {metadata['flavor']}")
 print(f"Selector: {metadata.get('selector_type', '')}={metadata.get('selector_value', '')}")
+print(f"Device group: {metadata.get('android_device_group', '')}")
 print(f"Resolved build number: {metadata.get('resolved_build_number', '')}")
 print(f"Leftover failed tests: {len(failed_tests)}")
 
@@ -111,6 +112,7 @@ write_output("isUpgrade", str(metadata.get("is_upgrade", False)).lower())
 write_output("oldBuildNumber", str(metadata.get("old_build_number", "")))
 write_output("enforceAppInstall", str(metadata.get("enforce_app_install", False)).lower())
 write_output("androidDeviceId", str(metadata.get("android_device_id", "")))
+write_output("androidDeviceGroup", str(metadata.get("android_device_group", "")))
 write_output("rerunFailedEnabled", str(metadata.get("rerun_failed_enabled", False)).lower())
 write_output("rerunFailedCount", str(metadata.get("rerun_failed_count", "")))
 write_output("failedTestCount", str(len(failed_tests)))
@@ -128,6 +130,7 @@ summary_lines = [
     f"- selected ref: {metadata['source_ref_name']}",
     f"- flavor: {metadata['flavor']}",
     f"- selector: {metadata.get('selector_type', '')} = {metadata.get('selector_value', '')}",
+    f"- device group: {metadata.get('android_device_group', '')}",
     f"- resolved build number: {metadata.get('resolved_build_number', '')}",
     f"- leftover failed tests: {len(failed_tests)}",
 ]

--- a/scripts/qa_android_ui_tests/prepare_deflake_bundle.py
+++ b/scripts/qa_android_ui_tests/prepare_deflake_bundle.py
@@ -59,11 +59,14 @@ elif resolved_category:
     selector_value = resolved_category
 
 android_device_id = env("ANDROID_DEVICE_ID")
+android_device_group = env("ANDROID_DEVICE_GROUP")
 device_mode = "auto_pool"
 if android_device_id:
     device_mode = "specific_device"
 elif resolved_test_case_id:
     device_mode = "single_testcase_auto"
+elif android_device_group:
+    device_mode = "device_group"
 
 metadata = {
     "schema_version": 1,
@@ -91,6 +94,7 @@ metadata = {
     "enforce_app_install": env_bool("ENFORCE_APP_INSTALL"),
     "testiny_run_name": env("TESTINY_RUN_NAME"),
     "android_device_id": android_device_id,
+    "android_device_group": android_device_group,
     "device_mode": device_mode,
     "device_count": env_int("DEVICE_COUNT"),
     "rerun_failed_enabled": env_bool("RERUN_FAILED_ENABLED"),

--- a/scripts/qa_android_ui_tests/resolve_device_group.py
+++ b/scripts/qa_android_ui_tests/resolve_device_group.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Resolve one configured Android device group against online ADB devices."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Mapping
+
+
+class DeviceGroupError(ValueError):
+    """Raised when the device-group configuration is invalid or unusable."""
+
+
+def parse_groups(raw_json: str) -> dict[str, list[str]]:
+    if not raw_json.strip():
+        raise DeviceGroupError(
+            "ANDROID_DEVICE_GROUPS_JSON is empty. Configure it as a GitHub repository variable."
+        )
+
+    try:
+        raw_groups = json.loads(raw_json)
+    except json.JSONDecodeError as error:
+        raise DeviceGroupError(f"ANDROID_DEVICE_GROUPS_JSON is not valid JSON: {error.msg}") from error
+
+    if not isinstance(raw_groups, Mapping) or not raw_groups:
+        raise DeviceGroupError("ANDROID_DEVICE_GROUPS_JSON must be a non-empty JSON object.")
+
+    groups: dict[str, list[str]] = {}
+    device_owners: dict[str, str] = {}
+    for raw_name, raw_devices in raw_groups.items():
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise DeviceGroupError("Every device group must have a non-empty string name.")
+        name = raw_name.strip()
+        if name != raw_name:
+            raise DeviceGroupError(f"Device group name must not have surrounding whitespace: {raw_name!r}")
+        if not isinstance(raw_devices, list) or not raw_devices:
+            raise DeviceGroupError(f"Device group '{name}' must contain at least one device serial.")
+
+        devices: list[str] = []
+        for raw_device in raw_devices:
+            if not isinstance(raw_device, str) or not raw_device.strip():
+                raise DeviceGroupError(f"Device group '{name}' contains an invalid device serial.")
+            device = raw_device.strip()
+            if device != raw_device or any(character.isspace() for character in device):
+                raise DeviceGroupError(f"Device serial must not contain whitespace: {raw_device!r}")
+            if device in devices:
+                raise DeviceGroupError(f"Device serial '{device}' is duplicated in group '{name}'.")
+            if device in device_owners:
+                raise DeviceGroupError(
+                    f"Device serial '{device}' belongs to both '{device_owners[device]}' and '{name}'. "
+                    "Device groups must be disjoint so workflows cannot use the same phone concurrently."
+                )
+            devices.append(device)
+            device_owners[device] = name
+        groups[name] = devices
+
+    return groups
+
+
+def resolve_group(raw_json: str, group_name: str, online_devices: list[str]) -> tuple[list[str], list[str]]:
+    groups = parse_groups(raw_json)
+    requested_group = group_name.strip()
+    if not requested_group:
+        raise DeviceGroupError("DEVICE_GROUP is empty.")
+    if requested_group not in groups:
+        available_groups = ", ".join(sorted(groups))
+        raise DeviceGroupError(
+            f"Unknown device group '{requested_group}'. Configured groups: {available_groups}"
+        )
+
+    online = set(online_devices)
+    configured = groups[requested_group]
+    selected = [device for device in configured if device in online]
+    unavailable = [device for device in configured if device not in online]
+    if not selected:
+        raise DeviceGroupError(
+            f"Device group '{requested_group}' has no online devices. "
+            f"Configured devices: {', '.join(configured)}"
+        )
+    return selected, unavailable
+
+
+def main() -> None:
+    raw_json = os.environ.get("DEVICE_GROUPS_JSON", "")
+    group_name = os.environ.get("DEVICE_GROUP", "")
+    online_devices = os.environ.get("ONLINE_DEVICE_IDS", "").split()
+    try:
+        selected, unavailable = resolve_group(raw_json, group_name, online_devices)
+    except DeviceGroupError as error:
+        raise SystemExit(f"ERROR: {error}") from error
+
+    if unavailable:
+        print(
+            f"WARNING: Device group '{group_name}' has offline or unavailable devices: "
+            f"{', '.join(unavailable)}",
+            file=sys.stderr,
+        )
+    print(" ".join(selected))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qa_android_ui_tests/test_resolve_device_group.py
+++ b/scripts/qa_android_ui_tests/test_resolve_device_group.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Unit tests for Android device-group resolution."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+from scripts.qa_android_ui_tests.resolve_device_group import DeviceGroupError, parse_groups, resolve_group
+
+
+class ResolveDeviceGroupTest(unittest.TestCase):
+    def test_resolves_online_devices_in_configured_order(self) -> None:
+        groups = json.dumps(
+            {
+                "criticalFlow": ["critical-2", "critical-1"],
+                "e2eTests": ["e2e-1"],
+            }
+        )
+
+        selected, unavailable = resolve_group(
+            groups,
+            "criticalFlow",
+            ["unassigned", "critical-1", "critical-2"],
+        )
+
+        self.assertEqual(["critical-2", "critical-1"], selected)
+        self.assertEqual([], unavailable)
+
+    def test_keeps_running_when_part_of_group_is_offline(self) -> None:
+        groups = json.dumps({"criticalFlow": ["online", "offline"]})
+
+        selected, unavailable = resolve_group(groups, "criticalFlow", ["online"])
+
+        self.assertEqual(["online"], selected)
+        self.assertEqual(["offline"], unavailable)
+
+    def test_fails_when_group_has_no_online_devices(self) -> None:
+        groups = json.dumps({"criticalFlow": ["offline"]})
+
+        with self.assertRaisesRegex(DeviceGroupError, "has no online devices"):
+            resolve_group(groups, "criticalFlow", ["another-device"])
+
+    def test_fails_for_unknown_group(self) -> None:
+        groups = json.dumps({"criticalFlow": ["device-1"]})
+
+        with self.assertRaisesRegex(DeviceGroupError, "Unknown device group 'e2eTests'"):
+            resolve_group(groups, "e2eTests", ["device-1"])
+
+    def test_rejects_device_assigned_to_multiple_groups(self) -> None:
+        groups = json.dumps(
+            {
+                "criticalFlow": ["shared-device"],
+                "e2eTests": ["shared-device"],
+            }
+        )
+
+        with self.assertRaisesRegex(DeviceGroupError, "must be disjoint"):
+            parse_groups(groups)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27197
<!--jira-description-action-hidden-marker-end-->
## Intent

Split the office Android device farm into named pools that can be managed from GitHub configuration instead of editing workflow code whenever a phone is added, removed, or reassigned.

The current auto-selection treats every online ADB device as one shared pool. That makes it impossible to reserve different devices for critical flows, E2E tests, GrapheneOS, or future suites, and it forces unrelated runs to compete for the same lock.

## What changed

- Adds the repository variable contract `ANDROID_DEVICE_GROUPS_JSON`.
- Uses the exact group names `criticalFlow`, `e2eTests`, and `GrapheneOS`.
- Defaults nightly critical-flow runs to `criticalFlow`.
- Adds `androidDeviceGroup` to manual runs and manual deflake.
- Resolves the configured group against currently online ADB devices while preserving configured order.
- Rejects overlapping device membership so independently running groups cannot share a phone.
- Allows partially available groups with a warning, but fails closed when the variable, group, or all group devices are unavailable.
- Constrains explicit `androidDeviceId` selections to the selected group.
- Locks workflow concurrency per group, allowing disjoint pools to run concurrently.
- Stores the selected group in deflake metadata and validates it on later deflake runs.
- Documents the configuration and adds resolver unit coverage.

```mermaid
flowchart LR
  V["GitHub variable<br/>ANDROID_DEVICE_GROUPS_JSON"] --> G["Requested group"]
  G --> O["Intersect with online ADB devices"]
  O --> S["Shard tests across selected devices"]
  G --> L["Concurrency lock per group"]
```

## Rollout prerequisite

Create the repository variable before merging and replace the placeholders with the real ADB serials:

```json
{
  "criticalFlow": ["<serial>"],
  "e2eTests": ["<serial>"],
  "GrapheneOS": ["<serial>"]
}
```

Groups must be disjoint. Updating this variable is sufficient for future device additions, removals, or moves.

The existing GitHub-hosted API 29 emulator workflow is unaffected; this allocation applies to the self-hosted physical-device QA workflows.

## Validation

- Device-group resolver unit coverage passes.
- Modified shell scripts pass syntax validation.
- Modified GitHub Actions workflows parse as valid YAML.
- The resolver was exercised with all three configured group keys and online-device filtering.
