### PR TITLE
test(sync): recover after connectivity returns [WPB-27272]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/AppSyncTelemetry.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/AppSyncTelemetry.kt
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util.lifecycle
+
+import com.wire.android.AppJsonStyledLogger
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+
+internal enum class AppSyncTelemetryEvent {
+    APP_SYNC_VISIBILITY_CHANGED,
+    APP_SYNC_REQUEST_STARTED,
+    APP_SYNC_REQUEST_RELEASED,
+    APP_SYNC_WAIT_STARTED,
+    APP_SYNC_WAIT_COMPLETED,
+}
+
+internal enum class AppSyncTelemetryTrigger {
+    APP_FOREGROUND,
+    PUSH_NOTIFICATION,
+}
+
+internal enum class AppSyncTelemetryOutcome {
+    SUCCESS,
+    FAILURE,
+}
+
+internal fun KaliumLogger.logAppSyncTelemetry(
+    event: AppSyncTelemetryEvent,
+    data: Map<String, Any?> = emptyMap(),
+    level: KaliumLogLevel = KaliumLogLevel.INFO,
+) {
+    AppJsonStyledLogger.log(
+        level = level,
+        leadingMessage = "Sync telemetry",
+        jsonStringKeyValues = buildMap {
+            put("schemaVersion", 1)
+            put("event", event.name)
+            put("component", "APP_LIFECYCLE")
+            data.forEach { (key, value) ->
+                value?.let { put(key, it) }
+            }
+        },
+        logger = this,
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManager.kt
@@ -22,6 +22,7 @@ import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.util.CurrentScreenManager
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
+import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreLogic
@@ -70,17 +71,31 @@ class SyncLifecycleManager @Inject constructor(
             }
             .distinctUntilChanged()
             .collectLatest { (accounts, isAppVisible) ->
+                logger.logAppSyncTelemetry(
+                    event = AppSyncTelemetryEvent.APP_SYNC_VISIBILITY_CHANGED,
+                    data = mapOf(
+                        "visible" to isAppVisible,
+                        "sessionCount" to accounts.size,
+                    )
+                )
                 if (!isAppVisible) {
-                    logger.i("Not running foreground sync request for users, as App is not visible.")
                     return@collectLatest
                 }
                 coroutineScope {
                     accounts.forEach { accountInfo ->
                         val userId = accountInfo.userId
                         launch {
-                            logger.i("!!!!! Starting foreground sync request for user ${userId.value.obfuscateId()}.")
-                            coreLogic.getSessionScope(userId).syncExecutor.request {
-                                awaitCancellation()
+                            val requestData = mapOf(
+                                "trigger" to AppSyncTelemetryTrigger.APP_FOREGROUND.name,
+                                "userId" to userId.toTelemetryString(),
+                            )
+                            logger.logAppSyncTelemetry(AppSyncTelemetryEvent.APP_SYNC_REQUEST_STARTED, requestData)
+                            try {
+                                coreLogic.getSessionScope(userId).syncExecutor.request {
+                                    awaitCancellation()
+                                }
+                            } finally {
+                                logger.logAppSyncTelemetry(AppSyncTelemetryEvent.APP_SYNC_REQUEST_RELEASED, requestData)
                             }
                         }
                     }
@@ -95,22 +110,41 @@ class SyncLifecycleManager @Inject constructor(
      * If there are more ongoing sync requests, this will
      */
     suspend fun syncTemporarily(userId: UserId, stayAliveExtraDuration: Duration = 0.seconds) {
-        logger.d(
-            "Handling connection policy for push notification of " +
-                    "user=${userId.value.obfuscateId()}@${userId.domain.obfuscateDomain()}"
+        val requestData = mapOf(
+            "trigger" to AppSyncTelemetryTrigger.PUSH_NOTIFICATION.name,
+            "userId" to userId.toTelemetryString(),
+            "stayAliveInMillis" to stayAliveExtraDuration.inWholeMilliseconds,
         )
-        coreLogic.getSessionScope(userId).run {
-            logger.d("Starting Sync request")
-            syncExecutor.request {
-                logger.d("Waiting until live")
-                when (waitUntilLiveOrFailure()) {
-                    is SyncRequestResult.Failure ->
-                        logger.w("Failed waiting until live")
+        logger.logAppSyncTelemetry(AppSyncTelemetryEvent.APP_SYNC_REQUEST_STARTED, requestData)
+        try {
+            coreLogic.getSessionScope(userId).run {
+                syncExecutor.request {
+                    logger.logAppSyncTelemetry(AppSyncTelemetryEvent.APP_SYNC_WAIT_STARTED, requestData)
+                    when (val result = waitUntilLiveOrFailure()) {
+                        is SyncRequestResult.Failure -> logger.logAppSyncTelemetry(
+                            event = AppSyncTelemetryEvent.APP_SYNC_WAIT_COMPLETED,
+                            data = requestData + mapOf(
+                                "outcome" to AppSyncTelemetryOutcome.FAILURE.name,
+                                "failureType" to result.error::class.simpleName,
+                            ),
+                            level = KaliumLogLevel.WARN,
+                        )
 
-                    is SyncRequestResult.Success ->
-                        delay(stayAliveExtraDuration)
+                        is SyncRequestResult.Success -> {
+                            logger.logAppSyncTelemetry(
+                                event = AppSyncTelemetryEvent.APP_SYNC_WAIT_COMPLETED,
+                                data = requestData + ("outcome" to AppSyncTelemetryOutcome.SUCCESS.name),
+                            )
+                            delay(stayAliveExtraDuration)
+                        }
+                    }
                 }
             }
+        } finally {
+            logger.logAppSyncTelemetry(AppSyncTelemetryEvent.APP_SYNC_REQUEST_RELEASED, requestData)
         }
     }
+
+    private fun UserId.toTelemetryString(): String =
+        "${value.obfuscateId()}@${domain.obfuscateDomain()}"
 }

--- a/app/src/test/kotlin/com/wire/android/framework/fake/FakeSyncExecutor.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/fake/FakeSyncExecutor.kt
@@ -27,6 +27,9 @@ open class FakeSyncExecutor : SyncExecutor() {
 
     var waitUntilLiveCount = 0
     var requestCount = 0
+    var activeRequestCount = 0
+        private set
+
     open fun onWaitUntilLiveOrFailure(): SyncRequestResult = SyncRequestResult.Success.also { waitUntilLiveCount++ }
     open fun onWaitUntilOrFailure(syncState: SyncState): SyncRequestResult = SyncRequestResult.Success
     open fun onKeepSyncAlwaysOn() {}
@@ -39,7 +42,12 @@ open class FakeSyncExecutor : SyncExecutor() {
 
     override suspend fun <T> request(executorAction: suspend SyncRequest.() -> T): T {
         onRequest()
-        return FakeSyncRequest().executorAction()
+        activeRequestCount++
+        return try {
+            FakeSyncRequest().executorAction()
+        } finally {
+            activeRequestCount--
+        }
     }
 
     inner class FakeSyncRequest : SyncRequest {

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/AppSyncTelemetryTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/AppSyncTelemetryTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util.lifecycle
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AppSyncTelemetryTest {
+
+    @Test
+    fun givenAppSyncTelemetry_whenLogging_thenShouldWriteStableStructuredFieldsAndOmitNulls() {
+        val writer = RecordingLogWriter()
+        val logger = KaliumLogger(
+            config = KaliumLogger.Config(
+                initialLevel = KaliumLogLevel.DEBUG,
+                initialLogWriterList = listOf(writer),
+            ),
+            tag = "AppSyncTelemetryTest",
+        )
+
+        logger.logAppSyncTelemetry(
+            event = AppSyncTelemetryEvent.APP_SYNC_REQUEST_STARTED,
+            data = mapOf(
+                "trigger" to AppSyncTelemetryTrigger.APP_FOREGROUND.name,
+                "failureType" to null,
+            )
+        )
+
+        val entry = writer.entries.single()
+        assertEquals(Severity.Info, entry.severity)
+        assertTrue(entry.message.contains("Sync telemetry:"))
+        assertTrue(entry.message.contains("\"schemaVersion\":1"))
+        assertTrue(entry.message.contains("\"event\":\"APP_SYNC_REQUEST_STARTED\""))
+        assertTrue(entry.message.contains("\"component\":\"APP_LIFECYCLE\""))
+        assertTrue(entry.message.contains("\"trigger\":\"APP_FOREGROUND\""))
+        assertFalse(entry.message.contains("failureType"))
+    }
+
+    private class RecordingLogWriter : LogWriter() {
+        val entries = mutableListOf<Entry>()
+
+        override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+            entries += Entry(severity, message)
+        }
+    }
+
+    private data class Entry(
+        val severity: Severity,
+        val message: String,
+    )
+}

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManagerTest.kt
@@ -30,10 +30,12 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -98,6 +100,51 @@ class SyncLifecycleManagerTest {
         assertEquals(1, arrangement.syncExecutor.waitUntilLiveCount)
     }
 
+    @Test
+    fun givenForegroundSyncIsActive_whenAppReturnsFromBackground_thenShouldStartANewForegroundRequest() = runTest {
+        val (arrangement, syncLifecycleManager) = Arrangement()
+            .withAppInTheForeground()
+            .arrange()
+
+        backgroundScope.launch { syncLifecycleManager.observeAppLifecycle() }
+        runCurrent()
+
+        assertEquals(1, arrangement.syncExecutor.requestCount)
+        assertEquals(1, arrangement.syncExecutor.activeRequestCount)
+
+        arrangement.updateAppVisibility(false)
+        runCurrent()
+        assertEquals(0, arrangement.syncExecutor.activeRequestCount)
+
+        arrangement.updateAppVisibility(true)
+        runCurrent()
+
+        assertEquals(2, arrangement.syncExecutor.requestCount)
+        assertEquals(1, arrangement.syncExecutor.activeRequestCount)
+    }
+
+    @Test
+    fun givenPersistentSyncRequest_whenAppReturnsToForeground_thenShouldAddAnotherSyncRequest() = runTest {
+        val (arrangement, syncLifecycleManager) = Arrangement()
+            .withAppInTheBackground()
+            .arrange()
+
+        backgroundScope.launch {
+            arrangement.syncExecutor.request { awaitCancellation() }
+        }
+        backgroundScope.launch { syncLifecycleManager.observeAppLifecycle() }
+        runCurrent()
+
+        assertEquals(1, arrangement.syncExecutor.requestCount)
+        assertEquals(1, arrangement.syncExecutor.activeRequestCount)
+
+        arrangement.updateAppVisibility(true)
+        runCurrent()
+
+        assertEquals(2, arrangement.syncExecutor.requestCount)
+        assertEquals(2, arrangement.syncExecutor.activeRequestCount)
+    }
+
     private class Arrangement {
 
         @MockK
@@ -113,6 +160,7 @@ class SyncLifecycleManagerTest {
         lateinit var observeValidAccountsUseCase: ObserveSessionsUseCase
 
         var syncExecutor = FakeSyncExecutor()
+        private val appVisibility = MutableStateFlow(false)
 
         private val syncLifecycleManager by lazy {
             SyncLifecycleManager(currentScreenManager, coreLogic)
@@ -122,6 +170,7 @@ class SyncLifecycleManagerTest {
             MockKAnnotations.init(this, relaxUnitFun = true)
             every { coreLogic.getGlobalScope().observeAllValidSessionsFlow } returns observeValidAccountsUseCase
             every { coreLogic.getSessionScope(TestUser.SELF_USER_ID) } returns userSessionScope
+            every { currentScreenManager.isAppVisibleFlow() } returns appVisibility
             coEvery { observeValidAccountsUseCase.invoke() } returns flowOf(
                 GetAllSessionsResult.Success(
                     listOf(
@@ -132,11 +181,15 @@ class SyncLifecycleManagerTest {
         }
 
         fun withAppInTheBackground() = apply {
-            every { currentScreenManager.isAppVisibleFlow() } returns MutableStateFlow(false)
+            updateAppVisibility(false)
         }
 
         fun withAppInTheForeground() = apply {
-            every { currentScreenManager.isAppVisibleFlow() } returns MutableStateFlow(true)
+            updateAppVisibility(true)
+        }
+
+        fun updateAppVisibility(isVisible: Boolean) {
+            appVisibility.value = isVisible
         }
 
         fun arrange() = this to syncLifecycleManager.also {

--- a/core/ui-common/src/main/kotlin/com/wire/android/AppLogger.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/AppLogger.kt
@@ -54,8 +54,9 @@ object AppJsonStyledLogger {
         level: KaliumLogLevel,
         error: Throwable? = null,
         leadingMessage: String,
-        jsonStringKeyValues: Map<String, Any?>
-    ) = with(appLogger) {
+        jsonStringKeyValues: Map<String, Any?>,
+        logger: KaliumLogger = appLogger,
+    ) = with(logger) {
         val logJson = jsonStringKeyValues.toJsonElement()
         val sanitizedLeadingMessage = if (leadingMessage.endsWith(":")) leadingMessage else "$leadingMessage:"
         val logMessage = "$sanitizedLeadingMessage $logJson"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27272
<!--jira-description-action-hidden-marker-end-->
## Intent

Recover sync promptly when the app returns after a long offline period, and add Android consumer coverage for the foreground lifecycle behavior that triggers recovery.

Depends on [Kalium PR #4310](https://github.com/wireapp/kalium/pull/4310), which contains the retry and request-demand implementation.

## Reproduction from the F-Droid device logs

1. Leave the device offline long enough for incremental sync retry delays to grow from seconds into minutes.
2. Reconnect Wi-Fi. Android reports the network before DNS is fully usable, so the immediate sync attempt can fail with `UnknownHostException`.
3. Open the app or toggle Wi-Fi again.
4. Sync remains on `Waiting for network` because the DNS failure inherited the old exponential delay and the new foreground request did not restart an already-requested failed sync.
5. Force-stop and reopen the app. The recreated process resets the stale state, opens the websocket, and completes sync.

## What changed

- Update Kalium to reset retry backoff on a newly validated network and retry immediately.
- Restart failed sync when a new logical request arrives, including the request created when the app returns to the foreground.
- Keep state waiters separate from logical request demand so they cannot cause duplicate restarts.
- Extend the app test executor with active-request tracking.
- Cover foreground request recreation after a background transition.
- Cover adding a foreground request while a persistent sync request is already active.

## Resulting behavior

- The first active logical request starts sync.
- Returning to the foreground creates a fresh logical request.
- If sync is already live, the new request leaves the connection alone.
- If sync is failed and backing off, the new request cancels that wait and retries immediately.
- A newly validated network also interrupts the wait and resets exponential state.
- If DNS is still warming up, the next retry starts from the minimum delay instead of inheriting a multi-minute delay.
- Sync stops when the last logical request ends; internal state waiters do not affect that lifetime.

## Coverage

The Android tests verify both ordinary background-to-foreground request recreation and the persistent-request case that previously kept requester demand continuously non-zero.
