### PR TITLE
chore(sync): add structured recovery telemetry [WPB-27272]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/AppSyncTelemetry.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/AppSyncTelemetry.kt
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util.lifecycle
+
+import com.wire.android.AppJsonStyledLogger
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+
+internal enum class AppSyncTelemetryEvent {
+    APP_SYNC_VISIBILITY_CHANGED,
+    APP_SYNC_REQUEST_STARTED,
+    APP_SYNC_REQUEST_RELEASED,
+    APP_SYNC_WAIT_STARTED,
+    APP_SYNC_WAIT_COMPLETED,
+}
+
+internal enum class AppSyncTelemetryTrigger {
+    APP_FOREGROUND,
+    PUSH_NOTIFICATION,
+}
+
+internal enum class AppSyncTelemetryOutcome {
+    SUCCESS,
+    FAILURE,
+}
+
+internal fun KaliumLogger.logAppSyncTelemetry(
+    event: AppSyncTelemetryEvent,
+    data: Map<String, Any?> = emptyMap(),
+    level: KaliumLogLevel = KaliumLogLevel.INFO,
+) {
+    AppJsonStyledLogger.log(
+        level = level,
+        leadingMessage = "Sync telemetry",
+        jsonStringKeyValues = buildMap {
+            put("schemaVersion", 1)
+            put("event", event.name)
+            put("component", "APP_LIFECYCLE")
+            data.forEach { (key, value) ->
+                value?.let { put(key, it) }
+            }
+        },
+        logger = this,
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManager.kt
@@ -22,6 +22,7 @@ import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.util.CurrentScreenManager
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
+import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreLogic
@@ -70,17 +71,31 @@ class SyncLifecycleManager @Inject constructor(
             }
             .distinctUntilChanged()
             .collectLatest { (accounts, isAppVisible) ->
+                logger.logAppSyncTelemetry(
+                    event = AppSyncTelemetryEvent.APP_SYNC_VISIBILITY_CHANGED,
+                    data = mapOf(
+                        "visible" to isAppVisible,
+                        "sessionCount" to accounts.size,
+                    )
+                )
                 if (!isAppVisible) {
-                    logger.i("Not running foreground sync request for users, as App is not visible.")
                     return@collectLatest
                 }
                 coroutineScope {
                     accounts.forEach { accountInfo ->
                         val userId = accountInfo.userId
                         launch {
-                            logger.i("!!!!! Starting foreground sync request for user ${userId.value.obfuscateId()}.")
-                            coreLogic.getSessionScope(userId).syncExecutor.request {
-                                awaitCancellation()
+                            val requestData = mapOf(
+                                "trigger" to AppSyncTelemetryTrigger.APP_FOREGROUND.name,
+                                "userId" to userId.toTelemetryString(),
+                            )
+                            logger.logAppSyncTelemetry(AppSyncTelemetryEvent.APP_SYNC_REQUEST_STARTED, requestData)
+                            try {
+                                coreLogic.getSessionScope(userId).syncExecutor.request {
+                                    awaitCancellation()
+                                }
+                            } finally {
+                                logger.logAppSyncTelemetry(AppSyncTelemetryEvent.APP_SYNC_REQUEST_RELEASED, requestData)
                             }
                         }
                     }
@@ -95,22 +110,41 @@ class SyncLifecycleManager @Inject constructor(
      * If there are more ongoing sync requests, this will
      */
     suspend fun syncTemporarily(userId: UserId, stayAliveExtraDuration: Duration = 0.seconds) {
-        logger.d(
-            "Handling connection policy for push notification of " +
-                    "user=${userId.value.obfuscateId()}@${userId.domain.obfuscateDomain()}"
+        val requestData = mapOf(
+            "trigger" to AppSyncTelemetryTrigger.PUSH_NOTIFICATION.name,
+            "userId" to userId.toTelemetryString(),
+            "stayAliveInMillis" to stayAliveExtraDuration.inWholeMilliseconds,
         )
-        coreLogic.getSessionScope(userId).run {
-            logger.d("Starting Sync request")
-            syncExecutor.request {
-                logger.d("Waiting until live")
-                when (waitUntilLiveOrFailure()) {
-                    is SyncRequestResult.Failure ->
-                        logger.w("Failed waiting until live")
+        logger.logAppSyncTelemetry(AppSyncTelemetryEvent.APP_SYNC_REQUEST_STARTED, requestData)
+        try {
+            coreLogic.getSessionScope(userId).run {
+                syncExecutor.request {
+                    logger.logAppSyncTelemetry(AppSyncTelemetryEvent.APP_SYNC_WAIT_STARTED, requestData)
+                    when (val result = waitUntilLiveOrFailure()) {
+                        is SyncRequestResult.Failure -> logger.logAppSyncTelemetry(
+                            event = AppSyncTelemetryEvent.APP_SYNC_WAIT_COMPLETED,
+                            data = requestData + mapOf(
+                                "outcome" to AppSyncTelemetryOutcome.FAILURE.name,
+                                "failureType" to result.error::class.simpleName,
+                            ),
+                            level = KaliumLogLevel.WARN,
+                        )
 
-                    is SyncRequestResult.Success ->
-                        delay(stayAliveExtraDuration)
+                        is SyncRequestResult.Success -> {
+                            logger.logAppSyncTelemetry(
+                                event = AppSyncTelemetryEvent.APP_SYNC_WAIT_COMPLETED,
+                                data = requestData + ("outcome" to AppSyncTelemetryOutcome.SUCCESS.name),
+                            )
+                            delay(stayAliveExtraDuration)
+                        }
+                    }
                 }
             }
+        } finally {
+            logger.logAppSyncTelemetry(AppSyncTelemetryEvent.APP_SYNC_REQUEST_RELEASED, requestData)
         }
     }
+
+    private fun UserId.toTelemetryString(): String =
+        "${value.obfuscateId()}@${domain.obfuscateDomain()}"
 }

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/AppSyncTelemetryTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/AppSyncTelemetryTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util.lifecycle
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AppSyncTelemetryTest {
+
+    @Test
+    fun givenAppSyncTelemetry_whenLogging_thenShouldWriteStableStructuredFieldsAndOmitNulls() {
+        val writer = RecordingLogWriter()
+        val logger = KaliumLogger(
+            config = KaliumLogger.Config(
+                initialLevel = KaliumLogLevel.DEBUG,
+                initialLogWriterList = listOf(writer),
+            ),
+            tag = "AppSyncTelemetryTest",
+        )
+
+        logger.logAppSyncTelemetry(
+            event = AppSyncTelemetryEvent.APP_SYNC_REQUEST_STARTED,
+            data = mapOf(
+                "trigger" to AppSyncTelemetryTrigger.APP_FOREGROUND.name,
+                "failureType" to null,
+            )
+        )
+
+        val entry = writer.entries.single()
+        assertEquals(Severity.Info, entry.severity)
+        assertTrue(entry.message.contains("Sync telemetry:"))
+        assertTrue(entry.message.contains("\"schemaVersion\":1"))
+        assertTrue(entry.message.contains("\"event\":\"APP_SYNC_REQUEST_STARTED\""))
+        assertTrue(entry.message.contains("\"component\":\"APP_LIFECYCLE\""))
+        assertTrue(entry.message.contains("\"trigger\":\"APP_FOREGROUND\""))
+        assertFalse(entry.message.contains("failureType"))
+    }
+
+    private class RecordingLogWriter : LogWriter() {
+        val entries = mutableListOf<Entry>()
+
+        override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+            entries += Entry(severity, message)
+        }
+    }
+
+    private data class Entry(
+        val severity: Severity,
+        val message: String,
+    )
+}

--- a/core/ui-common/src/main/kotlin/com/wire/android/AppLogger.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/AppLogger.kt
@@ -54,8 +54,9 @@ object AppJsonStyledLogger {
         level: KaliumLogLevel,
         error: Throwable? = null,
         leadingMessage: String,
-        jsonStringKeyValues: Map<String, Any?>
-    ) = with(appLogger) {
+        jsonStringKeyValues: Map<String, Any?>,
+        logger: KaliumLogger = appLogger,
+    ) = with(logger) {
         val logJson = jsonStringKeyValues.toJsonElement()
         val sanitizedLeadingMessage = if (leadingMessage.endsWith(":")) leadingMessage else "$leadingMessage:"
         val logMessage = "$sanitizedLeadingMessage $logJson"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27272
<!--jira-description-action-hidden-marker-end-->
## Summary

- add structured app-lifecycle telemetry for foreground and push-triggered sync requests
- use typed event, trigger, and outcome enums to keep dashboard field values stable
- emit a shared `schemaVersion` / `event` / `component` envelope and omit null fields
- pin the app telemetry wire format with a regression test
- update Kalium to wireapp/kalium#4311 for structured executor, retry, and network telemetry

## Why

The reconnect recovery in the base PR needs an observable path from app foregrounding or push handling through Kalium retry execution. Previously the app emitted prose logs that could not be reliably joined with SDK retry and network events.

## Stack

- stacked on #5069 (`mo/fix/sync-retry-after-no-internet`)
- depends on wireapp/kalium#4311, which is itself stacked on the Kalium recovery PR #4310

This PR contains telemetry changes only.

## Validation

- `AppSyncTelemetryTest`
- `SyncLifecycleManagerTest`
- app static code analysis / Detekt
- Kalium logic JVM tests, Android network host tests, and Kalium Detekt in the dependency PR
