### PR TITLE
feat: dynamic support URLs (WPB-27031)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -133,7 +133,7 @@ fun Direction.handleNavigation(
     handleOtherDirection: (Direction) -> Unit
 ) = when (this) {
     is ExternalUriDirection -> CustomTabsHelper.launchUri(context, this.uri)
-    is ExternalUriStringResDirection -> CustomTabsHelper.launchUrl(context, context.resources.getString(this.uriStringRes))
+    is ExternalUriStringResDirection -> CustomTabsHelper.launchUrl(context, this.getUriString(context.resources))
     is IntentDirection -> context.startActivity(this.intent(context))
     else -> handleOtherDirection(this)
 }

--- a/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/OtherDestinations.kt
@@ -26,6 +26,8 @@ import com.ramcosta.composedestinations.spec.Direction
 import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.util.EmailComposer
+import com.wire.android.util.SupportPage
+import com.wire.android.util.SupportUrlResolver
 import com.wire.android.util.getDeviceIdString
 import com.wire.android.util.getGitBuildId
 import com.wire.android.util.sha256
@@ -50,21 +52,33 @@ interface ExternalUriStringResDirection : Direction {
     override val route: String
         get() = "android.resource://${BuildConfig.APPLICATION_ID}/$uriStringRes"
 
-    fun getUri(resources: Resources): Uri = Uri.parse(resources.getString(uriStringRes))
+    fun getUriString(resources: Resources): String = resources.getString(uriStringRes)
+
+    fun getUri(resources: Resources): Uri = Uri.parse(getUriString(resources))
+}
+
+interface ExternalSupportUriStringResDirection : ExternalUriStringResDirection {
+    val supportPage: SupportPage
+
+    override val uriStringRes: Int
+        get() = supportPage.hardcodedUrlRes
+
+    override fun getUriString(resources: Resources): String =
+        SupportUrlResolver.resolve(resources, supportPage)
 }
 
 interface IntentDirection : Direction {
     fun intent(context: Context): Intent
 }
 
-object SupportScreenDestination : ExternalUriStringResDirection {
-    override val uriStringRes: Int
-        get() = R.string.url_support
+object SupportScreenDestination : ExternalSupportUriStringResDirection {
+    override val supportPage: SupportPage
+        get() = SupportPage.SUPPORT
 }
 
-object ReportMisuseScreenDestination : ExternalUriStringResDirection {
-    override val uriStringRes: Int
-        get() = R.string.url_report_misuse
+object ReportMisuseScreenDestination : ExternalSupportUriStringResDirection {
+    override val supportPage: SupportPage
+        get() = SupportPage.REPORT_MISUSE
 }
 
 data object TeamManagementScreenDestination : ExternalDirectionLess
@@ -107,9 +121,9 @@ object GiveFeedbackDestination : IntentDirection {
         get() = "wire-intent:give-feedback"
 }
 
-object WelcomeToNewAndroidAppDestination : ExternalUriStringResDirection {
-    override val uriStringRes: Int
-        get() = R.string.url_welcome_to_new_android
+object WelcomeToNewAndroidAppDestination : ExternalSupportUriStringResDirection {
+    override val supportPage: SupportPage
+        get() = SupportPage.WELCOME_ANDROID
 }
 
 object AndroidReleaseNotesDestination : ExternalUriStringResDirection {

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -56,6 +56,7 @@ import com.wire.android.util.BackendSupportConfig
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportUrlResolver
 import com.wire.android.util.deeplink.DeepLinkProcessor
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.deeplink.LoginType
@@ -147,6 +148,7 @@ class WireActivityViewModel @Inject constructor(
     private val observeSelfUserFactory: ObserveSelfUserUseCaseProvider.Factory,
     private val monitorSyncWorkUseCase: MonitorSyncWorkUseCase,
     private val managedConfigurationsManager: ManagedConfigurationsManager,
+    private val defaultServerConfig: ServerConfig.Links,
     private val automatedLoginManager: AutomatedLoginManager,
     private val nomadProfilesFeatureConfig: NomadProfilesFeatureConfig,
     private val loginTypeSelector: LoginTypeSelector,
@@ -239,9 +241,12 @@ class WireActivityViewModel @Inject constructor(
                     }.getOrNull()
                 }
                 serverLinks?.let(BackendSupportConfig::setCurrentBackend)
-                val websiteUrl = serverLinks?.website ?: managedConfigurationsManager.currentServerConfig?.website
+                val websiteUrl = serverLinks?.website
+                    ?: managedConfigurationsManager.currentServerConfig?.website
+                    ?: defaultServerConfig.website
 
                 CustomTabsHelper.setBackendWebsiteUrl(websiteUrl)
+                SupportUrlResolver.setBaseUrl(websiteUrl)
             }
         }
     }
@@ -685,6 +690,7 @@ class WireActivityViewModel @Inject constructor(
         when (val result = getServerConfigUseCase.value.invoke(url)) {
             is GetServerConfigResult.Success -> result.serverConfigLinks.also {
                 CustomTabsHelper.setBackendWebsiteUrl(it.website)
+                SupportUrlResolver.setBaseUrl(it.website)
                 BackendSupportConfig.storeFromServerLinks(globalDataStore.value, it)
             }
             is GetServerConfigResult.Failure.Generic -> {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
@@ -78,6 +78,8 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.configuration.server.ServerConfig
 
@@ -209,7 +211,7 @@ private fun EmailContent(
 private fun EmailErrorText(error: CreateAccountEmailViewState.EmailError) {
     val learnMoreTag = "learn_more"
     val context = LocalContext.current
-    val learnMoreUrl = stringResource(id = R.string.url_create_account_learn_more)
+    val learnMoreUrl = supportUrlResource(SupportPage.CREATE_ACCOUNT)
     val learnMoreText = stringResource(id = R.string.label_learn_more)
     val annotatedText = buildAnnotatedString {
         append(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -45,6 +45,7 @@ import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.util.EMPTY
 import com.wire.android.util.BackendSupportConfig
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportUrlResolver
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.CountdownTimer
 import com.wire.kalium.logic.CoreLogic
@@ -169,6 +170,7 @@ class LoginEmailViewModel @AssistedInject constructor(
             when (val result = getServerConfigUseCase?.value?.invoke(configUrl)) {
                 is GetServerConfigResult.Success -> {
                     CustomTabsHelper.setBackendWebsiteUrl(result.serverConfigLinks.website)
+                    SupportUrlResolver.setBaseUrl(result.serverConfigLinks.website)
                     globalDataStore?.let {
                         BackendSupportConfig.storeFromServerLinks(it.value, result.serverConfigLinks)
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallNetworkQualitySheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/details/CallNetworkQualitySheetContent.kt
@@ -56,6 +56,8 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.call.CallQualityData
 import com.wire.android.ui.common.R as commonR
@@ -120,7 +122,7 @@ fun CallNetworkQualitySheetContent(
 @Composable
 private fun LearnMoreItem() {
     val context = LocalContext.current
-    val learnMoreUrl = stringResource(id = R.string.url_call_network_quality_learn_more)
+    val learnMoreUrl = supportUrlResource(SupportPage.CALL_QUALITY)
     MenuBottomSheetItem(
         onItemClick = {
             CustomTabsHelper.launchUrl(context, learnMoreUrl)

--- a/app/src/main/kotlin/com/wire/android/ui/common/dialogs/EmailAlreadyInUseClaimedDomainDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/dialogs/EmailAlreadyInUseClaimedDomainDialog.kt
@@ -42,6 +42,8 @@ import com.wire.android.ui.common.visbility.VisibilityState
 import com.wire.android.ui.common.wireDialogPropertiesBuilder
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
@@ -86,12 +88,12 @@ private fun Content() {
                 append(deletePersonalAccount)
 
                 addStyledLink(
-                    url = stringResource(id = R.string.url_change_email),
+                    url = supportUrlResource(SupportPage.CHANGE_EMAIL),
                     start = bullet.length,
                     end = (bullet + changeEmail).length
                 )
                 addStyledLink(
-                    url = stringResource(id = R.string.url_delete_personal_account),
+                    url = supportUrlResource(SupportPage.DELETE_ACCOUNT),
                     start = (bullet + changeEmail + bullet).length,
                     end = (bullet + changeEmail + bullet + deletePersonalAccount).length
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/e2eiEnrollment/E2EIEnrollmentScreen.kt
@@ -62,6 +62,8 @@ import com.wire.android.ui.settings.devices.e2ei.E2EICertificateDetails
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.feature.e2ei.usecase.FinalizeEnrollmentResult
 
@@ -187,7 +189,7 @@ private fun E2EIEnrollmentScreenContent(
             }
             TextWithLearnMore(
                 textAnnotatedString = text,
-                learnMoreLink = stringResource(R.string.url_e2ee_id_shield),
+                learnMoreLink = supportUrlResource(SupportPage.E2EE_IDENTITY),
                 modifier = Modifier.padding(
                     top = MaterialTheme.wireDimensions.dialogTextsSpacing,
                     bottom = MaterialTheme.wireDimensions.dialogTextsSpacing,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/channels/BrowseChannelsEmptyScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/channels/BrowseChannelsEmptyScreen.kt
@@ -41,6 +41,8 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
@@ -60,7 +62,7 @@ fun BrowseChannelsEmptyScreen(modifier: Modifier = Modifier) {
                 textAlign = TextAlign.Center
             )
             Spacer(modifier = Modifier.height(dimensions().spacing8x))
-            val searchUrl = stringResource(id = R.string.url_create_channel_learn_more)
+            val searchUrl = supportUrlResource(SupportPage.CREATE_CHANNEL)
             Text(
                 text = stringResource(R.string.label_learn_more_about_channels),
                 style = MaterialTheme.wireTypography.body02.copy(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messagedetails/MessageDetailsScreen.kt
@@ -57,6 +57,8 @@ import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.UIText
 import kotlinx.coroutines.launch
 
@@ -71,7 +73,7 @@ fun MessageDetailsScreen(
 ) {
     val context = LocalContext.current
 
-    val reactionsLearnMoreUrl = stringResource(id = R.string.url_message_details_reactions_learn_more)
+    val reactionsLearnMoreUrl = supportUrlResource(SupportPage.REACTIONS)
     val onReactionsLearnMore = remember {
         {
             CustomTabsHelper.launchUrl(
@@ -81,7 +83,7 @@ fun MessageDetailsScreen(
         }
     }
 
-    val readReceiptsLearnMoreUrl = stringResource(id = R.string.url_message_details_read_receipts_learn_more)
+    val readReceiptsLearnMoreUrl = supportUrlResource(SupportPage.READ_RECEIPTS)
     val onReadReceiptsLearnMore = remember {
         {
             CustomTabsHelper.launchUrl(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageItemComponents.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageItemComponents.kt
@@ -62,6 +62,8 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.EMPTY
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -258,7 +260,7 @@ internal fun MessageDecryptionFailure(
     conversationProtocol: Conversation.ProtocolInfo?
 ) {
     val context = LocalContext.current
-    val learnMoreUrl = stringResource(R.string.url_decryption_failure_learn_more)
+    val learnMoreUrl = supportUrlResource(SupportPage.DECRYPTION_FAILURE)
 
     val textAlign = if (messageStyle == MessageStyle.BUBBLE_SELF) {
         TextAlign.End
@@ -376,7 +378,7 @@ internal fun Modifier.customizeMessageBackground(
 
 @Composable
 internal fun OfflineBackendsLearnMoreLink(messageStyle: MessageStyle, context: Context = LocalContext.current) {
-    val learnMoreUrl = stringResource(R.string.url_message_details_offline_backends_learn_more)
+    val learnMoreUrl = supportUrlResource(SupportPage.OFFLINE_BACKENDS)
     VerticalSpace.x4()
     Text(
         modifier = Modifier.clickable { CustomTabsHelper.launchUrl(context, learnMoreUrl) },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SystemMessageItem.kt
@@ -62,6 +62,8 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.MarkdownTextStyle
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.markdownBold
@@ -108,7 +110,7 @@ fun SystemMessageItem(
             ) {
                 val context = LocalContext.current
                 var expanded: Boolean by remember { mutableStateOf(initiallyExpanded) }
-                val learnMoreLink = learnMoreLinkResId?.let { stringResource(id = it) }
+                val learnMoreLink = learnMorePage?.let { supportUrlResource(it) }
 
                 TextWithLinkSuffix(
                     textStyle = MaterialTheme.wireTypography.body01,
@@ -327,7 +329,7 @@ private fun SystemMessage.buildContent(isWireCellsEnabled: Boolean) = when (this
     is SystemMessage.MLSWrongEpochWarning -> buildContent(
         iconResId = commonR.drawable.ic_info,
         iconTintColor = MaterialTheme.wireColorScheme.onBackground,
-        learnMoreLinkResId = R.string.url_system_message_learn_more_about_mls
+        learnMorePage = SupportPage.MLS
     ) {
         stringResource(id = R.string.label_system_message_conversation_mls_wrong_epoch_error_handled).toMarkdownAnnotatedString()
     }
@@ -372,10 +374,10 @@ private fun SystemMessage.buildContent(isWireCellsEnabled: Boolean) = when (this
     is SystemMessage.ConversationProtocolChanged -> buildContent(
         iconResId = commonR.drawable.ic_info,
         iconTintColor = MaterialTheme.wireColorScheme.onBackground,
-        learnMoreLinkResId = when (protocol) {
+        learnMorePage = when (protocol) {
             Conversation.Protocol.PROTEUS -> null
-            Conversation.Protocol.MIXED -> R.string.url_system_message_learn_more_about_mls
-            Conversation.Protocol.MLS -> R.string.url_system_message_learn_more_about_mls
+            Conversation.Protocol.MIXED,
+            Conversation.Protocol.MLS -> SupportPage.MLS
         },
         learnMoreTextResId = when (protocol) {
             Conversation.Protocol.PROTEUS -> R.string.label_learn_more
@@ -449,7 +451,7 @@ private fun SystemMessage.buildContent(isWireCellsEnabled: Boolean) = when (this
     is SystemMessage.FederationStopped -> buildContent(
         iconResId = commonR.drawable.ic_info,
         iconTintColor = MaterialTheme.wireColorScheme.onBackground,
-        learnMoreLinkResId = R.string.url_federation_support,
+        learnMorePage = SupportPage.FEDERATION_SUPPORT,
     ) {
         stringResource(
             id = when {
@@ -463,7 +465,7 @@ private fun SystemMessage.buildContent(isWireCellsEnabled: Boolean) = when (this
     is SystemMessage.LegalHold -> buildContent(
         iconResId = R.drawable.ic_legal_hold,
         iconTintColor = MaterialTheme.wireColorScheme.error,
-        learnMoreLinkResId = commonR.string.url_legal_hold_learn_more,
+        learnMorePage = SupportPage.LEGAL_HOLD,
     ) {
         stringResource(
             id = when (this) {
@@ -484,11 +486,11 @@ private fun SystemMessage.buildContent(isWireCellsEnabled: Boolean) = when (this
         iconResId = commonR.drawable.ic_info,
         iconTintColor = MaterialTheme.wireColorScheme.error,
         expandable = true,
-        learnMoreLinkResId = when (type) {
-            Type.Federation -> R.string.url_message_details_offline_backends_learn_more
-            Type.LegalHold -> commonR.string.url_legal_hold_learn_more
+        learnMorePage = when (type) {
+            Type.Federation -> SupportPage.OFFLINE_BACKENDS
+            Type.LegalHold -> SupportPage.LEGAL_HOLD
             Type.Unknown -> null
-            Type.MissingKeyPackages -> R.string.url_mls_learn_more
+            Type.MissingKeyPackages -> SupportPage.MLS
         }
     ) { expanded ->
         val markdownTextStyle = DefaultMarkdownTextStyle.copy(
@@ -524,7 +526,7 @@ private fun SystemMessage.buildContent(isWireCellsEnabled: Boolean) = when (this
         iconTintColor = MaterialTheme.wireColorScheme.onPositiveVariant,
         backgroundColor = MaterialTheme.wireColorScheme.positiveVariant,
         additionalVerticalPaddings = MaterialTheme.wireDimensions.spacing12x,
-        learnMoreLinkResId = R.string.url_system_message_learn_more_about_e2ee
+        learnMorePage = SupportPage.E2EE
     ) {
         val markdownTextStyle = DefaultMarkdownTextStyle.copy(
             normalColor = MaterialTheme.wireColorScheme.onSurface,
@@ -644,7 +646,7 @@ private fun List<UIText>.limitList(
 @Composable
 private fun buildContent(
     expandable: Boolean = false,
-    @StringRes learnMoreLinkResId: Int? = null,
+    learnMorePage: SupportPage? = null,
     @StringRes learnMoreTextResId: Int = R.string.label_learn_more,
     @DrawableRes iconResId: Int = commonR.drawable.ic_info,
     iconTintColor: Color? = MaterialTheme.wireColorScheme.onBackground,
@@ -654,7 +656,7 @@ private fun buildContent(
     annotatedStringBuilder: @Composable (expanded: Boolean) -> AnnotatedString,
 ) = SystemMessageContent(
     expandable = expandable,
-    learnMoreLinkResId = learnMoreLinkResId,
+    learnMorePage = learnMorePage,
     learnMoreTextResId = learnMoreTextResId,
     iconResId = iconResId,
     iconTintColor = iconTintColor,
@@ -675,7 +677,7 @@ val DefaultMarkdownTextStyle
 @Stable
 data class SystemMessageContent(
     val expandable: Boolean,
-    @get:StringRes val learnMoreLinkResId: Int?,
+    val learnMorePage: SupportPage?,
     @get:StringRes val learnMoreTextResId: Int,
     @get:DrawableRes val iconResId: Int?,
     val iconTintColor: Color?,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesEmptyScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/messages/SearchConversationMessagesEmptyScreen.kt
@@ -39,6 +39,8 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 
 @Composable
@@ -46,7 +48,7 @@ fun SearchConversationMessagesEmptyScreen(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val searchUrl = stringResource(R.string.url_learn_about_conversation_search)
+    val searchUrl = supportUrlResource(SupportPage.CONVERSATION_SEARCH)
 
     Box(
         modifier = modifier.fillMaxSize(),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/ConversationsEmptyContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/all/ConversationsEmptyContent.kt
@@ -42,6 +42,8 @@ import com.ramcosta.composedestinations.generated.app.destinations.BrowseChannel
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.conversation.ConversationFilter
 
@@ -67,7 +69,7 @@ private fun EmptyContentFooter(currentFilter: ConversationFilter, navigator: Nav
     val context = LocalContext.current
     when (currentFilter) {
         ConversationFilter.Favorites -> {
-            val supportUrl = stringResource(id = R.string.url_how_to_add_favorites)
+            val supportUrl = supportUrlResource(SupportPage.ADD_FAVORITES)
             Text(
                 text = stringResource(R.string.favorites_empty_list_how_to_label),
                 style = MaterialTheme.wireTypography.body02.copy(
@@ -81,7 +83,7 @@ private fun EmptyContentFooter(currentFilter: ConversationFilter, navigator: Nav
         }
 
         ConversationFilter.Channels -> {
-            val supportUrl = stringResource(id = R.string.url_support) // todo. change to url for channels
+            val supportUrl = supportUrlResource(SupportPage.SUPPORT) // todo. change to url for channels
             Text(
                 text = stringResource(R.string.channels_empty_list_learn_more),
                 style = MaterialTheme.wireTypography.body02.copy(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/filter/ConversationFoldersSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/filter/ConversationFoldersSheetContent.kt
@@ -51,6 +51,8 @@ import com.wire.android.ui.common.typography
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.kalium.logic.data.conversation.ConversationFilter
 
 @Composable
@@ -129,7 +131,7 @@ private fun EmptyFolders() {
                 style = typography().body01,
             )
             VerticalSpace.x16()
-            val supportUrl = stringResource(id = R.string.url_how_to_add_folders)
+            val supportUrl = supportUrlResource(SupportPage.ADD_FOLDERS)
             Text(
                 text = stringResource(R.string.folders_empty_list_how_to_add),
                 style = MaterialTheme.wireTypography.body02.copy(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -69,6 +69,8 @@ import com.wire.android.ui.home.messagecomposer.state.MessageCompositionInputSta
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.stringWithStyledArgs
 import com.wire.kalium.logic.data.conversation.InteractionAvailability
@@ -126,7 +128,7 @@ fun MessageComposer(
             InteractionAvailability.LEGAL_HOLD -> DisabledInteractionMessageComposer(
                 conversationId = conversationId,
                 warningText = warningTextWithStyledArgs(R.string.legal_hold_system_message_interaction_disabled),
-                learnMoreLink = stringResource(id = commonR.string.url_legal_hold_learn_more),
+                learnMoreLink = supportUrlResource(SupportPage.LEGAL_HOLD),
                 messageListContent = messageListContent
             )
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
@@ -29,6 +29,8 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.typography
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.util.DialogErrorStrings
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.stringWithStyledArgs
 
@@ -63,7 +65,7 @@ fun CreateGroupErrorDialog(
             ),
         ) to DialogTextSuffixLink(
             linkText = stringResource(id = R.string.label_learn_more),
-            linkUrl = stringResource(id = R.string.url_message_details_offline_backends_learn_more)
+            linkUrl = supportUrlResource(SupportPage.OFFLINE_BACKENDS)
         )
         is CreateGroupState.Error.Forbidden -> DialogErrorStrings(
             title = stringResource(R.string.conversation_can_not_be_created_title),

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
@@ -73,6 +73,8 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.conversation.CreateConversationParam
 import com.wire.kalium.logic.data.id.ConversationId
@@ -361,7 +363,7 @@ private fun GroupOptionState.AllowAppsOptions(onAllowServicesChanged: (Boolean) 
 @Composable
 private fun GroupOptionState.EnableWireCellOptions(onEnableWireCell: (Boolean) -> Unit) {
     val context = LocalContext.current
-    val cellsLearnMoreUrl = stringResource(R.string.create_group_with_shared_drive_learn_more_url)
+    val cellsLearnMoreUrl = supportUrlResource(SupportPage.SHARED_DRIVE)
 
     GroupConversationOptionsItem(
         title = stringResource(R.string.enable_wire_cell),

--- a/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModel.kt
@@ -50,6 +50,7 @@ import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.util.BackendSupportConfig
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.EMPTY
+import com.wire.android.util.SupportUrlResolver
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.common.error.CoreFailure
@@ -202,6 +203,7 @@ class NewLoginViewModel(
         serverConfig = ServerConfigProvider.EmptyServerConfig
         canUseBackend = false
         CustomTabsHelper.setBackendWebsiteUrl(null)
+        SupportUrlResolver.setBaseUrl(null)
         updateLoginFlowState(NewLoginFlowState.MissingBackendConfig)
     }
 
@@ -217,6 +219,7 @@ class NewLoginViewModel(
             when (val result = getServerConfigUseCase?.value?.invoke(configUrl)) {
                 is GetServerConfigResult.Success -> {
                     CustomTabsHelper.setBackendWebsiteUrl(result.serverConfigLinks.website)
+                    SupportUrlResolver.setBaseUrl(result.serverConfigLinks.website)
                     globalDataStore?.let {
                         BackendSupportConfig.storeFromServerLinks(it.value, result.serverConfigLinks)
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/details/CreateAccountDataDetailScreen.kt
@@ -86,7 +86,9 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.EMPTY
+import com.wire.android.util.SupportPage
 import com.wire.android.util.isHostValidForAnalytics
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.configuration.server.ServerConfig
 
@@ -426,7 +428,7 @@ private fun TermsConditionsDialog(onDialogDismiss: () -> Unit, onContinuePressed
 private fun EmailErrorDetailText(error: CreateAccountDataDetailViewState.DetailsError) {
     val learnMoreTag = "learn_more"
     val context = LocalContext.current
-    val learnMoreUrl = stringResource(id = R.string.url_create_account_learn_more)
+    val learnMoreUrl = supportUrlResource(SupportPage.CREATE_ACCOUNT)
     val learnMoreText = stringResource(id = R.string.label_learn_more)
     val annotatedText = buildAnnotatedString {
         append(

--- a/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/settings/devices/DeviceDetailsScreen.kt
@@ -83,10 +83,12 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
 import com.wire.android.util.deviceDateTimeFormat
 import com.wire.android.util.dialogErrorStrings
 import com.wire.android.util.extension.formatAsFingerPrint
 import com.wire.android.util.extension.formatAsString
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -483,7 +485,7 @@ private fun VerificationDescription(
         if (isSelfClient) {
             DescriptionText(
                 text = stringResource(id = R.string.label_self_client_verification_description),
-                leanMoreLink = stringResource(id = R.string.url_self_client_verification_learn_more)
+                leanMoreLink = supportUrlResource(SupportPage.CLIENT_VERIFICATION)
             )
         } else {
             DescriptionText(
@@ -491,7 +493,7 @@ private fun VerificationDescription(
                     id = R.string.label_client_verification_description,
                     userName ?: stringResource(id = R.string.unknown_user_name)
                 ),
-                leanMoreLink = stringResource(id = R.string.url_self_client_verification_learn_more)
+                leanMoreLink = supportUrlResource(SupportPage.CLIENT_VERIFICATION)
             )
         }
 
@@ -504,7 +506,7 @@ private fun VerificationDescription(
         if (isSelfClient) {
             DescriptionText(
                 text = stringResource(id = R.string.label_self_fingerprint_description),
-                leanMoreLink = stringResource(id = R.string.url_self_client_fingerprint_learn_more)
+                leanMoreLink = supportUrlResource(SupportPage.CLIENT_FINGERPRINT)
             )
         } else {
             DescriptionText(

--- a/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/sharing/ImportMediaScreen.kt
@@ -109,7 +109,9 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
 import com.wire.android.util.extension.getActivity
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.LinkText
 import com.wire.android.util.ui.LinkTextData
 import com.wire.android.util.ui.PreviewMultipleThemes
@@ -410,7 +412,7 @@ fun FileSharingRestrictedContent(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val learnMoreUrl = stringResource(R.string.url_file_sharing_restricted_learn_more)
+    val learnMoreUrl = supportUrlResource(SupportPage.FILE_SHARING_RESTRICTED)
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserConnectionUnverifiedWarning.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserConnectionUnverifiedWarning.kt
@@ -43,6 +43,8 @@ import com.wire.android.ui.common.spacers.VerticalSpace
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
+import com.wire.android.util.supportUrlResource
 import com.wire.kalium.logic.data.user.ConnectionState
 
 @Composable
@@ -52,7 +54,7 @@ fun OtherUserConnectionUnverifiedWarning(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val reportMisuseUrl = stringResource(R.string.url_report_misuse)
+    val reportMisuseUrl = supportUrlResource(SupportPage.REPORT_MISUSE)
     val reportMisuseLabel = stringResource(R.string.report_misuse_screen_title)
     val reportMisuseLinkText = remember(reportMisuseLabel) {
         buildAnnotatedString {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
@@ -47,7 +47,9 @@ import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.SupportPage
 import com.wire.android.util.capitalizeFirstLetter
+import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.LinkText
 import com.wire.android.util.ui.LinkTextData
 
@@ -111,7 +113,7 @@ private fun OtherUserDevicesContent(
     onDeviceClick: (Device) -> Unit
 ) {
     val context = LocalContext.current
-    val supportUrl = stringResource(id = R.string.url_why_verify_conversation)
+    val supportUrl = supportUrlResource(SupportPage.VERIFY_CONVERSATION)
 
     LazyColumn(
         state = lazyListState,

--- a/app/src/main/kotlin/com/wire/android/util/logging/LogSharing.kt
+++ b/app/src/main/kotlin/com/wire/android/util/logging/LogSharing.kt
@@ -26,6 +26,8 @@ import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.util.BackendSupportConfig
 import com.wire.android.util.EmailComposer
+import com.wire.android.util.SupportPage
+import com.wire.android.util.SupportUrlResolver
 import com.wire.android.util.getDeviceIdString
 import com.wire.android.util.getGitBuildId
 import com.wire.android.util.getProviderAuthority
@@ -130,15 +132,14 @@ suspend fun Context.bugReportLogsSharingIntent(archiveFile: File): Intent {
     val supportEmail = BackendSupportConfig.resolveEmail(this, getString(R.string.send_bug_report_email))
     if (supportEmail == null) {
         BackendSupportConfig.supportPageIntent()?.let { return it }
-        getString(R.string.url_support).takeIf { it.isNotBlank() }?.let {
-            return Intent(Intent.ACTION_VIEW, Uri.parse(it))
-        }
+        return Intent(
+            Intent.ACTION_VIEW,
+            Uri.parse(SupportUrlResolver.resolve(resources, SupportPage.SUPPORT))
+        )
     }
 
     val intent = logsSharingIntent(archiveFile).apply {
-        supportEmail?.let {
-            putExtra(Intent.EXTRA_EMAIL, arrayOf(it))
-        }
+        putExtra(Intent.EXTRA_EMAIL, arrayOf(supportEmail))
         putExtra(Intent.EXTRA_SUBJECT, getString(R.string.send_bug_report_subject))
         putExtra(
             Intent.EXTRA_TEXT,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,38 +266,12 @@
     <string name="url_maps_location_coordinates_fallback" translatable="false">https://maps.google.com/maps?z=%1d&amp;q=loc:%2f+%2f</string>
     <!-- Wire Urls - Non translatable -->
     <string name="url_wire_website" translatable="false">https://www.wire.com</string>
-    <string name="url_support" translatable="false">https://support.wire.com</string>
-    <string name="url_report_misuse" translatable="false">https://support.wire.com/hc/articles/202857164</string>
     <string name="url_terms_of_use_legal" translatable="false">https://wire.com/legal</string>
     <string name="url_privacy_policy" translatable="false">https://wire.com/privacy-policy#:~:text=We%20process%20individual%20data%20about,%C2%A7%201%20a)%20GDPR).</string>
-    <string name="url_create_account_learn_more" translatable="false">https://support.wire.com/hc/articles/115004082129</string>
-    <string name="url_decryption_failure_learn_more" translatable="false">https://support.wire.com/hc/articles/207948115</string>
-    <string name="url_federation_support" translatable="false">https://support.wire.com/hc/categories/4719917054365</string>
-    <string name="url_file_sharing_restricted_learn_more" translatable="false">https://support.wire.com/hc/articles/4406404582673</string>
-    <string name="url_learn_about_conversation_search" translatable="false">https://support.wire.com/hc/articles/115001426529</string>
-    <string name="url_message_details_offline_backends_learn_more" translatable="false">https://support.wire.com/hc/articles/9357718008093</string>
-    <string name="url_mls_learn_more" translatable="false">https://support.wire.com/hc/articles/12434725011485</string>
-    <string name="url_message_details_reactions_learn_more" translatable="false">https://support.wire.com/hc/articles/212053645</string>
-    <string name="url_message_details_read_receipts_learn_more" translatable="false">https://support.wire.com/hc/articles/360000665277</string>
-    <string name="url_self_client_fingerprint_learn_more" translatable="false">https://support.wire.com/hc/articles/207692235</string>
-    <string name="url_self_client_verification_learn_more" translatable="false">https://support.wire.com/hc/articles/207693005</string>
-    <string name="url_system_message_learn_more_about_mls" translatable="false">https://support.wire.com/hc/articles/12434725011485</string>
-    <string name="url_welcome_to_new_android" translatable="false">https://support.wire.com/hc/articles/6655706999581</string>
-    <string name="url_why_verify_conversation" translatable="false">https://support.wire.com/hc/articles/207859815</string>
-    <string name="url_how_to_add_favorites" translatable="false">https://support.wire.com/hc/articles/360002855557</string>
-    <string name="url_how_to_add_folders" translatable="false">https://support.wire.com/hc/articles/360002855817</string>
     <string name="url_wire_plans" translatable="false">https://wire.com/pricing</string>
     <string name="url_team_management_login" translatable="false">https://teams.wire.com/login</string>
     <string name="url_wire_enterprise" translatable="false">https://wire.com/en/enterprise</string>
     <string name="url_wire_create_team" translatable="false">https://teams.wire.com/register/email</string>
-    <string name="url_create_channel_learn_more" translatable="false">https://support.wire.com/hc/articles/25732551379101</string>
-    <string name="url_change_email" translatable="false">https://support.wire.com/hc/articles/203762940</string>
-    <string name="url_delete_personal_account" translatable="false">https://support.wire.com/hc/articles/207555795</string>
-    <string name="url_system_message_learn_more_about_e2ee" translatable="false">https://support.wire.com/hc/articles/10898523878173</string>
-    <string name="url_e2ee_id_shield" translatable="false">https://support.wire.com/hc/articles/9211300150685</string>
-    <string name="url_how_to_add_apps" translatable="false">https://support.wire.com/hc/articles/360000296158</string>
-    <string name="create_group_with_shared_drive_learn_more_url" translatable="false">https://support.wire.com/hc/articles/32207749480477</string>
-    <string name="url_call_network_quality_learn_more" translatable="false">https://support.wire.com/hc/articles/34087740781213</string>
     <!-- Navigation -->
     <string name="vault_screen_title">Vault</string>
     <string name="channels_screen_title">Channels</string>

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -54,6 +54,8 @@ import com.wire.android.ui.joinConversation.JoinConversationViaCodeState
 import com.wire.android.ui.theme.ThemeOption
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
+import com.wire.android.util.SupportPage
+import com.wire.android.util.SupportUrlResolver
 import com.wire.android.util.deeplink.DeepLinkProcessor
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.deeplink.LoginType
@@ -96,6 +98,7 @@ import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.ObserveSessionsUseCase
 import com.wire.kalium.logic.feature.user.ObserveSelfUserUseCase
+import com.wire.kalium.logic.feature.user.SelfServerConfigUseCase
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCase
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
@@ -120,6 +123,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -127,6 +131,11 @@ import org.junit.jupiter.api.extension.ExtendWith
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
 class WireActivityViewModelTest {
+
+    @AfterEach
+    fun tearDown() {
+        SupportUrlResolver.setBaseUrl(null)
+    }
 
     @Test
     fun `given Intent is null, when currentSession is present, then initialAppState is LOGGED_IN`() = runTest {
@@ -787,6 +796,64 @@ class WireActivityViewModelTest {
     }
 
     @Test
+    fun `given session changes, when resolving support url, then use current session website`() = runTest {
+        val firstSession = AccountInfo.Valid(UserId("user1", "domain1"))
+        val secondSession = AccountInfo.Valid(UserId("user2", "domain2"))
+        val firstServerConfig = newServerConfig(1)
+        val secondServerConfig = newServerConfig(2)
+        val currentSessionFlow = MutableStateFlow(firstSession)
+        Arrangement()
+            .withCurrentSessionFlow(currentSessionFlow.map { CurrentSessionResult.Success(it) })
+            .withServerConfigForUser(firstSession.userId, firstServerConfig)
+            .withServerConfigForUser(secondSession.userId, secondServerConfig)
+            .arrange()
+        advanceUntilIdle()
+        assertEquals(
+            "${firstServerConfig.links.website.trimEnd('/')}/support/search",
+            SupportUrlResolver.resolve("", SupportPage.SEARCH)
+        )
+
+        currentSessionFlow.emit(secondSession)
+        advanceUntilIdle()
+
+        assertEquals(
+            "${secondServerConfig.links.website.trimEnd('/')}/support/search",
+            SupportUrlResolver.resolve("", SupportPage.SEARCH)
+        )
+    }
+
+    @Test
+    fun `given no current session, when resolving support url, then use default server website`() = runTest {
+        val defaultServerConfig = newServerConfig(3).links
+        Arrangement()
+            .withNoCurrentSession()
+            .withDefaultServerConfig(defaultServerConfig)
+            .arrange()
+        advanceUntilIdle()
+
+        assertEquals(
+            "${defaultServerConfig.website.trimEnd('/')}/support/search",
+            SupportUrlResolver.resolve("", SupportPage.SEARCH)
+        )
+    }
+
+    @Test
+    fun `given managed server and no current session, when resolving support url, then use managed server website`() = runTest {
+        val managedServerConfig = newServerConfig(4).links
+        Arrangement()
+            .withNoCurrentSession()
+            .withDefaultServerConfig(newServerConfig(3).links)
+            .withManagedServerConfig(managedServerConfig)
+            .arrange()
+        advanceUntilIdle()
+
+        assertEquals(
+            "${managedServerConfig.website.trimEnd('/')}/support/search",
+            SupportUrlResolver.resolve("", SupportPage.SEARCH)
+        )
+    }
+
+    @Test
     fun `given app theme change, when observing it, then update state with theme option`() = runTest {
         val (_, viewModel) = Arrangement()
             .withThemeOption(ThemeOption.DARK)
@@ -1071,6 +1138,7 @@ class WireActivityViewModelTest {
 
         val managedConfigurationsManager: ManagedConfigurationsManager = mockk(relaxed = true)
         private val persistentWebSocketEnforcedByMDMFlow = MutableStateFlow(false)
+        private var defaultServerConfig = newServerConfig(0).links
         val automatedLoginManager = AutomatedLoginManager()
 
         init {
@@ -1106,6 +1174,7 @@ class WireActivityViewModelTest {
             every { observeSelfUserFactory.create(any()).observeSelfUser } returns observeSelfUserUseCase
             coEvery { observeSelfUserUseCase() } returns flowOf(SELF_USER)
             every { managedConfigurationsManager.persistentWebSocketEnforcedByMDM } returns persistentWebSocketEnforcedByMDMFlow
+            every { managedConfigurationsManager.currentServerConfig } returns null
             every { nomadProfilesFeatureConfig.isEnabled() } returns true
             every { coreLogic.versionedAuthenticationScope(any()) } returns autoVersionAuthScopeUseCase
             coEvery { autoVersionAuthScopeUseCase(any()) } returns AutoVersionAuthScopeUseCase.Result.Success(authenticationScope)
@@ -1233,6 +1302,7 @@ class WireActivityViewModelTest {
                 observeSelfUserFactory = observeSelfUserFactory,
                 monitorSyncWorkUseCase = monitorSyncWorkUseCase,
                 managedConfigurationsManager = managedConfigurationsManager,
+                defaultServerConfig = defaultServerConfig,
                 automatedLoginManager = automatedLoginManager,
                 nomadProfilesFeatureConfig = nomadProfilesFeatureConfig,
                 loginTypeSelector = loginTypeSelector,
@@ -1277,6 +1347,19 @@ class WireActivityViewModelTest {
 
         fun verifyTryToSwitchToNextAccount() {
             coVerify(exactly = 1) { switchAccount(SwitchAccountParam.TryToSwitchToNextAccount) }
+        }
+
+        fun withServerConfigForUser(userId: UserId, serverConfig: ServerConfig): Arrangement = apply {
+            coEvery { coreLogic.getSessionScope(userId).users.serverLinks() } returns
+                    SelfServerConfigUseCase.Result.Success(serverConfig)
+        }
+
+        fun withDefaultServerConfig(serverConfig: ServerConfig.Links): Arrangement = apply {
+            defaultServerConfig = serverConfig
+        }
+
+        fun withManagedServerConfig(serverConfig: ServerConfig.Links): Arrangement = apply {
+            every { managedConfigurationsManager.currentServerConfig } returns serverConfig
         }
 
         fun withE2EIRequiredDuringLogin(required: Boolean): Arrangement = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -22,6 +22,8 @@ import com.wire.android.ui.authentication.login.sso.LoginSSOViewModelExtension
 import com.wire.android.ui.authentication.login.sso.SSOUrlConfig
 import com.wire.android.ui.newauthentication.login.ValidateEmailOrSSOCodeUseCase.Result.ValidEmail
 import com.wire.android.util.EMPTY
+import com.wire.android.util.SupportPage
+import com.wire.android.util.SupportUrlResolver
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.deeplink.SSOFailureCodes
 import com.wire.android.util.newServerConfig
@@ -63,6 +65,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.extension.ExtendWith
@@ -72,6 +75,11 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class, NavigationTestExtension::class)
 class NewLoginViewModelTest {
     private val dispatchers = TestDispatcherProvider()
+
+    @AfterEach
+    fun tearDown() {
+        SupportUrlResolver.setBaseUrl(null)
+    }
 
     @Test
     fun `given onLoginStarted is called, when valid input is SSO, then proceed to SSO flow`() = runTest(dispatchers.main()) {
@@ -994,6 +1002,7 @@ class NewLoginViewModelTest {
             val (arrangement, viewModel) = Arrangement()
                 .withUserIdentifierAlreadySet("user@example.com")
                 .arrange()
+            SupportUrlResolver.setBaseUrl("https://previous.example")
 
             viewModel.onNoBackendSelected()
             advanceUntilIdle()
@@ -1003,6 +1012,7 @@ class NewLoginViewModelTest {
             assertEquals(ServerConfigProvider.EmptyServerConfig, viewModel.serverConfig)
             assertEquals(NewLoginFlowState.MissingBackendConfig, viewModel.state.flowState)
             assertEquals(false, viewModel.state.nextEnabled)
+            assertEquals("/support/search", SupportUrlResolver.resolve("", SupportPage.SEARCH))
             verify(exactly = 0) {
                 arrangement.validateEmailOrSSOCodeUseCase(any())
             }
@@ -1045,6 +1055,10 @@ class NewLoginViewModelTest {
 
             assertEquals(serverConfig, viewModel.serverConfig)
             assertEquals(NewLoginFlowState.BackendConfigSuccess, viewModel.state.flowState)
+            assertEquals(
+                "${serverConfig.website.trimEnd('/')}/support/search",
+                SupportUrlResolver.resolve("", SupportPage.SEARCH)
+            )
             coVerify(exactly = 1) {
                 arrangement.getServerConfigUseCase(configUrl)
             }

--- a/core/search/src/main/kotlin/com/wire/android/search/users/EmptySearchQueryScreen.kt
+++ b/core/search/src/main/kotlin/com/wire/android/search/users/EmptySearchQueryScreen.kt
@@ -42,7 +42,9 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.SupportPage
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.supportUrlResource
 import com.wire.android.search.util.ui.PreviewMultipleThemes
 
 @Composable
@@ -51,7 +53,7 @@ fun EmptySearchQueryScreen(
     text: String = stringResource(R.string.label_search_people_instruction),
     learnMoreTextToLink: Pair<String, String> = Pair(
         stringResource(R.string.label_learn_more_searching_user),
-        stringResource(R.string.url_learn_about_search)
+        supportUrlResource(SupportPage.SEARCH)
     )
 ) {
     val context = LocalContext.current

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/legalhold/dialog/common/LearnMoreAboutLegalHoldButton.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/legalhold/dialog/common/LearnMoreAboutLegalHoldButton.kt
@@ -31,13 +31,15 @@ import androidx.compose.ui.text.style.TextDecoration
 import com.wire.android.ui.common.R
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.SupportPage
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.PreviewMultipleThemes
+import com.wire.android.util.supportUrlResource
 
 @Composable
 fun LearnMoreAboutLegalHoldButton(modifier: Modifier = Modifier) {
     val context = LocalContext.current
-    val learnMoreUrl = stringResource(id = R.string.url_legal_hold_learn_more)
+    val learnMoreUrl = supportUrlResource(SupportPage.LEGAL_HOLD)
     Text(
         text = stringResource(R.string.legal_hold_learn_more_button),
         style = MaterialTheme.wireTypography.body02,

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/SupportPage.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/SupportPage.kt
@@ -1,0 +1,56 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import androidx.annotation.StringRes
+import com.wire.android.ui.common.R
+
+enum class SupportPage(
+    val path: String,
+    @StringRes val hardcodedUrlRes: Int
+) {
+    SUPPORT("", R.string.url_support),
+    REPORT_MISUSE("report_misuse", R.string.url_report_misuse),
+    CREATE_ACCOUNT("create_account", R.string.url_create_account_learn_more),
+    DECRYPTION_FAILURE("decryption_failure", R.string.url_decryption_failure_learn_more),
+    FEDERATION_SUPPORT("federation_support", R.string.url_federation_support),
+    FILE_SHARING_RESTRICTED("file_sharing_restricted", R.string.url_file_sharing_restricted_learn_more),
+    CONVERSATION_SEARCH("conversation_search", R.string.url_learn_about_conversation_search),
+    OFFLINE_BACKENDS("offline_backends", R.string.url_message_details_offline_backends_learn_more),
+    MLS("mls", R.string.url_mls_learn_more),
+    REACTIONS("reactions", R.string.url_message_details_reactions_learn_more),
+    READ_RECEIPTS("read_receipts", R.string.url_message_details_read_receipts_learn_more),
+    CLIENT_FINGERPRINT("client_fingerprint", R.string.url_self_client_fingerprint_learn_more),
+    CLIENT_VERIFICATION("client_verification", R.string.url_self_client_verification_learn_more),
+    WELCOME_ANDROID("welcome_android", R.string.url_welcome_to_new_android),
+    VERIFY_CONVERSATION("verify_conversation", R.string.url_why_verify_conversation),
+    ADD_FAVORITES("add_favorites", R.string.url_how_to_add_favorites),
+    ADD_FOLDERS("add_folders", R.string.url_how_to_add_folders),
+    CREATE_CHANNEL("create_channel", R.string.url_create_channel_learn_more),
+    CHANGE_EMAIL("change_email", R.string.url_change_email),
+    DELETE_ACCOUNT("delete_account", R.string.url_delete_personal_account),
+    E2EE("e2ee", R.string.url_system_message_learn_more_about_e2ee),
+    E2EE_IDENTITY("e2ee_identity", R.string.url_e2ee_id_shield),
+    ADD_APPS("add_apps", R.string.url_how_to_add_apps),
+    SHARED_DRIVE("shared_drive", R.string.create_group_with_shared_drive_learn_more_url),
+    CALL_QUALITY("call_quality", R.string.url_call_network_quality_learn_more),
+    LEGAL_HOLD("legal_hold", R.string.url_legal_hold_learn_more),
+    SEARCH("search", R.string.url_learn_about_search),
+    CELLS_CONVERSATION("cells_conversation", R.string.empty_screen_learn_more_link_conversation),
+    CELLS_ALL_FILES("cells_all_files", R.string.empty_screen_learn_more_link_all_files_screen)
+}

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/SupportUrlResolver.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/SupportUrlResolver.kt
@@ -1,0 +1,92 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import android.content.res.Resources
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.wire.android.ui.common.R
+
+object SupportUrlResolver {
+    @Volatile
+    private var baseUrl: String = ""
+
+    fun setBaseUrl(baseUrl: String?) {
+        this.baseUrl = baseUrl?.trim()?.trimEnd('/').orEmpty()
+    }
+
+    fun resolve(
+        hardcodedUrl: String,
+        page: SupportPage
+    ): String = hardcodedUrl.takeIf { it.isNotBlank() } ?: buildDynamicUrl(baseUrl, page)
+
+    fun resolve(
+        resources: Resources,
+        page: SupportPage
+    ): String = resolve(resources.getString(page.hardcodedUrlRes), page)
+
+    fun resolve(
+        resources: Resources,
+        @StringRes hardcodedUrlRes: Int,
+        page: SupportPage
+    ): String = resolve(resources.getString(hardcodedUrlRes), page)
+
+    private fun buildDynamicUrl(baseUrl: String, page: SupportPage): String =
+        "${baseUrl.trim().trimEnd('/')}/support/${page.path}"
+}
+
+enum class SupportPage(
+    val path: String,
+    @StringRes val hardcodedUrlRes: Int
+) {
+    SUPPORT("support", R.string.url_support),
+    REPORT_MISUSE("report_misuse", R.string.url_report_misuse),
+    CREATE_ACCOUNT("create_account", R.string.url_create_account_learn_more),
+    DECRYPTION_FAILURE("decryption_failure", R.string.url_decryption_failure_learn_more),
+    FEDERATION_SUPPORT("federation_support", R.string.url_federation_support),
+    FILE_SHARING_RESTRICTED("file_sharing_restricted", R.string.url_file_sharing_restricted_learn_more),
+    CONVERSATION_SEARCH("conversation_search", R.string.url_learn_about_conversation_search),
+    OFFLINE_BACKENDS("offline_backends", R.string.url_message_details_offline_backends_learn_more),
+    MLS("mls", R.string.url_mls_learn_more),
+    REACTIONS("reactions", R.string.url_message_details_reactions_learn_more),
+    READ_RECEIPTS("read_receipts", R.string.url_message_details_read_receipts_learn_more),
+    CLIENT_FINGERPRINT("client_fingerprint", R.string.url_self_client_fingerprint_learn_more),
+    CLIENT_VERIFICATION("client_verification", R.string.url_self_client_verification_learn_more),
+    WELCOME_ANDROID("welcome_android", R.string.url_welcome_to_new_android),
+    VERIFY_CONVERSATION("verify_conversation", R.string.url_why_verify_conversation),
+    ADD_FAVORITES("add_favorites", R.string.url_how_to_add_favorites),
+    ADD_FOLDERS("add_folders", R.string.url_how_to_add_folders),
+    CREATE_CHANNEL("create_channel", R.string.url_create_channel_learn_more),
+    CHANGE_EMAIL("change_email", R.string.url_change_email),
+    DELETE_ACCOUNT("delete_account", R.string.url_delete_personal_account),
+    E2EE("e2ee", R.string.url_system_message_learn_more_about_e2ee),
+    E2EE_IDENTITY("e2ee_identity", R.string.url_e2ee_id_shield),
+    ADD_APPS("add_apps", R.string.url_how_to_add_apps),
+    SHARED_DRIVE("shared_drive", R.string.create_group_with_shared_drive_learn_more_url),
+    CALL_QUALITY("call_quality", R.string.url_call_network_quality_learn_more),
+    LEGAL_HOLD("legal_hold", R.string.url_legal_hold_learn_more),
+    SEARCH("search", R.string.url_learn_about_search),
+    CELLS_CONVERSATION("cells_conversation", R.string.empty_screen_learn_more_link_conversation),
+    CELLS_ALL_FILES("cells_all_files", R.string.empty_screen_learn_more_link_all_files_screen)
+}
+
+@Composable
+fun supportUrlResource(
+    page: SupportPage
+): String = SupportUrlResolver.resolve(stringResource(id = page.hardcodedUrlRes), page)

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/SupportUrlResolver.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/SupportUrlResolver.kt
@@ -21,8 +21,14 @@ import android.content.res.Resources
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import com.wire.android.ui.common.R
 
+/**
+ * Resolves support page URLs using a bundled URL when one is defined, otherwise building one from
+ * the website URL configured in deeplinks.
+ *
+ * Set the server URL after obtaining the server configuration, then call [resolve] or [supportUrlResource]
+ * with the required [SupportPage].
+ */
 object SupportUrlResolver {
     @Volatile
     private var baseUrl: String = ""
@@ -47,43 +53,10 @@ object SupportUrlResolver {
         page: SupportPage
     ): String = resolve(resources.getString(hardcodedUrlRes), page)
 
-    private fun buildDynamicUrl(baseUrl: String, page: SupportPage): String =
-        "${baseUrl.trim().trimEnd('/')}/support/${page.path}"
-}
-
-enum class SupportPage(
-    val path: String,
-    @StringRes val hardcodedUrlRes: Int
-) {
-    SUPPORT("support", R.string.url_support),
-    REPORT_MISUSE("report_misuse", R.string.url_report_misuse),
-    CREATE_ACCOUNT("create_account", R.string.url_create_account_learn_more),
-    DECRYPTION_FAILURE("decryption_failure", R.string.url_decryption_failure_learn_more),
-    FEDERATION_SUPPORT("federation_support", R.string.url_federation_support),
-    FILE_SHARING_RESTRICTED("file_sharing_restricted", R.string.url_file_sharing_restricted_learn_more),
-    CONVERSATION_SEARCH("conversation_search", R.string.url_learn_about_conversation_search),
-    OFFLINE_BACKENDS("offline_backends", R.string.url_message_details_offline_backends_learn_more),
-    MLS("mls", R.string.url_mls_learn_more),
-    REACTIONS("reactions", R.string.url_message_details_reactions_learn_more),
-    READ_RECEIPTS("read_receipts", R.string.url_message_details_read_receipts_learn_more),
-    CLIENT_FINGERPRINT("client_fingerprint", R.string.url_self_client_fingerprint_learn_more),
-    CLIENT_VERIFICATION("client_verification", R.string.url_self_client_verification_learn_more),
-    WELCOME_ANDROID("welcome_android", R.string.url_welcome_to_new_android),
-    VERIFY_CONVERSATION("verify_conversation", R.string.url_why_verify_conversation),
-    ADD_FAVORITES("add_favorites", R.string.url_how_to_add_favorites),
-    ADD_FOLDERS("add_folders", R.string.url_how_to_add_folders),
-    CREATE_CHANNEL("create_channel", R.string.url_create_channel_learn_more),
-    CHANGE_EMAIL("change_email", R.string.url_change_email),
-    DELETE_ACCOUNT("delete_account", R.string.url_delete_personal_account),
-    E2EE("e2ee", R.string.url_system_message_learn_more_about_e2ee),
-    E2EE_IDENTITY("e2ee_identity", R.string.url_e2ee_id_shield),
-    ADD_APPS("add_apps", R.string.url_how_to_add_apps),
-    SHARED_DRIVE("shared_drive", R.string.create_group_with_shared_drive_learn_more_url),
-    CALL_QUALITY("call_quality", R.string.url_call_network_quality_learn_more),
-    LEGAL_HOLD("legal_hold", R.string.url_legal_hold_learn_more),
-    SEARCH("search", R.string.url_learn_about_search),
-    CELLS_CONVERSATION("cells_conversation", R.string.empty_screen_learn_more_link_conversation),
-    CELLS_ALL_FILES("cells_all_files", R.string.empty_screen_learn_more_link_all_files_screen)
+    private fun buildDynamicUrl(baseUrl: String, page: SupportPage): String {
+        val supportUrl = "${baseUrl.trim().trimEnd('/')}/support"
+        return if (page.path.isEmpty()) supportUrl else "$supportUrl/${page.path}"
+    }
 }
 
 @Composable

--- a/core/ui-common/src/main/res/values/strings.xml
+++ b/core/ui-common/src/main/res/values/strings.xml
@@ -31,7 +31,34 @@
     <string name="username_unavailable_label">Name not available</string>
     <string name="content_description_add_contact">Add contact</string>
     <string name="content_description_open_link_label">open link</string>
+    <string name="url_support" translatable="false">https://support.wire.com</string>
+    <string name="url_report_misuse" translatable="false">https://support.wire.com/hc/articles/202857164</string>
+    <string name="url_create_account_learn_more" translatable="false">https://support.wire.com/hc/articles/115004082129</string>
+    <string name="url_decryption_failure_learn_more" translatable="false">https://support.wire.com/hc/articles/207948115</string>
+    <string name="url_federation_support" translatable="false">https://support.wire.com/hc/categories/4719917054365</string>
+    <string name="url_file_sharing_restricted_learn_more" translatable="false">https://support.wire.com/hc/articles/4406404582673</string>
+    <string name="url_learn_about_conversation_search" translatable="false">https://support.wire.com/hc/articles/115001426529</string>
+    <string name="url_message_details_offline_backends_learn_more" translatable="false">https://support.wire.com/hc/articles/9357718008093</string>
+    <string name="url_mls_learn_more" translatable="false">https://support.wire.com/hc/articles/12434725011485</string>
+    <string name="url_message_details_reactions_learn_more" translatable="false">https://support.wire.com/hc/articles/212053645</string>
+    <string name="url_message_details_read_receipts_learn_more" translatable="false">https://support.wire.com/hc/articles/360000665277</string>
+    <string name="url_self_client_fingerprint_learn_more" translatable="false">https://support.wire.com/hc/articles/207692235</string>
+    <string name="url_self_client_verification_learn_more" translatable="false">https://support.wire.com/hc/articles/207693005</string>
+    <string name="url_welcome_to_new_android" translatable="false">https://support.wire.com/hc/articles/6655706999581</string>
+    <string name="url_why_verify_conversation" translatable="false">https://support.wire.com/hc/articles/207859815</string>
+    <string name="url_how_to_add_favorites" translatable="false">https://support.wire.com/hc/articles/360002855557</string>
+    <string name="url_how_to_add_folders" translatable="false">https://support.wire.com/hc/articles/360002855817</string>
+    <string name="url_create_channel_learn_more" translatable="false">https://support.wire.com/hc/articles/25732551379101</string>
+    <string name="url_change_email" translatable="false">https://support.wire.com/hc/articles/203762940</string>
+    <string name="url_delete_personal_account" translatable="false">https://support.wire.com/hc/articles/207555795</string>
+    <string name="url_system_message_learn_more_about_e2ee" translatable="false">https://support.wire.com/hc/articles/10898523878173</string>
+    <string name="url_e2ee_id_shield" translatable="false">https://support.wire.com/hc/articles/9211300150685</string>
+    <string name="url_how_to_add_apps" translatable="false">https://support.wire.com/hc/articles/360000296158</string>
+    <string name="create_group_with_shared_drive_learn_more_url" translatable="false">https://support.wire.com/hc/articles/32207749480477</string>
+    <string name="url_call_network_quality_learn_more" translatable="false">https://support.wire.com/hc/articles/34087740781213</string>
     <string name="url_legal_hold_learn_more" translatable="false">https://support.wire.com/hc/articles/360002018278</string>
+    <string name="empty_screen_learn_more_link_conversation" translatable="false">https://support.wire.com/hc/articles/32207745256221</string>
+    <string name="empty_screen_learn_more_link_all_files_screen" translatable="false">https://support.wire.com/hc/articles/32207800433309</string>
     <string name="legal_hold_learn_more_button">Learn more about legal hold</string>
     <string name="legal_hold_connection_failed_dialog_title">Connecting not possible</string>
     <string name="legal_hold_connection_failed_dialog_description">You can not connect to this user due to legal hold.</string>

--- a/core/ui-common/src/test/kotlin/com/wire/android/util/SupportUrlResolverTest.kt
+++ b/core/ui-common/src/test/kotlin/com/wire/android/util/SupportUrlResolverTest.kt
@@ -83,7 +83,7 @@ class SupportUrlResolverTest {
 
         val result = SupportUrlResolver.resolve(hardcodedUrl = "", page = SupportPage.SUPPORT)
 
-        assertEquals("https://custom.example/support/support", result)
+        assertEquals("https://custom.example/support", result)
     }
 
     @Test

--- a/core/ui-common/src/test/kotlin/com/wire/android/util/SupportUrlResolverTest.kt
+++ b/core/ui-common/src/test/kotlin/com/wire/android/util/SupportUrlResolverTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class SupportUrlResolverTest {
+
+    @AfterEach
+    fun tearDown() {
+        SupportUrlResolver.setBaseUrl(null)
+    }
+
+    @Test
+    fun givenHardcodedUrl_whenResolving_thenReturnHardcodedUrl() {
+        val hardcodedUrl = "https://support.wire.com/hc/articles/123"
+        SupportUrlResolver.setBaseUrl("https://custom.example")
+
+        val result = SupportUrlResolver.resolve(
+            hardcodedUrl = hardcodedUrl,
+            page = SupportPage.FEDERATION_SUPPORT
+        )
+
+        assertEquals(hardcodedUrl, result)
+    }
+
+    @Test
+    fun givenBlankHardcodedUrl_whenResolving_thenReturnDynamicUrl() {
+        SupportUrlResolver.setBaseUrl("https://custom.example")
+
+        val result = SupportUrlResolver.resolve(
+            hardcodedUrl = "",
+            page = SupportPage.FEDERATION_SUPPORT
+        )
+
+        assertEquals("https://custom.example/support/federation_support", result)
+    }
+
+    @Test
+    fun givenWhitespaceHardcodedUrl_whenResolving_thenReturnDynamicUrl() {
+        SupportUrlResolver.setBaseUrl("https://custom.example")
+
+        val result = SupportUrlResolver.resolve(
+            hardcodedUrl = "  ",
+            page = SupportPage.SEARCH
+        )
+
+        assertEquals("https://custom.example/support/search", result)
+    }
+
+    @Test
+    fun givenBaseUrlWithTrailingSlash_whenResolving_thenReturnDynamicUrlWithSingleSlash() {
+        SupportUrlResolver.setBaseUrl(" https://custom.example/ ")
+
+        val result = SupportUrlResolver.resolve(
+            hardcodedUrl = "",
+            page = SupportPage.CALL_QUALITY
+        )
+
+        assertEquals("https://custom.example/support/call_quality", result)
+    }
+
+    @Test
+    fun givenSupportHomePage_whenResolving_thenReturnDynamicSupportPageUrl() {
+        SupportUrlResolver.setBaseUrl("https://custom.example/")
+
+        val result = SupportUrlResolver.resolve(hardcodedUrl = "", page = SupportPage.SUPPORT)
+
+        assertEquals("https://custom.example/support/support", result)
+    }
+
+    @Test
+    fun givenBaseUrlChanges_whenResolving_thenUseLatestBaseUrl() {
+        SupportUrlResolver.setBaseUrl("https://first.example")
+        SupportUrlResolver.setBaseUrl("https://second.example")
+
+        val result = SupportUrlResolver.resolve(hardcodedUrl = "", page = SupportPage.SEARCH)
+
+        assertEquals("https://second.example/support/search", result)
+    }
+}

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellScreenContent.kt
@@ -63,6 +63,7 @@ import com.wire.android.feature.cells.ui.publiclink.PublicLinkScreenData
 import com.wire.android.feature.cells.ui.recyclebin.RestoreConfirmationDialog
 import com.wire.android.feature.cells.ui.recyclebin.RestoreParentFolderConfirmationDialog
 import com.wire.android.feature.cells.ui.recyclebin.UnableToRestoreDialog
+import com.wire.android.util.SupportPage
 import com.wire.android.ui.common.HandleActions
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.preview.MultipleThemePreviews
@@ -70,6 +71,7 @@ import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.common.typography
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.supportUrlResource
 import com.wire.kalium.cells.domain.paging.FileListLoadError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -330,14 +332,14 @@ private fun EmptyScreen(
         if (!isRecycleBin && !isAllFiles) {
             LearnMoreLink(
                 textRes = R.string.empty_screen_learn_more_conversation,
-                urlRes = R.string.empty_screen_learn_more_link_conversation,
+                page = SupportPage.CELLS_CONVERSATION,
             )
         }
 
         if (isAllFiles) {
             LearnMoreLink(
                 textRes = R.string.empty_screen_learn_more,
-                urlRes = R.string.empty_screen_learn_more_link_all_files_screen,
+                page = SupportPage.CELLS_ALL_FILES,
             )
         }
 
@@ -352,12 +354,12 @@ private fun EmptyScreen(
 @Composable
 private fun LearnMoreLink(
     @StringRes textRes: Int,
-    @StringRes urlRes: Int,
+    page: SupportPage,
 ) {
     val context = LocalContext.current.applicationContext
     val onlineEditor = remember(context) { OnlineEditor(context) }
 
-    val url = stringResource(urlRes)
+    val url = supportUrlResource(page)
     Text(
         text = stringResource(textRes),
         style = MaterialTheme.wireTypography.body01,

--- a/features/cells/src/main/res/values/strings.xml
+++ b/features/cells/src/main/res/values/strings.xml
@@ -16,9 +16,6 @@
   ~ along with this program. If not, see http://www.gnu.org/licenses/.
   -->
 <resources>
-    <string name="empty_screen_learn_more_link_conversation" translatable="false">https://support.wire.com/hc/articles/32207745256221</string>
-    <string name="empty_screen_learn_more_link_all_files_screen" translatable="false">https://support.wire.com/hc/articles/32207800433309</string>
-
     <string name="retry">Retry</string>
     <string name="file_list_load_error_title">Error</string>
     <string name="file_list_load_error">The list of files couldn\'t be loaded. Please try again.</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27031
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-27031
----

# What's new in this PR?

### Issues

Support URLs are hardcoded in the strings.xml file. We need a way to build them dynamically from the websiteURL for the Wire Gov applicaion.

### Solutions

New SupportUrlResolver is used to build dynamic URL if hardcoded URL is empty.