### PR TITLE
fix(cells): secure file sharing [WPB-26687] PR 6

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -20,21 +20,17 @@
 
 package com.wire.android.util
 
-import android.app.ActivityOptions
 import android.app.DownloadManager
 import android.content.ActivityNotFoundException
-import android.content.ComponentName
 import android.content.ContentResolver
 import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.database.Cursor
 import android.media.MediaMetadataRetriever
 import android.media.MediaMetadataRetriever.METADATA_KEY_DURATION
 import android.net.Uri
 import android.os.Build
-import android.os.Bundle
 import android.os.Environment
 import android.os.Environment.DIRECTORY_DOWNLOADS
 import android.os.Parcelable
@@ -46,7 +42,6 @@ import android.provider.MediaStore.MediaColumns.SIZE
 import android.provider.OpenableColumns
 import android.provider.Settings
 import android.webkit.MimeTypeMap
-import androidx.annotation.VisibleForTesting
 import androidx.core.content.FileProvider
 import com.wire.android.R
 import com.wire.android.appLogger
@@ -55,8 +50,6 @@ import com.wire.android.util.ImageUtil.ImageSizeClass.Medium
 import com.wire.android.util.dispatchers.DefaultDispatcherProvider
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.asset.isAudioMimeType
-import com.wire.kalium.logic.util.buildFileName
-import com.wire.kalium.logic.util.splitFileExtensionAndCopyCounter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -66,7 +59,6 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InputStream
-import java.nio.file.Files
 import java.util.Locale
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -385,94 +377,6 @@ fun shareAssetFileWithExternalApp(assetDataPath: Path, context: Context, assetNa
     }
 }
 
-fun Context.externalShareChooserIntent(
-    sendIntent: Intent,
-    title: CharSequence? = null,
-    excludeOwnComponents: Boolean = true
-): Intent =
-    Intent.createChooser(sendIntent, title).apply {
-        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        if (!excludeOwnComponents) return@apply
-        val ownShareComponents = packageManager.queryIntentActivitiesCompat(sendIntent)
-            .map { ComponentName(it.activityInfo.packageName, it.activityInfo.name) }
-            .filter { it.packageName == packageName }
-            .toTypedArray()
-        if (ownShareComponents.isNotEmpty()) {
-            putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, ownShareComponents)
-        }
-    }
-
-fun Context.startShareIntentWithTrustedWireTarget(sendIntent: Intent, title: CharSequence? = null) {
-    val chooserIntent = externalShareChooserIntent(
-        sendIntent = sendIntent,
-        title = title,
-        excludeOwnComponents = !supportsTrustedWireShareCaller()
-    )
-    startActivity(chooserIntent, shareIdentityOptionsBundle())
-}
-
-fun supportsTrustedWireShareCaller(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM
-
-private fun shareIdentityOptionsBundle(): Bundle? =
-    if (supportsTrustedWireShareCaller()) {
-        ActivityOptions.makeBasic()
-            .setShareIdentityEnabled(true)
-            .toBundle()
-    } else {
-        null
-    }
-
-fun Context.fileProviderSharedCacheFile(fileName: String): File {
-    val shareDirectory = fileProviderSharedCacheDirectory()
-    deleteStaleFileProviderSharedCacheFiles(shareDirectory)
-    return File(shareDirectory, findFirstUniqueName(shareDirectory, fileName.ifBlank { ATTACHMENT_FILENAME }))
-}
-
-fun Context.shareableFileProviderUri(sourceFile: File, displayName: String? = null): Uri {
-    val shareFile = when {
-        sourceFile.isInDirectory(fileProviderSharedCacheDirectory()) -> sourceFile
-        else -> linkOrCopyToFileProviderSharedCache(sourceFile, displayName ?: sourceFile.name)
-    }
-    return fileProviderUri(shareFile, displayName)
-}
-
-private fun Context.linkOrCopyToFileProviderSharedCache(sourceFile: File, displayName: String): File {
-    val shareFile = fileProviderSharedCacheFile(displayName)
-    runCatching {
-        Files.createLink(shareFile.toPath(), sourceFile.toPath())
-    }.recoverCatching {
-        sourceFile.copyTo(shareFile, overwrite = true)
-    }.getOrThrow()
-    return shareFile
-}
-
-private fun Context.fileProviderSharedCacheDirectory(): File =
-    File(cacheDir, FILE_PROVIDER_SHARED_CACHE_DIRECTORY).apply { mkdirs() }
-
-private fun Context.fileProviderUri(file: File, displayName: String? = null): Uri =
-    FileProvider.getUriForFile(this, getProviderAuthority(), file, displayName ?: file.name)
-
-private fun File.isInDirectory(directory: File): Boolean {
-    val directoryPath = directory.canonicalFile.toPath()
-    return canonicalFile.toPath().startsWith(directoryPath)
-}
-
-private fun deleteStaleFileProviderSharedCacheFiles(directory: File) {
-    val oldestAllowedTimestamp = System.currentTimeMillis() - FILE_PROVIDER_SHARED_CACHE_MAX_AGE_MILLIS
-    directory.listFiles()
-        ?.filter { it.isFile && it.lastModified() < oldestAllowedTimestamp }
-        ?.forEach(File::delete)
-}
-
-private fun PackageManager.queryIntentActivitiesCompat(intent: Intent) =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        queryIntentActivities(intent, PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_DEFAULT_ONLY.toLong()))
-    } else {
-        @Suppress("DEPRECATION")
-        queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
-    }
-
 inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? = when {
     Build.VERSION.SDK_INT >= SDK_VERSION -> getParcelableExtra(key, T::class.java)
     else -> @Suppress("DEPRECATION") getParcelableExtra(key) as? T
@@ -550,26 +454,6 @@ suspend fun Context.getDependenciesVersion(): Map<String, String?> = withContext
     }
 }
 
-fun Context.getProviderAuthority() = "$packageName.provider"
-
-@VisibleForTesting
-fun findFirstUniqueName(dir: File, desiredName: String): String {
-    var currentName: String = desiredName.sanitizeFilename()
-    while (File(dir, currentName).exists()) {
-        val (nameWithoutCopyCounter, copyCounter, extension) = currentName.splitFileExtensionAndCopyCounter()
-        currentName = buildFileName(nameWithoutCopyCounter, extension, copyCounter + 1).sanitizeFilename()
-    }
-    return currentName
-}
-
-/**
- * Removes disallowed characters and returns valid filename.
- *
- * Uses the same cases as in `isValidFatFilenameChar` and `isValidExtFilenameChar` from [android.os.FileUtils].
- */
-@VisibleForTesting
-fun String.sanitizeFilename(): String = replace(Regex("[\u0000-\u001f\u007f\"*/:<>?\\\\|]"), "_")
-
 fun getAudioLengthInMs(dataPath: Path, mimeType: String): Long =
     if (isAudioMimeType(mimeType)) {
         val retriever = MediaMetadataRetriever()
@@ -584,8 +468,5 @@ fun getAudioLengthInMs(dataPath: Path, mimeType: String): Long =
 
 private const val ATTACHMENT_FILENAME = "attachment"
 private const val DATA_COPY_BUFFER_SIZE = 2048
-const val FILE_PROVIDER_SHARED_FILES_ROOT = "shared_files"
-private const val FILE_PROVIDER_SHARED_CACHE_DIRECTORY = "file-provider-shares"
-private const val FILE_PROVIDER_SHARED_CACHE_MAX_AGE_MILLIS = 24 * 60 * 60 * 1000L
 const val SDK_VERSION = 33
 const val SUPPORTED_AUDIO_MIME_TYPE = "audio/wav"

--- a/app/src/test/kotlin/com/wire/android/feature/cells/util/FileHelperSharingTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/cells/util/FileHelperSharingTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.feature.cells.util
+
+import android.app.Application
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import com.wire.android.util.FILE_PROVIDER_SHARED_FILES_ROOT
+import okio.Path.Companion.toOkioPath
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class FileHelperSharingTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+    private val fileHelper = FileHelper(context)
+
+    @Test
+    fun givenCellFileOutsideProviderRoot_whenOpeningExternally_thenSharedCacheUriIsGranted() {
+        val sourceFile = createCellFile("open-cell.txt")
+        var errorCalled = false
+
+        fileHelper.openAssetFileWithExternalApp(
+            localPath = sourceFile.toOkioPath(),
+            assetName = sourceFile.name,
+            mimeType = MIME_TYPE,
+            onError = { errorCalled = true }
+        )
+
+        val viewIntent = shadowOf(context).nextStartedActivity
+        val sharedUri = viewIntent.data
+        assertFalse(errorCalled)
+        assertEquals(Intent.ACTION_VIEW, viewIntent.action)
+        assertNotNull(sharedUri)
+        assertEquals(FILE_PROVIDER_SHARED_FILES_ROOT, sharedUri?.pathSegments?.first())
+        assertEquals(FILE_CONTENT, sharedUri?.readText())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun givenCellFileOutsideProviderRoot_whenSharingExternally_thenChooserContainsSharedCacheUri() {
+        val sourceFile = createCellFile("share-cell.txt")
+        var errorCalled = false
+
+        fileHelper.shareFileChooser(
+            assetDataPath = sourceFile.toOkioPath(),
+            assetName = sourceFile.name,
+            mimeType = MIME_TYPE,
+            onError = { errorCalled = true }
+        )
+
+        val chooserIntent = shadowOf(context).nextStartedActivity
+        val sendIntent = chooserIntent.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+        val sharedUri = sendIntent?.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+        assertFalse(errorCalled)
+        assertEquals(Intent.ACTION_CHOOSER, chooserIntent.action)
+        assertEquals(Intent.ACTION_SEND, sendIntent?.action)
+        assertNotNull(sharedUri)
+        assertEquals(FILE_PROVIDER_SHARED_FILES_ROOT, sharedUri?.pathSegments?.first())
+        assertEquals(FILE_CONTENT, sharedUri?.readText())
+    }
+
+    private fun createCellFile(name: String): File =
+        File(requireNotNull(context.getExternalFilesDir(null)), name).apply {
+            writeText(FILE_CONTENT)
+        }
+
+    private fun Uri.readText(): String {
+        val inputStream = requireNotNull(context.contentResolver.openInputStream(this)) {
+            "Expected FileProvider URI to be readable"
+        }
+        return inputStream.bufferedReader().use { it.readText() }
+    }
+
+    private companion object {
+        const val MIME_TYPE = "text/plain"
+        const val FILE_CONTENT = "cell content"
+    }
+}

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/FileNameUtil.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/FileNameUtil.kt
@@ -1,0 +1,42 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.util
+
+import androidx.annotation.VisibleForTesting
+import com.wire.kalium.logic.util.buildFileName
+import com.wire.kalium.logic.util.splitFileExtensionAndCopyCounter
+import java.io.File
+
+@VisibleForTesting
+fun findFirstUniqueName(dir: File, desiredName: String): String {
+    var currentName: String = desiredName.sanitizeFilename()
+    while (File(dir, currentName).exists()) {
+        val (nameWithoutCopyCounter, copyCounter, extension) = currentName.splitFileExtensionAndCopyCounter()
+        currentName = buildFileName(nameWithoutCopyCounter, extension, copyCounter + 1).sanitizeFilename()
+    }
+    return currentName
+}
+
+/**
+ * Removes disallowed characters and returns valid filename.
+ *
+ * Uses the same cases as in `isValidFatFilenameChar` and `isValidExtFilenameChar` from [android.os.FileUtils].
+ */
+@VisibleForTesting
+fun String.sanitizeFilename(): String = replace(Regex("[\u0000-\u001f\u007f\"*/:<>?\\\\|]"), "_")

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/SecureFileSharing.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/SecureFileSharing.kt
@@ -1,0 +1,126 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.util
+
+import android.app.ActivityOptions
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import androidx.core.content.FileProvider
+import java.io.File
+import java.nio.file.Files
+
+fun Context.externalShareChooserIntent(
+    sendIntent: Intent,
+    title: CharSequence? = null,
+    excludeOwnComponents: Boolean = true
+): Intent =
+    Intent.createChooser(sendIntent, title).apply {
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        if (!excludeOwnComponents) return@apply
+        val ownShareComponents = packageManager.queryIntentActivitiesCompat(sendIntent)
+            .map { ComponentName(it.activityInfo.packageName, it.activityInfo.name) }
+            .filter { it.packageName == packageName }
+            .toTypedArray()
+        if (ownShareComponents.isNotEmpty()) {
+            putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, ownShareComponents)
+        }
+    }
+
+fun Context.startShareIntentWithTrustedWireTarget(sendIntent: Intent, title: CharSequence? = null) {
+    val chooserIntent = externalShareChooserIntent(
+        sendIntent = sendIntent,
+        title = title,
+        excludeOwnComponents = !supportsTrustedWireShareCaller()
+    )
+    startActivity(chooserIntent, shareIdentityOptionsBundle())
+}
+
+fun supportsTrustedWireShareCaller(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM
+
+private fun shareIdentityOptionsBundle(): Bundle? =
+    if (supportsTrustedWireShareCaller()) {
+        ActivityOptions.makeBasic()
+            .setShareIdentityEnabled(true)
+            .toBundle()
+    } else {
+        null
+    }
+
+fun Context.fileProviderSharedCacheFile(fileName: String): File {
+    val shareDirectory = fileProviderSharedCacheDirectory()
+    deleteStaleFileProviderSharedCacheFiles(shareDirectory)
+    return File(shareDirectory, findFirstUniqueName(shareDirectory, fileName.ifBlank { ATTACHMENT_FILENAME }))
+}
+
+fun Context.shareableFileProviderUri(sourceFile: File, displayName: String? = null): Uri {
+    val shareFile = when {
+        sourceFile.isInDirectory(fileProviderSharedCacheDirectory()) -> sourceFile
+        else -> linkOrCopyToFileProviderSharedCache(sourceFile, displayName ?: sourceFile.name)
+    }
+    return fileProviderUri(shareFile, displayName)
+}
+
+private fun Context.linkOrCopyToFileProviderSharedCache(sourceFile: File, displayName: String): File {
+    val shareFile = fileProviderSharedCacheFile(displayName)
+    runCatching {
+        Files.createLink(shareFile.toPath(), sourceFile.toPath())
+    }.recoverCatching {
+        sourceFile.copyTo(shareFile, overwrite = true)
+    }.getOrThrow()
+    return shareFile
+}
+
+private fun Context.fileProviderSharedCacheDirectory(): File =
+    File(cacheDir, FILE_PROVIDER_SHARED_CACHE_DIRECTORY).apply { mkdirs() }
+
+fun Context.fileProviderUri(file: File, displayName: String? = null): Uri =
+    FileProvider.getUriForFile(this, getProviderAuthority(), file, displayName ?: file.name)
+
+private fun File.isInDirectory(directory: File): Boolean {
+    val directoryPath = directory.canonicalFile.toPath()
+    return canonicalFile.toPath().startsWith(directoryPath)
+}
+
+private fun deleteStaleFileProviderSharedCacheFiles(directory: File) {
+    val oldestAllowedTimestamp = System.currentTimeMillis() - FILE_PROVIDER_SHARED_CACHE_MAX_AGE_MILLIS
+    directory.listFiles()
+        ?.filter { it.isFile && it.lastModified() < oldestAllowedTimestamp }
+        ?.forEach(File::delete)
+}
+
+private fun PackageManager.queryIntentActivitiesCompat(intent: Intent) =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        queryIntentActivities(intent, PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_DEFAULT_ONLY.toLong()))
+    } else {
+        @Suppress("DEPRECATION")
+        queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+    }
+
+fun Context.getProviderAuthority() = "$packageName.provider"
+
+const val FILE_PROVIDER_SHARED_FILES_ROOT = "shared_files"
+private const val FILE_PROVIDER_SHARED_CACHE_DIRECTORY = "file-provider-shares"
+private const val FILE_PROVIDER_SHARED_CACHE_MAX_AGE_MILLIS = 24 * 60 * 60 * 1000L
+private const val ATTACHMENT_FILENAME = "attachment"

--- a/core/ui-common/src/test/kotlin/com/wire/android/util/SecureFileSharingTest.kt
+++ b/core/ui-common/src/test/kotlin/com/wire/android/util/SecureFileSharingTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.util
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+class SecureFileSharingTest {
+
+    @TempDir
+    lateinit var temporaryDirectory: Path
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(FileProvider::class)
+    }
+
+    @Test
+    fun givenFileOutsideSharedCache_whenCreatingShareableUri_thenProviderReceivesDedicatedCacheFile() {
+        val cacheDirectory = temporaryDirectory.resolve("cache").toFile().apply(File::mkdirs)
+        val sourceFile = temporaryDirectory.resolve("external/cell.txt").toFile().apply {
+            parentFile?.mkdirs()
+            writeText(FILE_CONTENT)
+        }
+        val context = mockk<Context> {
+            every { cacheDir } returns cacheDirectory
+            every { packageName } returns PACKAGE_NAME
+        }
+        val expectedUri = mockk<Uri>()
+        val providerFile = slot<File>()
+        mockkStatic(FileProvider::class)
+        every {
+            FileProvider.getUriForFile(context, PROVIDER_AUTHORITY, capture(providerFile), DISPLAY_NAME)
+        } returns expectedUri
+
+        val result = context.shareableFileProviderUri(sourceFile, DISPLAY_NAME)
+
+        val sharedDirectory = File(cacheDirectory, FILE_PROVIDER_SHARED_CACHE_DIRECTORY)
+        assertEquals(expectedUri, result)
+        assertTrue(providerFile.captured.canonicalFile.toPath().startsWith(sharedDirectory.canonicalFile.toPath()))
+        assertEquals(FILE_CONTENT, providerFile.captured.readText())
+    }
+
+    @Test
+    fun givenTraversalCharactersInDisplayName_whenCreatingShareableUri_thenCacheFileStaysInsideDedicatedDirectory() {
+        val cacheDirectory = temporaryDirectory.resolve("cache").toFile().apply(File::mkdirs)
+        val sourceFile = temporaryDirectory.resolve("external/cell.txt").toFile().apply {
+            parentFile?.mkdirs()
+            writeText(FILE_CONTENT)
+        }
+        val context = mockk<Context> {
+            every { cacheDir } returns cacheDirectory
+            every { packageName } returns PACKAGE_NAME
+        }
+        val providerFile = slot<File>()
+        mockkStatic(FileProvider::class)
+        every {
+            FileProvider.getUriForFile(context, PROVIDER_AUTHORITY, capture(providerFile), TRAVERSAL_DISPLAY_NAME)
+        } returns mockk()
+
+        context.shareableFileProviderUri(sourceFile, TRAVERSAL_DISPLAY_NAME)
+
+        val sharedDirectory = File(cacheDirectory, FILE_PROVIDER_SHARED_CACHE_DIRECTORY)
+        assertTrue(providerFile.captured.canonicalFile.toPath().startsWith(sharedDirectory.canonicalFile.toPath()))
+        assertEquals(".._.._cell.txt", providerFile.captured.name)
+    }
+
+    private companion object {
+        const val PACKAGE_NAME = "com.wire"
+        const val PROVIDER_AUTHORITY = "$PACKAGE_NAME.provider"
+        const val FILE_PROVIDER_SHARED_CACHE_DIRECTORY = "file-provider-shares"
+        const val DISPLAY_NAME = "Cell document.txt"
+        const val TRAVERSAL_DISPLAY_NAME = "../../cell.txt"
+        const val FILE_CONTENT = "cell content"
+    }
+}

--- a/features/cells/src/main/java/com/wire/android/feature/cells/util/FileHelper.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/util/FileHelper.kt
@@ -18,22 +18,21 @@
 package com.wire.android.feature.cells.util
 
 import android.content.ActivityNotFoundException
-import android.content.ComponentName
 import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
-import android.os.Build
-import androidx.core.content.FileProvider
 import com.wire.android.di.ApplicationContext
+import com.wire.android.util.shareableFileProviderUri
+import com.wire.android.util.startShareIntentWithTrustedWireTarget
+import dev.zacsweers.metro.Inject
 import okio.Path
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
-import dev.zacsweers.metro.Inject
 
 class FileHelper @Inject constructor(
     @ApplicationContext private val context: Context
@@ -117,12 +116,7 @@ class FileHelper @Inject constructor(
                 setDataAndType(assetUri, mimeType)
                 putExtra(Intent.EXTRA_STREAM, assetUri)
             }
-            val chooserIntent = Intent.createChooser(intent, null).apply {
-                excludeOwnShareTargets(intent)
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            }
-            context.startActivity(chooserIntent)
+            context.startShareIntentWithTrustedWireTarget(intent)
         } catch (e: java.lang.IllegalArgumentException) {
             onError()
         } catch (noActivityFoundException: ActivityNotFoundException) {
@@ -137,11 +131,7 @@ class FileHelper @Inject constructor(
                 setType("text/plain")
                 putExtra(Intent.EXTRA_TEXT, url)
             }
-            val chooserIntent = Intent.createChooser(intent, null).apply {
-                excludeOwnShareTargets(intent)
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-            context.startActivity(chooserIntent)
+            context.startShareIntentWithTrustedWireTarget(intent)
         } catch (e: java.lang.IllegalArgumentException) {
             onError()
         } catch (noActivityFoundException: ActivityNotFoundException) {
@@ -157,26 +147,6 @@ class FileHelper @Inject constructor(
      */
     fun getExternalFilesDir(): File = context.getExternalFilesDir(null) ?: context.filesDir
 
-    private fun Context.getProviderAuthority() = "$packageName.provider"
-
     private fun Context.pathToUri(assetDataPath: Path, assetName: String?): Uri =
-        FileProvider.getUriForFile(this, getProviderAuthority(), assetDataPath.toFile(), assetName ?: assetDataPath.name)
-
-    private fun Intent.excludeOwnShareTargets(sendIntent: Intent) {
-        val ownShareComponents = context.packageManager.queryIntentActivitiesCompat(sendIntent)
-            .map { ComponentName(it.activityInfo.packageName, it.activityInfo.name) }
-            .filter { it.packageName == context.packageName }
-            .toTypedArray()
-        if (ownShareComponents.isNotEmpty()) {
-            putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, ownShareComponents)
-        }
-    }
-
-    private fun PackageManager.queryIntentActivitiesCompat(intent: Intent) =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            queryIntentActivities(intent, PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_DEFAULT_ONLY.toLong()))
-        } else {
-            @Suppress("DEPRECATION")
-            queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
-        }
+        shareableFileProviderUri(assetDataPath.toFile(), assetName ?: assetDataPath.name)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26687
<!--jira-description-action-hidden-marker-end-->
## Goal

Keep the narrowed FileProvider surface introduced by this stack while restoring Cells file open and share flows.

## Issue

1. Download a file through Cells.
2. Open it in an external app or share it.
3. Cells passes the file from the app-specific external-files directory directly to FileProvider.
4. The narrowed provider paths reject that location, so URI creation fails.

## Changes

- Move the secure sharing helpers into core:ui-common so both the app and Cells use the same policy.
- Link or copy only the selected Cells file into the dedicated file-provider-shares cache directory before creating its URI.
- Keep pre-Android 15 Wire targets excluded from the chooser.
- Enable trusted share identity on Android 15 and newer.
- Add regression coverage for Cells open/share flows and shared-cache path confinement.

## Security

The provider configuration is not widened. External apps receive a temporary read grant for a URI under the dedicated shared-cache root only, and untrusted display names cannot escape that directory.

## Stack

1. [#5033](https://github.com/wireapp/wire-android/pull/5033)
2. [#5034](https://github.com/wireapp/wire-android/pull/5034)
3. [#5035](https://github.com/wireapp/wire-android/pull/5035)
4. [#5036](https://github.com/wireapp/wire-android/pull/5036)
5. [#5037](https://github.com/wireapp/wire-android/pull/5037)
6. This PR

Depends on #5037.