### PR TITLE
fix(navigation): reset graph state after client removal  [WPB-27228] [WPB-27362]

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/ui/WireActivityNavigatorTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/WireActivityNavigatorTest.kt
@@ -21,7 +21,11 @@ package com.wire.android.ui
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import androidx.navigation.createGraph
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 
@@ -62,5 +66,57 @@ class WireActivityNavigatorTest {
             assertNotSame(blockedController, currentController)
             assertNotSame(sessionController, currentController)
         }
+    }
+
+    @Test
+    fun givenNavigatorIsRecreatedWithoutActivityRecreation_whenReadingBackStack_thenStateTracksNewGraph() {
+        val isUserUiBlocked = mutableStateOf(false)
+        lateinit var currentController: NavHostController
+        var currentRoute: String? = null
+
+        composeTestRule.setContent {
+            val navigator = rememberWireActivityNavigator(
+                isUserUiBlocked = isUserUiBlocked.value,
+                finish = {},
+                isAllowedToNavigate = { true },
+            )
+            currentController = navigator.navController
+            currentRoute = rememberWireActivityCurrentBackStackEntryState(navigator)
+                .value
+                ?.destination
+                ?.route
+        }
+
+        composeTestRule.runOnIdle {
+            currentController.graph = currentController.createGraph(startDestination = SESSION_ROUTE) {
+                composable(SESSION_ROUTE) {}
+            }
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle {
+            assertEquals(SESSION_ROUTE, currentRoute)
+            isUserUiBlocked.value = true
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle {
+            assertNull(currentRoute)
+            isUserUiBlocked.value = false
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle {
+            assertNull(currentRoute)
+            currentController.graph = currentController.createGraph(startDestination = AUTH_ROUTE) {
+                composable(AUTH_ROUTE) {}
+            }
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle {
+            assertEquals(AUTH_ROUTE, currentRoute)
+        }
+    }
+
+    private companion object {
+        const val AUTH_ROUTE = "authentication"
+        const val SESSION_ROUTE = "session"
     }
 }

--- a/app/src/androidTest/kotlin/com/wire/android/ui/WireActivityNavigatorTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/ui/WireActivityNavigatorTest.kt
@@ -81,7 +81,7 @@ class WireActivityNavigatorTest {
                 isAllowedToNavigate = { true },
             )
             currentController = navigator.navController
-            currentRoute = rememberWireActivityCurrentBackStackEntryState(navigator)
+            currentRoute = wireActivityCurrentBackStackEntryAsState(navigator)
                 .value
                 ?.destination
                 ?.route

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -397,7 +397,7 @@ class WireActivity : BaseActivity() {
             finish = this@WireActivity::finish,
             isAllowedToNavigate = ::isNavigationAllowed
         )
-        val currentBackStackEntryState = rememberWireActivityCurrentBackStackEntryState(navigator)
+        val currentBackStackEntryState = wireActivityCurrentBackStackEntryAsState(navigator)
         val currentBaseRoute = currentBackStackEntryState.value
             ?.destination
             ?.route
@@ -1307,7 +1307,7 @@ internal fun observeAppLockUserId(
 }.filterNotNull()
 
 @Composable
-internal fun rememberWireActivityCurrentBackStackEntryState(
+internal fun wireActivityCurrentBackStackEntryAsState(
     navigator: Navigator,
 ): State<NavBackStackEntry?> = key(navigator.navController) {
     // collectAsState retains its previous value while changing flows, so reset its composition

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -57,6 +58,8 @@ import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -347,7 +350,7 @@ class WireActivity : BaseActivity() {
         sessionGraphStore: SessionGraphStoreViewModel = viewModel(
             factory = viewModelFactory {
                 initializer {
-                    SessionGraphStoreViewModel(appGraph)
+                    SessionGraphStoreViewModel(appGraph::createSessionViewModelGraph)
                 }
             }
         ),
@@ -405,6 +408,7 @@ class WireActivity : BaseActivity() {
             ?.sessionBackedAuthenticationUserId()
         val isAuthenticationRoute = currentBaseRoute in authenticationGraphRoutes
         val isSessionTransitionInProgress = viewModel.globalAppState.isSessionTransitionInProgress
+        val sessionTransitionReason = viewModel.globalAppState.sessionTransitionReason
         var noSessionAuthenticationStartedWithoutSession by remember { mutableStateOf(false) }
         LaunchedEffect(currentBaseRoute, currentUserId) {
             when {
@@ -438,6 +442,15 @@ class WireActivity : BaseActivity() {
         if (graphContext?.sessionGraph != null) {
             lastSessionGraphContext.value = graphContext
         }
+        val shouldInvalidateRetainedSessionGraph = shouldInvalidateWireActivitySessionGraph(
+            isUserUiBlocked = isUserUiBlocked,
+            sessionTransitionReason = sessionTransitionReason,
+        )
+        HandleRetainedSessionGraphInvalidation(
+            shouldInvalidate = shouldInvalidateRetainedSessionGraph,
+            lastSessionGraphContext = lastSessionGraphContext,
+            sessionGraphStore = sessionGraphStore,
+        )
         val graphContextWithRetainedImageLoader = graphContext?.copy(
             imageLoaderSessionGraph = resolveWireActivityImageLoaderSessionGraph(
                 activeSessionGraph = graphContext.sessionGraph,
@@ -485,6 +498,20 @@ class WireActivity : BaseActivity() {
         canUseNewLogin = loginTypeSelector.canUseNewLogin(),
         noSessionAuthenticationStartedWithoutSession = noSessionAuthenticationStartedWithoutSession,
     )
+
+    @Composable
+    private fun HandleRetainedSessionGraphInvalidation(
+        shouldInvalidate: Boolean,
+        lastSessionGraphContext: MutableState<WireActivityGraphContext?>,
+        sessionGraphStore: SessionGraphStoreViewModel,
+    ) {
+        LaunchedEffect(shouldInvalidate) {
+            if (shouldInvalidate) {
+                lastSessionGraphContext.value?.sessionGraph?.currentAccount?.let(sessionGraphStore::invalidate)
+                lastSessionGraphContext.value = null
+            }
+        }
+    }
 
     private fun isNavigationAllowed(navigationCommand: NavigationCommand): Boolean {
         if (navigationCommand.destination.baseRoute != NewLoginScreenDestination.baseRoute) return true
@@ -611,7 +638,7 @@ class WireActivity : BaseActivity() {
         val usesAuthenticationGraph = effectiveBaseRoute in authenticationGraphRoutes
         val usesSessionBackedAuthenticationGraph = effectiveBaseRoute in sessionBackedAuthenticationGraphRoutes
         val usesInvalidSessionBackedAuthenticationGraph = usesSessionBackedAuthenticationGraph && currentUserId == null
-        val sessionGraph = remember(
+        val retainedSessionGraph = remember(
             appGraph,
             currentUserId,
             sessionBackedAuthenticationUserId,
@@ -627,6 +654,7 @@ class WireActivity : BaseActivity() {
                 isSessionTransitionInProgress = isSessionTransitionInProgress,
             )
         }
+        val sessionGraph = retainedSessionGraph?.graph
         val graph = resolveActiveGraph(
             WireActivityActiveGraphRequest(
                 authenticationViewModelGraph = authenticationViewModelGraph,
@@ -639,7 +667,7 @@ class WireActivity : BaseActivity() {
                 isSessionTransitionInProgress = isSessionTransitionInProgress,
             )
         )
-        val activityViewModels = sessionGraph?.let {
+        val activityViewModels = retainedSessionGraph?.let {
             wireActivityScopedViewModels(it)
         }
         return graph?.let {
@@ -659,12 +687,12 @@ class WireActivity : BaseActivity() {
         usesNoSessionAuthenticationGraph: Boolean,
         usesInvalidSessionBackedAuthenticationGraph: Boolean,
         isSessionTransitionInProgress: Boolean,
-    ): AppSessionViewModelGraph? = when {
+    ): RetainedSessionGraph? = when {
         usesNoSessionAuthenticationGraph -> null
         usesInvalidSessionBackedAuthenticationGraph -> null
         isSessionTransitionInProgress -> null
-        sessionBackedAuthenticationUserId != null -> graphFor(sessionBackedAuthenticationUserId)
-        currentUserId != null -> graphFor(currentUserId)
+        sessionBackedAuthenticationUserId != null -> retainedGraphFor(sessionBackedAuthenticationUserId)
+        currentUserId != null -> retainedGraphFor(currentUserId)
         else -> null
     }
 
@@ -743,10 +771,12 @@ class WireActivity : BaseActivity() {
     }
 
     @Composable
-    private fun wireActivityScopedViewModels(graph: AppSessionViewModelGraph): WireActivityScopedViewModels {
+    private fun wireActivityScopedViewModels(retainedSessionGraph: RetainedSessionGraph): WireActivityScopedViewModels {
+        val graph = retainedSessionGraph.graph
         val scopeKey = graph.viewModelScopeKey
         return WireActivityScopedViewModels(
             callFeedbackViewModel = viewModel(
+                viewModelStoreOwner = retainedSessionGraph,
                 key = "CallFeedbackViewModel:$scopeKey",
                 factory = viewModelFactory {
                     initializer {
@@ -755,6 +785,7 @@ class WireActivity : BaseActivity() {
                 }
             ),
             featureFlagNotificationViewModel = viewModel(
+                viewModelStoreOwner = retainedSessionGraph,
                 key = "FeatureFlagNotificationViewModel:$scopeKey",
                 factory = viewModelFactory {
                     initializer {
@@ -763,6 +794,7 @@ class WireActivity : BaseActivity() {
                 }
             ),
             commonTopAppBarViewModel = viewModel(
+                viewModelStoreOwner = retainedSessionGraph,
                 key = "CommonTopAppBarViewModel:$scopeKey",
                 factory = viewModelFactory {
                     initializer {
@@ -773,6 +805,7 @@ class WireActivity : BaseActivity() {
                 }
             ),
             legalHoldRequestedViewModel = viewModel(
+                viewModelStoreOwner = retainedSessionGraph,
                 key = "LegalHoldRequestedViewModel:$scopeKey",
                 factory = viewModelFactory {
                     initializer {
@@ -781,6 +814,7 @@ class WireActivity : BaseActivity() {
                 }
             ),
             legalHoldDeactivatedViewModel = viewModel(
+                viewModelStoreOwner = retainedSessionGraph,
                 key = "LegalHoldDeactivatedViewModel:$scopeKey",
                 factory = viewModelFactory {
                     initializer {
@@ -1298,16 +1332,39 @@ private data class WireActivityGraphContext(
     val activityViewModels: WireActivityScopedViewModels?,
 )
 
-private class SessionGraphStoreViewModel(
-    private val appGraph: WireApplicationGraph,
+internal class SessionGraphStoreViewModel(
+    private val createSessionGraph: (UserId) -> AppSessionViewModelGraph,
 ) : ViewModel() {
-    private val sessionGraphs = mutableMapOf<UserId, AppSessionViewModelGraph>()
+    private val sessionGraphs = mutableMapOf<UserId, RetainedSessionGraph>()
 
-    fun graphFor(userId: UserId): AppSessionViewModelGraph =
+    fun retainedGraphFor(userId: UserId): RetainedSessionGraph =
         sessionGraphs.getOrPut(userId) {
             appLogger.i("WireActivity creating lifecycle-retained session graph for $userId")
-            appGraph.createSessionViewModelGraph(userId)
+            RetainedSessionGraph(createSessionGraph(userId))
         }
+
+    fun invalidate(userId: UserId) {
+        sessionGraphs.remove(userId)?.also {
+            appLogger.i("WireActivity clearing lifecycle-retained session graph for $userId")
+            it.clear()
+        }
+    }
+
+    override fun onCleared() {
+        sessionGraphs.values.forEach(RetainedSessionGraph::clear)
+        sessionGraphs.clear()
+    }
+}
+
+internal class RetainedSessionGraph(
+    val graph: AppSessionViewModelGraph,
+    override val viewModelStore: ViewModelStore = ViewModelStore(),
+) : ViewModelStoreOwner {
+
+    fun clear() {
+        viewModelStore.clear()
+        graph.wireSessionImageLoader.shutdown()
+    }
 }
 
 internal data class WireActivityActiveGraphRequest(
@@ -1419,6 +1476,11 @@ internal fun resolveWireActivityImageLoaderSessionGraph(
     activeSessionGraph: AppSessionViewModelGraph?,
     retainedSessionGraph: AppSessionViewModelGraph?,
 ): AppSessionViewModelGraph? = activeSessionGraph ?: retainedSessionGraph
+
+internal fun shouldInvalidateWireActivitySessionGraph(
+    isUserUiBlocked: Boolean,
+    sessionTransitionReason: SessionTransitionReason?,
+): Boolean = isUserUiBlocked || sessionTransitionReason != null
 
 private fun Bundle.sessionBackedAuthenticationUserId(): UserId? {
     val value = getString(SessionBackedAuthenticationNavArgs.USER_ID_VALUE_KEY)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -39,7 +39,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -446,11 +446,13 @@ class WireActivity : BaseActivity() {
             isUserUiBlocked = isUserUiBlocked,
             sessionTransitionReason = sessionTransitionReason,
         )
-        HandleRetainedSessionGraphInvalidation(
-            shouldInvalidate = shouldInvalidateRetainedSessionGraph,
-            lastSessionGraphContext = lastSessionGraphContext,
-            sessionGraphStore = sessionGraphStore,
-        )
+        LaunchedEffect(shouldInvalidateRetainedSessionGraph) {
+            lastSessionGraphContext.value = invalidateRetainedSessionGraphIfNeeded(
+                shouldInvalidate = shouldInvalidateRetainedSessionGraph,
+                lastSessionGraphContext = lastSessionGraphContext.value,
+                sessionGraphStore = sessionGraphStore,
+            )
+        }
         val graphContextWithRetainedImageLoader = graphContext?.copy(
             imageLoaderSessionGraph = resolveWireActivityImageLoaderSessionGraph(
                 activeSessionGraph = graphContext.sessionGraph,
@@ -499,18 +501,15 @@ class WireActivity : BaseActivity() {
         noSessionAuthenticationStartedWithoutSession = noSessionAuthenticationStartedWithoutSession,
     )
 
-    @Composable
-    private fun HandleRetainedSessionGraphInvalidation(
+    private fun invalidateRetainedSessionGraphIfNeeded(
         shouldInvalidate: Boolean,
-        lastSessionGraphContext: MutableState<WireActivityGraphContext?>,
+        lastSessionGraphContext: WireActivityGraphContext?,
         sessionGraphStore: SessionGraphStoreViewModel,
-    ) {
-        LaunchedEffect(shouldInvalidate) {
-            if (shouldInvalidate) {
-                lastSessionGraphContext.value?.sessionGraph?.currentAccount?.let(sessionGraphStore::invalidate)
-                lastSessionGraphContext.value = null
-            }
-        }
+    ): WireActivityGraphContext? {
+        if (!shouldInvalidate) return lastSessionGraphContext
+
+        lastSessionGraphContext?.sessionGraph?.currentAccount?.let(sessionGraphStore::invalidate)
+        return null
     }
 
     private fun isNavigationAllowed(navigationCommand: NavigationCommand): Boolean {
@@ -1356,6 +1355,7 @@ internal class SessionGraphStoreViewModel(
     }
 }
 
+@Stable
 internal class RetainedSessionGraph(
     val graph: AppSessionViewModelGraph,
     override val viewModelStore: ViewModelStore = ViewModelStore(),

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -508,7 +508,7 @@ class WireActivity : BaseActivity() {
     ): WireActivityGraphContext? {
         if (!shouldInvalidate) return lastSessionGraphContext
 
-        lastSessionGraphContext?.sessionGraph?.currentAccount?.let(sessionGraphStore::invalidate)
+        sessionGraphStore.invalidateActive()
         return null
     }
 
@@ -1335,23 +1335,34 @@ internal class SessionGraphStoreViewModel(
     private val createSessionGraph: (UserId) -> AppSessionViewModelGraph,
 ) : ViewModel() {
     private val sessionGraphs = mutableMapOf<UserId, RetainedSessionGraph>()
+    private var activeUserId: UserId? = null
 
-    fun retainedGraphFor(userId: UserId): RetainedSessionGraph =
-        sessionGraphs.getOrPut(userId) {
+    fun retainedGraphFor(userId: UserId): RetainedSessionGraph {
+        activeUserId = userId
+        return sessionGraphs.getOrPut(userId) {
             appLogger.i("WireActivity creating lifecycle-retained session graph for $userId")
             RetainedSessionGraph(createSessionGraph(userId))
         }
+    }
+
+    fun invalidateActive() {
+        activeUserId?.let(::invalidate)
+    }
 
     fun invalidate(userId: UserId) {
         sessionGraphs.remove(userId)?.also {
             appLogger.i("WireActivity clearing lifecycle-retained session graph for $userId")
             it.clear()
         }
+        if (activeUserId == userId) {
+            activeUserId = null
+        }
     }
 
     override fun onCleared() {
         sessionGraphs.values.forEach(RetainedSessionGraph::clear)
         sessionGraphs.clear()
+        activeUserId = null
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -39,7 +39,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -63,6 +63,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.ramcosta.composedestinations.generated.app.destinations.CreateAccountCodeScreenDestination
@@ -393,7 +394,7 @@ class WireActivity : BaseActivity() {
             finish = this@WireActivity::finish,
             isAllowedToNavigate = ::isNavigationAllowed
         )
-        val currentBackStackEntryState = navigator.navController.currentBackStackEntryAsState()
+        val currentBackStackEntryState = rememberWireActivityCurrentBackStackEntryState(navigator)
         val currentBaseRoute = currentBackStackEntryState.value
             ?.destination
             ?.route
@@ -449,12 +450,8 @@ class WireActivity : BaseActivity() {
             currentBaseRoute != null && canRetainSessionGraphForContent -> lastSessionGraphContext.value
             else -> null
         }
-        val backgroundType by remember {
-            derivedStateOf {
-                currentBackStackEntryState.value?.safeDestination()?.style.let {
-                    (it as? BackgroundStyle)?.backgroundType() ?: BackgroundType.Default
-                }
-            }
+        val backgroundType = currentBackStackEntryState.value?.safeDestination()?.style.let {
+            (it as? BackgroundStyle)?.backgroundType() ?: BackgroundType.Default
         }
 
         HandleSessionGraphEffects(
@@ -1275,6 +1272,15 @@ internal fun observeAppLockUserId(
 ): Flow<UserId> = combine(isAppLocked, currentUserId) { isLocked, userId ->
     if (isLocked) userId else null
 }.filterNotNull()
+
+@Composable
+internal fun rememberWireActivityCurrentBackStackEntryState(
+    navigator: Navigator,
+): State<NavBackStackEntry?> = key(navigator.navController) {
+    // collectAsState retains its previous value while changing flows, so reset its composition
+    // identity with the controller to avoid exposing a route from the discarded navigation graph.
+    navigator.navController.currentBackStackEntryAsState()
+}
 
 private data class WireActivityScopedViewModels(
     val callFeedbackViewModel: CallFeedbackViewModel,

--- a/app/src/test/kotlin/com/wire/android/feature/AccountSwitchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/AccountSwitchUseCaseTest.kt
@@ -37,6 +37,9 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AccountSwitchUseCaseTest {
@@ -86,9 +89,12 @@ class AccountSwitchUseCaseTest {
             }
         }
 
-    @Test
-    fun givenCurrentSessionIsInvalid_whenSwitchingToAccount_thenUpdateCurrentSessionAndDeleteTheOldOne() = testScope.runTest {
-        val currentAccount = ACCOUNT_INVALID_3
+    @ParameterizedTest
+    @MethodSource("terminalLogoutReasons")
+    fun givenCurrentSessionIsInvalid_whenSwitchingToAccount_thenUpdateCurrentSessionAndDeleteTheOldOne(
+        logoutReason: LogoutReason
+    ) = testScope.runTest {
+        val currentAccount = AccountInfo.Invalid(ACCOUNT_INVALID_3.userId, logoutReason)
         val switchTo = ACCOUNT_VALID_2
 
         val expectedResult = SwitchAccountResult.SwitchedToAnotherAccount
@@ -151,6 +157,16 @@ class AccountSwitchUseCaseTest {
         val ACCOUNT_VALID_2 = AccountInfo.Valid(UserId("userId_valid_2", "domain_valid_2"))
         val ACCOUNT_INVALID_3 =
             AccountInfo.Invalid(UserId("userId_invalid_3", "domain_invalid_3"), LogoutReason.SELF_SOFT_LOGOUT)
+
+        @JvmStatic
+        fun terminalLogoutReasons(): Stream<LogoutReason> = Stream.of(
+            LogoutReason.SELF_SOFT_LOGOUT,
+            LogoutReason.SELF_HARD_LOGOUT,
+            LogoutReason.MIGRATION_TO_CC_FAILED,
+            LogoutReason.DELETED_ACCOUNT,
+            LogoutReason.REMOVED_CLIENT,
+            LogoutReason.SESSION_EXPIRED,
+        )
     }
 
     private class Arrangement(val testScope: TestScope) {

--- a/app/src/test/kotlin/com/wire/android/ui/SessionGraphStoreViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/SessionGraphStoreViewModelTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.wire.android.di.metro.AppSessionViewModelGraph
+import com.wire.android.util.ui.WireSessionImageLoader
+import com.wire.kalium.logic.data.user.UserId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SessionGraphStoreViewModelTest {
+
+    @Test
+    fun givenSessionGraphIsInvalidated_whenSameUserLogsInAgain_thenGraphAndViewModelsAreRecreated() {
+        val oldImageLoader = mockk<WireSessionImageLoader>(relaxed = true)
+        val oldGraph = graphWith(oldImageLoader)
+        val newGraph = graphWith(mockk(relaxed = true))
+        val graphs = ArrayDeque(listOf(oldGraph, newGraph))
+        val store = SessionGraphStoreViewModel { graphs.removeFirst() }
+        val oldRetainedGraph = store.retainedGraphFor(USER_ID)
+        val oldViewModel = TrackingViewModel()
+        ViewModelProvider(
+            oldRetainedGraph,
+            viewModelFactory { initializer { oldViewModel } }
+        )[TrackingViewModel::class.java]
+
+        store.invalidate(USER_ID)
+        val newRetainedGraph = store.retainedGraphFor(USER_ID)
+
+        assertNotSame(oldRetainedGraph, newRetainedGraph)
+        assertSame(newGraph, newRetainedGraph.graph)
+        assertTrue(oldViewModel.wasCleared)
+        verify(exactly = 1) { oldImageLoader.shutdown() }
+    }
+
+    @Test
+    fun givenSessionGraphIsStillValid_whenRequestedAgain_thenGraphIsReused() {
+        val graph = graphWith(mockk(relaxed = true))
+        val store = SessionGraphStoreViewModel { graph }
+
+        val first = store.retainedGraphFor(USER_ID)
+        val second = store.retainedGraphFor(USER_ID)
+
+        assertSame(first, second)
+    }
+
+    @Test
+    fun givenSameUserIsRemovedAndLogsInRepeatedly_whenGraphsAreInvalidated_thenEveryLoginGetsAFreshGraph() {
+        val imageLoaders = List(RELOGIN_COUNT) { mockk<WireSessionImageLoader>(relaxed = true) }
+        val graphs = ArrayDeque(imageLoaders.map(::graphWith))
+        val store = SessionGraphStoreViewModel { graphs.removeFirst() }
+
+        val retainedGraphs = buildList {
+            repeat(RELOGIN_COUNT) { index ->
+                add(store.retainedGraphFor(USER_ID))
+                if (index < RELOGIN_COUNT - 1) {
+                    store.invalidate(USER_ID)
+                }
+            }
+        }
+
+        retainedGraphs.zipWithNext().forEach { (oldGraph, newGraph) ->
+            assertNotSame(oldGraph, newGraph)
+            assertNotSame(oldGraph.graph, newGraph.graph)
+        }
+        imageLoaders.dropLast(1).forEach { imageLoader ->
+            verify(exactly = 1) { imageLoader.shutdown() }
+        }
+        verify(exactly = 0) { imageLoaders.last().shutdown() }
+    }
+
+    @Test
+    fun givenTwoRetainedUsers_whenRemovedUserIsInvalidated_thenOtherUsersGraphRemainsActive() {
+        val removedUserImageLoader = mockk<WireSessionImageLoader>(relaxed = true)
+        val otherUserImageLoader = mockk<WireSessionImageLoader>(relaxed = true)
+        val graphsByUser = mapOf(
+            USER_ID to graphWith(removedUserImageLoader),
+            OTHER_USER_ID to graphWith(otherUserImageLoader),
+        )
+        val store = SessionGraphStoreViewModel { userId -> graphsByUser.getValue(userId) }
+        val removedUsersGraph = store.retainedGraphFor(USER_ID)
+        val otherUsersGraph = store.retainedGraphFor(OTHER_USER_ID)
+
+        store.invalidate(USER_ID)
+
+        assertSame(otherUsersGraph, store.retainedGraphFor(OTHER_USER_ID))
+        assertNotSame(removedUsersGraph, store.retainedGraphFor(USER_ID))
+        verify(exactly = 1) { removedUserImageLoader.shutdown() }
+        verify(exactly = 0) { otherUserImageLoader.shutdown() }
+    }
+
+    private fun graphWith(imageLoader: WireSessionImageLoader) = mockk<AppSessionViewModelGraph> {
+        every { wireSessionImageLoader } returns imageLoader
+    }
+
+    private class TrackingViewModel : ViewModel() {
+        var wasCleared = false
+            private set
+
+        override fun onCleared() {
+            wasCleared = true
+        }
+    }
+
+    private companion object {
+        const val RELOGIN_COUNT = 3
+        val USER_ID = UserId("user", "domain")
+        val OTHER_USER_ID = UserId("other-user", "domain")
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/SessionGraphStoreViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/SessionGraphStoreViewModelTest.kt
@@ -59,6 +59,23 @@ class SessionGraphStoreViewModelTest {
     }
 
     @Test
+    fun givenActivityIsRecreated_whenActiveGraphIsInvalidated_thenSameUserGetsFreshGraph() {
+        val oldImageLoader = mockk<WireSessionImageLoader>(relaxed = true)
+        val oldGraph = graphWith(oldImageLoader)
+        val newGraph = graphWith(mockk(relaxed = true))
+        val graphs = ArrayDeque(listOf(oldGraph, newGraph))
+        val store = SessionGraphStoreViewModel { graphs.removeFirst() }
+        val oldRetainedGraph = store.retainedGraphFor(USER_ID)
+
+        store.invalidateActive()
+        val newRetainedGraph = store.retainedGraphFor(USER_ID)
+
+        assertNotSame(oldRetainedGraph, newRetainedGraph)
+        assertSame(newGraph, newRetainedGraph.graph)
+        verify(exactly = 1) { oldImageLoader.shutdown() }
+    }
+
+    @Test
     fun givenSessionGraphIsStillValid_whenRequestedAgain_thenGraphIsReused() {
         val graph = graphWith(mockk(relaxed = true))
         val store = SessionGraphStoreViewModel { graph }
@@ -103,10 +120,10 @@ class SessionGraphStoreViewModelTest {
             OTHER_USER_ID to graphWith(otherUserImageLoader),
         )
         val store = SessionGraphStoreViewModel { userId -> graphsByUser.getValue(userId) }
-        val removedUsersGraph = store.retainedGraphFor(USER_ID)
         val otherUsersGraph = store.retainedGraphFor(OTHER_USER_ID)
+        val removedUsersGraph = store.retainedGraphFor(USER_ID)
 
-        store.invalidate(USER_ID)
+        store.invalidateActive()
 
         assertSame(otherUsersGraph, store.retainedGraphFor(OTHER_USER_ID))
         assertNotSame(removedUsersGraph, store.retainedGraphFor(USER_ID))

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityActiveGraphResolverTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityActiveGraphResolverTest.kt
@@ -380,6 +380,36 @@ class WireActivityActiveGraphResolverTest {
         assertSame(sessionGraph, imageLoaderSessionGraph)
     }
 
+    @Test
+    fun givenSessionErrorBlocksTheUi_whenCheckingSessionGraphInvalidation_thenGraphIsInvalidated() {
+        val shouldInvalidate = shouldInvalidateWireActivitySessionGraph(
+            isUserUiBlocked = true,
+            sessionTransitionReason = null,
+        )
+
+        assertEquals(true, shouldInvalidate)
+    }
+
+    @Test
+    fun givenSelfLogoutIsInProgress_whenCheckingSessionGraphInvalidation_thenGraphIsInvalidated() {
+        val shouldInvalidate = shouldInvalidateWireActivitySessionGraph(
+            isUserUiBlocked = false,
+            sessionTransitionReason = SessionTransitionReason.SELF_LOGOUT,
+        )
+
+        assertEquals(true, shouldInvalidate)
+    }
+
+    @Test
+    fun givenSessionIsActive_whenCheckingSessionGraphInvalidation_thenGraphIsRetained() {
+        val shouldInvalidate = shouldInvalidateWireActivitySessionGraph(
+            isUserUiBlocked = false,
+            sessionTransitionReason = null,
+        )
+
+        assertEquals(false, shouldInvalidate)
+    }
+
     private fun resolveActiveGraph(
         sessionGraph: AppSessionViewModelGraph?,
         effectiveBaseRoute: String,

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/ui/WireSessionImageLoader.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/ui/WireSessionImageLoader.kt
@@ -122,6 +122,11 @@ class WireSessionImageLoader(
         return painter
     }
 
+    /** Cancels pending image requests and releases resources tied to this user session. */
+    fun shutdown() {
+        coilImageLoader.shutdown()
+    }
+
     class Factory(
         val context: Context,
         private val getAvatarAsset: GetAvatarAssetUseCase,

--- a/core/ui-common/src/test/kotlin/com/wire/android/util/ui/WireSessionImageLoaderTest.kt
+++ b/core/ui-common/src/test/kotlin/com/wire/android/util/ui/WireSessionImageLoaderTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.util.ui
+
+import coil3.ImageLoader
+import com.wire.kalium.network.NetworkStateObserver
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+class WireSessionImageLoaderTest {
+
+    @Test
+    fun givenSessionImageLoader_whenShutdown_thenPendingImageRequestsAreCancelled() {
+        val coilImageLoader = mockk<ImageLoader>(relaxed = true)
+        val imageLoader = WireSessionImageLoader(
+            coilImageLoader = coilImageLoader,
+            networkStateObserver = mockk<NetworkStateObserver>(relaxed = true)
+        )
+
+        imageLoader.shutdown()
+
+        verify(exactly = 1) { coilImageLoader.shutdown() }
+    }
+}

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/MultiAccountSessionScope.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/MultiAccountSessionScope.kt
@@ -124,9 +124,10 @@ class MultiAccountSessionScope : BaseUiTest() {
     @TestCaseId("TC-11261")
     @Category("regression", "RC", "multiAccountSessionScope")
     @Test
-    fun givenSingleLoggedInAccount_whenCurrentClientIsRemovedRemotely_thenLoginScreenOpens() {
+    fun givenSingleLoggedInAccount_whenCurrentClientIsRemovedAndUserLogsInAgain_thenMlsSessionIsRestored() {
         step("Prepare staging users") {
             prepareTeamUsers(teamName = "SessionScopeMetroRemovedSingle")
+            testServiceHelper.addDevice("user2Name", null, "Device1")
         }
 
         step("Login the first account") {
@@ -143,6 +144,41 @@ class MultiAccountSessionScope : BaseUiTest() {
                 confirmRemovedDeviceDialog()
             }
             pages.registrationPage.assertAuthEntryVisible()
+        }
+
+        step("Log the removed user in again without restarting the app") {
+            loginUser(primaryUser, configureStagingBackend = false)
+        }
+
+        step("Open the existing MLS conversation from the recreated session") {
+            pages.conversationListPage.tapConversationNameInConversationList(secondaryUser?.name.orEmpty())
+        }
+
+        step("Receive an MLS message after the new client joins by external commit") {
+            testServiceHelper.userSendMessageToPersonalMlsConversation(
+                "user2Name",
+                POST_RELOGIN_MLS_MESSAGE,
+                "Device1",
+                "user1Name"
+            )
+            pages.conversationViewPage.assertReceivedMessageIsVisibleInCurrentConversation(POST_RELOGIN_MLS_MESSAGE)
+        }
+
+        step("Send an MLS message from the recreated session") {
+            pages.conversationViewPage.apply {
+                typeMessageInInputField(POST_RELOGIN_REPLY)
+                clickSendButton()
+                assertSentMessageIsVisibleInCurrentConversation(POST_RELOGIN_REPLY)
+            }
+        }
+
+        step("Verify the test-service device receives and decrypts the MLS reply") {
+            testServiceHelper.assertMessageReceivedInPersonalMlsConversation(
+                receiverAlias = "user2Name",
+                deviceName = "Device1",
+                conversationWithAlias = "user1Name",
+                message = POST_RELOGIN_REPLY,
+            )
         }
     }
 
@@ -341,6 +377,8 @@ class MultiAccountSessionScope : BaseUiTest() {
 
     private companion object {
         const val EXISTING_CLIENTS_LIMIT = 7
+        const val POST_RELOGIN_MLS_MESSAGE = "MLS after client re-registration"
+        const val POST_RELOGIN_REPLY = "MLS reply after client re-registration"
         val POST_REMOVE_DEVICE_LOGIN_TIMEOUT = 120.seconds
     }
 }

--- a/tests/testsSupport/src/main/service/TestServiceHelper.kt
+++ b/tests/testsSupport/src/main/service/TestServiceHelper.kt
@@ -505,6 +505,37 @@ class TestServiceHelper(
         )
     }
 
+    fun assertMessageReceivedInPersonalMlsConversation(
+        receiverAlias: String,
+        deviceName: String,
+        conversationWithAlias: String,
+        message: String,
+    ) {
+        val receiver = toClientUser(receiverAlias)
+        val conversation = toConvoObjPersonal(receiver, conversationWithAlias)
+        val received = UiWaitUtils.retryUntilTimeout(
+            timeout = UiWaitUtils.MEDIUM_TIMEOUT,
+            pollingInterval = 1.seconds
+        ) {
+            runCatching {
+                testServiceClient.getMessageIdByText(
+                    owner = receiver,
+                    deviceName = deviceName,
+                    convoId = conversation.qualifiedID.id,
+                    convoDomain = conversation.qualifiedID.domain,
+                    text = message,
+                )
+            }.isSuccess
+        }
+
+        if (!received) {
+            throw AssertionError(
+                "Test-service device '$deviceName' for '$receiverAlias' did not receive '$message' " +
+                    "in its MLS conversation with '$conversationWithAlias'."
+            )
+        }
+    }
+
     fun userSendEphemeralMessageToConversation(
         senderAlias: String,
         msg: String,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27228
<!--jira-description-action-hidden-marker-end-->
## Intent

Make removed-client recovery safe while the app process remains alive: rebuild navigation from synchronized session state, discard all state owned by the invalid session, and allow the same user to log in again with a fresh Kalium session.

Depends on [wireapp/kalium#4318](https://github.com/wireapp/kalium/pull/4318).

## Reproduction

1. Log in and delete the current client remotely.
2. Let the app receive its own client-removal event.
3. Confirm the removed-client dialog without swiping the app away.
4. The activity can navigate with a replacement controller before its graph is installed.
5. After logging in again, retained session graphs, activity-scoped view models, or image requests can still belong to the deleted session.
6. The replacement session can then fail to join MLS conversations or be logged out again by stale session state.

## Root cause

The navigation controller was replaced in place while Compose could still expose the old back-stack entry. That stale route could trigger navigation against the new graphless controller.

The activity also retained its session graph and activity-scoped view models for the process lifetime. Removing a client did not invalidate those objects, so logging the same user in again could reuse dependencies and resources tied to the destroyed Kalium session.

```mermaid
flowchart LR
    A["Remote client removal"] --> B["Block session UI"]
    B --> C["Confirm dialog"]
    C --> D["Invalidate retained graph"]
    D --> E["Clear session view models and image loader"]
    E --> F["Rebuild authentication graph"]
    F --> G["Login same user"]
    G --> H["Create fresh app and Kalium session state"]
    H --> I["Join MLS conversations"]
```

## Changes

- Reset observed back-stack state whenever the navigation controller is replaced.
- Derive the background from the active back-stack entry rather than the discarded controller.
- Give each retained session graph its own `ViewModelStore` and session image loader lifetime.
- Invalidate the retained graph when the UI is blocked by a terminal session error or a session transition starts.
- Recreate the graph and activity-scoped view models when the same user logs in again.
- Point the app at the Kalium client-registration and teardown fixes from PR #4318.
- Cover repeated removal/re-login cycles, multi-account isolation, all terminal Kalium logout reasons, and image-loader shutdown.
- Extend the staging E2E flow through same-process re-login and bidirectional MLS messaging, with the test-service device verifying receipt and decryption of the app reply.

## Coverage

- Removed-client navigation and retained-graph regression tests.
- Complete app unit suite and static analysis.
- Staging E2E source compiled with the real backend and test-service flow.
