### PR TITLE
fix(release): merge 4.30.1 hotfixes

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -59,6 +59,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
@@ -163,7 +164,6 @@ import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.launchUpdateTheApp
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
@@ -215,7 +215,6 @@ class WireActivity : BaseActivity() {
 
     // This flag is used to keep the splash screen open until the first screen is drawn.
     private var shouldKeepSplashOpen = true
-    private var appLockObservationJob: Job? = null
     private var isAppLockActivityLaunching = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -242,7 +241,8 @@ class WireActivity : BaseActivity() {
             viewModel.observePersistentConnectionStatus()
 
             traceStartup("activity.initialAppState.start", startupAt)
-            val startDestination = when (val initialAppState = viewModel.initialAppState()) {
+            val initialAppState = viewModel.initialAppState()
+            val startDestination = when (initialAppState) {
                 InitialAppState.NotLoggedIn -> when (loginTypeSelector.canUseNewLogin()) {
                     true -> NewWelcomeEmptyStartScreenDestination()
                     false -> WelcomeScreenDestination()
@@ -258,8 +258,19 @@ class WireActivity : BaseActivity() {
             setComposableContent(startDestination)
             traceStartup("activity.setContent.done", startupAt)
 
-            if (lockCodeTimeManager.value.isAppLocked()) {
-                startAppLockActivity(currentUserId = viewModel.globalAppState.currentUserId)
+            // When the app is locked, get the app lock screen up before the splash screen is
+            // dismissed so that protected content never flashes. Waiting for the current user id
+            // is finite here because a locked app implies a logged-in session; when not logged in
+            // there is nothing to protect. Locks that happen after startup are handled by the
+            // lifecycle observer below.
+            if (initialAppState != InitialAppState.NotLoggedIn && lockCodeTimeManager.value.isAppLocked()) {
+                observeAppLockUserId(
+                    isAppLocked = lockCodeTimeManager.value.observeAppLock(),
+                    currentUserId = snapshotFlow { viewModel.globalAppState.currentUserId },
+                ).first().let { currentUserId ->
+                    startAppLockActivity(currentUserId = currentUserId)
+                }
+                traceStartup("activity.appLock.launched", startupAt)
             }
 
             traceStartup("activity.splash.hide", startupAt)
@@ -270,6 +281,18 @@ class WireActivity : BaseActivity() {
 
             handleNewIntent(intent, savedInstanceState)
             traceStartup("activity.initialIntent.dispatched", startupAt)
+        }
+
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                isAppLockActivityLaunching = false
+                observeAppLockUserId(
+                    isAppLocked = lockCodeTimeManager.value.observeAppLock(),
+                    currentUserId = snapshotFlow { viewModel.globalAppState.currentUserId },
+                ).first().let { currentUserId ->
+                    startAppLockActivity(currentUserId = currentUserId)
+                }
+            }
         }
     }
 
@@ -1102,22 +1125,9 @@ class WireActivity : BaseActivity() {
     override fun onResume() {
         super.onResume()
         shakeDetector.start()
-        isAppLockActivityLaunching = false
-
-        appLockObservationJob?.cancel()
-        appLockObservationJob = lifecycleScope.launch {
-            observeAppLockUserId(
-                isAppLocked = lockCodeTimeManager.value.observeAppLock(),
-                currentUserId = snapshotFlow { viewModel.globalAppState.currentUserId },
-            ).first().let { currentUserId ->
-                startAppLockActivity(currentUserId = currentUserId)
-            }
-        }
     }
 
     override fun onPause() {
-        appLockObservationJob?.cancel()
-        appLockObservationJob = null
         shakeDetector.stop()
         super.onPause()
     }
@@ -1126,7 +1136,14 @@ class WireActivity : BaseActivity() {
         setTeamAppLock: Boolean = false,
         currentUserId: UserId? = viewModel.globalAppState.currentUserId,
     ) {
-        if (isAppLockActivityLaunching) return
+        if (isAppLockActivityLaunching) {
+            // Dedupes concurrent launches (startup path vs. resumed observer). A team app lock
+            // setup landing in this tiny window is also dropped: AppLockActivity only reads its
+            // extras in onCreate, so launching again would either be ignored (singleTop onNewIntent)
+            // or stack a duplicate instance. The team feature-flag flow re-prompts later.
+            appLogger.w("$TAG appLock: launch already in flight, skipping (setTeamAppLock=$setTeamAppLock)")
+            return
+        }
         val resolvedUserId = currentUserId ?: run {
             appLogger.e("$TAG appLock: missing current user id, skipping app lock activity")
             return
@@ -1243,7 +1260,7 @@ internal fun observeAppLockUserId(
     isAppLocked: Flow<Boolean>,
     currentUserId: Flow<UserId?>,
 ): Flow<UserId> = combine(isAppLocked, currentUserId) { isLocked, userId ->
-    userId.takeIf { isLocked }
+    if (isLocked) userId else null
 }.filterNotNull()
 
 private data class WireActivityScopedViewModels(

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -162,12 +163,15 @@ import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.launchUpdateTheApp
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
@@ -211,6 +215,8 @@ class WireActivity : BaseActivity() {
 
     // This flag is used to keep the splash screen open until the first screen is drawn.
     private var shouldKeepSplashOpen = true
+    private var appLockObservationJob: Job? = null
+    private var isAppLockActivityLaunching = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val startupAt = SystemClock.elapsedRealtime()
@@ -251,6 +257,10 @@ class WireActivity : BaseActivity() {
             traceStartup("activity.initialAppState.resolved:$startDestination", startupAt)
             setComposableContent(startDestination)
             traceStartup("activity.setContent.done", startupAt)
+
+            if (lockCodeTimeManager.value.isAppLocked()) {
+                startAppLockActivity(currentUserId = viewModel.globalAppState.currentUserId)
+            }
 
             traceStartup("activity.splash.hide", startupAt)
             shouldKeepSplashOpen = false
@@ -1092,34 +1102,39 @@ class WireActivity : BaseActivity() {
     override fun onResume() {
         super.onResume()
         shakeDetector.start()
+        isAppLockActivityLaunching = false
 
-        lifecycleScope.launch {
-            lockCodeTimeManager.value.observeAppLock()
-                // Listen to one flow in a lifecycle-aware manner using flowWithLifecycle
-                .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
-                .first().let {
-                    if (it) {
-                        withContext(Dispatchers.Main) {
-                            startAppLockActivity()
-                        }
-                    }
-                }
+        appLockObservationJob?.cancel()
+        appLockObservationJob = lifecycleScope.launch {
+            observeAppLockUserId(
+                isAppLocked = lockCodeTimeManager.value.observeAppLock(),
+                currentUserId = snapshotFlow { viewModel.globalAppState.currentUserId },
+            ).first().let { currentUserId ->
+                startAppLockActivity(currentUserId = currentUserId)
+            }
         }
     }
 
     override fun onPause() {
+        appLockObservationJob?.cancel()
+        appLockObservationJob = null
         shakeDetector.stop()
         super.onPause()
     }
 
-    private fun startAppLockActivity(setTeamAppLock: Boolean = false) {
-        val currentUserId = viewModel.globalAppState.currentUserId ?: run {
+    private fun startAppLockActivity(
+        setTeamAppLock: Boolean = false,
+        currentUserId: UserId? = viewModel.globalAppState.currentUserId,
+    ) {
+        if (isAppLockActivityLaunching) return
+        val resolvedUserId = currentUserId ?: run {
             appLogger.e("$TAG appLock: missing current user id, skipping app lock activity")
             return
         }
+        isAppLockActivityLaunching = true
         startActivity(
             Intent(this, AppLockActivity::class.java).apply {
-                putExtra(AppLockActivity.EXTRA_USER_ID, currentUserId.toString())
+                putExtra(AppLockActivity.EXTRA_USER_ID, resolvedUserId.toString())
                 if (setTeamAppLock) {
                     putExtra(AppLockActivity.SET_TEAM_APP_LOCK, true)
                 }
@@ -1223,6 +1238,13 @@ class WireActivity : BaseActivity() {
         private const val TAG = "WireActivity"
     }
 }
+
+internal fun observeAppLockUserId(
+    isAppLocked: Flow<Boolean>,
+    currentUserId: Flow<UserId?>,
+): Flow<UserId> = combine(isAppLocked, currentUserId) { isLocked, userId ->
+    userId.takeIf { isLocked }
+}.filterNotNull()
 
 private data class WireActivityScopedViewModels(
     val callFeedbackViewModel: CallFeedbackViewModel,

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityAppLockTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityAppLockTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui
+
+import com.wire.kalium.logic.data.user.UserId
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+class WireActivityAppLockTest {
+
+    @Test
+    fun givenAppIsLockedAndUserIdIsDelayed_whenUserIdLoads_thenAppLockUserIdIsEmitted() = runTest {
+        val isAppLocked = MutableStateFlow(true)
+        val currentUserId = MutableStateFlow<UserId?>(null)
+        val expectedUserId = UserId("user", "domain")
+
+        val result = async {
+            observeAppLockUserId(isAppLocked, currentUserId).first()
+        }
+        runCurrent()
+        assertFalse(result.isCompleted)
+
+        currentUserId.value = expectedUserId
+
+        assertEquals(expectedUserId, result.await())
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityAppLockTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityAppLockTest.kt
@@ -45,4 +45,54 @@ class WireActivityAppLockTest {
 
         assertEquals(expectedUserId, result.await())
     }
+
+    @Test
+    fun givenAppIsNotLockedAndUserIdIsPresent_whenObserving_thenNothingIsEmitted() = runTest {
+        val isAppLocked = MutableStateFlow(false)
+        val currentUserId = MutableStateFlow<UserId?>(UserId("user", "domain"))
+
+        val result = async {
+            observeAppLockUserId(isAppLocked, currentUserId).first()
+        }
+        runCurrent()
+
+        assertFalse(result.isCompleted)
+        result.cancel()
+    }
+
+    @Test
+    fun givenUserIdIsPresent_whenAppBecomesLocked_thenAppLockUserIdIsEmitted() = runTest {
+        val isAppLocked = MutableStateFlow(false)
+        val expectedUserId = UserId("user", "domain")
+        val currentUserId = MutableStateFlow<UserId?>(expectedUserId)
+
+        val result = async {
+            observeAppLockUserId(isAppLocked, currentUserId).first()
+        }
+        runCurrent()
+        assertFalse(result.isCompleted)
+
+        isAppLocked.value = true
+
+        assertEquals(expectedUserId, result.await())
+    }
+
+    @Test
+    fun givenAppGetsUnlockedBeforeUserIdLoads_whenUserIdLoads_thenNothingIsEmitted() = runTest {
+        val isAppLocked = MutableStateFlow(true)
+        val currentUserId = MutableStateFlow<UserId?>(null)
+
+        val result = async {
+            observeAppLockUserId(isAppLocked, currentUserId).first()
+        }
+        runCurrent()
+
+        isAppLocked.value = false
+        runCurrent()
+        currentUserId.value = UserId("user", "domain")
+        runCurrent()
+
+        assertFalse(result.isCompleted)
+        result.cancel()
+    }
 }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/ApplockTest.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/ApplockTest.kt
@@ -343,7 +343,7 @@ class ApplockTest : BaseUiTest() {
     @Test
     fun givenAppLockIsEnabled_whenAppIsColdStarted_thenUnlockGateIsShownBeforeConversationList() {
         val teamName = "AppLockColdStart"
-        val appLockPasscode = "A1a!".repeat(2)
+        val appLockPasscode = "A1a!A1a!"
 
         step("Given there is a team owner on the Staging backend") {
             backendSetupHelper.createTeamOwnerByAlias(
@@ -404,7 +404,10 @@ class ApplockTest : BaseUiTest() {
             }
 
             step("Then the unlock gate is visible before conversation content, attempt ${attempt + 1}") {
-                pages.appLockPage.assertAppLockGateVisible()
+                pages.appLockPage.assertAppLockGateVisibleBefore(
+                    otherScreen = pages.conversationListPage.conversationListHeadingSelector(),
+                    otherScreenName = "Conversation list"
+                )
                 pages.conversationListPage.assertConversationListNotVisible()
             }
 

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/ApplockTest.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/e2eTests/ApplockTest.kt
@@ -23,6 +23,7 @@ import backendUtils.team.TeamRoles
 import com.wire.android.tests.core.BaseUiTest
 import com.wire.android.tests.support.UiAutomatorSetup
 import com.wire.android.tests.support.tags.Category
+import com.wire.android.tests.support.tags.Tag
 import com.wire.android.tests.support.tags.TestCaseId
 import org.junit.Before
 import org.junit.Test
@@ -337,6 +338,92 @@ class ApplockTest : BaseUiTest() {
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
+    @Category("regression", "RC", "applock", "security")
+    @Tag(key = "feature", value = "appLockColdStart")
+    @Test
+    fun givenAppLockIsEnabled_whenAppIsColdStarted_thenUnlockGateIsShownBeforeConversationList() {
+        val teamName = "AppLockColdStart"
+        val appLockPasscode = "A1a!".repeat(2)
+
+        step("Given there is a team owner on the Staging backend") {
+            backendSetupHelper.createTeamOwnerByAlias(
+                "user1Name",
+                teamName,
+                "en_US",
+                true,
+                backendClient,
+                context
+            )
+            teamOwner = clientUserManager.findUserBy("user1Name", ClientUserManager.FindBy.NAME_ALIAS)
+        }
+
+        step("When I open the staging deep link and log in as the team owner") {
+            pages.loginPage.apply {
+                clickStagingDeepLink()
+                clickProceedButtonOnDeeplinkOverlay()
+                enterTeamOwnerLoggingEmail(teamOwner?.email ?: "")
+                clickLoginButton()
+                enterTeamOwnerLoggingPassword(teamOwner?.password ?: "")
+                clickLoginButton()
+            }
+        }
+
+        step("And I complete post-login permission and privacy prompts") {
+            pages.registrationPage.apply {
+                waitUntilLoginFlowIsCompleted()
+                clickAllowNotificationButton()
+                clickDeclineShareDataAlert()
+            }
+        }
+
+        step("And I enable app lock with a passcode") {
+            pages.conversationListPage.apply {
+                assertConversationListVisible()
+                UiWaitUtils.waitFor(2.seconds)
+                clickConversationsMenuEntry()
+                clickSettingsButtonOnMenuEntry()
+            }
+            pages.settingsPage.apply {
+                assertLockWithPasswordToggleIsOff()
+                turnOnLockWithPasscodeToggle()
+                assertSetUpAppLockPageVisible()
+                enterPasscode(appLockPasscode)
+                tapSetPasscodeButton()
+                assertLockWithPasswordToggleIsOn()
+                clickBackButtonOnSettingsPage()
+            }
+            pages.conversationListPage.assertConversationListVisible()
+        }
+
+        repeat(COLD_START_REPETITIONS) { attempt ->
+            step("When I force-stop and cold-start Wire, attempt ${attempt + 1}") {
+                UiAutomatorSetup.stopApp()
+                device.executeShellCommand(
+                    "monkey -p $appPackage -c android.intent.category.LAUNCHER 1"
+                )
+            }
+
+            step("Then the unlock gate is visible before conversation content, attempt ${attempt + 1}") {
+                pages.appLockPage.assertAppLockGateVisible()
+                pages.conversationListPage.assertConversationListNotVisible()
+            }
+
+            step("When I unlock Wire with the app lock passcode, attempt ${attempt + 1}") {
+                pages.appLockPage.apply {
+                    tapUsePasscodeOnBiometricPromptIfVisible()
+                    assertAppLockPageVisible()
+                    enterPasscode(appLockPasscode)
+                    tapUnlockButtonOnAppLockPage()
+                }
+            }
+
+            step("Then I see the conversation list, attempt ${attempt + 1}") {
+                pages.conversationListPage.assertConversationListVisible()
+            }
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     @TestCaseId("TC-8145", "TC-8146")
     @Category("regression", "RC", "applock")
     @Test
@@ -465,5 +552,9 @@ class ApplockTest : BaseUiTest() {
                 assertLockWithPasscodeToggleCannotBeChanged()
             }
         }
+    }
+
+    private companion object {
+        const val COLD_START_REPETITIONS = 3
     }
 }

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/AppLockPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/AppLockPage.kt
@@ -22,17 +22,37 @@ import androidx.test.uiautomator.UiDevice
 import org.junit.Assert.assertTrue
 import uiautomatorutils.UiSelectorParams
 import uiautomatorutils.UiWaitUtils
+import kotlin.time.Duration.Companion.seconds
 
 data class AppLockPage(private val device: UiDevice) {
     private val appLockPageTitle = UiSelectorParams(text = "Enter passcode to unlock Wire")
     private val passcodeField = UiSelectorParams(resourceId = "password")
     private val unlockButton = UiSelectorParams(text = "Unlock")
     private val wrongPasscodeErrorMessage = UiSelectorParams(text = "Check your passcode and try again")
+    private val biometricPromptTitle = UiSelectorParams(text = "Authenticate with biometrics")
+    private val biometricPromptSubtitle = UiSelectorParams(text = "To unlock Wire")
+    private val usePasscodeButton = UiSelectorParams(text = "Use passcode")
     private val editTextClass = By.clazz("android.widget.EditText")
+
+    fun assertAppLockGateVisible(): AppLockPage {
+        val gate = UiWaitUtils.waitAnyVisible(
+            selectors = listOf(appLockPageTitle, biometricPromptTitle, biometricPromptSubtitle),
+            timeout = UiWaitUtils.VERY_LONG_TIMEOUT
+        ) ?: throw AssertionError("Neither the biometric prompt nor the app lock passcode page is visible")
+        assertTrue("App lock gate is not visible", !gate.visibleBounds.isEmpty)
+        return this
+    }
 
     fun assertAppLockPageVisible(): AppLockPage {
         val title = UiWaitUtils.waitElement(appLockPageTitle)
         assertTrue("App lock page is not visible", !title.visibleBounds.isEmpty)
+        return this
+    }
+
+    fun tapUsePasscodeOnBiometricPromptIfVisible(): AppLockPage {
+        if (UiWaitUtils.clickWhenClickable(usePasscodeButton, timeout = 1.seconds)) {
+            device.waitForIdle()
+        }
         return this
     }
 

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/AppLockPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/AppLockPage.kt
@@ -33,13 +33,30 @@ data class AppLockPage(private val device: UiDevice) {
     private val biometricPromptSubtitle = UiSelectorParams(text = "To unlock Wire")
     private val usePasscodeButton = UiSelectorParams(text = "Use passcode")
     private val editTextClass = By.clazz("android.widget.EditText")
+    private val appLockGateSelectors = listOf(appLockPageTitle, biometricPromptTitle, biometricPromptSubtitle)
 
     fun assertAppLockGateVisible(): AppLockPage {
         val gate = UiWaitUtils.waitAnyVisible(
-            selectors = listOf(appLockPageTitle, biometricPromptTitle, biometricPromptSubtitle),
+            selectors = appLockGateSelectors,
             timeout = UiWaitUtils.VERY_LONG_TIMEOUT
         ) ?: throw AssertionError("Neither the biometric prompt nor the app lock passcode page is visible")
         assertTrue("App lock gate is not visible", !gate.visibleBounds.isEmpty)
+        return this
+    }
+
+    /**
+     * Asserts that the app lock gate is the first screen to become visible, failing when
+     * [otherScreen] appears before it. Polling-based, so a flash shorter than the polling
+     * interval can still go unnoticed.
+     */
+    fun assertAppLockGateVisibleBefore(otherScreen: UiSelectorParams, otherScreenName: String): AppLockPage {
+        val winner = UiWaitUtils.waitFirstVisibleSelector(
+            selectors = appLockGateSelectors + otherScreen,
+            timeout = UiWaitUtils.VERY_LONG_TIMEOUT
+        ) ?: throw AssertionError("Neither the app lock gate nor $otherScreenName became visible")
+        if (winner == otherScreen) {
+            throw AssertionError("$otherScreenName became visible before the app lock gate")
+        }
         return this
     }
 

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationListPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationListPage.kt
@@ -70,6 +70,7 @@ data class ConversationListPage(private val device: UiDevice) {
     private val userConversationNamePendingLabelSelector =
         UiSelector().description("pending approval of connection request")
     private val pendingApprovalLabel = UiSelectorParams(description = "pending approval of connection request")
+
     /**
      * Exposes the heading selector for cross-screen assertions, e.g. verifying that another
      * screen becomes visible before the conversation list on cold start.

--- a/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationListPage.kt
+++ b/tests/testsCore/src/androidTest/kotlin/com/wire/android/tests/core/pages/ConversationListPage.kt
@@ -70,6 +70,12 @@ data class ConversationListPage(private val device: UiDevice) {
     private val userConversationNamePendingLabelSelector =
         UiSelector().description("pending approval of connection request")
     private val pendingApprovalLabel = UiSelectorParams(description = "pending approval of connection request")
+    /**
+     * Exposes the heading selector for cross-screen assertions, e.g. verifying that another
+     * screen becomes visible before the conversation list on cold start.
+     */
+    fun conversationListHeadingSelector(): UiSelectorParams = conversationListHeading
+
     fun assertConversationListVisible(): ConversationListPage {
         val heading = UiWaitUtils.waitElement(conversationListHeading)
         Assert.assertTrue(

--- a/tests/testsSupport/src/main/uiautomatorutils/UiWaitUtils.kt
+++ b/tests/testsSupport/src/main/uiautomatorutils/UiWaitUtils.kt
@@ -182,6 +182,35 @@ object UiWaitUtils {
     }
 
     /**
+     * Waits until any selector from [selectors] resolves to a visible element and reports which one.
+     *
+     * Selectors are evaluated in list order within each poll, so earlier entries win ties.
+     * Polling-based: a flash shorter than [pollingInterval] can go unnoticed.
+     *
+     * @return the first selector that became visible, or `null` when none becomes visible in time.
+     */
+    fun waitFirstVisibleSelector(
+        selectors: List<UiSelectorParams>,
+        timeout: Duration = DEFAULT_TIMEOUT,
+        pollingInterval: Duration = POLLING_FAST
+    ): UiSelectorParams? {
+        var found: UiSelectorParams? = null
+
+        val isFound = retryUntilTimeout(
+            timeout = timeout,
+            pollingInterval = pollingInterval
+        ) {
+            found = selectors.firstOrNull { params ->
+                findElementOrNull(params)
+                    ?.let { runCatching { !it.visibleBounds.isEmpty }.getOrDefault(false) } == true
+            }
+            found != null
+        }
+
+        return if (isFound) found else null
+    }
+
+    /**
      * Waits for an element to become visible and enabled, then clicks it.
      *
      * Handles transient `StaleObjectException` by retrying until timeout.


### PR DESCRIPTION
# What's new in this PR?

### Issues

- On a cold start, Wire could display the conversation list without requesting biometric or passcode authentication when app lock was enabled.
- Message paging could return messages in the wrong order.

### Causes

- `AppLockActivity` requires the current user ID, but cold-start handling could consume the locked state before that ID was available. The launch was skipped and was not retried.
- Message paging used the previous paging-source implementation and ordering behavior.

### Solutions

- Keep the splash screen visible for a locked session until the user ID is available and the app-lock activity has been launched.
- Observe lock state and user ID together with activity lifecycle awareness, while preventing duplicate app-lock launches.
- Add unit regression coverage and an end-to-end cold-start check that fails if the conversation list appears before the unlock gate.

This prevents protected conversation content from being exposed before authentication and makes paged message ordering consistent.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

1. Sign in and enable app lock with biometrics and a passcode.
2. Force-stop Wire or leave it idle long enough to lock.
3. Cold-start Wire several times.
4. Verify that the biometric prompt or passcode screen always appears before the conversation list.
5. Unlock Wire and verify that the conversation list becomes available normally.

Focused app-lock unit coverage passes, and the Android acceptance-test sources compile successfully.
