### PR TITLE
fix(calling): show incoming 1:1 calls [WPB-26713]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
@@ -72,7 +72,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             isArchived = conversationDetails.conversation.archived,
             mlsVerificationStatus = conversationDetails.conversation.mlsVerificationStatus,
             proteusVerificationStatus = conversationDetails.conversation.proteusVerificationStatus,
-            hasNewActivitiesToShow = hasNewActivitiesToShow || hasJoinableCall,
+            hasNewActivitiesToShow = hasNewActivitiesToShow.withJoinableCall(hasJoinableCall),
             isFavorite = conversationDetails.isFavorite,
             folder = conversationDetails.folder
         )
@@ -98,7 +98,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             isArchived = conversationDetails.conversation.archived,
             mlsVerificationStatus = conversationDetails.conversation.mlsVerificationStatus,
             proteusVerificationStatus = conversationDetails.conversation.proteusVerificationStatus,
-            hasNewActivitiesToShow = hasNewActivitiesToShow || hasJoinableCall,
+            hasNewActivitiesToShow = hasNewActivitiesToShow.withJoinableCall(hasJoinableCall),
             isFavorite = conversationDetails.isFavorite,
             folder = conversationDetails.folder,
             isPrivate = conversationDetails.access == Group.Channel.ChannelAccess.PRIVATE
@@ -106,6 +106,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
     }
 
     is OneOne -> {
+        val hasJoinableCall = joinableCallsByConversationId.containsKey(conversationDetails.conversation.id)
         PrivateConversation(
             userAvatarData = UserAvatarData(
                 asset = conversationDetails.otherUser.previewPicture?.let { UserAvatarAsset(it) },
@@ -137,7 +138,8 @@ fun ConversationDetailsWithEvents.toConversationItem(
             isArchived = conversationDetails.conversation.archived,
             mlsVerificationStatus = conversationDetails.conversation.mlsVerificationStatus,
             proteusVerificationStatus = conversationDetails.conversation.proteusVerificationStatus,
-            hasNewActivitiesToShow = hasNewActivitiesToShow,
+            hasNewActivitiesToShow = hasNewActivitiesToShow.withJoinableCall(hasJoinableCall),
+            hasOnGoingCall = hasJoinableCall,
             isFavorite = conversationDetails.isFavorite,
             folder = conversationDetails.folder
         )
@@ -181,6 +183,8 @@ fun ConversationDetailsWithEvents.toConversationItem(
 
 private fun Group.hasJoinableCall(joinableCallsByConversationId: Map<ConversationId, Call>): Boolean =
     joinableCallsByConversationId.containsKey(conversation.id) && isSelfUserMember
+
+private fun Boolean.withJoinableCall(hasJoinableCall: Boolean): Boolean = this || hasJoinableCall
 
 private fun parseConnectionEventType(connectionState: ConnectionState) =
     if (connectionState == ConnectionState.SENT) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCase.kt
@@ -124,9 +124,6 @@ class GetConversationsFromSearchUseCase @Inject constructor(
         initialJoinableCallsByConversationId: Map<ConversationId, Call>,
         joinableCallsFlow: Flow<Map<ConversationId, Call>>
     ): Flow<PagingData<ConversationItem>> {
-        val includeJoinableCalls = queryConfig.conversationFilter != ConversationFilter.OneOnOne
-        val initialCalls = if (includeJoinableCalls) initialJoinableCallsByConversationId else emptyMap()
-        val callsFlow = if (includeJoinableCalls) joinableCallsFlow else flowOf(emptyMap())
         return useCase(
             queryConfig = queryConfig,
             pagingConfig = pagingConfig,
@@ -134,8 +131,8 @@ class GetConversationsFromSearchUseCase @Inject constructor(
             strictMlsFilter = useStrictMlsFilter
         ).mapToConversationItems(
             selfUserTeamId = selfUserTeamId,
-            initialJoinableCallsByConversationId = initialCalls,
-            joinableCallsFlow = callsFlow
+            initialJoinableCallsByConversationId = initialJoinableCallsByConversationId,
+            joinableCallsFlow = joinableCallsFlow
         )
     }
 
@@ -163,13 +160,14 @@ class GetConversationsFromSearchUseCase @Inject constructor(
             }
             try {
                 this@mapToConversationItems.collect { pagingData ->
+                    val joinableCallsByConversationId = latestJoinableCallsByConversationId.get()
                     emit(
                         pagingData.map {
                             it.toConversationItem(
                                 userTypeMapper = userTypeMapper,
                                 uiTextResolver = uiTextResolver,
                                 selfUserTeamId = selfUserTeamId,
-                                joinableCallsByConversationId = latestJoinableCallsByConversationId.get()
+                                joinableCallsByConversationId = joinableCallsByConversationId
                             )
                         }
                     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -374,7 +374,7 @@ private fun List<ConversationItem>.unreadToReadConversationsItems(): Pair<List<C
                 }
 
             MutedConversationStatus.AllMuted -> false
-        } || (it is ConversationItem.Group && it.hasOnGoingCall)
+        } || it.hasOnGoingCall
     }
 
     val remainingConversations = this - unreadConversations.toSet()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -273,7 +273,12 @@ private fun GeneralConversationItem(
                     clickable = onConversationItemClick,
                     actions = {
                         if (!isSelectable) {
-                            if (playingAudio != null) {
+                            if (hasOnGoingCall) {
+                                JoinButton(
+                                    buttonClick = onJoinCallClick,
+                                    onAudioPermissionPermanentlyDenied = onAudioPermissionPermanentlyDenied,
+                                )
+                            } else if (playingAudio != null) {
                                 AudioControlButtons(
                                     playingAudio = playingAudio,
                                     onPlayPauseCurrentAudio = onPlayPauseCurrentAudio,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -48,13 +48,14 @@ sealed interface ConversationItem : ConversationItemType {
     val mlsVerificationStatus: Conversation.VerificationStatus
     val proteusVerificationStatus: Conversation.VerificationStatus
     val hasNewActivitiesToShow: Boolean
+    val hasOnGoingCall: Boolean get() = false
 
     val isTeamConversation get() = teamId != null
 
     @Serializable
     sealed interface Group : ConversationItem {
         val groupName: String
-        val hasOnGoingCall: Boolean
+        override val hasOnGoingCall: Boolean
         val selfMemberRole: Conversation.Member.Role?
         val isFromTheSameTeam: Boolean
         val isSelfUserMember: Boolean
@@ -122,6 +123,7 @@ sealed interface ConversationItem : ConversationItemType {
         override val mlsVerificationStatus: Conversation.VerificationStatus,
         override val proteusVerificationStatus: Conversation.VerificationStatus,
         override val hasNewActivitiesToShow: Boolean = false,
+        override val hasOnGoingCall: Boolean = false,
     ) : ConversationItem
 
     @Serializable

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/usecase/GetConversationsFromSearchUseCaseTest.kt
@@ -19,6 +19,7 @@ package com.wire.android.ui.home.conversations.usecase
 
 import androidx.paging.PagingData
 import androidx.paging.testing.asSnapshot
+import app.cash.turbine.test
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.TestConversationDetails
@@ -36,6 +37,7 @@ import com.wire.kalium.logic.data.conversation.ConversationFilter
 import com.wire.kalium.logic.data.conversation.ConversationFolder
 import com.wire.kalium.logic.data.conversation.ConversationQueryConfig
 import com.wire.kalium.logic.data.conversation.FolderType
+import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.usecase.ObserveJoinableCallsUseCase
 import com.wire.kalium.logic.feature.conversation.GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCase
@@ -48,8 +50,11 @@ import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -221,6 +226,81 @@ class GetConversationsFromSearchUseCaseTest {
         }
 
     @Test
+    fun givenIncomingOneOnOneCall_whenGettingPaginatedList_thenPrivateItemHasOngoingCallMarker() =
+        runTest(dispatcherProvider.main()) {
+            // Given
+            val conversation = ConversationDetailsWithEvents(TestConversationDetails.CONVERSATION_ONE_ONE)
+            val (arrangement, useCase) = Arrangement()
+                .withPaginatedResult(listOf(conversation))
+                .withJoinableCalls(
+                    listOf(
+                        joinableCall(
+                            conversationId = conversation.conversationDetails.conversation.id,
+                            status = CallStatus.INCOMING,
+                            conversationType = Conversation.Type.OneOnOne
+                        )
+                    )
+                )
+                .arrange()
+
+            // When
+            val result = with(arrangement.queryConfig) {
+                useCase(
+                    searchQuery = searchQuery,
+                    fromArchive = fromArchive,
+                    newActivitiesOnTop = newActivitiesOnTop,
+                    onlyInteractionEnabled = onlyInteractionEnabled,
+                    useStrictMlsFilter = true
+                ).asSnapshot()
+            }
+
+            // Then
+            val privateConversation = assertInstanceOf<ConversationItem.PrivateConversation>(result.first())
+            assertEquals(true, privateConversation.hasOnGoingCall)
+            assertEquals(true, privateConversation.hasNewActivitiesToShow)
+        }
+
+    @Test
+    fun givenIncomingOneOnOneCallInMutedConversation_whenGettingOneOnOneList_thenPrivateItemHasOngoingCallMarker() =
+        runTest(dispatcherProvider.main()) {
+            // Given
+            val conversation = ConversationDetailsWithEvents(
+                TestConversationDetails.CONVERSATION_ONE_ONE.copy(
+                    conversation = TestConversationDetails.CONVERSATION_ONE_ONE.conversation.copy(
+                        mutedStatus = MutedConversationStatus.AllMuted
+                    )
+                )
+            )
+            val (arrangement, useCase) = Arrangement()
+                .withPaginatedResult(listOf(conversation))
+                .withJoinableCalls(
+                    listOf(
+                        joinableCall(
+                            conversationId = conversation.conversationDetails.conversation.id,
+                            status = CallStatus.INCOMING,
+                            conversationType = Conversation.Type.OneOnOne
+                        )
+                    )
+                )
+                .arrange()
+
+            // When
+            val result = useCase(
+                searchQuery = "",
+                fromArchive = false,
+                newActivitiesOnTop = true,
+                onlyInteractionEnabled = false,
+                conversationFilter = ConversationFilter.OneOnOne,
+                useStrictMlsFilter = true
+            ).asSnapshot()
+
+            // Then
+            val privateConversation = assertInstanceOf<ConversationItem.PrivateConversation>(result.first())
+            assertEquals(true, privateConversation.hasOnGoingCall)
+            assertEquals(true, privateConversation.hasNewActivitiesToShow)
+        }
+
+    @Test
     fun givenJoinableCallsChange_whenGettingPaginatedList_thenDoNotReEmitSamePagingData() =
         runTest(dispatcherProvider.main()) {
             // Given
@@ -249,6 +329,57 @@ class GetConversationsFromSearchUseCaseTest {
 
             // Then
             assertEquals(1, result.size)
+        }
+
+    @Test
+    fun givenJoinableCallsChangeAfterPagingEmission_whenItemsLoad_thenUseCallStateFromPagingEmission() =
+        runTest(dispatcherProvider.main()) {
+            // Given
+            val conversation = ConversationDetailsWithEvents(TestConversationDetails.CONVERSATION_ONE_ONE)
+            val call = joinableCall(
+                conversationId = conversation.conversationDetails.conversation.id,
+                status = CallStatus.INCOMING,
+                conversationType = Conversation.Type.OneOnOne
+            )
+            val joinableCallsFlow = MutableStateFlow<Map<ConversationId, Call>>(emptyMap())
+            val pagingDataFlow = MutableSharedFlow<PagingData<ConversationDetailsWithEvents>>()
+            val (_, useCase) = Arrangement()
+                .withPaginatedResultFlow(pagingDataFlow)
+                .withJoinableCallsFlow(joinableCallsFlow)
+                .arrange()
+
+            val result = with(ConversationQueryConfig("search")) {
+                useCase(
+                    searchQuery = searchQuery,
+                    fromArchive = fromArchive,
+                    newActivitiesOnTop = newActivitiesOnTop,
+                    onlyInteractionEnabled = onlyInteractionEnabled,
+                    useStrictMlsFilter = true
+                )
+            }
+
+            result.test {
+                pagingDataFlow.emit(PagingData.from(listOf(conversation)))
+                val pagingDataBeforeCall = awaitItem()
+
+                // When the call changes after this paging generation was emitted
+                joinableCallsFlow.value = mapOf(call.conversationId to call)
+                runCurrent()
+
+                // Then items from the existing generation keep its call-state snapshot
+                val privateConversationBeforeCall = assertInstanceOf<ConversationItem.PrivateConversation>(
+                    flowOf(pagingDataBeforeCall).asSnapshot().first()
+                )
+                assertEquals(false, privateConversationBeforeCall.hasOnGoingCall)
+
+                // And the next paging generation receives the new call state
+                pagingDataFlow.emit(PagingData.from(listOf(conversation)))
+                val privateConversationWithCall = assertInstanceOf<ConversationItem.PrivateConversation>(
+                    flowOf(awaitItem()).asSnapshot().first()
+                )
+                assertEquals(true, privateConversationWithCall.hasOnGoingCall)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
 
     inner class Arrangement {
@@ -304,6 +435,12 @@ class GetConversationsFromSearchUseCaseTest {
             } returns flowOf(PagingData.from(conversations))
         }
 
+        fun withPaginatedResultFlow(result: Flow<PagingData<ConversationDetailsWithEvents>>) = apply {
+            coEvery {
+                useCase.invoke(any(), any(), any(), any())
+            } returns result
+        }
+
         fun withFavoriteFolderResult(result: GetFavoriteFolderUseCase.Result) = apply {
             coEvery { getFavoriteFolderUseCase.invoke() } returns result
         }
@@ -338,15 +475,19 @@ class GetConversationsFromSearchUseCaseTest {
         )
     }
 
-    private fun joinableCall(conversationId: ConversationId) = Call(
+    private fun joinableCall(
+        conversationId: ConversationId,
+        status: CallStatus = CallStatus.STILL_ONGOING,
+        conversationType: Conversation.Type = Conversation.Type.Group.Regular
+    ) = Call(
         conversationId = conversationId,
-        status = CallStatus.STILL_ONGOING,
+        status = status,
         isMuted = false,
         isCameraOn = false,
         isCbrEnabled = false,
         callerId = TestUser.SELF_USER_ID,
         conversationName = null,
-        conversationType = Conversation.Type.Group.Regular,
+        conversationType = conversationType,
         callerName = null,
         callerTeamName = null
     )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26713
<!--jira-description-action-hidden-marker-end-->
## Intent

Fix [WPB-26713](https://wearezeta.atlassian.net/browse/WPB-26713) by showing a foreground affordance for incoming 1:1 calls when ringing and notifications are suppressed.

Depends on [wireapp/kalium#4329](https://github.com/wireapp/kalium/pull/4329) for New Activity ordering.

## Root cause

Joinable calls were mapped and rendered only for group conversations. A muted 1:1 conversation, or one received while the user was Away, could therefore have no foreground indication until the call became missed.

The initial paging mapping also read mutable call state while an existing paging generation was loading. When an already-visible conversation changed section, Compose could receive duplicate section keys and crash.

## Changes

- Map joinable-call state onto 1:1 conversation items.
- Show the join/answer button for an incoming 1:1 call.
- Treat an active 1:1 call as New Activity, including muted conversations.
- Snapshot call state per paging generation so section membership remains internally consistent.
- Update the Kalium submodule to the functional ordering commit.
- Add regression coverage for incoming, muted, filtered, and already-visible 1:1 conversations.

## Reproduction

1. Set the receiving user to Away or mute a 1:1 conversation.
2. Keep the Android app open in the foreground.
3. Receive a 1:1 call from that conversation.
4. Observe that no call affordance is visible before the call ends.

## Result

The incoming 1:1 conversation moves into New Activity and shows its join/answer affordance before it becomes a missed call. Ringing, notification, and background behavior are unchanged.

## Validation

- Android app unit suite
- Conversation-list regression tests
- Android static analysis
- Kalium persistence tests


[WPB-26713]: https://wearezeta.atlassian.net/browse/WPB-26713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ