### PR TITLE
refactor(call): use Instant for established time [WPB-10090]

### DIFF
--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/mapper/MeetingMapper.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/mapper/MeetingMapper.kt
@@ -24,7 +24,6 @@ import com.wire.android.model.UserAvatarData
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.meeting.MeetingOccurrence
-import com.wire.kalium.util.DateTimeUtil
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.minutes
@@ -79,9 +78,7 @@ fun Call.toOngoingCallStatus() = when (status) {
     CallStatus.ESTABLISHED,
     CallStatus.INCOMING,
     CallStatus.STILL_ONGOING -> MeetingItem.OngoingCallStatus(
-        currentCallEstablishedTime = establishedTime?.let {
-            Instant.fromEpochMilliseconds(DateTimeUtil.fromIsoDateTimeStringToEpochMillis(it))
-        },
+        currentCallEstablishedTime = establishedTime,
         isSelfUserAttending = status in listOf(CallStatus.STARTED, CallStatus.ANSWERED, CallStatus.ESTABLISHED),
     )
 

--- a/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/mapper/MeetingMapperTest.kt
+++ b/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/mapper/MeetingMapperTest.kt
@@ -145,7 +145,7 @@ class MeetingMapperTest {
 
     private fun call(
         status: CallStatus = CallStatus.ESTABLISHED,
-        establishedTime: String? = ESTABLISHED_TIME
+        establishedTime: Instant? = ESTABLISHED_TIME
     ) = Call(
         conversationId = CONVERSATION_ID,
         status = status,
@@ -163,7 +163,7 @@ class MeetingMapperTest {
     private companion object {
         val MEETING_ID = MeetingId(value = "meeting-id", domain = "wire.com")
         const val TITLE = "Engineering sync"
-        const val ESTABLISHED_TIME = "2026-01-01T11:40:00.000Z"
+        val ESTABLISHED_TIME = Instant.parse("2026-01-01T11:40:00Z")
         val currentTime = Instant.parse("2026-01-01T12:00:00Z")
         val CONVERSATION_ID = ConversationId(value = "conversation-id", domain = "wire.com")
         val BELONGING_TYPE = BelongingType.Group(name = TITLE)

--- a/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/list/MeetingListViewModelTest.kt
+++ b/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/list/MeetingListViewModelTest.kt
@@ -132,7 +132,7 @@ class MeetingListViewModelTest {
         )
         val activeCall = call(
             conversationId = meetingWithActiveCall.conversationId,
-            establishedTime = "2026-01-01T11:55:00.000Z"
+            establishedTime = Instant.parse("2026-01-01T11:55:00Z")
         )
         val (_, viewModel) = Arrangement(dispatcher)
             .withCurrentTimeProvider { currentTime }
@@ -201,7 +201,7 @@ class MeetingListViewModelTest {
     private fun call(
         conversationId: ConversationId,
         status: CallStatus = CallStatus.ESTABLISHED,
-        establishedTime: String? = null,
+        establishedTime: Instant? = null,
     ) = Call(
         conversationId = conversationId,
         status = status,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-10090
<!--jira-description-action-hidden-marker-end-->
## What changed

- Use Kalium's `Instant` directly for the ongoing call start time.
- Update the meeting test fixtures.
- Update the Kalium submodule.

## Why

This avoids parsing an ISO string every time the meeting model is mapped.

Depends on [Kalium PR #4335](https://github.com/wireapp/kalium/pull/4335).
