### PR TITLE
refactor(cells): use Instant for version modified time PR 2 [WPB-10090]

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/versioning/VersionHistoryViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/versioning/VersionHistoryViewModel.kt
@@ -44,8 +44,9 @@ import com.wire.kalium.common.functional.onSuccess
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toJavaInstant
 import okio.sink
-import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -110,7 +111,8 @@ class VersionHistoryViewModel(
         val yesterday = today.minusDays(1)
 
         val grouped = this.groupBy { item ->
-            Instant.ofEpochSecond(item.modifiedTime?.toLong() ?: 0L)
+            (item.modifiedTime ?: Instant.fromEpochSeconds(0))
+                .toJavaInstant()
                 .atZone(ZoneId.systemDefault())
                 .toLocalDate()
         }
@@ -137,9 +139,7 @@ class VersionHistoryViewModel(
 
                 val uiItems = items.mapIndexed { itemIndex, apiItem ->
 
-                    val formattedTime = apiItem.modifiedTime?.toLong()?.let {
-                        kotlinx.datetime.Instant.fromEpochSeconds(it).cellFileTime()
-                    } ?: ""
+                    val formattedTime = apiItem.modifiedTime?.cellFileTime() ?: ""
 
                     CellVersion(
                         versionId = apiItem.id,

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/versioning/VersionHistoryViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/versioning/VersionHistoryViewModelTest.kt
@@ -50,6 +50,8 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toJavaInstant
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -57,7 +59,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.OutputStream
-import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZoneOffset
@@ -119,8 +120,8 @@ class VersionHistoryViewModelTest {
         assertEquals("Today, $todayFormattedDate", actualTodayText)
         assertEquals(1, groupedVersions[0].versions.size)
         assertEquals("User A", groupedVersions[0].versions[0].modifiedBy)
-        val expectedTime = Instant
-            .ofEpochSecond(versionNode.modifiedTime!!.toLong())
+        val expectedTime = versionNode.modifiedTime!!
+            .toJavaInstant()
             .atZone(ZoneId.systemDefault())
             .toLocalTime()
             .format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))
@@ -497,7 +498,7 @@ class VersionHistoryViewModelTest {
             editorUrls = null,
             filePreviews = null,
             isHead = false,
-            modifiedTime = today.atTime(10, 30).toEpochSecond(ZoneOffset.UTC).toString(),
+            modifiedTime = Instant.fromEpochSeconds(today.atTime(10, 30).toEpochSecond(ZoneOffset.UTC)),
             ownerName = "User A",
             ownerUuid = "uuid",
             getUrl = PreSignedUrl("expiration", "url"),
@@ -509,19 +510,19 @@ class VersionHistoryViewModelTest {
             versionNode.copy(
                 id = "v2",
                 ownerName = "User B",
-                modifiedTime = yesterday.atTime(14, 0).toEpochSecond(ZoneOffset.UTC).toString(),
+                modifiedTime = Instant.fromEpochSeconds(yesterday.atTime(14, 0).toEpochSecond(ZoneOffset.UTC)),
                 size = "2048"
             ),
             versionNode.copy(
                 id = "v3",
                 ownerName = "User A",
-                modifiedTime = yesterday.atTime(9, 15).toEpochSecond(ZoneOffset.UTC).toString(),
+                modifiedTime = Instant.fromEpochSeconds(yesterday.atTime(9, 15).toEpochSecond(ZoneOffset.UTC)),
                 size = "5000000"
             ),
             versionNode.copy(
                 id = "v4",
                 ownerName = "User C",
-                modifiedTime = twoDaysAgo.atStartOfDay().toEpochSecond(ZoneOffset.UTC).toString(),
+                modifiedTime = Instant.fromEpochSeconds(twoDaysAgo.atStartOfDay().toEpochSecond(ZoneOffset.UTC)),
                 size = "123"
             ),
         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-10090
<!--jira-description-action-hidden-marker-end-->
## What changed

- Use `NodeVersion.modifiedTime` as an `Instant`.
- Group and format versions without parsing strings in the app.
- Update the Kalium submodule.

## Why

The app previously parsed every timestamp once for grouping and again for formatting. For `N` versions, that meant `2N` string conversions per load.

The timestamp is now converted once in Kalium, reducing this to `N` conversions.

## Stack

- #5095

Depends on [Kalium PR #4336](https://github.com/wireapp/kalium/pull/4336).
