### PR TITLE
fix: align radio buttons with conversation avatars [WPB-27631]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -192,7 +192,7 @@ private fun GeneralConversationItem(
                     modifier = modifier.padding(start = dimensions().spacing8x),
                     titleStartPadding = dimensions().spacing0x,
                     leadingIcon = {
-                        Row {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
                             if (isSelectable) {
                                 WireRadioButton(checked = isChecked, onButtonChecked = {
                                     selectOnRadioGroup()
@@ -252,7 +252,7 @@ private fun GeneralConversationItem(
                     modifier = modifier.padding(start = dimensions().spacing8x),
                     titleStartPadding = dimensions().spacing0x,
                     leadingIcon = {
-                        Row {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
                             if (isSelectable) {
                                 WireRadioButton(checked = isChecked, onButtonChecked = {
                                     selectOnRadioGroup()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27631
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixes radio button alignment with conversation avatars on the Share With Wire screen.