### PR TITLE
feat: support for new adminless groups feature events (WPB-25284)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
@@ -81,6 +81,9 @@ class SystemMessageContentMapper @Inject constructor(
             content,
             members
         )
+
+        is MessageContent.AdminlessDeleteReminder ->
+            UIMessageContent.SystemMessage.AdminlessDeleteReminder(content.deletionScheduledFor)
     }
 
     private fun mapConversationConversationAppsAccessChanged(

--- a/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
@@ -84,6 +84,9 @@ class SystemMessageContentMapper @Inject constructor(
             content,
             members
         )
+
+        is MessageContent.AdminlessDeleteReminder ->
+            UIMessageContent.SystemMessage.AdminlessDeleteReminder(content.deletionScheduledFor)
     }
 
     private fun mapConversationConversationAppsAccessChanged(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SystemMessageItem.kt
@@ -19,6 +19,7 @@
 
 package com.wire.android.ui.home.conversations.messages.item
 
+import android.text.format.DateFormat
 import androidx.annotation.DrawableRes
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
@@ -63,6 +64,7 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.SupportPage
+import com.wire.android.util.formatMonthDayShortTime
 import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.MarkdownTextStyle
 import com.wire.android.util.ui.UIText
@@ -608,6 +610,26 @@ private fun SystemMessage.buildContent(isWireCellsEnabled: Boolean) = when (this
                 appendLine()
                 append(footer.toMarkdownAnnotatedString(markdownTextStyle))
             }
+        }
+    }
+
+    is SystemMessage.AdminlessDeleteReminder -> buildContent(
+        iconResId = commonR.drawable.ic_info,
+        iconTintColor = MaterialTheme.wireColorScheme.error,
+        learnMorePage = SupportPage.ADMINLESS_GROUP_DELETE,
+    ) {
+        val is24Hour = DateFormat.is24HourFormat(LocalContext.current)
+        val markdownTextStyle = DefaultMarkdownTextStyle.copy(
+            normalColor = MaterialTheme.wireColorScheme.error,
+            boldColor = MaterialTheme.wireColorScheme.error
+        )
+        buildAnnotatedString {
+            append(
+                stringResource(
+                    id = R.string.label_system_message_adminless_delete_reminder,
+                    formatArgs = arrayOf(deletionScheduledFor.formatMonthDayShortTime(is24Hour))
+                ).toMarkdownAnnotatedString(markdownTextStyle)
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SystemMessageItem.kt
@@ -19,6 +19,7 @@
 
 package com.wire.android.ui.home.conversations.messages.item
 
+import android.text.format.DateFormat
 import androidx.annotation.DrawableRes
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
@@ -63,6 +64,7 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.SupportPage
+import com.wire.android.util.formatMonthDayShortTime
 import com.wire.android.util.supportUrlResource
 import com.wire.android.util.ui.MarkdownTextStyle
 import com.wire.android.util.ui.UIText
@@ -639,6 +641,26 @@ private fun SystemMessage.buildContent(isWireCellsEnabled: Boolean) = when (this
                 appendLine()
                 append(footer.toMarkdownAnnotatedString(markdownTextStyle))
             }
+        }
+    }
+
+    is SystemMessage.AdminlessDeleteReminder -> buildContent(
+        iconResId = commonR.drawable.ic_info,
+        iconTintColor = MaterialTheme.wireColorScheme.error,
+        learnMorePage = SupportPage.ADMINLESS_GROUP_DELETE,
+    ) {
+        val is24Hour = DateFormat.is24HourFormat(LocalContext.current)
+        val markdownTextStyle = DefaultMarkdownTextStyle.copy(
+            normalColor = MaterialTheme.wireColorScheme.error,
+            boldColor = MaterialTheme.wireColorScheme.error
+        )
+        buildAnnotatedString {
+            append(
+                stringResource(
+                    id = R.string.label_system_message_adminless_delete_reminder,
+                    formatArgs = arrayOf(deletionScheduledFor.formatMonthDayShortTime(is24Hour))
+                ).toMarkdownAnnotatedString(markdownTextStyle)
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewSystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewSystemMessageItem.kt
@@ -29,6 +29,7 @@ import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.toUIText
 import com.wire.kalium.logic.data.conversation.Conversation
+import kotlinx.datetime.Instant
 
 @PreviewMultipleThemes
 @Composable
@@ -481,6 +482,20 @@ fun PreviewSystemMessageConversationMessageAppsAccessEnabled() {
                     author = UIText.DynamicString("Barbara"),
                     isAuthorSelfUser = true,
                     isAccessEnabled = true
+                )
+            )
+        )
+    }
+}
+
+@PreviewMultipleThemes
+@Composable
+fun PreviewSystemMessageAdminlessDeleteReminder() {
+    WireTheme {
+        SystemMessageItem(
+            message = mockMessageWithKnock.copy(
+                messageContent = UIMessageContent.SystemMessage.AdminlessDeleteReminder(
+                    deletionScheduledFor = Instant.parse("2026-04-23T12:00:00Z")
                 )
             )
         )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -650,6 +650,11 @@ sealed interface UIMessageContent {
             val isAuthorSelfUser: Boolean = false,
             val isAccessEnabled: Boolean
         ) : SystemMessage
+
+        @Serializable
+        data class AdminlessDeleteReminder(
+            val deletionScheduledFor: Instant
+        ) : SystemMessage
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -656,6 +656,11 @@ sealed interface UIMessageContent {
             val isAuthorSelfUser: Boolean = false,
             val isAccessEnabled: Boolean
         ) : SystemMessage
+
+        @Serializable
+        data class AdminlessDeleteReminder(
+            val deletionScheduledFor: Instant
+        ) : SystemMessage
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1903,6 +1903,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="label_system_message_apps_access_disabled_by_other">%1$s disabled **apps** for this conversation</string>
     <string name="label_system_message_apps_access_enabled_disclaimer">Added apps have access to the content of this conversation.</string>
     <string name="label_system_message_admin_role_assigned">You were promoted to group admin</string>
+    <string name="label_system_message_adminless_delete_reminder">This group will be automatically deleted on %1$s, as there are no eligible group admins.</string>
     <string name="more_information_about_this_server">More information about this backend</string>
 
     <!-- Pending messages service notification -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1951,6 +1951,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="label_system_message_apps_access_disabled_by_other">%1$s disabled **apps** for this conversation</string>
     <string name="label_system_message_apps_access_enabled_disclaimer">Added apps have access to the content of this conversation.</string>
     <string name="label_system_message_admin_role_assigned">You were promoted to group admin</string>
+    <string name="label_system_message_adminless_delete_reminder">This group will be automatically deleted on %1$s, as there are no eligible group admins.</string>
     <string name="more_information_about_this_server">More information about this backend</string>
 
     <!-- Pending messages service notification -->

--- a/app/src/test/kotlin/com/wire/android/mapper/SystemMessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/SystemMessageContentMapperTest.kt
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.Locale
+import kotlinx.datetime.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
@@ -73,6 +74,18 @@ class SystemMessageContentMapperTest {
 
         // Then
         assertTrue(uiContent is SystemMessage.ConversationMessageTimerDeactivated)
+    }
+
+    @Test
+    fun givenAdminlessDeleteReminder_whenMappingToSystemMessage_thenScheduledDeletionIsPreserved() = runTest {
+        val (_, mapper) = Arrangement().arrange()
+        val scheduledDeletion = Instant.parse("2026-04-23T12:00:00Z")
+        val content = MessageContent.AdminlessDeleteReminder(scheduledDeletion)
+
+        val uiContent = mapper.mapMessage(TestMessage.SYSTEM_MESSAGE.copy(content = content), emptyList())
+
+        assertIs<SystemMessage.AdminlessDeleteReminder>(uiContent!!)
+        assertEquals(scheduledDeletion, uiContent.deletionScheduledFor)
     }
 
     @Test

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/DateAndTimeParsers.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/DateAndTimeParsers.kt
@@ -17,9 +17,11 @@
  */
 package com.wire.android.util
 
+import android.text.format.DateFormat
 import androidx.compose.runtime.Stable
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toJavaInstant
+import java.text.SimpleDateFormat
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -38,6 +40,10 @@ fun Instant.formatMediumDateTime(): String = DateAndTimeParsers.formatMediumDate
 
 @Stable
 fun Instant.formatFullDateShortTime(): String = DateAndTimeParsers.formatFullDateShortTime(this)
+
+@Stable
+fun Instant.formatMonthDayShortTime(is24Hour: Boolean): String =
+    DateAndTimeParsers.formatMonthDayShortTime(this, is24Hour)
 
 @Stable
 fun Instant.uiMessageDateTime(): String = DateAndTimeParsers.uiMessageDateTime(this)
@@ -106,6 +112,16 @@ class DateAndTimeParsers private constructor() {
         fun formatMediumDateTime(instant: Instant): String = mediumDateTimeFormat.format(instant.toJavaInstant())
 
         fun formatFullDateShortTime(instant: Instant): String = fullDateShortTimeFormatter.format(instant.toJavaInstant())
+
+        fun formatMonthDayShortTime(instant: Instant, is24Hour: Boolean): String {
+            val locale = Locale.getDefault()
+            val date = Date.from(instant.toJavaInstant())
+            val datePattern = DateFormat.getBestDateTimePattern(locale, "MMMMd")
+            val timePattern = DateFormat.getBestDateTimePattern(locale, if (is24Hour) "Hm" else "hm")
+            val formattedDate = SimpleDateFormat(datePattern, locale).format(date)
+            val formattedTime = SimpleDateFormat(timePattern, locale).format(date)
+            return "$formattedDate, $formattedTime"
+        }
 
         fun cellTimeFormat(instant: Instant): String {
             val timeFormatter = java.text.DateFormat.getTimeInstance(

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/SupportPage.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/SupportPage.kt
@@ -52,5 +52,6 @@ enum class SupportPage(
     LEGAL_HOLD("legal_hold", R.string.url_legal_hold_learn_more),
     SEARCH("search", R.string.url_learn_about_search),
     CELLS_CONVERSATION("cells_conversation", R.string.empty_screen_learn_more_link_conversation),
-    CELLS_ALL_FILES("cells_all_files", R.string.empty_screen_learn_more_link_all_files_screen)
+    CELLS_ALL_FILES("cells_all_files", R.string.empty_screen_learn_more_link_all_files_screen),
+    ADMINLESS_GROUP_DELETE("adminless_group_delete", R.string.url_system_message_adminless_group_delete),
 }

--- a/core/ui-common/src/main/kotlin/com/wire/android/util/SupportPage.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/util/SupportPage.kt
@@ -53,5 +53,6 @@ enum class SupportPage(
     SEARCH("search", R.string.url_learn_about_search),
     CELLS_CONVERSATION("cells_conversation", R.string.empty_screen_learn_more_link_conversation),
     CELLS_ALL_FILES("cells_all_files", R.string.empty_screen_learn_more_link_all_files_screen),
-    FILE_PERMISSIONS_IN_SHARED_DRIVE("file_permissions_in_shared_drive", R.string.file_permissions_in_shared_drive)
+    FILE_PERMISSIONS_IN_SHARED_DRIVE("file_permissions_in_shared_drive", R.string.file_permissions_in_shared_drive),
+    ADMINLESS_GROUP_DELETE("adminless_group_delete", R.string.url_system_message_adminless_group_delete),
 }

--- a/core/ui-common/src/main/res/values/strings.xml
+++ b/core/ui-common/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="url_legal_hold_learn_more" translatable="false">https://support.wire.com/hc/articles/360002018278</string>
     <string name="empty_screen_learn_more_link_conversation" translatable="false">https://support.wire.com/hc/articles/32207745256221</string>
     <string name="empty_screen_learn_more_link_all_files_screen" translatable="false">https://support.wire.com/hc/articles/32207800433309</string>
+    <string name="url_system_message_adminless_group_delete" translatable="false">https://support.wire.com/hc/en-us/articles/37518608388125-Prevent-adminless-groups</string>
     <string name="legal_hold_learn_more_button">Learn more about legal hold</string>
     <string name="legal_hold_connection_failed_dialog_title">Connecting not possible</string>
     <string name="legal_hold_connection_failed_dialog_description">You can not connect to this user due to legal hold.</string>

--- a/core/ui-common/src/main/res/values/strings.xml
+++ b/core/ui-common/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="url_legal_hold_learn_more" translatable="false">https://support.wire.com/hc/articles/360002018278</string>
     <string name="empty_screen_learn_more_link_conversation" translatable="false">https://support.wire.com/hc/articles/32207745256221</string>
     <string name="empty_screen_learn_more_link_all_files_screen" translatable="false">https://support.wire.com/hc/articles/32207800433309</string>
+    <string name="url_system_message_adminless_group_delete" translatable="false">https://support.wire.com/hc/en-us/articles/37518608388125-Prevent-adminless-groups</string>
     <string name="file_permissions_in_shared_drive" translatable="false">https://support.wire.com/hc/articles/36679600377373</string>
     <string name="legal_hold_learn_more_button">Learn more about legal hold</string>
     <string name="legal_hold_connection_failed_dialog_title">Connecting not possible</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25284
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25284
----

# What's new in this PR?

Showing new `AdminlessDeleteReminder` system message for "Prevent Adminless groups" feature.
Message will be sent periodically by BE notifying users that this conversation will be removed.