### PR TITLE
fix(ci): scope AVD cache key on main

### DIFF
--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -70,9 +70,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: ${{ runner.os }}-avd-${{ matrix.api-level }}
-          restore-keys: |
-            ${{ runner.os }}-avd-
+          key: ${{ runner.os }}-avd-${{ matrix.api-level }}-google_apis-x86_64
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Goal

Prevent production-release UI tests on `main` from restoring an incompatible Android emulator cache.

## Changes

- Include the API target and architecture in the AVD cache key.
- Remove the broad `Linux-avd-` restore prefix that allowed cross-API cache restores.
- Keep the correction limited to `.github/workflows/gradle-run-ui-tests.yml`.

## Root cause

The API 29 release job requested `Linux-avd-29`, but its fallback restored `Linux-avd-31-google_apis-x86_64`. The cached AVD then referenced a missing API 31 system image, so the emulator never booted and the release build/deploy jobs were skipped.

## Impact

When an exact cache is unavailable, the workflow will create a matching AVD instead of restoring one for a different API level or architecture.

Cherry-picked from the cache-only commit in #5063.
