### PR TITLE
feat: show last message for ghost group (WPB-25285)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ConversationMapper.kt
@@ -17,10 +17,12 @@
  */
 package com.wire.android.mapper
 
+import com.wire.android.R
 import com.wire.android.model.BadgeEventType
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.model.NameBasedAvatar
 import com.wire.android.model.UserAvatarData
+import com.wire.android.ui.home.conversations.model.MessageBody
 import com.wire.android.ui.home.conversations.model.UILastMessageContent
 import com.wire.android.ui.home.conversationslist.model.BlockState
 import com.wire.android.ui.home.conversationslist.model.ConversationInfo
@@ -30,6 +32,7 @@ import com.wire.android.ui.home.conversationslist.model.ConversationItem.Group.C
 import com.wire.android.ui.home.conversationslist.model.ConversationItem.Group.Regular
 import com.wire.android.ui.home.conversationslist.model.ConversationItem.PrivateConversation
 import com.wire.android.util.ui.UiTextResolver
+import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationDetails.Connection
@@ -59,7 +62,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
             legalHoldStatus = conversationDetails.conversation.legalHoldStatus,
-            lastMessageContent = lastMessage.toUIPreview(unreadEventCount, uiTextResolver),
+            lastMessageContent = adminlessDeleteAwareLastMessage(uiTextResolver),
             badgeEventType = parseConversationEventType(
                 mutedStatus = conversationDetails.conversation.mutedStatus,
                 unreadEventCount = unreadEventCount
@@ -85,7 +88,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
             legalHoldStatus = conversationDetails.conversation.legalHoldStatus,
-            lastMessageContent = lastMessage.toUIPreview(unreadEventCount, uiTextResolver),
+            lastMessageContent = adminlessDeleteAwareLastMessage(uiTextResolver),
             badgeEventType = parseConversationEventType(
                 mutedStatus = conversationDetails.conversation.mutedStatus,
                 unreadEventCount = unreadEventCount
@@ -121,7 +124,7 @@ fun ConversationDetailsWithEvents.toConversationItem(
             conversationId = conversationDetails.conversation.id,
             mutedStatus = conversationDetails.conversation.mutedStatus,
             legalHoldStatus = conversationDetails.conversation.legalHoldStatus,
-            lastMessageContent = lastMessage.toUIPreview(unreadEventCount, uiTextResolver),
+            lastMessageContent = adminlessDeleteAwareLastMessage(uiTextResolver),
             badgeEventType = parsePrivateConversationEventType(
                 conversationDetails.otherUser.connectionStatus,
                 conversationDetails.otherUser.deleted,
@@ -177,6 +180,18 @@ fun ConversationDetailsWithEvents.toConversationItem(
     is Group.Meeting -> {
         throw IllegalArgumentException("Meeting conversations should not be visible to the user.")
     }
+}
+
+private fun ConversationDetailsWithEvents.adminlessDeleteAwareLastMessage(
+    uiTextResolver: UiTextResolver
+): UILastMessageContent = if (
+    !conversationDetails.conversation.archived && conversationDetails.conversation.adminlessGroupDeletionTimestamp != null
+) {
+    UILastMessageContent.TextMessage(
+        MessageBody(UIText.StringResource(R.string.last_message_adminless_delete_reminder))
+    )
+} else {
+    lastMessage.toUIPreview(unreadEventCount, uiTextResolver)
 }
 
 private fun Group.hasJoinableCall(joinableCallsByConversationId: Map<ConversationId, Call>): Boolean =

--- a/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/SystemMessageContentMapper.kt
@@ -82,8 +82,6 @@ class SystemMessageContentMapper @Inject constructor(
             members
         )
 
-        is MessageContent.AdminlessDeleteReminder ->
-            UIMessageContent.SystemMessage.AdminlessDeleteReminder(content.deletionScheduledFor)
     }
 
     private fun mapConversationConversationAppsAccessChanged(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -159,6 +159,7 @@ import com.wire.android.ui.home.conversations.media.preview.ImagesPreviewNavBack
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewModel
 import com.wire.android.ui.home.conversations.messages.ConversationMessagesViewState
 import com.wire.android.ui.home.conversations.messages.draft.MessageDraftViewModel
+import com.wire.android.ui.home.conversations.messages.item.AdminlessGroupDeleteReminderItem
 import com.wire.android.ui.home.conversations.messages.item.AssetLocalPathArgs
 import com.wire.android.ui.home.conversations.messages.item.MessageClickActions
 import com.wire.android.ui.home.conversations.messages.item.MessageContainerItem
@@ -935,6 +936,7 @@ private fun ConversationScreen(
                         playingAudioMessage = conversationMessagesViewState.playingAudioMessage,
                         assetStatuses = conversationMessagesViewState.assetStatuses,
                         lastUnreadMessageInstant = conversationMessagesViewState.firstUnreadInstant,
+                        adminlessGroupDeletionTimestamp = conversationMessagesViewState.adminlessGroupDeletionTimestamp,
                         unreadEventCount = conversationMessagesViewState.firstUnreadEventIndex,
                         conversationDetailsData = conversationInfoViewState.conversationDetailsData,
                         selectedMessageId = conversationMessagesViewState.searchedMessageId,
@@ -1023,6 +1025,7 @@ private fun ConversationScreenContent(
     conversationId: ConversationId,
     bottomSheetVisible: Boolean,
     lastUnreadMessageInstant: Instant?,
+    adminlessGroupDeletionTimestamp: Instant?,
     unreadEventCount: Int,
     playingAudioMessage: PlayingAudioMessage,
     assetStatuses: PersistentMap<String, MessageAssetStatus>,
@@ -1085,6 +1088,7 @@ private fun ConversationScreenContent(
                 lazyPagingMessages = lazyPagingMessages,
                 lazyListState = lazyListState,
                 lastUnreadMessageInstant = lastUnreadMessageInstant,
+                adminlessGroupDeletionTimestamp = adminlessGroupDeletionTimestamp,
                 playingAudioMessage = playingAudioMessage,
                 assetStatuses = assetStatuses,
                 onUpdateConversationReadDate = onUpdateConversationReadDate,
@@ -1183,6 +1187,7 @@ fun MessageList(
     lazyPagingMessages: LazyPagingItems<UIMessage>,
     lazyListState: LazyListState,
     lastUnreadMessageInstant: Instant?,
+    adminlessGroupDeletionTimestamp: Instant?,
     playingAudioMessage: PlayingAudioMessage,
     assetStatuses: PersistentMap<String, MessageAssetStatus>,
     onUpdateConversationReadDate: (Instant) -> Unit,
@@ -1315,6 +1320,14 @@ fun MessageList(
                 modifier = Modifier
                     .fillMaxSize()
             ) {
+                if (adminlessGroupDeletionTimestamp != null && lazyPagingMessages.itemCount == 0) {
+                    item(
+                        key = "adminless_group_delete_reminder",
+                        contentType = "adminless_group_delete_reminder",
+                    ) {
+                        AdminlessGroupDeleteReminderItem(adminlessGroupDeletionTimestamp)
+                    }
+                }
                 items(
                     count = lazyPagingMessages.itemCount,
                     key = lazyPagingMessages.itemKey { it.header.messageId },
@@ -1366,6 +1379,12 @@ fun MessageList(
                         } else {
                             SwipeableMessageConfiguration.NotSwipeable
                         }
+                    }
+
+                    // Multiple children in a reverse-layout item are placed in reverse order,
+                    // so emitting the reminder first displays it below the newest message.
+                    if (index == 0 && adminlessGroupDeletionTimestamp != null) {
+                        AdminlessGroupDeleteReminderItem(adminlessGroupDeletionTimestamp)
                     }
 
                     MessageContainerItem(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModel.kt
@@ -288,7 +288,9 @@ class ConversationMessagesViewModel(
                             conversationDetailsResult.conversationDetails.isWireCellEnabled()
                     val lastUnreadInstant = conversationDetailsResult.conversationDetails.conversation.lastReadDate
                     conversationViewState = conversationViewState.copy(
-                        firstUnreadInstant = lastUnreadInstant
+                        firstUnreadInstant = lastUnreadInstant,
+                        adminlessGroupDeletionTimestamp =
+                            conversationDetailsResult.conversationDetails.conversation.adminlessGroupDeletionTimestamp,
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewState.kt
@@ -32,6 +32,7 @@ import kotlinx.datetime.Instant
 data class ConversationMessagesViewState(
     val messages: Flow<PagingData<UIMessage>> = emptyFlow(),
     val firstUnreadInstant: Instant? = null,
+    val adminlessGroupDeletionTimestamp: Instant? = null,
     val firstUnreadEventIndex: Int = 0,
     val downloadedAssetDialogState: DownloadedAssetDialogVisibilityState = DownloadedAssetDialogVisibilityState.Hidden,
     val playingAudioMessage: PlayingAudioMessage = PlayingAudioMessage.None,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/SystemMessageItem.kt
@@ -84,7 +84,41 @@ fun SystemMessageItem(
     failureInteractionAvailable: Boolean = true,
     onFailedMessageRetryClicked: (String, ConversationId) -> Unit = { _, _ -> },
     onFailedMessageCancelClicked: (String) -> Unit = {},
-) = with(message.messageContent.buildContent(isWireCellsEnabled)) {
+) {
+    SystemMessageContentItem(
+        content = message.messageContent.buildContent(isWireCellsEnabled),
+        message = message,
+        modifier = modifier,
+        initiallyExpanded = initiallyExpanded,
+        failureInteractionAvailable = failureInteractionAvailable,
+        onFailedMessageRetryClicked = onFailedMessageRetryClicked,
+        onFailedMessageCancelClicked = onFailedMessageCancelClicked,
+    )
+}
+
+@Composable
+fun AdminlessGroupDeleteReminderItem(
+    deletionScheduledFor: kotlinx.datetime.Instant,
+    modifier: Modifier = Modifier,
+    is24HourFormat: Boolean? = null,
+) {
+    SystemMessageContentItem(
+        content = adminlessGroupDeleteReminderContent(deletionScheduledFor, is24HourFormat),
+        modifier = modifier,
+    )
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun SystemMessageContentItem(
+    content: SystemMessageContent,
+    modifier: Modifier = Modifier,
+    message: UIMessage.System? = null,
+    initiallyExpanded: Boolean = false,
+    failureInteractionAvailable: Boolean = true,
+    onFailedMessageRetryClicked: (String, ConversationId) -> Unit = { _, _ -> },
+    onFailedMessageCancelClicked: (String) -> Unit = {},
+) = with(content) {
     val textStyle = MaterialTheme.wireTypography.body01
     val lineHeightDp: Dp = with(LocalDensity.current) { textStyle.lineHeight.toDp() }
     MessageItemTemplate(
@@ -138,7 +172,7 @@ fun SystemMessageItem(
                         contentPadding = PaddingValues(horizontal = dimensions().spacing12x, vertical = dimensions().spacing8x),
                     )
                 }
-                if (message.sendingFailed) {
+                if (message?.sendingFailed == true) {
                     MessageSendFailureWarning(
                         messageStatus = message.header.messageStatus.flowStatus as MessageFlowStatus.Failure.Send,
                         isInteractionAvailable = failureInteractionAvailable,
@@ -613,12 +647,18 @@ private fun SystemMessage.buildContent(isWireCellsEnabled: Boolean) = when (this
         }
     }
 
-    is SystemMessage.AdminlessDeleteReminder -> buildContent(
+}
+
+@Composable
+private fun adminlessGroupDeleteReminderContent(
+    deletionScheduledFor: kotlinx.datetime.Instant,
+    is24HourFormat: Boolean?,
+) = buildContent(
         iconResId = commonR.drawable.ic_info,
         iconTintColor = MaterialTheme.wireColorScheme.error,
         learnMorePage = SupportPage.ADMINLESS_GROUP_DELETE,
     ) {
-        val is24Hour = DateFormat.is24HourFormat(LocalContext.current)
+        val is24Hour = is24HourFormat ?: DateFormat.is24HourFormat(LocalContext.current)
         val markdownTextStyle = DefaultMarkdownTextStyle.copy(
             normalColor = MaterialTheme.wireColorScheme.error,
             boldColor = MaterialTheme.wireColorScheme.error
@@ -632,7 +672,6 @@ private fun SystemMessage.buildContent(isWireCellsEnabled: Boolean) = when (this
             )
         }
     }
-}
 
 private fun AnnotatedString.Builder.appendVerticalSpace() = withStyle(ParagraphStyle()) { append(" ") }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewSystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/preview/PreviewSystemMessageItem.kt
@@ -20,6 +20,7 @@
 package com.wire.android.ui.home.conversations.messages.preview
 
 import androidx.compose.runtime.Composable
+import com.wire.android.ui.home.conversations.messages.item.AdminlessGroupDeleteReminderItem
 import com.wire.android.ui.home.conversations.messages.item.SystemMessageItem
 import com.wire.android.ui.home.conversations.mock.mockMessageWithKnock
 import com.wire.android.ui.home.conversations.mock.mockUsersUITexts
@@ -490,14 +491,10 @@ fun PreviewSystemMessageConversationMessageAppsAccessEnabled() {
 
 @PreviewMultipleThemes
 @Composable
-fun PreviewSystemMessageAdminlessDeleteReminder() {
+fun PreviewAdminlessGroupDeleteReminder() {
     WireTheme {
-        SystemMessageItem(
-            message = mockMessageWithKnock.copy(
-                messageContent = UIMessageContent.SystemMessage.AdminlessDeleteReminder(
-                    deletionScheduledFor = Instant.parse("2026-04-23T12:00:00Z")
-                )
-            )
+        AdminlessGroupDeleteReminderItem(
+            deletionScheduledFor = Instant.parse("2026-04-23T12:00:00Z")
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -651,10 +651,6 @@ sealed interface UIMessageContent {
             val isAccessEnabled: Boolean
         ) : SystemMessage
 
-        @Serializable
-        data class AdminlessDeleteReminder(
-            val deletionScheduledFor: Instant
-        ) : SystemMessage
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1904,6 +1904,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="label_system_message_apps_access_enabled_disclaimer">Added apps have access to the content of this conversation.</string>
     <string name="label_system_message_admin_role_assigned">You were promoted to group admin</string>
     <string name="label_system_message_adminless_delete_reminder">This group will be automatically deleted on %1$s, as there are no eligible group admins.</string>
+    <string name="last_message_adminless_delete_reminder">Will be deleted soon</string>
     <string name="more_information_about_this_server">More information about this backend</string>
 
     <!-- Pending messages service notification -->

--- a/app/src/test/kotlin/com/wire/android/mapper/ConversationMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/ConversationMapperTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.android.mapper
+
+import com.wire.android.R
+import com.wire.android.framework.TestConversationDetails
+import com.wire.android.framework.TestMessage
+import com.wire.android.model.BadgeEventType
+import com.wire.android.ui.home.conversations.model.UILastMessageContent
+import com.wire.android.ui.home.conversationslist.model.ConversationItem
+import com.wire.android.util.ui.UIText
+import com.wire.android.util.ui.UiTextResolver
+import com.wire.kalium.logic.data.conversation.ConversationDetailsWithEvents
+import com.wire.kalium.logic.data.message.MessagePreviewContent
+import com.wire.kalium.logic.data.message.UnreadEventType
+import io.mockk.mockk
+import kotlinx.datetime.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class ConversationMapperTest {
+
+    @Test
+    fun givenActiveConversationWithAdminlessDeletion_whenMapping_thenReminderOverridesDraftAndBadgeIsPreserved() {
+        val item = conversation(archived = false).toConversationItem(
+            userTypeMapper = mockk(relaxed = true),
+            uiTextResolver = uiTextResolver,
+            selfUserTeamId = null,
+        ) as ConversationItem.Group.Regular
+
+        val preview = assertInstanceOf(UILastMessageContent.TextMessage::class.java, item.lastMessageContent)
+        assertEquals(R.string.last_message_adminless_delete_reminder, (preview.messageBody.message as UIText.StringResource).resId)
+        assertEquals(BadgeEventType.UnreadMention, item.badgeEventType)
+    }
+
+    @Test
+    fun givenArchivedConversationWithAdminlessDeletion_whenMapping_thenReminderPreviewIsNotUsed() {
+        val item = conversation(archived = true).toConversationItem(
+            userTypeMapper = mockk(relaxed = true),
+            uiTextResolver = uiTextResolver,
+            selfUserTeamId = null,
+        ) as ConversationItem.Group.Regular
+
+        val preview = assertInstanceOf(UILastMessageContent.TextMessage::class.java, item.lastMessageContent)
+        val message = preview.messageBody.message as UIText.PluralResource
+        assertNotEquals(R.string.last_message_adminless_delete_reminder, message.resId)
+        assertEquals(BadgeEventType.UnreadMention, item.badgeEventType)
+    }
+
+    private fun conversation(archived: Boolean) = ConversationDetailsWithEvents(
+        conversationDetails = TestConversationDetails.GROUP.copy(
+            conversation = TestConversationDetails.GROUP.conversation.copy(
+                archived = archived,
+                adminlessGroupDeletionTimestamp = Instant.parse("2026-08-30T12:00:00Z"),
+            )
+        ),
+        unreadEventCount = mapOf(UnreadEventType.MENTION to 2),
+        lastMessage = TestMessage.PREVIEW.copy(content = MessagePreviewContent.Draft("draft")),
+    )
+
+    private val uiTextResolver = object : UiTextResolver {
+        override fun resolve(text: UIText): String = when (text) {
+            is UIText.DynamicString -> text.value
+            is UIText.StringResource -> "res_${text.resId}"
+            is UIText.PluralResource -> "plural_${text.resId}_${text.count}"
+        }
+
+        override fun localeTag(): String = "test-locale"
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/mapper/SystemMessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/SystemMessageContentMapperTest.kt
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.Locale
-import kotlinx.datetime.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
@@ -74,18 +73,6 @@ class SystemMessageContentMapperTest {
 
         // Then
         assertTrue(uiContent is SystemMessage.ConversationMessageTimerDeactivated)
-    }
-
-    @Test
-    fun givenAdminlessDeleteReminder_whenMappingToSystemMessage_thenScheduledDeletionIsPreserved() = runTest {
-        val (_, mapper) = Arrangement().arrange()
-        val scheduledDeletion = Instant.parse("2026-04-23T12:00:00Z")
-        val content = MessageContent.AdminlessDeleteReminder(scheduledDeletion)
-
-        val uiContent = mapper.mapMessage(TestMessage.SYSTEM_MESSAGE.copy(content = content), emptyList())
-
-        assertIs<SystemMessage.AdminlessDeleteReminder>(uiContent!!)
-        assertEquals(scheduledDeletion, uiContent.deletionScheduledFor)
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -72,6 +72,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Instant
 import okio.Path
 
@@ -186,6 +187,18 @@ class ConversationMessagesViewModelArrangement {
 
     fun withSuccessfulViewModelInit() = apply {
         coEvery { conversationAudioMessagePlayer.observableAudioMessagesState } returns flowOf()
+    }
+
+    fun withAdminlessGroupDeletionTimestampFlow(timestamps: Flow<Instant?>) = apply {
+        coEvery { observeConversationDetails(any()) } returns timestamps.map { timestamp ->
+            ObserveConversationDetailsUseCase.Result.Success(
+                ConversationDetails.Group.Regular(
+                    conversation = conversationStub.copy(adminlessGroupDeletionTimestamp = timestamp),
+                    isSelfUserMember = true,
+                    selfRole = Conversation.Member.Role.Member,
+                )
+            )
+        }
     }
 
     fun withSuccessfulOpenAssetMessage(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -54,10 +54,12 @@ import com.wire.kalium.network.NetworkState
 import io.mockk.coVerify
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import okio.Path.Companion.toPath
 import com.wire.android.assertions.shouldBeEqualTo
 import com.wire.android.ui.home.conversations.messages.item.withOfflineIndicator
@@ -70,6 +72,26 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(CoroutineTestExtension::class)
 @ExtendWith(NavigationTestExtension::class)
 class ConversationMessagesViewModelTest {
+
+    @Test
+    fun givenAdminlessDeletionTimestampChanges_whenObservingConversation_thenStateIsUpdated() = runTest {
+        val deletionTimestamps = MutableStateFlow<Instant?>(null)
+        val scheduledDeletion = Instant.parse("2026-08-30T12:00:00Z")
+        val (_, viewModel) = ConversationMessagesViewModelArrangement()
+            .withSuccessfulViewModelInit()
+            .withAdminlessGroupDeletionTimestampFlow(deletionTimestamps)
+            .arrange()
+        advanceUntilIdle()
+        assertEquals(null, viewModel.conversationViewState.adminlessGroupDeletionTimestamp)
+
+        deletionTimestamps.value = scheduledDeletion
+        advanceUntilIdle()
+        assertEquals(scheduledDeletion, viewModel.conversationViewState.adminlessGroupDeletionTimestamp)
+
+        deletionTimestamps.value = null
+        advanceUntilIdle()
+        assertEquals(null, viewModel.conversationViewState.adminlessGroupDeletionTimestamp)
+    }
 
     @Test
     fun `given an message ID, when downloading or fetching into internal storage, then should get message details by ID`() = runTest {


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25285
<!--jira-description-action-hidden-marker-end-->


https://wearezeta.atlassian.net/browse/WPB-25285

----

# What's new in this PR?

### Issues

For "ghost" groups (groups pending automatic deletion because they have no
eligible admins), the client should surface the pending-deletion state both in
the conversation list (as the last message) and inside the conversation itself,
and it must not be hidden behind unread-event summaries.

### Causes

Kalium now exposes the pending deletion as a conversation-level field
(`Conversation.adminlessGroupDeletionTimestamp`) instead of a system message, so
the Android side needs to read that field and render the indicator itself.

### Solutions

- **Conversation list** (`ConversationMapper`): added
  `adminlessDeleteAwareLastMessage`, which for a non-archived conversation with a
  non-null `adminlessGroupDeletionTimestamp` overrides the last-message preview
  with the new `last_message_adminless_delete_reminder` string ("Will be deleted
  soon"), regardless of unread-event counts. Otherwise it falls back to the normal
  `toUIPreview`.
- **Inside the conversation** (`ConversationScreen` / `MessageList`): surface
  `adminlessGroupDeletionTimestamp` from `ConversationMessagesViewState` and render
  an `AdminlessGroupDeleteReminderItem` — as a standalone item when the list is
  empty, or attached to the newest message (reverse-layout aware) otherwise.
- Refactored `SystemMessageItem` to extract a reusable `SystemMessageContentItem`
  so the reminder can be rendered without a backing `UIMessage`, and pulled the
  reminder content into a standalone `adminlessGroupDeleteReminderContent`.
- Removed the obsolete system-message plumbing now gone from Kalium:
  `UIMessageContent.SystemMessage.AdminlessDeleteReminder` and its mapping in
  `SystemMessageContentMapper`.
- Added string `last_message_adminless_delete_reminder` → "Will be deleted soon".
- Bumped the Kalium submodule to include the ghost-group support.

### Dependencies

Needs releases with:

- [x] Kalium: https://github.com/wireapp/kalium/pull/4356 (submodule bump included)