### PR TITLE
ci: shallow clone Kalium in workflows  [WPB-27819]

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive # Needed in order to fetch Kalium sources for building
-          fetch-depth: 0
+          fetch-depth: 1 # Keep the large Kalium submodule checkout shallow
       - name: Set up JDK 21
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
@@ -118,7 +118,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive # Needed in order to fetch Kalium sources for building
-          fetch-depth: 0
+          fetch-depth: 1 # Keep the large Kalium submodule checkout shallow
       - name: Set up JDK 21
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
@@ -153,7 +153,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive # Needed in order to fetch Kalium sources for building
-          fetch-depth: 0
+          fetch-depth: 1 # Keep the large Kalium submodule checkout shallow
       - name: Set up JDK 21
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
@@ -222,7 +222,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-          fetch-depth: 0
+          fetch-depth: 1 # Keep the large Kalium submodule checkout shallow
 
       - name: Set up JDK 21
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0

--- a/.github/workflows/generate-baseline-profile.yml
+++ b/.github/workflows/generate-baseline-profile.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           ref: ${{ env.BASE_BRANCH }}
           clean: true
-          fetch-depth: 0
+          fetch-depth: 1 # Keep the large Kalium submodule checkout shallow
           submodules: recursive
 
       - name: Set up Java 21

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
-          submodules: recursive # Needed in order to fetch Kalium sources for building
 
       - name: 'Set current Git tag from input'
         env:

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -20,8 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          submodules: recursive
           fetch-depth: 0
+
+      - name: Checkout Kalium submodule
+        run: git submodule update --init --recursive --depth=1
 
       - name: Set up JDK 21
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           submodules: recursive # Needed in order to fetch Kalium sources for building
-          fetch-depth: 0
+          fetch-depth: 1 # Keep the large Kalium submodule checkout shallow
 
       # trying https://github.com/actions/runner-images/issues/10386#issuecomment-2271613335
       - name: Free Disk Space Before Build

--- a/.github/workflows/gradle-run-unit-tests.yml
+++ b/.github/workflows/gradle-run-unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           submodules: recursive # Needed in order to fetch Kalium sources for building
-          fetch-depth: 0
+          fetch-depth: 1 # Keep the large Kalium submodule checkout shallow
 
       - name: Set up JDK 21
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27819
<!--jira-description-action-hidden-marker-end-->
the app is checking out the full kalium and app repos totaling over 5g of data on each checkout, taking over 4.5-6m and for each pipeline we have 3 checkouts so this save 15-18m per run