### PR TITLE
feat: adjust meeting creation field-level errors [WPB-27433]

### DIFF
--- a/features/meetings/src/main/res/values-de/strings.xml
+++ b/features/meetings/src/main/res/values-de/strings.xml
@@ -57,7 +57,6 @@
     <string name="new_meeting_participants_input_placeholder">Teilnehmer auswählen</string>
     <string name="content_description_new_meeting_back_icon">Ansicht neues Meeting schließen</string>
     <string name="content_description_new_meeting_participants_back_icon">Teilnehmer auswählen Ansicht schließen</string>
-    <string name="new_meeting_title_name_error_empty">Meeting-Namen eingeben</string>
     <string name="new_meeting_title_name_error_exceeded_limit">Meeting-Name höchstens 64 Zeichen</string>
     <string name="new_meeting_starts_input_label">Beginnt</string>
     <string name="new_meeting_start_date_input_placeholder">Startdatum auswählen</string>
@@ -65,9 +64,6 @@
     <string name="new_meeting_ends_input_label">Endet</string>
     <string name="new_meeting_end_date_input_placeholder">Enddatum auswählen</string>
     <string name="new_meeting_end_time_input_placeholder">Endzeit auswählen</string>
-    <string name="new_meeting_start_in_past_error">Startzeit darf nicht in der Vergangenheit liegen</string>
-    <string name="new_meeting_end_in_past_error">Endzeit kann nicht in der Vergangenheit sein</string>
-    <string name="new_meeting_end_before_start_error">Die Endzeit darf nicht vor der Startzeit liegen</string>
     <string name="new_meeting_repeats_input_label">Wiederholt sich</string>
     <string name="content_description_new_meeting_repeating_options">Wiederholungsoption auswählen</string>
     <string name="new_meeting_allow_guests_label">Gäste zulassen</string>

--- a/features/meetings/src/main/res/values-ru/strings.xml
+++ b/features/meetings/src/main/res/values-ru/strings.xml
@@ -59,7 +59,6 @@
     <string name="new_meeting_participants_input_placeholder">Выбрать участников</string>
     <string name="content_description_new_meeting_back_icon">Закрыть вид новой встречи</string>
     <string name="content_description_new_meeting_participants_back_icon">Закрыть вид выбора участников</string>
-    <string name="new_meeting_title_name_error_empty">Пожалуйста, введите название встречи</string>
     <string name="new_meeting_title_name_error_exceeded_limit">Название встречи не должно превышать 64 символа</string>
     <string name="new_meeting_starts_input_label">Начало</string>
     <string name="new_meeting_start_date_input_placeholder">Выберите дату начала</string>
@@ -67,9 +66,6 @@
     <string name="new_meeting_ends_input_label">Окончание</string>
     <string name="new_meeting_end_date_input_placeholder">Выберите дату окончания</string>
     <string name="new_meeting_end_time_input_placeholder">Выберите время окончания</string>
-    <string name="new_meeting_start_in_past_error">Время начала не может быть в прошлом</string>
-    <string name="new_meeting_end_in_past_error">Время окончания не может быть в прошлом</string>
-    <string name="new_meeting_end_before_start_error">Время окончания не может быть раньше времени начала</string>
     <string name="new_meeting_repeats_input_label">Повторы</string>
     <string name="content_description_new_meeting_repeating_options">Выберите опцию повтора</string>
     <string name="new_meeting_allow_guests_label">Разрешить гостей</string>

--- a/features/meetings/src/main/res/values/strings.xml
+++ b/features/meetings/src/main/res/values/strings.xml
@@ -60,7 +60,7 @@
     <string name="new_meeting_participants_input_placeholder">Select participants</string>
     <string name="content_description_new_meeting_back_icon">Close new meeting view</string>
     <string name="content_description_new_meeting_participants_back_icon">Close select participants view</string>
-    <string name="new_meeting_title_name_error_empty">Please enter a meeting name</string>
+    <string name="new_meeting_title_name_error_empty">Title is required</string>
     <string name="new_meeting_title_name_error_exceeded_limit">Meeting name should not exceed 64 characters</string>
     <string name="new_meeting_starts_input_label">Starts</string>
     <string name="new_meeting_start_date_input_placeholder">Select start date</string>
@@ -68,9 +68,9 @@
     <string name="new_meeting_ends_input_label">Ends</string>
     <string name="new_meeting_end_date_input_placeholder">Select end date</string>
     <string name="new_meeting_end_time_input_placeholder">Select end time</string>
-    <string name="new_meeting_start_in_past_error">Start time cannot be in the past</string>
-    <string name="new_meeting_end_in_past_error">End time cannot be in the past</string>
-    <string name="new_meeting_end_before_start_error">End time cannot be before start time</string>
+    <string name="new_meeting_start_in_past_error">Start time must be in the future</string>
+    <string name="new_meeting_end_in_past_error">End time must be in the future</string>
+    <string name="new_meeting_end_before_start_error">End time must be after start time</string>
     <string name="new_meeting_repeats_input_label">Repeats</string>
     <string name="content_description_new_meeting_repeating_options">Select repeat option</string>
     <string name="new_meeting_allow_guests_label">Allow guests</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27433
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Handling field-level (inline) errors when creating meetings.
Logic for these errors is already implemented, added when implementing the creation flow, but it required some small updates of labels, to unify across all platforms. All existing translations are removed so that it can be translated properly again.

### Testing

#### How to Test

Open dev-debug build, go to "Meetings", click "New" and try to create a meeting with empty title or selecting dates from the past.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
