### PR TITLE
fix: add missing X mark in filter chip (WPB-27299)

### DIFF
--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/chip/WireFilterChip.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/chip/WireFilterChip.kt
@@ -141,7 +141,6 @@ fun PreviewSelectedFilterChip() {
     }
 }
 
-
 @MultipleThemePreviews
 @Composable
 fun PreviewSelectedFilterChipWithoutCount() {

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/chip/WireFilterChip.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/chip/WireFilterChip.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import com.wire.android.ui.common.R
 import com.wire.android.ui.common.button.wireChipColors
 import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
@@ -58,7 +59,7 @@ fun WireFilterChip(
         label = {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(dimensions().spacing8x)
+                horizontalArrangement = Arrangement.spacedBy(dimensions().spacing4x)
             ) {
                 Text(
                     text = label,
@@ -75,12 +76,22 @@ fun WireFilterChip(
         selected = isSelected,
         colors = wireChipColors(),
         trailingIcon = {
-            trailingIconResource ?.let {
-                Icon(
-                    modifier = Modifier.width(dimensions().spacing14x),
-                    painter = painterResource(id = it),
-                    contentDescription = null,
-                )
+            Row {
+                trailingIconResource?.let {
+                    Icon(
+                        modifier = Modifier.width(dimensions().spacing14x),
+                        painter = painterResource(id = it),
+                        contentDescription = null,
+                    )
+                }
+                if (count == null && isSelected) {
+                    Icon(
+                        modifier = Modifier
+                            .width(dimensions().spacing12x),
+                        painter = painterResource(R.drawable.ic_close),
+                        contentDescription = null
+                    )
+                }
             }
         },
         border = FilterChipDefaults.filterChipBorder(
@@ -127,6 +138,15 @@ fun PreviewFilterChip() {
 fun PreviewSelectedFilterChip() {
     WireTheme {
         WireFilterChip(label = "Selected", count = 4, isSelected = true)
+    }
+}
+
+
+@MultipleThemePreviews
+@Composable
+fun PreviewSelectedFilterChipWithoutCount() {
+    WireTheme {
+        WireFilterChip(label = "Selected", isSelected = true)
     }
 }
 

--- a/core/ui-common/src/main/res/drawable/ic_close.xml
+++ b/core/ui-common/src/main/res/drawable/ic_close.xml
@@ -1,5 +1,26 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
-      
-    <path android:fillColor="@android:color/white" android:pathData="M256,760L200,704L424,480L200,256L256,200L480,424L704,200L760,256L536,480L760,704L704,760L480,536L256,760Z"/>
-    
+<!--
+  ~ Wire
+  ~ Copyright (C) 2026 Wire Swiss GmbH
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see http://www.gnu.org/licenses/.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="16dp"
+        android:height="16dp"
+        android:viewportWidth="16"
+        android:viewportHeight="16">
+    <path
+            android:fillColor="#000000"
+            android:pathData="M2.757,14.656L8,9.414L13.243,14.656L14.657,13.242L9.414,8L14.657,2.757L13.243,1.343L8,6.585L2.757,1.343L1.343,2.757L6.586,8L1.343,13.242L2.757,14.656Z" />
 </vector>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27299
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

Add missing X mark in filter chip

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
